### PR TITLE
Fix #874: Calling null.synchronized does not throw NPE/TypeError.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BuglistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BuglistedTests.txt
@@ -3,8 +3,5 @@
 # which are neither in BuglistedTests.txt, WhitelistedTests.txt or
 # BlacklistedTests.txt
 
-# Filed under #874
-run/t8601d.scala
-
 # Filed under #879
 run/virtpatmat_typetag.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/WhitelistedTests.txt
@@ -2931,4 +2931,5 @@ run/t8610.scala
 run/macro-rangepos-subpatterns
 run/t8611c.scala
 run/macroPlugins-isBlackbox
+run/t8601d.scala
 run/t8607.scala

--- a/test-suite/src/test/scala/scala/scalajs/test/compiler/RegressionTest.scala
+++ b/test-suite/src/test/scala/scala/scalajs/test/compiler/RegressionTest.scala
@@ -251,5 +251,16 @@ object RegressionTest extends JasmineTest {
       }
       foo(2, 4)
     }
+
+    it("null.synchronized should throw - #874") {
+      expect(() => null.synchronized(5)).toThrow
+    }
+
+    it("x.synchronized should preserve side-effects of x") {
+      var c = 0
+      def x = { c += 1; this }
+      expect(x.synchronized(5)).toEqual(5)
+      expect(c).toEqual(1)
+    }
   }
 }

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -154,6 +154,14 @@ var ScalaJS = {
     }
   },
 
+  checkNonNull: function(obj) {
+    return obj !== null ? obj : ScalaJS.throwNullPointerException();
+  },
+
+  throwNullPointerException: function() {
+    throw new ScalaJS.c.jl_NullPointerException().init___();
+  },
+
   anyEqEq: function(lhs, rhs) {
     if (ScalaJS.isScalaJSObject(lhs) || typeof lhs === "number") {
       return ScalaJS.m.sr_BoxesRunTime().equals__O__O__Z(lhs, rhs);

--- a/tools/src/main/scala/scala/scalajs/tools/optimizer/Analyzer.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/optimizer/Analyzer.scala
@@ -140,6 +140,7 @@ class Analyzer(logger0: Logger, allData: Seq[Infos.ClassInfo],
     instantiateClassWith(s"jl_Character", s"init___C")
 
     instantiateClassWith("jl_ClassCastException", "init___T")
+    instantiateClassWith("jl_NullPointerException", "init___")
     instantiateClassWith("sjs_js_JavaScriptException", "init___sjs_js_Any")
 
     instantiateClassWith("jl_Class", "init___jl_ScalaJSClassData")

--- a/tools/src/main/scala/scala/scalajs/tools/optimizer/IRChecker.scala
+++ b/tools/src/main/scala/scala/scalajs/tools/optimizer/IRChecker.scala
@@ -472,6 +472,16 @@ class IRChecker(analyzer: Analyzer, allClassDefs: Seq[ClassDef], logger: Logger)
 
       case ClassOf(cls) =>
 
+      case CallHelper("checkNonNull", args) =>
+        // our only polymorphic helper
+        if (args.size != 1)
+          reportError(s"Arity mismatch: 1 expected but ${args.size} found")
+        if (args.nonEmpty) {
+          val argType = typecheckExpr(args.head, env)
+          if (tree.tpe != argType)
+            reportError(s"Helper checkNonNull of type $argType typed as ${tree.tpe}")
+        }
+
       case CallHelper(helper, args) =>
         if (!HelperSignature.contains(helper)) {
           reportError(s"Invalid helper $helper")


### PR DESCRIPTION
Also fix the fact that side-effects of the receiver were dropped.
