### PR TITLE
Fix #1171: Split: Sometimes remove leading empty match

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -36,33 +36,35 @@ final class Pattern private (pattern0: String, flags0: Int) {
     split(input, 0)
 
   def split(input: CharSequence, limit: Int): Array[String] = {
-    val hasLimit = limit > 0
-    val lim = if (hasLimit) limit else Int.MaxValue
+    val lim = if (limit > 0) limit else Int.MaxValue
 
-    val result = new js.Array[String](0)
+    val result = js.Array[String]()
     val inputStr = input.toString
     val matcher = this.matcher(inputStr)
     var prevEnd = 0
 
+    // Actually split original string
     while ((result.length < lim-1) && matcher.find()) {
       result.push(inputStr.substring(prevEnd, matcher.start))
       prevEnd = matcher.end
     }
     result.push(inputStr.substring(prevEnd))
 
-    var len = result.length.toInt
-    if (limit == 0) {
-      while (len > 1 && result(len-1).isEmpty)
-        len -= 1
-    }
+    // Remove a leading empty element iff the first match was zero-length 
+    // and there is no other place the regex matches
+    if (prevEnd == 0 && result.length == 2 && (lim > 2 || !matcher.find())) {
+      Array(inputStr)
+    } else {
+      var len = result.length
+      if (limit == 0) {
+        while (len > 1 && result(len-1).isEmpty)
+          len -= 1
+      }
 
-    val actualResult = new Array[String](len)
-    var i = 0
-    while (i < len) {
-      actualResult(i) = result(i)
-      i += 1
+      val actualResult = new Array[String](len)
+      result.copyToArray(actualResult)
+      actualResult
     }
-    actualResult
   }
 }
 

--- a/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/RegexTest.scala
+++ b/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/RegexTest.scala
@@ -52,6 +52,24 @@ object RegexTest extends JasmineTest {
       split("", "\n", Array(""))
       split("", "", Array(""))
 
+      // Should remove leading empty match under some conditions - #1171
+      // These tests are "measured" on the JVM since the spec is unclear
+      split("abc", "(?=a)", Array("abc"))
+      split("abc", "(?=b)", Array("a", "bc"))
+      split("abc", "(?=a)|b", Array("", "a", "c"))
+      split("abc", "", Array("", "a", "b", "c"))
+      split("abc", "(?=a)|(?=b)", Array("", "a", "bc"))
+      split("abc", "(?=a)|(?=a)", Array("abc"))
+      split("abc", "(?=a|b)", Array("", "a", "bc"))
+      split("abc", "(?=a|d)", Array("abc"))
+      split("abc", "^d*", Array("abc"))
+      split("abc", "d*", Array("", "a", "b", "c"))
+      split("a", "", Array("", "a"))
+      split("a", "^d*", Array("a"))
+      split("a", "d*", Array("", "a"))
+      split("a", "(?=a)", Array("a"))
+      split("ab", "a", Array("", "b"))
+
       def split(input: String, regex: String, expected: Array[String]): Unit = {
         val result = Pattern.compile(regex).split(input)
         expect(result.toJSArray).toEqual(expected.toJSArray)
@@ -72,6 +90,11 @@ object RegexTest extends JasmineTest {
       splitWithLimit("", "\\*", 5, Array(""))
       splitWithLimit("", "\n", -2, Array(""))
       splitWithLimit("", "", 1, Array(""))
+
+      // Should remove leading empty match under some conditions - #1171
+      splitWithLimit("abc", "", 2, Array("", "abc"))
+      splitWithLimit("abc", "(?=a)", 2, Array("abc"))
+      splitWithLimit("ab", "a", 1, Array("ab"))
 
       def splitWithLimit(input: String, regex: String, limit: Int, expected: Array[String]): Unit = {
         val result = Pattern.compile(regex).split(input, limit)


### PR DESCRIPTION
The conditions were determined experimentally since the JavaDoc is
note precise enough.
