### PR TITLE
Delete java.io.Appendable.

### DIFF
--- a/javalib/source/src/java/io/Appendable.scala
+++ b/javalib/source/src/java/io/Appendable.scala
@@ -1,7 +1,0 @@
-package java.io
-
-trait Appendable {
-  def append(c: Char): Appendable
-  def append(csq: CharSequence): Appendable
-  def append(csq: CharSequence, start: Int, end: Int): Appendable
-}


### PR DESCRIPTION
I noticed that there is both a java.lang and java.io version of Appendable. The java.io version is not part of the JRE so let's rid Scala.js of it.
