### PR TITLE
Fix quoting in CI definition

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -98,7 +98,7 @@
 
   <task id="partest-noopt"><![CDATA[
     export JAVA_HOME=$HOME/apps/java-$java
-    sbt ++$scala package partestSuite/testOnly -- --showDiff
+    sbt ++$scala package "partestSuite/testOnly -- --showDiff"
   ]]></task>
 
   <task id="partest-fastopt"><![CDATA[


### PR DESCRIPTION
Quote the command introduced in
6a9992b9ea35eb67a9dab1a9a5a218c0a57c2efc.
