### PR TITLE
Fixed escaping of file separator on windows when relativeSourceMaps is enabled

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/SourceMapCat.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/SourceMapCat.scala
@@ -10,6 +10,7 @@ import sbt._
 import scala.annotation.tailrec
 
 import java.io.PrintWriter
+import java.util.regex.Pattern
 
 import com.google.debugging.sourcemap.{ FilePosition, _ }
 
@@ -111,7 +112,7 @@ object SourceMapCat {
     import java.io.File
 
     def getPathSegments(path: String) =
-      path.split(File.separator).toList.filter(_.length > 0).filter(_ != ".")
+      path.split(Pattern.quote(File.separator)).toList.filter(_.length > 0).filter(_ != ".")
         .foldLeft(List[String]()) { (p, s) => if (s == "..") p.tail else s :: p }
         .reverse
 


### PR DESCRIPTION
path.split takes a regex pattern but the windows path separator is a special character and needs to be escaped. Currently it breaks and this fixes the problem.
