### PR TITLE
Fix #1025: Turn the sbt plugin into an AutoPlugin.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -17,69 +17,69 @@
     export JAVA_HOME=$HOME/apps/java-$java
     sbt ++$scala package packageDoc &&
     sbt ++$scala helloworld/run \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala helloworld/run \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
-        ++$scala helloworld/run \
-        helloworld/clean &&
-    sbt 'set ScalaJSKeys.scalaJSOptimizerOptions in ScalaJSBuild.helloworld ~= (_.withDisableOptimizer(true))' \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala helloworld/run \
         helloworld/clean &&
-    sbt 'set ScalaJSKeys.postLinkJSEnv in ScalaJSBuild.helloworld := new scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv' \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+    sbt 'set scalaJSOptimizerOptions in ScalaJSBuild.helloworld ~= (_.withDisableOptimizer(true))' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala helloworld/run \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
+        helloworld/clean &&
+    sbt 'set postLinkJSEnv in ScalaJSBuild.helloworld := new scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv' \
+        'set scalaJSStage in Global := FastOptStage' \
+        ++$scala helloworld/run \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala helloworld/run &&
     sbt ++$scala testingExample/test \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala testingExample/test \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala testingExample/test \
         testingExample/clean &&
-    sbt 'set ScalaJSKeys.scalaJSOptimizerOptions in ScalaJSBuild.testingExample ~= (_.withDisableOptimizer(true))' \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+    sbt 'set scalaJSOptimizerOptions in ScalaJSBuild.testingExample ~= (_.withDisableOptimizer(true))' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala testingExample/test &&
     sbt ++$scala "testSuite/testOnly -- -- -trhino -tsource-maps" \
                  "noIrCheckTest/testOnly -- -- -trhino -tsource-maps" \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" \
                  "noIrCheckTest/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" \
                  "noIrCheckTest/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" \
         testSuite/clean &&
-    sbt 'set ScalaJSKeys.scalaJSOptimizerOptions in ScalaJSBuild.testSuite ~= (_.withDisableOptimizer(true))' \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+    sbt 'set scalaJSOptimizerOptions in ScalaJSBuild.testSuite ~= (_.withDisableOptimizer(true))' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" \
         testSuite/clean &&
-    sbt 'set ScalaJSKeys.scalaJSSemantics in ScalaJSBuild.testSuite ~= { _.withAsInstanceOfs(scala.scalajs.tools.sem.CheckedBehavior.Compliant).withStrictFloats(true) }' \
+    sbt 'set scalaJSSemantics in ScalaJSBuild.testSuite ~= { _.withAsInstanceOfs(scala.scalajs.tools.sem.CheckedBehavior.Compliant).withStrictFloats(true) }' \
         ++$scala "testSuite/testOnly -- -- -trhino -tsource-maps -tcompliant-asinstanceofs -tstrict-floats" \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps -tcompliant-asinstanceofs -tstrict-floats" \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
-        ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps -tcompliant-asinstanceofs -tstrict-floats" \
-        testSuite/clean &&
-    sbt 'set ScalaJSKeys.scalaJSSemantics in ScalaJSBuild.testSuite ~= { _.withAsInstanceOfs(scala.scalajs.tools.sem.CheckedBehavior.Compliant).withStrictFloats(true) }' \
-        'set ScalaJSKeys.scalaJSOptimizerOptions in ScalaJSBuild.testSuite ~= (_.withDisableOptimizer(true))' \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps -tcompliant-asinstanceofs -tstrict-floats" \
         testSuite/clean &&
-    sbt 'set ScalaJSKeys.postLinkJSEnv in ScalaJSBuild.testSuite := new scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv' \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+    sbt 'set scalaJSSemantics in ScalaJSBuild.testSuite ~= { _.withAsInstanceOfs(scala.scalajs.tools.sem.CheckedBehavior.Compliant).withStrictFloats(true) }' \
+        'set scalaJSOptimizerOptions in ScalaJSBuild.testSuite ~= (_.withDisableOptimizer(true))' \
+        'set scalaJSStage in Global := FastOptStage' \
+        ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps -tcompliant-asinstanceofs -tstrict-floats" \
+        testSuite/clean &&
+    sbt 'set postLinkJSEnv in ScalaJSBuild.testSuite := new scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala "testSuite/testOnly -- -- -tphantomjs" \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala "testSuite/testOnly -- -- -tphantomjs" \
         testSuite/clean &&
     sbt 'set scalacOptions in ScalaJSBuild.testSuite += "-Xexperimental"' \
         ++$scala "testSuite/testOnly -- -- -trhino -tsource-maps" \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+        'set scalaJSStage in Global := FastOptStage' \
         ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" &&
-    sbt 'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+    sbt 'set scalaJSStage in Global := FastOptStage' \
         ++$scala "javalibExTestSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala "javalibExTestSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps" &&
     sbt ++$scala compiler/test reversi/fastOptJS reversi/fullOptJS &&
     sbt ++$scala partest/fetchScalaSource &&
@@ -89,9 +89,9 @@
 
   <task id="bootstrap"><![CDATA[
     export JAVA_HOME=$HOME/apps/java-$java
-    sbt 'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+    sbt 'set scalaJSStage in Global := FastOptStage' \
         ++$scala toolsJS/test \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FullOpt' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala toolsJS/test
   ]]></task>
 
@@ -117,7 +117,7 @@
     # Go into standalone project and test
     cd sbt-plugin-test
     sbt noDOM/run withDOM/run test \
-        'set ScalaJSKeys.scalaJSStage in Global := scala.scalajs.sbtplugin.Stage.FastOpt' \
+        'set scalaJSStage in Global := FastOptStage' \
         jetty9/run test
   ]]></task>
 

--- a/project/ExternalCompile.scala
+++ b/project/ExternalCompile.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 import scala.scalajs.sbtplugin.ScalaJSPlugin
-import ScalaJSPlugin.ScalaJSKeys.jsDependencyManifest
+import ScalaJSPlugin.autoImport.jsDependencyManifest
 
 object ExternalCompile {
 

--- a/project/ScalaJSBuild.scala
+++ b/project/ScalaJSBuild.scala
@@ -17,8 +17,7 @@ import scala.util.Properties
 import scala.scalajs.ir
 import scala.scalajs.sbtplugin._
 import scala.scalajs.sbtplugin.env.rhino.RhinoJSEnv
-import ScalaJSPlugin._
-import ScalaJSKeys._
+import ScalaJSPlugin.autoImport._
 import ExternalCompile.scalaJSExternalCompileSettings
 import Implicits._
 
@@ -131,18 +130,20 @@ object ScalaJSBuild extends Build {
   // Used when compiling the compiler, adding it to scalacOptions does not help
   scala.util.Properties.setProp("scalac.patmat.analysisBudget", "1024")
 
-  override lazy val settings = super.settings :+ {
-    // Most of the projects cross-compile
-    crossScalaVersions := Seq(
-      "2.10.2",
-      "2.10.3",
-      "2.10.4",
-      "2.11.0",
-      "2.11.1",
-      "2.11.2",
-      "2.11.4"
-    )
-  }
+  override lazy val settings = super.settings ++ Seq(
+      // Most of the projects cross-compile
+      crossScalaVersions := Seq(
+        "2.10.2",
+        "2.10.3",
+        "2.10.4",
+        "2.11.0",
+        "2.11.1",
+        "2.11.2",
+        "2.11.4"
+      ),
+      // Default stage
+      scalaJSStage in Global := PreLinkStage
+  )
 
   lazy val root: Project = Project(
       id = "scalajs",

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -1,5 +1,3 @@
-import ScalaJSKeys._
-
 import scala.scalajs.sbtplugin.RuntimeDOM
 
 import scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv
@@ -8,35 +6,42 @@ name := "Scala.js sbt test"
 
 version := scalaJSVersion
 
-val baseSettings = scalaJSSettings ++ Seq(
+val baseSettings = Seq(
   version := scalaJSVersion,
   scalaVersion := "2.11.2",
   libraryDependencies +=
     "org.scala-lang.modules.scalajs" %% "scalajs-jasmine-test-framework" % scalaJSVersion % "test"
 )
 
-lazy val root = project.in(file(".")).aggregate(noDOM, withDOM)
+lazy val root = project.in(file(".")).
+  aggregate(noDOM, withDOM)
 
-lazy val noDOM = project.settings(baseSettings: _*).settings(
-  name := "Scala.js sbt test w/o DOM"
-)
-
-lazy val withDOM = project.settings(baseSettings: _*).settings(
-  name := "Scala.js sbt test w/ DOM",
-  jsDependencies ++= Seq(
-      RuntimeDOM,
-      "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
+lazy val noDOM = project.settings(baseSettings: _*).
+  enablePlugins(ScalaJSPlugin).
+  settings(
+    name := "Scala.js sbt test w/o DOM"
   )
-)
 
-lazy val jetty9 = project.settings(baseSettings: _*).settings(
-  name := "Scala.js sbt test with jetty9 on classpath",
-  jsDependencies ++= Seq(
-      RuntimeDOM,
-      "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
-  ),
-  postLinkJSEnv := new PhantomJSEnv(
-    addArgs = List("--web-security=no"), // allow cross domain requests
-    jettyClassLoader = scalaJSPhantomJSClassLoader.value),
-  Jetty9Test.runSetting
-)
+lazy val withDOM = project.settings(baseSettings: _*).
+  enablePlugins(ScalaJSPlugin).
+  settings(
+    name := "Scala.js sbt test w/ DOM",
+    jsDependencies ++= Seq(
+        RuntimeDOM,
+        "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
+    )
+  )
+
+lazy val jetty9 = project.settings(baseSettings: _*).
+  enablePlugins(ScalaJSPlugin).
+  settings(
+    name := "Scala.js sbt test with jetty9 on classpath",
+    jsDependencies ++= Seq(
+        RuntimeDOM,
+        "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
+    ),
+    postLinkJSEnv := new PhantomJSEnv(
+      addArgs = List("--web-security=no"), // allow cross domain requests
+      jettyClassLoader = scalaJSPhantomJSClassLoader.value),
+    Jetty9Test.runSetting
+  )

--- a/sbt-plugin-test/project/Jetty9Test.scala
+++ b/sbt-plugin-test/project/Jetty9Test.scala
@@ -2,8 +2,7 @@ import sbt._
 import Keys._
 
 import scala.scalajs.sbtplugin._
-import ScalaJSPlugin._
-import ScalaJSKeys._
+import ScalaJSPlugin.autoImport._
 import Implicits._
 
 import scala.scalajs.tools.env._

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -19,13 +19,23 @@ import scala.scalajs.tools.optimizer.ScalaJSOptimizer
 
 import scala.scalajs.ir.ScalaJSVersions
 
-object ScalaJSPlugin extends Plugin with impl.DependencyBuilders {
-  val scalaJSVersion = ScalaJSVersions.current
-  val scalaJSIsSnapshotVersion = ScalaJSVersions.currentIsSnapshot
-  val scalaJSBinaryVersion = ScalaJSCrossVersion.currentBinaryVersion
+object ScalaJSPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
 
-  object ScalaJSKeys {
+  object autoImport extends impl.DependencyBuilders {
     import KeyRanks._
+
+    // Some constants
+    val scalaJSVersion = ScalaJSVersions.current
+    val scalaJSIsSnapshotVersion = ScalaJSVersions.currentIsSnapshot
+    val scalaJSBinaryVersion = ScalaJSCrossVersion.currentBinaryVersion
+
+    // Stage values
+    val PreLinkStage = Stage.PreLink
+    val FastOptStage = Stage.FastOpt
+    val FullOptStage = Stage.FullOpt
+
+    // All our public-facing keys
 
     val fastOptJS = TaskKey[Attributed[File]]("fastOptJS",
         "Quickly link all compiled JavaScript into a single file", APlusTask)
@@ -104,25 +114,17 @@ object ScalaJSPlugin extends Plugin with impl.DependencyBuilders {
         KeyRanks.Invisible)
   }
 
+  import autoImport._
   import ScalaJSPluginInternal._
 
   override def globalSettings: Seq[Setting[_]] = {
     super.globalSettings ++ Seq(
-        ScalaJSKeys.scalaJSStage := Stage.PreLink
+        scalaJSStage := Stage.PreLink
     )
   }
 
-  /** All Scala.js settings */
-  val scalaJSSettings: Seq[Setting[_]] = (
+  override def projectSettings: Seq[Setting[_]] = (
       scalaJSAbstractSettings ++
-      scalaJSEcosystemSettings
-  )
-
-  /** Scala.js build settings: Allows to build Scala.js, but doesn't change
-   *  run / test commands
-   */
-  val scalaJSBuildSettings: Seq[Setting[_]] = (
-      scalaJSAbstractBuildSettings ++
       scalaJSEcosystemSettings
   )
 }

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -39,8 +39,7 @@ import java.net.URLClassLoader
  */
 object ScalaJSPluginInternal {
 
-  import ScalaJSPlugin.ScalaJSKeys._
-  import ScalaJSPlugin.scalaJSVersion
+  import ScalaJSPlugin.autoImport._
 
   /** Dummy setting to ensure we do not fork in Scala.js run & test. */
   val scalaJSEnsureUnforked = SettingKey[Boolean]("ensureUnforked",

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/impl/DependencyBuilders.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/impl/DependencyBuilders.scala
@@ -74,8 +74,8 @@ object ScalaJSGroupID {
     // Hack to work around bug in sbt macros (wrong way of collecting local
     // definitions)
     val keysSym = rootMirror.staticModule(
-        "_root_.scala.scalajs.sbtplugin.ScalaJSPlugin.ScalaJSKeys")
-    val keys = c.Expr[ScalaJSPlugin.ScalaJSKeys.type](Ident(keysSym))
+        "_root_.scala.scalajs.sbtplugin.ScalaJSPlugin.autoImport")
+    val keys = c.Expr[ScalaJSPlugin.autoImport.type](Ident(keysSym))
 
     reify {
       val cross = {


### PR DESCRIPTION
Note that we cannot use the AutoPlugin in our build itself, because we need the _abstract_ set of settings. However, the AutoPlugin is tested in sbt-plugin-test.
