### PR TITLE
Fix #802: While(true, body) should always typecheck as NothingType.

### DIFF
--- a/ir/src/main/scala/scala/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/Trees.scala
@@ -156,9 +156,10 @@ object Trees {
 
   case class While(cond: Tree, body: Tree, label: Option[Ident] = None)(implicit val pos: Position) extends Tree {
     // cannot be in expression position, unless it is infinite
-    val tpe =
-      if (cond == BooleanLiteral(true) && body.tpe == NothingType) NothingType
-      else NoType
+    val tpe = cond match {
+      case BooleanLiteral(true) => NothingType
+      case _                    => NoType
+    }
   }
 
   case class DoWhile(body: Tree, cond: Tree, label: Option[Ident] = None)(implicit val pos: Position) extends Tree {


### PR DESCRIPTION
This also uses a pattern match instead of an == because it
avoids the allocation of the BooleanLiteral and the virtual
dispatch of ==.
