### PR TITLE
Upgrade to apigee's fork of Rhino, which is used by sbt-web.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -340,7 +340,7 @@ object Build extends sbt.Build {
       settings = commonSettings ++ publishSettings ++ Seq(
           name := "Scala.js JS Envs",
           libraryDependencies ++= Seq(
-              "org.mozilla" % "rhino" % "1.7R4",
+              "io.apigee" % "rhino" % "1.7R5pre4",
               "org.webjars" % "envjs" % "1.2",
               "com.novocode" % "junit-interface" % "0.9" % "test"
           ) ++ ScalaJSPluginInternal.phantomJSJettyModules.map(_ % "provided")
@@ -967,7 +967,7 @@ object Build extends sbt.Build {
                 "org.scala-sbt" % "sbt" % sbtVersion.value,
                 "org.scala-lang.modules" %% "scala-partest" % "1.0.1",
                 "com.google.javascript" % "closure-compiler" % "v20130603",
-                "org.mozilla" % "rhino" % "1.7R4",
+                "io.apigee" % "rhino" % "1.7R5pre4",
                 "com.googlecode.json-simple" % "json-simple" % "1.1.1"
               )
             else Seq()

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -9,7 +9,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.11.2")
 
 libraryDependencies += "com.google.javascript" % "closure-compiler" % "v20130603"
 
-libraryDependencies += "org.mozilla" % "rhino" % "1.7R4"
+libraryDependencies += "io.apigee" % "rhino" % "1.7R5pre4"
 
 libraryDependencies += "org.webjars" % "envjs" % "1.2"
 


### PR DESCRIPTION
sbt-web depends on Trireme, which itself depends on this fork of Rhino. Using the standard Rhino, we risk conflicts on the classpath between these two forks. This fixes this potential issue by using the same fork or Rhino.