### PR TITLE
Added freshName function to make local variables more readable

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSEncoding.scala
@@ -45,10 +45,9 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
     js.DotSelect(environment, js.Ident(name, Some(name)))
   }
 
-  def encodeLabelSym(sym: Symbol)(implicit pos: Position): js.Ident = {
+  def encodeLabelSym(sym: Symbol, freshName: Symbol => String)(implicit pos: Position): js.Ident = {
     require(sym.isLabel, "encodeLabelSym called with non-label symbol: " + sym)
-    js.Ident("$jslabel$" + sym.name.toString + "$" + sym.id,
-        Some(sym.originalName.decoded))
+    js.Ident(freshName(sym), Some(sym.originalName.decoded))
   }
 
   private lazy val allRefClasses: Set[Symbol] = {
@@ -100,13 +99,12 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
         Some(sym.originalName.decoded))
   }
 
-  def encodeLocalSym(sym: Symbol)(implicit pos: Position): js.Ident = {
+  def encodeLocalSym(sym: Symbol, freshName: Symbol => String)(implicit pos: Position): js.Ident = {
     require(!sym.owner.isClass && sym.isTerm && !sym.isMethod && !sym.isModule,
         "encodeLocalSym called with non-local symbol: " + sym)
 
     val origName = Some(sym.originalName.decoded)
-    if (sym.isValueParameter) js.Ident("arg$" + sym.name.toString, origName)
-    else js.Ident(sym.name.toString + "$jsid$" + sym.id, origName)
+    js.Ident(freshName(sym), origName)
   }
 
   def encodeClassSym(sym: Symbol)(implicit pos: Position): js.Tree = {


### PR DESCRIPTION
This makes local variables, method arguments and labels use a per-method freshName generator, rather than always appending the long annoying symbol ID. This makes the generated code slightly shorter, but significantly more readable.
