### PR TITLE
Make Predef.singleton_<:< and Predef.singleton_=:= inlineable.

### DIFF
--- a/tools/shared/src/main/scala/scala/scalajs/tools/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/scala/scalajs/tools/optimizer/OptimizerCore.scala
@@ -1000,6 +1000,9 @@ private[optimizer] abstract class OptimizerCore(semantics: Semantics) {
     case LoadModule(ClassType(moduleClassName)) =>
       if (hasElidableModuleAccessor(moduleClassName)) Skip()(stat.pos)
       else stat
+    case Select(LoadModule(ClassType(moduleClassName)), _, _) =>
+      if (hasElidableModuleAccessor(moduleClassName)) Skip()(stat.pos)
+      else stat
     case Closure(_, _, _, captureValues) =>
       Block(captureValues.map(keepOnlySideEffects))(stat.pos)
     case UnaryOp(_, arg) =>
@@ -1248,7 +1251,12 @@ private[optimizer] abstract class OptimizerCore(semantics: Semantics) {
         true
 
       case _ =>
-        false
+        arg.tpe.base match {
+          case ClassType("s_Predef$$less$colon$less" | "s_Predef$$eq$colon$eq") =>
+            true
+          case _ =>
+            false
+        }
     }
     receiverAndArgs.exists(isLikelyOptimizable)
   }


### PR DESCRIPTION
Because they are singletons for efficiency, they are not allocated every time you use them. But then they are not inlineable classes, and hence did not cause the method call to be inlined, which is a pity, since their apply method is an identity.

This commit makes any tree of these two types are likely optimizable. With this, all that remains is a statement loading the field. We make this elideable as well by noting that `Select(x, y)` preserves the pureness of `x`, provided it is not `null`. If `x` is a `LoadModule()`, it cannot be `null`, so we can remove it.
