### PR TITLE
Fix #68: JS optional arguments via Scala default arguments in interop

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrinters.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrinters.scala
@@ -285,6 +285,9 @@ trait JSPrinters { self: JSGlobalAddons =>
         case js.Undefined() =>
           print("undefined")
 
+        case js.UndefinedParam() =>
+          print("<undefined param>")
+
         case js.Null() =>
           print("null")
 

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSTrees.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSTrees.scala
@@ -189,6 +189,8 @@ trait JSTrees { self: JSGlobalAddons =>
 
     case class Undefined()(implicit val pos: Position) extends Literal
 
+    case class UndefinedParam()(implicit val pos: Position) extends Literal
+
     case class Null()(implicit val pos: Position) extends Literal
 
     case class BooleanLiteral(value: Boolean)(implicit val pos: Position) extends Literal


### PR DESCRIPTION
All tests and partests pass on 2.11
