### PR TITLE
Fetch Scala lib sources from the sources artifacts.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ target/
 .project
 .settings/
 /scalalib/fetchedSources/
+/partest/fetchedSources/
 /cli/pack/
 /.idea/
 /.idea_modules/

--- a/ci/check-partest-coverage.sh
+++ b/ci/check-partest-coverage.sh
@@ -22,7 +22,7 @@ FULLVER="$1"
 
 # Config
 BASEDIR="`dirname $0`/.."
-TESTDIR="$BASEDIR/scalalib/fetchedSources/$1/test/files"
+TESTDIR="$BASEDIR/partest/fetchedSources/$1/test/files"
 KNOWDIR="$BASEDIR/partest-suite/src/test/resources/scala/tools/partest/scalajs/$1/"
 
 # If the classification directory does not exist, this means (by

--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -63,6 +63,7 @@
          "javalibExTestSuite/fastOptStage::testOnly -- -- -ttypedarray -tnodejs -tsource-maps" \
          "javalibExTestSuite/fullOptStage::testOnly -- -- -ttypedarray -tnodejs -tsource-maps" &&
     sbt ++$scala compiler/test reversi/fastOptJS reversi/fullOptJS &&
+    sbt ++$scala partest/fetchScalaSource &&
     sh ci/checksizes.sh $scala &&
     sh ci/check-partest-coverage.sh $scala
   ]]></task>

--- a/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala
+++ b/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala
@@ -91,7 +91,7 @@ case class PartestTask(taskDef: TaskDef, args: Array[String]) extends Task {
     maybeOptions foreach { options =>
       val runner = SBTRunner(
           Framework.fingerprint, eventHandler, loggers,
-          new File(s"../scalalib/fetchedSources/${scalaVersion}"),
+          new File(s"../partest/fetchedSources/${scalaVersion}"),
           classLoader, null, null, Array.empty[String], options, scalaVersion)
 
       try runner execute Array("run", "pos", "neg")


### PR DESCRIPTION
Instead of cloning the git repo. This should make the dbuild build happy, assuming it does publish the source artifacts.

For partest, we still need to use the git clone strategy, since the published artifacts do not contain the partest tests (obviously).
