### PR TITLE
Add insert methods to java.lang.StringBuilder

### DIFF
--- a/javalanglib/src/main/scala/java/lang/StringBuffer.scala
+++ b/javalanglib/src/main/scala/java/lang/StringBuffer.scala
@@ -90,4 +90,48 @@ class StringBuffer(private var content: String) extends CharSequence
     }
   }
 
+  def insert(index: Int, b: scala.Boolean): StringBuffer        = insert(index, b.toString)
+  def insert(index: Int, b: scala.Byte): StringBuffer           = insert(index, b.toString)
+  def insert(index: Int, s: scala.Short): StringBuffer          = insert(index, s.toString)
+  def insert(index: Int, i: scala.Int): StringBuffer            = insert(index, i.toString)
+  def insert(index: Int, l: scala.Long): StringBuffer           = insert(index, l.toString)
+  def insert(index: Int, f: scala.Float): StringBuffer          = insert(index, f.toString)
+  def insert(index: Int, d: scala.Double): StringBuffer         = insert(index, d.toString)
+  def insert(index: Int, c: scala.Char): StringBuffer           = insert(index, c.toString)
+  def insert(index: Int, csq: CharSequence): StringBuffer       = insert(index: Int, csq: AnyRef)
+  def insert(index: Int, arr: Array[scala.Char]): StringBuffer  = insert(index, arr, 0, arr.length)
+
+  def insert(index: Int, ref: AnyRef): StringBuffer =
+    if (ref == null)
+      insert(index, null: String)
+    else
+      insert(index, ref.toString)
+
+  def insert(index: Int, csq: CharSequence, start: Int, end: Int): StringBuffer =
+    if (csq == null)
+      insert(index, "null", start, end)
+    else
+      insert(index, csq.subSequence(start, end).toString)
+
+
+  def insert(index: Int, arr: Array[scala.Char], offset: Int, len: Int): StringBuffer = {
+    var str = ""
+    var i = 0
+    while (i < len) {
+      str += arr(i + offset)
+      i += 1
+    }
+    insert(index, str)
+  }
+
+  def insert(index: Int, str: String): StringBuffer = {
+    val thisLength = length()
+    if (index < 0 || index > thisLength)
+      throw new StringIndexOutOfBoundsException(index)
+    else if (index == thisLength)
+      append(str)
+    else
+      content = content.substring(0, index) + Option(str).getOrElse("null") + content.substring(index)
+    this
+  }
 }

--- a/javalanglib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalanglib/src/main/scala/java/lang/StringBuilder.scala
@@ -109,4 +109,48 @@ class StringBuilder(private var content: String) extends CharSequence
     }
   }
 
+  def insert(index: Int, b: scala.Boolean): StringBuilder       = insert(index, b.toString)
+  def insert(index: Int, b: scala.Byte): StringBuilder          = insert(index, b.toString)
+  def insert(index: Int, s: scala.Short): StringBuilder         = insert(index, s.toString)
+  def insert(index: Int, i: scala.Int): StringBuilder           = insert(index, i.toString)
+  def insert(index: Int, l: scala.Long): StringBuilder          = insert(index, l.toString)
+  def insert(index: Int, f: scala.Float): StringBuilder         = insert(index, f.toString)
+  def insert(index: Int, d: scala.Double): StringBuilder        = insert(index, d.toString)
+  def insert(index: Int, c: scala.Char): StringBuilder          = insert(index, c.toString)
+  def insert(index: Int, csq: CharSequence): StringBuilder      = insert(index: Int, csq: AnyRef)
+  def insert(index: Int, arr: Array[scala.Char]): StringBuilder = insert(index, arr, 0, arr.length)
+
+  def insert(index: Int, ref: AnyRef): StringBuilder =
+    if (ref == null)
+      insert(index, null: String)
+    else
+      insert(index, ref.toString)
+
+  def insert(index: Int, csq: CharSequence, start: Int, end: Int): StringBuilder =
+    if (csq == null)
+      insert(index, "null", start, end)
+    else
+      insert(index, csq.subSequence(start, end).toString)
+
+
+  def insert(index: Int, arr: Array[scala.Char], offset: Int, len: Int): StringBuilder = {
+    var str = ""
+    var i = 0
+    while (i < len) {
+      str += arr(i + offset)
+      i += 1
+    }
+    insert(index, str)
+  }
+
+  def insert(index: Int, str: String): StringBuilder = {
+    val thisLength = length()
+    if (index < 0 || index > thisLength)
+      throw new StringIndexOutOfBoundsException(index)
+    else if (index == thisLength)
+      append(str)
+    else
+      content = content.substring(0, index) + Option(str).getOrElse("null") + content.substring(index)
+    this
+  }
 }

--- a/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/StringBufferTest.scala
+++ b/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/StringBufferTest.scala
@@ -7,14 +7,25 @@
 \*                                                                      */
 package scala.scalajs.testsuite.javalib
 
+import scala.reflect.{classTag, ClassTag}
 import scala.scalajs.js
 import org.scalajs.jasminetest.JasmineTest
 
 object StringBufferTest extends JasmineTest {
 
+  def shouldThrow[T : ClassTag](fn: => Unit) =
+    try {
+      fn
+      expect("exception").toBe("thrown")
+    } catch {
+      case e: T =>
+      case x: Throwable => expect(x.toString).toBe(classTag[T].runtimeClass.getSimpleName)
+    }
+
   describe("java.lang.StringBuffer") {
 
     def newBuf = new java.lang.StringBuffer
+    def initBuf(str: String) = new java.lang.StringBuffer(str)
 
     it("should respond to `append`") {
       expect(newBuf.append("asdf").toString).toEqual("asdf")
@@ -31,6 +42,33 @@ object StringBufferTest extends JasmineTest {
       expect(newBuf.append(100000).toString).toEqual("100000")
       expect(newBuf.append(2.5f).toString).toEqual("2.5")
       expect(newBuf.append(3.5).toString).toEqual("3.5")
+    }
+
+    it("should respond to `insert`") {
+      expect(newBuf.insert(0, "asdf").toString).toEqual("asdf")
+      expect(newBuf.insert(0, null: AnyRef).toString).toEqual("null")
+      expect(newBuf.insert(0, null: String).toString).toEqual("null")
+      expect(newBuf.insert(0, null: CharSequence,0,2).toString).toEqual("nu")
+      expect(newBuf.insert(0, js.undefined).toString).toEqual("undefined")
+      expect(newBuf.insert(0, true).toString).toEqual("true")
+      expect(newBuf.insert(0, 'a').toString).toEqual("a")
+      expect(newBuf.insert(0, Array('a','b','c','d')).toString).toEqual("abcd")
+      expect(newBuf.insert(0, Array('a','b','c','d'), 1, 2).toString).toEqual("bc")
+      expect(newBuf.insert(0, 4.toByte).toString).toEqual("4")
+      expect(newBuf.insert(0, 304.toShort).toString).toEqual("304")
+      expect(newBuf.insert(0, 100000).toString).toEqual("100000")
+      expect(newBuf.insert(0, 2.5f).toString).toEqual("2.5")
+      expect(newBuf.insert(0, 3.5).toString).toEqual("3.5")
+
+      expect(initBuf("adef").insert(1, "bc")).toEqual("abcdef")
+      expect(initBuf("abcd").insert(4, "ef")).toEqual("abcdef")
+      expect(initBuf("adef").insert(1, Array('b','c'))).toEqual("abcdef")
+      expect(initBuf("adef").insert(1, initBuf("bc"))).toEqual("abcdef")
+      expect(initBuf("abef").insert(2, Array('a','b','c','d','e'), 2, 2)).toEqual("abcdef")
+      expect(initBuf("abef").insert(2, initBuf("abcde"), 2, 4)).toEqual("abcdef")
+
+      shouldThrow[StringIndexOutOfBoundsException](initBuf("abcd").insert(5, "whatever"))
+      shouldThrow[StringIndexOutOfBoundsException](initBuf("abcd").insert(-1, "whatever"))
     }
 
     it("should respond to `setCharAt`") {
@@ -61,23 +99,51 @@ object StringBufferTest extends JasmineTest {
 
   describe("java.lang.StringBuilder") {
 
-    def newBuf = new java.lang.StringBuilder
+    def newBuilder = new java.lang.StringBuilder
+    def initBuilder(str: String) = new java.lang.StringBuilder(str)
 
     it("should respond to `append`") {
-      expect(newBuf.append("asdf").toString).toEqual("asdf")
-      expect(newBuf.append(null: AnyRef).toString).toEqual("null")
-      expect(newBuf.append(null: String).toString).toEqual("null")
-      expect(newBuf.append(null: CharSequence,0,2).toString).toEqual("nu")
-      expect(newBuf.append(js.undefined).toString).toEqual("undefined")
-      expect(newBuf.append(true).toString).toEqual("true")
-      expect(newBuf.append('a').toString).toEqual("a")
-      expect(newBuf.append(Array('a','b','c','d')).toString).toEqual("abcd")
-      expect(newBuf.append(Array('a','b','c','d'), 1, 2).toString).toEqual("bc")
-      expect(newBuf.append(4.toByte).toString).toEqual("4")
-      expect(newBuf.append(304.toShort).toString).toEqual("304")
-      expect(newBuf.append(100000).toString).toEqual("100000")
-      expect(newBuf.append(2.5f).toString).toEqual("2.5")
-      expect(newBuf.append(3.5).toString).toEqual("3.5")
+      expect(newBuilder.append("asdf").toString).toEqual("asdf")
+      expect(newBuilder.append(null: AnyRef).toString).toEqual("null")
+      expect(newBuilder.append(null: String).toString).toEqual("null")
+      expect(newBuilder.append(null: CharSequence,0,2).toString).toEqual("nu")
+      expect(newBuilder.append(js.undefined).toString).toEqual("undefined")
+      expect(newBuilder.append(true).toString).toEqual("true")
+      expect(newBuilder.append('a').toString).toEqual("a")
+      expect(newBuilder.append(Array('a','b','c','d')).toString).toEqual("abcd")
+      expect(newBuilder.append(Array('a','b','c','d'), 1, 2).toString).toEqual("bc")
+      expect(newBuilder.append(4.toByte).toString).toEqual("4")
+      expect(newBuilder.append(304.toShort).toString).toEqual("304")
+      expect(newBuilder.append(100000).toString).toEqual("100000")
+      expect(newBuilder.append(2.5f).toString).toEqual("2.5")
+      expect(newBuilder.append(3.5).toString).toEqual("3.5")
+    }
+
+    it("should respond to `insert`") {
+      expect(newBuilder.insert(0, "asdf").toString).toEqual("asdf")
+      expect(newBuilder.insert(0, null: AnyRef).toString).toEqual("null")
+      expect(newBuilder.insert(0, null: String).toString).toEqual("null")
+      expect(newBuilder.insert(0, null: CharSequence,0,2).toString).toEqual("nu")
+      expect(newBuilder.insert(0, js.undefined).toString).toEqual("undefined")
+      expect(newBuilder.insert(0, true).toString).toEqual("true")
+      expect(newBuilder.insert(0, 'a').toString).toEqual("a")
+      expect(newBuilder.insert(0, Array('a','b','c','d')).toString).toEqual("abcd")
+      expect(newBuilder.insert(0, Array('a','b','c','d'), 1, 2).toString).toEqual("bc")
+      expect(newBuilder.insert(0, 4.toByte).toString).toEqual("4")
+      expect(newBuilder.insert(0, 304.toShort).toString).toEqual("304")
+      expect(newBuilder.insert(0, 100000).toString).toEqual("100000")
+      expect(newBuilder.insert(0, 2.5f).toString).toEqual("2.5")
+      expect(newBuilder.insert(0, 3.5).toString).toEqual("3.5")
+
+      expect(initBuilder("adef").insert(1, "bc")).toEqual("abcdef")
+      expect(initBuilder("abcd").insert(4, "ef")).toEqual("abcdef")
+      expect(initBuilder("adef").insert(1, Array('b','c'))).toEqual("abcdef")
+      expect(initBuilder("adef").insert(1, initBuilder("bc"))).toEqual("abcdef")
+      expect(initBuilder("abef").insert(2, Array('a','b','c','d','e'), 2, 2)).toEqual("abcdef")
+      expect(initBuilder("abef").insert(2, initBuilder("abcde"), 2, 4)).toEqual("abcdef")
+
+      shouldThrow[StringIndexOutOfBoundsException](initBuilder("abcd").insert(5, "whatever"))
+      shouldThrow[StringIndexOutOfBoundsException](initBuilder("abcd").insert(-1, "whatever"))
     }
 
     it("should allow string interpolation to survive `null` and `undefined`") {
@@ -86,27 +152,27 @@ object StringBufferTest extends JasmineTest {
     }
 
     it("should respond to `setCharAt`") {
-      val buf = newBuf
-      buf.append("foobar")
+      val b = newBuilder
+      b.append("foobar")
 
-      buf.setCharAt(2, 'x')
-      expect(buf.toString).toEqual("foxbar")
+      b.setCharAt(2, 'x')
+      expect(b.toString).toEqual("foxbar")
 
-      buf.setCharAt(5, 'h')
-      expect(buf.toString).toEqual("foxbah")
+      b.setCharAt(5, 'h')
+      expect(b.toString).toEqual("foxbah")
 
-      expect(() => buf.setCharAt(-1, 'h')).toThrow
-      expect(() => buf.setCharAt(6,  'h')).toThrow
+      expect(() => b.setCharAt(-1, 'h')).toThrow
+      expect(() => b.setCharAt(6,  'h')).toThrow
     }
 
     it("should properly setLength") {
-      val buf = newBuf
-      buf.append("foobar")
+      val b = newBuilder
+      b.append("foobar")
 
-      expect(() => buf.setLength(-3)).toThrow
+      expect(() => b.setLength(-3)).toThrow
 
-      expect({ buf.setLength(3); buf.toString }).toEqual("foo")
-      expect({ buf.setLength(6); buf.toString }).toEqual("foo\u0000\u0000\u0000")
+      expect({ b.setLength(3); b.toString }).toEqual("foo")
+      expect({ b.setLength(6); b.toString }).toEqual("foo\u0000\u0000\u0000")
     }
 
   }


### PR DESCRIPTION
StringBuilder is missing insert methods, I tried to make it as similar as possible to `append` methods.

Two things:
1) inserting is using `substring` instead of `splitAt` cause it's obviously more effective way if you look at the impl
2) the `removing` stuff in StringBufferTest is just renaming of a variable that had a misleading name `newBuf` - it's a builder, not buffer
