### PR TITLE
Restart sbt from time to time when publishing

### DIFF
--- a/scripts/publish-to-bintray.sh
+++ b/scripts/publish-to-bintray.sh
@@ -8,33 +8,28 @@ else
     CMD=cat
 fi
 
-# Subshell to generate SBT commands
-(
-    FULL_VERSIONS="2.10.2 2.10.3 2.10.4 2.11.0 2.11.1 2.11.2"
-    BIN_VERSIONS="2.10.4 2.11.2"
-    SBT_VERSION="2.10.4"
+FULL_VERSIONS="2.10.2 2.10.3 2.10.4 2.11.0 2.11.1 2.11.2"
+BIN_VERSIONS="2.10.4 2.11.2"
+SBT_VERSION="2.10.4"
 
-    LIBS="library javalibEx jasmineTestFramework tools toolsJS testBridge"
+LIBS="library javalibEx jasmineTestFramework tools toolsJS testBridge"
 
-    # Publish compiler
-    echo "project compiler"
-    for v in $FULL_VERSIONS; do
+# Publish compiler
+for v in $FULL_VERSIONS; do
+    echo "++$v"
+    echo "compiler/publish"
+done | $CMD
+
+# Package libraries
+for p in $LIBS; do
+    for v in $BIN_VERSIONS; do
         echo "++$v"
-        echo "publish"
-    done
+        echo "$p/publish"
+    done | $CMD
+done
 
-    # Package libraries
-    for p in $LIBS; do
-        echo "project $p"
-        for v in $BIN_VERSIONS; do
-            echo "++$v"
-            echo "publish"
-        done
-    done
-
-    # Publish sbt-plugin
-    echo "project sbtPlugin"
+# Publish sbt-plugin
+(
     echo "++$SBT_VERSION"
-    echo "publish"
-
+    echo "sbtPlugin/publish"
 ) | $CMD


### PR DESCRIPTION
If sbt is not restarted, the JVM will fall back to interpreted mode
after some time. This makes compilation extremely slow.
