### PR TITLE
Fix #426: Cross-compile the compiler with full Scala version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ script:
   - if [ $KIND == sbtplugin ]; then sbt "${SBT_SETUP}" scalajs-tools/package scalajs-sbt-plugin/package; fi
 after_success:
   - if [[ "${PUBLISH_ENABLED}" == "true" && "${TRAVIS_PULL_REQUEST}" == "false" && "${KIND}" == "main" && "${PUBLISH_USER}" != "" && "${PUBLISH_PASS}" != "" ]]; then sbt "${SBT_SETUP}" ++$TRAVIS_SCALA_VERSION publish; fi
+  - if [[ "${PUBLISH_COMPILER}" == "true" && "${TRAVIS_PULL_REQUEST}" == "false" && "${KIND}" == "main" && "${PUBLISH_USER}" != "" && "${PUBLISH_PASS}" != "" ]]; then sbt "${SBT_SETUP}" ++$TRAVIS_SCALA_VERSION scalajs-compiler/publish; fi
   - if [[ "${PUBLISH_ENABLED}" == "true" && "${TRAVIS_PULL_REQUEST}" == "false" && "${KIND}" == "sbtplugin" && "${PUBLISH_USER}" != "" && "${PUBLISH_PASS}" != "" ]]; then sbt "${SBT_SETUP}" scalajs-tools/publish scalajs-sbt-plugin/publish; fi
 env:
   global:
@@ -28,10 +29,12 @@ matrix:
       scala: 2.10.3
       env:
         - KIND=main
+        - PUBLISH_COMPILER=true
     - jdk: openjdk6
       scala: 2.10.4
       env:
         - KIND=main
+        - PUBLISH_COMPILER=true
     - jdk: openjdk6
       scala: 2.11.0-M7
       env:

--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -126,6 +126,7 @@ object ScalaJSBuild extends Build {
       base = file("compiler"),
       settings = defaultSettings ++ publishSettings ++ Seq(
           name := "Scala.js compiler",
+          crossVersion := CrossVersion.full, // because compiler api is not binary compatible
           libraryDependencies ++= Seq(
               "org.scala-lang" % "scala-compiler" % scalaVersion.value,
               "org.scala-lang" % "scala-reflect" % scalaVersion.value,

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -363,7 +363,8 @@ object ScalaJSPlugin extends Plugin {
 
       // you will need the Scala.js compiler plugin
       autoCompilerPlugins := true,
-      addCompilerPlugin("org.scala-lang.modules.scalajs" %% "scalajs-compiler" % scalaJSVersion),
+      addCompilerPlugin(
+          "org.scala-lang.modules.scalajs" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.full),
 
       // and of course the Scala.js library
       libraryDependencies += "org.scala-lang.modules.scalajs" %% "scalajs-library" % scalaJSVersion


### PR DESCRIPTION
Because the Scala compiler API is not binary compatible between
minor versions, compiler plugins should be cross-compiled
against the full Scala version (not the binary Scala version).
