### PR TITLE
Make the path of the output of optimizeJS configurable.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -334,12 +334,18 @@ object ScalaJSPlugin extends Plugin {
             (unmanagedSources in optimizeJS).value)
       },
 
+      moduleName in optimizeJS := moduleName.value,
+
+      artifactPath in optimizeJS :=
+        ((crossTarget in optimizeJS).value /
+            ((moduleName in optimizeJS).value + "-opt.js")),
+
       optimizeJS := {
         val s = streams.value
         val logger = s.log
         val cacheDir = s.cacheDirectory
         val allJSFiles = (sources in optimizeJS).value
-        val output = (crossTarget in optimizeJS).value / (moduleName.value + "-opt.js")
+        val output = (artifactPath in optimizeJS).value
 
         val cachedOptimizeJS = FileFunction.cached(cacheDir / "optimize-js",
             FilesInfo.lastModified, FilesInfo.exists) { dependencies =>


### PR DESCRIPTION
Exactly in the same way that paths of the outputs of
packageXyzJS are configurable, i.e., through
(moduleName in optimizeJS), (crossTarget in optimizeJS) and
(artifactPath in optimizeJS).
