### PR TITLE
Fix #390: Reflective call proxies for default parameter methods

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -740,8 +740,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       val excludedFlags = (
           Flags.BRIDGE  |
           Flags.PRIVATE |
-          Flags.MACRO   |
-          Flags.DEFAULTPARAM
+          Flags.MACRO
       )
 
       /** Check if two method symbols conform in name and parameter types */

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0-RC3/BuglistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0-RC3/BuglistedTests.txt
@@ -2,6 +2,3 @@
 # use scala.tools.partest.scalajs.testunknownonly to only run tests
 # which are neither in BuglistedTests.txt, WhitelistedTests.txt or
 # BlacklistedTests.txt
-
-# Filed as #390
-run/t5565.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0-RC3/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0-RC3/WhitelistedTests.txt
@@ -2900,3 +2900,4 @@ run/t261.scala
 run/t3235-minimal.scala
 run/t1503_future.scala
 run/t1503.scala
+run/t5565.scala

--- a/test/src/test/scala/scala/scalajs/test/compiler/ReflectiveCallTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/ReflectiveCallTest.scala
@@ -244,5 +244,14 @@ object ReflectiveCallTest extends JasmineTest {
       expect(objNeTest(a1,a1)).toBeFalsy
     }
 
+    it("should work with default arguments - #390") {
+      def pimpIt(a: Int) = new {
+        def foo(b: Int, c: Int = 1): Int = a + b + c
+      }
+
+      expect(pimpIt(1).foo(2)).toEqual(4)
+      expect(pimpIt(2).foo(2,4)).toEqual(8)
+    }
+
   }
 }


### PR DESCRIPTION
Strangely, travis passed in my branch for the sizes w/o modification. I'll leave them unmodified here.
