### PR TITLE
Fix #376: regression in packageJS performance.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -185,9 +185,7 @@ object ScalaJSPlugin extends Plugin {
           }
         }
 
-        // Return a sorted list of the inputs
-
-        sortScalaJSOutputFiles(inputs.result())
+        inputs.result()
       },
 
       sources in packageJSKey := {
@@ -216,7 +214,8 @@ object ScalaJSPlugin extends Plugin {
           FileFunction.cached(taskCacheDir / "package",
               FilesInfo.lastModified, FilesInfo.exists) { dependencies =>
             s.log.info("Packaging %s ..." format output)
-            catJSFilesAndTheirSourceMaps(inputs, output, relativeSourceMaps.value)
+            val sorted = sortScalaJSOutputFiles(inputs)
+            catJSFilesAndTheirSourceMaps(sorted, output, relativeSourceMaps.value)
             Set(output)
           } (inputs.toSet)
         }


### PR DESCRIPTION
The mistake was shamefully stupid.
Since 22a579c938de0ddf19176e3b57276547b9b8e649, we have been
using data stored in .sjsinfo files to sort the files to be
fed to packageJS instead of a prefix to the file name.
Opening that file and actually reading its content is of
course slower than taking a prefix of the file name, but it
was not supposed to be a bottleneck compared to reading the
file itself and, worse, its source map and all the complicated
parsing of the source map. And indeed it is not, assuming these
processings are actually done.

However, when no source file has changed (which is often the
case for extdeps), opening the .js and .js.map files is _not_
done (which is a good thing), but **the .sjsinfo file was read
all the same**, because we used to sort the .js files as part
of the (sources in packageXyzJS) tasks, which is always run,
irrespective of whether a file has changed or not.

So the fix was easy: only sort .js input files inside the block
of code protected by the caching mechanism, so that it is also
executed only when a file has changed.
