### PR TITLE
Fix #228: Add primitive js.debugger() mapping to debugger statement.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -2322,6 +2322,8 @@ abstract class GenJSCode extends plugins.PluginComponent
               js.StringLiteral(scala.reflect.NameTransformer.MODULE_SUFFIX_STRING)
             case NTR_NAME_JOIN =>
               js.StringLiteral(scala.reflect.NameTransformer.NAME_JOIN_STRING)
+            case DEBUGGER =>
+              statToExpr(js.Debugger())
           }
 
         case List(arg) =>

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
@@ -25,6 +25,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val MaybeJSAnyTpe = if (isScalaJSDefined) MaybeJSAnyClass.toTypeConstructor else NoType
 
     lazy val ScalaJSJSPackage = getRequiredPackage("scala.scalajs.js")
+      lazy val JSPackage_debugger = getMemberMethod(ScalaJSJSPackage, newTermName("debugger"))
 
     lazy val JSAnyClass       = getRequiredClass("scala.scalajs.js.Any")
     lazy val JSDynamicClass   = getRequiredClass("scala.scalajs.js.Dynamic")

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDesugaring.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDesugaring.scala
@@ -196,6 +196,9 @@ trait JSDesugaring extends SubComponent { self: GenJSCode =>
             super.transformStat(js.Switch(newSelector, cases, body))
           }
 
+        case js.Debugger() =>
+          tree
+
         // Treat 'return' as an LHS
 
         case js.Return(expr, label) =>
@@ -564,7 +567,8 @@ trait JSDesugaring extends SubComponent { self: GenJSCode =>
              */
             rhs match {
               case _:js.FunDef | _:js.Skip | _:js.VarDef | _:js.Assign |
-                  _:js.While | _:js.DoWhile | _:js.Switch | _:js.DocComment =>
+                  _:js.While | _:js.DoWhile | _:js.Switch | _:js.Debugger |
+                  _:js.DocComment =>
                 transformStat(rhs)
               case _ =>
                 abort("Illegal tree in JSDesugar.pushLhsInto():\n" +

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
@@ -59,6 +59,8 @@ abstract class JSPrimitives {
   val NTR_MOD_SUFF  = 337 // scala.reflect.NameTransformer.MODULE_SUFFIX_STRING
   val NTR_NAME_JOIN = 338 // scala.relfect.NameTransformer.NAME_JOIN_STRING
 
+  val DEBUGGER = 340 // js.debugger()
+
   /** Initialize the map of primitive methods */
   def init() {
     if (!isScalaJSDefined)
@@ -100,8 +102,10 @@ abstract class JSPrimitives {
 
     addPrimitive(getMember(ntModule, newTermName("MODULE_SUFFIX_STRING")), NTR_MOD_SUFF)
     addPrimitive(getMember(ntModule, newTermName("NAME_JOIN_STRING")), NTR_NAME_JOIN)
+
+    addPrimitive(JSPackage_debugger, DEBUGGER)
   }
 
   def isJavaScriptPrimitive(code: Int) =
-    code >= 300 && code < 340
+    code >= 300 && code < 350
 }

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrinters.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrinters.scala
@@ -236,6 +236,9 @@ trait JSPrinters { self: JSGlobalAddons =>
           }
           undent; println(); print("}")
 
+        case js.Debugger() =>
+          print("debugger")
+
         // Expressions
 
         case js.DotSelect(qualifier, item) =>

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSTrees.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSTrees.scala
@@ -165,6 +165,8 @@ trait JSTrees { self: JSGlobalAddons =>
     /** Like match in Scala (i.e., a break-free switch) */
     case class Match(selector: Tree, cases: List[(List[Tree], Tree)], default: Tree)(implicit val pos: Position) extends Tree
 
+    case class Debugger()(implicit val pos: Position) extends Tree
+
     // Expressions
 
     case class DotSelect(qualifier: Tree, item: Ident)(implicit val pos: Position) extends Tree

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -53,6 +53,18 @@ package object js extends js.GlobalScope {
   /** The constant Positive Infinity. */
   val Infinity: Number = ???
 
+  /** Invokes any available debugging functionality.
+   *  If no debugging functionality is available, this statement has no effect.
+   *
+   *  MDN
+   *
+   *  Browser support:
+   *    * Has no effect in Rhino nor, apparently, in Firefox
+   *    * In Chrome, it has no effect unless the developer tools are opened
+   *      beforehand.
+   */
+  def debugger(): Unit = sys.error("stub")
+
   /** Evaluates JavaScript code and returns the result. */
   def eval(x: String): Any = ???
 


### PR DESCRIPTION
Untestable almost by definition ... But tested manually. Doesn't have any effect with Rhino (expected) nor with Firefox (!). It does have an effect on Chrome but only when the dev tools are already open.
