### PR TITLE
Return "undefined" when calling .toString() on JS undefined.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -1529,12 +1529,12 @@ abstract class GenJSCode extends plugins.PluginComponent
 
             val Select(receiver, _) = fun
 
-            if (ToStringMaybeOnString contains fun.symbol) {
-              js.ApplyMethod(genExpr(receiver), js.Ident("toString"), Nil)
-            } else if (MethodWithHelperInEnv contains fun.symbol) {
+            if (MethodWithHelperInEnv contains fun.symbol) {
               val helper = MethodWithHelperInEnv(fun.symbol)
               val arguments = (receiver :: args) map genExpr
               genCallHelper(helper, arguments:_*)
+            } else if (ToStringMaybeOnString contains fun.symbol) {
+              js.ApplyMethod(genExpr(receiver), js.Ident("toString"), Nil)
             } else if (isStringType(receiver.tpe)) {
               genStringCall(app)
             } else if (isRawJSType(receiver.tpe)) {
@@ -1563,13 +1563,13 @@ abstract class GenJSCode extends plugins.PluginComponent
     }
 
     private lazy val ToStringMaybeOnString = Set[Symbol](
-      Object_toString,
       getMemberMethod(CharSequenceClass, nme.toString_),
       getMemberMethod(StringClass, nme.toString_)
     )
 
     // TODO Make these primitives?
     private lazy val MethodWithHelperInEnv = Map[Symbol, String](
+      Object_toString  -> "objectToString",
       Object_getClass  -> "objectGetClass",
       Object_clone     -> "objectClone",
       Object_finalize  -> "objectFinalize",

--- a/corejslib/scalajsenv.js
+++ b/corejslib/scalajsenv.js
@@ -177,6 +177,13 @@ var ScalaJS = {
       return lhs === rhs;
   },
 
+  objectToString: function(instance) {
+    if (instance === void 0)
+      return "undefined";
+    else
+      return instance.toString();
+  },
+
   objectGetClass: function(instance) {
     if (ScalaJS.isScalaJSObject(instance) || (instance === null))
       return instance.getClass__java_lang_Class();

--- a/javalib/source/src/java/util/Formatter.scala
+++ b/javalib/source/src/java/util/Formatter.scala
@@ -78,6 +78,8 @@ final class Formatter(private val dest: Appendable) extends Closeable with Flush
             lastImplicitIndex
           }
           lastIndex = index
+          if (index <= 0 || index > args.length)
+            throw new MissingFormatArgumentException(matchResult(5))
           val arg = args(index-1)
 
           val widthStr = matchResult(3)

--- a/test/src/test/scala/scala/scalajs/test/javalib/FormatterTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/javalib/FormatterTest.scala
@@ -174,6 +174,16 @@ object FormatterTest extends JasmineTest {
       expectF("%d%n%d", new JInteger(1), new JInteger(2)).toEqual("1\n2")
     }
 
+    it("should survive `null` and `undefined`") {
+      expectF("%s", null).toEqual("null")
+      expectF("%s", (): js.Undefined).toEqual("undefined")
+    }
+
+    it("should allow 'f' string interpolation to survive `null` and `undefined`") {
+      expect(f"${null}%s").toEqual("null")
+      expect(f"${(): js.Undefined}%s").toEqual("undefined")
+    }
+
     it("should allow positional arguments") {
       expectF("%2$d %1$d",    new JInteger(1), new JInteger(2)).toEqual("2 1")
       expectF("%2$d %2$d %d", new JInteger(1), new JInteger(2)).toEqual("2 2 1")

--- a/test/src/test/scala/scala/scalajs/test/javalib/StringBufferTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/javalib/StringBufferTest.scala
@@ -20,7 +20,9 @@ object StringBufferTest extends JasmineTest {
     it("should respond to `append`") {
       expect(newBuf.append("asdf").toString).toEqual("asdf")
       expect(newBuf.append(null: AnyRef).toString).toEqual("null")
+      expect(newBuf.append(null: String).toString).toEqual("null")
       expect(newBuf.append(null: CharSequence,0,2).toString).toEqual("nu")
+      expect(newBuf.append((): js.Undefined).toString).toEqual("undefined")
     }
 
   }
@@ -32,7 +34,14 @@ object StringBufferTest extends JasmineTest {
     it("should respond to `append`") {
       expect(newBuf.append("asdf").toString).toEqual("asdf")
       expect(newBuf.append(null: AnyRef).toString).toEqual("null")
+      expect(newBuf.append(null: String).toString).toEqual("null")
       expect(newBuf.append(null: CharSequence,0,2).toString).toEqual("nu")
+      expect(newBuf.append((): js.Undefined).toString).toEqual("undefined")
+    }
+
+    it("should allow string interpolation to survive `null` and `undefined`") {
+      expect(s"${null}").toEqual("null")
+      expect(s"${(): js.Undefined}").toEqual("undefined")
     }
 
   }


### PR DESCRIPTION
String builders, formatter, and hence string interpolators protect
themselves from `null` and use the string "null" as its
representation for display. But they fail to protect against
`undefined`, the one other JavaScript value on which you cannot
call .toString().

This commit makes the compiler treat Object.toString() specially
so that it will handle `undefined` properly and return the string
"undefined" instead of causing a TypeError. Calling null.toString()
will still cause a TypeError.

This fixes #224.
