### PR TITLE
Fix #178: Add bridges for methods inherited from traits

### DIFF
--- a/checksizes.sh
+++ b/checksizes.sh
@@ -6,4 +6,4 @@ REVERSI_OPT_SIZE=$(stat '-c%s' examples/reversi/target/scala-2.10/reversi-opt.js
 echo "Reversi extdeps size = $REVERSI_EXTDEPS_SIZE"
 echo "Reversi self size = $REVERSI_SELF_SIZE"
 echo "Reversi opt size = $REVERSI_OPT_SIZE"
-[ "$REVERSI_EXTDEPS_SIZE" -le 18000000 ] && [ "$REVERSI_SELF_SIZE" -le 85000 ] && [ "$REVERSI_OPT_SIZE" -le 285000 ]
+[ "$REVERSI_EXTDEPS_SIZE" -le 20500000 ] && [ "$REVERSI_SELF_SIZE" -le 85000 ] && [ "$REVERSI_OPT_SIZE" -le 285000 ]

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSBridges.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSBridges.scala
@@ -23,10 +23,15 @@ trait JSBridges extends SubComponent { self: GenJSCode =>
   private def isCandidateForBridge(sym: Symbol): Boolean =
     sym.isMethod && !sym.isBridge && sym.isPublic && !isPrimitive(sym)
 
+  /** checks if a symbol is overriding a symbol we already made a bridge for */
+  private def isOverridingBridge(sym: Symbol): Boolean = {
+    lazy val osym = sym.nextOverriddenSymbol
+    sym.isOverridingSymbol && osym.isPublic && !osym.owner.isInterface
+  }
+
   def genBridgesForClass(sym: Symbol): List[js.Tree] = {
     val declaredMethods = sym.info.decls.filter(isCandidateForBridge)
-    val newlyDeclaredMethods = declaredMethods.filterNot(
-        x => x.isOverridingSymbol && x.nextOverriddenSymbol.isPublic)
+    val newlyDeclaredMethods = declaredMethods.filterNot(isOverridingBridge)
     val newlyDeclaredMethodNames =
       newlyDeclaredMethods.map(_.name).toList.distinct
     newlyDeclaredMethodNames map (genBridge(sym, _))

--- a/test/src/test/scala/scala/scalajs/test/compiler/InteroperabilityTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/InteroperabilityTest.scala
@@ -201,6 +201,18 @@ object InteroperabilityTest extends JasmineTest {
           `1` = 5))
     }
 
+    it("should generate bridges for methods inherited from traits - #178") {
+      trait Foo {
+        def theValue = 1
+      }
+      class Bar extends Foo
+
+      val x = (new Bar).asInstanceOf[js.Dynamic]
+
+      // Call bridge by using js.Dynamic
+      expect(x.theValue()).toEqual(1)
+    }
+
   }
 }
 


### PR DESCRIPTION
All test and partests on 2.11 pass, except for 
- `pos/SI-4012-a.scala`
- `pos/SI-7638.scala`
  which cause bugs in the Scala compiler, as filed in [SI-7288](https://issues.scala-lang.org/browse/SI-7288)

The increase in library size is due to the bridges we now actually generate (and should have before).
