### PR TITLE
Fix #83: swallow Unit expr when converting to js.Undefined.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -2135,7 +2135,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
         case List(arg) =>
           code match {
-            case V2JS => js.Undefined()
+            case V2JS => statToExpr(exprToStat(arg))
             case Z2JS => arg
             case N2JS => arg
             case S2JS => arg

--- a/test/src/test/scala/scala/scalajs/test/compiler/RegressionTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/RegressionTest.scala
@@ -68,5 +68,13 @@ object RegressionTest extends ScalaJSTest {
     it("should emit static calls when forwarding to another constructor - #66") {
       new Bug66B("", "")
     }
+
+    it("should not swallow Unit expressions when converting to js.Undefined - #83") {
+      var effectHappened = false
+      def doEffect(): Unit = effectHappened = true
+      def f(): js.Undefined = doEffect()
+      f()
+      expect(effectHappened).toBeTruthy
+    }
   }
 }


### PR DESCRIPTION
With a minimized test case (failed before, succeeds now).
