### PR TITLE
Remove js.Function.apply().

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Function.scala
+++ b/library/src/main/scala/scala/scalajs/js/Function.scala
@@ -58,11 +58,11 @@ class Function extends Object {
   val length: Number = ???
 
   /**
-   * The apply() method calls a function with a given this value and arguments
-   * provided as an array (or an array-like object).
+   * The call() method calls a function with a given this value and arguments
+   * provided individually.
    *
    * You can assign a different this object when calling an existing function.
-   * this refers to the current object, the calling object. With apply, you
+   * this refers to the current object, the calling object. With call, you
    * can write a method once and then inherit it in another object, without
    * having to rewrite the method for the new object.
    *
@@ -77,17 +77,21 @@ class Function extends Object {
    * fun.apply(this, new Array('eat', 'bananas')).
    *
    * MDN
-   */
-  def $apply[A](thisArg: Any, argArray: Array[A]): Dynamic = ???
-  def $apply(thisArg: Any): Dynamic = ???
-
-  /**
-   * The call() method calls a function with a given this value and arguments
-   * provided individually.
    *
-   * MDN
+   * Scala.js-specific note: call() can be used instead of the apply() method
+   * available in JavaScript. Simply use the :_* notation to expand a Seq as
+   * variadic arguments, e.g.,
+   *
+   * {{{
+   * someFun.call(thisArg, argSeq: _*)
+   * }}}
+   *
    */
   def call(thisArg: Any, argArray: Any*): Dynamic = ???
+
+  // Do not expose apply: use call(thisArg, argArray: _*) instead.
+  // def apply[A](thisArg: Any, argArray: Array[A]): Dynamic = ???
+  // def apply(thisArg: Any): Dynamic = ???
 
   /**
    * The bind() method creates a new function that, when called, has its this

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/FunctionTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/FunctionTest.scala
@@ -1,0 +1,42 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test
+package jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.test.JasmineTest
+
+object FunctionTest extends JasmineTest {
+
+  import js.Dynamic.{literal => lit}
+
+  describe("scala.scalajs.js.Function") {
+
+    it("should support call() with expanded arguments") {
+      val f = js.eval("""
+          var f = function() { return arguments; }; f;
+      """).asInstanceOf[js.Function]
+
+      expect(f.call(null, 42, true)).toEqual(lit(
+          `0` = 42,
+          `1` = true))
+    }
+
+    it("should support call() with the :_* notation to expand a Seq") {
+      val f = js.eval("""
+          var f = function() { return arguments; }; f;
+      """).asInstanceOf[js.Function]
+
+      val args = Seq[js.Any](42, true)
+      expect(f.call(null, args: _*)).toEqual(lit(
+          `0` = 42,
+          `1` = true))
+    }
+
+  }
+}


### PR DESCRIPTION
Its name clashes with the meaning of apply in Scala, and call() can be used instead with the :_\* notation.

The test ensures that `call()` can _indeed_ be used with that notation ^^
