### PR TITLE
moved scala class escaping from \ufe33-\ufe34-_ to _-__-$und

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -189,7 +189,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       // Generate the bridges, then steal the constructor bridges (1 at most)
       val bridges0 = genBridgesForClass(sym)
       val (constructorBridges0, bridges) = bridges0.partition {
-        case js.MethodDef(js.Ident("init\ufe33", _), _, _) => true
+        case js.MethodDef(js.Ident("init_", _), _, _) => true
         case _ => false
       }
       assert(constructorBridges0.size <= 1)
@@ -608,7 +608,7 @@ abstract class GenJSCode extends plugins.PluginComponent
             IF (!(moduleInstance)) {
               moduleInstance := js.ApplyMethod(
                   js.New(encodeClassSym(sym), Nil),
-                  js.Ident("init\ufe33\ufe34"),
+                  js.Ident("init___"),
                   Nil)
             },
             js.Return(moduleInstance)

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSBridges.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSBridges.scala
@@ -63,7 +63,7 @@ trait JSBridges extends SubComponent { self: GenJSCode =>
     }
 
     val jsName = name.toString match {
-      case "<init>" => "init\ufe33" // will be stolen by the JS constructor
+      case "<init>" => "init_" // will be stolen by the JS constructor
       case "constructor" => "$constructor"
       case x if js.isKeyword(x) => "$" + x
       case x => x

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSEncoding.scala
@@ -32,6 +32,14 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
   /** Inner separator character as a string */
   final val InnerSepStr = InnerSep.toString
 
+  final val FinalOuter = "__"
+  final val FinalInner = "_"
+  def encode(st: String) = {
+    st.replace("_", "$und")
+      .replace(OuterSepStr, FinalOuter)
+      .replace(InnerSepStr, FinalInner)
+  }
+
   /** Name given to the local Scala.js environment variable */
   final val ScalaJSEnvironmentName = "ScalaJS"
 
@@ -84,9 +92,9 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
   def encodeMethodSym(sym: Symbol)(implicit pos: Position): js.Ident = {
     require(sym.isMethod, "encodeMethodSym called with non-method symbol: " + sym)
     val encodedName =
-      if (sym.isClassConstructor) "init" + InnerSep
+      if (sym.isClassConstructor) "init" + FinalInner
       else if (!foreignIsImplClass(sym.owner)) sym.name.toString
-      else encodeClassFullName(sym.owner) + OuterSep + sym.name.toString
+      else encodeClassFullName(sym.owner) + FinalOuter + sym.name.toString
     val paramsString = makeParamsString(sym)
     js.Ident(encodedName + paramsString,
         Some(sym.originalName.decoded + paramsString))
@@ -187,12 +195,12 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
   }
 
   def encodeClassFullName(sym: Symbol, separator: Char = InnerSep): String = {
-    val base = sym.fullNameAsName(separator).toString
+    val base = encode(sym.fullNameAsName(separator).toString)
     if (sym.isModuleClass && !foreignIsImplClass(sym)) base + "$" else base
   }
 
   def encodeModuleFullName(sym: Symbol, separator: Char = InnerSep): String =
-    sym.fullNameAsName(separator).toString
+    encode(sym.fullNameAsName(separator).toString)
 
   // Encoding of method signatures
 
@@ -205,7 +213,7 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
   }
 
   private def makeParamsString(paramAndResultTypeNames: List[String]) =
-    paramAndResultTypeNames.mkString(OuterSepStr, OuterSepStr, "")
+    paramAndResultTypeNames.mkString(FinalOuter, FinalOuter, "")
 
   /** Compute the internal name for a type
    *  The internal name is inspired by the encoding of the JVM, with some

--- a/corejslib/DummyParents.js
+++ b/corejslib/DummyParents.js
@@ -4,46 +4,46 @@
  */
 
 /** @constructor */
-ScalaJS.inheritable.java\ufe33beans\ufe33SimpleBeanInfo = function() {};
+ScalaJS.inheritable.java_beans_SimpleBeanInfo = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33io\ufe33FilterInputStream = function() {};
+ScalaJS.inheritable.java_io_FilterInputStream = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33lang\ufe33Thread = function() {};
+ScalaJS.inheritable.java_lang_Thread = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33lang\ufe33ref\ufe33PhantomReference = function() {};
+ScalaJS.inheritable.java_lang_ref_PhantomReference = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33lang\ufe33ref\ufe33SoftReference = function() {};
+ScalaJS.inheritable.java_lang_ref_SoftReference = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33lang\ufe33ref\ufe33WeakReference = function() {};
+ScalaJS.inheritable.java_lang_ref_WeakReference = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33util\ufe33AbstractCollection = function() {};
+ScalaJS.inheritable.java_util_AbstractCollection = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33util\ufe33AbstractList = function() {};
+ScalaJS.inheritable.java_util_AbstractList = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33util\ufe33AbstractMap = function() {};
+ScalaJS.inheritable.java_util_AbstractMap = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33util\ufe33AbstractSet = function() {};
+ScalaJS.inheritable.java_util_AbstractSet = function() {};
 /** @constructor */
-ScalaJS.inheritable.java\ufe33util\ufe33Dictionary = function() {};
+ScalaJS.inheritable.java_util_Dictionary = function() {};
 /** @constructor */
-ScalaJS.inheritable.org\ufe33xml\ufe33sax\ufe33helpers\ufe33DefaultHandler = function() {};
+ScalaJS.inheritable.org_xml_sax_helpers_DefaultHandler = function() {};
 /** @constructor */
-ScalaJS.inheritable.org\ufe33xml\ufe33sax\ufe33helpers\ufe33XMLFilterImpl = function() {};
+ScalaJS.inheritable.org_xml_sax_helpers_XMLFilterImpl = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33collection\ufe33concurrent\ufe33BasicNode = function() {};
+ScalaJS.inheritable.scala_collection_concurrent_BasicNode = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33collection\ufe33concurrent\ufe33CNodeBase = function() {};
+ScalaJS.inheritable.scala_collection_concurrent_CNodeBase = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33collection\ufe33concurrent\ufe33INodeBase = function() {};
+ScalaJS.inheritable.scala_collection_concurrent_INodeBase = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33collection\ufe33concurrent\ufe33MainNode = function() {};
+ScalaJS.inheritable.scala_collection_concurrent_MainNode = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33concurrent\ufe33forkjoin\ufe33ForkJoinTask = function() {};
+ScalaJS.inheritable.scala_concurrent_forkjoin_ForkJoinTask = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33concurrent\ufe33forkjoin\ufe33ForkJoinWorkerThread = function() {};
+ScalaJS.inheritable.scala_concurrent_forkjoin_ForkJoinWorkerThread = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33concurrent\ufe33forkjoin\ufe33RecursiveAction = function() {};
+ScalaJS.inheritable.scala_concurrent_forkjoin_RecursiveAction = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33concurrent\ufe33impl\ufe33AbstractPromise = function() {};
+ScalaJS.inheritable.scala_concurrent_impl_AbstractPromise = function() {};
 /** @constructor */
-ScalaJS.inheritable.scala\ufe33math\ufe33ScalaNumber = function() {};
+ScalaJS.inheritable.scala_math_ScalaNumber = function() {};

--- a/corejslib/javalangObject.js
+++ b/corejslib/javalangObject.js
@@ -8,48 +8,48 @@
  * ------------------ */
 
 /** @constructor */
-ScalaJS.c.java\ufe33lang\ufe33Object = function() {
+ScalaJS.c.java_lang_Object = function() {
 };
 
 /** @constructor */
-ScalaJS.inheritable.java\ufe33lang\ufe33Object = function() {};
-ScalaJS.inheritable.java\ufe33lang\ufe33Object.prototype =
-  ScalaJS.c.java\ufe33lang\ufe33Object.prototype;
+ScalaJS.inheritable.java_lang_Object = function() {};
+ScalaJS.inheritable.java_lang_Object.prototype =
+  ScalaJS.c.java_lang_Object.prototype;
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.init\ufe33\ufe34 = function() {
+ScalaJS.c.java_lang_Object.prototype.init___ = function() {
   return this;
 }
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.getClass\ufe34java\ufe33lang\ufe33Class = function() {
+ScalaJS.c.java_lang_Object.prototype.getClass__java_lang_Class = function() {
   return this.$classData.getClassOf();
 }
 
 // Bridge for getClass()
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.getClass = function() {
-  return this.getClass\ufe34java\ufe33lang\ufe33Class();
+ScalaJS.c.java_lang_Object.prototype.getClass = function() {
+  return this.getClass__java_lang_Class();
 }
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.hashCode\ufe34I = function() {
+ScalaJS.c.java_lang_Object.prototype.hashCode__I = function() {
   // TODO
   return 42;
 }
 
 // Bridge for hashCode()
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.hashCode = function() {
-  return this.hashCode\ufe34I();
+ScalaJS.c.java_lang_Object.prototype.hashCode = function() {
+  return this.hashCode__I();
 }
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.equals\ufe34O\ufe34Z = function(rhs) {
+ScalaJS.c.java_lang_Object.prototype.equals__O__Z = function(rhs) {
   return this === rhs;
 }
 
 // Bridge for equals(Object)
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.equals = function(that) {
-  return this.equals\ufe34O\ufe34Z(that);
+ScalaJS.c.java_lang_Object.prototype.equals = function(that) {
+  return this.equals__O__Z(that);
 }
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.clone\ufe34O = function() {
-  if (ScalaJS.is.java\ufe33lang\ufe33Cloneable(this)) {
+ScalaJS.c.java_lang_Object.prototype.clone__O = function() {
+  if (ScalaJS.is.java_lang_Cloneable(this)) {
     function Clone(from) {
       for (var field in from)
         if (from["hasOwnProperty"](field))
@@ -58,61 +58,61 @@ ScalaJS.c.java\ufe33lang\ufe33Object.prototype.clone\ufe34O = function() {
     Clone.prototype = ScalaJS.g["Object"]["getPrototypeOf"](this);
     return new Clone(this);
   } else {
-    throw new ScalaJS.c.java\ufe33lang\ufe33CloneNotSupportedException().init\ufe33\ufe34();
+    throw new ScalaJS.c.java_lang_CloneNotSupportedException().init___();
   }
 }
 
 // Bridge for clone()
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.clone = function() {
-  return this.clone\ufe34O();
+ScalaJS.c.java_lang_Object.prototype.clone = function() {
+  return this.clone__O();
 }
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.toString\ufe34T = function() {
+ScalaJS.c.java_lang_Object.prototype.toString__T = function() {
   // getClass().getName() + "@" + Integer.toHexString(hashCode())
-  var className = this.getClass\ufe34java\ufe33lang\ufe33Class().getName\ufe34T();
-  var hashCode = this.hashCode\ufe34I();
+  var className = this.getClass__java_lang_Class().getName__T();
+  var hashCode = this.hashCode__I();
   return className + '@' + hashCode.toString(16);
 }
 
 // Bridge for toString()
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.toString = function() {
-  return this.toString\ufe34T();
+ScalaJS.c.java_lang_Object.prototype.toString = function() {
+  return this.toString__T();
 }
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.notify\ufe34V = function() {}
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.notifyAll\ufe34V = function() {}
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.wait\ufe34J\ufe34V = function() {}
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.wait\ufe34J\ufe34I\ufe34V = function() {}
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.wait\ufe34V = function() {}
+ScalaJS.c.java_lang_Object.prototype.notify__V = function() {}
+ScalaJS.c.java_lang_Object.prototype.notifyAll__V = function() {}
+ScalaJS.c.java_lang_Object.prototype.wait__J__V = function() {}
+ScalaJS.c.java_lang_Object.prototype.wait__J__I__V = function() {}
+ScalaJS.c.java_lang_Object.prototype.wait__V = function() {}
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.finalize\ufe34V = function() {}
+ScalaJS.c.java_lang_Object.prototype.finalize__V = function() {}
 
 // Constructor bridge
 
 /** @constructor */
-ScalaJS.classes.java\ufe33lang\ufe33Object = function() {
-  ScalaJS.c.java\ufe33lang\ufe33Object.call(this);
-  return this.init\ufe33\ufe34();
+ScalaJS.classes.java_lang_Object = function() {
+  ScalaJS.c.java_lang_Object.call(this);
+  return this.init___();
 }
-ScalaJS.classes.java\ufe33lang\ufe33Object.prototype =
-  ScalaJS.c.java\ufe33lang\ufe33Object.prototype;
+ScalaJS.classes.java_lang_Object.prototype =
+  ScalaJS.c.java_lang_Object.prototype;
 
 // Instance tests
 
-ScalaJS.is.java\ufe33lang\ufe33Object = function(obj) {
+ScalaJS.is.java_lang_Object = function(obj) {
   return !!((obj && obj.$classData &&
-    obj.$classData.ancestors.java\ufe33lang\ufe33Object) ||
+    obj.$classData.ancestors.java_lang_Object) ||
     (typeof(obj) === "string"));
 };
 
-ScalaJS.as.java\ufe33lang\ufe33Object = function(obj) {
-  if (ScalaJS.is.java\ufe33lang\ufe33Object(obj) || obj === null)
+ScalaJS.as.java_lang_Object = function(obj) {
+  if (ScalaJS.is.java_lang_Object(obj) || obj === null)
     return obj;
   else
     ScalaJS.throwClassCastException(obj, "java.lang.Object");
 };
 
-ScalaJS.isArrayOf.java\ufe33lang\ufe33Object = (function(obj, depth) {
+ScalaJS.isArrayOf.java_lang_Object = (function(obj, depth) {
   var data = obj && obj.$classData;
   if (!data)
     return false;
@@ -126,8 +126,8 @@ ScalaJS.isArrayOf.java\ufe33lang\ufe33Object = (function(obj, depth) {
     return !data.arrayBase.isPrimitive; // because Array[Int] </: Array[Object]
 });
 
-ScalaJS.asArrayOf.java\ufe33lang\ufe33Object = (function(obj, depth) {
-  if ((ScalaJS.isArrayOf.java\ufe33lang\ufe33Object(obj, depth) || (obj === null))) {
+ScalaJS.asArrayOf.java_lang_Object = (function(obj, depth) {
+  if ((ScalaJS.isArrayOf.java_lang_Object(obj, depth) || (obj === null))) {
     return obj
   } else {
     ScalaJS.throwArrayCastException(obj, "Ljava.lang.Object;", depth)
@@ -136,12 +136,12 @@ ScalaJS.asArrayOf.java\ufe33lang\ufe33Object = (function(obj, depth) {
 
 // Data
 
-ScalaJS.data.java\ufe33lang\ufe33Object =
+ScalaJS.data.java_lang_Object =
   new ScalaJS.ClassTypeData(
-    {java\ufe33lang\ufe33Object:0},
+    {java_lang_Object:0},
     false, "java.lang.Object", null, {},
-    ScalaJS.is.java\ufe33lang\ufe33Object,
-    ScalaJS.isArrayOf.java\ufe33lang\ufe33Object);
+    ScalaJS.is.java_lang_Object,
+    ScalaJS.isArrayOf.java_lang_Object);
 
-ScalaJS.c.java\ufe33lang\ufe33Object.prototype.$classData =
-  ScalaJS.data.java\ufe33lang\ufe33Object;
+ScalaJS.c.java_lang_Object.prototype.$classData =
+  ScalaJS.data.java_lang_Object;

--- a/corejslib/javalangString.js
+++ b/corejslib/javalangString.js
@@ -12,11 +12,11 @@
  * Hence, we only define data and instance tests.
  */
 
-ScalaJS.is.java\ufe33lang\ufe33String = (function(obj) {
+ScalaJS.is.java_lang_String = (function(obj) {
   return typeof(obj) === "string"
 });
 
-ScalaJS.as.java\ufe33lang\ufe33String = (function(obj) {
+ScalaJS.as.java_lang_String = (function(obj) {
   if (typeof(obj) === "string" || obj === null) {
     return obj
   } else {
@@ -24,27 +24,27 @@ ScalaJS.as.java\ufe33lang\ufe33String = (function(obj) {
   }
 });
 
-ScalaJS.isArrayOf.java\ufe33lang\ufe33String = (function(obj, depth) {
-  return (!(!(((obj && obj.$classData) && (obj.$classData.arrayDepth === depth)) && obj.$classData.arrayBase.ancestors.java\ufe33lang\ufe33String)))
+ScalaJS.isArrayOf.java_lang_String = (function(obj, depth) {
+  return (!(!(((obj && obj.$classData) && (obj.$classData.arrayDepth === depth)) && obj.$classData.arrayBase.ancestors.java_lang_String)))
 });
 
-ScalaJS.asArrayOf.java\ufe33lang\ufe33String = (function(obj, depth) {
-  if ((ScalaJS.isArrayOf.java\ufe33lang\ufe33String(obj, depth) || (obj === null))) {
+ScalaJS.asArrayOf.java_lang_String = (function(obj, depth) {
+  if ((ScalaJS.isArrayOf.java_lang_String(obj, depth) || (obj === null))) {
     return obj
   } else {
     ScalaJS.throwArrayCastException(obj, "Ljava.lang.String;", depth)
   }
 });
 
-ScalaJS.data.java\ufe33lang\ufe33String =
+ScalaJS.data.java_lang_String =
   new ScalaJS.ClassTypeData(
-    {java\ufe33lang\ufe33String:0},
-    false, "java.lang.String", ScalaJS.data.java\ufe33lang\ufe33Object,
+    {java_lang_String:0},
+    false, "java.lang.String", ScalaJS.data.java_lang_Object,
     {
-      java\ufe33lang\ufe33String: true,
-      java\ufe33io\ufe33Serializable: true,
-      java\ufe33lang\ufe33CharSequence: true,
-      java\ufe33lang\ufe33Comparable: true,
-      java\ufe33lang\ufe33Object: true
+      java_lang_String: true,
+      java_io_Serializable: true,
+      java_lang_CharSequence: true,
+      java_lang_Comparable: true,
+      java_lang_Object: true
     },
-    ScalaJS.is.java\ufe33lang\ufe33String);
+    ScalaJS.is.java_lang_String);

--- a/corejslib/scalajsenv.js
+++ b/corejslib/scalajsenv.js
@@ -70,15 +70,15 @@ var ScalaJS = {
   dynamicIsAssignableFrom: function(lhsData, rhsData) {
     if (lhsData.isPrimitive || rhsData.isPrimitive)
       return lhsData === rhsData;
-    if (rhsData === ScalaJS.data.java\ufe33lang\ufe33String)
+    if (rhsData === ScalaJS.data.java_lang_String)
       return ScalaJS.dynamicIsInstanceOf("some string", lhsData);
     else
       return ScalaJS.dynamicIsInstanceOf({$classData: rhsData}, lhsData);
   },
 
   throwClassCastException: function(instance, classFullName) {
-    throw new ScalaJS.c.java\ufe33lang\ufe33ClassCastException()
-      .init\ufe33\ufe34T(
+    throw new ScalaJS.c.java_lang_ClassCastException()
+      .init___T(
         instance + " is not an instance of " + classFullName);
   },
 
@@ -92,8 +92,8 @@ var ScalaJS = {
     if (ScalaJS.isScalaJSObject(exception))
       return exception;
     else
-      return new ScalaJS.c.scala\ufe33scalajs\ufe33js\ufe33JavaScriptException()
-        .init\ufe33\ufe34Lscala\ufe33scalajs\ufe33js\ufe33Any(exception);
+      return new ScalaJS.c.scala_scalajs_js_JavaScriptException()
+        .init___Lscala_scalajs_js_Any(exception);
   },
 
   makeNativeArrayWrapper: function(arrayClassData, nativeArray) {
@@ -147,8 +147,8 @@ var ScalaJS = {
 
   anyEqEq: function(lhs, rhs) {
     if (ScalaJS.isScalaJSObject(lhs)) {
-      return ScalaJS.modules.scala\ufe33runtime\ufe33BoxesRunTime()
-        .equals\ufe34O\ufe34O\ufe34Z(lhs, rhs);
+      return ScalaJS.modules.scala_runtime_BoxesRunTime()
+        .equals__O__O__Z(lhs, rhs);
     } else {
       return lhs === rhs;
     }
@@ -156,7 +156,7 @@ var ScalaJS = {
 
   anyRefEqEq: function(lhs, rhs) {
     if (ScalaJS.isScalaJSObject(lhs))
-      return lhs.equals\ufe34O\ufe34Z(rhs);
+      return lhs.equals__O__Z(rhs);
     else
       return lhs === rhs;
   },
@@ -170,18 +170,18 @@ var ScalaJS = {
 
   objectGetClass: function(instance) {
     if (ScalaJS.isScalaJSObject(instance) || (instance === null))
-      return instance.getClass\ufe34java\ufe33lang\ufe33Class();
+      return instance.getClass__java_lang_Class();
     else if (typeof(instance) === "string")
-      return ScalaJS.data.java\ufe33lang\ufe33String.getClassOf();
+      return ScalaJS.data.java_lang_String.getClassOf();
     else
       return null; // Exception?
   },
 
   objectClone: function(instance) {
     if (ScalaJS.isScalaJSObject(instance) || (instance === null))
-      return instance.clone\ufe34O();
+      return instance.clone__O();
     else
-      throw new ScalaJS.c.java\ufe33lang\ufe33CloneNotSupportedException().init\ufe33\ufe34();
+      throw new ScalaJS.c.java_lang_CloneNotSupportedException().init___();
   },
 
   objectFinalize: function(instance) {
@@ -198,24 +198,24 @@ var ScalaJS = {
 
   objectEquals: function(instance, rhs) {
     if (ScalaJS.isScalaJSObject(instance) || (instance === null))
-      return instance.equals\ufe34O\ufe34Z(rhs);
+      return instance.equals__O__Z(rhs);
     else
       return instance === rhs;
   },
 
   objectHashCode: function(instance) {
     if (ScalaJS.isScalaJSObject(instance))
-      return instance.hashCode\ufe34I();
+      return instance.hashCode__I();
     else
       return 42; // TODO
   },
 
   comparableCompareTo: function(instance, rhs) {
     if (typeof(instance) === "string") {
-      ScalaJS.as.java\ufe33lang\ufe33String(rhs);
+      ScalaJS.as.java_lang_String(rhs);
       return instance === rhs ? 0 : (instance < rhs ? -1 : 1);
     } else {
-      return instance.compareTo\ufe34O\ufe34I(rhs);
+      return instance.compareTo__O__I(rhs);
     }
   },
 
@@ -223,21 +223,21 @@ var ScalaJS = {
     if (typeof(instance) === "string")
       return instance["length"];
     else
-      return instance.length\ufe34I();
+      return instance.length__I();
   },
 
   charSequenceCharAt: function(instance, index) {
     if (typeof(instance) === "string")
       return instance["charCodeAt"](index);
     else
-      return instance.charAt\ufe34I\ufe34C(index);
+      return instance.charAt__I__C(index);
   },
 
   charSequenceSubSequence: function(instance, start, end) {
     if (typeof(instance) === "string")
       return instance["substring"](start, end);
     else
-      return instance.subSequence\ufe34I\ufe34I\ufe34java\ufe33lang\ufe33CharSequence(start, end);
+      return instance.subSequence__I__I__java_lang_CharSequence(start, end);
   },
 
   truncateToLong: function(value) {
@@ -255,34 +255,34 @@ var ScalaJS = {
   // Boxes - inline all the way through java.lang.X.valueOf()
 
   bV: function() {
-    return ScalaJS.modules.scala\ufe33runtime\ufe33BoxedUnit().UNIT$1;
+    return ScalaJS.modules.scala_runtime_BoxedUnit().UNIT$1;
   },
   bZ: function(value) {
     if (value)
-      return ScalaJS.modules.java\ufe33lang\ufe33Boolean().TRUE$1;
+      return ScalaJS.modules.java_lang_Boolean().TRUE$1;
     else
-      return ScalaJS.modules.java\ufe33lang\ufe33Boolean().FALSE$1;
+      return ScalaJS.modules.java_lang_Boolean().FALSE$1;
   },
   bC: function(value) {
-    return new ScalaJS.c.java\ufe33lang\ufe33Character().init\ufe33\ufe34C(value);
+    return new ScalaJS.c.java_lang_Character().init___C(value);
   },
   bB: function(value) {
-    return new ScalaJS.c.java\ufe33lang\ufe33Byte().init\ufe33\ufe34B(value);
+    return new ScalaJS.c.java_lang_Byte().init___B(value);
   },
   bS: function(value) {
-    return new ScalaJS.c.java\ufe33lang\ufe33Short().init\ufe33\ufe34S(value);
+    return new ScalaJS.c.java_lang_Short().init___S(value);
   },
   bI: function(value) {
-    return new ScalaJS.c.java\ufe33lang\ufe33Integer().init\ufe33\ufe34I(value);
+    return new ScalaJS.c.java_lang_Integer().init___I(value);
   },
   bJ: function(value) {
-    return new ScalaJS.c.java\ufe33lang\ufe33Long().init\ufe33\ufe34J(value);
+    return new ScalaJS.c.java_lang_Long().init___J(value);
   },
   bF: function(value) {
-    return new ScalaJS.c.java\ufe33lang\ufe33Float().init\ufe33\ufe34F(value);
+    return new ScalaJS.c.java_lang_Float().init___F(value);
   },
   bD: function(value) {
-    return new ScalaJS.c.java\ufe33lang\ufe33Double().init\ufe33\ufe34D(value);
+    return new ScalaJS.c.java_lang_Double().init___D(value);
   },
 
   // Unboxes - inline all the way through obj.xValue()
@@ -291,28 +291,28 @@ var ScalaJS = {
     return undefined;
   },
   uZ: function(value) {
-    return ScalaJS.as.java\ufe33lang\ufe33Boolean(value).value$1;
+    return ScalaJS.as.java_lang_Boolean(value).value$1;
   },
   uC: function(value) {
-    return ScalaJS.as.java\ufe33lang\ufe33Character(value).value$1;
+    return ScalaJS.as.java_lang_Character(value).value$1;
   },
   uB: function(value) {
-    return ScalaJS.as.java\ufe33lang\ufe33Byte(value).value$1;
+    return ScalaJS.as.java_lang_Byte(value).value$1;
   },
   uS: function(value) {
-    return ScalaJS.as.java\ufe33lang\ufe33Short(value).value$2;
+    return ScalaJS.as.java_lang_Short(value).value$2;
   },
   uI: function(value) {
-    return ScalaJS.as.java\ufe33lang\ufe33Integer(value).value$2;
+    return ScalaJS.as.java_lang_Integer(value).value$2;
   },
   uJ: function(value) {
-    return ScalaJS.as.java\ufe33lang\ufe33Long(value).value$2;
+    return ScalaJS.as.java_lang_Long(value).value$2;
   },
   uF: function(value) {
-    return ScalaJS.as.java\ufe33lang\ufe33Float(value).value$2;
+    return ScalaJS.as.java_lang_Float(value).value$2;
   },
   uD: function(value) {
-    return ScalaJS.as.java\ufe33lang\ufe33Double(value).value$2;
+    return ScalaJS.as.java_lang_Double(value).value$2;
   }
 }
 
@@ -373,8 +373,8 @@ ScalaJS.ArrayTypeData = function(componentData) {
   var componentZero = componentData.zero;
   /** @constructor */
   var ArrayClass = function(arg) {
-    ScalaJS.c.java\ufe33lang\ufe33Object.call(this);
-    ScalaJS.c.java\ufe33lang\ufe33Object.prototype.init\ufe33\ufe34.call(this);
+    ScalaJS.c.java_lang_Object.call(this);
+    ScalaJS.c.java_lang_Object.prototype.init___.call(this);
 
     if (typeof(arg) === "number") {
       // arg is the length of the array
@@ -386,11 +386,11 @@ ScalaJS.ArrayTypeData = function(componentData) {
       this.underlying = arg;
     }
   }
-  ArrayClass.prototype = new ScalaJS.inheritable.java\ufe33lang\ufe33Object;
+  ArrayClass.prototype = new ScalaJS.inheritable.java_lang_Object;
   ArrayClass.prototype.constructor = ArrayClass;
   ArrayClass.prototype.$classData = this;
 
-  ArrayClass.prototype.clone\ufe34O = function() {
+  ArrayClass.prototype.clone__O = function() {
     return new ArrayClass(this.underlying["slice"](0));
   };
 
@@ -406,8 +406,8 @@ ScalaJS.ArrayTypeData = function(componentData) {
   }
 
   this.constr = ArrayClass;
-  this.parentData = ScalaJS.data.java\ufe33lang\ufe33Object;
-  this.ancestors = {java\ufe33lang\ufe33Object: true};
+  this.parentData = ScalaJS.data.java_lang_Object;
+  this.ancestors = {java_lang_Object: true};
   this.isPrimitive = false;
   this.isInterface = false;
   this.isArrayClass = true;
@@ -426,8 +426,8 @@ ScalaJS.ArrayTypeData = function(componentData) {
 ScalaJS.ClassTypeData.prototype.getClassOf = function() {
   if (!this._classOf)
     this._classOf =
-      new ScalaJS.c.java\ufe33lang\ufe33Class()
-        .init\ufe33\uFE34Lscala\ufe33scalajs\ufe33js\uFE33Dynamic(this);
+      new ScalaJS.c.java_lang_Class()
+        .init___Lscala_scalajs_js_Dynamic(this);
   return this._classOf;
 };
 
@@ -442,46 +442,46 @@ ScalaJS.ArrayTypeData.prototype = ScalaJS.ClassTypeData.prototype;
 
 // Create primitive types
 
-ScalaJS.data.scala\ufe33Unit    = new ScalaJS.PrimitiveTypeData(undefined, "V", "void");
-ScalaJS.data.scala\ufe33Boolean = new ScalaJS.PrimitiveTypeData(false, "Z", "boolean");
-ScalaJS.data.scala\ufe33Char    = new ScalaJS.PrimitiveTypeData(0, "C", "char");
-ScalaJS.data.scala\ufe33Byte    = new ScalaJS.PrimitiveTypeData(0, "B", "byte");
-ScalaJS.data.scala\ufe33Short   = new ScalaJS.PrimitiveTypeData(0, "S", "short");
-ScalaJS.data.scala\ufe33Int     = new ScalaJS.PrimitiveTypeData(0, "I", "int");
-ScalaJS.data.scala\ufe33Long    = new ScalaJS.PrimitiveTypeData(0, "J", "long");
-ScalaJS.data.scala\ufe33Float   = new ScalaJS.PrimitiveTypeData(0.0, "F", "float");
-ScalaJS.data.scala\ufe33Double  = new ScalaJS.PrimitiveTypeData(0.0, "D", "double");
+ScalaJS.data.scala_Unit    = new ScalaJS.PrimitiveTypeData(undefined, "V", "void");
+ScalaJS.data.scala_Boolean = new ScalaJS.PrimitiveTypeData(false, "Z", "boolean");
+ScalaJS.data.scala_Char    = new ScalaJS.PrimitiveTypeData(0, "C", "char");
+ScalaJS.data.scala_Byte    = new ScalaJS.PrimitiveTypeData(0, "B", "byte");
+ScalaJS.data.scala_Short   = new ScalaJS.PrimitiveTypeData(0, "S", "short");
+ScalaJS.data.scala_Int     = new ScalaJS.PrimitiveTypeData(0, "I", "int");
+ScalaJS.data.scala_Long    = new ScalaJS.PrimitiveTypeData(0, "J", "long");
+ScalaJS.data.scala_Float   = new ScalaJS.PrimitiveTypeData(0.0, "F", "float");
+ScalaJS.data.scala_Double  = new ScalaJS.PrimitiveTypeData(0.0, "D", "double");
 
 // Instance tests for array of primitives
 
-ScalaJS.isArrayOf.scala\ufe33Boolean = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala\ufe33Boolean);
-ScalaJS.asArrayOf.scala\ufe33Boolean = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala\ufe33Boolean, "Z");
-ScalaJS.data.scala\ufe33Boolean.isArrayOf = ScalaJS.isArrayOf.scala\ufe33Boolean;
+ScalaJS.isArrayOf.scala_Boolean = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala_Boolean);
+ScalaJS.asArrayOf.scala_Boolean = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala_Boolean, "Z");
+ScalaJS.data.scala_Boolean.isArrayOf = ScalaJS.isArrayOf.scala_Boolean;
 
-ScalaJS.isArrayOf.scala\ufe33Char = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala\ufe33Char);
-ScalaJS.asArrayOf.scala\ufe33Char = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala\ufe33Char, "C");
-ScalaJS.data.scala\ufe33Char.isArrayOf = ScalaJS.isArrayOf.scala\ufe33Char;
+ScalaJS.isArrayOf.scala_Char = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala_Char);
+ScalaJS.asArrayOf.scala_Char = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala_Char, "C");
+ScalaJS.data.scala_Char.isArrayOf = ScalaJS.isArrayOf.scala_Char;
 
-ScalaJS.isArrayOf.scala\ufe33Byte = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala\ufe33Byte);
-ScalaJS.asArrayOf.scala\ufe33Byte = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala\ufe33Byte, "B");
-ScalaJS.data.scala\ufe33Byte.isArrayOf = ScalaJS.isArrayOf.scala\ufe33Byte;
+ScalaJS.isArrayOf.scala_Byte = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala_Byte);
+ScalaJS.asArrayOf.scala_Byte = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala_Byte, "B");
+ScalaJS.data.scala_Byte.isArrayOf = ScalaJS.isArrayOf.scala_Byte;
 
-ScalaJS.isArrayOf.scala\ufe33Short = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala\ufe33Short);
-ScalaJS.asArrayOf.scala\ufe33Short = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala\ufe33Short, "S");
-ScalaJS.data.scala\ufe33Short.isArrayOf = ScalaJS.isArrayOf.scala\ufe33Short;
+ScalaJS.isArrayOf.scala_Short = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala_Short);
+ScalaJS.asArrayOf.scala_Short = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala_Short, "S");
+ScalaJS.data.scala_Short.isArrayOf = ScalaJS.isArrayOf.scala_Short;
 
-ScalaJS.isArrayOf.scala\ufe33Int = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala\ufe33Int);
-ScalaJS.asArrayOf.scala\ufe33Int = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala\ufe33Int, "I");
-ScalaJS.data.scala\ufe33Int.isArrayOf = ScalaJS.isArrayOf.scala\ufe33Int;
+ScalaJS.isArrayOf.scala_Int = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala_Int);
+ScalaJS.asArrayOf.scala_Int = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala_Int, "I");
+ScalaJS.data.scala_Int.isArrayOf = ScalaJS.isArrayOf.scala_Int;
 
-ScalaJS.isArrayOf.scala\ufe33Long = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala\ufe33Long);
-ScalaJS.asArrayOf.scala\ufe33Long = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala\ufe33Long, "J");
-ScalaJS.data.scala\ufe33Long.isArrayOf = ScalaJS.isArrayOf.scala\ufe33Long;
+ScalaJS.isArrayOf.scala_Long = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala_Long);
+ScalaJS.asArrayOf.scala_Long = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala_Long, "J");
+ScalaJS.data.scala_Long.isArrayOf = ScalaJS.isArrayOf.scala_Long;
 
-ScalaJS.isArrayOf.scala\ufe33Float = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala\ufe33Float);
-ScalaJS.asArrayOf.scala\ufe33Float = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala\ufe33Float, "F");
-ScalaJS.data.scala\ufe33Float.isArrayOf = ScalaJS.isArrayOf.scala\ufe33Float;
+ScalaJS.isArrayOf.scala_Float = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala_Float);
+ScalaJS.asArrayOf.scala_Float = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala_Float, "F");
+ScalaJS.data.scala_Float.isArrayOf = ScalaJS.isArrayOf.scala_Float;
 
-ScalaJS.isArrayOf.scala\ufe33Double = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala\ufe33Double);
-ScalaJS.asArrayOf.scala\ufe33Double = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala\ufe33Double, "D");
-ScalaJS.data.scala\ufe33Double.isArrayOf = ScalaJS.isArrayOf.scala\ufe33Double;
+ScalaJS.isArrayOf.scala_Double = ScalaJS.makeIsArrayOfPrimitive(ScalaJS.data.scala_Double);
+ScalaJS.asArrayOf.scala_Double = ScalaJS.makeAsArrayOfPrimitive(ScalaJS.isArrayOf.scala_Double, "D");
+ScalaJS.data.scala_Double.isArrayOf = ScalaJS.isArrayOf.scala_Double;

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/RhinoBasedRun.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/RhinoBasedRun.scala
@@ -43,7 +43,7 @@ object RhinoBasedRun {
    *
    *  E.g., ScalaJS.c, which is a scope with the Scala.js classes, can be
    *  turned to a LazyScalaJSScope. Upon first access to a field of ScalaJS.c,
-   *  say ScalaJS.c.scala\ufe33Option, the script defining that particular
+   *  say ScalaJS.c.scala_Option, the script defining that particular
    *  field will be loaded.
    *  This is possible because the relative path to the script can be derived
    *  from the name of the property being accessed.
@@ -82,10 +82,10 @@ object RhinoBasedRun {
     }
 
     private def nameToRelativeFileName(name0: String): String = {
-      val name = name0.replace("\ufe33", "/")
+        val name = name0.replaceAll("(?<!_)_(?!_[^_])", "/")
       if (isModule) name + "$.js"
       else if (!isTraitImpl) name + ".js"
-      else name.split("\ufe34")(0) + ".js"
+      else name.split("__")(0) + ".js"
     }
 
     override def getClassName() = "LazyScalaJSScope"


### PR DESCRIPTION
Changes ScalaJS's escaping scheme for class names embedded in method signatures, using nice pretty underlines instead of ugly unicode escapes which break every editor ever's syntax highlighting. Also significantly cuts down on uncompressed file size from ~35mb to ~29mb. 
