### PR TITLE
Fix #1050: Fix one known and some potential setting name conflicts.

### DIFF
--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -299,8 +299,8 @@ object ScalaJSBuild extends Build {
           val launcher = new MemVirtualJSFile("Generated launcher file")
             .withContent(code)
 
-          jsEnv.value.runJS(execClasspath.value, launcher,
-              streams.value.log, jsConsole.value)
+          jsEnv.value.runJS(scalaJSExecClasspath.value, launcher,
+              streams.value.log, scalaJSConsole.value)
         }
 
         Seq(test := error("Can't run toolsJS/test in preLink stage")) ++
@@ -731,7 +731,7 @@ object ScalaJSBuild extends Build {
           /* Generate a scala source file that throws exceptions in
              various places (while attaching the source line to the
              exception). When we catch the exception, we can then
-             compare the attached source line and the source line 
+             compare the attached source line and the source line
              calculated via the source maps.
 
              see test-suite/src/test/resources/SourceMapTestTemplate.scala

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -47,8 +47,9 @@ object ScalaJSPlugin extends Plugin with impl.DependencyBuilders {
     val packageExportedProductsJS = TaskKey[PartialClasspath]("packageExportedProductsJS",
         "Package the .js files of the project", DTask)
 
-    val packageLauncher = TaskKey[Attributed[File]]("packageLauncher",
+    val packageScalaJSLauncher = TaskKey[Attributed[File]]("packageScalaJSLauncher",
         "Writes the persistent launcher file. Fails if the mainClass is ambigous", CTask)
+    val packageLauncher = packageScalaJSLauncher // TODO Remove in 0.6.0
 
     val packageJSDependencies = TaskKey[File]("packageJSDependencies",
         "Packages all dependencies of the preLink classpath in a single file. " +
@@ -57,20 +58,24 @@ object ScalaJSPlugin extends Plugin with impl.DependencyBuilders {
     val jsDependencyManifest = TaskKey[File]("jsDependencyManifest",
         "Writes the JS_DEPENDENCIES file.", DTask)
 
-    val preLinkClasspath = TaskKey[CompleteIRClasspath]("preLinkClasspath",
+    val scalaJSPreLinkClasspath = TaskKey[CompleteIRClasspath]("scalaJSPreLinkClasspath",
         "Completely resolved classpath just after compilation", DTask)
+    val preLinkClasspath = scalaJSPreLinkClasspath // TODO Remove in 0.6.0
 
-    val execClasspath = TaskKey[CompleteClasspath]("execClasspath",
+    val scalaJSExecClasspath = TaskKey[CompleteClasspath]("scalaJSExecClasspath",
         "The classpath used for running and testing", DTask)
+    val execClasspath = scalaJSExecClasspath // TODO Remove in 0.6.0
 
-    val launcher = TaskKey[Attributed[VirtualJSFile]]("launcher",
+    val scalaJSLauncher = TaskKey[Attributed[VirtualJSFile]]("scalaJSLauncher",
         "Code used to run. (Attributed with used class name)", DTask)
+    val launcher = scalaJSLauncher // TODO Remove in 0.6.0
 
     val fullOptJSPrettyPrint = SettingKey[Boolean]("fullOptJSPrettyPrint",
         "Pretty-print the output of fullOptJS", CSetting)
 
-    val jsConsole = TaskKey[JSConsole]("jsConsole",
+    val scalaJSConsole = TaskKey[JSConsole]("scalaJSConsole",
         "The JS console used by the Scala.js runner/tester", DTask)
+    val jsConsole = scalaJSConsole // TODO Remove in 0.6.0
 
     val preLinkJSEnv = SettingKey[JSEnv]("preLinkJSEnv",
         "The jsEnv used to execute before linking (packaging / optimizing) Scala.js files", BSetting)


### PR DESCRIPTION
Since sbt identifies settings and tasks by name, they must be
unique globally amonst all plugins in the world. This commit
renames some of the tasks and settings that would most likely
cause troubles while not being used much in builds.
