### PR TITLE
Fix #681: Make js.Dictionary.delete return Unit

### DIFF
--- a/ir/src/main/scala/scala/scalajs/ir/JSDesugaring.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/JSDesugaring.scala
@@ -229,6 +229,11 @@ object JSDesugaring {
         case Debugger() =>
           tree
 
+        case JSDelete(obj, prop) =>
+          unnest(obj, prop) { (newObj, newProp) =>
+            JSDelete(newObj, newProp)
+          }
+
         // Treat 'return' as an LHS
 
         case Return(expr, label) =>
@@ -685,11 +690,6 @@ object JSDesugaring {
             redo(JSApply(newFun, newArgs))
           }
 
-        case JSDelete(obj, prop) =>
-          unnest(obj, prop) { (newObj, newProp) =>
-            redo(JSDelete(newObj, newProp))
-          }
-
         case JSDotSelect(qualifier, item) =>
           unnest(qualifier) { newQualifier =>
             redo(JSDotSelect(newQualifier, item))
@@ -756,8 +756,8 @@ object JSDesugaring {
              */
             rhs match {
               case _:Skip | _:VarDef | _:Assign | _:While | _:DoWhile |
-                  _:Switch | _:Debugger | _:DocComment | _:StoreModule |
-                  _:ClassDef =>
+                  _:Switch | _:Debugger | _:JSDelete | _:DocComment |
+                  _:StoreModule | _:ClassDef =>
                 transformStat(rhs)
               case _ =>
                 sys.error("Illegal tree in JSDesugar.pushLhsInto():\n" +

--- a/ir/src/main/scala/scala/scalajs/ir/Transformers.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/Transformers.scala
@@ -260,9 +260,6 @@ object Transformers {
         case JSApply(fun, args) =>
           JSApply(transformExpr(fun), args map transformExpr)
 
-        case JSDelete(obj, prop) =>
-          JSDelete(transformExpr(obj), transformExpr(prop))
-
         case JSUnaryOp(op, lhs) =>
           JSUnaryOp(op, transformExpr(lhs))
 

--- a/ir/src/main/scala/scala/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/Trees.scala
@@ -367,7 +367,7 @@ object Trees {
   }
 
   case class JSDelete(obj: Tree, prop: Tree)(implicit val pos: Position) extends Tree {
-    val tpe = BooleanType
+    val tpe = NoType
   }
 
   /** Unary operation (always preserves pureness). */

--- a/library/src/main/scala/scala/scalajs/js/Dictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dictionary.scala
@@ -29,10 +29,11 @@ sealed trait Dictionary[A] extends Object {
   /** Deletes a property of this object by its name.
    *  The property must be configurable.
    *  This method is equivalent to the "delete" keyword in JavaScript.
-   *  @return true on success (the property did not exist or was configurable),
-   *          false otherwise
+   *
+   *  Since we are using strict mode, this throws an exception, if the property
+   *  isn't configurable.
    */
-  def delete(key: String): Boolean = sys.error("stub")
+  def delete(key: String): Unit = sys.error("stub")
 }
 
 /** Factory for [[Dictionary]] instances. */

--- a/test/src/test/scala/scala/scalajs/test/jsinterop/DictionaryTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/jsinterop/DictionaryTest.scala
@@ -22,7 +22,7 @@ object DictionaryTest extends JasmineTest {
 
       expect(obj("foo")).toEqual(42)
       expect(obj("bar")).toEqual("foobar")
-      expect(obj.delete("foo")).toBeTruthy
+      obj.delete("foo")
       expect(obj("foo")).toBeUndefined
       expect(obj.asInstanceOf[js.Object].hasOwnProperty("foo")).toBeFalsy
       expect(obj("bar")).toEqual("foobar")

--- a/tools/src/main/scala/scala/scalajs/tools/optimizer/IRChecker.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/optimizer/IRChecker.scala
@@ -232,6 +232,11 @@ class IRChecker(analyzer: Analyzer, allClassDefs: Seq[ClassDef], logger: Logger)
       case Debugger() =>
         env
 
+      case JSDelete(obj, prop) =>
+        typecheckExpect(obj, env, DynType)
+        typecheckExpr(prop, env)
+        env
+
       case _ =>
         typecheck(tree, env)
         env
@@ -502,10 +507,6 @@ class IRChecker(analyzer: Analyzer, allClassDefs: Seq[ClassDef], logger: Logger)
         typecheckExpect(fun, env, DynType)
         for (arg <- args)
           typecheckExpr(arg, env)
-
-      case JSDelete(obj, prop) =>
-        typecheckExpect(obj, env, DynType)
-        typecheckExpr(prop, env)
 
       case JSUnaryOp(op, lhs) =>
         typecheckExpect(lhs, env, DynType)


### PR DESCRIPTION
Consequently, the JSDelete tree becomes a statement.
