### PR TITLE
Fix #36: Comparing scala.String and js.String raises false warning

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
@@ -34,7 +34,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val JSDictionary_update = getMemberMethod(JSDictionaryClass, newTermName("update"))
     lazy val JSNumberClass    = getRequiredClass("scala.scalajs.js.Number")
     lazy val JSBooleanClass   = getRequiredClass("scala.scalajs.js.Boolean")
-    lazy val JSStringClass    = getRequiredClass("scala.scalajs.js.String")
+    lazy val JSStringClass    = getRequiredClass("java.lang.String")
     lazy val JSUndefinedClass = getRequiredClass("scala.scalajs.js.Undefined")
     lazy val JSObjectClass    = getRequiredClass("scala.scalajs.js.Object")
 
@@ -89,7 +89,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val JSBoolean_toBoolean = getMemberMethod(JSBooleanModule, newTermName("toBoolean"))
 
     lazy val JSStringModule = JSStringClass.companionModule
-      lazy val JSString_toScalaString = getMemberMethod(JSStringModule, newTermName("toScalaString"))
+
 
     lazy val JSArrayModule = JSArrayClass.companionModule
       lazy val JSArray_create = getMemberMethod(JSArrayModule, newTermName("apply"))

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
@@ -70,7 +70,6 @@ abstract class JSPrimitives {
 
     addPrimitive(JSBoolean_toBoolean, JS2Z)
     addPrimitive(JSNumber_toDouble, JS2N)
-    addPrimitive(JSString_toScalaString, JS2S)
 
     addPrimitive(JSDynamic_global, GETGLOBAL)
     addPrimitive(JSDynamic_newInstance, DYNNEW)

--- a/javalib/source/src/java/lang/String.scala
+++ b/javalib/source/src/java/lang/String.scala
@@ -1,9 +1,13 @@
 package java.lang
-
+import scala.language.implicitConversions
 import scala.annotation.switch
 import scala.scalajs.js
 
 object String {
+
+  implicit def f1(s: java.lang.String) = s.asInstanceOf[scalajs.js.JsString]
+  implicit def f2(s: scalajs.js.JsString) = s.asInstanceOf[java.lang.String]
+
   def valueOf(value: scala.Boolean) = new java.lang.Boolean(value).toString()
   def valueOf(value: scala.Char) = new java.lang.Character(value).toString()
   def valueOf(value: scala.Byte) = new java.lang.Byte(value).toString()
@@ -107,7 +111,7 @@ object String {
               else Integer.toHexString(arg.hashCode)
             case 's' | 'S' =>
               val s: js.String = if (arg eq null) "null" else arg.toString()
-              if (hasPrecision) s.substring(0, precision)
+              if (hasPrecision) s.substring(0, precision.toInt)
               else s
             case 'c' | 'C' =>
               js.String.fromCharCode(numberArg)

--- a/javalib/source/src/java/lang/System.scala
+++ b/javalib/source/src/java/lang/System.scala
@@ -68,7 +68,7 @@ extends io.PrintStream(StandardOut, true) with JSConsoleBasedPrintStream {
 
   override protected def doWriteLine(line: String): Unit = {
     if (!(!global.console))
-      global.console.log(line)
+      global.console.log(js.Any.fromString(line))
   }
 }
 
@@ -77,7 +77,7 @@ extends io.PrintStream(StandardErr, true) with JSConsoleBasedPrintStream {
 
   override protected def doWriteLine(line: String): Unit = {
     if (!(!global.console))
-      global.console.error(line)
+      global.console.error(js.Any.fromString(line))
   }
 }
 

--- a/library/src/main/scala/scala/scalajs/js/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/Primitives.scala
@@ -50,7 +50,7 @@ object Any {
   implicit def fromFloat(value: scala.Float): Number = sys.error("stub")
   implicit def fromDouble(value: scala.Double): Number = sys.error("stub")
 
-  implicit def fromString(s: java.lang.String): String = sys.error("stub")
+  implicit def fromString(s: java.lang.String): JsString = sys.error("stub")
 
   implicit def fromArray[A](array: scala.Array[A]): Array[A] = {
     val length = array.length
@@ -258,13 +258,15 @@ sealed trait Boolean extends Any {
 /** The top-level `Boolean` JavaScript object. */
 object Boolean extends Object {
   implicit def toBoolean(value: Boolean): scala.Boolean = sys.error("stub")
+  
 }
 
+
 /** Primitive JavaScript string. */
-sealed trait String extends Any {
+sealed trait JsString extends Any {
   def +(that: Any): String
   override def +(that: String): String = sys.error("stub")
-  override def +(that: Dynamic): String = sys.error("stub")
+  override def +(that: Dynamic): JsString = sys.error("stub")
 
   def ||(that: String): String
 
@@ -301,11 +303,13 @@ sealed trait String extends Any {
   def trim(): String = ???
 }
 
+object JsString{
+  implicit def Stringify(s: String) = s.asInstanceOf[JsString]
+
+}
 /** The top-level `String` JavaScript object. */
 object String extends Object {
-  implicit def toScalaString(value: String): java.lang.String = sys.error("stub")
-
-  def fromCharCode(codes: Number*): String = ???
+  def fromCharCode(codes: Number*): JsString = ???
 }
 
 /** Primitive JavaScript undefined value. */

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -87,4 +87,6 @@ package object js extends js.GlobalScope {
    *  @see [[decodeURIComponent]]
    */
   def encodeURIComponent(uriComponent: String): String = ???
+
+  type String = java.lang.String
 }

--- a/test/src/test/scala/scala/scalajs/test/javalib/StringTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/javalib/StringTest.scala
@@ -9,10 +9,11 @@ package scala.scalajs.test
 package javalib
 
 import scala.scalajs.js
+import scala.scalajs.js.Any._
 import scala.scalajs.test.ScalaJSTest
 
 object StringTest extends ScalaJSTest {
-
+  
   describe("java.lang.String") {
 
     it("should respond to `length`") {
@@ -113,6 +114,17 @@ object StringTest extends ScalaJSTest {
 
     it("should respond to `split`") {
       expect("Scala.js".split("a")).toEqual(js.Array("Sc", "l", ".js"))
+    }
+
+    it("should not complain when pattern matching") {
+      expect(
+        ("hello": js.String) match {
+          case "hello" => true
+        }
+      )
+    }
+    it("JsString methods on java.lang.Strings should work") {
+      expect("hello".search(" "))
     }
 
   }


### PR DESCRIPTION
Makes `js.String` a type alias for `java.lang.String`. Since almost all of the cleverness of `js.String` was already handled by the compiler, this requires almost no changes inside ScalaJS itself. Verified that it passes the test suite, and runs my game (http://lihaoyi.github.io/scala-js-game-2/) perfectly fine. Added a test to verify that pattern matching `js.String` against literal strings no longer causes compilation failure.

We may want to do the same for other js.\* types in future (`Double` -> `js.Number`, `FunctionN` -> `js.FunctionN`), in order to avoid the same pattern-matching weirdness when the types are not exactly identical, but those would take some work to special case in the compiler. 
