### PR TITLE
Fix #395: Sanitize boxing in JS interop.

### DIFF
--- a/compiler/src/test/scala/scala/scalajs/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/scala/scalajs/compiler/test/JSExportTest.scala
@@ -80,16 +80,16 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
     class Confl {
       @JSExport
-      def rtType(x: Short) = x
+      def rtType(x: Float) = x
 
       @JSExport
-      def rtType(x: Int) = x
+      def rtType(x: Double) = x
     }
     """ hasErrors
     """
       |newSource1.scala:7: error: Cannot disambiguate overloads for exported method $js$exported$meth$rtType with types
-      |  (x: Int)Object
-      |  (x: Short)Object
+      |  (x: Double)Object
+      |  (x: Float)Object
       |      @JSExport
       |       ^
     """
@@ -130,15 +130,15 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
     class Confl {
       @JSExport
-      def foo(x: Int, y: String)(z: Int = 1) = x
+      def foo(x: Float, y: String)(z: Int = 1) = x
       @JSExport
-      def foo(x: Short, y: String)(z: String*) = x
+      def foo(x: Double, y: String)(z: String*) = x
     }
     """ hasErrors
     """
       |newSource1.scala:4: error: Cannot disambiguate overloads for exported method $js$exported$meth$foo with types
-      |  (x: Int, y: String, z: Int)Object
-      |  (x: Short, y: String, z: Seq)Object
+      |  (x: Float, y: String, z: Int)Object
+      |  (x: Double, y: String, z: Seq)Object
       |      @JSExport
       |       ^
     """

--- a/library/src/main/scala/scala/scalajs/runtime/JSArraySeq.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/JSArraySeq.scala
@@ -5,16 +5,15 @@ import scala.scalajs.js
 /** A simple wrapper Seq for a native JS array. Is used by JSExports
   * for repeated parameter lists. The map function is used for boxing
   */
-class JSArraySeq[A,B](
+class JSArraySeq[A](
   private val arr: js.Array[A],
-  private val offset: Int,
-  private val map: js.Function1[A,B]) extends Seq[B] {
+  private val offset: Int) extends Seq[A] {
 
-  def apply(i: Int): B = map(arr(i+offset))
-  def iterator: Iterator[B] = new JSArraySeqIterator
+  def apply(i: Int): A = arr(i+offset)
+  def iterator: Iterator[A] = new JSArraySeqIterator
   def length: Int = (arr.length - offset).toInt
 
-  class JSArraySeqIterator extends Iterator[B] {
+  class JSArraySeqIterator extends Iterator[A] {
     private[this] var nextIndex: Int = 0
     def next() = {
       val elem = JSArraySeq.this.apply(nextIndex)

--- a/test/src/test/scala/scala/scalajs/test/utils/JSUtils.scala
+++ b/test/src/test/scala/scala/scalajs/test/utils/JSUtils.scala
@@ -1,0 +1,26 @@
+package scala.scalajs.test.utils
+
+import scala.scalajs.js
+import js.annotation.JSExport
+
+@JSExport
+object JSUtils {
+  /* We use java.lang.Character explicitly, because this class is used by
+   * tests that check that Chars are actually boxed by the compiler.
+   * If we rely on the compiler doing the job in here, we might have false
+   * positives just because the value was never boxed, and never unboxed.
+   */
+
+  @JSExport
+  def isChar(c: Any): Boolean = c.isInstanceOf[java.lang.Character]
+
+  @JSExport
+  def stringToChar(s: String): java.lang.Character = {
+    assert(s.length == 1, "makeChar() requires a string of length 1")
+    new java.lang.Character(s.charAt(0))
+  }
+
+  @JSExport
+  def charToString(c: Any): String =
+    c.asInstanceOf[java.lang.Character].toString()
+}


### PR DESCRIPTION
Until now, the way boxing has been handled in JS interop has
been implementation-driven (least effort), giving un-spec'able
semantics. This commit fixes this by giving the following simple
semantics to Scala data types seen from JavaScript code
(in all circumstances):

```
+---------------------------------+------------------+
| Scala types                     | JavaScript types |
+---------------------------------+------------------+
| Boolean                         | boolean          |
| Byte, Short, Int, Float, Double | number           |
| String                          | string           |
| Unit (value `()`)               | undefined        |
| Null (value `null`)             | null             |
+---------------------------------+------------------+
```

(the canonical Scala type for JS number being Double.)

All types inheriting from js.Any are, of course, themselves,
from JavaScript's point of view.

All other types (including Char, Long, and value classes) are
opaque data types that cannot be manipulated from JavaScript,
other than calling toString() and accessing @JSExport'ed members.

From an implementation point of view, these semantics boil down
to a dead simple rule: everything is always boxed in JavaScript.
