### PR TITLE
Fix #225: provide an equivalent of JS' `typeof x`.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -2410,6 +2410,10 @@ abstract class GenJSCode extends plugins.PluginComponent
             case JS2N => arg
             case JS2S => arg
 
+            case TYPEOF =>
+              // js.Dynamic.typeOf(arg)
+              js.UnaryOp("typeof", arg)
+
             case DYNSELECT =>
               // js.Dynamic.selectDynamic(arg)
               maybeDynamicSelect(receiver, arg)

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
@@ -80,6 +80,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSDynamicModule = JSDynamicClass.companionModule
       lazy val JSDynamic_global      = getMemberMethod(JSDynamicModule, newTermName("global"))
       lazy val JSDynamic_newInstance = getMemberMethod(JSDynamicModule, newTermName("newInstance"))
+      lazy val JSDynamic_typeOf      = getMemberMethod(JSDynamicModule, newTermName("typeOf"))
 
     lazy val JSNumberModule = JSNumberClass.companionModule
       lazy val JSNumber_toDouble = getMemberMethod(JSNumberModule, newTermName("toDouble"))

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
@@ -44,6 +44,7 @@ abstract class JSPrimitives {
 
   val GETGLOBAL = 320 // Get the top-level object (`window` in browsers)
   val DYNNEW = 321    // Instantiate a new JavaScript object
+  val TYPEOF = 322    // typeof x
 
   val DYNSELECT = 330 // js.Dynamic.selectDynamic
   val DYNUPDATE = 331 // js.Dynamic.updateDynamic
@@ -84,6 +85,7 @@ abstract class JSPrimitives {
 
     addPrimitive(JSDynamic_global, GETGLOBAL)
     addPrimitive(JSDynamic_newInstance, DYNNEW)
+    addPrimitive(JSDynamic_typeOf, TYPEOF)
 
     addPrimitive(JSDynamic_selectDynamic, DYNSELECT)
     addPrimitive(JSDynamic_updateDynamic, DYNUPDATE)

--- a/library/src/main/scala/scala/scalajs/js/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/Primitives.scala
@@ -221,6 +221,9 @@ object Dynamic {
   /** Instantiates a new object of a JavaScript class. */
   def newInstance(clazz: Dynamic)(args: Any*): Dynamic = sys.error("stub")
 
+  /** Returns the type of `x` as identified by `typeof x` in JavaScript. */
+  def typeOf(x: Any): String = sys.error("stub")
+
   /** Creates a new object with a literal syntax.
    *
    *  For example,

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/DynamicTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/DynamicTest.scala
@@ -55,5 +55,16 @@ object DynamicTest extends JasmineTest {
       val x = obj()
       expect(x.isInstanceOf[js.Object]).toBeTruthy()
     }
+
+    it("should provide an equivalent to `typeof x`") {
+      import js.Dynamic.typeOf
+      expect(typeOf(5)).toEqual("number")
+      expect(typeOf(false)).toEqual("boolean")
+      expect(typeOf("hello")).toEqual("string")
+      expect(typeOf(null)).toEqual("object")
+      expect(typeOf(new js.Object)).toEqual("object")
+      expect(typeOf(())).toEqual("undefined")
+      expect(typeOf(() => 42)).toEqual("function")
+    }
   }
 }


### PR DESCRIPTION
It is introduced as `js.Dynamic.typeOf(x)`.
