### PR TITLE
Fix #725: Escape newlines in test output messages

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/testing/TestOutputConsole.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/testing/TestOutputConsole.scala
@@ -20,6 +20,8 @@ import scala.collection.mutable.ArrayBuffer
 
 import scala.util.Try
 
+import java.util.regex._
+
 class TestOutputConsole(
     base: JSConsole,
     handler: EventHandler,
@@ -53,7 +55,7 @@ class TestOutputConsole(
         log(_.error, s"Malformed message: $msgStr")
       else {
         val op = data.substring(0, sepPos)
-        val message = data.substring(sepPos + 1)
+        val message = unescape(data.substring(sepPos + 1))
 
         op match {
           case "error" =>
@@ -153,4 +155,21 @@ class TestOutputConsole(
 
   private def removeColors(message: String): String =
     message.replaceAll(colorPattern, "")
+
+  private val unEscPat = Pattern.compile("(\\\\\\\\|\\\\n|\\\\r)")
+  private def unescape(message: String): String = {
+    val m = unEscPat.matcher(message)
+    val res = new StringBuffer()
+    while (m.find()) {
+      val repl = m.group() match {
+        case "\\\\" => "\\\\"
+        case "\\n" => "\n"
+        case "\\r" => "\r"
+      }
+      m.appendReplacement(res, repl);
+    }
+    m.appendTail(res);
+    res.toString
+  }
+
 }

--- a/test-bridge/src/main/scala/scala/scalajs/test/internal/ConsoleTestOutput.scala
+++ b/test-bridge/src/main/scala/scala/scalajs/test/internal/ConsoleTestOutput.scala
@@ -65,8 +65,13 @@ object ConsoleTestOutput extends TestOutput {
 
   private val messagePrefix = "``|%^scala.js-test-comm&&"
 
-  private def send(fct: String, msg: String) =
-    println(messagePrefix + fct + "|" + msg)
+  private def send(fct: String, msg: String) = {
+    val escaped = msg
+      .replace("\\", "\\\\")
+      .replace("\n", "\\n")
+      .replace("\r", "\\r")
+    println(messagePrefix + fct + "|" + escaped)
+  }
 
   private def sendTrace(stack: Array[StackTraceElement]) = for {
     el <- stack


### PR DESCRIPTION
Tested by renaming a test:

``` Diff
diff --git a/test/src/test/scala/scala/scalajs/test/compiler/BooleanTest.scala b/test/src/test/scala/scala/scalajs/test/compiler/BooleanTest.scala
index 9756237..7a72c23 100644
--- a/test/src/test/scala/scala/scalajs/test/compiler/BooleanTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/compiler/BooleanTest.scala
@@ -15,7 +15,7 @@ object BooleanTest extends JasmineTest {

   describe("Boolean primitives") {

-    it("&, | and ^ on booleans should return booleans") {
+    it("&, | and ^ on booleans \\should \r\n\n\n\r\n \\\\return booleans") {
       expect(js.typeOf(true & false)).toEqual("boolean")
       expect(js.typeOf(true | false)).toEqual("boolean")
       expect(js.typeOf(true ^ false)).toEqual("boolean")
```
