### PR TITLE
Replace a for-range loop by a while loop in javalib.

### DIFF
--- a/javalib/source/src/java/io/PrintStream.scala
+++ b/javalib/source/src/java/io/PrintStream.scala
@@ -33,8 +33,11 @@ class PrintStream(_out: OutputStream, autoFlush: Boolean, ecoding: String)
 
   private def writeString(s: String) = {
     val bytes = new Array[Byte](s.length)
-    for (i <- 0 until s.length)
+    var i = 0
+    while (i < s.length) {
       bytes(i) = s.charAt(i).toByte
+      i += 1
+    }
     write(bytes)
   }
 


### PR DESCRIPTION
It was on the path of Predef.println(), which is worth
making not too slow. Besides, it was the only for-range
loop in javalib.
