### PR TITLE
Implemented AtomicXXX and YYYReferences in javalib, including tests

### DIFF
--- a/corejslib/DummyParents.js
+++ b/corejslib/DummyParents.js
@@ -10,12 +10,6 @@ ScalaJS.inheritable.java_io_FilterInputStream = function() {};
 /** @constructor */
 ScalaJS.inheritable.java_lang_Thread = function() {};
 /** @constructor */
-ScalaJS.inheritable.java_lang_ref_PhantomReference = function() {};
-/** @constructor */
-ScalaJS.inheritable.java_lang_ref_SoftReference = function() {};
-/** @constructor */
-ScalaJS.inheritable.java_lang_ref_WeakReference = function() {};
-/** @constructor */
 ScalaJS.inheritable.java_util_AbstractCollection = function() {};
 /** @constructor */
 ScalaJS.inheritable.java_util_AbstractList = function() {};

--- a/javalib/source/src/java/lang/ref/PhantomReference.scala
+++ b/javalib/source/src/java/lang/ref/PhantomReference.scala
@@ -1,0 +1,7 @@
+package java.lang.ref
+
+
+class PhantomReference[T >: Null <: AnyRef](referent: T, queue: ReferenceQueue[_]) extends Reference[T](referent) {
+  def this(referent: T) = this(referent, null)
+  override def get: T = null
+}

--- a/javalib/source/src/java/lang/ref/Reference.scala
+++ b/javalib/source/src/java/lang/ref/Reference.scala
@@ -1,0 +1,8 @@
+package java.lang.ref
+
+abstract class Reference[T >: Null <: AnyRef](private[this] var referent: T) {
+  def get: T = referent
+  def clear: Unit = referent = null
+  def isEnqueued: Boolean = false
+  def enqueue: Boolean = false
+}

--- a/javalib/source/src/java/lang/ref/SoftReference.scala
+++ b/javalib/source/src/java/lang/ref/SoftReference.scala
@@ -1,0 +1,5 @@
+package java.lang.ref
+
+class SoftReference[T >: Null <: AnyRef](referent: T, queue: ReferenceQueue[_]) extends Reference[T](referent) {
+  def this(referent: T) = this(referent, null)
+}

--- a/javalib/source/src/java/lang/ref/WeakReference.scala
+++ b/javalib/source/src/java/lang/ref/WeakReference.scala
@@ -1,0 +1,5 @@
+package java.lang.ref
+
+class WeakReference[T >: Null <: AnyRef](referent: T, queue: ReferenceQueue[_]) extends Reference[T](referent) {
+  def this(referent: T) = this(referent, null)
+}

--- a/javalib/source/src/java/util/concurrent/atomic/AtomicBoolean.scala
+++ b/javalib/source/src/java/util/concurrent/atomic/AtomicBoolean.scala
@@ -1,0 +1,19 @@
+package java.util.concurrent.atomic
+
+class AtomicBoolean(private[this] var value: Boolean) extends Serializable {
+  def get(): Boolean = value
+  def set(newValue: Boolean): Unit = value = newValue
+  def lazySet(newValue: Boolean): Unit = set(newValue)
+  def compareAndSet(expect: Boolean, newValue: Boolean): Boolean = {
+    if (expect != value) false else {
+      value = newValue
+      true
+    }
+  }
+  def weakCompareAndSet(expect: Boolean, newValue: Boolean): Boolean = compareAndSet(expect, newValue)
+  def getAndSet(newValue: Boolean) = {
+    val old = value
+    value = newValue
+    old
+  }
+}

--- a/javalib/source/src/java/util/concurrent/atomic/AtomicInteger.scala
+++ b/javalib/source/src/java/util/concurrent/atomic/AtomicInteger.scala
@@ -1,0 +1,47 @@
+package java.util.concurrent.atomic
+
+class AtomicInteger(var value: Int) extends Serializable {
+  def get(): Int = value
+  def set(newValue: Int): Unit = value = newValue
+  def lazySet(newValue: Int): Unit = set(newValue)
+  def compareAndSet(expect: Int, newValue: Int): Boolean = {
+    if (expect != value) false else {
+      value = newValue
+      true
+    }
+  }
+  def weakCompareAndSet(expect: Int, newValue: Int): Boolean = compareAndSet(expect, newValue)
+  def getAndSet(newValue: Int): Int = {
+    val old = value
+    value = newValue
+    old
+  }
+  def getAndIncrement(): Int = {
+    value += 1
+    value - 1
+  }
+  def getAndDecrement(): Int = {
+    value -= 1
+    value + 1
+  }
+  def getAndAdd(delta: Int): Int = {
+    value += delta
+    value - delta
+  }
+  def incrementAndGet(): Int = {
+    value += 1
+    value
+  }
+  def decrementAndGet(): Int = {
+    value -= 1
+    value
+  }
+  def addAndGet(delta: Int): Int = {
+    value += delta
+    value
+  }
+  def intValue(): Int = value.toInt
+  def longValue(): Long = value.toLong
+  def floatValue(): Float = value.toFloat
+  def doubleValue(): Double = value.toDouble
+}

--- a/javalib/source/src/java/util/concurrent/atomic/AtomicLong.scala
+++ b/javalib/source/src/java/util/concurrent/atomic/AtomicLong.scala
@@ -1,0 +1,47 @@
+package java.util.concurrent.atomic
+
+class AtomicLong(var value: Long) extends Serializable {
+  def get(): Long = value
+  def set(newValue: Long): Unit = value = newValue
+  def lazySet(newValue: Long): Unit = set(newValue)
+  def compareAndSet(expect: Long, newValue: Long): Boolean = {
+    if (expect != value) false else {
+      value = newValue
+      true
+    }
+  }
+  def weakCompareAndSet(expect: Long, newValue: Long): Boolean = compareAndSet(expect, newValue)
+  def getAndSet(newValue: Long): Long = {
+    val old = value
+    value = newValue
+    old
+  }
+  def getAndIncrement(): Long = {
+    value += 1
+    value - 1
+  }
+  def getAndDecrement(): Long = {
+    value -= 1
+    value + 1
+  }
+  def getAndAdd(delta: Long): Long = {
+    value += delta
+    value - delta
+  }
+  def incrementAndGet(): Long = {
+    value += 1
+    value
+  }
+  def decrementAndGet(): Long = {
+    value -= 1
+    value
+  }
+  def addAndGet(delta: Long): Long = {
+    value += delta
+    value
+  }
+  def intValue(): Int = value.toInt
+  def longValue(): Long = value.toLong
+  def floatValue(): Float = value.toFloat
+  def doubleValue(): Double = value.toDouble
+}

--- a/javalib/source/src/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/source/src/java/util/concurrent/atomic/AtomicReference.scala
@@ -1,0 +1,22 @@
+package java.util.concurrent.atomic
+
+/**
+ * Created by haoyi on 1/22/14.
+ */
+class AtomicReference[T](var value: T) extends java.io.Serializable {
+  def get(): T = value
+  def set(newValue: T): Unit = value = newValue
+  def lazySet(newValue: T): Unit = set(newValue)
+  def compareAndSet(expect: T, newValue: T): Boolean = {
+    if (expect != value) false else {
+      value = newValue
+      true
+    }
+  }
+  def weakCompareAndSet(expect: T, newValue: T): Boolean = compareAndSet(expect, newValue)
+  def getAndSet(newValue: T): T = {
+    val old = value
+    value = newValue
+    old
+  }
+}

--- a/test/src/test/scala/scala/scalajs/test/javalib/AtomicTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/javalib/AtomicTest.scala
@@ -1,0 +1,101 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test.javalib
+
+import scala.scalajs.test.JasmineTest
+
+object AtomicTest extends JasmineTest {
+
+  describe("java.util.concurrent.AtomicLong") {
+
+    it("Should have all the normal operations") {
+      val atomic = new java.util.concurrent.atomic.AtomicLong(10)
+      expect(atomic.get()).toEqual(10)
+      atomic.set(20)
+      expect(atomic.get()).toEqual(20)
+      expect(atomic.getAndIncrement()).toEqual(20)
+      expect(atomic.get()).toEqual(21)
+      expect(atomic.getAndDecrement()).toEqual(21)
+      expect(atomic.get()).toEqual(20)
+      expect(atomic.getAndSet(0)).toEqual(20)
+      expect(atomic.get()).toEqual(0)
+      expect(atomic.incrementAndGet()).toEqual(1)
+      expect(atomic.get()).toEqual(1)
+      expect(atomic.decrementAndGet()).toEqual(0)
+      expect(atomic.get()).toEqual(0)
+      expect(atomic.addAndGet(10)).toEqual(10)
+      expect(atomic.get()).toEqual(10)
+      expect(atomic.intValue).toEqual(10)
+      expect(atomic.longValue).toEqual(10L)
+      expect(atomic.floatValue).toEqual(10.0f)
+      expect(atomic.doubleValue).toEqual(10)
+      expect(atomic.compareAndSet(1, 20)).toEqual(false)
+      expect(atomic.get()).toEqual(10)
+      expect(atomic.compareAndSet(10, 20)).toEqual(true)
+      expect(atomic.get()).toEqual(20)
+    }
+  }
+  describe("java.util.concurrent.AtomicInteger") {
+    it("Should have all the normal operations") {
+      val atomic = new java.util.concurrent.atomic.AtomicInteger(10)
+      expect(atomic.get()).toEqual(10)
+      atomic.set(20)
+      expect(atomic.get()).toEqual(20)
+      expect(atomic.getAndIncrement()).toEqual(20)
+      expect(atomic.get()).toEqual(21)
+      expect(atomic.getAndDecrement()).toEqual(21)
+      expect(atomic.get()).toEqual(20)
+      expect(atomic.getAndSet(0)).toEqual(20)
+      expect(atomic.get()).toEqual(0)
+      expect(atomic.incrementAndGet()).toEqual(1)
+      expect(atomic.get()).toEqual(1)
+      expect(atomic.decrementAndGet()).toEqual(0)
+      expect(atomic.get()).toEqual(0)
+      expect(atomic.addAndGet(10)).toEqual(10)
+      expect(atomic.get()).toEqual(10)
+      expect(atomic.intValue).toEqual(10)
+      expect(atomic.longValue).toEqual(10L)
+      expect(atomic.floatValue).toEqual(10.0f)
+      expect(atomic.doubleValue).toEqual(10)
+      expect(atomic.compareAndSet(1, 20)).toEqual(false)
+      expect(atomic.get()).toEqual(10)
+      expect(atomic.compareAndSet(10, 20)).toEqual(true)
+      expect(atomic.get()).toEqual(20)
+    }
+  }
+  describe("java.util.concurrent.AtomicBoolean") {
+    it("Should have all the normal operations") {
+      val atomic = new java.util.concurrent.atomic.AtomicBoolean(true)
+      expect(atomic.get()).toEqual(true)
+      atomic.set(false)
+      expect(atomic.get()).toEqual(false)
+      expect(atomic.compareAndSet(true, true)).toEqual(false)
+      expect(atomic.get()).toEqual(false)
+      expect(atomic.compareAndSet(false, true)).toEqual(true)
+      expect(atomic.get()).toEqual(true)
+      expect(atomic.getAndSet(false)).toEqual(true)
+      expect(atomic.get()).toEqual(false)
+    }
+  }
+  describe("java.util.concurrent.AtomicReference") {
+    it("Should have all the normal operations") {
+      val thing1 = "string1"
+      val thing2 = "string2"
+      val atomic = new java.util.concurrent.atomic.AtomicReference(thing1)
+      expect(atomic.get()).toEqual(thing1)
+      atomic.set(thing2)
+      expect(atomic.get()).toEqual(thing2)
+      expect(atomic.compareAndSet(thing1, thing1)).toEqual(false)
+      expect(atomic.get()).toEqual(thing2)
+      expect(atomic.compareAndSet(thing2, thing1)).toEqual(true)
+      expect(atomic.get()).toEqual(thing1)
+      expect(atomic.getAndSet(thing2)).toEqual(thing1)
+      expect(atomic.get()).toEqual(thing2)
+    }
+  }
+}

--- a/test/src/test/scala/scala/scalajs/test/javalib/ReferenceTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/javalib/ReferenceTest.scala
@@ -1,0 +1,28 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test.javalib
+
+import scala.scalajs.test.JasmineTest
+
+object ReferenceTest extends JasmineTest {
+
+  describe("java.land.ref.Reference") {
+
+    it("Should have all the normal operations") {
+      val s = "string"
+      val ref = new java.lang.ref.WeakReference(s)
+      expect(ref.get).toEqual(s)
+      expect(ref.enqueue).toEqual(false)
+      expect(ref.isEnqueued).toEqual(false)
+      ref.clear
+      // can't use `expect` because it tries to be clever and .toString things,
+      // which makes it blow up when you pass in null
+      assert(ref.get == null)
+    }
+  }
+}


### PR DESCRIPTION
This is all I need to get [scala.rx](https://github.com/lihaoyi/scala.rx) working flawlessly in the browser! It's tests all pass for `publishLocal`ed version of scala-js.

The `WeakReference` family is fake, but I figured having non-working weak references (which you can still clear manually) beats out forcing people to re-implement their custom reference class and do the annoying switching between them on cross compilation. Even if you did that, the API would be 100% identical as the broken-weak-references anyway
