### PR TITLE
Remove 'extends NotNull' for 'js.Undefined'.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/Primitives.scala
@@ -687,7 +687,7 @@ object String extends Object {
 }
 
 /** Primitive JavaScript undefined value. */
-sealed trait Undefined extends Any with NotNull
+sealed trait Undefined extends Any
 
 /** Base class of all JavaScript objects. */
 class Object extends Any {


### PR DESCRIPTION
The NotNull trait is deprecated as of Scala 2.11.

This also unifies our library/ (the part that is really ours, not the overrides) between 2.10 and 2.11, so the source is the same now.
