### PR TITLE
Fix #804: Delay protect() mechanism until desugaring, no JSDotSelect.

### DIFF
--- a/ir/src/main/scala/scala/scalajs/ir/ScalaJSClassEmitter.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/ScalaJSClassEmitter.scala
@@ -79,14 +79,15 @@ object ScalaJSClassEmitter {
       } { parentIdent =>
         implicit val pos = tree.pos
         JSApply(
-            JSDotSelect(encodeClassVar(ClassType(parentIdent.name)), Ident("call")),
+            JSBracketSelect(encodeClassVar(ClassType(parentIdent.name)),
+                StringLiteral("call")),
             List(This()(tpe)))
       }
       val fieldDefs = for {
         field @ VarDef(name, vtpe, mutable, rhs) <- tree.defs
       } yield {
         implicit val pos = field.pos
-        Assign(JSDotSelect(This()(tpe), name), rhs)
+        Assign(Select(This()(tpe), name, mutable)(vtpe), rhs)
       }
       Function(tpe, Nil, NoType,
           Block(superCtorCall :: fieldDefs)(tree.pos))(tree.pos)
@@ -455,7 +456,8 @@ object ScalaJSClassEmitter {
       createNamespace,
       DocComment("@constructor"),
       expCtorVar := Function(classType, args, NoType, Block(
-        JSApply(JSDotSelect(baseCtor, Ident("call")), List(This()(DynType))),
+        JSApply(JSBracketSelect(baseCtor, StringLiteral("call")),
+            List(This()(DynType))),
         body
       )),
       expCtorVar DOT "prototype" := baseCtor DOT "prototype"

--- a/ir/src/main/scala/scala/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/Serializers.scala
@@ -560,7 +560,6 @@ object Serializers {
 
         case TagJSGlobal        => JSGlobal()
         case TagJSNew           => JSNew(readTree(), readTrees())
-        case TagJSDotSelect     => JSDotSelect(readTree(), readIdent())
         case TagJSBracketSelect => JSBracketSelect(readTree(), readTree())
         case TagJSApply         => JSApply(readTree(), readTrees())
         case TagJSDelete        => JSDelete(readTree(), readTree())
@@ -569,6 +568,12 @@ object Serializers {
         case TagJSArrayConstr   => JSArrayConstr(readTrees())
         case TagJSObjectConstr  =>
           JSObjectConstr(List.fill(readInt())((readPropertyName(), readTree())))
+
+        // Deserialization-time removal of JSDotSelect
+        case TagJSDotSelect =>
+          val qual = readTree()
+          val item = readIdent()
+          JSBracketSelect(qual, StringLiteral(item.name, item.originalName))
 
         case TagUndefined      => Undefined()
         case TagUndefinedParam => UndefinedParam()(readType())

--- a/tools/src/main/scala/scala/scalajs/tools/optimizer/IRChecker.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/optimizer/IRChecker.scala
@@ -496,9 +496,6 @@ class IRChecker(analyzer: Analyzer, allClassDefs: Seq[ClassDef], logger: Logger)
         for (arg <- args)
           typecheckExpr(arg, env)
 
-      case JSDotSelect(qualifier, item) =>
-        typecheckExpect(qualifier, env, DynType)
-
       case JSBracketSelect(qualifier, item) =>
         typecheckExpect(qualifier, env, DynType)
         typecheckExpr(item, env)


### PR DESCRIPTION
This is an alternative to #806 where I previously remove the last two remaining `JSDotSelect`s emitted by the compiler from the IR. They are converted to `JSBracketSelect`s at deserialization time for binary compatibility.
