### PR TITLE
Add js.ThisFunctionN to capture JS `this` as parameter.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -1721,7 +1721,7 @@ abstract class GenJSCode extends plugins.PluginComponent
         !(toTypeKind(ltpe).isInstanceOf[FLOAT] ||
           toTypeKind(rtpe).isInstanceOf[FLOAT] ||
           isStringType(ltpe) || isStringType(rtpe))
-      
+
       val sources = args map genExpr
 
       sources match {
@@ -1732,7 +1732,7 @@ abstract class GenJSCode extends plugins.PluginComponent
             case NOT => genLongCall(source, "unary_~")
             case _   => abort("Unknown or invalid op code on Long: " + code)
           }
-        
+
         // Unary operation
         case List(source) =>
           (code match {
@@ -1757,10 +1757,10 @@ abstract class GenJSCode extends plugins.PluginComponent
               case IntClass   => genLongModuleCall("fromInt",   tree)
               case LongClass  => tree
             }
-          
+
           val ltree = toLong(lsrc, args(0).tpe)
           val rtree = toLong(rsrc, args(1).tpe)
-          
+
           code match {
             case ADD => genOlLongCall(ltree, "+",   rtree)(RuntimeLongClass.tpe)
             case SUB => genLongCall  (ltree, "-",   rtree)
@@ -1782,7 +1782,7 @@ abstract class GenJSCode extends plugins.PluginComponent
             case _ =>
               abort("Unknown binary operation code: " + code)
           }
-          
+
         // Binary operation
         case List(lsrc_in, rsrc_in) =>
           def fromLong(tree: js.Tree, tpe: Type) = tpe.typeSymbol match {
@@ -1790,10 +1790,10 @@ abstract class GenJSCode extends plugins.PluginComponent
             case LongClass => genLongCall(tree, "toDouble")
             case _ => tree
           }
-          
+
           lazy val leftKind = toTypeKind(args.head.tpe)
           lazy val resultKind = toTypeKind(tree.tpe)
-          
+
           val lsrc = fromLong(lsrc_in, args(0).tpe)
           val rsrc = fromLong(rsrc_in, args(1).tpe)
 
@@ -1951,12 +1951,12 @@ abstract class GenJSCode extends plugins.PluginComponent
         case L2C =>
           genLongCall(source, "toChar")
         case L2I =>
-          genLongCall(source, "toInt")          
-        case L2F => 
-          genLongCall(source, "toFloat")          
+          genLongCall(source, "toInt")
+        case L2F =>
+          genLongCall(source, "toFloat")
         case L2D =>
           genLongCall(source, "toDouble")
-        
+
         // From something to long
         case B2L =>
           genLongModuleCall("fromByte", source)
@@ -1970,7 +1970,7 @@ abstract class GenJSCode extends plugins.PluginComponent
           genLongModuleCall("fromFloat", source)
         case D2L =>
           genLongModuleCall("fromDouble", source)
-        
+
         case B2F | B2D | S2F | S2D | C2F | C2D | I2F | I2D =>
           source
 
@@ -2175,6 +2175,28 @@ abstract class GenJSCode extends plugins.PluginComponent
                   }
               }
 
+            /** Convert a scala.FunctionN f to a js.ThisFunction{N-1}
+             *  Generates:
+             *    (function(f) {
+             *      return function(args...) {
+             *        return f.apply__something(this, args...);
+             *      };
+             *    })(f);
+             */
+            case F2JSTHIS =>
+              val inputTpe = args.head.tpe
+              val applyMeth = getMemberMethod(inputTpe.typeSymbol,
+                  newTermName("apply"))
+              val arity = applyMeth.tpe.params.size
+              val theFunction = js.Ident("f")
+              val arguments = (1 until arity).toList map (x => js.Ident("arg"+x))
+              js.captureWithin(theFunction, arg) {
+                js.Function(arguments, {
+                  js.Return(js.ApplyMethod(theFunction,
+                      encodeMethodSym(applyMeth), js.This() :: arguments))
+                })
+              }
+
             case JS2Z => arg
             case JS2N => arg
             case JS2S => arg
@@ -2256,6 +2278,9 @@ abstract class GenJSCode extends plugins.PluginComponent
              "&" | "|" | "^" | "&&" | "||" =>
           assert(argc == 1)
           js.BinaryOp(funName, receiver, args.head)
+
+        case "apply" if receiver0.tpe.typeSymbol.isSubClass(JSThisFunctionClass) =>
+          js.ApplyMethod(receiver, js.StringLiteral("call"), args)
 
         case "apply" if !hasExplicitJSEncoding =>
           /* Protect the receiver so that if the receiver is, e.g.,
@@ -2339,7 +2364,7 @@ abstract class GenJSCode extends plugins.PluginComponent
               newTermName("split")).suchThat(_.tpe.params.size == args.size)
           js.ApplyMethod(pattern, encodeMethodSym(splitMethod),
               receiver :: args.tail)
-              
+
         case "toCharArray" if isString =>
           // Call js.Any.stringToCharArray(<the string>)
           val jsAnyMod = genLoadModule(JSAnyModule)
@@ -2859,7 +2884,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       else if (isRawJSType(sym.tpe)) genPrimitiveJSModule(sym)
       else encodeModuleSym(sym)
     }
-    
+
     /** Generate a call to scala.scalajs.runtime.Long companion */
     private def genLongModuleCall(methodName: String, args: js.Tree*)(implicit pos: Position) = {
       val LongModule = genLoadModule(jsDefinitions.RuntimeLongModule)
@@ -2867,28 +2892,28 @@ abstract class GenJSCode extends plugins.PluginComponent
       val method = getMemberMethod(jsDefinitions.RuntimeLongModule, newTermName(encName))
       js.ApplyMethod(LongModule, encodeMethodSym(method), args.toList)
     }
-    
+
     private def genOlLongCall(
         receiver: js.Tree,
         methodName: String,
         args: js.Tree*)(argTypes: Type*)
         (implicit pos: Position): js.Tree = {
-      
+
       val encName = scala.reflect.NameTransformer.encode(methodName)
       val method = getMemberMethod(
           jsDefinitions.RuntimeLongClass, newTermName(encName))
       assert(method.isOverloaded)
-      
+
       def checkParams(types: List[Type]) = types.size == argTypes.size &&
       	(argTypes zip types).forall { case (t1,t2) => t1 =:= t2 }
-      
+
       val opt = method.alternatives find { m =>
         checkParams(m.paramss.head.map(_.typeSignature))
       }
 
       genLongCall(receiver, opt.get, args :_*)
-    } 
-    
+    }
+
     private def genLongCall(
         receiver: js.Tree,
         methodName: String,
@@ -2898,7 +2923,7 @@ abstract class GenJSCode extends plugins.PluginComponent
           jsDefinitions.RuntimeLongClass, newTermName(encName))
        genLongCall(receiver, method, args :_*)
     }
-    
+
     private def genLongCall(receiver: js.Tree, method: Symbol, args: js.Tree*)
       (implicit pos: Position): js.Tree =
       js.ApplyMethod(receiver, encodeMethodSym(method), args.toList)
@@ -2937,7 +2962,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
   private def isStringType(tpe: Type): Boolean =
     tpe.typeSymbol == StringClass
-    
+
   private def isLongType(tpe: Type): Boolean =
     tpe.typeSymbol == LongClass
 

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
@@ -37,6 +37,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSStringClass    = getRequiredClass("scala.scalajs.js.String")
     lazy val JSUndefinedClass = getRequiredClass("scala.scalajs.js.Undefined")
     lazy val JSObjectClass    = getRequiredClass("scala.scalajs.js.Object")
+    lazy val JSThisFunctionClass = getRequiredClass("scala.scalajs.js.ThisFunction")
 
     lazy val JSGlobalScopeClass = getRequiredClass("scala.scalajs.js.GlobalScope")
 
@@ -92,6 +93,9 @@ trait JSDefinitions { self: JSGlobalAddons =>
 
     lazy val JSArrayModule = JSArrayClass.companionModule
       lazy val JSArray_create = getMemberMethod(JSArrayModule, newTermName("apply"))
+
+    lazy val JSThisFunctionModule = JSThisFunctionClass.companionModule
+      def JSThisFunction_fromFunction(arity: Int) = getMemberMethod(JSThisFunctionModule, newTermName("fromFunction"+arity))
 
     lazy val RawJSTypeAnnot = getClassIfDefined("scala.scalajs.js.annotation.RawJSType")
 

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
@@ -32,6 +32,7 @@ abstract class JSPrimitives {
   val N2JS = 303 // Number (any numeric type except for Long)
   val S2JS = 304 // String
   val F2JS = 305 // FunctionN
+  val F2JSTHIS = 306 // ThisFunctionN
 
   // Conversions from JS types to Scala types
   val JS2Z = 311 // Boolean
@@ -69,6 +70,8 @@ abstract class JSPrimitives {
 
     for (i <- 0 to 22)
       addPrimitive(JSAny_fromFunction(i), F2JS)
+    for (i <- 1 to 22)
+      addPrimitive(JSThisFunction_fromFunction(i), F2JSTHIS)
 
     addPrimitive(JSBoolean_toBoolean, JS2Z)
     addPrimitive(JSNumber_toDouble, JS2N)

--- a/library/src/main/scala/scala/scalajs/js/ThisFunction.scala
+++ b/library/src/main/scala/scala/scalajs/js/ThisFunction.scala
@@ -1,0 +1,159 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+/**
+ * All doc-comments marked as "MDN" are by Mozilla Contributors,
+ * distributed under the Creative Commons Attribution-ShareAlike license from
+ * https://developer.mozilla.org/en-US/docs/Web/Reference/API
+ */
+package scala.scalajs.js
+
+import scala.language.implicitConversions
+
+/**
+ * A JavaScript function where `this` is considered as a first parameter.
+ */
+trait ThisFunction extends Function {
+}
+
+object ThisFunction {
+  implicit def fromFunction1[T1, R](f: scala.Function1[T1, R]): ThisFunction0[T1, R] = sys.error("stub")
+  implicit def fromFunction2[T1, T2, R](f: scala.Function2[T1, T2, R]): ThisFunction1[T1, T2, R] = sys.error("stub")
+  implicit def fromFunction3[T1, T2, T3, R](f: scala.Function3[T1, T2, T3, R]): ThisFunction2[T1, T2, T3, R] = sys.error("stub")
+  implicit def fromFunction4[T1, T2, T3, T4, R](f: scala.Function4[T1, T2, T3, T4, R]): ThisFunction3[T1, T2, T3, T4, R] = sys.error("stub")
+  implicit def fromFunction5[T1, T2, T3, T4, T5, R](f: scala.Function5[T1, T2, T3, T4, T5, R]): ThisFunction4[T1, T2, T3, T4, T5, R] = sys.error("stub")
+  implicit def fromFunction6[T1, T2, T3, T4, T5, T6, R](f: scala.Function6[T1, T2, T3, T4, T5, T6, R]): ThisFunction5[T1, T2, T3, T4, T5, T6, R] = sys.error("stub")
+  implicit def fromFunction7[T1, T2, T3, T4, T5, T6, T7, R](f: scala.Function7[T1, T2, T3, T4, T5, T6, T7, R]): ThisFunction6[T1, T2, T3, T4, T5, T6, T7, R] = sys.error("stub")
+  implicit def fromFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](f: scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R]): ThisFunction7[T1, T2, T3, T4, T5, T6, T7, T8, R] = sys.error("stub")
+  implicit def fromFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](f: scala.Function9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]): ThisFunction8[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = sys.error("stub")
+  implicit def fromFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](f: scala.Function10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]): ThisFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = sys.error("stub")
+  implicit def fromFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](f: scala.Function11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]): ThisFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = sys.error("stub")
+  implicit def fromFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](f: scala.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]): ThisFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] = sys.error("stub")
+  implicit def fromFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](f: scala.Function13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]): ThisFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] = sys.error("stub")
+  implicit def fromFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](f: scala.Function14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]): ThisFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] = sys.error("stub")
+  implicit def fromFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](f: scala.Function15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]): ThisFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] = sys.error("stub")
+  implicit def fromFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](f: scala.Function16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]): ThisFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] = sys.error("stub")
+  implicit def fromFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](f: scala.Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]): ThisFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = sys.error("stub")
+  implicit def fromFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](f: scala.Function18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]): ThisFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] = sys.error("stub")
+  implicit def fromFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](f: scala.Function19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]): ThisFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] = sys.error("stub")
+  implicit def fromFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](f: scala.Function20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]): ThisFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] = sys.error("stub")
+  implicit def fromFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](f: scala.Function21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]): ThisFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] = sys.error("stub")
+  implicit def fromFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](f: scala.Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]): ThisFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = sys.error("stub")
+
+  implicit def toFunction1[T1, R](f: ThisFunction0[T1, R]): scala.Function1[T1, R] = (x1) => f(x1)
+  implicit def toFunction2[T1, T2, R](f: ThisFunction1[T1, T2, R]): scala.Function2[T1, T2, R] = (x1, x2) => f(x1, x2)
+  implicit def toFunction3[T1, T2, T3, R](f: ThisFunction2[T1, T2, T3, R]): scala.Function3[T1, T2, T3, R] = (x1, x2, x3) => f(x1, x2, x3)
+  implicit def toFunction4[T1, T2, T3, T4, R](f: ThisFunction3[T1, T2, T3, T4, R]): scala.Function4[T1, T2, T3, T4, R] = (x1, x2, x3, x4) => f(x1, x2, x3, x4)
+  implicit def toFunction5[T1, T2, T3, T4, T5, R](f: ThisFunction4[T1, T2, T3, T4, T5, R]): scala.Function5[T1, T2, T3, T4, T5, R] = (x1, x2, x3, x4, x5) => f(x1, x2, x3, x4, x5)
+  implicit def toFunction6[T1, T2, T3, T4, T5, T6, R](f: ThisFunction5[T1, T2, T3, T4, T5, T6, R]): scala.Function6[T1, T2, T3, T4, T5, T6, R] = (x1, x2, x3, x4, x5, x6) => f(x1, x2, x3, x4, x5, x6)
+  implicit def toFunction7[T1, T2, T3, T4, T5, T6, T7, R](f: ThisFunction6[T1, T2, T3, T4, T5, T6, T7, R]): scala.Function7[T1, T2, T3, T4, T5, T6, T7, R] = (x1, x2, x3, x4, x5, x6, x7) => f(x1, x2, x3, x4, x5, x6, x7)
+  implicit def toFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R](f: ThisFunction7[T1, T2, T3, T4, T5, T6, T7, T8, R]): scala.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R] = (x1, x2, x3, x4, x5, x6, x7, x8) => f(x1, x2, x3, x4, x5, x6, x7, x8)
+  implicit def toFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R](f: ThisFunction8[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]): scala.Function9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9)
+  implicit def toFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R](f: ThisFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]): scala.Function10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10)
+  implicit def toFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R](f: ThisFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]): scala.Function11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11)
+  implicit def toFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R](f: ThisFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]): scala.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12)
+  implicit def toFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R](f: ThisFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]): scala.Function13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13)
+  implicit def toFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R](f: ThisFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]): scala.Function14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14)
+  implicit def toFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R](f: ThisFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]): scala.Function15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15)
+  implicit def toFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R](f: ThisFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]): scala.Function16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16)
+  implicit def toFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R](f: ThisFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]): scala.Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17)
+  implicit def toFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R](f: ThisFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]): scala.Function18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18)
+  implicit def toFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R](f: ThisFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]): scala.Function19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19)
+  implicit def toFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R](f: ThisFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]): scala.Function20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20)
+  implicit def toFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](f: ThisFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]): scala.Function21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21)
+  implicit def toFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](f: ThisFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]): scala.Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22)
+}
+
+trait ThisFunction0[-T0, +R] extends ThisFunction {
+  def apply(thisArg: T0): R
+}
+
+trait ThisFunction1[-T0, -T1, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1): R
+}
+
+trait ThisFunction2[-T0, -T1, -T2, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2): R
+}
+
+trait ThisFunction3[-T0, -T1, -T2, -T3, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3): R
+}
+
+trait ThisFunction4[-T0, -T1, -T2, -T3, -T4, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4): R
+}
+
+trait ThisFunction5[-T0, -T1, -T2, -T3, -T4, -T5, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): R
+}
+
+trait ThisFunction6[-T0, -T1, -T2, -T3, -T4, -T5, -T6, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): R
+}
+
+trait ThisFunction7[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): R
+}
+
+trait ThisFunction8[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): R
+}
+
+trait ThisFunction9[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): R
+}
+
+trait ThisFunction10[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): R
+}
+
+trait ThisFunction11[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11): R
+}
+
+trait ThisFunction12[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12): R
+}
+
+trait ThisFunction13[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13): R
+}
+
+trait ThisFunction14[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14): R
+}
+
+trait ThisFunction15[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15): R
+}
+
+trait ThisFunction16[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16): R
+}
+
+trait ThisFunction17[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17): R
+}
+
+trait ThisFunction18[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18): R
+}
+
+trait ThisFunction19[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19): R
+}
+
+trait ThisFunction20[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20): R
+}
+
+trait ThisFunction21[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends ThisFunction {
+  def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20, arg21: T21): R
+}

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/ThisFunctionTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/ThisFunctionTest.scala
@@ -1,0 +1,71 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test
+package jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.test.JasmineTest
+
+object ThisFunctionTest extends JasmineTest {
+
+  describe("scala.scalajs.js.ThisFunctionN") {
+
+    it("should provide an implicit conversion from Scala function to js.ThisFunction") {
+      val g = js.eval("""
+          var g = function(f, x) { return f.call(x, 42, x.foo); }; g;
+      """).asInstanceOf[js.Function2[js.ThisFunction2[
+          js.Dynamic, js.Number, js.String, js.String], js.Dynamic, js.String]]
+
+      val f = { (thiz: js.Dynamic, v: js.Number, u: js.String) =>
+        expect(thiz).toBeTruthy()
+        expect(thiz.foobar).toEqual("foobar")
+        u + v
+      }
+      val obj = js.Object().asInstanceOf[js.Dynamic]
+      obj.foo = "foo"
+      obj.foobar = "foobar"
+      expect(g(f, obj)).toEqual("foo42")
+    }
+
+    it("should accept a lambda where a js.ThisFunction is expected") {
+      val g = js.eval("""
+          var g = function(f, x) { return f.call(x, 42, x.foo); }; g;
+      """).asInstanceOf[js.Function2[js.ThisFunction2[
+          js.Dynamic, js.Number, js.String, js.String], js.Dynamic, js.String]]
+
+      val obj = js.Object().asInstanceOf[js.Dynamic]
+      obj.foo = "foo"
+      obj.foobar = "foobar"
+      expect(g({ (thiz: js.Dynamic, v: js.Number, u: js.String) =>
+        expect(thiz).toBeTruthy()
+        expect(thiz.foobar).toEqual("foobar")
+        u + v
+      }, obj)).toEqual("foo42")
+    }
+
+    it("should bind the first argument to this when applying js.ThisFunctionN") {
+      val g = js.eval("""
+          var g = function(x) { return this.foo + ":" + x; }; g;
+      """).asInstanceOf[js.ThisFunction1[js.Dynamic, js.Number, js.String]]
+      val obj = js.Object().asInstanceOf[js.Dynamic]
+      obj.foo = "foo"
+      expect(g(obj, 42)).toEqual("foo:42")
+    }
+
+    it("should provide an implicit conversion from js.ThisFunction to Scala function") {
+      val g = js.eval("""
+          var g = function(x) { return this.foo + ":" + x; }; g;
+      """).asInstanceOf[js.ThisFunction1[js.Dynamic, js.Number, js.String]]
+      val f: scala.Function2[js.Dynamic, js.Number, js.String] = g
+      val obj = js.Object().asInstanceOf[js.Dynamic]
+      obj.foo = "foo"
+      expect(f(obj, 42)).toEqual("foo:42")
+    }
+
+  }
+}


### PR DESCRIPTION
The traits `js.ThisFunctionN` model JavaScript functions that consider `this` as a parameter. They map to `scala.Function{N+1}` where `this` is explicitly stated as a first parameter.

See the unit tests enclosed in this pull request for the three features provided by `js.ThisFunctionN`.
