### PR TITLE
Fix #1452: PhantomJS sometimes doesn't shut down properly.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSRunner.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSRunner.scala
@@ -15,7 +15,17 @@ trait AsyncJSRunner {
    */
   def start(): Future[Unit]
 
-  /** Abort the associated run */
+  /** Aborts the associated run.
+   *
+   *  There is no guarantee that the runner will be effectively terminated
+   *  by the time this method returns. If necessary, this call can be followed
+   *  by a call to `await()`.
+   *
+   *  If the run has already completed, this does nothing. Similarly,
+   *  subsequent calls to `stop()` will do nothing.
+   *
+   *  This method cannot be called before `start()` has been called.
+   */
   def stop(): Unit
 
   /**

--- a/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSRunner.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSRunner.scala
@@ -48,12 +48,31 @@ trait AsyncJSRunner {
 
   /** Await completion of the started Run for the duration specified
    *  by [[atMost]]. Strictly equivalent to:
-   * 
+   *
    *  {{{
    *  Await.result(future, atMost)
    *  }}}
-   * 
+   *
    */
   final def await(atMost: Duration): Unit = Await.result(future, atMost)
+
+  /** Awaits completion of the started Run for the duration specified by
+   *  [[atMost]], or force it to stop.
+   *
+   *  If any exception is thrown while awaiting completion (including a
+   *  [[scala.concurrent.TimeoutException TimeoutException]], forces the runner
+   *  to stop by calling `stop()` before rethrowing the exception.
+   *
+   *  Strictly equivalent to:
+   *
+   *  {{{
+   *  try await(atMost)
+   *  finally stop()
+   *  }}}
+   */
+  final def awaitOrStop(atMost: Duration): Unit = {
+    try await(atMost)
+    finally stop()
+  }
 
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ComJSRunner.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ComJSRunner.scala
@@ -1,14 +1,27 @@
 package org.scalajs.jsenv
 
+import scala.concurrent.duration.Duration
+
 trait ComJSRunner extends AsyncJSRunner {
 
   /** Send a message to the JS VM. Throws if the message cannot be sent. */
   def send(msg: String): Unit
 
-  /** Block until a message is received. Throws a [[ComClosedExcpetion]]
-   *  if the channel is closed before a message is received.
+  /** Blocks until a message is received and returns it.
+   *
+   *  @throws ComClosedException if the channel is closed before a message
+   *    is received
    */
-  def receive(): String
+  final def receive(): String = receive(Duration.Inf)
+
+  /** Blocks until a message is received and returns it.
+   *
+   *  @throws ComClosedException if the channel is closed before a message
+   *    is received
+   *  @throws scala.concurrent.TimeoutException if the timeout expires
+   *    before a message is received and the channel is still open
+   */
+  def receive(timeout: Duration): String
 
   /** Close the communication channel. Allows the VM to terminate if it is
    *  still waiting for callback. The JVM side **must** call close in

--- a/js-envs/src/main/scala/org/scalajs/jsenv/Utils.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/Utils.scala
@@ -1,0 +1,34 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js JS environments   **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package org.scalajs.jsenv
+
+import scala.concurrent.duration._
+
+private[jsenv] object Utils {
+  final class OptDeadline private (
+      val deadline: Deadline /* nullable */) extends AnyVal {
+    def millisLeft: Long =
+      if (deadline == null) 0
+      else (deadline.timeLeft.toMillis max 1L)
+
+    def isOverdue: Boolean =
+      if (deadline == null) false
+      else deadline.isOverdue
+  }
+
+  object OptDeadline {
+    def apply(timeout: Duration): OptDeadline = {
+      new OptDeadline(timeout match {
+        case timeout: FiniteDuration => timeout.fromNow
+        case _                       => null
+      })
+    }
+  }
+}

--- a/js-envs/src/test/scala/org/scalajs/jsenv/test/AsyncTests.scala
+++ b/js-envs/src/test/scala/org/scalajs/jsenv/test/AsyncTests.scala
@@ -12,7 +12,7 @@ import org.junit.Assert._
 import scala.concurrent.Await
 import scala.concurrent.duration._
 
-/** A couple of tests that test communication for mix-in into a test suite */
+/** A couple of tests that test async runners for mix-in into a test suite */
 trait AsyncTests {
 
   protected final val DefaultTimeout: Duration = 10.seconds
@@ -35,6 +35,16 @@ trait AsyncTests {
     Await.result(fut, DefaultTimeout)
 
     assertFalse("VM should be terminated", runner.isRunning)
+  }
+
+  @Test
+  def stopAfterTerminatedTest = {
+    val runner = asyncRunner("")
+    val fut = runner.start()
+
+    Await.result(fut, DefaultTimeout)
+
+    runner.stop() // should do nothing, and not fail
   }
 
 }

--- a/js-envs/src/test/scala/org/scalajs/jsenv/test/ComTests.scala
+++ b/js-envs/src/test/scala/org/scalajs/jsenv/test/ComTests.scala
@@ -53,6 +53,8 @@ trait ComTests extends AsyncTests {
 
     com.close()
     com.await(DefaultTimeout)
+
+    com.stop() // should do nothing, and not fail
   }
 
   def comCloseJSTestCommon(timeout: Long) = {
@@ -75,6 +77,8 @@ trait ComTests extends AsyncTests {
 
     com.close()
     com.await(DefaultTimeout)
+
+    com.stop() // should do nothing, and not fail
   }
 
   @Test

--- a/js-envs/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
+++ b/js-envs/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
@@ -9,6 +9,7 @@ import org.scalajs.core.tools.logging._
 import org.scalajs.core.tools.sem._
 
 import scala.concurrent.Future
+import scala.concurrent.duration.Duration
 
 import org.junit.Test
 
@@ -50,7 +51,7 @@ class RetryingComJSEnvTest extends JSEnvTest with ComTests {
 
     private class FailingComJSRunner(baseRunner: ComJSRunner)
         extends DummyJSRunner with ComJSRunner {
-      
+
       def future = baseRunner.future
 
       def send(msg: String): Unit = {
@@ -58,12 +59,12 @@ class RetryingComJSEnvTest extends JSEnvTest with ComTests {
         baseRunner.send(msg)
       }
 
-      def receive(): String = {
+      def receive(timeout: Duration): String = {
         if (shouldFail) {
           failedReceive = true
           fail()
         }
-        baseRunner.receive()
+        baseRunner.receive(timeout)
       }
 
 
@@ -85,7 +86,7 @@ class RetryingComJSEnvTest extends JSEnvTest with ComTests {
       private def shouldFail = !failedReceive && fails < maxFails
 
       private def maybeFail() = {
-        if (shouldFail) 
+        if (shouldFail)
           fail()
       }
 

--- a/js-envs/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
+++ b/js-envs/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
@@ -67,7 +67,6 @@ class RetryingComJSEnvTest extends JSEnvTest with ComTests {
         baseRunner.receive(timeout)
       }
 
-
       def start(): Future[Unit] = {
         maybeFail()
         baseRunner.start()

--- a/js-envs/src/test/scala/org/scalajs/jsenv/test/TimeoutComTests.scala
+++ b/js-envs/src/test/scala/org/scalajs/jsenv/test/TimeoutComTests.scala
@@ -124,6 +124,28 @@ trait TimeoutComTests extends TimeoutTests with ComTests {
       case t: Throwable => // all is well
     }
 
+    async.stop() // should do nothing, and not fail
+
+  }
+
+  @Test
+  def doubleStopTest = {
+    val async = asyncRunner(s"""
+      setInterval(function() {}, 0);
+    """)
+
+    async.start()
+    async.stop()
+    async.stop() // should do nothing, and not fail
+
+    try {
+      async.await(DefaultTimeout)
+      fail("Expected await to fail")
+    } catch {
+      case t: Throwable => // all is well
+    }
+
+    async.stop() // should do nothing, and not fail
   }
 
 }


### PR DESCRIPTION
In fact, I believe this could have applied as well to other environments. Anyway, now the whole shutdown process protects against any exception that is being thrown, and still proceeds with terminating all the VMs. Any thrown exception is recorded and rethrown at the end.