### PR TITLE
Simplify lazy loading in Scala.js env by using encodedName in .sjsinfo.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/ClassInfos.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/ClassInfos.scala
@@ -28,6 +28,7 @@ trait ClassInfos extends SubComponent { self: GenJSCode =>
     val name = symbol.fullName + (
         if (isStaticModule) nme.MODULE_SUFFIX_STRING else "")
     val ancestorCount = symbol.ancestors.count(!_.isInterface)
+    val encodedName = encodeClassFullName(symbol)
 
     def toJSON: js.Tree = {
       obj(
@@ -36,7 +37,8 @@ trait ClassInfos extends SubComponent { self: GenJSCode =>
           "isStaticModule" -> isStaticModule,
           "isInterface" -> isInterface,
           "isImplClass" -> isImplClass,
-          "isRawJSType" -> isRawJSType
+          "isRawJSType" -> isRawJSType,
+          "encodedName" -> encodedName
       )
     }
   }

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -85,17 +85,15 @@ object ScalaJSPlugin extends Plugin {
   def sortScalaJSOutputFiles(files: Seq[File]): Seq[File] = {
     files sortWith { (lhs, rhs) =>
       def rankOf(jsFile: File): Int = {
-        if (jsFile.name == "scalajs-corejslib.js") -1
-        else {
-          val infoFile = changeExt(jsFile, ".js", ".sjsinfo")
-          if (!infoFile.exists) 10000
-          else {
+        jsFile match {
+          case CoreJSLibFile() => -1
+          case ScalaJSClassFile(infoFile) =>
             IO.readLines(infoFile).collectFirst {
               case AncestorCountLine(countStr) => countStr.toInt
             }.getOrElse {
               throw new AssertionError(s"Did not find ancestor count in $infoFile")
             }
-          }
+          case _ => 10000
         }
       }
       val lhsRank = rankOf(lhs)

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/Utils.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/Utils.scala
@@ -5,4 +5,26 @@ import sbt._
 object Utils {
   def changeExt(f: File, oldExt: String, newExt: String): File =
     file(f.getPath.stripSuffix(oldExt) + newExt)
+
+  object ScalaJSClassFile {
+    /** Returns the .sjsinfo file when matches. */
+    def unapply(f: File): Option[File] = {
+      if (!f.getPath.endsWith(".js")) None
+      else {
+        val infoFile = changeExt(f, ".js", ".sjsinfo")
+        if (!infoFile.exists) None
+        else Some(infoFile)
+      }
+    }
+  }
+
+  def isScalaJSClassFile(f: File): Boolean =
+    ScalaJSClassFile.unapply(f).isDefined
+
+  def isCoreJSLibFile(f: File): Boolean =
+    f.name == "scalajs-corejslib.js"
+
+  object CoreJSLibFile {
+    def unapply(f: File): Boolean = isCoreJSLibFile(f)
+  }
 }

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/environment/rhino/LazyScalaJSScope.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/environment/rhino/LazyScalaJSScope.scala
@@ -48,19 +48,17 @@ class LazyScalaJSScope(
   }
 
   private def load(name: String): Unit = {
-    val relativeFileName = nameToRelativeFileName(name)
-    providers.get(relativeFileName) foreach { file =>
+    val encodedName = propNameToEncodedName(name)
+    providers.get(encodedName) foreach { file =>
       val ctx = Context.getCurrentContext()
       ctx.evaluateFile(globalScope, file)
     }
   }
 
-  private def nameToRelativeFileName(name: String): String = {
-    val name1 = if (isTraitImpl) name.split("__")(0) else name
-    val name2 = name1.replace("_", "/").replace("$und", "_")
-    val name3 = if (name2(0) == '$') name2.substring(1) else name2
-    if (isModule) name3 + "$.js"
-    else name3 + ".js"
+  private def propNameToEncodedName(name: String): String = {
+    if (isTraitImpl) name.split("__")(0)
+    else if (isModule) name + "$"
+    else name
   }
 
   override def getClassName() = "LazyScalaJSScope"


### PR DESCRIPTION
Instead of inferring the relative path of a Scala.js-emitted file
wrt to the directories in the class path, we simply store the
encoded name of the class in the .sjsinfo, and use that information.
It is simpler and more reliable.
