### PR TITLE
Separate usedInstanceTests from accessedClassData in info.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1512,6 +1512,9 @@ abstract class GenJSCode extends plugins.PluginComponent
       for (cls <- funInfo.accessedModules)
         builder.addAccessedModule(cls)
 
+      for (cls <- funInfo.usedInstanceTests)
+        builder.addUsedInstanceTest(cls)
+
       for (cls <- funInfo.accessedClassData)
         builder.addAccessedClassData(cls)
     }
@@ -1716,7 +1719,7 @@ abstract class GenJSCode extends plugins.PluginComponent
         }
       } else {
         val refType = toReferenceType(to)
-        currentMethodInfoBuilder.addAccessedClassData(refType)
+        currentMethodInfoBuilder.addUsedInstanceTest(refType)
         js.IsInstanceOf(value, refType)
       }
     }
@@ -1727,7 +1730,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
       def default: js.Tree = {
         val refType = toReferenceType(to)
-        currentMethodInfoBuilder.addAccessedClassData(refType)
+        currentMethodInfoBuilder.addUsedInstanceTest(refType)
         js.AsInstanceOf(value, refType)
       }
 

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -426,7 +426,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
             val optCond = typeTest match {
               case HijackedTypeTest(boxedClassName, _) =>
                 val tpe = jstpe.ClassType(boxedClassName)
-                currentMethodInfoBuilder.addAccessedClassData(tpe)
+                currentMethodInfoBuilder.addUsedInstanceTest(tpe)
                 Some(js.IsInstanceOf(param.ref, tpe))
 
               case InstanceOfTypeTest(tpe) =>

--- a/ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
@@ -77,6 +77,7 @@ object InfoSerializers {
         }
         writeStrings(instantiatedClasses)
         writeStrings(accessedModules)
+        writeStrings(usedInstanceTests)
         writeStrings(accessedClassData)
       }
 
@@ -117,10 +118,12 @@ object InfoSerializers {
         val staticMethodsCalled = readList(readUTF() -> readStrings()).toMap
         val instantiatedClasses = readStrings()
         val accessedModules = readStrings()
+        val usedInstanceTests = readStrings()
         val accessedClassData = readStrings()
         MethodInfo(encodedName, isStatic, isAbstract, isExported,
             methodsCalled, methodsCalledStatically, staticMethodsCalled,
-            instantiatedClasses, accessedModules, accessedClassData)
+            instantiatedClasses, accessedModules, usedInstanceTests,
+            accessedClassData)
       }
 
       val methods = readList(readMethod())

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -733,6 +733,10 @@ object Printers {
         println("accessedModules: ",
             accessedModules.map(escapeJS).mkString("[", ", ", "]"))
       }
+      if (usedInstanceTests.nonEmpty) {
+        println("usedInstanceTests: ",
+            usedInstanceTests.map(escapeJS).mkString("[", ", ", "]"))
+      }
       if (accessedClassData.nonEmpty) {
         println("accessedClassData: ",
             accessedClassData.map(escapeJS).mkString("[", ", ", "]"))

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Analyzer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Analyzer.scala
@@ -436,7 +436,7 @@ final class Analyzer(semantics: Semantics,
         lookupClass(className).instantiated()
       }
 
-      for (className <- data.accessedClassData) {
+      for (className <- data.usedInstanceTests ++ data.accessedClassData) {
         if (!Definitions.PrimitiveClasses.contains(className))
           lookupClass(className).accessData()
       }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/InfoChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/InfoChecker.scala
@@ -122,6 +122,7 @@ class InfoChecker(infoAndTrees: Traversable[(ClassInfo, ClassDef)],
         !mapIncludes(info.staticMethodsCalled, expectedInfo.staticMethodsCalled) ||
         !listIncludes(info.instantiatedClasses, expectedInfo.instantiatedClasses) ||
         !listIncludes(info.accessedModules, expectedInfo.accessedModules) ||
+        !listIncludes(info.usedInstanceTests, expectedInfo.usedInstanceTests) ||
         !listIncludes(info.accessedClassData, expectedInfo.accessedClassData)) {
       _errorCount += 1
       logger.error(s"Method info mismatch for $className.${expectedInfo.encodedName}" +


### PR DESCRIPTION
We don't need the full class data just to do instance tests (is/asInstanceOf). We just need the instance test methods. In theory, a future version of the analyzer can leverage these more detailed info to avoid including class data for classes and interfaces which are only used for instance tests. Currently the analyzer still considers both uniformly.