### PR TITLE
Fix #1499: Make fullOptJS generate the launcher script.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -204,6 +204,8 @@ object ScalaJSPluginInternal {
 
         Attributed.blank(output).put(scalaJSCompleteClasspath, outCP)
       },
+      fullOptJS <<=
+        fullOptJS.dependsOn(packageJSDependencies, packageScalaJSLauncher),
 
       artifactPath in packageScalaJSLauncher :=
         ((crossTarget in packageScalaJSLauncher).value /


### PR DESCRIPTION
Before, only fastOptJS did so.