### PR TITLE
Fix #1169: Make IR printer print cases of match tree nicely

### DIFF
--- a/ir/src/main/scala/scala/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/scala/scalajs/ir/Printers.scala
@@ -216,9 +216,9 @@ object Printers {
         case Match(selector, cases, default) =>
           print("match (", selector, ") ")
           print("{"); indent
-          for ((value, body) <- cases) {
+          for ((values, body) <- cases) {
             println()
-            print("case ", value, ":"); indent; println()
+            printRow(values, "case ", " | ", ":"); indent; println()
             printTree(body)
             print(";")
             undent


### PR DESCRIPTION
It now looks like this:

```
match (x1) {
  case 1 | 2 | 3:
    mod:s_Predef$.println__O__V("low");
  case 4:
    mod:s_Predef$.println__O__V("four");
  default:
    mod:s_Predef$.println__O__V("other");
}
```
