### PR TITLE
Partial #163: Added Copyto and copyOfRange for Java.util.Arrays

### DIFF
--- a/javalib/source/src/java/util/Arrays.scala
+++ b/javalib/source/src/java/util/Arrays.scala
@@ -308,4 +308,164 @@ object Arrays {
     return -low - 1
   }
 
+  def copyOf(original: Array[Int], newLen: Int): Array[Int] = {
+    if (newLen >= 0)
+      return copyOfRange(original, 0, newLen)
+    throw new NegativeArraySizeException();
+  }
+
+  def copyOfRange(original: Array[Int], start: Int, end: Int): Array[Int] = {
+    if (start <= end) {
+      if (0 <= start && start <= original.length) {
+        val retLength = end - start
+        val copyLength = Math.min(retLength, original.length - start)
+        val ret = new Array[Int](retLength)
+        System.arraycopy(original, start, ret, 0, copyLength)
+        return ret
+      }
+      throw new ArrayIndexOutOfBoundsException()
+    }
+    throw new IllegalArgumentException()
+  }
+
+  def copyOf(original: Array[Long], newLen: Int): Array[Long] = {
+    if (newLen >= 0)
+      return copyOfRange(original, 0, newLen)
+    throw new NegativeArraySizeException();
+  }
+
+  def copyOfRange(original: Array[Long], start: Int, end: Int): Array[Long] = {
+    if (start <= end) {
+      if (0 <= start && start <= original.length) {
+        val retLength = end - start
+        val copyLength = Math.min(retLength, original.length - start)
+        val ret = new Array[Long](retLength)
+        System.arraycopy(original, start, ret, 0, copyLength)
+        return ret
+      }
+      throw new ArrayIndexOutOfBoundsException()
+    }
+    throw new IllegalArgumentException()
+  }
+
+  def copyOf(original: Array[Short], newLen: Int): Array[Short] = {
+    if (newLen >= 0)
+      return copyOfRange(original, 0, newLen)
+    throw new NegativeArraySizeException();
+  }
+
+  def copyOfRange(original: Array[Short], start: Int, end: Int): Array[Short] = {
+    if (start <= end) {
+      if (0 <= start && start <= original.length) {
+        val retLength = end - start
+        val copyLength = Math.min(retLength, original.length - start)
+        val ret = new Array[Short](retLength)
+        System.arraycopy(original, start, ret, 0, copyLength)
+        return ret
+      }
+      throw new ArrayIndexOutOfBoundsException()
+    }
+    throw new IllegalArgumentException()
+  }
+
+  def copyOf(original: Array[Byte], newLen: Int): Array[Byte] = {
+    if (newLen >= 0)
+      return copyOfRange(original, 0, newLen)
+    throw new NegativeArraySizeException();
+  }
+
+  def copyOfRange(original: Array[Byte], start: Int, end: Int): Array[Byte] = {
+    if (start <= end) {
+      if (0 <= start && start <= original.length) {
+        val retLength = end - start
+        val copyLength = Math.min(retLength, original.length - start)
+        val ret = new Array[Byte](retLength)
+        System.arraycopy(original, start, ret, 0, copyLength)
+        return ret
+      }
+      throw new ArrayIndexOutOfBoundsException()
+    }
+    throw new IllegalArgumentException()
+  }
+
+  def copyOf(original: Array[Char], newLen: Int): Array[Char] = {
+    if (newLen >= 0)
+      return copyOfRange(original, 0, newLen)
+    throw new NegativeArraySizeException();
+  }
+
+  def copyOfRange(original: Array[Char], start: Int, end: Int): Array[Char] = {
+    if (start <= end) {
+      if (0 <= start && start <= original.length) {
+        val retLength = end - start
+        val copyLength = Math.min(retLength, original.length - start)
+        val ret = new Array[Char](retLength)
+        System.arraycopy(original, start, ret, 0, copyLength)
+        return ret
+      }
+      throw new ArrayIndexOutOfBoundsException()
+    }
+    throw new IllegalArgumentException()
+  }
+
+  def copyOf(original: Array[Float], newLen: Int): Array[Float] = {
+    if (newLen >= 0)
+      return copyOfRange(original, 0, newLen)
+    throw new NegativeArraySizeException();
+  }
+
+  def copyOfRange(original: Array[Float], start: Int, end: Int): Array[Float] = {
+    if (start <= end) {
+      if (0 <= start && start <= original.length) {
+        val retLength = end - start
+        val copyLength = Math.min(retLength, original.length - start)
+        val ret = new Array[Float](retLength)
+        System.arraycopy(original, start, ret, 0, copyLength)
+        return ret
+      }
+      throw new ArrayIndexOutOfBoundsException()
+    }
+    throw new IllegalArgumentException()
+  }
+
+  def copyOf(original: Array[Double], newLen: Int): Array[Double] = {
+    if (newLen >= 0)
+      return copyOfRange(original, 0, newLen)
+    throw new NegativeArraySizeException();
+  }
+
+  def copyOfRange(original: Array[Double], start: Int, end: Int): Array[Double] = {
+    if (start <= end) {
+      if (0 <= start && start <= original.length) {
+        val retLength = end - start
+        val copyLength = Math.min(retLength, original.length - start)
+        val ret = new Array[Double](retLength)
+        System.arraycopy(original, start, ret, 0, copyLength)
+        return ret
+      }
+      throw new ArrayIndexOutOfBoundsException()
+    }
+    throw new IllegalArgumentException()
+  }
+
+  def copyOf(original: Array[Boolean], newLen: Int): Array[Boolean] = {
+    if (newLen >= 0)
+      return copyOfRange(original, 0, newLen)
+    throw new NegativeArraySizeException();
+  }
+
+  def copyOfRange(original: Array[Boolean], start: Int, end: Int): Array[Boolean] = {
+    if (start <= end) {
+      if (0 <= start && start <= original.length) {
+        val retLength = end - start
+        val copyLength = Math.min(retLength, original.length - start)
+        val ret = new Array[Boolean](retLength)
+        System.arraycopy(original, start, ret, 0, copyLength)
+        return ret
+      }
+      throw new ArrayIndexOutOfBoundsException()
+    }
+    throw new IllegalArgumentException()
+  }
+
 }

--- a/test/src/test/scala/scala/scalajs/test/javalib/ArraysTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/javalib/ArraysTest.scala
@@ -428,7 +428,57 @@ object ArraysTest extends JasmineTest {
         case exception: ArrayIndexOutOfBoundsException =>
           expect(exception.getMessage).toBe("Array index out of range: 5")
       }
-    }    
+    }
+
+    it("should respond to `copyOf` with key for Int") {
+      val ints: Array[Int] = Array(1, 2, 3)
+      val intscopy = Arrays.copyOf(ints, 5)
+      expect(intscopy).toEqual(Array(1, 2, 3, 0, 0))
+    }
+
+    it("should respond to `copyOf` with key for Long") {
+      val longs: Array[Long] = Array(1, 2, 3)
+      val longscopy = Arrays.copyOf(longs, 5)
+      expect(longscopy).toEqual(Array[Long](1, 2, 3, 0, 0))
+    }
+
+    it("should respond to `copyOf` with key for Short") {
+      val shorts: Array[Short] = Array(1, 2, 3)
+      val shortscopy = Arrays.copyOf(shorts, 5)
+      expect(shortscopy).toEqual(Array[Short](1, 2, 3, 0, 0))
+    }
+
+    it("should respond to `copyOf` with key for Byte") {
+      val bytes: Array[Byte] = Array(42, 43, 44)
+      val floatscopy = Arrays.copyOf(bytes, 5)
+      expect(floatscopy).toEqual(Array[Byte](42, 43, 44, 0, 0))
+    }
+
+    it("should respond to `copyOf` with key for Char") {
+      val chars: Array[Char] = Array('a', 'b', '0')
+      val charscopy = Arrays.copyOf(chars, 5)
+      println("dlskdjlskdjlks=" + charscopy(3))
+      expect(charscopy(4)).toEqual(0.toChar)
+    }
+
+    it("should respond to `copyOf` with key for Double") {
+      val doubles: Array[Double] = Array(0.1, 0.2, 0.3)
+      val doublescopy = Arrays.copyOf(doubles, 5)
+      expect(doublescopy).toEqual(Array[Double](0.1, 0.2, 0.3, 0, 0))
+    }
+
+    it("should respond to `copyOf` with key for Float") {
+      val floats: Array[Float] = Array(0.1f, 0.2f, 0.3f)
+      val floatscopy = Arrays.copyOf(floats, 5)
+      expect(floatscopy).toEqual(Array[Float](0.1f, 0.2f, 0.3f, 0f, 0f))
+    }
+
+    it("should respond to `copyOf` with key for Boolean") {
+      val bools: Array[Boolean] = Array(false, true, false)
+      val boolscopy = Arrays.copyOf(bools, 5)
+      expect(boolscopy).toEqual(Array[Boolean](false, true, false, false, false))
+    }
+
   }
 
 }


### PR DESCRIPTION
Added Copyto and copyOfRange for Java Arrays for Int, Long, Short, Double, float, Byte, Char, Boolean
