### PR TITLE
Fix #218: class literal for existential value classes.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSEncoding.scala
@@ -199,6 +199,8 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
     toTypeKind(tpe) match {
       case REFERENCE(ScalaRTMapped(rtSym)) =>
         encodeClassDataOfType(rtSym.tpe)
+      case REFERENCE(sym) =>
+        encodeClassDataOfSym(sym)
       case array : ARRAY =>
         var result = encodeClassDataOfType(array.elementKind.toType)
         for (i <- 0 until array.dimensions)

--- a/compiler/src/main/scala/scala/scalajs/compiler/TypeKinds.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/TypeKinds.scala
@@ -11,7 +11,7 @@ import scala.tools.nsc._
  *
  *  @author Sébastien Doeraene
  */
-trait TypeKinds extends SubComponent {
+trait TypeKinds extends SubComponent { this: GenJSCode =>
   import global._
 
   import definitions.{ UnitClass, BooleanClass, CharClass, ByteClass,
@@ -154,6 +154,12 @@ trait TypeKinds extends SubComponent {
     // Apparently, this case does occur (see pos/CustomGlobal.scala)
     case AnnotatedType(_, t, _)          => toTypeKind(t)
     //case RefinedType(parents, _)         => parents map toTypeKind reduceLeft lub
+
+    /* This case is not in scalac. We need it for the test
+     * run/valueclasses-classtag-existential. I have no idea how icode does
+     * not fail this test: we do everything the same as icode up to here.
+     */
+    case tpe: ErasedValueType            => newReference(tpe.valueClazz)
 
     // For sure WildcardTypes shouldn't reach here either, but when
     // debugging such situations this may come in handy.

--- a/test/src/test/scala/scala/scalajs/test/compiler/RegressionTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/RegressionTest.scala
@@ -13,6 +13,8 @@ import scala.scalajs.test.JasmineTest
 
 object RegressionTest extends JasmineTest {
 
+  class Bug218Foo[T](val x: T) extends AnyVal
+
   describe("Scala.js compiler regression tests") {
 
     it("Wrong division conversion (7 / 2.0) - #18") {
@@ -154,6 +156,11 @@ object RegressionTest extends JasmineTest {
       expect(x.`1`).toEqual(1)
       expect(x.`2`).toEqual(2)
       expect(x.`3`).toEqual(3)
+    }
+
+    it("should support class literals for existential value types - #218") {
+      expect(scala.reflect.classTag[Bug218Foo[_]].toString).toEqual(
+          "scala.scalajs.test.compiler.RegressionTest$Bug218Foo")
     }
   }
 }


### PR DESCRIPTION
I still hate ErasedValueTypes.
