### PR TITLE
Fix #261: reversi-opt broken.

### DIFF
--- a/corejslib/scalajsenv.js
+++ b/corejslib/scalajsenv.js
@@ -224,7 +224,7 @@ var ScalaJS = {
       return instance.hashCode__I();
     else if (typeof(instance) === "string") {
       // calculate hash of String as specified by JavaDoc
-      var n = instance.length;
+      var n = instance["length"];
       var res = 0;
       var mul = 1; // holds pow(31, n-i-1)
       // multiplications with `mul` do never overflow the 52 bits of precision:
@@ -234,7 +234,7 @@ var ScalaJS = {
       // 32 + max(5, 16) = 48 < 52 => no overflow
       for (var i = n-1; i >= 0; --i) {
         // calculate s[i] * pow(31, n-i-1)
-        res = res + (instance.charCodeAt(i) * mul | 0) | 0
+        res = res + (instance["charCodeAt"](i) * mul | 0) | 0
         // update mul for next iteration
         mul = mul * 31 | 0
       }


### PR DESCRIPTION
It was broken in 3f59f11f1a446bd5681e67d69667eaa80a6105d9.

In the future we'll have to find a good way to automate our tests of optimizeJS and make them part of our CI.
