### PR TITLE
Add factories to sbt plugin for PhantomJSEnv and NodeJSEnv

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -26,7 +26,7 @@
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala helloworld/run \
         helloworld/clean &&
-    sbt 'set postLinkJSEnv in ScalaJSBuild.helloworld := new scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv' \
+    sbt 'set inScope(ThisScope in ScalaJSBuild.helloworld)(postLinkJSEnv := PhantomJSEnv().value)' \
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala helloworld/run \
         'set scalaJSStage in Global := FullOptStage' \
@@ -65,7 +65,7 @@
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala "testSuite/testOnly -- -- -ttypedarray -tnodejs -tsource-maps -tcompliant-asinstanceofs -tstrict-floats" \
         testSuite/clean &&
-    sbt 'set postLinkJSEnv in ScalaJSBuild.testSuite := new scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv' \
+    sbt 'set inScope(ThisScope in ScalaJSBuild.helloworld)(postLinkJSEnv := PhantomJSEnv().value)' \
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala "testSuite/testOnly -- -- -tphantomjs" \
         'set scalaJSStage in Global := FullOptStage' \

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -1,7 +1,5 @@
 import scala.scalajs.sbtplugin.RuntimeDOM
 
-import scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv
-
 name := "Scala.js sbt test"
 
 version := scalaJSVersion
@@ -40,8 +38,7 @@ lazy val jetty9 = project.settings(baseSettings: _*).
         RuntimeDOM,
         "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
     ),
-    postLinkJSEnv := new PhantomJSEnv(
-      addArgs = List("--web-security=no"), // allow cross domain requests
-      jettyClassLoader = scalaJSPhantomJSClassLoader.value),
+    // Use PhantomJS, allow cross domain requests
+    postLinkJSEnv := PhantomJSEnv(args = Seq("--web-security=no")).value,
     Jetty9Test.runSetting
   )

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -19,6 +19,9 @@ import scala.scalajs.tools.optimizer.ScalaJSOptimizer
 
 import scala.scalajs.ir.ScalaJSVersions
 
+import scala.scalajs.sbtplugin.env.nodejs.NodeJSEnv
+import scala.scalajs.sbtplugin.env.phantomjs.PhantomJSEnv
+
 object ScalaJSPlugin extends AutoPlugin {
   override def requires = plugins.JvmPlugin
 
@@ -34,6 +37,52 @@ object ScalaJSPlugin extends AutoPlugin {
     val PreLinkStage = Stage.PreLink
     val FastOptStage = Stage.FastOpt
     val FullOptStage = Stage.FullOpt
+
+    // Factory methods for JSEnvs
+
+    /**
+     *  Creates a [[Def.Initialize]] for a NodeJSEnv. Use this to explicitly
+     *  specify in your build that you would like to run with Node.js:
+     *
+     *  {{{
+     *  postLinkJSEnv := NodeJSEnv().value
+     *  }}}
+     *
+     *  Note that the resulting [[Setting]] is not scoped at all, but must be
+     *  scoped in a project that has the ScalaJSPlugin enabled to work properly.
+     *  Therefore, either put the upper line in your project settings (common
+     *  case) or scope it manually, using [[Project.inScope]].
+     */
+    def NodeJSEnv(
+        executable: String = "node",
+        args: Seq[String] = Seq.empty,
+        env: Map[String, String] = Map.empty
+    ): Def.Initialize[Task[NodeJSEnv]] = Def.task {
+      new NodeJSEnv(executable, args, env)
+    }
+
+    /**
+     *  Creates a [[Def.Initialize]] for a PhantomJSEnv. Use this to explicitly
+     *  specify in your build that you would like to run with PhantomJS:
+     *
+     *  {{{
+     *  postLinkJSEnv := PhantomJSEnv().value
+     *  }}}
+     *
+     *  Note that the resulting [[Setting]] is not scoped at all, but must be
+     *  scoped in a project that has the ScalaJSPlugin enabled to work properly.
+     *  Therefore, either put the upper line in your project settings (common
+     *  case) or scope it manually, using [[Project.inScope]].
+     */
+    def PhantomJSEnv(
+        executable: String = "phantomjs",
+        args: Seq[String] = Seq.empty,
+        env: Map[String, String] = Map.empty,
+        autoExit: Boolean = true
+    ): Def.Initialize[Task[PhantomJSEnv]] = Def.task {
+      val loader = scalaJSPhantomJSClassLoader.value
+      new PhantomJSEnv(executable, args, env, autoExit, loader)
+    }
 
     // All our public-facing keys
 


### PR DESCRIPTION
This hopefully simplifies build definitions that need to tweak some
command line options or just force a given environment.

At the same time, this also fixes #1302 (use proper class loader for
PhantomJSEnv in our CI).
