### PR TITLE
Rename scala.scalajs.runtime.Long => RuntimeLong.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -3651,7 +3651,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       }
     }
 
-    /** Generate a call to scala.scalajs.runtime.Long companion */
+    /** Generate a call to scala.scalajs.runtime.RuntimeLong companion */
     private def genLongModuleCall(methodName: String, args: js.Tree*)(implicit pos: Position) = {
       val LongModule = genLoadModule(RuntimeLongModule)
       val encName = scala.reflect.NameTransformer.encode(methodName)

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
@@ -113,7 +113,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
 
     lazy val RawJSTypeAnnot = getClassIfDefined("scala.scalajs.js.annotation.RawJSType")
 
-    lazy val RuntimeLongClass  = getRequiredClass("scala.scalajs.runtime.Long")
+    lazy val RuntimeLongClass  = getRequiredClass("scala.scalajs.runtime.RuntimeLong")
     lazy val RuntimeLongModule = RuntimeLongClass.companionModule
       lazy val RuntimeLong_from = getMemberMethod(RuntimeLongModule, newTermName("fromRuntimeLong"))
       lazy val RuntimeLong_to   = getMemberMethod(RuntimeLongModule, newTermName("toRuntimeLong"))

--- a/corejslib/scalajsenv.js
+++ b/corejslib/scalajsenv.js
@@ -410,8 +410,8 @@ ScalaJS.ArrayTypeData = function(componentData) {
   // is a special case here, since the class has not
   // been defined yet, when this file is read
   if (componentZero == "longZero") {
-    componentZero = ScalaJS.modules.scala_scalajs_runtime_Long().
-      zero__Lscala_scalajs_runtime_Long();
+    componentZero = ScalaJS.modules.scala_scalajs_runtime_RuntimeLong().
+      zero__Lscala_scalajs_runtime_RuntimeLong();
   }
 
   /** @constructor */

--- a/javalib/source/src/java/lang/Long.scala
+++ b/javalib/source/src/java/lang/Long.scala
@@ -7,7 +7,7 @@ final class Long(private val value: scala.Long)
 
   def this(s: String) = this(Long.parseLong(s))
 
-  import scala.scalajs.runtime.Long.{fromRuntimeLong, toRuntimeLong}
+  import scala.scalajs.runtime.RuntimeLong.{fromRuntimeLong, toRuntimeLong}
 
   override def byteValue() = toRuntimeLong(value).toByte
   override def shortValue() = toRuntimeLong(value).toShort
@@ -161,8 +161,8 @@ final class Long(private val value: scala.Long)
 }
 
 object Long {
-  import scala.scalajs.runtime.{ Long => RTLong }
-  import RTLong.{fromRuntimeLong, toRuntimeLong}
+  import scala.scalajs.runtime.RuntimeLong
+  import RuntimeLong.{fromRuntimeLong, toRuntimeLong}
 
   val TYPE = classOf[scala.Long]
   val MIN_VALUE: scala.Long = -9223372036854775808L
@@ -173,10 +173,11 @@ object Long {
   def valueOf(s: String): Long = valueOf(parseLong(s))
   def valueOf(s: String, radix: Int): Long = valueOf(parseLong(s, radix))
 
-  def parseLong(s: String): scala.Long = fromRuntimeLong(RTLong.fromString(s))
+  def parseLong(s: String): scala.Long =
+    fromRuntimeLong(RuntimeLong.fromString(s))
 
   def parseLong(s: String, radix: Int): scala.Long =
-    fromRuntimeLong(RTLong.fromString(s, radix))
+    fromRuntimeLong(RuntimeLong.fromString(s, radix))
 
   def toString(l: scala.Long): String = toRuntimeLong(l).toString
 

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/RuntimeLongTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/RuntimeLongTest.scala
@@ -8,7 +8,7 @@
 package scala.scalajs.test
 package jsinterop
 
-import scala.scalajs.runtime.Long
+import scala.scalajs.runtime.RuntimeLong
 import org.scalajs.jasmine.JasmineExpectation
 
 import scala.util.Try
@@ -19,94 +19,99 @@ import scala.util.Try
  */
 object RuntimeLongTest extends JasmineTest {
 
+  import RuntimeLong.{
+    fromByte, fromShort, fromInt, fromDouble, fromString, fromHexString
+  }
+
   /** overload expect for long to add toString */
-  def expect(l: Long): JasmineExpectation = expect(l.toHexString)
+  def expect(l: RuntimeLong): JasmineExpectation = expect(l.toHexString)
 
   describe("scala.scalajs.runtime.Long") {
 
-    val maxInt  = Long.fromInt(Int.MaxValue)
-    val minInt  = Long.fromInt(Int.MinValue)
-    val one     = Long.fromInt(1)
-    val billion = Long.fromInt(1000000000)
+    val maxInt  = fromInt(Int.MaxValue)
+    val minInt  = fromInt(Int.MinValue)
+    val one     = fromInt(1)
+    val billion = fromInt(1000000000)
 
     it("should correctly implement negation") {
-      expect(-Long.fromInt(5)).toEqual("fffffffffffffffb")
-      expect(-Long.fromInt(0)).toEqual("0000000000000000")
-      expect(-minInt).toEqual(         "0000000080000000")
+      expect(-fromInt(5)).toEqual("fffffffffffffffb")
+      expect(-fromInt(0)).toEqual("0000000000000000")
+      expect(-minInt    ).toEqual("0000000080000000")
     }
 
     it("should correctly implement comparison") {
-      expect(Long.fromInt(7) < Long.fromInt(15)).toBe(true)
+      expect(fromInt(7) < fromInt(15)).toBe(true)
     }
 
     it("should correctly implement addition") {
-      expect(Long.fromInt(7) + Long.fromInt(15)).toEqual("0000000000000016")
-      expect(maxInt + maxInt).toEqual(                   "00000000fffffffe")
-      expect(maxInt+one).toEqual(                        "0000000080000000")
+      expect(fromInt(7) + fromInt(15)).toEqual("0000000000000016")
+      expect(    maxInt + maxInt     ).toEqual("00000000fffffffe")
+      expect(    maxInt + one        ).toEqual("0000000080000000")
     }
 
     it("should correctly implement subtraction") {
-      expect(Long.fromInt(7) - Long.fromInt(15)).toEqual("fffffffffffffff8")
-      expect(maxInt - maxInt).toEqual(                   "0000000000000000")
+      expect(fromInt(7) - fromInt(15)).toEqual("fffffffffffffff8")
+      expect(    maxInt - maxInt    ).toEqual("0000000000000000")
     }
 
     it("should correctly implement multiplication") {
-      expect(Long.fromInt(7)  * Long.fromInt(15)).toEqual("0000000000000069")
-      expect(Long.fromInt(-7) * Long.fromInt(15)).toEqual("ffffffffffffff97")
-      expect(maxInt * maxInt).toEqual(                    "3fffffff00000001")
-      expect(Long.fromHexString("001000000000000e") *
-             Long.fromInt(-4)).toEqual("ffbfffffffffffc8")
+      expect(fromInt(7)  * fromInt(15)).toEqual("0000000000000069")
+      expect(fromInt(-7) * fromInt(15)).toEqual("ffffffffffffff97")
+      expect(    maxInt  * maxInt     ).toEqual("3fffffff00000001")
+      expect(fromHexString("001000000000000e") *
+             fromInt(-4)).toEqual("ffbfffffffffffc8")
     }
 
     it("should correctly implement division") {
-      expect(Long.fromInt(7)  / Long.fromInt(15)).toEqual("0000000000000000")
-      expect(Long.fromInt(24) / Long.fromInt(5)).toEqual( "0000000000000004")
-      expect(Long.fromInt(24) / Long.fromInt(-5)).toEqual("fffffffffffffffc")
-      expect(maxInt / Long.fromInt(-5)).toEqual(          "ffffffffe6666667")
-      expect(maxInt / billion).toEqual(                   "0000000000000002")
-      expect((maxInt+one) / billion).toEqual(             "0000000000000002")
+      expect( fromInt(7)  / fromInt(15)).toEqual("0000000000000000")
+      expect( fromInt(24) / fromInt(5) ).toEqual("0000000000000004")
+      expect( fromInt(24) / fromInt(-5)).toEqual("fffffffffffffffc")
+      expect(      maxInt / fromInt(-5)).toEqual("ffffffffe6666667")
+      expect(      maxInt / billion    ).toEqual("0000000000000002")
+      expect((maxInt+one) / billion    ).toEqual("0000000000000002")
     }
 
     it("should correctly implement modulus") {
-      expect(Long.fromInt(7)  % Long.fromInt(15)).toEqual("0000000000000007")
-      expect(Long.fromInt(24) % Long.fromInt(5)).toEqual( "0000000000000004")
-      expect(Long.fromInt(24) % Long.fromInt(-5)).toEqual("0000000000000004")
-      expect(maxInt % billion).toEqual(                   "0000000008ca6bff")
-      expect((maxInt+one) % billion).toEqual(             "0000000008ca6c00")
-      expect(maxInt % Long.fromInt(-5)).toEqual(          "0000000000000002")
+      expect( fromInt(7)  % fromInt(15)).toEqual("0000000000000007")
+      expect( fromInt(24) % fromInt(5) ).toEqual("0000000000000004")
+      expect( fromInt(24) % fromInt(-5)).toEqual("0000000000000004")
+      expect(      maxInt % billion    ).toEqual("0000000008ca6bff")
+      expect((maxInt+one) % billion    ).toEqual("0000000008ca6c00")
+      expect(      maxInt % fromInt(-5)).toEqual("0000000000000002")
     }
 
     it("should correctly implement toString") {
       expect(maxInt.toString).toEqual("2147483647")
-      expect(Long.fromInt(-50).toString).toEqual("-50")
-      expect(Long.fromInt(-1000000000).toString).toEqual("-1000000000")
+      expect(fromInt(-50).toString).toEqual("-50")
+      expect(fromInt(-1000000000).toString).toEqual("-1000000000")
       expect((maxInt+one).toString).toEqual("2147483648")
       expect(minInt.toString).toEqual("-2147483648")
     }
 
     it("should correctly implement fromDouble") {
-      expect(Long.fromDouble(4.5)).toEqual( "0000000000000004")
-      expect(Long.fromDouble(-4.5)).toEqual("fffffffffffffffc")
+      expect(fromDouble( 4.5)).toEqual("0000000000000004")
+      expect(fromDouble(-4.5)).toEqual("fffffffffffffffc")
     }
 
     it("should correctly implement toDouble") {
-      expect(Long.fromInt(5).toDouble).toEqual(5.0)
+      expect(fromInt(5).toDouble).toEqual(5.0)
       expect((maxInt+one).toDouble).toEqual(2147483648.0)
     }
 
     it("should correctly implement fromString") {
-      expect(Long.fromString("4")).toEqual(         "0000000000000004")
-      expect(Long.fromString("-4")).toEqual(        "fffffffffffffffc")
-      expect(Long.fromString("4000000000")).toEqual("00000000ee6b2800")
-      expect(Long.fromString("-18014398509482040")).toEqual("ffbfffffffffffc8")
-      expect(Try(Long.fromString("asdf")).isFailure).toBeTruthy
+      expect(fromString("4")                 ).toEqual("0000000000000004")
+      expect(fromString("-4")                ).toEqual("fffffffffffffffc")
+      expect(fromString("4000000000")        ).toEqual("00000000ee6b2800")
+      expect(fromString("-18014398509482040")).toEqual("ffbfffffffffffc8")
+
+      expect(Try(fromString("asdf")).isFailure).toBeTruthy
     }
 
     it("should correctly implement numberOfLeadingZeros") {
-      expect(Long.fromInt(0).numberOfLeadingZeros).toEqual(64)
-      expect(Long.fromInt(1).numberOfLeadingZeros).toEqual(63)
-      expect(Long.fromInt(-1).numberOfLeadingZeros).toEqual(0)
-      expect(Long.fromInt(2).numberOfLeadingZeros).toEqual(62)
+      expect(fromInt( 0).numberOfLeadingZeros).toEqual(64)
+      expect(fromInt( 1).numberOfLeadingZeros).toEqual(63)
+      expect(fromInt(-1).numberOfLeadingZeros).toEqual(0)
+      expect(fromInt( 2).numberOfLeadingZeros).toEqual(62)
     }
 
   }

--- a/tools/src/main/scala/scala/scalajs/tools/optimizer/Analyzer.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/optimizer/Analyzer.scala
@@ -128,9 +128,9 @@ class Analyzer(logger0: Logger, allData: Seq[ClassInfoData]) {
 
     instantiateClassWith("java_lang_Class", "init___Lscala_scalajs_js_Dynamic")
 
-    val LongModule = lookupClass("scala_scalajs_runtime_Long$")
+    val LongModule = lookupClass("scala_scalajs_runtime_RuntimeLong$")
     LongModule.accessModule()
-    LongModule.callMethod("zero__Lscala_scalajs_runtime_Long")
+    LongModule.callMethod("zero__Lscala_scalajs_runtime_RuntimeLong")
 
     val BoxesRunTime = lookupClass("scala_runtime_BoxesRunTime$")
     BoxesRunTime.accessModule()


### PR DESCRIPTION
Let the PR avalanche begin!

This is similar to RuntimeString, and has the strong
advantage not to clash with, well, Long.
