### PR TITLE
Fix #338: optionally retarget @JSExport.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSExports.scala
@@ -59,7 +59,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
       val js.MethodDef(_, args, body) = genExportMethod(ctors, jsName)
 
       val jsCtor = envField("c") DOT encodeClassFullNameIdent(classSym)
-      val (createNamespace, expCtorVar) = genCreateNamespaceInGlobal(jsName)
+      val (createNamespace, expCtorVar) = genCreateNamespaceInExports(jsName)
 
       js.Block(
         createNamespace,
@@ -84,7 +84,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
 
       val accessorVar =
         envField("modules") DOT encodeModuleFullNameIdent(classSym)
-      val (createNamespace, expAccessorVar) = genCreateNamespaceInGlobal(jsName)
+      val (createNamespace, expAccessorVar) = genCreateNamespaceInExports(jsName)
 
       js.Block(
         createNamespace,
@@ -93,19 +93,19 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
     }
   }
 
-  /** Gen JS code for assigning an rhs to a qualified name in the global scope.
+  /** Gen JS code for assigning an rhs to a qualified name in the exports scope.
    *  For example, given the qualified name "foo.bar.Something", generates:
    *
-   *  ScalaJS["g"]["foo"] = ScalaJS["g"]["foo"] || {};
-   *  ScalaJS["g"]["foo"]["bar"] = ScalaJS["g"]["foo"]["bar"] || {};
+   *  ScalaJS.e["foo"] = ScalaJS.e["foo"] || {};
+   *  ScalaJS.e["foo"]["bar"] = ScalaJS.e["foo"]["bar"] || {};
    *
-   *  Returns (statements, ScalaJS["g"]["foo"]["bar"]["Something"])
+   *  Returns (statements, ScalaJS.e["foo"]["bar"]["Something"])
    */
-  private def genCreateNamespaceInGlobal(qualName: String)(
+  private def genCreateNamespaceInExports(qualName: String)(
       implicit pos: Position): (js.Tree, js.Tree) = {
     val parts = qualName.split("\\.")
     val statements = mutable.ListBuffer.empty[js.Tree]
-    var namespace = envField("g")
+    var namespace = envField("e")
     for (i <- 0 until parts.length-1) {
       namespace = js.BracketSelect(namespace, js.StringLiteral(parts(i)))
       statements +=

--- a/corejslib/scalajsenv.js
+++ b/corejslib/scalajsenv.js
@@ -10,6 +10,8 @@
 var ScalaJS = {
   // Fields
   g: (typeof global === "object" && global && global["Object"] === Object) ? global : this, // Global scope
+  e: (typeof __ScalaJSExportsNamespace === "object" && __ScalaJSExportsNamespace) ? __ScalaJSExportsNamespace : // Where to send exports
+      ((typeof global === "object" && global && global["Object"] === Object) ? global : this),
   data: {},            // Data for types
   c: {},               // Scala.js constructors
   inheritable: {},     // Inheritable constructors (without initialization code)
@@ -341,6 +343,12 @@ var ScalaJS = {
   }
 }
 
+/* We have to force a non-elidable *read* of ScalaJS.e, otherwise Closure will
+ * eliminate it altogether, along with all the exports, which is ... er ...
+ * plain wrong.
+ */
+ScalaJS.g["__ScalaJSExportsNamespace"] = ScalaJS.e;
+
 // Type data constructors
 
 /** @constructor */
@@ -360,7 +368,7 @@ ScalaJS.PrimitiveTypeData = function(zero, arrayEncodedName, displayName, boxFun
   this.isInstance = function(obj) { return false; };
   this.isArrayOf = function(obj, depth) { return false; };
   this.boxValue = boxFun
-},
+};
 
 /** @constructor */
 ScalaJS.ClassTypeData = function(internalNameObj, isInterface, fullName,

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -118,6 +118,7 @@ object ScalaJSPlugin extends Plugin {
     Function.prototype.call = function() {};
     Function.prototype.apply = function() {};
     var global = {};
+    var __ScalaJSExportsNamespace = {};
     """
 
   def packageClasspathJSTasks(classpathKey: TaskKey[Classpath],


### PR DESCRIPTION
The "API" to do so is to define a variable named
__ScalaJSExportsNamespace in the scope (typically the global
scope) before code emitted by Scala.js is executed. If defined
and an object, exports of classes and objects will be stored
in that object. If it is not defined, they are stored in the
global scope, as they used to be.
