### PR TITLE
Fix #303: Reflective calls to methods on java.lang.Object

### DIFF
--- a/corejslib/javalangObject.js
+++ b/corejslib/javalangObject.js
@@ -61,13 +61,37 @@ ScalaJS.c.java_lang_Object.prototype.toString = function() {
   return this.toString__T();
 }
 
+// Notify and notify all:
+// Although we do not support wait on Object as it does not make sense in JS, we
+// allow notify to be called in order to support code that calls only notify but
+// never wait. Further, note that these methods are not in the sjsinfo file.
+// Therefore, dce will complain about them not being reachable, but the code
+// will still work.
 ScalaJS.c.java_lang_Object.prototype.notify__V = function() {}
 ScalaJS.c.java_lang_Object.prototype.notifyAll__V = function() {}
-ScalaJS.c.java_lang_Object.prototype.wait__J__V = function() {}
-ScalaJS.c.java_lang_Object.prototype.wait__J__I__V = function() {}
-ScalaJS.c.java_lang_Object.prototype.wait__V = function() {}
 
 ScalaJS.c.java_lang_Object.prototype.finalize__V = function() {}
+
+// Reflective call proxies for methods on java.lang.Object
+// Note that we do not need to proxy the following methods, since they are
+// defined on Any in the Scala hierarchy and therefore a reflective call is
+// never issued:
+// - equals
+// - getClass
+// - hashCode
+// - toString
+ScalaJS.c.java_lang_Object.prototype.clone__ = function() {
+  return this.clone__O()
+}
+ScalaJS.c.java_lang_Object.prototype.notify__ = function() {
+  return ScalaJS.bV(this.notify__V())
+}
+ScalaJS.c.java_lang_Object.prototype.notifyAll__ = function() {
+  return ScalaJS.bV(this.notifyAll__V())
+}
+ScalaJS.c.java_lang_Object.prototype.finalize__ = function() {
+  return ScalaJS.bV(this.finalize__V())
+}
 
 // Instance tests
 

--- a/test/src/test/scala/scala/scalajs/test/compiler/ReflectiveCallTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/ReflectiveCallTest.scala
@@ -193,5 +193,56 @@ object ReflectiveCallTest extends JasmineTest {
       expect(call(new C)).toEqual(1)
     }
 
+    it("should work on java.lang.Object.{ notify, notifyAll } - #303") {
+      type ObjNotifyLike = Any {
+        def notify(): Unit
+        def notifyAll(): Unit
+      }
+      def objNotifyTest(obj: ObjNotifyLike) = {
+        obj.notify()
+        obj.notifyAll()
+        1
+      }
+
+      class A
+
+      expect(objNotifyTest(new A())).toEqual(1)
+    }
+
+    it("should work on java.lang.Object.clone - #303") {
+      type ObjCloneLike = Any { def clone(): AnyRef }
+      def objCloneTest(obj: ObjCloneLike) = obj.clone()
+
+      class B(val x: Int) extends Cloneable {
+        override def clone() = super.clone
+      }
+
+      val b = new B(1)
+      val bClone = objCloneTest(b).asInstanceOf[B]
+
+      expect(b eq bClone).toBeFalsy
+      expect(bClone.x).toEqual(1)
+    }
+
+    it("should work on scala.AnyRef.{ eq, ne } - #303") {
+      type ObjEqLike = Any {
+        def eq(that: AnyRef): Boolean
+        def ne(that: AnyRef): Boolean
+      }
+      def objEqTest(obj: ObjEqLike, that: AnyRef) = obj eq that
+      def objNeTest(obj: ObjEqLike, that: AnyRef) = obj ne that
+
+      class A
+
+      val a1 = new A
+      val a2 = new A
+
+      expect(objEqTest(a1,a2)).toBeFalsy
+      expect(objEqTest(a1,a1)).toBeTruthy
+
+      expect(objNeTest(a1,a2)).toBeTruthy
+      expect(objNeTest(a1,a1)).toBeFalsy
+    }
+
   }
 }


### PR DESCRIPTION
Reflective calls to java.lang.Object made the Scala.js compiler crash
because of the special handling for strings in reflective calls. This
commit fixes the issue. It also adds reflective call proxies to the JS
implementation of java.lang.Object.

Further, it emits an error message if a reflective call is attempted
on a method of java.lang.Object that is not supported by Scala.js
(e.g. wait).
