### PR TITLE
Fix #906: Remove accessor flags on exporter methods.

### DIFF
--- a/compiler/src/main/scala/scala/scalajs/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/scala/scalajs/compiler/PrepJSExports.scala
@@ -112,7 +112,8 @@ trait PrepJSExports { this: PrepJSInterop =>
     // Update flags
     expSym.setFlag(Flags.SYNTHETIC)
     expSym.resetFlag(
-        Flags.DEFERRED |  // We always have a body now
+        Flags.DEFERRED |  // We always have a body
+        Flags.ACCESSOR |  // We are never a "direct" accessor
         Flags.OVERRIDE    // Synthetic methods need not bother with this
     )
 


### PR DESCRIPTION
The accessor flags triggered sbt warnings for exported setters, since
they don't have the proper type (return type is Any instead of
Unit). Removing the accessor flag removes the warning and is also
better, since exporters are not accessors.
