### PR TITLE
Separate the knowledge query getMethodBody() from resolve calls.

### DIFF
--- a/tools/shared/src/main/scala/scala/scalajs/tools/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/scala/scalajs/tools/optimizer/OptimizerCore.scala
@@ -30,20 +30,27 @@ import scala.scalajs.tools.logging._
  *  optimizer does. To perform inlining, it relies on abstract protected
  *  methods to identify the target of calls.
  */
-abstract class OptimizerCore(myself: OptimizerCore.MethodImpl) {
+abstract class OptimizerCore {
   import OptimizerCore._
+
+  type MethodID <: AbstractMethodID
+
+  val myself: MethodID
+
+  /** Returns the body of a method. */
+  protected def getMethodBody(method: MethodID): MethodDef
 
   /** Returns the list of possible targets for a dynamically linked call. */
   protected def dynamicCall(intfName: String,
-      methodName: String): List[MethodImpl]
+      methodName: String): List[MethodID]
 
   /** Returns the target of a static call. */
   protected def staticCall(className: String,
-      methodName: String): Option[MethodImpl]
+      methodName: String): Option[MethodID]
 
   /** Returns the target of a trait impl call. */
   protected def traitImplCall(traitImplName: String,
-      methodName: String): Option[MethodImpl]
+      methodName: String): Option[MethodID]
 
   /** Returns the list of ancestors of a class or interface. */
   protected def getAncestorsOf(encodedName: String): List[String]
@@ -67,14 +74,13 @@ abstract class OptimizerCore(myself: OptimizerCore.MethodImpl) {
   private var disableOptimisticOptimizations: Boolean = false
   private var rollbacksCount: Int = 0
 
-  private val attemptedInlining = mutable.ListBuffer.empty[MethodImpl]
+  private val attemptedInlining = mutable.ListBuffer.empty[MethodID]
 
   private var curTrampolineId = 0
 
-  def optimize(originalDef: MethodDef): (MethodDef, Infos.MethodInfo) = {
+  def optimize(thisType: Type, originalDef: MethodDef): (MethodDef, Infos.MethodInfo) = {
     try {
       val MethodDef(name, params, resultType, body) = originalDef
-      val thisType = myself.thisType
       val (newParams, newBody) = try {
         transformIsolatedBody(Some(myself), thisType, params, resultType, body)
       } catch {
@@ -1004,8 +1010,8 @@ abstract class OptimizerCore(myself: OptimizerCore.MethodImpl) {
                 if (impls.forall(_.isTraitImplForwarder)) {
                   val reference = impls.head
                   val TraitImplApply(ClassType(traitImpl), Ident(methodName, _), _) =
-                    reference.originalDef.body
-                  if (!impls.tail.forall(_.originalDef.body match {
+                    getMethodBody(reference).body
+                  if (!impls.tail.forall(getMethodBody(_).body match {
                     case TraitImplApply(ClassType(`traitImpl`),
                         Ident(`methodName`, _), _) => true
                     case _ => false
@@ -1154,15 +1160,14 @@ abstract class OptimizerCore(myself: OptimizerCore.MethodImpl) {
   }
 
   private def inline(optReceiver: Option[PreTransform],
-      args: List[PreTransform], target: MethodImpl, isStat: Boolean,
+      args: List[PreTransform], target: MethodID, isStat: Boolean,
       usePreTransform: Boolean)(
       cont: PreTransCont)(
       implicit scope: Scope, pos: Position): TailRec[Tree] = {
-    assert(target.inlineable, s"Trying to inline non-inlineable method $target")
 
     attemptedInlining += target
 
-    val MethodDef(_, formals, resultType, body) = target.originalDef
+    val MethodDef(_, formals, resultType, body) = getMethodBody(target)
 
     body match {
       case Skip() =>
@@ -1288,7 +1293,8 @@ abstract class OptimizerCore(myself: OptimizerCore.MethodImpl) {
     if (scope.implsBeingInlined.contains(target))
       cancelFun()
 
-    val MethodDef(_, formals, _, BlockOrAlone(stats, This())) = target.originalDef
+    val MethodDef(_, formals, _, BlockOrAlone(stats, This())) =
+      getMethodBody(target)
 
     val argsBindings = for {
       (ParamDef(Ident(name, originalName), tpe, mutable), arg) <- formals zip args
@@ -1707,7 +1713,7 @@ abstract class OptimizerCore(myself: OptimizerCore.MethodImpl) {
     }
   }
 
-  def transformIsolatedBody(optTarget: Option[MethodImpl],
+  def transformIsolatedBody(optTarget: Option[MethodID],
       thisType: Type, params: List[ParamDef], resultType: Type,
       body: Tree): (List[ParamDef], Tree) = {
     val (paramLocalDefs, newParamDefs) = (for {
@@ -2223,11 +2229,12 @@ object OptimizerCore {
     val Empty: OptEnv = new OptEnv(Map.empty, Map.empty)
   }
 
-  private class Scope(val env: OptEnv, val implsBeingInlined: Set[MethodImpl]) {
+  private class Scope(val env: OptEnv,
+      val implsBeingInlined: Set[AbstractMethodID]) {
     def withEnv(env: OptEnv): Scope =
       new Scope(env, implsBeingInlined)
 
-    def inlining(impl: MethodImpl): Scope = {
+    def inlining(impl: AbstractMethodID): Scope = {
       assert(!implsBeingInlined(impl), s"Circular inlining of $impl")
       new Scope(env, implsBeingInlined + impl)
     }
@@ -2343,6 +2350,12 @@ object OptimizerCore {
     def restore(backup: A): Unit = value = backup
   }
 
+  trait AbstractMethodID {
+    def inlineable: Boolean
+    def isTraitImplForwarder: Boolean
+  }
+
+  /** Parts of [[GenIncOptimizer#MethodImpl]] with decisions about optimizations. */
   abstract class MethodImpl {
     def encodedName: String
     def optimizerHints: OptimizerHints
@@ -2605,8 +2618,8 @@ object OptimizerCore {
     }
   }
 
-  private def exceptionMsg(myself: OptimizerCore.MethodImpl,
-      attemptedInlining: List[MethodImpl]) = {
+  private def exceptionMsg(myself: AbstractMethodID,
+      attemptedInlining: List[AbstractMethodID]) = {
     val buf = new StringBuilder()
 
     buf.append("The Scala.js optimizer crashed while optimizing " + myself)
@@ -2628,8 +2641,8 @@ object OptimizerCore {
       val savedStates: List[Any],
       val cont: () => TailRec[Tree]) extends ControlThrowable
 
-  class OptimizeException(val myself: OptimizerCore.MethodImpl,
-      val attemptedInlining: List[MethodImpl], cause: Throwable
+  class OptimizeException(val myself: AbstractMethodID,
+      val attemptedInlining: List[AbstractMethodID], cause: Throwable
   ) extends Exception(exceptionMsg(myself, attemptedInlining), cause)
 
 }


### PR DESCRIPTION
The three existing knowledge queries staticCall, dynamicCall and
traitImplCall are not invalidated anymore if the _body_ (the
`originalDef`) of a MethodImpl changes. They are invalidated only
for added methods, removed methods, and when a public "attribute"
of a method changes.

Attributes are the `inlineable` and `isTraitImplForwarder` flags.
They are exposed clearly in the MethodID interface, which is what
is returned from the three queries above.

A MethodID does not give access to its body. To do that, another,
separate knowledge query getMethodBody() is provided.

This separation follows what we described in the paper. It makes
sure we do not break our own assumptions by encoding in the type
system that MethodID only gives access to the flags that are
examined for the three xxCalls queries; and not to the body
itself.

It has at least one direct advantage in terms of accuracy of
detecting what to reoptimize: if only the body of an inlineable
method changes (but it remains inlineable and keeps the value of
its isTraitImplForwarder flag), then call sites that could call
that method with a dynamicCall, but cannot actually inline it
because there are multiple targets, need not be reoptimized.
This is especially important for the FunctionN.apply() case,
because all anonymous functions that are compiled as classes have
their apply method marked with `@inline`.

There is another potential advantage for the future: it makes it
possible, and sound, to decide to inline a method even if it does
not have the inlineable flag on.
