### PR TITLE
Fix #622: (x: Long) << (y: Int) generates invalid code.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -2011,6 +2011,13 @@ abstract class GenJSCode extends plugins.PluginComponent
           val rtree = toLong(rsrc, args(1).tpe)
           val rtLongTpe = RuntimeLongClass.tpe
 
+          def genShift(methodName: String): js.Tree = {
+            val rtree =
+              if (isLongType(args(1).tpe)) genLongCall(rsrc, "toInt")
+              else rsrc
+            genOlLongCall(ltree, methodName, rtree)(IntTpe)
+          }
+
           code match {
             case ADD => genOlLongCall(ltree, "+",   rtree)(rtLongTpe)
             case SUB => genOlLongCall(ltree, "-",   rtree)(rtLongTpe)
@@ -2020,15 +2027,15 @@ abstract class GenJSCode extends plugins.PluginComponent
             case OR  => genOlLongCall(ltree, "|",   rtree)(rtLongTpe)
             case XOR => genOlLongCall(ltree, "^",   rtree)(rtLongTpe)
             case AND => genOlLongCall(ltree, "&",   rtree)(rtLongTpe)
-            case LSL => genOlLongCall(ltree, "<<",  rtree)(IntTpe)
-            case LSR => genOlLongCall(ltree, ">>>", rtree)(IntTpe)
-            case ASR => genOlLongCall(ltree, ">>",  rtree)(IntTpe)
             case LT  => genOlLongCall(ltree, "<",   rtree)(rtLongTpe)
             case LE  => genOlLongCall(ltree, "<=",  rtree)(rtLongTpe)
             case GT  => genOlLongCall(ltree, ">",   rtree)(rtLongTpe)
             case GE  => genOlLongCall(ltree, ">=",  rtree)(rtLongTpe)
             case EQ  => genLongCall  (ltree, "equals", rtree)
             case NE  => genLongCall  (ltree, "notEquals", rtree)
+            case LSL => genShift("<<")
+            case LSR => genShift(">>>")
+            case ASR => genShift(">>")
             case _ =>
               abort("Unknown binary operation code: " + code)
           }

--- a/test/src/test/scala/scala/scalajs/test/compiler/LongTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/LongTest.scala
@@ -41,6 +41,27 @@ object LongTest extends JasmineTest {
       expect(5F * 4L == 20F).toBeTruthy
     }
 
+    it("should support shifts with Longs - #622") {
+      def l(x: Long): Long = x
+      def i(x: Int): Int = x
+
+      expect(l(-7L) >>> 100L == 268435455L).toBeTruthy
+      expect(l(-7L) >> 100L == -1L).toBeTruthy
+      expect(l(-7L) >> 100 == -1L).toBeTruthy
+      expect(l(-7L) >>> 100 == 268435455).toBeTruthy
+      expect(l(-7L) << 100L == -481036337152L).toBeTruthy
+      expect(l(-7L) << 100 == -481036337152L).toBeTruthy
+      expect(l(7L) << 100L == 481036337152L).toBeTruthy
+      expect(l(8L) << 100L == 549755813888L).toBeTruthy
+      expect(l(-7L) >>> 4 == 1152921504606846975L).toBeTruthy
+
+      expect(i(7) << 100).toEqual(112)
+      expect(i(-7) >> 100).toEqual(-1)
+      expect(i(-7) >>> 100).toEqual(268435455)
+      expect(i(-65) >> 100).toEqual(-5)
+      expect(i(-65) >> 4).toEqual(-5)
+    }
+
     it("primitives should convert to Long") {
       // Byte
       expect(112.toByte.toLong == 112L).toBeTruthy


### PR DESCRIPTION
(also >>> and >>)
