### PR TITLE
Fix #717: deprecate unary_! on arbitrary js.Any.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/Primitives.scala
@@ -26,6 +26,8 @@ import scala.collection.{ immutable, mutable }
  *  boxing of proxying of any kind.
  */
 trait Any extends scala.AnyRef {
+  @deprecated("Considered abuse in typed JavaScript, will be removed in 0.6. "+
+      "Use js.Dynamic or js.prim.Boolean instead.", "0.5.0")
   def unary_!(): Boolean = sys.error("stub")
 }
 
@@ -150,6 +152,8 @@ sealed trait Dynamic extends Any with scala.Dynamic {
   def apply(args: Any*): Dynamic
 
   import prim.Number
+
+  override def unary_!(): Boolean = sys.error("stub")
 
   def unary_+(): Number
   def unary_-(): Number

--- a/library/src/main/scala/scala/scalajs/js/prim/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/prim/Primitives.scala
@@ -155,6 +155,8 @@ object Number extends Object {
 
 /** Primitive JavaScript boolean. */
 sealed trait Boolean extends Any {
+  override def unary_!(): scala.Boolean = sys.error("stub")
+
   def &&(that: Boolean): Boolean
   def ||(that: Boolean): Boolean
 

--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
@@ -111,7 +111,7 @@ private[runtime] trait RuntimeString { this: jsString =>
    */
   def intern(): String = this
 
-  def isEmpty(): Boolean = !(this: jsString).length
+  def isEmpty(): Boolean = (this: jsString).length.toInt == 0
 
   def lastIndexOf(ch: Int): Int = {
     val search = js.String.fromCharCode(ch)

--- a/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
@@ -78,7 +78,7 @@ object StackTrace {
     var i = 0
     while (i < lines.length) {
       val line = lines(i)
-      if (!(!line)) {
+      if (!line.isEmpty) {
         val mtch1 = NormalizedFrameLineWithColumn.exec(line)
         if (mtch1 ne null) {
           val (className, methodName) = extractClassMethod(mtch1(1).get)


### PR DESCRIPTION
It is redefined as not deprecated on js.Dynamic and js.prim.Boolean.
