### PR TITLE
Refactor hierarchy of virtual files to VirtualTextFiles.

### DIFF
--- a/tools/src/main/scala/scala/scalajs/tools/classpath/ClasspathBuilder.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/classpath/ClasspathBuilder.scala
@@ -12,7 +12,7 @@ import scala.annotation.tailrec
 private[classpath] class ClasspathBuilder {
 
   private var coreJSLibFile: Option[VirtualJSFile] = None
-  private val coreInfoFiles = mutable.ListBuffer.empty[VirtualFile]
+  private val coreInfoFiles = mutable.ListBuffer.empty[VirtualTextFile]
   private val classFiles = mutable.Map.empty[String, VirtualScalaJSClassfile]
   private val packFiles = mutable.Map.empty[String, VirtualScalaJSPackfile]
   private val otherJSFiles = mutable.Map.empty[String, VirtualJSFile]
@@ -23,7 +23,7 @@ private[classpath] class ClasspathBuilder {
     coreJSLibFile = Some(file)
   }
 
-  def addCoreInfoFile(file: VirtualFile): Unit = {
+  def addCoreInfoFile(file: VirtualTextFile): Unit = {
     coreInfoFiles += file
   }
 
@@ -225,7 +225,7 @@ private[classpath] class ClasspathBuilder {
 
           case "javalangObject.sjsinfo" | "javalangString.sjsinfo" =>
             addCoreInfoFile(
-                new MemVirtualFile(fullPath)
+                new MemVirtualTextFile(fullPath)
                   .withContent(entryContent)
                   .withVersion(entryVersion))
 

--- a/tools/src/main/scala/scala/scalajs/tools/classpath/ScalaJSClasspath.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/classpath/ScalaJSClasspath.scala
@@ -14,7 +14,7 @@ import scala.scalajs.tools.io._
 
 final case class ScalaJSClasspath(
     coreJSLibFile: VirtualJSFile,
-    coreInfoFiles: Seq[VirtualFile],
+    coreInfoFiles: Seq[VirtualTextFile],
     /** note that the class files are unordered
      *  use mainJSFiles for ordered class files
      */

--- a/tools/src/main/scala/scala/scalajs/tools/io/FileVirtualWriters.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/io/FileVirtualWriters.scala
@@ -2,7 +2,7 @@ package scala.scalajs.tools.io
 
 import java.io._
 
-class FileVirtualFileWriter(val file: File) extends VirtualFileWriter {
+class FileVirtualTextFileWriter(val file: File) extends VirtualTextFileWriter {
 
   private[this] var _contentWriter: Writer = null
 
@@ -19,7 +19,7 @@ class FileVirtualFileWriter(val file: File) extends VirtualFileWriter {
 
 }
 
-class FileVirtualJSFileWriter(f: File) extends FileVirtualFileWriter(f)
+class FileVirtualJSFileWriter(f: File) extends FileVirtualTextFileWriter(f)
                                           with VirtualJSFileWriter {
 
   import FileVirtualFile.withExtension

--- a/tools/src/main/scala/scala/scalajs/tools/io/MemFiles.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/io/MemFiles.scala
@@ -9,18 +9,9 @@
 
 package scala.scalajs.tools.io
 
-/** A simple in-memory mutable virtual file. */
+/** A base class for simple in-memory mutable virtual files. */
 class MemVirtualFile(val path: String) extends VirtualFile {
-  private[this] var _content: String = ""
   private[this] var _version: Option[Any] = None
-
-  override def content: String = _content
-  def content_=(v: String): Unit = _content = v
-
-  final def withContent(v: String): this.type = {
-    content = v
-    this
-  }
 
   override def version: Option[Any] = _version
   def version_=(v: Option[Any]): Unit = _version = v
@@ -31,8 +22,23 @@ class MemVirtualFile(val path: String) extends VirtualFile {
   }
 }
 
+/** A simple in-memory mutable virtual text file. */
+class MemVirtualTextFile(p: String) extends MemVirtualFile(p)
+                                       with VirtualTextFile {
+  private[this] var _content: String = ""
+
+  override def content: String = _content
+  def content_=(v: String): Unit = _content = v
+
+  final def withContent(v: String): this.type = {
+    content = v
+    this
+  }
+}
+
 /** A simple in-memory mutable virtual JS file. */
-class MemVirtualJSFile(p: String) extends MemVirtualFile(p) with VirtualJSFile {
+class MemVirtualJSFile(p: String) extends MemVirtualTextFile(p)
+                                     with VirtualJSFile {
   private[this] var _sourceMap: Option[String] = None
 
   override def sourceMap: Option[String] = _sourceMap

--- a/tools/src/main/scala/scala/scalajs/tools/io/MemVirtualWriters.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/io/MemVirtualWriters.scala
@@ -2,21 +2,21 @@ package scala.scalajs.tools.io
 
 import java.io.StringWriter
 
-class MemVirtualFileWriter extends VirtualFileWriter {
+class MemVirtualTextFileWriter extends VirtualTextFileWriter {
   val contentWriter = new StringWriter
 
-  def toVirtualFile(name: String): MemVirtualFile =
-    addToFile(new MemVirtualFile(name))
+  def toVirtualFile(name: String): MemVirtualTextFile =
+    addToFile(new MemVirtualTextFile(name))
 
   def close() = {
     contentWriter.close()
   }
 
-  protected def addToFile(vf: MemVirtualFile): vf.type =
+  protected def addToFile(vf: MemVirtualTextFile): vf.type =
     vf.withContent(contentWriter.toString)
 }
 
-class MemVirtualJSFileWriter extends MemVirtualFileWriter
+class MemVirtualJSFileWriter extends MemVirtualTextFileWriter
                                 with VirtualJSFileWriter {
 
   private var sourceMapUsed = false

--- a/tools/src/main/scala/scala/scalajs/tools/io/VirtualFiles.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/io/VirtualFiles.scala
@@ -16,17 +16,6 @@ trait VirtualFile {
     else path.substring(pos + 1)
   }
 
-  /** Returns the content of the file. */
-  def content: String
-
-  /** Returns a new Reader of the file. */
-  def reader: Reader = new StringReader(content)
-
-  /** Returns the lines in the content.
-   *  Lines do not contain the new line characters.
-   */
-  def readLines(): List[String] = IO.readLines(reader)
-
   /** Optionally returns an implementation-dependent "version" token.
    *  Versions are compared with ==.
    *  If non-empty, a different version must be returned when the content
@@ -38,15 +27,30 @@ trait VirtualFile {
   def version: Option[Any] = None
 }
 
-object VirtualFile {
-  def empty(path: String): VirtualFile =
-    new MemVirtualFile(path).withVersion(Some(path))
+/** A virtual input file.
+ */
+trait VirtualTextFile extends VirtualFile {
+  /** Returns the content of the file. */
+  def content: String
+
+  /** Returns a new Reader of the file. */
+  def reader: Reader = new StringReader(content)
+
+  /** Returns the lines in the content.
+   *  Lines do not contain the new line characters.
+   */
+  def readLines(): List[String] = IO.readLines(reader)
+}
+
+object VirtualTextFile {
+  def empty(path: String): VirtualTextFile =
+    new MemVirtualTextFile(path)
 }
 
 /** A virtual input file which contains JavaScript code.
  *  It may have a source map associated with it.
  */
-trait VirtualJSFile extends VirtualFile {
+trait VirtualJSFile extends VirtualTextFile {
   /** Optionally, content of the source map file associated with this
    *  JavaScript source.
    */

--- a/tools/src/main/scala/scala/scalajs/tools/io/VirtualWriters.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/io/VirtualWriters.scala
@@ -2,11 +2,11 @@ package scala.scalajs.tools.io
 
 import java.io.Writer
 
-trait VirtualFileWriter {
+trait VirtualTextFileWriter {
   def contentWriter: Writer
 }
 
-trait VirtualJSFileWriter extends VirtualFileWriter {
+trait VirtualJSFileWriter extends VirtualTextFileWriter {
   def sourceMapWriter: Writer
 }
 


### PR DESCRIPTION
The current virtual files are implicitly text files, but
eventually we will need to also represent virtual binary
files. This commit refactors the hierarchy to separate
VirtualTextFile (text) from VirtualFile (agnostic). This
refactoring will allow the later introduction of binary
files as VirtualBinaryFiles.
