### PR TITLE
Fix #220: Correct runtime return type for boolean & and | ops

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -1971,6 +1971,13 @@ abstract class GenJSCode extends plugins.PluginComponent
           }
 
           (code match {
+            // Special cases for (bool & bool) and (bool | bool) since in
+            // JavaScript, the return type is number rather than boolean
+            case AND if args.forall(_.tpe.typeSymbol == BooleanClass) =>
+              js.UnaryOp("!", js.UnaryOp("!", js.BinaryOp("&", lsrc, rsrc)))
+            case OR if args.forall(_.tpe.typeSymbol == BooleanClass) =>
+              js.UnaryOp("!", js.UnaryOp("!", js.BinaryOp("|", lsrc, rsrc)))
+
             case ADD => js.BinaryOp("+", lsrc, rsrc)
             case SUB => js.BinaryOp("-", lsrc, rsrc)
             case MUL => js.BinaryOp("*", lsrc, rsrc)

--- a/test/src/test/scala/scala/scalajs/test/compiler/BooleanTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/BooleanTest.scala
@@ -1,0 +1,36 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test
+package compiler
+
+import scala.scalajs.test.JasmineTest
+import scala.scalajs.js
+
+object BooleanTest extends JasmineTest {
+
+  describe("Boolean primitives") {
+
+    it("& and | on booleans should return booleans") {
+      expect(js.typeOf(true & false)).toEqual("boolean")
+      expect(js.typeOf(true | false)).toEqual("boolean")
+    }
+
+    it("& and | on booleans should return correct results") {
+      expect(false & false).toBeFalsy
+      expect(false & true).toBeFalsy
+      expect(true & false).toBeFalsy
+      expect(true & true).toBeTruthy
+
+      expect(false | false).toBeFalsy
+      expect(true | false).toBeTruthy
+      expect(false | true).toBeTruthy
+      expect(true | true).toBeTruthy
+    }
+
+  }
+}


### PR DESCRIPTION
All 2.11 tests and partests pass.
