### PR TITLE
Fix #1491: Give proper equals/hashCode to JSDependencyManifest.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependency.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependency.scala
@@ -23,6 +23,8 @@ final class JSDependency(
     val dependencies: List[String] = Nil,
     val commonJSName: Option[String] = None) {
 
+  import JSDependency._
+
   require(commonJSName.forall(isValidIdentifier),
     "commonJSName must be a valid JavaScript identifier")
 
@@ -39,9 +41,29 @@ final class JSDependency(
       commonJSName: Option[String] = this.commonJSName) = {
     new JSDependency(resourceName, dependencies, commonJSName)
   }
+
+  override def equals(that: Any): Boolean = that match {
+    case that: JSDependency =>
+      this.resourceName == that.resourceName &&
+      this.dependencies == that.dependencies &&
+      this.commonJSName == that.commonJSName
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int = {
+    import scala.util.hashing.MurmurHash3._
+    var acc = HashSeed
+    acc = mix(acc, resourceName.##)
+    acc = mix(acc, dependencies.##)
+    acc = mixLast(acc, commonJSName.##)
+    finalizeHash(acc, 3)
+  }
 }
 
 object JSDependency {
+  // "org.scalajs.core.tools.jsdep.JSDependency".##
+  private final val HashSeed = 2103455349
 
   implicit object JSDepJSONSerializer extends JSONSerializer[JSDependency] {
     def serialize(x: JSDependency): JSON = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependencyManifest.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependencyManifest.scala
@@ -13,10 +13,36 @@ final class JSDependencyManifest(
     val libDeps: List[JSDependency],
     val requiresDOM: Boolean,
     val compliantSemantics: List[String]) {
+
+  import JSDependencyManifest._
+
   def flatten: List[FlatJSDependency] = libDeps.map(_.withOrigin(origin))
+
+  override def equals(that: Any): Boolean = that match {
+    case that: JSDependencyManifest =>
+      this.origin == that.origin &&
+      this.libDeps == that.libDeps &&
+      this.requiresDOM == that.requiresDOM &&
+      this.compliantSemantics == that.compliantSemantics
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int = {
+    import scala.util.hashing.MurmurHash3._
+    var acc = HashSeed
+    acc = mix(acc, origin.##)
+    acc = mix(acc, libDeps.##)
+    acc = mix(acc, requiresDOM.##)
+    acc = mixLast(acc, compliantSemantics.##)
+    finalizeHash(acc, 4)
+  }
 }
 
 object JSDependencyManifest {
+
+  // "org.scalajs.core.tools.jsdep.JSDependencyManifest".##
+  private final val HashSeed = 943487940
 
   final val ManifestFileName = "JS_DEPENDENCIES"
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/Origin.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/Origin.scala
@@ -4,10 +4,31 @@ import org.scalajs.core.tools.json._
 
 /** The place a JSDependency originated from */
 final class Origin(val moduleName: String, val configuration: String) {
+  import Origin._
+
   override def toString(): String = s"$moduleName:$configuration"
+
+  override def equals(that: Any): Boolean = that match {
+    case that: Origin =>
+      this.moduleName == that.moduleName &&
+      this.configuration == that.configuration
+    case _ =>
+      false
+  }
+
+  override def hashCode(): Int = {
+    import scala.util.hashing.MurmurHash3._
+    var acc = HashSeed
+    acc = mix(acc, moduleName.##)
+    acc = mixLast(acc, configuration.##)
+    finalizeHash(acc, 2)
+  }
 }
 
 object Origin {
+  // "org.scalajs.core.tools.jsdep.Origin".##
+  private final val HashSeed = -2085327609
+
   implicit object OriginJSONSerializer extends JSONSerializer[Origin] {
     def serialize(x: Origin): JSON = {
       new JSONObjBuilder()


### PR DESCRIPTION
This is necessary for the sbt plugin to avoid recreating the `JS_DEPENDENCIES` file over and over again, constantly invalidating the output of fastOptJS and fullOptJS.