### PR TITLE
Add Scala.js specific scala.Symbol implementation

### DIFF
--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -216,6 +216,7 @@ object ScalaJSBuild extends Build {
               (path.endsWith("/scala/package.scala")
                   || path.endsWith("/scala/App.scala")
                   || path.endsWith("/scala/Console.scala")
+                  || path.endsWith("/scala/Symbol.scala")
                   || path.endsWith("/scala/compat/Platform.scala")
                   || path.endsWith("/scala/runtime/BoxesRunTime.scala")
                   || path.endsWith("/scala/util/control/NoStackTrace.scala")

--- a/test/src/test/scala/scala/scalajs/test/scalalib/SymbolTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/scalalib/SymbolTest.scala
@@ -1,0 +1,64 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test
+package scalalib
+
+import scala.scalajs.js
+import scala.scalajs.test.JasmineTest
+
+object SymbolTest extends JasmineTest {
+
+  describe("scala.Symbol") {
+
+    it("should ensure unique identity") {
+      def expectEqual(sym1: Symbol, sym2: Symbol): Unit = {
+        expect(sym1 eq sym2).toBeTruthy
+        expect(sym1 == sym2).toBeTruthy
+        expect(sym1.equals(sym2)).toBeTruthy
+        expect(sym1.## == sym2.##).toBeTruthy
+      }
+
+      expectEqual('ScalaJS, Symbol("ScalaJS"))
+      expectEqual('$, Symbol("$"))
+      expectEqual('-, Symbol("-"))
+
+      val `42` = Symbol("42")
+      val map = Map[Symbol, js.Any](Symbol("ScalaJS") -> "Scala.js", '$ -> 1.2, `42` -> 42)
+      expect(map('ScalaJS)).toEqual("Scala.js")
+      expect(map(Symbol("$"))).toEqual(1.2)
+      expect(map(Symbol("42"))).toEqual(42)
+      expect(map(`42`)).toEqual(42)
+    }
+
+    it("should support `name`") {
+      val scalajs = 'ScalaJS
+
+      expect(scalajs.name).toEqual("ScalaJS")
+      expect(Symbol("$").name).toEqual("$")
+      expect('$$.name).toEqual("$$")
+      expect('-.name).toEqual("-")
+      expect('*.name).toEqual("*")
+      expect(Symbol("'").name).toEqual("'")
+      expect(Symbol("\"").name).toEqual("\"")
+    }
+
+    it("should support `toString`") {
+      val scalajs = 'ScalaJS
+
+      expect(scalajs.toString).toEqual("'ScalaJS")
+      expect(Symbol("$").toString).toEqual("'$")
+      expect('$$.toString).toEqual("'$$")
+      expect('-.toString).toEqual("'-")
+      expect('*.toString).toEqual("'*")
+      expect(Symbol("'").toString).toEqual("''")
+      expect(Symbol("\"").toString).toEqual("'\"")
+    }
+
+  }
+
+}


### PR DESCRIPTION
The cache that scala.Symbol uses to maintain symbol instances depends on
java.util.WeakHashMap and java.util.concurrent.locks.ReentrantReadWriteLock
which are neither supported and don't make sense for JavaScript.

Replace scala.Symbol's cache implementation with a simple js.Dictionary
backed cache to fix runtime issues, such as:

```
[error]     TypeError: org.mozilla.javascript.Undefined@1221f81 is not a function, it is undefined. in
[error] @file:///.../scala-js/scalalib/source/src/library/scala/Symbol.scala:48
[error] @file:///.../scala-js/scalalib/source/src/library/scala/Symbol.scala:34
```
