### PR TITLE
Dedicated IR node FieldDef for class fields.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -505,7 +505,7 @@ abstract class GenJSCode extends plugins.PluginComponent
     /** Gen definitions for the fields of a class.
      *  The fields are initialized with the zero of their types.
      */
-    def genClassFields(cd: ClassDef): List[js.VarDef] = {
+    def genClassFields(cd: ClassDef): List[js.FieldDef] = {
       // Non-method term members are fields, except for module members.
       (for {
         f <- currentClassSym.info.decls
@@ -514,8 +514,7 @@ abstract class GenJSCode extends plugins.PluginComponent
         implicit val pos = f.pos
         val mutable =
           suspectFieldMutable(f) || unexpectedMutatedFields.contains(f)
-        js.VarDef(encodeFieldSym(f), toIRType(f.tpe),
-            mutable, genZeroOf(f.tpe))
+        js.FieldDef(encodeFieldSym(f), toIRType(f.tpe), mutable)
       }).toList
     }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -378,6 +378,10 @@ object Serializers {
           writeTrees(defs)
           writeInt(tree.optimizerHints.bits)
 
+        case FieldDef(ident, ftpe, mutable) =>
+          writeByte(TagFieldDef)
+          writeIdent(ident); writeType(ftpe); writeBoolean(mutable)
+
         case methodDef: MethodDef =>
           val MethodDef(static, name, args, resultType, body) = methodDef
 
@@ -643,6 +647,9 @@ object Serializers {
           val defs = readTrees()
           val optimizerHints = new OptimizerHints(readInt())
           ClassDef(name, kind, superClass, parents, jsName, defs)(optimizerHints)
+
+        case TagFieldDef =>
+          FieldDef(readIdent(), readType(), readBoolean())
 
         case TagMethodDef =>
           val optHash = readOptHash()

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -82,7 +82,8 @@ private[ir] object Tags {
   final val TagClosure = TagThis + 1
 
   final val TagClassDef = TagClosure + 1
-  final val TagMethodDef = TagClassDef + 1
+  final val TagFieldDef = TagClassDef + 1
+  final val TagMethodDef = TagFieldDef + 1
   final val TagPropertyDef = TagMethodDef + 1
   final val TagConstructorExportDef = TagPropertyDef + 1
   final val TagModuleExportDef = TagConstructorExportDef + 1

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -191,8 +191,8 @@ object Transformers {
       implicit val pos = tree.pos
 
       tree match {
-        case VarDef(name, vtpe, mutable, rhs) =>
-          VarDef(name, vtpe, mutable, transformExpr(rhs))
+        case FieldDef(_, _, _) =>
+          tree
 
         case tree: MethodDef =>
           val MethodDef(static, name, args, resultType, body) = tree

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -187,7 +187,8 @@ object Traversers {
       // Trees that need not be traversed
 
       case _:Skip | _:Continue | _:Debugger | _:LoadModule | _:JSEnvInfo |
-          _:Literal | _:VarRef | _:This | _:ModuleExportDef | EmptyTree =>
+          _:Literal | _:VarRef | _:This | _:FieldDef | _:ModuleExportDef |
+          EmptyTree =>
 
       case _ =>
         sys.error(s"Invalid tree in traverse() of class ${tree.getClass}")

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -552,6 +552,11 @@ object Trees {
     val tpe = NoType
   }
 
+  case class FieldDef(name: Ident, ftpe: Type, mutable: Boolean)(
+      implicit val pos: Position) extends Tree {
+    val tpe = NoType
+  }
+
   case class MethodDef(static: Boolean, name: PropertyName,
       args: List[ParamDef], resultType: Type, body: Tree)(
       val optimizerHints: OptimizerHints, val hash: Option[TreeHash])(

--- a/ir/src/main/scala/org/scalajs/core/ir/Types.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Types.scala
@@ -11,6 +11,8 @@ package org.scalajs.core.ir
 
 import scala.annotation.tailrec
 
+import Trees._
+
 object Types {
 
   /** Type of an expression in the IR. */
@@ -115,6 +117,18 @@ object Types {
 
   /** No type. */
   case object NoType extends Type
+
+  /** Generates a literal zero of the given type. */
+  def zeroOf(tpe: Type)(implicit pos: Position): Literal = tpe match {
+    case BooleanType => BooleanLiteral(false)
+    case IntType     => IntLiteral(0)
+    case LongType    => LongLiteral(0L)
+    case FloatType   => FloatLiteral(0.0f)
+    case DoubleType  => DoubleLiteral(0.0)
+    case StringType  => StringLiteral("")
+    case UndefType   => Undefined()
+    case _           => Null()
+  }
 
   /** Tests whether a type `lhs` is a subtype of `rhs` (or equal).
    *  [[NoType]] is never a subtype or supertype of anything (including

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/ScalaJSClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/ScalaJSClassEmitter.scala
@@ -98,11 +98,11 @@ final class ScalaJSClassEmitter(semantics: Semantics) {
             List(js.This()))
       }
       val fieldDefs = for {
-        field @ VarDef(name, vtpe, mutable, rhs) <- tree.fields
+        field @ FieldDef(name, ftpe, mutable) <- tree.fields
       } yield {
         implicit val pos = field.pos
         desugarJavaScript(
-            Assign(Select(This()(tpe), name)(vtpe), rhs),
+            Assign(Select(This()(tpe), name)(ftpe), zeroOf(ftpe)),
             semantics)
       }
       js.Function(Nil,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/GenIncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/GenIncOptimizer.scala
@@ -343,7 +343,7 @@ abstract class GenIncOptimizer(semantics: Semantics,
     var isModuleClass: Boolean = false
     var hasElidableModuleAccessor: Boolean = false
 
-    var fields: List[VarDef] = Nil
+    var fields: List[FieldDef] = Nil
     var isInlineable: Boolean = false
     var tryNewInlineable: Option[RecordValue] = None
 
@@ -511,9 +511,10 @@ abstract class GenIncOptimizer(semantics: Semantics,
       } else {
         val allFields = reverseParentChain.flatMap(_.fields)
         val (fieldValues, fieldTypes) = (for {
-          VarDef(Ident(name, originalName), tpe, mutable, rhs) <- allFields
+          f @ FieldDef(Ident(name, originalName), tpe, mutable) <- allFields
         } yield {
-          (rhs, RecordType.Field(name, originalName, tpe, mutable))
+          (zeroOf(tpe)(f.pos),
+              RecordType.Field(name, originalName, tpe, mutable))
         }).unzip
         tryNewInlineable = Some(
             RecordValue(RecordType(fieldTypes), fieldValues)(Position.NoPosition))

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/IRChecker.scala
@@ -151,14 +151,12 @@ class IRChecker(unit: LinkingUnit, logger: Logger) {
     }
   }
 
-  def checkFieldDef(fieldDef: VarDef, classDef: LinkedClass): Unit = {
-    val VarDef(name, tpe, mutable, rhs) = fieldDef
+  def checkFieldDef(fieldDef: FieldDef, classDef: LinkedClass): Unit = {
+    val FieldDef(name, tpe, mutable) = fieldDef
     implicit val ctx = ErrorContext(fieldDef)
 
     if (tpe == NoType)
-      reportError(s"VarDef cannot have type NoType")
-    else
-      typecheckExpect(rhs, Env.empty, tpe)
+      reportError(s"FieldDef cannot have type NoType")
   }
 
   def checkMethodDef(methodDef: MethodDef, classDef: LinkedClass): Unit = {
@@ -901,8 +899,8 @@ class IRChecker(unit: LinkingUnit, logger: Logger) {
   }
 
   object CheckedClass {
-    private def checkedField(varDef: VarDef) = {
-      val VarDef(Ident(name, _), tpe, mutable, _) = varDef
+    private def checkedField(fieldDef: FieldDef) = {
+      val FieldDef(Ident(name, _), tpe, mutable) = fieldDef
       new CheckedField(name, tpe, mutable)
     }
   }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/LinkedClass.scala
@@ -32,7 +32,7 @@ final case class LinkedClass(
     superClass: Option[Ident],
     interfaces: List[Ident],
     jsName: Option[String],
-    fields: List[VarDef],
+    fields: List[FieldDef],
     staticMethods: List[LinkedMember[MethodDef]],
     memberMethods: List[LinkedMember[MethodDef]],
     abstractMethods: List[LinkedMember[MethodDef]],
@@ -75,7 +75,7 @@ object LinkedClass {
 
     val memberInfoByName = Map(info.methods.map(m => m.encodedName -> m): _*)
 
-    val fields = mutable.Buffer.empty[VarDef]
+    val fields = mutable.Buffer.empty[FieldDef]
     val staticMethods = mutable.Buffer.empty[LinkedMember[MethodDef]]
     val memberMethods = mutable.Buffer.empty[LinkedMember[MethodDef]]
     val abstractMethods = mutable.Buffer.empty[LinkedMember[MethodDef]]
@@ -98,7 +98,7 @@ object LinkedClass {
         staticMethods += linkedMethod(m)
 
       // Fields
-      case field @ VarDef(_, _, _, _) =>
+      case field @ FieldDef(_, _, _) =>
         fields += field
 
       // Normal methods

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Linker.scala
@@ -165,7 +165,7 @@ final class Linker(semantics: Semantics, considerPositions: Boolean) {
 
     val memberInfoByName = Map(info.methods.map(m => m.encodedName -> m): _*)
 
-    val fields = mutable.Buffer.empty[VarDef]
+    val fields = mutable.Buffer.empty[FieldDef]
     val staticMethods = mutable.Buffer.empty[LinkedMember[MethodDef]]
     val memberMethods = mutable.Buffer.empty[LinkedMember[MethodDef]]
     val abstractMethods = mutable.Buffer.empty[LinkedMember[MethodDef]]
@@ -190,7 +190,7 @@ final class Linker(semantics: Semantics, considerPositions: Boolean) {
           staticMethods += linkedMethod(m)
 
       // Fields
-      case field @ VarDef(_, _, _, _) =>
+      case field @ FieldDef(_, _, _) =>
         if (analyzerInfo.isAnySubclassInstantiated)
           fields += field
 


### PR DESCRIPTION
Previously, `VarDef`s were used, with a duplicate meaning. The new `FieldDef`s do not have an rhs. Instead, the rhs is always implicitly the zero of the IR type of the field.