### PR TITLE
Implement StringBuilder.setLength

### DIFF
--- a/javalib/source/src/java/lang/StringBuffer.scala
+++ b/javalib/source/src/java/lang/StringBuffer.scala
@@ -60,4 +60,21 @@ class StringBuffer(private var content: String) extends CharSequence
     content = content.substring(0, index) + ch + content.substring(index + 1)
   }
 
+  def setLength(newLength: Int): Unit = {
+    if (newLength < 0)
+      throw new IndexOutOfBoundsException("String index out of range: " + newLength)
+
+    val len = length()
+    if (len == newLength) {
+    } else if (len < newLength) {
+      var index = len
+      while (index < newLength) {
+        append("\u0000")
+        index += 1
+      }
+    } else {
+      content = substring(0, newLength)
+    }
+  }
+
 }

--- a/javalib/source/src/java/lang/StringBuilder.scala
+++ b/javalib/source/src/java/lang/StringBuilder.scala
@@ -79,4 +79,21 @@ class StringBuilder(private var content: String) extends CharSequence
     content = content.substring(0, index) + ch + content.substring(index + 1)
   }
 
+  def setLength(newLength: Int): Unit = {
+    if (newLength < 0)
+      throw new IndexOutOfBoundsException("String index out of range: " + newLength)
+
+    val len = length()
+    if (len == newLength) {
+    } else if (len < newLength) {
+      var index = len
+      while (index < newLength) {
+        append("\u0000")
+        index += 1
+      }
+    } else {
+      content = substring(0, newLength)
+    }
+  }
+
 }

--- a/test-suite/src/test/scala/scala/scalajs/test/javalib/StringBufferTest.scala
+++ b/test-suite/src/test/scala/scala/scalajs/test/javalib/StringBufferTest.scala
@@ -46,6 +46,16 @@ object StringBufferTest extends JasmineTest {
       expect(() => buf.setCharAt(6,  'h')).toThrow
     }
 
+    it("should properly setLength") {
+      val buf = newBuf
+      buf.append("foobar")
+
+      expect(() => buf.setLength(-3)).toThrow
+
+      expect({ buf.setLength(3); buf.toString }).toEqual("foo")
+      expect({ buf.setLength(6); buf.toString }).toEqual("foo\u0000\u0000\u0000")
+    }
+
   }
 
   describe("java.lang.StringBuilder") {
@@ -84,6 +94,16 @@ object StringBufferTest extends JasmineTest {
 
       expect(() => buf.setCharAt(-1, 'h')).toThrow
       expect(() => buf.setCharAt(6,  'h')).toThrow
+    }
+
+    it("should properly setLength") {
+      val buf = newBuf
+      buf.append("foobar")
+
+      expect(() => buf.setLength(-3)).toThrow
+
+      expect({ buf.setLength(3); buf.toString }).toEqual("foo")
+      expect({ buf.setLength(6); buf.toString }).toEqual("foo\u0000\u0000\u0000")
     }
 
   }


### PR DESCRIPTION
Doesn't differ at all from @alexander-myltsev's original PR (#771), except for the squashing of the commits. The increase in size from #780 also accounts for the additional size this PR introduces.
