### PR TITLE
Remove failing bootstrapping test.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -155,10 +155,7 @@
       <v n="scala">2.10.2</v>
       <v n="java">1.8</v>
     </run>
-    <run task="bootstrap">
-      <v n="scala">2.11.2</v>
-      <v n="java">1.6</v>
-    </run>
+    <!-- Tools do not compile on JDK6, Scala 2.11.x (see #1235) -->
     <run task="bootstrap">
       <v n="scala">2.11.2</v>
       <v n="java">1.7</v>


### PR DESCRIPTION
The tools do not compile on JDK6 with Scala 2.11.x. (see #1235)
