### PR TITLE
Fix #1252: Missing asInstanceOf's/unbox'es in scalajsenv.js.

### DIFF
--- a/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/StringTest.scala
+++ b/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/StringTest.scala
@@ -103,6 +103,12 @@ object StringTest extends JasmineTest {
       expect("Scala.js".charAt(6)).not.toBe('.')
     }
 
+    when("compliant-asinstanceofs").
+    it("charAt() should throw with out-of-bound indices") {
+      expect(() => "Scala.js".charAt(-3)).toThrow
+      expect(() => "Scala.js".charAt(20)).toThrow
+    }
+
     it("should respond to `codePointAt`") {
       // String that starts with a BMP symbol
       expect("abc\uD834\uDF06def".codePointAt(0)).toEqual(0x61)

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -215,22 +215,7 @@ ScalaJS.numberEquals = function(lhs, rhs) {
 ScalaJS.objectHashCode = function(instance) {
   switch (typeof instance) {
     case "string":
-      // calculate hash of String as specified by JavaDoc
-      var n = instance["length"];
-      var res = 0;
-      var mul = 1; // holds pow(31, n-i-1)
-      // multiplications with `mul` do never overflow the 52 bits of precision:
-      // - we truncate `mul` to 32 bits on each operation
-      // - 31 has 5 significant bits only
-      // - s[i] has 16 significant bits max
-      // 32 + max(5, 16) = 48 < 52 => no overflow
-      for (var i = n-1; i >= 0; --i) {
-        // calculate s[i] * pow(31, n-i-1)
-        res = res + (instance["charCodeAt"](i) * mul | 0) | 0
-        // update mul for next iteration
-        mul = mul * 31 | 0
-      }
-      return res;
+      return ScalaJS.m.sjsr_RuntimeString().hashCode__T__I(instance);
     case "number":
       return instance | 0;
     case "boolean":
@@ -269,21 +254,33 @@ ScalaJS.comparableCompareTo = function(instance, rhs) {
 
 ScalaJS.charSequenceLength = function(instance) {
   if (typeof(instance) === "string")
-    return instance["length"];
+//!if asInstanceOfs != Unchecked
+    return ScalaJS.uI(instance["length"]);
+//!else
+    return instance["length"] | 0;
+//!endif
   else
     return instance.length__I();
 };
 
 ScalaJS.charSequenceCharAt = function(instance, index) {
   if (typeof(instance) === "string")
-    return instance["charCodeAt"](index);
+//!if asInstanceOfs != Unchecked
+    return ScalaJS.uI(instance["charCodeAt"](index)) & 0xffff;
+//!else
+    return instance["charCodeAt"](index) & 0xffff;
+//!endif
   else
     return instance.charAt__I__C(index);
 };
 
 ScalaJS.charSequenceSubSequence = function(instance, start, end) {
   if (typeof(instance) === "string")
+//!if asInstanceOfs != Unchecked
+    return ScalaJS.as.T(instance["substring"](start, end));
+//!else
     return instance["substring"](start, end);
+//!endif
   else
     return instance.subSequence__I__I__jl_CharSequence(start, end);
 };

--- a/tools/shared/src/main/scala/scala/scalajs/tools/optimizer/Analyzer.scala
+++ b/tools/shared/src/main/scala/scala/scalajs/tools/optimizer/Analyzer.scala
@@ -149,6 +149,10 @@ class Analyzer(logger0: Logger, semantics: Semantics,
 
     instantiateClassWith("jl_Class", "init___jl_ScalaJSClassData")
 
+    val RTStringModuleClass = lookupClass("sjsr_RuntimeString$")
+    RTStringModuleClass.accessModule()
+    RTStringModuleClass.callMethod("hashCode__T__I")
+
     val RTLongClass = lookupClass(LongImpl.RuntimeLongClass)
     RTLongClass.instantiated()
     for (method <- LongImpl.AllConstructors ++ LongImpl.AllMethods)


### PR DESCRIPTION
Only one was really a danger, i.e., the result of `charCodeAt()` in `charSequenceCharAt()` with an out-of-bounds index. The others, being calls to methods of primitive data types, are hardly a problem, because the implementations cannot return wrong results. (Of course, they could be overwritten by an evil user, so it's better to check them.)
