### PR TITLE
Fix #343: do not set scalaVersion in our sbt plugin.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -527,9 +527,6 @@ object ScalaJSPlugin extends Plugin {
       // the resolver to find the compiler and library (and others)
       resolvers ++= Seq(scalaJSReleasesResolver, scalaJSSnapshotsResolver),
 
-      // you had better use the same version of Scala as Scala.js
-      scalaVersion := scalaJSScalaVersion,
-
       // you will need the Scala.js compiler plugin
       autoCompilerPlugins := true,
       addCompilerPlugin("org.scala-lang.modules.scalajs" %% "scalajs-compiler" % scalaJSVersion),


### PR DESCRIPTION
Setting this dated back from the early days when only a
very specific version of Scala was supported. This does
not make sense anymore, and can be confusing if you set
a scalaVersion before importing scalaJSSettings in a
build file.
