### PR TITLE
RFC: Implement java.util.Arrays method needed by scala.collection

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -1960,12 +1960,14 @@ abstract class GenJSCode extends plugins.PluginComponent
       genCallHelper(boxHelperName, expr)
     }
 
-    /** java.lang.reflect.Array module */
-    lazy val ReflectArrayModuleClass = {
-      val module = getModuleIfDefined("java.lang.reflect.Array")
+    private def lookupModuleClass(name: String) = {
+      val module = getModuleIfDefined(name)
       if (module == NoSymbol) NoSymbol
       else module.moduleClass
     }
+
+    lazy val ReflectArrayModuleClass = lookupModuleClass("java.lang.reflect.Array")
+    lazy val UtilArraysModuleClass = lookupModuleClass("java.util.Arrays")
 
     /** Gen JS code for a Scala.js-specific primitive method */
     private def genJSPrimitive(tree: Apply, receiver0: Tree,
@@ -1979,13 +1981,14 @@ abstract class GenJSCode extends plugins.PluginComponent
 
       lazy val js.ArrayConstr(genArgs) = genArgArray
 
-      /* The implementations of java.lang.Class and java.lang.reflect.Array
-       * use fields and methods of the Scala.js global environment through
-       * js.Dynamic calls.
+      /* The implementations of java.lang.Class, java.lang.reflect.Array
+       * and java.util.Arrays use fields and methods of the Scala.js global
+       * environment through js.Dynamic calls.
        * These must be emitted as dot-selects when possible.
        */
       def shouldUseDynamicSelect: Boolean =
-        currentClassSym == ClassClass || currentClassSym == ReflectArrayModuleClass
+        currentClassSym == ClassClass || currentClassSym == ReflectArrayModuleClass ||
+        currentClassSym == UtilArraysModuleClass
 
       def maybeDynamicSelect(receiver: js.Tree, item: js.Tree): js.Tree = {
         if (shouldUseDynamicSelect) {

--- a/javalib/source/src/java/util/Arrays.scala
+++ b/javalib/source/src/java/util/Arrays.scala
@@ -1,0 +1,22 @@
+package java.util
+
+import scala.scalajs.js
+
+object Arrays {
+  def sort[T](array: Array[Any], comparator: Comparator[T]): Unit = {
+    def compareFn(o1: T, o2: T): js.Number =
+      comparator.compare(o1, o2)
+
+    val jsArray: js.Array[T] =
+        array.asInstanceOf[js.Dynamic].underlying.asInstanceOf[js.Array[T]]
+    jsArray.sort(compareFn _)
+  }
+
+  def fill(a: Array[Int], value: Int): Unit = {
+    var i = 0
+    while (i < a.length) {
+      a(i) = value
+      i += 1
+    }
+  }
+}


### PR DESCRIPTION
This is an attempt to implement especially Arrays.sort which is required by the SeqLike.sorted method.

I've marked this as RFC, since the sorting is done using the native js.Array.sort method. In order to do this I had to copy the code from java.lang.reflect.Array.getUnderlying to access the underlying JS array. :-(

The good news is that with these two additional patches, 3 more partests now pass:
- run/colltest1.scala
- run/comparable-comparator.scala
- run/mutable-treeset.scala
