### PR TITLE
Fix #1332: Correct package names for CLI runners

### DIFF
--- a/cli/src/main/resources/scalajsld
+++ b/cli/src/main/resources/scalajsld
@@ -7,4 +7,4 @@ BASE="$(dirname $0)/.."
 CLILIB="$BASE/lib/scalajs-cli-assembly_$SCALA_BIN_VER-$SCALAJS_VER.jar"
 JSLIB="$BASE/lib/scalajs-library_$SCALA_BIN_VER-$SCALAJS_VER.jar"
 
-scala -classpath "$CLILIB" scala.scalajs.cli.Scalajsld --stdlib "$JSLIB" "$@"
+scala -classpath "$CLILIB" org.scalajs.cli.Scalajsld --stdlib "$JSLIB" "$@"

--- a/cli/src/main/resources/scalajsld.bat
+++ b/cli/src/main/resources/scalajsld.bat
@@ -5,4 +5,4 @@ set SCALAJS_VER=@SCALAJS_VER@
 set CLILIB="%~dp0\..\lib\scalajs-cli-assembly_%SCALA_BIN_VER%-%SCALAJS_VER%.jar"
 set JSLIB="%~dp0\..\lib\scalajs-library_%SCALA_BIN_VER%-%SCALAJS_VER%.jar"
 
-scala -classpath %CLILIB% scala.scalajs.cli.Scalajsld --stdlib %JSLIB% %*
+scala -classpath %CLILIB% org.scalajs.cli.Scalajsld --stdlib %JSLIB% %*

--- a/cli/src/main/resources/scalajsp
+++ b/cli/src/main/resources/scalajsp
@@ -6,4 +6,4 @@ SCALAJS_VER="@SCALAJS_VER@"
 BASE="$(dirname $0)/.."
 CLILIB="$BASE/lib/scalajs-cli-assembly_$SCALA_BIN_VER-$SCALAJS_VER.jar"
 
-scala -classpath "$CLILIB" scala.scalajs.cli.Scalajsp "$@"
+scala -classpath "$CLILIB" org.scalajs.cli.Scalajsp "$@"

--- a/cli/src/main/resources/scalajsp.bat
+++ b/cli/src/main/resources/scalajsp.bat
@@ -4,4 +4,4 @@ set SCALAJS_VER=@SCALAJS_VER@
 
 set CLILIB="%~dp0\..\lib\scalajs-cli-assembly_%SCALA_BIN_VER%-%SCALAJS_VER%.jar"
 
-scala -classpath %CLILIB% scala.scalajs.cli.Scalajsp %*
+scala -classpath %CLILIB% org.scalajs.cli.Scalajsp %*


### PR DESCRIPTION
This was forgotten in the refactoring commit:
3200c872b1f567393eaf6632048b2c21a1154c11
