### PR TITLE
Review js.Dictionary as a generic class <: js.Object.

### DIFF
--- a/examples/reversi/JSTypes.scala
+++ b/examples/reversi/JSTypes.scala
@@ -26,7 +26,7 @@ trait DOMElement extends js.Object {
 
 trait JQueryStatic extends js.Object {
   def apply(arg: js.Any): JQuery
-  def apply(arg: js.Any, attributes: js.Dictionary): JQuery
+  def apply(arg: js.Any, attributes: js.Any): JQuery
 }
 
 trait JQuery extends js.Object {

--- a/examples/reversi/Reversi.scala
+++ b/examples/reversi/Reversi.scala
@@ -5,8 +5,6 @@
 
 package reversi
 
-import scala.language.implicitConversions
-
 import scala.annotation.tailrec
 import scala.scalajs.js
 
@@ -64,14 +62,14 @@ class Reversi(jQuery: JQueryStatic, playground: JQuery) {
   buildUI()
 
   def createResetButton() = {
-    jQuery("<input>", js.Dictionary(
-        "type" -> "button", "value" -> "Reset"
+    jQuery("<input>", js.Dynamic.literal(
+        `type` = "button", value = "Reset"
     )).click(reset _)
   }
 
   def createPassButton() = {
-    jQuery("<input>", js.Dictionary(
-        "type" -> "button", "value" -> "Pass"
+    jQuery("<input>", js.Dynamic.literal(
+        `type` = "button", value = "Pass"
     )).click(pass _)
   }
 

--- a/library/src/main/scala/scala/scalajs/js/Dictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dictionary.scala
@@ -1,0 +1,52 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+/**
+ * All doc-comments marked as "MDN" are by Mozilla Contributors,
+ * distributed under the Creative Commons Attribution-ShareAlike license from
+ * https://developer.mozilla.org/en-US/docs/Web/Reference/API
+ */
+package scala.scalajs.js
+
+import annotation.JSBracketAccess
+
+/** Dictionary "view" of a JavaScript value. */
+sealed trait Dictionary[A] extends Object {
+  /** Reads a field of this object by its name. */
+  @JSBracketAccess
+  def apply(key: String): A
+
+  /** Writes a field of this object by its name. */
+  @JSBracketAccess
+  def update(key: String, value: A): Unit
+
+  /** Deletes a property of this object by its name.
+   *  The property must be configurable.
+   *  This method is equivalent to the "delete" keyword in JavaScript.
+   *  @return true on success (the property did not exist or was configurable),
+   *          false otherwise
+   */
+  def delete(key: String): Boolean = sys.error("stub")
+}
+
+/** Factory for [[Dictionary]] instances. */
+object Dictionary {
+  /** Returns a new empty dictionary */
+  def empty[A]: Dictionary[A] = (new Object).asInstanceOf[Dictionary[A]]
+
+  def apply[A](properties: (String, A)*): Dictionary[A] = {
+    val result = empty[A]
+    for ((key, value) <- properties)
+      result(key) = value
+    result
+  }
+
+  /** Returns the names of all the enumerable properties of this object. */
+  def propertiesOf(obj: Any): Array[String] = sys.error("stub")
+}

--- a/library/src/main/scala/scala/scalajs/js/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/Primitives.scala
@@ -249,57 +249,6 @@ object Dynamic {
   }
 }
 
-/** Dictionary "view" of a JavaScript value */
-sealed trait Dictionary extends Any {
-  /** Reads a field of this object by its name. */
-  @JSBracketAccess
-  def apply(key: String): Any
-
-  /** Writes a field of this object by its name. */
-  @JSBracketAccess
-  def update(key: String, value: Any): Unit
-
-  /** Deletes a property of this object by its name.
-   *  The property must be configurable.
-   *  This method is equivalent to the "delete" keyword in JavaScript.
-   *  @return true on success (the property did not exist or was configurable),
-   *          false otherwise
-   */
-  def delete(key: String): Boolean = sys.error("stub")
-}
-
-/** Factory for [[Dictionary]] instances. */
-object Dictionary {
-  /** Returns a new empty dictionary */
-  def empty: Dictionary = new Object
-
-  def apply(properties: (String, Any)*): Dictionary =
-    apply(properties)
-
-  def apply(properties: TraversableOnce[(String, Any)]): Dictionary = {
-    val result = empty
-    for ((key, value) <- properties)
-      result(key) = value
-    result
-  }
-
-  def apply[A <% String, B <% Any](properties: (A, B)*): Dictionary =
-    apply(properties)
-
-  def apply[A <% String, B <% Any](
-      properties: TraversableOnce[(A, B)]): Dictionary = {
-    val result = empty
-    for ((key, value) <- properties)
-      result(key) = value
-    result
-  }
-
-  /** Returns the names of all the enumerable properties of this object. */
-  def propertiesOf(obj: Any): Array[String] = sys.error("stub")
-
-  implicit def fromAny(value: Any): Dictionary = value.asInstanceOf[Dictionary]
-}
-
 /** Primitive JavaScript number. */
 sealed trait Number extends Any {
   def unary_+(): Number

--- a/library/src/main/scala/scala/scalajs/test/EventProxy.scala
+++ b/library/src/main/scala/scala/scalajs/test/EventProxy.scala
@@ -12,8 +12,8 @@ package scala.scalajs.test
 import scala.scalajs.js
 
 trait EventProxy extends js.Object {
-  def error(message: js.String, stack: js.Array[js.Dictionary]): Unit = ???
-  def failure(message: js.String, stack: js.Array[js.Dictionary]): Unit = ???
+  def error(message: js.String, stack: js.Array[js.Any]): Unit = ???
+  def failure(message: js.String, stack: js.Array[js.Any]): Unit = ???
   def succeeded(message: js.String): Unit = ???
   def skipped(message: js.String): Unit = ???
   def pending(message: js.String): Unit = ???

--- a/library/src/main/scala/scala/scalajs/test/TestOutputBridge.scala
+++ b/library/src/main/scala/scala/scalajs/test/TestOutputBridge.scala
@@ -70,16 +70,16 @@ class TestOutputBridge(eventProxy: EventProxy) extends TestOutput {
     stack.toArray
   }
 
-  private def toJsArray(a: Array[ScriptStackElement]): js.Array[js.Dictionary] =
-    elementToDictionary(a)
+  private def toJsArray(a: Array[ScriptStackElement]): js.Array[js.Any] =
+    elementToJS(a)
 
-  private def elementToDictionary(a: Seq[ScriptStackElement]): Array[js.Dictionary] =
-    (for (el <- a) yield stackElementToDictionary(el)).toArray
+  private def elementToJS(a: Seq[ScriptStackElement]): Array[js.Any] =
+    (for (el <- a) yield stackElementToJS(el)).toArray
 
-  private def stackElementToDictionary(s: ScriptStackElement): js.Dictionary = {
-    js.Dictionary(
-        "fileName" -> (s.fileName: js.String),
-        "functionName" -> (s.functionName: js.String),
-        "lineNumber" -> (s.lineNumber: js.Number))
+  private def stackElementToJS(s: ScriptStackElement): js.Any = {
+    js.Dynamic.literal(
+        fileName = (s.fileName: js.String),
+        functionName = (s.functionName: js.String),
+        lineNumber = (s.lineNumber: js.Number))
   }
 }

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/DictionaryTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/DictionaryTest.scala
@@ -17,7 +17,7 @@ object DictionaryTest extends JasmineTest {
 
     it("should provide equivalent of JS for-in loop of {} - #13") {
       val obj = js.eval("var dictionaryTest13 = { a: 'Scala.js', b: 7357 }; dictionaryTest13;")
-      val dict: js.Dictionary = obj
+      val dict = obj.asInstanceOf[js.Dictionary[js.Any]]
       var propCount = 0
       var propString = ""
 
@@ -32,7 +32,7 @@ object DictionaryTest extends JasmineTest {
 
     it("should provide equivalent of JS for-in loop of [] - #13") {
       val obj = js.eval("var arrayTest13 = [ 7, 3, 5, 7 ]; arrayTest13;")
-      val array: js.Dictionary = obj
+      val array = obj.asInstanceOf[js.Dictionary[js.Any]]
       var propCount = 0
       var propString = ""
 
@@ -46,7 +46,7 @@ object DictionaryTest extends JasmineTest {
     }
 
     it("should provide an equivalent of the JS delete keyword - #255") {
-      val obj = js.Dictionary.empty
+      val obj = js.Dictionary.empty[js.Any]
       obj("foo") = 42
       obj("bar") = "foobar"
       js.Object.defineProperty(obj.asInstanceOf[js.Object], "nonconfig",


### PR DESCRIPTION
The design of js.Dictionary has been left in a very primitive
state since the early versions of Scala.js. This reviews its
status, and makes it 1) generic in its element type, like
js.Array, and 2) a subtype of js.Object.

Fixes #258.
