### PR TITLE
Fix ScalaDoc runs

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -80,7 +80,7 @@
         ++$scala javalibExTestSuite/test \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala javalibExTestSuite/test &&
-    sbt ++$scala compiler/test reversi/fastOptJS reversi/fullOptJS &&
+    sbt ++$scala testSuite/test:doc compiler/test reversi/fastOptJS reversi/fullOptJS &&
     sbt ++$scala partest/fetchScalaSource &&
     sh ci/checksizes.sh $scala &&
     sh ci/check-partest-coverage.sh $scala

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -51,14 +51,7 @@ trait PrepJSExports { this: PrepJSInterop =>
     else if (hasIllegalDefaultParam(baseSym))
       err(s"In an exported $memType, all parameters with defaults " +
         "must be at the end")
-    else if (currentRun.uncurryPhase == NoPhase) {
-      /* When using scaladoc, the uncurry phase does not exist. This makes
-       * our code down below blow up (see bug #323). So we do not do anything
-       * more here if the phase does not exist. It's no big deal because we do
-       * not need exports for scaladoc.
-       */
-      Nil
-    } else if (baseSym.isConstructor) {
+    else if (baseSym.isConstructor) {
       // we can generate constructors entirely in the backend, since they
       // do not need inheritance and such. But we want to check their sanity
       // here by previous tests and the following ones.


### PR DESCRIPTION
The second commit introduces `testSuite/test:doc` in the CI matrix to verify that we can always run ScalaDoc on a project with all sorts of crazy JS stuff.