### PR TITLE
Fix #225: provide an equivalent of JS' `typeof x`.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -2430,6 +2430,10 @@ abstract class GenJSCode extends plugins.PluginComponent
 
             case RTJ2J => arg
             case J2RTJ => arg
+
+            case TYPEOF =>
+              // js.Dynamic.typeOf(arg)
+              js.UnaryOp("typeof", arg)
           }
 
         case List(arg1, arg2) =>

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
@@ -25,6 +25,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val MaybeJSAnyTpe = if (isScalaJSDefined) MaybeJSAnyClass.toTypeConstructor else NoType
 
     lazy val ScalaJSJSPackage = getRequiredPackage("scala.scalajs.js")
+      lazy val JSPackage_typeOf   = getMemberMethod(ScalaJSJSPackage, newTermName("typeOf"))
       lazy val JSPackage_debugger = getMemberMethod(ScalaJSJSPackage, newTermName("debugger"))
 
     lazy val JSAnyClass       = getRequiredClass("scala.scalajs.js.Any")

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
@@ -59,7 +59,8 @@ abstract class JSPrimitives {
   val NTR_MOD_SUFF  = 337 // scala.reflect.NameTransformer.MODULE_SUFFIX_STRING
   val NTR_NAME_JOIN = 338 // scala.relfect.NameTransformer.NAME_JOIN_STRING
 
-  val DEBUGGER = 340 // js.debugger()
+  val TYPEOF = 340   // typeof x
+  val DEBUGGER = 341 // js.debugger()
 
   /** Initialize the map of primitive methods */
   def init() {
@@ -103,6 +104,7 @@ abstract class JSPrimitives {
     addPrimitive(getMember(ntModule, newTermName("MODULE_SUFFIX_STRING")), NTR_MOD_SUFF)
     addPrimitive(getMember(ntModule, newTermName("NAME_JOIN_STRING")), NTR_NAME_JOIN)
 
+    addPrimitive(JSPackage_typeOf, TYPEOF)
     addPrimitive(JSPackage_debugger, DEBUGGER)
   }
 

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -53,6 +53,9 @@ package object js extends js.GlobalScope {
   /** The constant Positive Infinity. */
   val Infinity: Number = ???
 
+  /** Returns the type of `x` as identified by `typeof x` in JavaScript. */
+  def typeOf(x: Any): String = sys.error("stub")
+
   /** Invokes any available debugging functionality.
    *  If no debugging functionality is available, this statement has no effect.
    *

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/MiscInteropTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/MiscInteropTest.scala
@@ -1,0 +1,30 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test
+package jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.test.JasmineTest
+
+object MiscInteropTest extends JasmineTest {
+
+  describe("scala.scalajs.js.package") {
+
+    it("should provide an equivalent to `typeof x`") {
+      import js.typeOf
+      expect(typeOf(5)).toEqual("number")
+      expect(typeOf(false)).toEqual("boolean")
+      expect(typeOf("hello")).toEqual("string")
+      expect(typeOf(null)).toEqual("object")
+      expect(typeOf(new js.Object)).toEqual("object")
+      expect(typeOf(())).toEqual("undefined")
+      expect(typeOf(() => 42)).toEqual("function")
+    }
+  }
+
+}


### PR DESCRIPTION
It is introduced as `js.typeOf(x)`.

Supersedes #226. Now `typeOf` in in the package object, as requested.
