### PR TITLE
Fix freshName bug

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -67,7 +67,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       def longName = base + n
       while (usedNames.contains(longName) || isKeywordOrReserved(longName)) n += 1
       
-      usedNameMap.add(longName)
+      usedNames.add(longName)
       longName
     }
 


### PR DESCRIPTION
This fixes a bug where `x$1` generated by freshName conflicts with `x$1` generated by the pattern matcher. Instead of trying to keep counts, this simply tracks every freshName allocated ever and refuses to allocate a name more than once.

A while loop is probably less efficient than doing clever math, but I don't think the perf hit is going to cause anyone to notice.
