### PR TITLE
Fix #183: Add Thread.currentThread() to support Future.flatMap.

### DIFF
--- a/javalib/source/src/java/lang/Thread.scala
+++ b/javalib/source/src/java/lang/Thread.scala
@@ -3,3 +3,9 @@ package java.lang
 class Thread extends Runnable {
   def run() {}
 }
+
+object Thread {
+  private[this] val SingleThread = new Thread
+
+  def currentThread(): Thread = SingleThread
+}

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/AsyncTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/AsyncTest.scala
@@ -95,4 +95,26 @@ object AsyncTest extends JasmineTest {
 
   }
 
+  describe("scala.concurrent.Future") {
+
+    it("should support map") {
+      implicit val ec = JSExecutionContext.runNow
+      val f = Future(3).map(x => x*2)
+      expect(f.value.get.get).toEqual(6)
+    }
+
+    it("should support flatMap") {
+      implicit val ec = JSExecutionContext.runNow
+      val f = Future(Future(3)).flatMap(x => x)
+      expect(f.value.get.get).toEqual(3)
+    }
+
+    it("should support sequence") {
+      implicit val ec = JSExecutionContext.runNow
+      val f = Future.sequence(Seq(Future(3), Future(5)))
+      expect(f.value.get.get.toArray).toEqual(js.Array(3, 5))
+    }
+
+  }
+
 }


### PR DESCRIPTION
Trivial implementation of `Thread.currentThread()` to make `Future.flatMap` happy.
