### PR TITLE
Enforce empty method body when extending js.Any (classes & traits)

### DIFF
--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/JasmineExpectation.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/JasmineExpectation.scala
@@ -7,7 +7,8 @@ trait JasmineExpectation extends js.Object {
   def toBe(exp: js.Any): Unit
   def toEqual(exp: js.Any): Unit
   def toMatch(exp: Pattern): Unit
-  def toMatch(exp: String): Unit = toMatch(Pattern.compile(exp))
+  // TODO why was there an implementation here?
+  def toMatch(exp: String): Unit// = toMatch(Pattern.compile(exp))
   def toBeDefined(): Unit
   def toBeUndefined(): Unit
   def toBeNull(): Unit

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Results.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Results.scala
@@ -3,11 +3,11 @@ package org.scalajs.jasmine
 import scala.scalajs.js
 
 trait Result extends js.Object {
-  def `type`: js.String = ???
-  val trace: js.Dynamic = ???
+  def `type`: js.String
+  val trace: js.Dynamic
 }
 
 trait ExpectationResult extends Result {
-  def passed(): js.Boolean = ???
-  val message: js.String = ???
+  def passed(): js.Boolean
+  val message: js.String
 }

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Spec.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Spec.scala
@@ -3,7 +3,7 @@ package org.scalajs.jasmine
 import scala.scalajs.js
 
 trait Spec extends js.Object {
-  def results(): SpecResults = ???
-  val description: js.String = ???
-  val suite: Suite = ???
+  def results(): SpecResults
+  val description: js.String
+  val suite: Suite
 }

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/SpecResults.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/SpecResults.scala
@@ -3,6 +3,6 @@ package org.scalajs.jasmine
 import scala.scalajs.js
 
 trait SpecResults extends js.Object {
-  def passed(): js.Boolean = ???
-  def getItems(): js.Array[Result] = ???
+  def passed(): js.Boolean
+  def getItems(): js.Array[Result]
 }

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Suite.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Suite.scala
@@ -3,6 +3,6 @@ package org.scalajs.jasmine
 import scala.scalajs.js
 
 trait Suite extends js.Object {
-  def results(): SuiteResults = ???
-  val description: js.String = ???
+  def results(): SuiteResults
+  val description: js.String
 }

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/SuiteResults.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/SuiteResults.scala
@@ -3,7 +3,7 @@ package org.scalajs.jasmine
 import scala.scalajs.js
 
 trait SuiteResults extends js.Object {
-  val passedCount: js.Number = ???
-  val failedCount: js.Number = ???
-  val totalCount: js.Number = ???
+  val passedCount: js.Number
+  val failedCount: js.Number
+  val totalCount: js.Number
 }

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -46,14 +46,14 @@ class Array[A] extends Object {
   // def this(items: A*) = this()
 
   /** Length of the array. */
-  def length: Number = ???
+  def length: Number
 
   /** Access the element at the given index. */
   @JSBracketAccess
-  def apply(index: Number): A = ???
+  def apply(index: Number): A
   /** Set the element at the given index. */
   @JSBracketAccess
-  def update(index: Number, value: A): Unit = ???
+  def update(index: Number, value: A): Unit
 
   /**
    * concat creates a new array consisting of the elements in the this object
@@ -63,7 +63,7 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def concat(items: Array[A]*): Array[A] = ???
+  def concat(items: Array[A]*): Array[A]
   /**
    * concat creates a new array consisting of the elements in the this object
    * on which it is called, followed in order by, for each argument, the
@@ -72,7 +72,7 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def concat(item: A, items: A*): Array[A] = ???
+  def concat(item: A, items: A*): Array[A]
 
   /**
    * The join() method joins all elements of an array into a string.
@@ -81,7 +81,7 @@ class Array[A] extends Object {
    * The separator is converted to a string if necessary. If omitted, the
    * array elements are separated with a comma.
    */
-  def join(seperator: String): String = ???
+  def join(seperator: String): String
 
   /**
    * The join() method joins all elements of an array into a string.
@@ -90,7 +90,7 @@ class Array[A] extends Object {
    * The separator is converted to a string if necessary. If omitted, the
    * array elements are separated with a comma.
    */
-  def join(): String = ???
+  def join(): String
 
   /**
    * The pop() method removes the last element from an array and returns that
@@ -98,7 +98,7 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def pop(): A = ???
+  def pop(): A
 
   /**
    * The push() method mutates an array by appending the given elements and
@@ -106,7 +106,7 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def push(items: A*): Number = ???
+  def push(items: A*): Number
 
   /**
    * The reverse() method reverses an array in place. The first array element
@@ -114,7 +114,7 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def reverse(): Array[A] = ???
+  def reverse(): Array[A]
 
   /**
    * The shift() method removes the first element from an array and returns that
@@ -122,15 +122,15 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def shift(): A = ???
+  def shift(): A
 
   /**
    * The slice() method returns a shallow copy of a portion of an array.
    *
    * MDN
    */
-  def slice(start: Number, end: Number): Array[A] = ???
-  def slice(start: Number): Array[A] = ???
+  def slice(start: Number, end: Number): Array[A]
+  def slice(start: Number): Array[A]
 
   /**
    * The sort() method sorts the elements of an array in place and returns the
@@ -144,8 +144,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def sort(compareFn: Function2[A, A, Number]): Array[A] = ???
-  def sort(): Array[A] = ???
+  def sort(compareFn: Function2[A, A, Number]): Array[A]
+  def sort(): Array[A]
 
   /**
    * The splice() method changes the content of an array, adding new elements
@@ -153,14 +153,14 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def splice(index: Number): Array[A] = ???
+  def splice(index: Number): Array[A]
   /**
    * The splice() method changes the content of an array, adding new elements
    * while removing old elements.
    *
    * MDN
    */
-  def splice(index: Number, deleteCount: Number, items: A*): Array[A] = ???
+  def splice(index: Number, deleteCount: Number, items: A*): Array[A]
 
   /**
    * The unshift() method adds one or more elements to the beginning of an array
@@ -168,7 +168,7 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def unshift(items: A*): Number = ???
+  def unshift(items: A*): Number
 
   /**
    * The indexOf() method returns the first index at which a given element can
@@ -176,8 +176,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def indexOf(searchElement: A, fromIndex: Number): Number = ???
-  def indexOf(searchElement: A): Number = ???
+  def indexOf(searchElement: A, fromIndex: Number): Number
+  def indexOf(searchElement: A): Number
 
   /**
    * The lastIndexOf() method returns the last index at which a given element
@@ -186,8 +186,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def lastIndexOf(searchElement: A, fromIndex: Number): Number = ???
-  def lastIndexOf(searchElement: A): Number = ???
+  def lastIndexOf(searchElement: A, fromIndex: Number): Number
+  def lastIndexOf(searchElement: A): Number
 
   /**
    * The every method executes the provided callback function once for each
@@ -217,8 +217,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def every(callbackfn: Function3[A, Number, Array[A], Boolean], thisArg: Any): Boolean = ???
-  def every(callbackfn: Function3[A, Number, Array[A], Boolean]): Boolean = ???
+  def every(callbackfn: Function3[A, Number, Array[A], Boolean], thisArg: Any): Boolean
+  def every(callbackfn: Function3[A, Number, Array[A], Boolean]): Boolean
 
   /**
    * some executes the callback function once for each element present in the
@@ -239,8 +239,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def some(callbackfn: Function3[A, Number, Array[A], Boolean], thisArg: Any): Boolean = ???
-  def some(callbackfn: Function3[A, Number, Array[A], Boolean]): Boolean = ???
+  def some(callbackfn: Function3[A, Number, Array[A], Boolean], thisArg: Any): Boolean
+  def some(callbackfn: Function3[A, Number, Array[A], Boolean]): Boolean
 
   /**
    * forEach executes the provided callback once for each element of the array
@@ -262,8 +262,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def forEach[U](callbackfn: Function3[A, Number, Array[A], U], thisArg: Any): Unit = ???
-  def forEach[U](callbackfn: Function3[A, Number, Array[A], U]): Unit = ???
+  def forEach[U](callbackfn: Function3[A, Number, Array[A], U], thisArg: Any): Unit
+  def forEach[U](callbackfn: Function3[A, Number, Array[A], U]): Unit
 
   /**
    * map calls a provided callback function once for each element in an array,
@@ -283,8 +283,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def map[B](callbackfn: Function3[A, Number, Array[A], B], thisArg: Any): Array[B] = ???
-  def map[B](callbackfn: Function3[A, Number, Array[A], B]): Array[B] = ???
+  def map[B](callbackfn: Function3[A, Number, Array[A], B], thisArg: Any): Array[B]
+  def map[B](callbackfn: Function3[A, Number, Array[A], B]): Array[B]
 
   /**
    * filter calls a provided callback function once for each element in an array,
@@ -308,8 +308,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def filter(callbackfn: Function3[A, Number, Array[A], Boolean], thisArg: Any): Array[A] = ???
-  def filter(callbackfn: Function3[A, Number, Array[A], Boolean]): Array[A] = ???
+  def filter(callbackfn: Function3[A, Number, Array[A], Boolean], thisArg: Any): Array[A]
+  def filter(callbackfn: Function3[A, Number, Array[A], Boolean]): Array[A]
 
   /**
    * reduce executes the callback function once for each element present in
@@ -327,8 +327,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def reduce[B](callbackfn: Function4[B, A, Number, Array[A], B], initialValue: B): B = ???
-  def reduce[B](callbackfn: Function4[B, A, Number, Array[A], B]): B = ???
+  def reduce[B](callbackfn: Function4[B, A, Number, Array[A], B], initialValue: B): B
+  def reduce[B](callbackfn: Function4[B, A, Number, Array[A], B]): B
 
   /**
    * reduceRight executes the callback function once for each element present
@@ -339,8 +339,8 @@ class Array[A] extends Object {
    *
    * MDN
    */
-  def reduceRight[B](callbackfn: Function4[B, A, Number, Array[A], B], initialValue: B): B = ???
-  def reduceRight[B](callbackfn: Function4[B, A, Number, Array[A], B]): B = ???
+  def reduceRight[B](callbackfn: Function4[B, A, Number, Array[A], B], initialValue: B): B
+  def reduceRight[B](callbackfn: Function4[B, A, Number, Array[A], B]): B
 }
 
 /** Factory for [[js.Array]] objects. */

--- a/library/src/main/scala/scala/scalajs/js/Date.scala
+++ b/library/src/main/scala/scala/scalajs/js/Date.scala
@@ -33,171 +33,171 @@ class Date extends Object {
   def this(year: Number, month: Number, date: Number) = this()
   def this(year: Number, month: Number) = this()
 
-  def toDateString(): String = ???
-  def toTimeString(): String = ???
-  def toLocaleDateString(): String = ???
-  def toLocaleTimeString(): String = ???
+  def toDateString(): String
+  def toTimeString(): String
+  def toLocaleDateString(): String
+  def toLocaleTimeString(): String
 
-  override def valueOf(): Number = ???
+  override def valueOf(): Number
 
-  def getTime(): Number = ???
+  def getTime(): Number
 
   /**
    * Returns the year (4 digits for 4-digit years) of the specified date according to local time.
    *
    * MDN
    */
-  def getFullYear(): Number = ???
+  def getFullYear(): Number
 
   /**
    * Returns the year (4 digits for 4-digit years) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCFullYear(): Number = ???
+  def getUTCFullYear(): Number
 
   /**
    * Returns the month (0-11) in the specified date according to local time.
    *
    * MDN
    */
-  def getMonth(): Number = ???
+  def getMonth(): Number
 
   /**
    * Returns the month (0-11) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCMonth(): Number = ???
+  def getUTCMonth(): Number
 
   /**
    * Returns the day of the month (1-31) for the specified date according to local time.
    *
    * MDN
    */
-  def getDate(): Number = ???
+  def getDate(): Number
 
   /**
    * Returns the day (date) of the month (1-31) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCDate(): Number = ???
+  def getUTCDate(): Number
 
   /**
    * Returns the day of the week (0-6) for the specified date according to local time.
    *
    * MDN
    */
-  def getDay(): Number = ???
+  def getDay(): Number
 
   /**
    * Returns the day of the week (0-6) in the specified date according to universal time.
    * MDN
    */
-  def getUTCDay(): Number = ???
+  def getUTCDay(): Number
 
   /**
    * Returns the hour (0-23) in the specified date according to local time.
    *
    * MDN
    */
-  def getHours(): Number = ???
+  def getHours(): Number
 
   /**
    * Returns the hours (0-23) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCHours(): Number = ???
+  def getUTCHours(): Number
 
   /**
    * Returns the minutes (0-59) in the specified date according to local time.
    *
    * MDN
    */
-  def getMinutes(): Number = ???
+  def getMinutes(): Number
 
   /**
    * Returns the minutes (0-59) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCMinutes(): Number = ???
+  def getUTCMinutes(): Number
 
   /**
    * Returns the seconds (0-59) in the specified date according to local time.
    *
    * MDN
    */
-  def getSeconds(): Number = ???
+  def getSeconds(): Number
 
   /**
    * Returns the seconds (0-59) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCSeconds(): Number = ???
+  def getUTCSeconds(): Number
 
   /**
    * Returns the milliseconds (0-999) in the specified date according to local time.
    *
    * MDN
    */
-  def getMilliseconds(): Number = ???
+  def getMilliseconds(): Number
 
   /**
    * Returns the milliseconds (0-999) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCMilliseconds(): Number = ???
+  def getUTCMilliseconds(): Number
 
   /**
    * Returns the time-zone offset in minutes for the current locale.
    *
    * MDN
    */
-  def getTimezoneOffset(): Number = ???
+  def getTimezoneOffset(): Number
 
-  def setTime(time: Number): Unit = ???
-  def setMilliseconds(ms: Number): Unit = ???
-  def setUTCMilliseconds(ms: Number): Unit = ???
-  def setSeconds(sec: Number, ms: Number): Unit = ???
-  def setSeconds(sec: Number): Unit = ???
-  def setUTCSeconds(sec: Number, ms: Number): Unit = ???
-  def setUTCSeconds(sec: Number): Unit = ???
-  def setMinutes(min: Number, sec: Number, ms: Number): Unit = ???
-  def setMinutes(min: Number, sec: Number): Unit = ???
-  def setMinutes(min: Number): Unit = ???
-  def setUTCMinutes(min: Number, sec: Number, ms: Number): Unit = ???
-  def setUTCMinutes(min: Number, sec: Number): Unit = ???
-  def setUTCMinutes(min: Number): Unit = ???
-  def setHours(hours: Number, min: Number, sec: Number, ms: Number): Unit = ???
-  def setHours(hours: Number, min: Number, sec: Number): Unit = ???
-  def setHours(hours: Number, min: Number): Unit = ???
-  def setHours(hours: Number): Unit = ???
-  def setUTCHours(hours: Number, min: Number, sec: Number, ms: Number): Unit = ???
-  def setUTCHours(hours: Number, min: Number, sec: Number): Unit = ???
-  def setUTCHours(hours: Number, min: Number): Unit = ???
-  def setUTCHours(hours: Number): Unit = ???
-  def setDate(date: Number): Unit = ???
-  def setUTCDate(date: Number): Unit = ???
-  def setMonth(month: Number, date: Number): Unit = ???
-  def setMonth(month: Number): Unit = ???
-  def setUTCMonth(month: Number, date: Number): Unit = ???
-  def setUTCMonth(month: Number): Unit = ???
-  def setFullYear(year: Number, month: Number, date: Number): Unit = ???
-  def setFullYear(year: Number, month: Number): Unit = ???
-  def setFullYear(year: Number): Unit = ???
-  def setUTCFullYear(year: Number, month: Number, date: Number): Unit = ???
-  def setUTCFullYear(year: Number, month: Number): Unit = ???
-  def setUTCFullYear(year: Number): Unit = ???
+  def setTime(time: Number): Unit
+  def setMilliseconds(ms: Number): Unit
+  def setUTCMilliseconds(ms: Number): Unit
+  def setSeconds(sec: Number, ms: Number): Unit
+  def setSeconds(sec: Number): Unit
+  def setUTCSeconds(sec: Number, ms: Number): Unit
+  def setUTCSeconds(sec: Number): Unit
+  def setMinutes(min: Number, sec: Number, ms: Number): Unit
+  def setMinutes(min: Number, sec: Number): Unit
+  def setMinutes(min: Number): Unit
+  def setUTCMinutes(min: Number, sec: Number, ms: Number): Unit
+  def setUTCMinutes(min: Number, sec: Number): Unit
+  def setUTCMinutes(min: Number): Unit
+  def setHours(hours: Number, min: Number, sec: Number, ms: Number): Unit
+  def setHours(hours: Number, min: Number, sec: Number): Unit
+  def setHours(hours: Number, min: Number): Unit
+  def setHours(hours: Number): Unit
+  def setUTCHours(hours: Number, min: Number, sec: Number, ms: Number): Unit
+  def setUTCHours(hours: Number, min: Number, sec: Number): Unit
+  def setUTCHours(hours: Number, min: Number): Unit
+  def setUTCHours(hours: Number): Unit
+  def setDate(date: Number): Unit
+  def setUTCDate(date: Number): Unit
+  def setMonth(month: Number, date: Number): Unit
+  def setMonth(month: Number): Unit
+  def setUTCMonth(month: Number, date: Number): Unit
+  def setUTCMonth(month: Number): Unit
+  def setFullYear(year: Number, month: Number, date: Number): Unit
+  def setFullYear(year: Number, month: Number): Unit
+  def setFullYear(year: Number): Unit
+  def setUTCFullYear(year: Number, month: Number, date: Number): Unit
+  def setUTCFullYear(year: Number, month: Number): Unit
+  def setUTCFullYear(year: Number): Unit
 
-  def toUTCString(): String = ???
-  def toISOString(): String = ???
-  def toJSON(key: Any): String = ???
-  def toJSON(): String = ???
+  def toUTCString(): String
+  def toISOString(): String
+  def toJSON(key: Any): String
+  def toJSON(): String
 }
 
 /** Factory for [[js.Date]] objects. */

--- a/library/src/main/scala/scala/scalajs/js/Error.scala
+++ b/library/src/main/scala/scala/scalajs/js/Error.scala
@@ -18,13 +18,13 @@ class Error extends Object {
   def this(message: String) = this()
 
 
-  val name: String = ???
+  val name: String
   /**
    * Human-readable description of the error
    *
    * MDN
    */
-  val message: String = ???
+  val message: String
 }
 
 object Error extends Object {

--- a/library/src/main/scala/scala/scalajs/js/Function.scala
+++ b/library/src/main/scala/scala/scalajs/js/Function.scala
@@ -55,7 +55,7 @@ class Function extends Object {
    *
    * MDN
    */
-  val length: Number = ???
+  val length: Number
 
   /**
    * The apply() method calls a function with a given this value and arguments
@@ -78,8 +78,8 @@ class Function extends Object {
    *
    * MDN
    */
-  def $apply[A](thisArg: Any, argArray: Array[A]): Dynamic = ???
-  def $apply(thisArg: Any): Dynamic = ???
+  def $apply[A](thisArg: Any, argArray: Array[A]): Dynamic
+  def $apply(thisArg: Any): Dynamic
 
   /**
    * The call() method calls a function with a given this value and arguments
@@ -87,7 +87,7 @@ class Function extends Object {
    *
    * MDN
    */
-  def call(thisArg: Any, argArray: Any*): Dynamic = ???
+  def call(thisArg: Any, argArray: Any*): Dynamic
 
   /**
    * The bind() method creates a new function that, when called, has its this
@@ -96,7 +96,7 @@ class Function extends Object {
    *
    * MDN
    */
-  def bind(thisArg: Any, argArray: Any*): Dynamic = ???
+  def bind(thisArg: Any, argArray: Any*): Dynamic
 }
 
 object Function extends Object {

--- a/library/src/main/scala/scala/scalajs/js/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/Primitives.scala
@@ -26,19 +26,19 @@ import scala.collection.{ immutable, mutable }
  *  boxing of proxying of any kind.
  */
 sealed trait Any extends scala.AnyRef {
-  def unary_+(): Number = sys.error("stub")
-  def unary_-(): Number = sys.error("stub")
-  def unary_~(): Number = sys.error("stub")
+  def unary_+(): Number
+  def unary_-(): Number
+  def unary_~(): Number
 
-  def unary_!(): Boolean = sys.error("stub")
+  def unary_!(): Boolean
 
-  def +(that: String): String = sys.error("stub")
-  def +(that: Dynamic): Any = sys.error("stub") // JSNumber v JSString
+  def +(that: String): String
+  def +(that: Dynamic): Any // JSNumber v JSString
 
-  def &&[A <: Any](that: A): that.type = sys.error("stub")
+  def &&[A <: Any](that: A): that.type
 
   // def ||[A <: Any](that: A): this.type v that.type = sys.error("stub")
-  def ||(that: Any): Any = sys.error("stub")
+  def ||(that: Any): Any
 }
 
 /** Provides implicit conversions from Scala values to JavaScript values. */
@@ -312,7 +312,7 @@ sealed trait Number extends Any {
 
   def ||(that: Number): Number
 
-  def toString(radix: Number): String = ???
+  def toString(radix: Number): String
 
   /**
    * Returns a string representation of number that does not use exponential
@@ -324,8 +324,8 @@ sealed trait Number extends Any {
    *
    * MDN
    */
-  def toFixed(fractionDigits: Number): String = ???
-  def toFixed(): String = ???
+  def toFixed(fractionDigits: Number): String
+  def toFixed(): String
 
   /**
    * Returns a string representing a Number object in exponential notation with one
@@ -341,8 +341,8 @@ sealed trait Number extends Any {
    *
    * MDN
    */
-  def toExponential(fractionDigits: Number): String = ???
-  def toExponential(): String = ???
+  def toExponential(fractionDigits: Number): String
+  def toExponential(): String
 
   /**
    * Returns a string representing a Number object in fixed-point or exponential
@@ -355,8 +355,8 @@ sealed trait Number extends Any {
    *
    * MDN
    */
-  def toPrecision(precision: Number): String = ???
-  def toPrecision(): String = ???
+  def toPrecision(precision: Number): String
+  def toPrecision(): String
 }
 
 /** The top-level `Number` JavaScript object */
@@ -422,8 +422,8 @@ object Boolean extends Object {
 /** Primitive JavaScript string. */
 sealed trait String extends Any {
   def +(that: Any): String
-  override def +(that: String): String = sys.error("stub")
-  override def +(that: Dynamic): String = sys.error("stub")
+  override def +(that: String): String
+  override def +(that: Dynamic): String
 
   def ||(that: String): String
 
@@ -438,7 +438,7 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  val length: Number = ???
+  val length: Number
 
   /**
    * The chartAt() method returns the specified character from a string.
@@ -450,7 +450,7 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def charAt(pos: Number): String = ???
+  def charAt(pos: Number): String
 
   /**
    * The charCodeAt() method returns the numeric Unicode value of the character
@@ -458,14 +458,14 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def charCodeAt(index: Number): Number = ???
+  def charCodeAt(index: Number): Number
 
   /**
    * concat combines the text from one or more strings and returns a new string.
    * Changes to the text in one string do not affect the other string.
    * MDN
    */
-  def concat(strings: String*): String = ???
+  def concat(strings: String*): String
 
   /**
    * Returns the index within the calling String object of the first occurrence
@@ -475,8 +475,8 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def indexOf(searchString: String, position: Number): Number = ???
-  def indexOf(searchString: String): Number = ???
+  def indexOf(searchString: String, position: Number): Number
+  def indexOf(searchString: String): Number
 
   /**
    * Returns the index within the calling String object of the last occurrence
@@ -485,8 +485,8 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def lastIndexOf(searchString: String, position: Number): Number = ???
-  def lastIndexOf(searchString: String): Number = ???
+  def lastIndexOf(searchString: String, position: Number): Number
+  def lastIndexOf(searchString: String): Number
 
   /**
    * Returns a number indicating whether a reference string comes before or
@@ -498,7 +498,7 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def localeCompare(that: String): Number = ???
+  def localeCompare(that: String): Number
 
   /**
    * Used to retrieve the matches when matching a string against a regular
@@ -515,8 +515,8 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def `match`(regexp: String): Array[String] = ???
-  def `match`(regexp: RegExp): Array[String] = ???
+  def `match`(regexp: String): Array[String]
+  def `match`(regexp: RegExp): Array[String]
 
   /**
    * Returns a new string with some or all matches of a pattern replaced by a
@@ -532,10 +532,10 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def replace(searchValue: String, replaceValue: String): String = ???
-  def replace(searchValue: String, replaceValue: Any): String = ???
-  def replace(searchValue: RegExp, replaceValue: String): String = ???
-  def replace(searchValue: RegExp, replaceValue: Any): String = ???
+  def replace(searchValue: String, replaceValue: String): String
+  def replace(searchValue: String, replaceValue: Any): String
+  def replace(searchValue: RegExp, replaceValue: String): String
+  def replace(searchValue: RegExp, replaceValue: Any): String
 
   /**
    * If successful, search returns the index of the regular expression inside
@@ -548,8 +548,8 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def search(regexp: String): Number = ???
-  def search(regexp: RegExp): Number = ???
+  def search(regexp: String): Number
+  def search(regexp: RegExp): Number
 
   /**
    * slice extracts the text from one string and returns a new string. Changes
@@ -564,8 +564,8 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def slice(start: Number, end: Number): String = ???
-  def slice(start: Number): String = ???
+  def slice(start: Number, end: Number): String
+  def slice(start: Number): String
 
   /**
    * Splits a String object into an array of strings by separating the string
@@ -586,10 +586,10 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def split(separator: String, limit: Number): Array[String] = ???
-  def split(separator: String): Array[String] = ???
-  def split(separator: RegExp, limit: Number): Array[String] = ???
-  def split(separator: RegExp): Array[String] = ???
+  def split(separator: String, limit: Number): Array[String]
+  def split(separator: String): Array[String]
+  def split(separator: RegExp, limit: Number): Array[String]
+  def split(separator: RegExp): Array[String]
 
   /**
    * Returns a subset of a string between one index and another, or through
@@ -597,15 +597,15 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def substring(start: Number, end: Number): String = ???
-  def substring(start: Number): String = ???
+  def substring(start: Number, end: Number): String
+  def substring(start: Number): String
 
   /**
    * Returns the calling string value converted to lowercase.
    *
    * MDN
    */
-  def toLowerCase(): String = ???
+  def toLowerCase(): String
 
   /**
    * The toLocaleLowerCase method returns the value of the string converted to
@@ -617,14 +617,14 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def toLocaleLowerCase(): String = ???
+  def toLocaleLowerCase(): String
 
   /**
    * Returns the calling string value converted to uppercase.
    *
    * MDN
    */
-  def toUpperCase(): String = ???
+  def toUpperCase(): String
 
   /**
    * The toLocaleUpperCase method returns the value of the string converted to
@@ -636,14 +636,14 @@ sealed trait String extends Any {
    *
    * MDN
    */
-  def toLocaleUpperCase(): String = ???
+  def toLocaleUpperCase(): String
 
   /**
    * Removes whitespace from both ends of the string.
    *
    * MDN
    */
-  def trim(): String = ???
+  def trim(): String
 }
 
 /** The top-level `String` JavaScript object. */
@@ -660,8 +660,8 @@ sealed trait Undefined extends Any with NotNull
 class Object extends Any {
   def this(value: Any) = this()
 
-  def toLocaleString(): String = ???
-  def valueOf(): Any = ???
+  def toLocaleString(): String
+  def valueOf(): Any
 
   /**
    * Every object descended from Object inherits the hasOwnProperty method.
@@ -671,7 +671,7 @@ class Object extends Any {
    *
    * MDN
    */
-  def hasOwnProperty(v: String): Boolean = ???
+  def hasOwnProperty(v: String): Boolean
 
   /**
    * The isPrototypeOf mehtod allows you to check whether or not an object exists
@@ -679,7 +679,7 @@ class Object extends Any {
    *
    * MDN
    */
-  def isPrototypeOf(v: Object): Boolean = ???
+  def isPrototypeOf(v: Object): Boolean
 
   /**
    * Every object has a propertyIsEnumerable method. This method can determine
@@ -690,7 +690,7 @@ class Object extends Any {
    *
    * MDN
    */
-  def propertyIsEnumerable(v: String): Boolean = ???
+  def propertyIsEnumerable(v: String): Boolean
 }
 
 /** The top-level `Object` JavaScript object. */

--- a/library/src/main/scala/scala/scalajs/js/PropertyDescriptor.scala
+++ b/library/src/main/scala/scala/scalajs/js/PropertyDescriptor.scala
@@ -11,10 +11,10 @@
 package scala.scalajs.js
 
 trait PropertyDescriptor extends Object {
-  var configurable: Boolean = _
-  var enumerable: Boolean = _
-  var value: Any = _
-  var writable: Boolean = _
-  var get: Function0[Any] = _
-  var set: Function1[Any, Any] = _
+  var configurable: Boolean
+  var enumerable: Boolean
+  var value: Any
+  var writable: Boolean
+  var get: Function0[Any]
+  var set: Function1[Any, Any]
 }

--- a/library/src/main/scala/scala/scalajs/js/RegExp.scala
+++ b/library/src/main/scala/scala/scalajs/js/RegExp.scala
@@ -32,7 +32,7 @@ class RegExp protected () extends Object {
    *
    * MDN
    */
-  val source: String = ???
+  val source: String
   /**
    * The value of global is a Boolean and true if the "g" flag was used;
    * otherwise, false. The "g" flag indicates that the regular expression
@@ -40,7 +40,7 @@ class RegExp protected () extends Object {
    *
    * MDN
    */
-  val global: Boolean = ???
+  val global: Boolean
   /**
    * The value of ignoreCase is a Boolean and true if the "i" flag was used;
    * otherwise, false. The "i" flag indicates that case should be ignored while
@@ -48,7 +48,7 @@ class RegExp protected () extends Object {
    *
    * MDN
    */
-  val ignoreCase: Boolean = ???
+  val ignoreCase: Boolean
   /**
    * The value of multiline is a Boolean and is true if the "m" flag was used;
    * otherwise, false. The "m" flag indicates that a multiline input string
@@ -58,7 +58,7 @@ class RegExp protected () extends Object {
 
    * MDN
    */
-  val multiline: Boolean = ???
+  val multiline: Boolean
 
   /**
    * The lastIndex is a read/write integer property of regular expressions that
@@ -66,7 +66,7 @@ class RegExp protected () extends Object {
    *
    * MDN
    */
-  var lastIndex: Number = ???
+  var lastIndex: Number
 
   /**
    * The exec() method executes a search for a match in a specified string.
@@ -84,7 +84,7 @@ class RegExp protected () extends Object {
    *
    * MDN
    */
-  def exec(string: String): RegExp.ExecResult = ???
+  def exec(string: String): RegExp.ExecResult
 
   /**
    * The test() method executes a search for a match between a regular expression
@@ -98,7 +98,7 @@ class RegExp protected () extends Object {
    *
    * MDN
    */
-  def test(string: String): Boolean = ???
+  def test(string: String): Boolean
 }
 
 object RegExp extends Object {
@@ -106,7 +106,7 @@ object RegExp extends Object {
   def apply(pattern: String): RegExp = ???
 
   trait ExecResult extends Array[String] {
-    var index: Number = _
-    var input: String = _
+    var index: Number
+    var input: String
   }
 }

--- a/library/src/main/scala/scala/scalajs/test/EventProxy.scala
+++ b/library/src/main/scala/scala/scalajs/test/EventProxy.scala
@@ -12,14 +12,14 @@ package scala.scalajs.test
 import scala.scalajs.js
 
 trait EventProxy extends js.Object {
-  def error(message: js.String, stack: js.Array[js.Dictionary]): Unit = ???
-  def failure(message: js.String, stack: js.Array[js.Dictionary]): Unit = ???
-  def succeeded(message: js.String): Unit = ???
-  def skipped(message: js.String): Unit = ???
-  def pending(message: js.String): Unit = ???
-  def ignored(message: js.String): Unit = ???
-  def canceled(message: js.String): Unit = ???
+  def error(message: js.String, stack: js.Array[js.Dictionary]): Unit
+  def failure(message: js.String, stack: js.Array[js.Dictionary]): Unit
+  def succeeded(message: js.String): Unit
+  def skipped(message: js.String): Unit
+  def pending(message: js.String): Unit
+  def ignored(message: js.String): Unit
+  def canceled(message: js.String): Unit
 
-  def error(message: js.String): Unit = ???
-  def info(message: js.String): Unit = ???
+  def error(message: js.String): Unit
+  def info(message: js.String): Unit
 }


### PR DESCRIPTION
This is in partial state: The same should be enforced for objects extending js.Any. This is currently not possible, since the Scala compiler enforces methods to have implementations in objects in the Typer phase (see scala/scala#3375).

Should we merge this or is it better to wait until we have full support (hopefully when 2.11 is released)?
