### PR TITLE
Fix #1083: Don't write stub annotations to class files.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/annotation/README.md
+++ b/library/src/main/scala/scala/scalajs/js/annotation/README.md
@@ -1,3 +1,3 @@
 **Attention**: Some files in here are also published in the Scala.js stubs JVM library (see the stubs project in the Scala.js build).
 
-If you add (or rename) a file, make sure the file list in the stubs project is up to date.
+If you add (or rename) a file, make sure the files in the stubs project are up to date.

--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -598,23 +598,7 @@ object ScalaJSBuild extends Build {
       id = "stubs",
       base = file("stubs"),
       settings = defaultSettings ++ publishSettings ++ Seq(
-          name := "Scala.js Stubs",
-          sources in Compile ++= {
-            val annotFiles = Set(
-                "JSBracketAccess.scala",
-                "JSExport.scala",
-                "JSExportAll.scala",
-                "JSExportDescendentObjects.scala",
-                "JSExportNamed.scala"
-            )
-
-            val libSrcDir =
-              (scalaSource in library in Compile).value.getAbsoluteFile
-            val annotDir = libSrcDir / "scala/scalajs/js/annotation/"
-
-            val filter = new SimpleFilter(annotFiles)
-            (annotDir * filter).get
-          }
+          name := "Scala.js Stubs"
       )
   )
 

--- a/stubs/src/main/scala/scala/scalajs/js/annotation/ExportAnnotations.scala
+++ b/stubs/src/main/scala/scala/scalajs/js/annotation/ExportAnnotations.scala
@@ -1,0 +1,23 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+package scala.scalajs.js.annotation
+
+import scala.annotation.Annotation
+
+class JSExportAll extends scala.annotation.Annotation
+class JSExportDescendentObjects extends scala.annotation.Annotation
+
+class JSExportNamed extends scala.annotation.Annotation {
+  def this(name: String) = this()
+}
+
+class JSExport extends scala.annotation.Annotation {
+  def this(name: String) = this()
+}


### PR DESCRIPTION
Note: The JSBracketAccess annotation should never have been in the
stubs library. It is removed with this commit.
