### PR TITLE
Fix #1445: Blacklist partests run/t6253{a,b,c}.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/BlacklistedTests.txt
@@ -136,6 +136,9 @@ run/t408.scala
 run/t6584.scala
 run/t6853.scala
 run/UnrolledBuffer.scala
+run/t6253a.scala
+run/t6253b.scala
+run/t6253c.scala
 
 # Crashes Rhino
 

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/WhitelistedTests.txt
@@ -2629,9 +2629,6 @@ run/macroPlugins-macroExpand
 run/t8010.scala
 run/macroPlugins-typedMacroBody
 run/t7406.scala
-run/t6253c.scala
-run/t6253a.scala
-run/t6253b.scala
 pos/t8146a.scala
 pos/t8046c.scala
 pos/t8002-nested-scope.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/BlacklistedTests.txt
@@ -136,6 +136,9 @@ run/t408.scala
 run/t6584.scala
 run/t6853.scala
 run/UnrolledBuffer.scala
+run/t6253a.scala
+run/t6253b.scala
+run/t6253c.scala
 
 # Crashes Rhino
 

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/WhitelistedTests.txt
@@ -2629,9 +2629,6 @@ run/macroPlugins-macroExpand
 run/t8010.scala
 run/macroPlugins-typedMacroBody
 run/t7406.scala
-run/t6253c.scala
-run/t6253a.scala
-run/t6253b.scala
 pos/t8146a.scala
 pos/t8046c.scala
 pos/t8002-nested-scope.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BlacklistedTests.txt
@@ -137,6 +137,9 @@ run/t408.scala
 run/t6584.scala
 run/t6853.scala
 run/UnrolledBuffer.scala
+run/t6253a.scala
+run/t6253b.scala
+run/t6253c.scala
 
 # Crashes Rhino
 

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/WhitelistedTests.txt
@@ -2629,9 +2629,6 @@ run/macroPlugins-macroExpand
 run/t8010.scala
 run/macroPlugins-typedMacroBody
 run/t7406.scala
-run/t6253c.scala
-run/t6253a.scala
-run/t6253b.scala
 pos/t8146a.scala
 pos/t8046c.scala
 pos/t8002-nested-scope.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/BlacklistedTests.txt
@@ -139,6 +139,9 @@ run/t408.scala
 run/t6584.scala
 run/t6853.scala
 run/UnrolledBuffer.scala
+run/t6253a.scala
+run/t6253b.scala
+run/t6253c.scala
 
 # Crashes Rhino
 

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/WhitelistedTests.txt
@@ -2687,9 +2687,6 @@ run/macroPlugins-macroExpand
 run/t8010.scala
 run/macroPlugins-typedMacroBody
 run/t7406.scala
-run/t6253c.scala
-run/t6253a.scala
-run/t6253b.scala
 pos/t8146a.scala
 pos/t8046c.scala
 pos/t8002-nested-scope.scala


### PR DESCRIPTION
Because they're taking too much time and too much memory.