### PR TITLE
@JSName for methods and @JSEagerLoading

### DIFF
--- a/compiler/src/main/scala/scala/tools/nsc/scalajs/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/tools/nsc/scalajs/JSDefinitions.scala
@@ -54,6 +54,7 @@ trait JSDefinitions { self: SymbolTable =>
     lazy val JavaScriptExceptionClass = getClassIfDefined("scala.js.JavaScriptException")
 
     lazy val JSNameAnnotation = getRequiredClass("scala.js.annotation.JSName")
+    lazy val JSEagerLoadingAnnotation = getRequiredClass("scala.js.annotation.JSEagerLoading")
 
     lazy val JSAnyTpe       = JSAnyClass.toTypeConstructor
     lazy val JSDynamicTpe   = JSDynamicClass.toTypeConstructor

--- a/library/src/main/scala/scala/js/annotation/JSEagerLoading.scala
+++ b/library/src/main/scala/scala/js/annotation/JSEagerLoading.scala
@@ -1,0 +1,3 @@
+package scala.js.annotation
+
+class JSEagerLoading extends scala.annotation.StaticAnnotation


### PR DESCRIPTION
Make @JSName work for methods, so that we can use a different internal name in scala that maps to another name in js.

Create a new annotation @JSEagerLoading that can be applied to objects to avoid lazy loading when the programmer knows it is safe.
