### PR TITLE
Add hints for the (future) optimizer in method info.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/ClassInfos.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/ClassInfos.scala
@@ -64,6 +64,7 @@ trait ClassInfos extends SubComponent { self: GenJSCode =>
     val instantiatedClasses = mutable.Set.empty[String]
     val accessedModules = mutable.Set.empty[String]
     val accessedClassData = mutable.Set.empty[String]
+    var optimizerHints: OptimizerHints = OptimizerHints.empty
 
     def callsMethod(ownerIdent: js.Ident, method: js.Ident): Unit =
       calledMethods += ((patchClassName(ownerIdent.name), method.name))
@@ -113,7 +114,8 @@ trait ClassInfos extends SubComponent { self: GenJSCode =>
           calledMethodsStatic.toList.groupBy(_._1).mapValues(_.map(_._2)),
           instantiatedClasses.toList,
           accessedModules.result.toList,
-          accessedClassData.result.toList
+          accessedClassData.result.toList,
+          optimizerHints
       )
     }
   }

--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -543,6 +543,11 @@ abstract class GenJSCode extends plugins.PluginComponent
           withScopedVars(
               currentMethodInfoBuilder := createInfoBuilder()
           ) {
+            currentMethodInfoBuilder.optimizerHints =
+              currentMethodInfoBuilder.optimizerHints.copy(
+                  isAccessor = sym.isAccessor,
+                  hasInlineAnnot = sym.hasAnnotation(InlineAnnotationClass))
+
             val jsParams = for (param <- params) yield {
               implicit val pos = param.pos
               js.ParamDef(encodeLocalSym(param, freshName),
@@ -3732,6 +3737,8 @@ abstract class GenJSCode extends plugins.PluginComponent
 
   protected lazy val isHijackedBoxedClass: Set[Symbol] =
     HijackedBoxedClasses.toSet
+
+  private lazy val InlineAnnotationClass = requiredClass[scala.inline]
 
   private def isMaybeJavaScriptException(tpe: Type) =
     JavaScriptExceptionClass isSubClass tpe.typeSymbol

--- a/ir/src/main/scala/scala/scalajs/ir/InfoSerializers.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/InfoSerializers.scala
@@ -61,6 +61,7 @@ object InfoSerializers {
         writeStrings(instantiatedClasses)
         writeStrings(accessedModules)
         writeStrings(accessedClassData)
+        s.writeInt(optimizerHints.bits)
       }
 
       writeSeq(methods)(writeMethodInfo(_))
@@ -107,9 +108,11 @@ object InfoSerializers {
         val instantiatedClasses = readStrings()
         val accessedModules = readStrings()
         val accessedClassData = readStrings()
+        val optimizerHints = new OptimizerHints(readInt())
         MethodInfo(encodedName, isAbstract, isExported,
             calledMethods, calledMethodsStatic,
-            instantiatedClasses, accessedModules, accessedClassData)
+            instantiatedClasses, accessedModules, accessedClassData,
+            optimizerHints)
       }
 
       val methods = readList(readMethod())

--- a/ir/src/main/scala/scala/scalajs/ir/Infos.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/Infos.scala
@@ -59,7 +59,8 @@ object Infos {
       val calledMethodsStatic: Map[String, List[String]],
       val instantiatedClasses: List[String],
       val accessedModules: List[String],
-      val accessedClassData: List[String]
+      val accessedClassData: List[String],
+      val optimizerHints: OptimizerHints
   )
 
   object MethodInfo {
@@ -71,11 +72,45 @@ object Infos {
         calledMethodsStatic: Map[String, List[String]] = Map.empty,
         instantiatedClasses: List[String] = Nil,
         accessedModules: List[String] = Nil,
-        accessedClassData: List[String] = Nil): MethodInfo = {
+        accessedClassData: List[String] = Nil,
+        optimizerHints: OptimizerHints = OptimizerHints.empty): MethodInfo = {
       new MethodInfo(encodedName, isAbstract, isExported, calledMethods,
           calledMethodsStatic, instantiatedClasses, accessedModules,
-          accessedClassData)
+          accessedClassData, optimizerHints)
     }
+  }
+
+  final class OptimizerHints(val bits: Int) extends AnyVal {
+    import OptimizerHints._
+
+    private[scalajs] def isAccessor: Boolean = (bits & AccessorMask) != 0
+    private[scalajs] def hasInlineAnnot: Boolean = (bits & InlineAnnotMask) != 0
+
+    private[scalajs] def copy(
+        isAccessor: Boolean = this.isAccessor,
+        hasInlineAnnot: Boolean = this.hasInlineAnnot
+    ): OptimizerHints = {
+      var bits: Int = 0
+      if (isAccessor)
+        bits |= AccessorMask
+      if (hasInlineAnnot)
+        bits |= InlineAnnotMask
+      new OptimizerHints(bits)
+    }
+
+    override def toString(): String =
+      s"OptimizerHints($bits)"
+  }
+
+  object OptimizerHints {
+    private final val AccessorShift = 0
+    private final val AccessorMask = 1 << AccessorShift
+
+    private final val InlineAnnotShift = 1
+    private final val InlineAnnotMask = 1 << InlineAnnotShift
+
+    final val empty: OptimizerHints =
+      new OptimizerHints(0)
   }
 
 }

--- a/ir/src/main/scala/scala/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/Printers.scala
@@ -621,6 +621,8 @@ object Printers {
         println("accessedClassData: ",
             accessedClassData.map(escapeJS).mkString("[", ", ", "]"))
       }
+      if (optimizerHints != OptimizerHints.empty)
+        println("optimizerHints: ", optimizerHints)
 
       undent(); println()
     }


### PR DESCRIPTION
The hints are:
- whether the method is an accessor (getter or setter)
- whether it has the @inline annotation

These information are currently unused, but the (future) inlining
optimizer might use them as heuristics. Since this is a binary
incompatible change, it had better be added now.
