### PR TITLE
Fix #688: Remove return value of JSEnv#runJS.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -437,14 +437,8 @@ object ScalaJSPlugin extends Plugin with impl.DependencyBuilders {
     log.debug(s"with JSEnv of type ${env.getClass()}")
     log.debug(s"with classpath of type ${cp.getClass}")
 
-    try {
-      // Actually run code
-      env.runJS(cp, launcher, log, ConsoleJSConsole)
-    } catch {
-      case NonFatal(e) =>
-        log.error("Failed to run JS env ($env):")
-        log.trace(e)
-    }
+    // Actually run code
+    env.runJS(cp, launcher, log, ConsoleJSConsole)
   }
 
   private def memLauncher(mainCl: String) = {

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/env/ExternalJSEnv.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/env/ExternalJSEnv.scala
@@ -33,7 +33,7 @@ abstract class ExternalJSEnv(
     * an error message.
     */
   def runJS(classpath: CompleteClasspath, code: VirtualJSFile,
-    logger: Logger, console: JSConsole): Option[String] = {
+    logger: Logger, console: JSConsole): Unit = {
 
     val runJSArgs = RunJSArgs(classpath, code, logger, console)
 
@@ -57,10 +57,8 @@ abstract class ExternalJSEnv(
 
     // Get return value and return
     val retVal = vmInst.exitValue
-
-    if (retVal == 0) None
-    else Some(s"$vmName exited with code $retVal")
-
+    if (retVal != 0)
+      sys.error(s"$vmName exited with code $retVal")
   }
 
   /** send a bunch of JS files to an output stream */

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/env/rhino/RhinoJSEnv.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/env/rhino/RhinoJSEnv.scala
@@ -27,7 +27,7 @@ class RhinoJSEnv(withDOM: Boolean = false) extends JSEnv {
    *  `code` is called.
    */
   def runJS(classpath: CompleteClasspath, code: VirtualJSFile,
-      logger: Logger, console: JSConsole): Option[String] = {
+      logger: Logger, console: JSConsole): Unit = {
 
     val context = Context.enter()
     try {
@@ -79,12 +79,11 @@ class RhinoJSEnv(withDOM: Boolean = false) extends JSEnv {
         }
 
         context.evaluateFile(scope, code)
-
-        None
       } catch {
         case e: RhinoException =>
+          // Trace here, since we want to be in the context to trace.
           logger.trace(e)
-          Some(s"Exception while running JS code: ${e.getMessage}")
+          sys.error(s"Exception while running JS code: ${e.getMessage}")
       }
     } finally {
       Context.exit()

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/testing/TestTask.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/testing/TestTask.scala
@@ -40,12 +40,8 @@ class TestTask(
         loggers, new Events(taskDef), classpath, options.noSourceMap)
     val logger = new SbtTestLoggerAccWrapper(loggers)
 
-    try {
-      // Actually execute test
-      env.runJS(classpath, runnerFile, logger, testConsole)
-    } catch {
-      case NonFatal(e) => logger.trace(e)
-    }
+    // Actually execute test
+    env.runJS(classpath, runnerFile, logger, testConsole)
 
     Array.empty
   }

--- a/sbt-plugin/src/test/scala/scala/scalajs/sbtplugin/test/env/JSEnvTest.scala
+++ b/sbt-plugin/src/test/scala/scala/scalajs/sbtplugin/test/env/JSEnvTest.scala
@@ -18,11 +18,10 @@ abstract class JSEnvTest {
       val code    = new MemVirtualJSFile("testScript.js").withContent(codeStr)
 
       val emptyCP = PartialClasspath.empty.resolve()
-      val res = newJSEnv.runJS(emptyCP, code, logger, console)
+      newJSEnv.runJS(emptyCP, code, logger, console)
 
       val log = logger.getLog
 
-      assertTrue("VM shouldn't fail on snippet. Msg: " + res, res.isEmpty)
       assertTrue("VM shouldn't produce log. Log:\n" +
           log.mkString("\n"), log.isEmpty)
       assertEquals("Output should match", expectedOut, console.getLog)

--- a/tools/src/main/scala/scala/scalajs/tools/env/JSEnv.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/env/JSEnv.scala
@@ -14,9 +14,7 @@ import scala.scalajs.tools.classpath._
 import scala.scalajs.tools.logging._
 
 trait JSEnv {
-  /** Run the code in the virtual file. Return Some(<error message>) if failed
-   *  None otherwise
-   */
+  /** Run the code in the virtual file. Throw if failure */
   def runJS(classpath: CompleteClasspath, code: VirtualJSFile,
-      logger: Logger, console: JSConsole): Option[String]
+      logger: Logger, console: JSConsole): Unit
 }


### PR DESCRIPTION
JSEnv#runJS used to return `Some(<string>)` if it failed due to historic
reasons. This is no longer necessary and introduces useless clutter
and confusion (e.g. runners failing without the outer code
failing). runJS now throws an exception if it fails.
