### PR TITLE
Fix #685: Create dummy parents in fastOptJS

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -16,11 +16,14 @@
   <task id="main"><![CDATA[
     sbt ++$scala package packageDoc &&
     sbt ++$scala testing/test testing/packageStage::test testing/fastOptStage::test testing/fullOptStage::test &&
-    sbt ++$scala scalajs-test/test scalajs-test/packageStage::test scalajs-test/fastOptStage::test scalajs-test/fullOptStage::test &&
+    sbt ++$scala scalajs-test/test scalajs-test/packageStage::test scalajs-test/fastOptStage::test scalajs-test/fullOptStage::test \
+      scalajs-no-ir-check-test/test scalajs-no-ir-check-test/packageStage::test scalajs-no-ir-check-test/fastOptStage::test scalajs-no-ir-check-test/fullOptStage::test &&
     sbt 'set ScalaJSKeys.postLinkJSEnv in ScalaJSBuild.test := new scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv' \
         'set definedTests.in(ScalaJSBuild.test, Test) ~= (_.filter(_.name != "scala.scalajs.test.compiler.IntTest"))' \
          ++$scala \
-         scalajs-test/packageStage::test scalajs-test/fastOptStage::test scalajs-test/fullOptStage::test scalajs-test/clean &&
+         scalajs-test/packageStage::test scalajs-test/fastOptStage::test scalajs-test/fullOptStage::test \
+         scalajs-no-ir-check-test/packageStage::test scalajs-no-ir-check-test/fastOptStage::test scalajs-no-ir-check-test/fullOptStage::test \
+         scalajs-test/clean &&
     sbt 'set scalacOptions in ScalaJSBuild.test += "-Xexperimental"' ++$scala scalajs-test/test scalajs-test/fastOptStage::test scalajs-test/fullOptStage::test &&
     sbt ++$scala scalajs-compiler/test reversi/packageJS reversi/fullOptJS &&
     sh ci/checksizes.sh $scala &&

--- a/no-ir-check-test/src/test/scala/scala/scalajs/test/noircheck/DummyParentsTest.scala
+++ b/no-ir-check-test/src/test/scala/scala/scalajs/test/noircheck/DummyParentsTest.scala
@@ -1,0 +1,35 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test
+package noircheck
+
+import scala.scalajs.test.JasmineTest
+
+object DummyParentsTest extends JasmineTest {
+
+  describe("Linking Stages") {
+
+    it("should provide dummy parents if required") {
+
+      import scala.concurrent.forkjoin._
+
+      // scala.concurrent.forkjoin.ForkJoinWorkerThread is not defined
+      class DummyFJWorkerThread extends ForkJoinWorkerThread(null) {
+        override def onStart(): Unit = { /* something */ }
+      }
+
+      val x = "1".toInt
+
+      if (x + x < 0) {
+        // Ensure DummyFuture is not DCEd, but never instantiated
+        new DummyFJWorkerThread()
+      }
+    }
+
+  }
+}

--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -588,6 +588,19 @@ object ScalaJSBuild extends Build {
       )
   ).dependsOn(compiler % "plugin")
 
+  lazy val noIrCheckTest: Project = Project(
+      id = "scalajs-no-ir-check-test",
+      base = file("no-ir-check-test"),
+      settings = defaultSettings ++ myScalaJSSettings ++ (
+          useLibraryButDoNotDependOnIt ++
+          useJasmineTestFrameworkButDoNotDependOnIt
+      ) ++ Seq(
+          name := "Scala.js not IR checked tests",
+          checkScalaJSIR := false,
+          publishArtifact in Compile := false
+     )
+  ).dependsOn(compiler % "plugin")
+
   lazy val partest: Project = Project(
       id = "scalajs-partest",
       base = file("partest"),


### PR DESCRIPTION
Without that fix, the included test fails (at initialization time).
