### PR TITLE
Fix #1261: Forward-port additional test for #1252

### DIFF
--- a/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/StringTest.scala
+++ b/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/StringTest.scala
@@ -105,6 +105,10 @@ object StringTest extends JasmineTest {
 
     when("compliant-asinstanceofs").
     it("charAt() should throw with out-of-bound indices") {
+      // Type Strings both as CharSequence and String. One will invoke the
+      // helper, the other directly the method on RuntimeString.
+      expect(() => ("Scala.js": CharSequence).charAt(-3)).toThrow
+      expect(() => ("Scala.js": CharSequence).charAt(20)).toThrow
       expect(() => "Scala.js".charAt(-3)).toThrow
       expect(() => "Scala.js".charAt(20)).toThrow
     }


### PR DESCRIPTION
Originates from: c63d49981b4e7b86e13c4888b3bf680e27bcfdaf which is a
backport commit to 0.5.x that adds an additional test case.
