### PR TITLE
Publish Scala.js for 2.11.0-M8.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,6 +45,7 @@ matrix:
       scala: 2.11.0-M8
       env:
         - KIND=main
+        - PUBLISH_ENABLED=true
     - jdk: openjdk6
       scala: 2.11.0-M8
       env:


### PR DESCRIPTION
Requested by @lihaoyi at https://github.com/scala-js/scala-js/commit/3e5ff5e82b2570c22e1e27c87847a969278a73d6#commitcomment-5506801
