### PR TITLE
Fix #1072: Bump sbt version to 0.13.5

### DIFF
--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -37,7 +37,7 @@ object ScalaJSBuild extends Build {
   val shouldPartest = settingKey[Boolean](
     "Whether we should partest the current scala version (and fail if we can't)")
 
-  val commonSettings = Defaults.defaultSettings ++ Seq(
+  val commonSettings = Seq(
       organization := "org.scala-lang.modules.scalajs",
       version := scalaJSVersion,
 
@@ -55,7 +55,14 @@ object ScalaJSBuild extends Build {
             / "tools" / "partest" / "scalajs" / scalaVersion.value
         )
         testListDir.exists
-      }
+      },
+
+      scalacOptions ++= Seq(
+          "-deprecation",
+          "-unchecked",
+          "-feature",
+          "-encoding", "utf8"
+      )
   )
 
   private val snapshotsOrReleases =
@@ -93,13 +100,7 @@ object ScalaJSBuild extends Build {
   )
 
   val defaultSettings = commonSettings ++ Seq(
-      scalaVersion := "2.11.0",
-      scalacOptions ++= Seq(
-          "-deprecation",
-          "-unchecked",
-          "-feature",
-          "-encoding", "utf8"
-      )
+      scalaVersion := "2.11.0"
   )
 
   val myScalaJSSettings = ScalaJSPluginInternal.scalaJSAbstractSettings ++ Seq(
@@ -786,7 +787,7 @@ object ScalaJSBuild extends Build {
           libraryDependencies ++= {
             if (shouldPartest.value)
               Seq(
-                "org.scala-sbt" % "sbt" % "0.13.0",
+                "org.scala-sbt" % "sbt" % sbtVersion.value,
                 "org.scala-lang.modules" %% "scala-partest" % "1.0.0",
                 "com.google.javascript" % "closure-compiler" % "v20130603",
                 "org.mozilla" % "rhino" % "1.7R4",

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.0
+sbt.version=0.13.5

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -289,7 +289,7 @@ object ScalaJSPluginInternal {
             // Attach the name of the main class used, (ab?)using the name key
             Attributed(file)(AttributeMap.empty.put(name.key, mainCl))
           } getOrElse {
-            error("Cannot write launcher file, since there is no or multiple mainClasses")
+            sys.error("Cannot write launcher file, since there is no or multiple mainClasses")
           }
         }
       },
@@ -367,7 +367,7 @@ object ScalaJSPluginInternal {
       // Give tasks ability to check we are not forking at build reading time
       scalaJSEnsureUnforked := {
         if (fork.value)
-          error("Scala.js cannot be run in a forked JVM")
+          sys.error("Scala.js cannot be run in a forked JVM")
         else
           true
       },
@@ -439,7 +439,7 @@ object ScalaJSPluginInternal {
             Attributed[VirtualJSFile](memLaunch)(
                 AttributeMap.empty.put(name.key, mainClass))
           } getOrElse {
-            error("No main class detected.")
+            sys.error("No main class detected.")
           }
         }
       },


### PR DESCRIPTION
Also see #1008, #1038.

This re-does eede37cc4fb87db96eae28a9a536c507233f1dd1 and
8f2169a37e77bca4cee8300c638e15d9eca138aa which were
reverted in 353e9635a2276e48b6ea6541e49f6c7ab8763b71.
