### PR TITLE
Fix #275: Remove isScalaJSDefined (and company)

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -2608,11 +2608,9 @@ abstract class GenJSCode extends plugins.PluginComponent
       lazy val js.ArrayConstr(args) = argArray
       lazy val argc = args.length
 
-      def hasExplicitJSEncoding = {
-        isScalaJSDefined && (
-            sym.hasAnnotation(JSNameAnnotation) ||
-            sym.hasAnnotation(JSBracketAccessAnnotation))
-      }
+      def hasExplicitJSEncoding =
+        sym.hasAnnotation(JSNameAnnotation) ||
+        sym.hasAnnotation(JSBracketAccessAnnotation)
 
       def paramType(index: Int) = sym.tpe.params(index).tpe
 
@@ -2681,9 +2679,7 @@ abstract class GenJSCode extends plugins.PluginComponent
             }
           }
 
-          def isJSBracketAccess = {
-            isScalaJSDefined && sym.hasAnnotation(JSBracketAccessAnnotation)
-          }
+          def isJSBracketAccess = sym.hasAnnotation(JSBracketAccessAnnotation)
 
           if (sym.hasFlag(reflect.internal.Flags.DEFAULTPARAM)) {
             js.UndefinedParam()
@@ -3374,8 +3370,7 @@ abstract class GenJSCode extends plugins.PluginComponent
           "genLoadModule called with non-module symbol: " + sym0)
       val sym = if (sym0.isModule) sym0.moduleClass else sym0
 
-      val isGlobalScope = isScalaJSDefined &&
-        (sym.tpe.typeSymbol isSubClass JSGlobalScopeClass)
+      val isGlobalScope = sym.tpe.typeSymbol isSubClass JSGlobalScopeClass
 
       if (isGlobalScope) envField("g")
       else if (isRawJSType(sym.tpe)) genPrimitiveJSModule(sym)
@@ -3471,14 +3466,9 @@ abstract class GenJSCode extends plugins.PluginComponent
     JavaScriptExceptionClass isSubClass tpe.typeSymbol
 
   /** Get JS name of Symbol if it was specified with JSName annotation */
-  def jsNameOf(sym: Symbol): String = {
-    if (isScalaJSDefined) {
-      sym.getAnnotation(JSNameAnnotation).flatMap(_.stringArg(0)).getOrElse(
-          sym.unexpandedName.decoded)
-    } else {
-      sym.unexpandedName.decoded
-    }
-  }
+  def jsNameOf(sym: Symbol): String =
+    sym.getAnnotation(JSNameAnnotation).flatMap(_.stringArg(0)).getOrElse(
+        sym.unexpandedName.decoded)
 
   private def isStaticModule(sym: Symbol): Boolean =
     sym.isModuleClass && !sym.isImplClass && !sym.isLifted

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
@@ -20,9 +20,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
   import rootMirror._
 
   class JSDefinitionsClass {
-    lazy val MaybeJSAnyClass = getClassIfDefined("scala.scalajs.js.Any")
-    lazy val isScalaJSDefined = MaybeJSAnyClass != NoSymbol
-    lazy val MaybeJSAnyTpe = if (isScalaJSDefined) MaybeJSAnyClass.toTypeConstructor else NoType
 
     lazy val ScalaJSJSPackage = getPackage(newTermNameCached("scala.scalajs.js")) // compat 2.10/2.11
       lazy val JSPackage_typeOf   = getMemberMethod(ScalaJSJSPackage, newTermName("typeOf"))

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
@@ -68,8 +68,6 @@ abstract class JSPrimitives {
 
   /** Initialize the map of primitive methods */
   def init() {
-    if (!isScalaJSDefined)
-      return
 
     addPrimitive(JSAny_fromUnit, V2JS)
     addPrimitive(JSAny_fromBoolean, Z2JS)

--- a/compiler/src/main/scala/scala/scalajs/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/PrepJSInterop.scala
@@ -221,14 +221,13 @@ abstract class PrepJSInterop extends plugins.PluginComponent with transform.Tran
 
   }
 
-  private def isJSAny(implDef: ImplDef) = isScalaJSDefined &&
-    (implDef.symbol.tpe.typeSymbol isSubClass JSAnyClass)
+  private def isJSAny(implDef: ImplDef) =
+    implDef.symbol.tpe.typeSymbol isSubClass JSAnyClass
 
-  private def isJSGlobalScope(implDef: ImplDef) = isScalaJSDefined &&
-    (implDef.symbol.tpe.typeSymbol isSubClass JSGlobalScopeClass)
+  private def isJSGlobalScope(implDef: ImplDef) =
+    implDef.symbol.tpe.typeSymbol isSubClass JSGlobalScopeClass
 
-  private def isJSLambda(sym: Symbol) = isScalaJSDefined &&
-    sym.isAnonymousClass &&
+  private def isJSLambda(sym: Symbol) = sym.isAnonymousClass &&
     AllJSFunctionClasses.exists(sym.tpe.typeSymbol isSubClass _)
 
   private def isScalaEnum(implDef: ImplDef) =


### PR DESCRIPTION
The Scala.js compiler relies on the ScalaJS library being on the classpath since the introduction of RuntimeLong. Therefore, checking for `isScalaJSDefined` can only achieve the following two:
- Increase clutter
- Give the wrong impression that the ScalaJS library need not be on the classpath.

This commit removes `isScalaJSDefined` and references to it.
