### PR TITLE
Follow up on #802: fix the behavior of the IR checker for While.

### DIFF
--- a/tools/src/main/scala/scala/scalajs/tools/optimizer/IRChecker.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/optimizer/IRChecker.scala
@@ -303,7 +303,7 @@ class IRChecker(analyzer: Analyzer, allClassDefs: Seq[ClassDef], logger: Logger)
         typecheckExpect(elsep, env, tpe)
 
       case While(BooleanLiteral(true), body, label) if tree.tpe == NothingType =>
-        typecheckExpect(body, env, NothingType)
+        typecheckStat(body, env)
 
       case Try(block, errVar, handler, finalizer) =>
         val tpe = tree.tpe


### PR DESCRIPTION
Although the constructor of the While(BooleanLiteral(true), body)
always typechecked itself as NothingType, the IR checker still
required that the body typechecked as NothingType. This commit
fixes this inconsistency.
