### PR TITLE
Fix #1389: partest is broken.

### DIFF
--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -117,7 +117,7 @@ class MainGenericRunner {
   }
 
   private def runnerJSFile(mainObj: String, args: List[String]) = {
-    val jsObj = "ScalaJS.m." + mainObj
+    val jsObj = "ScalaJS.m." + mainObj + "$"
     val jsArgs = argArray(args)
     new MemVirtualJSFile("Generated launcher file").
       withContent(s"$jsObj().main__AT__V($jsArgs);")


### PR DESCRIPTION
It was broken in the refactoring of df111c62335a0591dcea54461df934923106276d which uniformly added $s to all occurrences of module class names.
