### PR TITLE
Fix #365: Move js.Dict.propertiesOf to js.Object.properties.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -3015,10 +3015,6 @@ abstract class GenJSCode extends plugins.PluginComponent
               // js.Dictionary.delete(arg)
               js.BracketDelete(receiver, arg)
 
-            case DICT_PROPS =>
-              // js.Dictionary.propertiesOf(arg)
-              genCallHelper("propertiesOf", arg)
-
             case RTJ2J => arg
             case J2RTJ => arg
 
@@ -3028,6 +3024,10 @@ abstract class GenJSCode extends plugins.PluginComponent
             case TYPEOF =>
               // js.typeOf(arg)
               js.UnaryOp("typeof", arg)
+
+            case OBJPROPS =>
+              // js.Object.properties(arg)
+              genCallHelper("propertiesOf", arg)
           }
 
         case List(arg1, arg2) =>

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSDefinitions.scala
@@ -97,9 +97,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSNumberModule = JSNumberClass.companionModule
       lazy val JSNumber_toDouble = getMemberMethod(JSNumberModule, newTermName("toDouble"))
 
-    lazy val JSDictionaryModule = JSDictionaryClass.companionModule
-      lazy val JSDictionary_propertiesOf = getMemberMethod(JSDictionaryModule, newTermName("propertiesOf"))
-
     lazy val JSBooleanModule = JSBooleanClass.companionModule
       lazy val JSBoolean_toBoolean = getMemberMethod(JSBooleanModule, newTermName("toBoolean"))
 
@@ -108,6 +105,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
 
     lazy val JSObjectModule = JSObjectClass.companionModule
       lazy val JSObject_hasProperty = getMemberMethod(JSObjectModule, newTermName("hasProperty"))
+      lazy val JSObject_properties  = getMemberMethod(JSObjectModule, newTermName("properties"))
 
     lazy val JSArrayModule = JSArrayClass.companionModule
       lazy val JSArray_create = getMemberMethod(JSArrayModule, newTermName("apply"))

--- a/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/JSPrimitives.scala
@@ -52,7 +52,6 @@ abstract class JSPrimitives {
   val DYNLIT = 334    // js.Dynamic.literal.applyDynamic
 
   val DICT_DEL = 335   // js.Dictionary.delete
-  val DICT_PROPS = 336 // js.Dictionary.propertiesOf
 
   val ARR_CREATE = 337 // js.Array.apply (array literal syntax)
 
@@ -66,10 +65,11 @@ abstract class JSPrimitives {
   val TYPEOF = 343   // typeof x
   val DEBUGGER = 344 // js.debugger()
   val HASPROP = 345  // js.Object.hasProperty(o, p), equiv to `p in o` in JS
+  val OBJPROPS = 346 // js.Object.properties(o), equiv to `for (p in o)` in JS
 
-  val RETURNRECEIVER = 346 // anything "return this;", e.g., Boolean.booleanValue()
-  val UNITVAL = 347        // () value, which is undefined
-  val UNITTYPE = 348       // BoxedUnit.TYPE (== classOf[Unit])
+  val RETURNRECEIVER = 347 // anything "return this;", e.g., Boolean.booleanValue()
+  val UNITVAL = 348        // () value, which is undefined
+  val UNITTYPE = 349       // BoxedUnit.TYPE (== classOf[Unit])
 
   /** Initialize the map of primitive methods */
   def init() {
@@ -102,7 +102,6 @@ abstract class JSPrimitives {
     addPrimitive(JSDynamicLiteral_applyDynamic, DYNLIT)
 
     addPrimitive(JSDictionary_delete, DICT_DEL)
-    addPrimitive(JSDictionary_propertiesOf, DICT_PROPS)
 
     addPrimitive(JSArray_create, ARR_CREATE)
 
@@ -120,6 +119,7 @@ abstract class JSPrimitives {
     addPrimitive(JSPackage_isUndefined, ISUNDEF)
 
     addPrimitive(JSObject_hasProperty, HASPROP)
+    addPrimitive(JSObject_properties, OBJPROPS)
 
     addPrimitive(getMember(requiredClass[java.lang.Boolean],
         newTermName("booleanValue")), RETURNRECEIVER)

--- a/library/src/main/scala/scala/scalajs/js/Dictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dictionary.scala
@@ -48,5 +48,7 @@ object Dictionary {
   }
 
   /** Returns the names of all the enumerable properties of this object. */
-  def propertiesOf(obj: Any): Array[String] = sys.error("stub")
+  @deprecated("Use js.Object.properties(obj) instead", "0.5.0")
+  def propertiesOf(obj: Any): Array[String] =
+    Object.properties(obj.asInstanceOf[Object])
 }

--- a/library/src/main/scala/scala/scalajs/js/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/Primitives.scala
@@ -444,4 +444,9 @@ object Object extends Object {
    * MDN
    */
   def keys(o: Object): Array[String] = ???
+
+  /** Returns the names of all the enumerable properties of this object.
+   *  This is the equivalent of a for...in loop in JavaScript.
+   */
+  def properties(o: Object): Array[String] = sys.error("stub")
 }

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/DictionaryTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/DictionaryTest.scala
@@ -15,36 +15,6 @@ object DictionaryTest extends JasmineTest {
 
   describe("scala.scalajs.js.Dictionary") {
 
-    it("should provide equivalent of JS for-in loop of {} - #13") {
-      val obj = js.eval("var dictionaryTest13 = { a: 'Scala.js', b: 7357 }; dictionaryTest13;")
-      val dict = obj.asInstanceOf[js.Dictionary[js.Any]]
-      var propCount = 0
-      var propString = ""
-
-      for (prop <- js.Dictionary.propertiesOf(dict)) {
-        propCount += 1
-        propString += dict(prop)
-      }
-
-      expect(propCount).toEqual(2)
-      expect(propString).toEqual("Scala.js7357")
-    }
-
-    it("should provide equivalent of JS for-in loop of [] - #13") {
-      val obj = js.eval("var arrayTest13 = [ 7, 3, 5, 7 ]; arrayTest13;")
-      val array = obj.asInstanceOf[js.Dictionary[js.Any]]
-      var propCount = 0
-      var propString = ""
-
-      for (prop <- js.Dictionary.propertiesOf(array)) {
-        propCount += 1
-        propString += array(prop)
-      }
-
-      expect(propCount).toEqual(4)
-      expect(propString).toEqual("7357")
-    }
-
     it("should provide an equivalent of the JS delete keyword - #255") {
       val obj = js.Dictionary.empty[js.Any]
       obj("foo") = 42

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/MiscInteropTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/MiscInteropTest.scala
@@ -51,6 +51,36 @@ object MiscInteropTest extends JasmineTest {
       expect(hasProp(o(), p())).toBeTruthy
       expect(indicator).toEqual(14)
     }
+
+    it("should provide equivalent of JS for-in loop of {} - #13") {
+      val obj = js.eval("var dictionaryTest13 = { a: 'Scala.js', b: 7357 }; dictionaryTest13;")
+      val dict = obj.asInstanceOf[js.Dictionary[js.Any]]
+      var propCount = 0
+      var propString = ""
+
+      for (prop <- js.Object.properties(dict)) {
+        propCount += 1
+        propString += dict(prop)
+      }
+
+      expect(propCount).toEqual(2)
+      expect(propString).toEqual("Scala.js7357")
+    }
+
+    it("should provide equivalent of JS for-in loop of [] - #13") {
+      val obj = js.eval("var arrayTest13 = [ 7, 3, 5, 7 ]; arrayTest13;")
+      val array = obj.asInstanceOf[js.Dictionary[js.Any]]
+      var propCount = 0
+      var propString = ""
+
+      for (prop <- js.Object.properties(array)) {
+        propCount += 1
+        propString += array(prop)
+      }
+
+      expect(propCount).toEqual(4)
+      expect(propString).toEqual("7357")
+    }
   }
 
 }


### PR DESCRIPTION
The 'Of' suffix was removed to be consistent with
js.Object.keys() which is very similar.
