### PR TITLE
Fix #1469: Add NaN, Infinity and undefined to Closure externs.

### DIFF
--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala
@@ -190,6 +190,7 @@ object ScalaJSClosureOptimizer {
     Function.prototype.apply = function() {};
     var global = {};
     var __ScalaJSEnv = {};
+    var NaN = 0.0/0.0, Infinity = 1.0/0.0, undefined = void 0;
     """
 
   val ScalaJSExternsFile = new MemVirtualJSFile("ScalaJSExterns.js").


### PR DESCRIPTION
Apparently, Closure really wants those to be defined in externs, otherwise its constant folding can cause it to crash.

I consider this a sufficiently low risk fix not to warrant an additional RC cycle.