### PR TITLE
Fix #1308: Auto import RuntimeDOM builder

### DIFF
--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -1,5 +1,3 @@
-import scala.scalajs.sbtplugin.RuntimeDOM
-
 name := "Scala.js sbt test"
 
 version := scalaJSVersion

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/AbstractJSDeps.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/AbstractJSDeps.scala
@@ -71,11 +71,9 @@ object ProvidedJSModuleID {
     ProvidedJSModuleID(new JSDependency(name, Nil), configurations)
 }
 
-sealed case class RuntimeDOM(
+final case class RuntimeDOMDep(
     configurations: Option[String]) extends AbstractJSDep {
 
-  protected def withConfigs(configs: Option[String]): RuntimeDOM =
+  protected def withConfigs(configs: Option[String]): RuntimeDOMDep =
     copy(configurations = configs)
 }
-
-object RuntimeDOM extends RuntimeDOM(None)

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -258,7 +258,7 @@ object ScalaJSPluginInternal {
         }
 
         val requiresDOM = jsDependencies.value.exists {
-          case RuntimeDOM(configurations) =>
+          case RuntimeDOMDep(configurations) =>
             configurations.forall(_ == config)
           case _ => false
         }

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/impl/DependencyBuilders.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/impl/DependencyBuilders.scala
@@ -23,21 +23,34 @@ trait DependencyBuilders {
     new ScalaJSGroupID(groupID)
   }
 
-  /** Builder to allow for stuff like:
+  /**
+   *  Dummy builder to allow declaractions like:
    *
-   *    ProvidedJS / "foo.js"
-   *    ProvidedJS / "foo.js" % "test"
+   *  {{{
+   *  RuntimeDOM % "test"
+   *  }}}
+   */
+  val RuntimeDOM = scala.scalajs.sbtplugin.RuntimeDOMDep(None)
+
+  /**
+   *  Builder to allow declarations like:
    *
+   *  {{{
+   *  ProvidedJS / "foo.js"
+   *  ProvidedJS / "foo.js" % "test"
+   *  }}}
    */
   object ProvidedJS {
     def /(name: String): ProvidedJSModuleID = ProvidedJSModuleID(name, None)
   }
 
-  /** Builder to allow for stuff like:
+  /**
+   *  Builder to allow declarations like:
    *
-   *    "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
-   *    "org.webjars" % "jquery" % "1.10.2" / "jquery.js" % "test"
-   *
+   *  {{{
+   *  "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
+   *  "org.webjars" % "jquery" % "1.10.2" / "jquery.js" % "test"
+   *  }}}
    */
   implicit class JSModuleIDBuilder(module: ModuleID) {
     def /(name: String): JarJSModuleID = JarJSModuleID(module, name)


### PR DESCRIPTION
Rename former RuntimeDOM to RuntimeDOMDep to avoid import conflicts.
