### PR TITLE
Fix #268: handle overlapping ranges in System.arraycopy.

### DIFF
--- a/javalib/source/src/java/lang/System.scala
+++ b/javalib/source/src/java/lang/System.scala
@@ -34,10 +34,19 @@ object System {
       dest: Object, destPos: scala.Int, length: scala.Int): Unit = {
     val jsSrc = reflect.Array.getUnderlying[Any](src)
     val jsDest = reflect.Array.getUnderlying[Any](dest)
-    var i = 0
-    while (i < length) {
-      jsDest(destPos+i) = jsSrc(srcPos+i)
-      i += 1
+
+    if ((jsSrc ne jsDest) || destPos < srcPos || srcPos + length < destPos) {
+      var i = 0
+      while (i < length) {
+        jsDest(destPos+i) = jsSrc(srcPos+i)
+        i += 1
+      }
+    } else {
+      var i = length - 1
+      while (i >= 0) {
+        jsDest(destPos+i) = jsSrc(srcPos+i)
+        i -= 1
+      }
     }
   }
 

--- a/test/src/test/scala/scala/scalajs/test/compiler/RegressionTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/RegressionTest.scala
@@ -162,5 +162,15 @@ object RegressionTest extends JasmineTest {
       expect(scala.reflect.classTag[Bug218Foo[_]].toString).toEqual(
           "scala.scalajs.test.compiler.RegressionTest$Bug218Foo")
     }
+
+    it("should support Buffer - #268") {
+      val a = scala.collection.mutable.Buffer.empty[Int]
+      a.insert(0, 0)
+      a.remove(0)
+      for (i <- 0 to 10) {
+        a.insert(a.length / 2, i)
+      }
+      expect(a.mkString(", ")).toEqual("1, 3, 5, 7, 9, 10, 8, 6, 4, 2, 0")
+    }
   }
 }

--- a/test/src/test/scala/scala/scalajs/test/javalib/SystemTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/javalib/SystemTest.scala
@@ -1,0 +1,72 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test
+package javalib
+
+import scala.scalajs.js
+import scala.scalajs.test.JasmineTest
+
+object SystemTest extends JasmineTest {
+
+  describe("java.lang.System") {
+
+    it("should respond to `arraycopy`") {
+      val object0 = Array[Any]("[", "b", "c", "d", "e", "f", "]")
+      val object1 = Array[Any](() => true, 1, "2", '3', 4.0, true, object0)
+
+      System.arraycopy(object1, 1, object0, 1, 5)
+      expect(object0.mkString).toEqual("[1234.0true]")
+
+      val string0 = Array("a", "b", "c", "d", "e", "f")
+      val string1 = Array("1", "2", "3", "4")
+
+      System.arraycopy(string1, 0, string0, 3, 3)
+      expect(string0.mkString).toEqual("abc123")
+
+      val ab01Chars = Array("ab".toCharArray, "01".toCharArray)
+      val chars = new Array[Array[Char]](32)
+      System.arraycopy(ab01Chars, 0, chars, 0, 2)
+      for (i <- Seq(0, 2, 4, 8, 16)) {
+        System.arraycopy(chars, i / 4, chars, i, i)
+      }
+
+      expect(chars.filter(_ == null).length).toEqual(12)
+      expect(chars.filter(_ != null).map(_.mkString).mkString).
+        toEqual("ab01ab0101ab01ab0101ab0101ab01ab0101ab01")
+    }
+
+    it("should respond to `arraycopy` with range overlaps for the same array") {
+      val array = new Array[Int](10)
+
+      for (i <- 1 to 6) {
+        array(i) = i
+      }
+
+      expect(array).toEqual(Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0))
+      System.arraycopy(array, 0, array, 3, 7)
+      expect(array).toEqual(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6))
+
+      System.arraycopy(array, 0, array, 1, 0)
+      expect(array).toEqual(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6))
+
+      System.arraycopy(array, 0, array, 1, 9)
+      expect(array).toEqual(Array(0, 0, 1, 2, 0, 1, 2, 3, 4, 5))
+
+      System.arraycopy(array, 1, array, 0, 9)
+      expect(array).toEqual(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5))
+
+      System.arraycopy(array, 0, array, 0, 10)
+      expect(array).toEqual(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5))
+
+      val reversed = array.reverse
+      System.arraycopy(reversed, 5, array, 5, 5)
+      expect(array).toEqual(Array(0, 1, 2, 0, 1, 1, 0, 2, 1, 0))
+    }
+
+  }
+}


### PR DESCRIPTION
Add check for overlapping ranges of entries within the same array and
fall-back to copy entries in reverse.
