### PR TITLE
Fix #543: Incremental optimizer would never really invalidate.

### DIFF
--- a/tools/src/main/scala/scala/scalajs/tools/optimizer/ScalaJSOptimizer.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/optimizer/ScalaJSOptimizer.scala
@@ -281,6 +281,7 @@ object ScalaJSOptimizer {
       } else {
         version = irFile.version
         _info = irFile.info
+        _tree = null
         _desugared = null
         false
       }


### PR DESCRIPTION
When the file changes, the dce would invalidate its info and
its desugared version, but not its tree. So it would recompute
the desugared version from ... the old tree.
