### PR TITLE
Fix binary version for snapshots of minor releases.

### DIFF
--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -78,7 +78,7 @@ object ScalaJSBuild extends Build {
   )
 
   val defaultSettings = commonSettings ++ Seq(
-      scalaVersion := scalaJSScalaVersion,
+      scalaVersion := "2.11.0",
       scalacOptions ++= Seq(
           "-deprecation",
           "-unchecked",

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSCrossVersion.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSCrossVersion.scala
@@ -11,19 +11,25 @@ package scala.scalajs.sbtplugin
 
 import sbt._
 
-import ScalaJSPlugin.scalaJSBinaryVersion
+import scala.scalajs.ir.ScalaJSVersions
 
 object ScalaJSCrossVersion {
   private val scalaJSVersionUnmapped: String => String =
-    _ => s"sjs$scalaJSBinaryVersion"
+    _ => s"sjs$currentBinaryVersion"
 
   private val scalaJSVersionMap: String => String =
-    version => s"sjs${scalaJSBinaryVersion}_$version"
+    version => s"sjs${currentBinaryVersion}_$version"
 
-  private final val ReleaseVersion = raw"""(\d+)\.(\d+)\.(\d+)""".r
+  private final val ReleaseVersion =
+    raw"""(\d+)\.(\d+)\.(\d+)""".r
+  private final val MinorSnapshotVersion =
+    raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
+
+  val currentBinaryVersion = binaryScalaJSVersion(ScalaJSVersions.current)
 
   def binaryScalaJSVersion(full: String): String = full match {
     case ReleaseVersion(major, minor, release) => s"$major.$minor"
+    case MinorSnapshotVersion(major, minor, _) => s"$major.$minor"
     case _                                     => full
   }
 

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -21,9 +21,10 @@ import scala.scalajs.ir.ScalaJSVersions
 object ScalaJSPlugin extends Plugin with impl.DependencyBuilders {
   val scalaJSVersion = ScalaJSVersions.current
   val scalaJSIsSnapshotVersion = ScalaJSVersions.currentIsSnapshot
+  val scalaJSBinaryVersion = ScalaJSCrossVersion.currentBinaryVersion
+
+  @deprecated("Meaningless. Use the sbt scalaVersion setting instead.", "0.5.3")
   val scalaJSScalaVersion = "2.11.0"
-  val scalaJSBinaryVersion =
-    ScalaJSCrossVersion.binaryScalaJSVersion(scalaJSVersion)
 
   object ScalaJSKeys {
     import KeyRanks._


### PR DESCRIPTION
The binary version for 0.5.3-SNAPSHOT should in fact be 0.5,
not 0.5.3-SNAPSHOT. However, the binary version for
0.6.0-SNAPSHOT, as well as 0.6.0-M1 and so on, should be the
full version indeed. In general, snapshots of minor releases
should have the binary version of their major release. This
is important for applications built on a snapshot to be able
to resolve libraries built with a release.

In the process, this commit also cleans up a few things
related to version numbers in the sbt plugin.
