### PR TITLE
Fix #974: Implement java.util.UUID.

### DIFF
--- a/javalib/src/main/scala/java/util/UUID.scala
+++ b/javalib/src/main/scala/java/util/UUID.scala
@@ -1,0 +1,163 @@
+package java.util
+
+import java.lang.{Long => JLong}
+
+import scala.scalajs.js
+
+final class UUID private (
+    private val i1: Int, private val i2: Int,
+    private val i3: Int, private val i4: Int,
+    private[this] var l1: JLong, private[this] var l2: JLong)
+    extends AnyRef with java.io.Serializable with Comparable[UUID] {
+
+  import UUID._
+
+  /* Most significant long:
+   *
+   *  0xFFFFFFFF00000000 time_low
+   *  0x00000000FFFF0000 time_mid
+   *  0x000000000000F000 version
+   *  0x0000000000000FFF time_hi
+   *
+   * Least significant long:
+   *
+   *  0xC000000000000000 variant
+   *  0x3FFF000000000000 clock_seq
+   *  0x0000FFFFFFFFFFFF node
+   */
+
+  def this(mostSigBits: Long, leastSigBits: Long) = {
+    this((mostSigBits >>> 32).toInt, mostSigBits.toInt,
+        (leastSigBits >>> 32).toInt, leastSigBits.toInt,
+        mostSigBits, leastSigBits)
+  }
+
+  def getLeastSignificantBits(): Long = {
+    if (l2 eq null)
+      l2 = (i3.toLong << 32) | (i4.toLong & 0xffffffffL)
+    l2.longValue
+  }
+
+  def getMostSignificantBits(): Long = {
+    if (l1 eq null)
+      l1 = (i1.toLong << 32) | (i2.toLong & 0xffffffffL)
+    l1.longValue
+  }
+
+  def version(): Int =
+    (i2 & 0xf000) >> 12
+
+  def variant(): Int = {
+    if ((i3 & 0x80000000) == 0) {
+      // MSB0 not set: NCS backwards compatibility variant
+      0
+    } else if ((i3 & 0x40000000) != 0) {
+      // MSB1 set: either MS reserved or future reserved
+      (i3 & 0xe0000000) >>> 29
+    } else {
+      // MSB1 not set: RFC 4122 variant
+      2
+    }
+  }
+
+  def timestamp(): Long = {
+    if (version() != TimeBased)
+      throw new UnsupportedOperationException("Not a time-based UUID")
+    (((i2 >>> 16) | ((i2 & 0x0fff) << 16)).toLong << 32) | (i1.toLong & 0xffffffffL)
+  }
+
+  def clockSequence(): Int = {
+    if (version() != TimeBased)
+      throw new UnsupportedOperationException("Not a time-based UUID")
+    (i3 & 0x3fff0000) >> 16
+  }
+
+  def node(): Long = {
+    if (version() != TimeBased)
+      throw new UnsupportedOperationException("Not a time-based UUID")
+    ((i3 & 0xffff).toLong << 32) | (i4.toLong & 0xffffffffL)
+  }
+
+  override def toString(): String = {
+    @inline def paddedHex8(i: Int): String = {
+      val s = Integer.toHexString(i)
+      "00000000".substring(s.length) + s
+    }
+
+    @inline def paddedHex4(i: Int): String = {
+      val s = Integer.toHexString(i)
+      "0000".substring(s.length) + s
+    }
+
+    paddedHex8(i1) + "-" + paddedHex4(i2 >>> 16) + "-" + paddedHex4(i2 & 0xffff) + "-" +
+    paddedHex4(i3 >>> 16) + "-" + paddedHex4(i3 & 0xffff) + paddedHex8(i4)
+  }
+
+  override def hashCode(): Int =
+    i1 ^ i2 ^ i3 ^ i4
+
+  override def equals(that: Any): Boolean = that match {
+    case that: UUID =>
+      i1 == that.i1 && i2 == that.i2 && i3 == that.i3 && i4 == that.i4
+    case _ =>
+      false
+  }
+
+  def compareTo(that: UUID): Int = {
+    if (this.i1 != that.i1) {
+      if (this.i1 > that.i1) 1 else -1
+    } else if (this.i2 != that.i2) {
+      if (this.i2 > that.i2) 1 else -1
+    } else if (this.i3 != that.i3) {
+      if (this.i3 > that.i3) 1 else -1
+    } else if (this.i4 != that.i4) {
+      if (this.i4 > that.i4) 1 else -1
+    } else {
+      0
+    }
+  }
+}
+
+object UUID {
+  private final val TimeBased = 1
+  private final val DCESecurity = 2
+  private final val NameBased = 3
+  private final val Random = 4
+
+  private lazy val rng = new Random() // TODO Use java.security.SecureRandom
+
+  def randomUUID(): UUID = {
+    val i1 = rng.nextInt()
+    val i2 = (rng.nextInt() & ~0x0000f000) | 0x00004000
+    val i3 = (rng.nextInt() & ~0xc0000000) | 0x80000000
+    val i4 = rng.nextInt()
+    new UUID(i1, i2, i3, i4, null, null)
+  }
+
+  // Not implemented (requires messing with MD5 or SHA-1):
+  //def nameUUIDFromBytes(name: Array[Byte]): UUID = ???
+
+  def fromString(name: String): UUID = {
+    import Integer.parseInt
+
+    def fail(): Nothing =
+      throw new IllegalArgumentException("Illegal UUID string: "+name)
+
+    @inline def parseHex8(his: String, los: String): Int =
+      (parseInt(his, 16) << 16) | parseInt(los, 16)
+
+    if (name.length != 36 || name.charAt(8) != '-' ||
+        name.charAt(13) != '-' || name.charAt(18) != '-' || name.charAt(23) != '-')
+      fail()
+
+    try {
+      val i1 = parseHex8(name.substring(0, 4), name.substring(4, 8))
+      val i2 = parseHex8(name.substring(9, 13), name.substring(14, 18))
+      val i3 = parseHex8(name.substring(19, 23), name.substring(24, 28))
+      val i4 = parseHex8(name.substring(28, 32), name.substring(32, 36))
+      new UUID(i1, i2, i3, i4, null, null)
+    } catch {
+      case _: NumberFormatException => fail()
+    }
+  }
+}

--- a/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/UUIDTest.scala
+++ b/test-suite/src/test/scala/scala/scalajs/testsuite/javalib/UUIDTest.scala
@@ -1,0 +1,182 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.testsuite.javalib
+
+import scala.scalajs.js
+import org.scalajs.jasminetest.JasmineTest
+
+import java.util.UUID
+
+object UUIDTest extends JasmineTest {
+  describe("java.util.UUID") {
+    it("constructor") {
+      val uuid = new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L)
+      expect(uuid.getMostSignificantBits() == 0xf81d4fae7dec11d0L).toBeTruthy
+      expect(uuid.getLeastSignificantBits() == 0xa76500a0c91e6bf6L).toBeTruthy
+      expect(uuid.variant()).toEqual(2)
+      expect(uuid.version()).toEqual(1)
+      expect(uuid.timestamp() == 0x1d07decf81d4faeL).toBeTruthy
+      expect(uuid.clockSequence()).toEqual(0x2765)
+      expect(uuid.node() == 0xA0C91E6BF6L).toBeTruthy
+    }
+
+    it("getLeastSignificantBits") {
+      expect(new UUID(0L, 0L).getLeastSignificantBits() == 0L).toBeTruthy
+      expect(new UUID(0L, Long.MinValue).getLeastSignificantBits() == Long.MinValue).toBeTruthy
+      expect(new UUID(0L, Long.MaxValue).getLeastSignificantBits() == Long.MaxValue).toBeTruthy
+    }
+
+    it("getMostSignificantBits") {
+      expect(new UUID(0L, 0L).getMostSignificantBits() == 0L).toBeTruthy
+      expect(new UUID(Long.MinValue, 0L).getMostSignificantBits() == Long.MinValue).toBeTruthy
+      expect(new UUID(Long.MaxValue, 0L).getMostSignificantBits() == Long.MaxValue).toBeTruthy
+    }
+
+    it("version") {
+      expect(new UUID(0L, 0L).version()).toEqual(0)
+      expect(new UUID(0x0000000000001000L, 0L).version()).toEqual(1)
+      expect(new UUID(0x00000000000f2f00L, 0L).version()).toEqual(2)
+    }
+
+    it("variant") {
+      expect(new UUID(0L, 0L).variant()).toEqual(0)
+      expect(new UUID(0L, 0x7000000000000000L).variant()).toEqual(0)
+      expect(new UUID(0L, 0x3ff0000000000000L).variant()).toEqual(0)
+      expect(new UUID(0L, 0x1ff0000000000000L).variant()).toEqual(0)
+
+      expect(new UUID(0L, 0x8000000000000000L).variant()).toEqual(2)
+      expect(new UUID(0L, 0xb000000000000000L).variant()).toEqual(2)
+      expect(new UUID(0L, 0xaff0000000000000L).variant()).toEqual(2)
+      expect(new UUID(0L, 0x9ff0000000000000L).variant()).toEqual(2)
+
+      expect(new UUID(0L, 0xc000000000000000L).variant()).toEqual(6)
+      expect(new UUID(0L, 0xdf00000000000000L).variant()).toEqual(6)
+    }
+
+    it("timestamp") {
+      expect(new UUID(0x0000000000001000L,
+          0x8000000000000000L).timestamp() == 0L).toBeTruthy
+      expect(new UUID(0x7777777755551333L,
+          0x8000000000000000L).timestamp() == 0x333555577777777L).toBeTruthy
+
+      expect(() => new UUID(0x0000000000000000L, 0x8000000000000000L).timestamp()).toThrow
+      expect(() => new UUID(0x0000000000002000L, 0x8000000000000000L).timestamp()).toThrow
+    }
+
+    it("clockSequence") {
+      expect(new UUID(0x0000000000001000L, 0x8000000000000000L).clockSequence()).toEqual(0)
+      expect(new UUID(0x0000000000001000L, 0x8fff000000000000L).clockSequence()).toEqual(0x0fff)
+      expect(new UUID(0x0000000000001000L, 0xBfff000000000000L).clockSequence()).toEqual(0x3fff)
+
+      expect(() => new UUID(0x0000000000000000L, 0x8000000000000000L).clockSequence()).toThrow
+      expect(() => new UUID(0x0000000000002000L, 0x8000000000000000L).clockSequence()).toThrow
+    }
+
+    it("node") {
+      expect(new UUID(0x0000000000001000L, 0x8000000000000000L).node() == 0L).toBeTruthy
+      expect(new UUID(0x0000000000001000L, 0x8000ffffffffffffL).node() == 0xffffffffffffL).toBeTruthy
+
+      expect(() => new UUID(0x0000000000000000L, 0x8000000000000000L).node()).toThrow
+      expect(() => new UUID(0x0000000000002000L, 0x8000000000000000L).node()).toThrow
+    }
+
+    it("compareTo") {
+      val uuid0101 = new UUID(1L, 1L)
+      val uuid0111 = new UUID(1L, 0x100000001L)
+      val uuid1000 = new UUID(0x100000000L, 0L)
+
+      expect(uuid0101.compareTo(uuid0101)).toEqual(0)
+      expect(uuid0111.compareTo(uuid0111)).toEqual(0)
+      expect(uuid1000.compareTo(uuid1000)).toEqual(0)
+
+      expect(uuid0101.compareTo(uuid0111)).toBeLessThan(0)
+      expect(uuid0101.compareTo(uuid1000)).toBeLessThan(0)
+      expect(uuid0111.compareTo(uuid1000)).toBeLessThan(0)
+
+      expect(uuid0111.compareTo(uuid0101)).toBeGreaterThan(0)
+      expect(uuid1000.compareTo(uuid0101)).toBeGreaterThan(0)
+      expect(uuid1000.compareTo(uuid0111)).toBeGreaterThan(0)
+    }
+
+    it("hashCode") {
+      expect(new UUID(0L, 0L).hashCode()).toEqual(0)
+      expect(new UUID(123L, 123L).hashCode()).toEqual(new UUID(123L, 123L).hashCode())
+    }
+
+    it("equals") {
+      val uuid1 = new UUID(0L, 0L)
+      expect(uuid1.equals(uuid1)).toBeTruthy
+      expect(uuid1.equals(null)).toBeFalsy
+      expect(uuid1.equals("something else")).toBeFalsy
+
+      val uuid2 = new UUID(0L, 0L)
+      expect(uuid1.equals(uuid2)).toBeTruthy
+
+      val uuid3 = new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L)
+      val uuid4 = new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L)
+      expect(uuid3.equals(uuid4)).toBeTruthy
+      expect(uuid3.equals(uuid1)).toBeFalsy
+
+      expect(uuid3.equals(new UUID(0x781d4fae7dec11d0L, 0xa76500a0c91e6bf6L))).toBeFalsy
+      expect(uuid3.equals(new UUID(0xf81d4fae7dec11d1L, 0xa76500a0c91e6bf6L))).toBeFalsy
+      expect(uuid3.equals(new UUID(0xf81d4fae7dec11d0L, 0xa76530a0c91e6bf6L))).toBeFalsy
+      expect(uuid3.equals(new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6cf6L))).toBeFalsy
+    }
+
+    it("toString") {
+      expect(new UUID(0xf81d4fae7dec11d0L,
+          0xa76500a0c91e6bf6L).toString()).toEqual("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+      expect(new UUID(0x0000000000001000L,
+          0x8000000000000000L).toString()).toEqual("00000000-0000-1000-8000-000000000000")
+    }
+
+    it("randomUUID") {
+      val uuid = UUID.randomUUID()
+      expect(uuid.variant()).toEqual(2)
+      expect(uuid.version()).toEqual(4)
+    }
+
+    it("fromString") {
+      val uuid1 = UUID.fromString("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
+      expect(uuid1.equals(new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L))).toBeTruthy
+      expect(uuid1.getMostSignificantBits() == 0xf81d4fae7dec11d0L).toBeTruthy
+      expect(uuid1.getLeastSignificantBits() == 0xa76500a0c91e6bf6L).toBeTruthy
+      expect(uuid1.variant()).toEqual(2)
+      expect(uuid1.version()).toEqual(1)
+      expect(uuid1.timestamp() == 130742845922168750L).toBeTruthy
+      expect(uuid1.clockSequence()).toEqual(10085)
+      expect(uuid1.node() == 690568981494L).toBeTruthy
+
+      val uuid2 = UUID.fromString("00000000-0000-1000-8000-000000000000")
+      expect(uuid2.equals(new UUID(0x0000000000001000L, 0x8000000000000000L)))
+      println(java.lang.Long.toHexString(uuid2.getMostSignificantBits()))
+      println(java.lang.Long.toHexString(uuid2.getLeastSignificantBits()))
+      expect(uuid2.getMostSignificantBits() == 0x0000000000001000L).toBeTruthy
+      expect(uuid2.getLeastSignificantBits() == 0x8000000000000000L).toBeTruthy
+      expect(uuid2.variant()).toEqual(2)
+      expect(uuid2.version()).toEqual(1)
+      expect(uuid2.timestamp() == 0L).toBeTruthy
+      expect(uuid2.clockSequence()).toEqual(0)
+      expect(uuid2.node() == 0L).toBeTruthy
+
+      expect(() => UUID.fromString(null)).toThrow
+      expect(() => UUID.fromString("")).toThrow
+      expect(() => UUID.fromString("f81d4fae_7dec-11d0-a765-00a0c91e6bf6")).toThrow
+      expect(() => UUID.fromString("f81d4fae-7dec_11d0-a765-00a0c91e6bf6")).toThrow
+      expect(() => UUID.fromString("f81d4fae-7dec-11d0_a765-00a0c91e6bf6")).toThrow
+      expect(() => UUID.fromString("f81d4fae-7dec-11d0-a765_00a0c91e6bf6")).toThrow
+      expect(() => UUID.fromString("-7dec-11d0-a765-00a0c91e6bf6")).toThrow
+      expect(() => UUID.fromString("f81d4fae--11d0-a765-00a0c91e6bf6")).toThrow
+      expect(() => UUID.fromString("f81d4fae-7dec--a765-00a0c91e6bf6")).toThrow
+      expect(() => UUID.fromString("f81d4fae-7dec-11d0--00a0c91e6bf6")).toThrow
+      expect(() => UUID.fromString("f81d4fae-7dec-11d0-a765-")).toThrow
+      expect(() => UUID.fromString("f81d4fae-7dec-11d0-a765")).toThrow
+      expect(() => UUID.fromString("f81d4fae-7dZc-11d0-a765-00a0c91e6bf6")).toThrow
+    }
+  }
+}


### PR DESCRIPTION
Except `UUID.nameUUIDFromBytes`, because that relies on computing an MD5 or SHA-1 hash.
