### PR TITLE
Fix #364: clash with exporting under org/com/java with Rhino.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/environment/RhinoBasedScalaJSEnvironment.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/environment/RhinoBasedScalaJSEnvironment.scala
@@ -21,6 +21,7 @@ import org.mozilla.javascript.Context
 import org.mozilla.javascript.RhinoException
 import org.mozilla.javascript.Scriptable
 import org.mozilla.javascript.ScriptableObject
+import org.mozilla.javascript.Undefined
 
 import rhino.ContextOps
 import rhino.ScalaJSCoreLib
@@ -115,6 +116,10 @@ class RhinoBasedScalaJSEnvironment(
     val context = Context.enter()
     try {
       val scope = context.initStandardObjects()
+
+      // Make sure Rhino does not do its magic for JVM top-level packages (#364)
+      for (name <- Seq("java", "scala", "com", "org"))
+        ScriptableObject.putProperty(scope, name, Undefined.instance)
 
       envJSLib.foreach { file =>
         context.setOptimizationLevel(-1)

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/ExportsTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/ExportsTest.scala
@@ -193,6 +193,13 @@ object ExportsTest extends JasmineTest {
       expect(foo.foo(trueJsLong)).toEqual(2)
     }
 
+    it("should support exporting under 'org' namespace - #364") {
+      val accessor = js.Dynamic.global.org.ExportedUnderOrgObject
+      expect(js.typeOf(accessor)).toEqual("function")
+      val obj = accessor()
+      expect(obj).toBe(ExportedUnderOrgObject.asInstanceOf[js.Any])
+    }
+
   } // describe
 
   describe("@JSExportDescendentObjects") {
@@ -236,6 +243,9 @@ class ExportedClass(_x: Int) {
   @JSExport
   val x = _x
 }
+
+@JSExport("org.ExportedUnderOrgObject")
+object ExportedUnderOrgObject
 
 @JSExportDescendentObjects
 trait AutoExportTrait


### PR DESCRIPTION
The fix is to erase the special values that Rhino puts in the
global scope with undefined values.
