### PR TITLE
Fix #360: Add a cross-building discipline.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSCrossVersion.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSCrossVersion.scala
@@ -1,0 +1,42 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.sbtplugin
+
+import sbt._
+
+import ScalaJSPlugin.scalaJSBinaryVersion
+
+object ScalaJSCrossVersion {
+  private val scalaJSVersionUnmapped: String => String =
+    _ => s"sjs$scalaJSBinaryVersion"
+
+  private val scalaJSVersionMap: String => String =
+    version => s"sjs${scalaJSBinaryVersion}_$version"
+
+  private final val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
+
+  def binaryScalaJSVersion(full: String): String = full match {
+    case ReleaseVersion(major, minor, release) => "$major.$minor"
+    case _                                     => full
+  }
+
+  def scalaJSMapped(cross: CrossVersion): CrossVersion = cross match {
+    case CrossVersion.Disabled =>
+      CrossVersion.binaryMapped(scalaJSVersionUnmapped)
+    case cross: CrossVersion.Binary =>
+      CrossVersion.binaryMapped(cross.remapVersion andThen scalaJSVersionMap)
+    case cross: CrossVersion.Full =>
+      CrossVersion.fullMapped(cross.remapVersion andThen scalaJSVersionMap)
+  }
+
+  def binary: CrossVersion = scalaJSMapped(CrossVersion.binary)
+
+  def full: CrossVersion = scalaJSMapped(CrossVersion.full)
+}

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -26,10 +26,12 @@ import scala.scalajs.sbtplugin.env.nodejs.NodeJSEnv
 
 import scala.scalajs.sbtplugin.testing.TestFramework
 
-object ScalaJSPlugin extends Plugin {
+object ScalaJSPlugin extends Plugin with impl.DependencyBuilders {
   val scalaJSVersion = "0.5.0-SNAPSHOT"
   val scalaJSIsSnapshotVersion = scalaJSVersion endsWith "-SNAPSHOT"
   val scalaJSScalaVersion = "2.11.0"
+  val scalaJSBinaryVersion =
+    ScalaJSCrossVersion.binaryScalaJSVersion(scalaJSVersion)
 
   object ScalaJSKeys {
     val packageJS = taskKey[Seq[File]](
@@ -469,6 +471,9 @@ object ScalaJSPlugin extends Plugin {
           "org.scala-lang.modules.scalajs" % "scalajs-compiler" % scalaJSVersion cross CrossVersion.full),
 
       // and of course the Scala.js library
-      libraryDependencies += "org.scala-lang.modules.scalajs" %% "scalajs-library" % scalaJSVersion
+      libraryDependencies += "org.scala-lang.modules.scalajs" %% "scalajs-library" % scalaJSVersion,
+
+      // and you will want to be cross-compiled on the Scala.js binary version
+      crossVersion := ScalaJSCrossVersion.binary
   )
 }

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/impl/DependencyBuilders.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/impl/DependencyBuilders.scala
@@ -1,0 +1,39 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.sbtplugin
+package impl
+
+import scala.language.implicitConversions
+
+import sbt._
+
+import StringUtilities.nonEmpty
+
+trait DependencyBuilders {
+  final implicit def toScalaJSGroupID(groupID: String): ScalaJSGroupID = {
+    nonEmpty(groupID, "Group ID")
+    new ScalaJSGroupID(groupID)
+  }
+}
+
+final class ScalaJSGroupID private[sbtplugin] (groupID: String) {
+  def %%%(artifactID: String): ScalaJSGroupArtifactID = {
+    nonEmpty(artifactID, "Artifact ID")
+    new ScalaJSGroupArtifactID(groupID, artifactID, ScalaJSCrossVersion.binary)
+  }
+}
+
+final class ScalaJSGroupArtifactID private[sbtplugin] (groupID: String,
+    artifactID: String, crossVersion: CrossVersion) {
+  def %(revision: String): ModuleID = {
+    nonEmpty(revision, "Revision")
+    ModuleID(groupID, artifactID, revision).cross(crossVersion)
+  }
+}


### PR DESCRIPTION
The discipline is to have a double binary version suffix for
Scala.js libraries: `_sjs<Scala.js-bin-ver>_<Scala-bin-ver>`.
For example, when building a library for Scala 2.11.0 and
Scala.js 0.5.0, the suffix will be `_sjs0.5_2.11`.

This commit adds the utilities to build CrossVersions that
follow this discipline, as well as an additional dependency
builder `%%%` which adds the double binary version suffix to
the module ID. Finally, it configures Scala.js projects to
be published with the double binary version suffix by default.

Note that the scalajs-library and scalajs-jasmine-test-framework
are only published with the Scala binary version, since their
release number is already tight to a Scala.js version. So they
should be added with `%%` and not `%%%`.
