### PR TITLE
Remove js.prim.* types, and everything related.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1659,18 +1659,14 @@ abstract class GenJSCode extends plugins.PluginComponent
       }
 
       if (isRawJSType(to)) {
-        to.typeSymbol match {
-          case JSNumberClass    => genTypeOfTest("number")
-          case JSStringClass    => genTypeOfTest("string")
-          case JSBooleanClass   => genTypeOfTest("boolean")
-          case JSUndefinedClass => genTypeOfTest("undefined")
-          case sym if sym.isTrait =>
-            reporter.error(pos,
-                s"isInstanceOf[${sym.fullName}] not supported because it is a raw JS trait")
-            js.BooleanLiteral(true)
-          case sym =>
-            js.Unbox(js.JSBinaryOp(
-                js.JSBinaryOp.instanceof, value, genGlobalJSObject(sym)), 'Z')
+        val sym = to.typeSymbol
+        if (sym.isTrait) {
+          reporter.error(pos,
+              s"isInstanceOf[${sym.fullName}] not supported because it is a raw JS trait")
+          js.BooleanLiteral(true)
+        } else {
+          js.Unbox(js.JSBinaryOp(
+              js.JSBinaryOp.instanceof, value, genGlobalJSObject(sym)), 'Z')
         }
       } else {
         val refType = toReferenceType(to)

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -698,17 +698,14 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
           case LongKind => InstanceOfTypeTest(boxedClass(LongClass).tpe)
 
           case REFERENCE(cls) =>
-            if (cls == StringClass) HijackedTypeTest(Defs.StringClass, 7)
-            else if (cls == ObjectClass) NoTypeTest
-            else if (isRawJSType(tpe)) {
-              cls match {
-                case JSUndefinedClass => HijackedTypeTest(Defs.BoxedUnitClass,    0)
-                case JSBooleanClass   => HijackedTypeTest(Defs.BoxedBooleanClass, 1)
-                case JSNumberClass    => HijackedTypeTest(Defs.BoxedDoubleClass,  6)
-                case JSStringClass    => HijackedTypeTest(Defs.StringClass,       7)
-                case _                => NoTypeTest
-              }
-            } else InstanceOfTypeTest(tpe)
+            cls match {
+              case BoxedUnitClass => HijackedTypeTest(Defs.BoxedUnitClass, 0)
+              case StringClass    => HijackedTypeTest(Defs.StringClass, 7)
+              case ObjectClass    => NoTypeTest
+              case _              =>
+                if (isRawJSType(tpe)) NoTypeTest
+                else InstanceOfTypeTest(tpe)
+            }
 
           case ARRAY(_) => InstanceOfTypeTest(tpe)
         }

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -34,10 +34,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSDynamicClass   = getRequiredClass("scala.scalajs.js.Dynamic")
     lazy val JSDictionaryClass = getRequiredClass("scala.scalajs.js.Dictionary")
       lazy val JSDictionary_delete = getMemberMethod(JSDictionaryClass, newTermName("delete"))
-    lazy val JSNumberClass    = getRequiredClass("scala.scalajs.js.prim.Number")
-    lazy val JSBooleanClass   = getRequiredClass("scala.scalajs.js.prim.Boolean")
-    lazy val JSStringClass    = getRequiredClass("scala.scalajs.js.prim.String")
-    lazy val JSUndefinedClass = getRequiredClass("scala.scalajs.js.prim.Undefined")
     lazy val JSObjectClass    = getRequiredClass("scala.scalajs.js.Object")
     lazy val JSThisFunctionClass = getRequiredClass("scala.scalajs.js.ThisFunction")
 
@@ -65,12 +61,8 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSExportAllAnnotation     = getRequiredClass("scala.scalajs.js.annotation.JSExportAll")
     lazy val JSExportNamedAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSExportNamed")
 
-    lazy val JSAnyTpe       = JSAnyClass.toTypeConstructor
-    lazy val JSNumberTpe    = JSNumberClass.toTypeConstructor
-    lazy val JSBooleanTpe   = JSBooleanClass.toTypeConstructor
-    lazy val JSStringTpe    = JSStringClass.toTypeConstructor
-    lazy val JSUndefinedTpe = JSUndefinedClass.toTypeConstructor
-    lazy val JSObjectTpe    = JSObjectClass.toTypeConstructor
+    lazy val JSAnyTpe    = JSAnyClass.toTypeConstructor
+    lazy val JSObjectTpe = JSObjectClass.toTypeConstructor
 
     lazy val JSGlobalScopeTpe = JSGlobalScopeClass.toTypeConstructor
 

--- a/examples/helloworld/HelloWorld.scala
+++ b/examples/helloworld/HelloWorld.scala
@@ -10,8 +10,10 @@ import js.annotation.JSName
 
 object HelloWorld extends js.JSApp {
   def main() {
-    if (!(!js.Dynamic.global.document) &&
-        !(!js.Dynamic.global.document.getElementById("playground"))) {
+    import js.DynamicImplicits.truthValue
+
+    if (js.Dynamic.global.document &&
+        js.Dynamic.global.document.getElementById("playground")) {
       sayHelloFromDOM()
       sayHelloFromTypedDOM()
       sayHelloFromJQuery()

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -271,7 +271,8 @@ object Character {
   /* Misc */
   //def reverseBytes(ch: scala.Char): scala.Char
 
-  @inline def toString(c: scala.Char) = js.String.fromCharCode(c.toInt)
+  @inline def toString(c: scala.Char): String =
+    js.Dynamic.global.String.fromCharCode(c.toInt).asInstanceOf[String]
 
   @inline def compare(x: scala.Char, y: scala.Char): scala.Int =
     x - y

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -124,6 +124,8 @@ object Integer {
   def toHexString(i: scala.Int): String = toStringBase(i, 16)
   def toOctalString(i: scala.Int): String = toStringBase(i, 8)
 
-  @inline private[this] def toStringBase(i: scala.Int, base: scala.Int): String =
-    ((i: js.prim.Number) >>> 0).toString(base)
+  @inline private[this] def toStringBase(i: scala.Int, base: scala.Int): String = {
+    import js.JSNumberOps._
+    i.toUint.toString(base)
+  }
 }

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -54,6 +54,8 @@ object Long {
     parseLong(s, 10)
 
   def parseLong(s: String, radix: Int): scala.Long = {
+    import js.JSStringOps._
+
     def fail() = throw new NumberFormatException(s"""For input string: "$s"""")
 
     if (s.isEmpty) {
@@ -72,13 +74,13 @@ object Long {
       @tailrec
       def loop(str0: String, acc: scala.Long): scala.Long = if (str0.length > 0) {
         val MaxLen = 9
-        val cur = (str0: js.prim.String).substring(0, MaxLen): String
+        val cur = str0.jsSubstring(0, MaxLen)
         val macc = acc * fastPow(radix, cur.length)
-        val ival = js.parseInt(cur, radix): scala.Double
+        val ival = js.parseInt(cur, radix)
         if (ival.isNaN)
           fail()
         val cval = ival.toInt.toLong // faster than ival.toLong
-        loop((str0: js.prim.String).substring(MaxLen), macc + cval)
+        loop(str0.jsSubstring(MaxLen), macc + cval)
       } else acc
 
       loop(s, 0L)

--- a/javalanglib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalanglib/src/main/scala/java/lang/StackTraceElement.scala
@@ -48,8 +48,7 @@ final class StackTraceElement(declaringClass: String, methodName: String,
   }
 
   private def columnNumber: Int = {
-    val rawNum = this.asInstanceOf[js.Dynamic].columnNumber
-    if (!(!rawNum)) rawNum.asInstanceOf[Int]
-    else -1
+    this.asInstanceOf[js.Dynamic].columnNumber
+      .asInstanceOf[js.UndefOr[Int]].getOrElse(-1)
   }
 }

--- a/javalanglib/src/main/scala/java/lang/System.scala
+++ b/javalanglib/src/main/scala/java/lang/System.scala
@@ -15,10 +15,13 @@ object System {
   }
 
   private[this] val getHighPrecisionTime: js.Function0[scala.Double] = {
-    if (!(!global.performance)) {
-      if (!(!global.performance.now)) {
+    import js.DynamicImplicits.truthValue
+
+    // We've got to use selectDynamic explicitly not to crash Scala 2.10
+    if (global.selectDynamic("performance")) {
+      if (global.performance.selectDynamic("now")) {
         () => global.performance.now().asInstanceOf[scala.Double]
-      } else if (!(!(global.performance.webkitNow))) {
+      } else if (global.performance.selectDynamic("webkitNow")) {
         () => global.performance.webkitNow().asInstanceOf[scala.Double]
       } else {
         () => new js.Date().getTime()
@@ -135,10 +138,9 @@ object System {
   }
 
   def identityHashCode(x: Object): scala.Int = {
-    import js.prim
-    x match {
+    (x: Any) match {
       case null => 0
-      case _:prim.Boolean | _:prim.Number | _:prim.String | _:prim.Undefined =>
+      case _:scala.Boolean | _:scala.Double | _:String | () =>
         x.hashCode()
       case _ =>
         if (x.getClass == null) {
@@ -254,8 +256,11 @@ private[lang] final class JSConsoleBasedPrintStream(isErr: Boolean)
   override def close(): Unit = ()
 
   private def doWriteLine(line: String): Unit = {
-    if (!(!global.console)) {
-      if (isErr && !(!global.console.error))
+    import js.DynamicImplicits.truthValue
+
+    // We've got to use selectDynamic explicitly not to crash Scala 2.10
+    if (global.selectDynamic("console")) {
+      if (isErr && global.console.selectDynamic("error"))
         global.console.error(line)
       else
         global.console.log(line)

--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -617,8 +617,10 @@ object URI {
     new RegExp("[^a-z0-9-_.!~*'(),;:$&+=%\\s]|%(?![0-9a-f]{2})", "ig")
 
   /** Quote any character not in unreserved, punct, escaped or other */
-  private def quoteUserInfo(str: String) =
-    (str: js.prim.String).replace(userInfoQuoteRe, quoteChar)
+  private def quoteUserInfo(str: String) = {
+    import js.JSStringOps._
+    str.jsReplace(userInfoQuoteRe, quoteChar)
+  }
 
   /** matches any character not in unreserved, punct, escaped, other or equal
    *  to '/' or '@'
@@ -629,8 +631,10 @@ object URI {
   /** Quote any character not in unreserved, punct, escaped, other or equal
    *  to '/' or '@'
    */
-  private def quotePath(str: String) =
-    (str: js.prim.String).replace(pathQuoteRe, quoteChar)
+  private def quotePath(str: String) = {
+    import js.JSStringOps._
+    str.jsReplace(pathQuoteRe, quoteChar)
+  }
 
   /** matches any character not in unreserved, punct, escaped, other or equal
    *  to '@', '[' or ']'
@@ -645,16 +649,20 @@ object URI {
   /** Quote any character not in unreserved, punct, escaped, other or equal
    *  to '@'
    */
-  private def quoteAuthority(str: String) =
-    (str: js.prim.String).replace(authorityQuoteRe, quoteChar)
+  private def quoteAuthority(str: String) = {
+    import js.JSStringOps._
+    str.jsReplace(authorityQuoteRe, quoteChar)
+  }
 
   /** matches any character not in unreserved, reserved, escaped or other */
   private val illegalQuoteRe =
     new RegExp("[^a-z0-9-_.!~*'(),;:$&+=?/\\[\\]%\\s]|%(?![0-9a-f]{2})", "ig")
 
   /** Quote any character not in unreserved, reserved, escaped or other */
-  private def quoteIllegal(str: String) =
-    (str: js.prim.String).replace(illegalQuoteRe, quoteChar)
+  private def quoteIllegal(str: String) = {
+    import js.JSStringOps._
+    str.jsReplace(illegalQuoteRe, quoteChar)
+  }
 
   /** Case-sensitive comparison that is case-insensitive inside URI
    *  escapes. Will compare `a%A0` and `a%a0` as equal, but `a%A0` and

--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -33,7 +33,7 @@ final class Formatter(private val dest: Appendable) extends Closeable with Flush
   // Begin implem of format()
 
   def format(format_in: String, args: Array[AnyRef]): Formatter = ifNotClosed {
-    import js.Any.fromDouble // to have .toFixed and .toExponential on Doubles
+    import js.JSNumberOps._
 
     var fmt: String = format_in
     var lastImplicitIndex: Int = 0
@@ -186,7 +186,7 @@ final class Formatter(private val dest: Appendable) extends Closeable with Flush
                 throw new FormatFlagsConversionMismatchException("#", 's')
             }
             case 'c' | 'C' =>
-              pad(js.String.fromCharCode(intArg))
+              pad(intArg.toChar.toString)
             case 'd' =>
               with_+(numberArg.toString())
             case 'o' =>
@@ -214,7 +214,7 @@ final class Formatter(private val dest: Appendable) extends Closeable with Flush
                 else precision
               // between 1e-4 and 10e(p): display as fixed
               if (m >= 1e-4 && m < Math.pow(10, p)) {
-                val sig = Math.ceil(Math.log10(m))
+                val sig = Math.ceil(Math.log10(m)).toInt
                 with_+(numberArg.toFixed(Math.max(p - sig, 0)))
               } else sciNotation(p - 1)
             case 'f' =>
@@ -229,7 +229,7 @@ final class Formatter(private val dest: Appendable) extends Closeable with Flush
             with_+({
               // check if we need additional 0 padding in exponent
               // JavaDoc: at least 2 digits
-              if ("e" == exp.charAt(exp.length - 3)) {
+              if ('e' == exp.charAt(exp.length - 3)) {
                 exp.substring(0, exp.length - 1) + "0" +
                   exp.charAt(exp.length - 1)
               } else exp

--- a/library/src/main/scala/scala/scalajs/js/DynamicImplicits.scala
+++ b/library/src/main/scala/scala/scalajs/js/DynamicImplicits.scala
@@ -1,0 +1,34 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.language.implicitConversions
+
+/** Provides implicit conversions and operations to write in JavaScript
+ *  style with [[Dynamic js.Dynamic]].
+ *
+ *  Be **very** careful when importing members of this object. You may want
+ *  to selectively import the implicits that you want to reduce the likelihood
+ *  of making mistakes.
+ */
+object DynamicImplicits {
+  @inline implicit def truthValue(x: Dynamic): Boolean =
+    (!(!x)).asInstanceOf[Boolean]
+
+  // Useful for Scala 2.10
+  implicit def number2dynamic(x: Int): Dynamic =
+    x.asInstanceOf[Dynamic]
+
+  implicit def number2dynamic(x: Double): Dynamic =
+    x.asInstanceOf[Dynamic]
+
+  implicit def boolean2dynamic(x: Boolean): Dynamic =
+    x.asInstanceOf[Dynamic]
+}

--- a/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
@@ -1,0 +1,104 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+/**
+ * All doc-comments marked as "MDN" are by Mozilla Contributors,
+ * distributed under the Creative Commons Attribution-ShareAlike license from
+ * https://developer.mozilla.org/en-US/docs/Web/Reference/API
+ */
+package scala.scalajs.js
+
+import scala.language.implicitConversions
+
+import scala.scalajs.js.annotation._
+
+/** Operations on JavaScript numbers. */
+trait JSNumberOps extends Any {
+
+  def toString(radix: Int): String = native
+
+  /**
+   * Returns a string representation of number that does not use exponential
+   * notation and has exactly digits digits after the decimal place. The number
+   * is rounded if necessary, and the fractional part is padded with zeros if
+   * necessary so that it has the specified length. If number is greater than
+   * 1e+21, this method simply calls Number.prototype.toString() and returns
+   * a string in exponential notation.
+   *
+   * MDN
+   */
+  def toFixed(fractionDigits: Int): String = native
+  def toFixed(): String = native
+
+  /**
+   * Returns a string representing a Number object in exponential notation with one
+   * digit before the decimal point, rounded to fractionDigits digits after the
+   * decimal point. If the fractionDigits argument is omitted, the number of
+   * digits after the decimal point defaults to the number of digits necessary
+   * to represent the value uniquely.
+   *
+   * If a number has more digits that requested by the fractionDigits parameter,
+   * the number is rounded to the nearest number represented by fractionDigits
+   * digits. See the discussion of rounding in the description of the toFixed()
+   * method, which also applies to toExponential().
+   *
+   * MDN
+   */
+  def toExponential(fractionDigits: Int): String = native
+  def toExponential(): String = native
+
+  /**
+   * Returns a string representing a Number object in fixed-point or exponential
+   * notation rounded to precision significant digits. See the discussion of
+   * rounding in the description of the Number.prototype.toFixed() method, which
+   * also applies to toPrecision.
+   *
+   * If the precision argument is omitted, behaves as Number.prototype.toString().
+   * If it is a non-integer value, it is rounded to the nearest integer.
+   *
+   * MDN
+   */
+  def toPrecision(precision: Int): String = native
+  def toPrecision(): String = native
+}
+
+object JSNumberOps {
+  implicit def enableJSNumberOps(x: Int): JSNumberOps =
+    x.asInstanceOf[JSNumberOps]
+
+  implicit def enableJSNumberOps(x: Double): JSNumberOps =
+    x.asInstanceOf[JSNumberOps]
+
+  implicit def enableJSNumberExtOps(x: Int): ExtOps =
+    new ExtOps(x.asInstanceOf[Dynamic])
+
+  implicit def enableJSNumberExtOps(x: Double): ExtOps =
+    new ExtOps(x.asInstanceOf[Dynamic])
+
+  final class ExtOps(val self: Dynamic) extends AnyVal {
+    @inline def toUint: Double =
+      (self >>> 0.asInstanceOf[Dynamic]).asInstanceOf[Double]
+  }
+
+  /* The following overloads make sure that the developer does not use JS
+   * number operations on a Long by error.
+   */
+
+  @deprecated("A Long is converted to Double to perform JavaScript "+
+      "operations. This is almost certainly not what you want. "+
+      "Use `.toDouble` explicitly if you need it.", "0.6.0")
+  implicit def enableJSNumberOps(x: Long): JSNumberOps =
+    x.toDouble.asInstanceOf[JSNumberOps]
+
+  @deprecated("A Long is converted to Double to perform JavaScript "+
+      "operations. This is almost certainly not what you want. "+
+      "Use `.toDouble` explicitly if you need it.", "0.6.0")
+  implicit def enableJSNumberExtOps(x: Long): ExtOps =
+    new ExtOps(x.toDouble.asInstanceOf[Dynamic])
+}

--- a/library/src/main/scala/scala/scalajs/js/JSStringOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSStringOps.scala
@@ -1,0 +1,205 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+/**
+ * All doc-comments marked as "MDN" are by Mozilla Contributors,
+ * distributed under the Creative Commons Attribution-ShareAlike license from
+ * https://developer.mozilla.org/en-US/docs/Web/Reference/API
+ */
+package scala.scalajs.js
+
+import scala.language.implicitConversions
+
+import scala.scalajs.js.annotation._
+
+/** Operations on JavaScript strings.
+ *
+ *  The methods with an equivalent signature in [[String]] but with a different
+ *  meaning are prefixed by `js` in this trait.
+ */
+trait JSStringOps extends Any {
+
+  /**
+   * Returns the index within the calling String object of the first occurrence
+   * of the specified value, starting the search at fromIndex,
+   *
+   * returns -1 if the value is not found.
+   *
+   * MDN
+   */
+  @JSName("indexOf")
+  def jsIndexOf(searchString: String, position: Int): Int = native
+  @JSName("indexOf")
+  def jsIndexOf(searchString: String): Int = native
+
+  /**
+   * Returns the index within the calling String object of the last occurrence
+   * of the specified value, or -1 if not found. The calling string is searched
+   * backward, starting at fromIndex.
+   *
+   * MDN
+   */
+  @JSName("lastIndexOf")
+  def jsLastIndexOf(searchString: String, position: Int): Int = native
+  @JSName("lastIndexOf")
+  def jsLastIndexOf(searchString: String): Int = native
+
+  /**
+   * Returns a number indicating whether a reference string comes before or
+   * after or is the same as the given string in sort order. The new locales
+   * and options arguments let applications specify the language whose sort
+   * order should be used and customize the behavior of the function. In older
+   * implementations, which ignore the locales and options arguments, the locale
+   * and sort order used are entirely implementation dependent.
+   *
+   * MDN
+   */
+  def localeCompare(that: String): Int = native
+
+  /**
+   * Used to retrieve the matches when matching a string against a regular
+   * expression.
+   *
+   * If the regular expression does not include the g flag, returns the same
+   * result as regexp.exec(string). The returned Array has an extra input
+   * property, which contains the original string that was parsed. In addition,
+   * it has an index property, which represents the zero-based index of the
+   * match in the string.
+   *
+   * If the regular expression includes the g flag, the method returns an Array
+   * containing all matches. If there were no matches, the method returns null.
+   *
+   * MDN
+   */
+  def `match`(regexp: String): Array[String] = native
+  def `match`(regexp: RegExp): Array[String] = native
+
+  /**
+   * Returns a new string with some or all matches of a pattern replaced by a
+   * replacement.  The pattern can be a string or a RegExp, and the replacement
+   * can be a string or a function to be called for each match.
+   *
+   * This method does not change the String object it is called on. It simply
+   * returns a new string.
+   *
+   * To perform a global search and replace, either include the g switch in the
+   * regular expression or if the first parameter is a string, include g in the
+   * flags parameter.
+   *
+   * MDN
+   */
+  @JSName("replace")
+  def jsReplace(searchValue: String, replaceValue: String): String = native
+  @JSName("replace")
+  def jsReplace(searchValue: String, replaceValue: Any): String = native
+  @JSName("replace")
+  def jsReplace(searchValue: RegExp, replaceValue: String): String = native
+  @JSName("replace")
+  def jsReplace(searchValue: RegExp, replaceValue: Any): String = native
+
+  /**
+   * If successful, search returns the index of the regular expression inside
+   * the string. Otherwise, it returns -1.
+   *
+   * When you want to know whether a pattern is found in a string use search
+   * (similar to the regular expression test method); for more information
+   * (but slower execution) use match (similar to the regular expression exec
+   * method).
+   *
+   * MDN
+   */
+  def search(regexp: String): Int = native
+  def search(regexp: RegExp): Int = native
+
+  /**
+   * slice extracts the text from one string and returns a new string. Changes
+   * to the text in one string do not affect the other string.
+   *
+   * slice extracts up to but not including endSlice. string.slice(1,4) extracts
+   * the second character through the fourth character (characters indexed 1, 2,
+   * and 3).
+   *
+   * As an example, string.slice(2,-1) extracts the third character through the
+   * second to last character in the string.
+   *
+   * MDN
+   */
+  @JSName("slice")
+  def jsSlice(start: Int, end: Int): String = native
+  @JSName("slice")
+  def jsSlice(start: Int): String = native
+
+  /**
+   * Splits a String object into an array of strings by separating the string
+   * into substrings.
+   *
+   * When found, separator is removed from the string and the substrings are
+   * returned in an array. If separator is omitted, the array contains one
+   * element consisting of the entire string. If separator is an empty string,
+   * string is converted to an array of characters.
+   *
+   * If separator is a regular expression that contains capturing parentheses,
+   * then each time separator is matched, the results (including any undefined
+   * results) of the capturing parentheses are spliced into the output array.
+   * However, not all browsers support this capability.
+   *
+   * Note: When the string is empty, split returns an array containing one
+   * empty string, rather than an empty array.
+   *
+   * MDN
+   */
+  @JSName("split")
+  def jsSplit(separator: String, limit: Int): Array[String] = native
+  @JSName("split")
+  def jsSplit(separator: String): Array[String] = native
+  @JSName("split")
+  def jsSplit(separator: RegExp, limit: Int): Array[String] = native
+  @JSName("split")
+  def jsSplit(separator: RegExp): Array[String] = native
+
+  /**
+   * Returns a subset of a string between one index and another, or through
+   * the end of the string.
+   *
+   * MDN
+   */
+  @JSName("substring")
+  def jsSubstring(start: Int, end: Int): String = native
+  @JSName("substring")
+  def jsSubstring(start: Int): String = native
+
+  /**
+   * The toLocaleLowerCase method returns the value of the string converted to
+   * lower case according to any locale-specific case mappings. toLocaleLowerCase
+   * does not affect the value of the string itself. In most cases, this will
+   * produce the same result as toLowerCase(), but for some locales, such as
+   * Turkish, whose case mappings do not follow the default case mappings in Unicode,
+   * there may be a different result.
+   *
+   * MDN
+   */
+  def toLocaleLowerCase(): String = native
+
+  /**
+   * The toLocaleUpperCase method returns the value of the string converted to
+   * upper case according to any locale-specific case mappings. toLocaleUpperCase
+   * does not affect the value of the string itself. In most cases, this will
+   * produce the same result as toUpperCase(), but for some locales, such as
+   * Turkish, whose case mappings do not follow the default case mappings in Unicode,
+   * there may be a different result.
+   *
+   * MDN
+   */
+  def toLocaleUpperCase(): String = native
+}
+
+object JSStringOps {
+  implicit def enableJSStringOps(x: String): JSStringOps =
+    x.asInstanceOf[JSStringOps]
+}

--- a/library/src/main/scala/scala/scalajs/js/Primitives.scala
+++ b/library/src/main/scala/scala/scalajs/js/Primitives.scala
@@ -44,31 +44,24 @@ trait Any extends scala.AnyRef
 
 /** Provides implicit conversions from Scala values to JavaScript values. */
 object Any extends LowPrioAnyImplicits {
-  @inline implicit def fromUnit(value: Unit): prim.Undefined =
-    value.asInstanceOf[prim.Undefined]
-  @inline implicit def fromBoolean(value: scala.Boolean): prim.Boolean =
-    value.asInstanceOf[prim.Boolean]
-  @inline implicit def fromByte(value: scala.Byte): prim.Number =
-    value.asInstanceOf[prim.Number]
-  @inline implicit def fromShort(value: scala.Short): prim.Number =
-    value.asInstanceOf[prim.Number]
-  @inline implicit def fromInt(value: scala.Int): prim.Number =
-    value.asInstanceOf[prim.Number]
-  @inline implicit def fromLong(value: scala.Long): prim.Number =
-    value.toDouble.asInstanceOf[prim.Number]
-  @inline implicit def fromFloat(value: scala.Float): prim.Number =
-    value.asInstanceOf[prim.Number]
-  @inline implicit def fromDouble(value: scala.Double): prim.Number =
-    value.asInstanceOf[prim.Number]
-  @inline implicit def fromString(s: java.lang.String): prim.String =
-    s.asInstanceOf[prim.String]
-
-  @inline implicit def toDouble(value: prim.Number): scala.Double =
-    value.asInstanceOf[scala.Double]
-  @inline implicit def toBoolean(value: prim.Boolean): scala.Boolean =
-    value.asInstanceOf[scala.Boolean]
-  @inline implicit def toScalaString(value: prim.String): java.lang.String =
-    value.asInstanceOf[java.lang.String]
+  @inline implicit def fromUnit(value: Unit): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromBoolean(value: Boolean): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromByte(value: Byte): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromShort(value: Short): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromInt(value: Int): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromLong(value: Long): Any =
+    value.toDouble.asInstanceOf[Any]
+  @inline implicit def fromFloat(value: Float): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromDouble(value: Double): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromString(s: String): Any =
+    s.asInstanceOf[Any]
 
   implicit def jsArrayOps[A](array: Array[A]): ArrayOps[A] =
     new ArrayOps(array)
@@ -134,14 +127,6 @@ object Any extends LowPrioAnyImplicits {
 }
 
 trait LowPrioAnyImplicits {
-  @inline implicit def richDouble(num: prim.Number): scala.runtime.RichDouble =
-    new scala.runtime.RichDouble(Any.toDouble(num))
-  @inline implicit def richBoolean(b: prim.Boolean): scala.runtime.RichBoolean =
-    new scala.runtime.RichBoolean(Any.toBoolean(b))
-
-  @inline implicit def stringOps(string: prim.String): immutable.StringOps =
-    new immutable.StringOps(Any.toScalaString(string))
-
   implicit def wrapArray[A](array: Array[A]): WrappedArray[A] =
     new WrappedArray(array)
   implicit def wrapDictionary[A](dict: Dictionary[A]): WrappedDictionary[A] =
@@ -157,76 +142,41 @@ trait LowPrioAnyImplicits {
 sealed trait Dynamic extends Any with scala.Dynamic {
   /** Calls a method of this object. */
   @JSBracketCall
-  def applyDynamic(name: java.lang.String)(args: Any*): Dynamic = native
+  def applyDynamic(name: String)(args: Any*): Dynamic = native
 
   /** Reads a field of this object. */
   @JSBracketAccess
-  def selectDynamic(name: java.lang.String): Dynamic = native
+  def selectDynamic(name: String): Dynamic = native
 
   /** Writes a field of this object. */
   @JSBracketAccess
-  def updateDynamic(name: java.lang.String)(value: Any): Unit = native
+  def updateDynamic(name: String)(value: Any): Unit = native
 
   /** Calls this object as a callable. */
   def apply(args: Any*): Dynamic = native
 
-  import prim.Number
+  def unary_!(): Dynamic = native
 
-  def unary_!(): Boolean = native
+  def unary_+(): Dynamic = native
+  def unary_-(): Dynamic = native
+  def unary_~(): Dynamic = native
 
-  def unary_+(): Number = native
-  def unary_-(): Number = native
-  def unary_~(): Number = native
+  def +(that: Dynamic): Dynamic = native
+  def -(that: Dynamic): Dynamic = native
+  def *(that: Dynamic): Dynamic = native
+  def /(that: Dynamic): Dynamic = native
+  def %(that: Dynamic): Dynamic = native
+  def <<(that: Dynamic): Dynamic = native
+  def >>(that: Dynamic): Dynamic = native
+  def >>>(that: Dynamic): Dynamic = native
+  def &(that: Dynamic): Dynamic = native
+  def |(that: Dynamic): Dynamic = native
+  def ^(that: Dynamic): Dynamic = native
 
-  def +(that: Number): Dynamic = native // could be a String if this is a String
-  def -(that: Number): Number = native
-  def *(that: Number): Number = native
-  def /(that: Number): Number = native
-  def %(that: Number): Number = native
-  def <<(that: Number): Number = native
-  def >>(that: Number): Number = native
-  def >>>(that: Number): Number = native
-  def &(that: Number): Number = native
-  def |(that: Number): Number = native
-  def ^(that: Number): Number = native
-
-  def +(that: Dynamic): Dynamic = native // could be String if this or that is a String
-  def -(that: Dynamic): Number = native
-  def *(that: Dynamic): Number = native
-  def /(that: Dynamic): Number = native
-  def %(that: Dynamic): Number = native
-  def <<(that: Dynamic): Number = native
-  def >>(that: Dynamic): Number = native
-  def >>>(that: Dynamic): Number = native
-  def &(that: Dynamic): Number = native
-  def |(that: Dynamic): Number = native
-  def ^(that: Dynamic): Number = native
-
-  def <(that: Number): Boolean = native
-  def >(that: Number): Boolean = native
-  def <=(that: Number): Boolean = native
-  def >=(that: Number): Boolean = native
-
-  def <(that: String): Boolean = native
-  def >(that: String): Boolean = native
-  def <=(that: String): Boolean = native
-  def >=(that: String): Boolean = native
-
-  def <(that: Dynamic): Boolean = native
-  def >(that: Dynamic): Boolean = native
-  def <=(that: Dynamic): Boolean = native
-  def >=(that: Dynamic): Boolean = native
-
-  /* The result of (dyn && bool) and (dyn || bool) has, in theory, type
-   * (Dynamic v Boolean). This type cannot be expressed in Scala, but if it
-   * could, the operations one could apply on a (Dynamic v Boolean) would be
-   * the *intersection* of the operations one can apply on a Dynamic and on a
-   * Boolean. Since any operation can be applied on a Dynamic, this
-   * intersection is equal to the set of operations supported by Boolean.
-   * Hence the result type is restricted to Boolean.
-   */
-  def &&(that: Boolean): Boolean = native
-  def ||(that: Boolean): Boolean = native
+  def <(that: Dynamic): Dynamic = native
+  def >(that: Dynamic): Dynamic = native
+  def <=(that: Dynamic): Dynamic = native
+  def >=(that: Dynamic): Dynamic = native
 
   def &&(that: Dynamic): Dynamic = native
   def ||(that: Dynamic): Dynamic = native
@@ -255,8 +205,8 @@ object Dynamic {
     /** literal creation like this:
      *  js.Dynamic.literal(name1 = "value", name2 = "value")
      */
-    def applyDynamicNamed(name: java.lang.String)(
-        fields: (java.lang.String, Any)*): Object with Dynamic = sys.error("stub")
+    def applyDynamicNamed(name: String)(
+        fields: (String, Any)*): Object with Dynamic = sys.error("stub")
 
     /** literal creation like this:
      *  js.Dynamic.literal("name1" -> "value", "name2" -> "value")
@@ -265,8 +215,8 @@ object Dynamic {
      *  applyDynamicNamed fail, since a call with named arguments would
      *  be routed to the `def apply`, rather than def dynamic version.
      */
-    def applyDynamic(name: java.lang.String)(
-        fields: (java.lang.String, Any)*): Object with Dynamic = sys.error("stub")
+    def applyDynamic(name: String)(
+        fields: (String, Any)*): Object with Dynamic = sys.error("stub")
 
   }
 }
@@ -472,417 +422,4 @@ object Object extends Object {
    *  this method (not just a subset).
    */
   def properties(o: Any): Array[String] = sys.error("stub")
-}
-
-package prim {
-
-/** Primitive JavaScript number.
- *
- *  In most situations, you should not need this trait, and use
- *  [[scala.Double]] instead (or [[scala.Int]] where appropriate).
- */
-sealed trait Number extends Any {
-  def unary_+(): Number = native
-  def unary_-(): Number = native
-  def unary_~(): Number = native
-
-  def +(that: Number): Number = native
-  def -(that: Number): Number = native
-  def *(that: Number): Number = native
-  def /(that: Number): Number = native
-  def %(that: Number): Number = native
-  def <<(that: Number): Number = native
-  def >>(that: Number): Number = native
-  def >>>(that: Number): Number = native
-  def &(that: Number): Number = native
-  def |(that: Number): Number = native
-  def ^(that: Number): Number = native
-
-  def +(that: Dynamic): Dynamic = native // could be a String if that is a String
-  def -(that: Dynamic): Number = native
-  def *(that: Dynamic): Number = native
-  def /(that: Dynamic): Number = native
-  def %(that: Dynamic): Number = native
-  def <<(that: Dynamic): Number = native
-  def >>(that: Dynamic): Number = native
-  def >>>(that: Dynamic): Number = native
-  def &(that: Dynamic): Number = native
-  def |(that: Dynamic): Number = native
-  def ^(that: Dynamic): Number = native
-
-  def <(that: Number): Boolean = native
-  def >(that: Number): Boolean = native
-  def <=(that: Number): Boolean = native
-  def >=(that: Number): Boolean = native
-
-  def <(that: Dynamic): Boolean = native
-  def >(that: Dynamic): Boolean = native
-  def <=(that: Dynamic): Boolean = native
-  def >=(that: Dynamic): Boolean = native
-
-  def toString(radix: Number): String = native
-
-  /**
-   * Returns a string representation of number that does not use exponential
-   * notation and has exactly digits digits after the decimal place. The number
-   * is rounded if necessary, and the fractional part is padded with zeros if
-   * necessary so that it has the specified length. If number is greater than
-   * 1e+21, this method simply calls Number.prototype.toString() and returns
-   * a string in exponential notation.
-   *
-   * MDN
-   */
-  def toFixed(fractionDigits: Number): String = native
-  def toFixed(): String = native
-
-  /**
-   * Returns a string representing a Number object in exponential notation with one
-   * digit before the decimal point, rounded to fractionDigits digits after the
-   * decimal point. If the fractionDigits argument is omitted, the number of
-   * digits after the decimal point defaults to the number of digits necessary
-   * to represent the value uniquely.
-   *
-   * If a number has more digits that requested by the fractionDigits parameter,
-   * the number is rounded to the nearest number represented by fractionDigits
-   * digits. See the discussion of rounding in the description of the toFixed()
-   * method, which also applies to toExponential().
-   *
-   * MDN
-   */
-  def toExponential(fractionDigits: Number): String = native
-  def toExponential(): String = native
-
-  /**
-   * Returns a string representing a Number object in fixed-point or exponential
-   * notation rounded to precision significant digits. See the discussion of
-   * rounding in the description of the Number.prototype.toFixed() method, which
-   * also applies to toPrecision.
-   *
-   * If the precision argument is omitted, behaves as Number.prototype.toString().
-   * If it is a non-integer value, it is rounded to the nearest integer.
-   *
-   * MDN
-   */
-  def toPrecision(precision: Number): String = native
-  def toPrecision(): String = native
-}
-
-/** The top-level `Number` JavaScript object */
-object Number extends Object {
-  /**
-   * The Number.MAX_VALUE property represents the maximum numeric value
-   * representable in JavaScript.
-   *
-   * The MAX_VALUE property has a value of approximately 1.79E+308. Values
-   * larger than MAX_VALUE are represented as "Infinity".
-   *
-   * MDN
-   */
-  val MAX_VALUE: Double = native
-  /**
-   * The Number.MIN_VALUE property represents the smallest positive numeric
-   * value representable in JavaScript.
-   *
-   * The MIN_VALUE property is the number closest to 0, not the most negative
-   * number, that JavaScript can represent.
-   *
-   * MIN_VALUE has a value of approximately 5e-324. Values smaller than MIN_VALUE
-   * ("underflow values") are converted to 0.
-   *
-   * MDN
-   */
-  val MIN_VALUE: Double = native
-  /**
-   * The Number.NaN property represents Not-A-Number. Equivalent of NaN.
-   *
-   * MDN
-   */
-  val NaN: Double = native
-
-  /**
-   * The Number.NEGATIVE_INFINITY property represents the negative Infinity value.
-   *
-   * MDN
-   */
-  val NEGATIVE_INFINITY: Double = native
-  /**
-   * The Number.POSITIVE_INFINITY property represents the positive Infinity value.
-   *
-   * MDN
-   */
-  val POSITIVE_INFINITY: Double = native
-}
-
-/** Primitive JavaScript boolean.
- *
- *  In most situations, you should not need this trait, and use
- *  [[scala.Boolean]] instead.
- */
-sealed trait Boolean extends Any {
-  def unary_!(): scala.Boolean = native
-
-  def &&(that: Boolean): Boolean = native
-  def ||(that: Boolean): Boolean = native
-
-  // See the comment in `Dynamic` for the rationale of returning Boolean here.
-  def &&(that: Dynamic): Boolean = native
-  def ||(that: Dynamic): Boolean = native
-}
-
-/** The top-level `Boolean` JavaScript object. */
-object Boolean extends Object
-
-/** Primitive JavaScript string.
- *
- *  In most situations, you should not need this trait, and use
- *  [[java.lang.String]] instead.
- */
-sealed trait String extends Any {
-  def +(that: String): String = native
-  def +(that: Any): String = native
-  def +(that: Dynamic): String = native
-
-  def < (that: String): Boolean = native
-  def < (that: Dynamic): Boolean = native
-
-  def > (that: String): Boolean = native
-  def > (that: Dynamic): Boolean = native
-
-  def <=(that: String): Boolean = native
-  def <=(that: Dynamic): Boolean = native
-
-  def >=(that: String): Boolean = native
-  def >=(that: Dynamic): Boolean = native
-
-  /**
-   * This property returns the number of code units in the string. UTF-16,
-   * the string format used by JavaScript, uses a single 16-bit code unit to
-   * represent the most common characters, but needs to use two code units for
-   * less commonly-used characters, so it's possible for the value returned by
-   * length to not match the actual number of characters in the string.
-   *
-   * For an empty string, length is 0.
-   *
-   * MDN
-   */
-  val length: Number = native
-
-  /**
-   * The chartAt() method returns the specified character from a string.
-   *
-   * Characters in a string are indexed from left to right. The index of the
-   * first character is 0, and the index of the last character in a string
-   * called stringName is stringName.length - 1. If the index you supply is out
-   * of range, JavaScript returns an empty string.
-   *
-   * MDN
-   */
-  def charAt(pos: Number): String = native
-
-  /**
-   * The charCodeAt() method returns the numeric Unicode value of the character
-   * at the given index (except for unicode codepoints > 0x10000).
-   *
-   * MDN
-   */
-  def charCodeAt(index: Number): Number = native
-
-  /**
-   * concat combines the text from one or more strings and returns a new string.
-   * Changes to the text in one string do not affect the other string.
-   * MDN
-   */
-  def concat(strings: String*): String = native
-
-  /**
-   * Returns the index within the calling String object of the first occurrence
-   * of the specified value, starting the search at fromIndex,
-   *
-   * returns -1 if the value is not found.
-   *
-   * MDN
-   */
-  def indexOf(searchString: String, position: Number): Number = native
-  def indexOf(searchString: String): Number = native
-
-  /**
-   * Returns the index within the calling String object of the last occurrence
-   * of the specified value, or -1 if not found. The calling string is searched
-   * backward, starting at fromIndex.
-   *
-   * MDN
-   */
-  def lastIndexOf(searchString: String, position: Number): Number = native
-  def lastIndexOf(searchString: String): Number = native
-
-  /**
-   * Returns a number indicating whether a reference string comes before or
-   * after or is the same as the given string in sort order. The new locales
-   * and options arguments let applications specify the language whose sort
-   * order should be used and customize the behavior of the function. In older
-   * implementations, which ignore the locales and options arguments, the locale
-   * and sort order used are entirely implementation dependent.
-   *
-   * MDN
-   */
-  def localeCompare(that: String): Number = native
-
-  /**
-   * Used to retrieve the matches when matching a string against a regular
-   * expression.
-   *
-   * If the regular expression does not include the g flag, returns the same
-   * result as regexp.exec(string). The returned Array has an extra input
-   * property, which contains the original string that was parsed. In addition,
-   * it has an index property, which represents the zero-based index of the
-   * match in the string.
-   *
-   * If the regular expression includes the g flag, the method returns an Array
-   * containing all matches. If there were no matches, the method returns null.
-   *
-   * MDN
-   */
-  def `match`(regexp: String): Array[String] = native
-  def `match`(regexp: RegExp): Array[String] = native
-
-  /**
-   * Returns a new string with some or all matches of a pattern replaced by a
-   * replacement.  The pattern can be a string or a RegExp, and the replacement
-   * can be a string or a function to be called for each match.
-   *
-   * This method does not change the String object it is called on. It simply
-   * returns a new string.
-   *
-   * To perform a global search and replace, either include the g switch in the
-   * regular expression or if the first parameter is a string, include g in the
-   * flags parameter.
-   *
-   * MDN
-   */
-  def replace(searchValue: String, replaceValue: String): String = native
-  def replace(searchValue: String, replaceValue: Any): String = native
-  def replace(searchValue: RegExp, replaceValue: String): String = native
-  def replace(searchValue: RegExp, replaceValue: Any): String = native
-
-  /**
-   * If successful, search returns the index of the regular expression inside
-   * the string. Otherwise, it returns -1.
-   *
-   * When you want to know whether a pattern is found in a string use search
-   * (similar to the regular expression test method); for more information
-   * (but slower execution) use match (similar to the regular expression exec
-   * method).
-   *
-   * MDN
-   */
-  def search(regexp: String): Number = native
-  def search(regexp: RegExp): Number = native
-
-  /**
-   * slice extracts the text from one string and returns a new string. Changes
-   * to the text in one string do not affect the other string.
-   *
-   * slice extracts up to but not including endSlice. string.slice(1,4) extracts
-   * the second character through the fourth character (characters indexed 1, 2,
-   * and 3).
-   *
-   * As an example, string.slice(2,-1) extracts the third character through the
-   * second to last character in the string.
-   *
-   * MDN
-   */
-  def slice(start: Number, end: Number): String = native
-  def slice(start: Number): String = native
-
-  /**
-   * Splits a String object into an array of strings by separating the string
-   * into substrings.
-   *
-   * When found, separator is removed from the string and the substrings are
-   * returned in an array. If separator is omitted, the array contains one
-   * element consisting of the entire string. If separator is an empty string,
-   * string is converted to an array of characters.
-   *
-   * If separator is a regular expression that contains capturing parentheses,
-   * then each time separator is matched, the results (including any undefined
-   * results) of the capturing parentheses are spliced into the output array.
-   * However, not all browsers support this capability.
-   *
-   * Note: When the string is empty, split returns an array containing one
-   * empty string, rather than an empty array.
-   *
-   * MDN
-   */
-  def split(separator: String, limit: Number): Array[String] = native
-  def split(separator: String): Array[String] = native
-  def split(separator: RegExp, limit: Number): Array[String] = native
-  def split(separator: RegExp): Array[String] = native
-
-  /**
-   * Returns a subset of a string between one index and another, or through
-   * the end of the string.
-   *
-   * MDN
-   */
-  def substring(start: Number, end: Number): String = native
-  def substring(start: Number): String = native
-
-  /**
-   * Returns the calling string value converted to lowercase.
-   *
-   * MDN
-   */
-  def toLowerCase(): String = native
-
-  /**
-   * The toLocaleLowerCase method returns the value of the string converted to
-   * lower case according to any locale-specific case mappings. toLocaleLowerCase
-   * does not affect the value of the string itself. In most cases, this will
-   * produce the same result as toLowerCase(), but for some locales, such as
-   * Turkish, whose case mappings do not follow the default case mappings in Unicode,
-   * there may be a different result.
-   *
-   * MDN
-   */
-  def toLocaleLowerCase(): String = native
-
-  /**
-   * Returns the calling string value converted to uppercase.
-   *
-   * MDN
-   */
-  def toUpperCase(): String = native
-
-  /**
-   * The toLocaleUpperCase method returns the value of the string converted to
-   * upper case according to any locale-specific case mappings. toLocaleUpperCase
-   * does not affect the value of the string itself. In most cases, this will
-   * produce the same result as toUpperCase(), but for some locales, such as
-   * Turkish, whose case mappings do not follow the default case mappings in Unicode,
-   * there may be a different result.
-   *
-   * MDN
-   */
-  def toLocaleUpperCase(): String = native
-
-  /**
-   * Removes whitespace from both ends of the string.
-   *
-   * MDN
-   */
-  def trim(): String = native
-}
-
-/** The top-level `String` JavaScript object. */
-object String extends Object {
-  def fromCharCode(codes: Int*): java.lang.String = native
-}
-
-/** Primitive JavaScript undefined value.
- *
- *  In most situations, you should not need this trait, and use
- *  [[scala.Unit]] instead.
- */
-sealed trait Undefined extends Any
-
 }

--- a/library/src/main/scala/scala/scalajs/js/UndefOr.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOr.scala
@@ -28,9 +28,6 @@ object UndefOr {
   implicit def any2undefOrA[A](value: A): UndefOr[A] =
     value.asInstanceOf[UndefOr[A]]
 
-  implicit def undef2undefOr(value: prim.Undefined): UndefOr[Nothing] =
-    value.asInstanceOf[UndefOr[Nothing]]
-
   implicit def undefOr2ops[A](value: UndefOr[A]): UndefOrOps[A] =
     new UndefOrOps(value)
 

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -57,41 +57,25 @@ package scala.scalajs
  *  to call any method and read and write any field of a value of type
  *  [[js.Dynamic]].
  *
- *  The package [[scala.scalajs.js.prim]] gives definitions for the four
- *  primitive types of JavaScript as subtraits of [[js.Any]], but generally
- *  it is preferable to use the corresponding Scala type.
- *  - [[js.prim.Number]] corresponds to [[scala.Double]]
- *  - [[js.prim.Boolean]] corresponds to [[scala.Boolean]]
- *  - [[js.prim.String]] corresponds to [[java.lang.String]]
- *  - [[js.prim.Undefined]] corresponds to [[scala.Unit]]
+ *  There are no explicit definitions for JavaScript primitive types, as one
+ *  could expect, because the corresponding Scala types stand in their stead:
+ *  - [[Boolean]] is a primitive JavaScript boolean
+ *  - [[Double]] is a primitive JavaScript number
+ *  - [[String]] is a primitive JavaScript string
+ *  - [[Unit]] is the type of the JavaScript undefined value
+ *  - [[Null]] is the type of the JavaScript null value
  *
  *  [[js.UndefOr]] gives a [[scala.Option]]-like interface where the JavaScript
  *  value `undefined` takes the role of `None`.
  */
 package object js extends js.GlobalScope {
-  /** The type of JavaScript numbers, which is [[scala.Double]]. */
-  type Number = scala.Double
-  /** The type of JavaScript booleans, which is [[scala.Boolean]]. */
-  type Boolean = scala.Boolean
-  /** The type of JavaScript strings, which is [[java.lang.String]]. */
-  type String = java.lang.String
-  /** The type of the JavaScript undefined value, which is [[scala.Unit]]. */
-  type Undefined = scala.Unit
-
-  /** The top-level `Number` JavaScript object. */
-  val Number: js.prim.Number.type = native
-  /** The top-level `Boolean` JavaScript object. */
-  val Boolean: js.prim.Boolean.type = native
-  /** The top-level `String` JavaScript object. */
-  val String: js.prim.String.type = native
-
   /** The constant Not-a-Number. */
   val NaN: Double = native
   /** The constant Positive Infinity. */
   val Infinity: Double = native
 
   /** The undefined value. */
-  def undefined: js.prim.Undefined = sys.error("stub")
+  def undefined: js.UndefOr[Nothing] = sys.error("stub")
 
   /** Tests whether the given value is undefined. */
   def isUndefined(v: scala.Any): Boolean = sys.error("stub")
@@ -115,9 +99,9 @@ package object js extends js.GlobalScope {
   def eval(x: String): Any = native
 
   /** Parses a string as an integer with a given radix. */
-  def parseInt(s: String, radix: Int): js.Number = native
+  def parseInt(s: String, radix: Int): Double = native
   /** Parses a string as an integer with auto-detected radix. */
-  def parseInt(s: String): js.Number = native
+  def parseInt(s: String): Double = native
   /** Parses a string as a floating point number. */
   def parseFloat(string: String): Double = native
 

--- a/library/src/main/scala/scala/scalajs/runtime/Bits.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/Bits.scala
@@ -16,9 +16,9 @@ import js.typedarray
 /** Low-level stuff. */
 object Bits {
 
-  val areTypedArraysSupported = (
-      !(!global.ArrayBuffer) && !(!global.Int32Array) &&
-      !(!global.Float32Array) && !(!global.Float64Array))
+  val areTypedArraysSupported = js.DynamicImplicits.truthValue(
+      global.ArrayBuffer && global.Int32Array &&
+      global.Float32Array && global.Float64Array)
 
   private val arrayBuffer =
     if (areTypedArraysSupported) new typedarray.ArrayBuffer(8)
@@ -134,11 +134,13 @@ object Bits {
   }
 
   private def longBitsToDoublePolyfill(bits: Long): Double = {
+    import js.JSNumberOps._
+
     val ebits = 11
     val fbits = 52
     val hifbits = fbits-32
     val hi = (bits >>> 32).toInt
-    val lo = ((bits.toInt: js.prim.Number) >>> 0).toDouble
+    val lo = bits.toInt.toUint
     val s = hi < 0
     val e = (hi >> hifbits) & ((1 << ebits) - 1)
     val f = (hi & ((1 << hifbits) - 1)).toDouble * 0x100000000L.toDouble + lo

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -44,9 +44,8 @@ package object runtime {
     c.prototype = ctor.prototype
     val instance = js.Dynamic.newInstance(c)()
     val result = ctor.applyDynamic("apply")(instance, args)
-    (result: js.Any) match {
-      case _:js.prim.Undefined | _:js.prim.Number | _:js.prim.Boolean |
-          _:js.prim.String | null =>
+    (result: Any) match {
+      case _:Double | _:Boolean | _:String | () | null =>
         instance
       case _ =>
         result
@@ -102,7 +101,7 @@ package object runtime {
   }
 
   /** Information about the environment Scala.js runs in
-   * 
+   *
    *  See [[EnvironmentInfo]] for details.
    */
   def environmentInfo: EnvironmentInfo = sys.error("stub")

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -354,27 +354,6 @@ object InteroperabilityTest extends JasmineTest {
     }
 
     when("compliant-asinstanceof").
-    it("should protect conversions from JS types to Scala types") {
-      class Foo
-      val foo: Any = new Foo
-
-      val invalidNumber: js.prim.Number = foo.asInstanceOf[js.prim.Number]
-      val nullNumber: js.prim.Number = null
-      expect(() => invalidNumber: Double).toThrow
-      expect(nullNumber: Double).toEqual(0)
-
-      val invalidBoolean: js.prim.Boolean = foo.asInstanceOf[js.prim.Boolean]
-      val nullBoolean: js.prim.Boolean = null
-      expect(() => invalidBoolean: Boolean).toThrow
-      expect(nullBoolean: Boolean).toEqual(false)
-
-      val invalidString: js.prim.String = foo.asInstanceOf[js.prim.String]
-      val nullString: js.prim.String = null
-      expect(() => invalidString: String).toThrow
-      expect(nullString: String).toBeNull
-    }
-
-    when("compliant-asinstanceof").
     it("should asInstanceOf values received from calling a JS interop method") {
       val obj = js.eval("""
         var obj = {

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -118,10 +118,9 @@ object LongTest extends JasmineTest {
       expect("45678901234567890".toLong == 45678901234567890L).toBeTruthy
     }
 
-    it("should convert from and to js.prim.Number") {
-      val x = 5: js.prim.Number
-      expect((5L: js.prim.Number) == x).toBeTruthy
-      expect(x.toLong == 5L).toBeTruthy
+    it("should convert to js.Any") {
+      val x = 5: js.Any
+      expect((5L: js.Any) == x).toBeTruthy
     }
 
     it("should correctly implement is/asInstanceOf Longs") {

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -28,13 +28,6 @@ object RegressionTest extends JasmineTest {
       expect(mod.getClass.getName).toEqual("double")
     }
 
-    it("js.prim.String + js.prim.String is ambiguous - #20") {
-      val a: js.prim.String = "a"
-      val b: js.prim.String = "b"
-      val c: js.prim.String = a + b
-      expect(c).toEqual("ab")
-    }
-
     it("Abort with some pattern match guards - #22") {
       object PatternMatchGuards {
         def go(f: Int => Int) = f(1)
@@ -72,10 +65,10 @@ object RegressionTest extends JasmineTest {
       new Bug66B("", "")
     }
 
-    it("should not swallow Unit expressions when converting to js.prim.Undefined - #83") {
+    it("should not swallow Unit expressions when converting to js.Any - #83") {
       var effectHappened = false
       def doEffect(): Unit = effectHappened = true
-      def f(): js.prim.Undefined = doEffect()
+      def f(): js.Any = doEffect()
       f()
       expect(effectHappened).toBeTruthy
     }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/MathTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/MathTest.scala
@@ -26,13 +26,13 @@ object MathTest extends JasmineTest {
 
     it("should respond to `log1p`") {
       expect(Math.log1p(-2.0).isNaN).toBeTruthy
-      expect(Math.log1p(js.Number.NaN.toDouble).isNaN).toBeTruthy
+      expect(Math.log1p(Double.NaN).isNaN).toBeTruthy
       expect(Math.log1p(0.0)).toEqual(0.0)
     }
 
     it("should respond to `log10`") {
       expect(Math.log10(-230.0).isNaN).toBeTruthy
-      expect(Math.log10(js.Number.NaN.toDouble).isNaN).toBeTruthy
+      expect(Math.log10(Double.NaN).isNaN).toBeTruthy
     }
 
     it("should respond to `signum` for Double") {
@@ -45,7 +45,7 @@ object MathTest extends JasmineTest {
       expect(Math.signum(-0.0)).toEqual(-0.0)
       expect(1 / Math.signum(-0.0) < 0).toBeTruthy
 
-      expect(Math.signum(js.Number.NaN.toDouble).isNaN).toBeTruthy
+      expect(Math.signum(Double.NaN).isNaN).toBeTruthy
     }
 
     it("should respond to `signum` for Float") {
@@ -58,7 +58,7 @@ object MathTest extends JasmineTest {
       expect(Math.signum(-0.0f)).toEqual(-0.0f)
       expect(1 / Math.signum(-0.0f) < 0).toBeTruthy
 
-      expect(Math.signum(js.Number.NaN.toFloat).isNaN).toBeTruthy
+      expect(Math.signum(Float.NaN).isNaN).toBeTruthy
     }
 
     it("should respond to `nextUp` for Double") {
@@ -75,8 +75,8 @@ object MathTest extends JasmineTest {
     }
 
     it("should respond to `nextAfter` for Double") {
-      expect(Math.nextAfter(1.0, js.Number.NaN.toDouble).isNaN).toBeTruthy
-      expect(Math.nextAfter(js.Number.NaN.toDouble, 1.0).isNaN).toBeTruthy
+      expect(Math.nextAfter(1.0, Double.NaN).isNaN).toBeTruthy
+      expect(Math.nextAfter(Double.NaN, 1.0).isNaN).toBeTruthy
       expect(Math.nextAfter(0.0, 0.0)).toEqual(0.0)
       expect(Math.nextAfter(0.0, -0.0)).toEqual(-0.0)
       expect(Math.nextAfter(-0.0, 0.0)).toEqual(0.0)
@@ -99,7 +99,7 @@ object MathTest extends JasmineTest {
     it("should respond to `hypot`") {
       expect(Math.hypot(0.0, 0.0)).toBeCloseTo(0.0)
       expect(Math.hypot(3.0, 4.0)).toBeCloseTo(5.0)
-      expect(Math.hypot(3.0, js.Number.NaN.toDouble).isNaN).toBeTruthy
+      expect(Math.hypot(3.0, Double.NaN).isNaN).toBeTruthy
       expect(Math.hypot(Double.NegativeInfinity, 4.0)).toEqual(Double.PositiveInfinity)
     }
 

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -441,13 +441,13 @@ object ExportsTest extends JasmineTest {
 
     }
 
-    it("should prefer overloads taking a js.Undefined over methods with default parameters") {
+    it("should prefer overloads taking a Unit over methods with default parameters") {
       class A {
         @JSExport
         def foo(a: Int)(b: String = "asdf") = s"$a $b"
 
         @JSExport
-        def foo(a: Int, b: js.prim.Undefined) = "woot"
+        def foo(a: Int, b: Unit) = "woot"
       }
 
       val a = (new A).asInstanceOf[js.Dynamic]

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -82,7 +82,7 @@ object MiscInteropTest extends JasmineTest {
     }
 
     it("should compile js.undefined") {
-      expect(() => js.undefined.asInstanceOf[js.prim.Number].toString(10)).toThrow
+      expect(() => js.undefined.asInstanceOf[js.Dynamic].toFixed()).toThrow
     }
 
     it("should allow to define direct subtraits of js.Any") {


### PR DESCRIPTION
The type aliases `js.Boolean`, `js.Number`, `js.String` and `js.Undefined` have been removed. The documentation specifies that the Scala types should be used.

Operations available on JavaScript numbers and strings that do not have an equivalent in the Scala/Java library can be made available through imports of implicit pimps of `Int`/`Double` and `String`:

``` scala
import js.JSNumberOps._
import js.JSStringOps._
```

Working with dynamically typed JavaScript-style code used to benefit from `js.prim.*` types for various things. To restore (and improve) that kind of code, a few chosen implicit conversions can be imported:

``` scala
import js.DynamicImplicits._
```

This fixes #1384.
