### PR TITLE
made (a: A).isInstanceOf[B] work sensibly for A <: js.Any and B <: js.Any, 

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -1401,13 +1401,17 @@ abstract class GenJSCode extends plugins.PluginComponent
 
     /** Gen JS code for an isInstanceOf test (for reference types only) */
     def genIsInstanceOf(from: Type, to: Type, value: js.Tree)(
-        implicit pos: Position = value.pos): js.Tree = {
-      if (isRawJSType(to)) {
-        // isInstanceOf is not supported for raw JavaScript types
-        abort("isInstanceOf["+to+"]")
-      } else {
-        encodeIsInstanceOf(value, to)
+      implicit pos: Position = value.pos): js.Tree = {
+
+      import js.TreeDSL._
+      to.typeSymbol match{
+        case JSBooleanClass => js.UnaryOp("typeof", value) === js.StringLiteral("boolean")
+        case JSNumberClass => js.UnaryOp("typeof", value) === js.StringLiteral("number")
+        case JSStringClass => js.UnaryOp("typeof", value) === js.StringLiteral("string")
+        case JSUndefinedClass => js.UnaryOp("typeof", value) === js.StringLiteral("undefined")
+        case _ => js.BinaryOp("instanceof", value, genGlobalJSObject(to.typeSymbol))
       }
+
     }
 
     /** Gen JS code for an asInstanceOf cast (for reference types only) */


### PR DESCRIPTION
We check for primitive types using `typeof` before falling back to `instanceof` for objects. Comparing between A <: js.Any and B !<: js.Any still throws a compile error, which I think is reasonable. I think this should catch everything, since most people should be using normal `.prototype` inheritance and `instanceof` should work.

For example, this works now:

``` scala
package helloworld

import scala.scalajs.js
import js.annotation.JSName

@JSName("ClassC")
class C(x: js.Number) extends js.Object

object HelloWorld {
  def main() {
    val num: js.Number = 1
    val str: js.String = ""
    val c = new C(num)
    println(num.isInstanceOf[js.Number]) // true
    println(str.isInstanceOf[js.Number]) // false
    println(str.isInstanceOf[js.String]) // true
    println(c.isInstanceOf[js.String])   // false
    println(c.isInstanceOf[js.RegExp])   // false
    println(c.isInstanceOf[C])           // true
    println(str.isInstanceOf[C])         // false
    println(c.isInstanceOf[js.Object])   // true

  }
}
```
