### PR TITLE
The sbt plugin must to be published separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Currently, two examples are provided:
 Simply publish it locally with:
 
     sbt> publishLocal
+    sbt> scalajs-sbt-plugin/publishLocal
 
 ## License
 


### PR DESCRIPTION
The sbt plugin is not aggregated by the root project anymore, because
the root project is cross-compilable but the sbt plugin is not. Thus to
publish a local version of scala.js you need to do both:

```
> publishLocal
```

and

```
> scalajs-sbt-plugin/publishLocal
```
