### PR TITLE
Add java.util.Date

### DIFF
--- a/javalib/source/src/java/util/Date.scala
+++ b/javalib/source/src/java/util/Date.scala
@@ -1,0 +1,142 @@
+/**
+ * 2014 Matt Seddon
+ * This code is donated in full to the scala-js project.
+ */
+
+package java.util
+
+import scalajs.js
+
+class Date private (private val date: js.Date) extends Object
+  with Serializable with Cloneable with Comparable[Date] {
+
+  import Date._
+
+  def this() = this(new js.Date())
+
+  @Deprecated
+  def this(year: Int, month: Int, date: Int, hrs: Int, min: Int, sec: Int) = {
+    this(new js.Date())
+    this.date.setFullYear(1900 + year, month, date)
+    this.date.setHours(hrs, min, sec, 0)
+  }
+
+  @Deprecated
+  def this(year: Int, month: Int, date: Int, hrs: Int, min: Int) =
+    this(year, month, date, hrs, min, 0)
+
+  @Deprecated
+  def this(year: Int, month: Int, date: Int) =
+    this(year, month, date, 0, 0, 0)
+
+  def this(date: Long) = this(new js.Date(date))
+
+  @Deprecated
+  def this(date: String) = this(new js.Date(date))
+
+  def after(when: Date): Boolean = date.getTime() > when.date.getTime()
+
+  def before(when: Date): Boolean = date.getTime() < when.date.getTime()
+
+  override def clone(): Object = new Date(new js.Date(date.getTime()))
+
+  override def compareTo(anotherDate: Date): Int =
+    date.getTime().compareTo(anotherDate.date.getTime())
+
+  override def equals(obj: Any): Boolean =
+    obj match {
+      case d: Date => d.date.getTime() == date.getTime()
+      case _ => false
+    }
+
+  override def hashCode(): Int = date.getTime().hashCode()
+
+  @Deprecated
+  def getDate(): Int = date.getDate()
+
+  @Deprecated
+  def getDay(): Int = date.getDay()
+
+  @Deprecated
+  def getHours(): Int = date.getHours()
+
+  @Deprecated
+  def getMinutes(): Int = date.getMinutes()
+
+  @Deprecated
+  def getMonth(): Int = date.getMonth()
+
+  @Deprecated
+  def getSeconds(): Int = date.getSeconds()
+
+  def getTime(): Long = date.getTime().toLong
+
+  @Deprecated
+  def getTimeZoneOffset(): Int = date.getTimezoneOffset()
+
+  @Deprecated
+  def getYear(): Int = date.getFullYear()-1900
+
+  @Deprecated
+  def setDate(date: Int): Unit = this.date.setDate(date)
+
+  @Deprecated
+  def setHours(hours: Int):Unit = date.setHours(hours)
+
+  @Deprecated
+  def setMinutes(minutes: Int): Unit = date.setMinutes(minutes)
+
+  @Deprecated
+  def setMonth(month: Int): Unit = date.setMonth(month)
+
+  @Deprecated
+  def setSeconds(seconds: Int): Unit = date.setSeconds(seconds)
+
+  def setTime(time: Long): Unit = date.setTime(time)
+
+  @Deprecated
+  def setYear(year: Int): Unit = date.setFullYear(1900+year)
+
+  @Deprecated
+  def toGMTString(): String =
+   date.getUTCDate() + " " + Months(date.getUTCMonth()) + " " +
+     date.getUTCFullYear() + " " + pad0(date.getUTCHours()) + ":" +
+     pad0(date.getUTCMinutes()) + ":" +
+     pad0(date.getUTCSeconds()) +" GMT"
+
+  @Deprecated
+  def toLocaleString(): String =
+    date.getDate() + "-" + Months(date.getMonth()) + "-" +
+      date.getFullYear() + "-" + pad0(date.getHours()) + ":" +
+      pad0(date.getMinutes()) + ":" + pad0(date.getSeconds())
+
+  override def toString(): String = {
+    val offset = -date.getTimezoneOffset()
+    val sign = if(offset < 0) "-" else "+"
+    val hours = pad0(Math.abs(offset) / 60)
+    val mins = pad0(Math.abs(offset) % 60)
+    Days(date.getDay()) + " "+ Months(date.getMonth()) + " " +
+      pad0(date.getHours()) + ":" + pad0(date.getMinutes()) + ":" +
+      pad0(date.getSeconds()) + " GMT" + sign + hours + mins + " " +
+      date.getFullYear()
+  }
+}
+
+object Date {
+  private val Days = Array("Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat")
+  private val Months = Array("Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul",
+                             "Aug", "Sep", "Oct", "Nov", "Dec")
+
+  private def pad0(i: Int): String = {
+    val str = "" + i
+    if(str.length < 2) "0"+str else str
+  }
+
+  @Deprecated
+  def UTC(year: Int, month: Int, date: Int,
+          hrs: Int, min: Int, sec: Int): Long =
+    js.Date.UTC(year + 1900, month, date, hrs, min, sec).toLong
+
+  @Deprecated
+  def parse(string: String) = new Date(new js.Date(string)).getTime.toLong
+}

--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -587,6 +587,8 @@ object ScalaJSBuild extends Build {
           name := "Scala.js test suite",
           publishArtifact in Compile := false,
 
+          scalacOptions ~= (_.filter(_ != "-deprecation")),
+
           sources in Test ++= {
             if (!scalaVersion.value.startsWith("2.10") &&
                 scalacOptions.value.contains("-Xexperimental")) {

--- a/test/src/test/scala/scala/scalajs/test/javalib/DateTest.scala
+++ b/test/src/test/scala/scala/scalajs/test/javalib/DateTest.scala
@@ -1,0 +1,85 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.test
+
+import java.util.Date
+
+/**
+ * tests the implementation of the java standard library Date
+ */
+object DateTest extends JasmineTest {
+
+  describe("java.lang.Date") {
+
+    it("should provide `compareTo`") {
+      def compare(x: Date, y: Date): Int = {
+        x.compareTo(y)
+      }
+
+      expect(compare(new Date(97, 11, 5, 0, 0), new Date(98, 11, 5, 0, 0))).toBeLessThan(0)
+      expect(compare(new Date(98, 11, 5, 0, 0), new Date(97, 11, 5, 0, 0))).toBeGreaterThan(0)
+      expect(compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5))).toEqual(0)
+      expect(compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5, 0, 1))).toBeLessThan(0)
+      expect(compare(new Date(97, 11, 5), new Date(97, 11, 5, 0, 0))).toEqual(0)
+    }
+
+    it("should be a Comparable") {
+      def compare(x: Any, y: Any): Int =
+        x.asInstanceOf[Comparable[Any]].compareTo(y)
+
+      expect(compare(new Date(97, 11, 5, 0, 0), new Date(98, 11, 5, 0, 0))).toBeLessThan(0)
+      expect(compare(new Date(98, 11, 5, 0, 0), new Date(97, 11, 5, 0, 0))).toBeGreaterThan(0)
+      expect(compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5))).toEqual(0)
+      expect(compare(new Date(97, 11, 5, 0, 0), new Date(97, 11, 5, 0, 1))).toBeLessThan(0)
+      expect(compare(new Date(97, 11, 5), new Date(97, 11, 5, 0, 0))).toEqual(0)
+    }
+
+    it("should parse strings") {
+      def test(s: String, v: Date): Unit =
+        expect(new Date(s).compareTo(v)).toEqual(0)
+
+      test("Nov 5 1997 5:23:27 GMT", new Date(Date.UTC(97, 10, 5, 5, 23, 27)))
+      test("Nov 1 1997 GMT", new Date(Date.UTC(97,10,1, 0, 0, 0)))
+      test("Jan 1 1970 18:11:01 GMT", new Date(Date.UTC(70,0,1,18,11,1)))
+    }
+
+    it("should provide after") {
+      expect(new Date(97, 11, 5, 0, 0).after(new Date(98, 11, 5, 0, 0))).toBe(false)
+      expect(new Date(99, 11, 5, 0, 0).after(new Date(98, 11, 5, 0, 0))).toBe(true)
+      expect(new Date(99, 11, 5, 0, 0).after(new Date(99, 11, 5, 0, 0))).toBe(false)
+    }
+
+    it("should provide before") {
+      expect(new Date(97, 11, 5, 0, 0).before(new Date(98, 11, 5, 0, 0))).toBe(true)
+      expect(new Date(99, 11, 5, 0, 0).before(new Date(98, 11, 5, 0, 0))).toBe(false)
+      expect(new Date(99, 11, 5, 0, 0).before(new Date(99, 11, 5, 0, 0))).toBe(false)
+    }
+
+    it("should provide clone") {
+      def testClone(date: Date) = {
+        val cloned = date.clone()
+        date == cloned
+      }
+
+      expect(testClone(new Date(97, 11, 5, 0, 0))).toBe(true)
+      expect(testClone(new Date(92, 14, 6, 2, 1))).toBe(true)
+      expect(testClone(new Date(4, 1, 2, 3, 0, 0))).toBe(true)
+    }
+
+    it("should respond to getYear") {
+      def testYear(year: Int) = {
+        val date = new Date()
+        date.setYear(year)
+        expect(date.getYear).toEqual(year)
+      }
+      testYear(1940)
+      testYear(1920)
+      testYear(2030)
+    }
+  }
+}


### PR DESCRIPTION
Simple java.util.Date implementation.

Note: Our Date.parse is less restrictive currently than Java's Date.parse, since it defers to the JavaScript Date constructor.
