### PR TITLE
Refactor TypeKinds, and translate Unit as NoType.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/GenJSExports.scala
@@ -504,14 +504,14 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
 
       case _ =>
         (toTypeKind(tpe): @unchecked) match {
-          case UndefinedKind => TypeOfTypeTest("undefined")
-          case BooleanKind   => TypeOfTypeTest("boolean")
-          case CharKind      => InstanceOfTypeTest(boxedClass(CharClass).tpe)
-          case ByteKind      => HelperTypeTest("isByte", 0)
-          case ShortKind     => HelperTypeTest("isShort", 1)
-          case IntKind       => HelperTypeTest("isInt", 2)
-          case LongKind      => InstanceOfTypeTest(RuntimeLongClass.tpe)
-          case _:FLOAT       => TypeOfTypeTest("number")
+          case VoidKind    => TypeOfTypeTest("undefined")
+          case BooleanKind => TypeOfTypeTest("boolean")
+          case CharKind    => InstanceOfTypeTest(boxedClass(CharClass).tpe)
+          case ByteKind    => HelperTypeTest("isByte", 0)
+          case ShortKind   => HelperTypeTest("isShort", 1)
+          case IntKind     => HelperTypeTest("isInt", 2)
+          case LongKind    => InstanceOfTypeTest(RuntimeLongClass.tpe)
+          case _:DOUBLE    => TypeOfTypeTest("number")
 
           case REFERENCE(cls) =>
             if (cls == StringClass) TypeOfTypeTest("string")

--- a/ir/src/main/scala/scala/scalajs/ir/JSDesugaring.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/JSDesugaring.scala
@@ -335,7 +335,7 @@ object JSDesugaring {
         "isByte", "isShort", "isInt",
         "asUnit", "asBoolean", "asByte", "asShort", "asInt",
         "asFloat", "asDouble",
-        "bC", "uV", "uZ", "uC", "uB", "uS", "uI", "uJ", "uF", "uD",
+        "bC", "uZ", "uC", "uB", "uS", "uI", "uJ", "uF", "uD",
         "imul"
     )
 
@@ -854,7 +854,11 @@ object JSDesugaring {
           transformExpr(expr)
 
         case Function(thisType, params, resultType, body) =>
-          Function(DynType, params.map(eraseParamType), DynType, transformStat(body))
+          val newBody = transformStat(body) match {
+            case Block(stats :+ Return(Undefined(), None)) => Block(stats)
+            case newBody                                   => newBody
+          }
+          Function(DynType, params.map(eraseParamType), DynType, newBody)
 
         case _ =>
           super.transformExpr(tree)

--- a/tools/src/main/resources/scala/scalajs/tools/corelib/scalajsenv.js
+++ b/tools/src/main/resources/scala/scalajs/tools/corelib/scalajsenv.js
@@ -422,9 +422,6 @@ var ScalaJS = {
 
   // Unboxes - inline all the way through obj.xValue()
 
-  uV: function(value) {
-    return undefined;
-  },
   uZ: function(value) {
     return null === value ? false : ScalaJS.asBoolean(value);
   },


### PR DESCRIPTION
This is a long overdue refactoring and cleanup of TypeKinds.
They are now really the minimal bridge between scalac Types
and IR Types, in the sense that they adopt the structure of
IR types, but still keep a reference to the scalac Symbols.

At the same time, we have fundamentally changed the meaning
of scala.Unit when translating to the IR. It used to be
translated as UndefType, hence with an actual value which
was `undefined`. Now, it is translated as NoType, which
means that there is _no_ value of type Unit at runtime. It
effectively means _void_. In the IR, trees of type NoType
can never appear in expression position.
