### PR TITLE
Fix dependencies of scalajs-library.

### DIFF
--- a/project/ExternalCompile.scala
+++ b/project/ExternalCompile.scala
@@ -36,12 +36,8 @@ object ExternalCompile {
         def cpToString(cp: Seq[File]) =
           cp.map(_.getAbsolutePath).mkString(java.io.File.pathSeparator)
 
-        val (compilerCp, cp0) = classpath.partition(isScalaJSCompilerJar)
-        val cp =
-          if (excludeDefaultScalaLibrary.value) cp0
-          else cp0 ++ compilerCp.filter(isScalaLibraryJar)
-
-        val cpStr = cpToString(cp)
+        val compilerCp = inputs.compilers.scalac.scalaInstance.allJars
+        val cpStr = cpToString(classpath)
 
         // List all my dependencies (recompile if any of these changes)
 
@@ -118,9 +114,6 @@ object ExternalCompile {
   val scalaJSExternalCompileSettings = (
       inConfig(Compile)(scalaJSExternalCompileConfigSettings) ++
       inConfig(Test)(scalaJSExternalCompileConfigSettings)
-  ) ++ Seq(
-      libraryDependencies +=
-        "org.scala-lang" % "scala-compiler" % scalaVersion.value
   )
 
 }


### PR DESCRIPTION
It used to depend artifially on scala-reflect.jar and
scala-compiler.jar, because I was still an sbt noob when
I wrote the first versions of external compilation. Now
I know better, and this commit cleans up the dependency
management of external compilation.
