### PR TITLE
Fix most warnings in the compiler.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/Compat210Component.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/Compat210Component.scala
@@ -23,6 +23,8 @@ trait Compat210Component {
   implicit final class SymbolCompat(self: Symbol) {
     def unexpandedName: Name = self.originalName
     def originalName: Name = sys.error("infinite loop in Compat")
+
+    def isLocalToBlock: Boolean = self.isLocal
   }
 
   // enteringPhase/exitingPhase replace beforePhase/afterPhase

--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSCode.scala
@@ -954,7 +954,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
         case Ident(name) =>
           val sym = tree.symbol
-          if (!sym.isPackage) {
+          if (!sym.hasPackageFlag) {
             if (sym.isModule) {
               assert(!sym.isPackageClass, "Cannot use package as value: " + tree)
               genLoadModule(sym)

--- a/compiler/src/main/scala/scala/scalajs/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/PrepJSExports.scala
@@ -7,6 +7,8 @@ package scala.scalajs.compiler
 
 import scala.annotation.tailrec
 
+import scala.tools.nsc.NoPhase
+
 /**
  *  Prepare export generation
  *
@@ -47,10 +49,11 @@ trait PrepJSExports { this: PrepJSInterop =>
     else if (hasIllegalDefaultParam(baseSym))
       err(s"In an exported $memType, all parameters with defaults " +
         "must be at the end")
-    else if (forScaladoc) {
-      /* Don't do anything under scaladoc because the uncurry phase does not
-       * exist in that setting (see bug #323). It's no big deal because we do
-       * not need exports for scaladoc
+    else if (currentRun.uncurryPhase == NoPhase) {
+      /* When using scaladoc, the uncurry phase does not exist. This makes
+       * our code down below blow up (see bug #323). So we do not do anything
+       * more here if the phase does not exist. It's no big deal because we do
+       * not need exports for scaladoc.
        */
       Nil
     } else if (baseSym.isConstructor) {
@@ -60,7 +63,7 @@ trait PrepJSExports { this: PrepJSInterop =>
 
       if (!clsSym.isPublic)
         err("You may not export a non-public class")
-      else if (clsSym.isLocal)
+      else if (clsSym.isLocalToBlock)
         err("You may not export a local class")
       else if (clsSym.isNestedClass)
         err("You may not export a nested class. Create an exported factory " +


### PR DESCRIPTION
Two deprecations warnings remain, but they are confined in
Compat210Component.

We also still have the "cannot check for unreachability"
warnings. I wish we could disable those.
