### PR TITLE
Fix #1113: Obfuscation of class names.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -312,7 +312,7 @@ object Build extends sbt.Build {
 
           val code = {
             s"""
-            var lib = scalajs.QuickLinker().linkNode(${cp.mkString(", ")});
+            var lib = scalajs.QuickLinker().linkTestSuiteNode(${cp.mkString(", ")});
 
             var __ScalaJSEnv = null;
 
@@ -835,6 +835,13 @@ object Build extends sbt.Build {
           publishArtifact in Compile := false,
 
           scalacOptions ~= (_.filter(_ != "-deprecation")),
+
+          scalaJSSemantics ~= (_.withRuntimeClassName(_.fullName match {
+            case "org.scalajs.testsuite.compiler.ReflectionTest$RenamedTestClass" =>
+              "renamed.test.Class"
+            case fullName =>
+              fullName
+          })),
 
           sources in Test ++= {
             if (!scalaVersion.value.startsWith("2.10") &&

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -17,9 +17,17 @@ import org.scalajs.jasminetest.JasmineTest
 object ReflectionTest extends JasmineTest {
 
   describe("Scala.js Reflection (through java.lang.Class)") {
+    it("java.lang.Class.getName under normal circumstances") {
+      expect(classOf[scala.Some[_]].getName).toEqual("scala.Some")
+    }
+
     it("should append $ to class name of objects") {
       expect(TestObject.getClass.getName).toEqual(
         "org.scalajs.testsuite.compiler.ReflectionTest$TestObject$")
+    }
+
+    it("java.lang.Class.getName renamed through semantics") {
+      expect(classOf[RenamedTestClass].getName).toEqual("renamed.test.Class")
     }
 
     it("should support isInstance") {
@@ -65,5 +73,7 @@ object ReflectionTest extends JasmineTest {
   }
 
   object TestObject
+
+  class RenamedTestClass
 
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/ScalaJSClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/ScalaJSClassEmitter.scala
@@ -401,7 +401,7 @@ final class ScalaJSClassEmitter(semantics: Semantics) {
     val typeData = js.New(envField("ClassTypeData"), List(
         js.ObjectConstr(List(classIdent -> js.IntLiteral(0))),
         js.BooleanLiteral(kind == ClassKind.Interface),
-        js.StringLiteral(decodeClassName(className)),
+        js.StringLiteral(semantics.runtimeClassName(tree)),
         parentData,
         ancestorsRecord
     ) ++ (
@@ -488,7 +488,7 @@ final class ScalaJSClassEmitter(semantics: Semantics) {
 
     js.Block(exports)(tree.pos)
   }
-  
+
   def genClassExports(tree: LinkedClass): js.Tree = {
     val exports = tree.classExports collect {
       case e: ConstructorExportDef =>

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/LinkedClass.scala
@@ -51,6 +51,8 @@ final case class LinkedClass(
   def encodedName: String = name.name
   def isExported: Boolean = classExports.nonEmpty
 
+  def fullName: String = Definitions.decodeClassName(encodedName)
+
   def toInfo: Infos.ClassInfo = {
     val methodInfos = (
         staticMethods.map(_.info) ++


### PR DESCRIPTION
The Semantics now offer a new option, which is a callback from `LinkedClass` to full name to be used for that class' `getName()` method. Since it works on a `LinkedClass`, it is possible to inspect the class' hierarchy, for example, to decide how to rename.