### PR TITLE
Fix #82: Only include Scala.js-emitted .js files in packageJS.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -93,7 +93,7 @@ object ScalaJSPlugin extends Plugin {
             }.getOrElse {
               throw new AssertionError(s"Did not find ancestor count in $infoFile")
             }
-          case _ => 10000
+          case _ => 10000 // just in case someone does something weird to our classpaths
         }
       }
       val lhsRank = rankOf(lhs)
@@ -194,7 +194,10 @@ object ScalaJSPlugin extends Plugin {
         val inputs = new mutable.ListBuffer[File]
 
         for (dir <- cp.map(_.data)) {
-          for (file <- (dir ** "*.js").get) {
+          for {
+            file <- (dir ** "*.js").get
+            if isScalaJSClassFile(file) || isCoreJSLibFile(file)
+          } {
             val path = IO.relativize(dir, file).get
             if (!existingPaths.contains(path)) {
               inputs += file


### PR DESCRIPTION
Other .js files on the classpath are not bundled by default by
packageJS (nor optimizeJS). Of course, .js files added explicitly
to (sources in (Compile, packageJS)) are still packaged, e.g.,
the typical startup.js file.
