### PR TITLE
Optimize java.util.Random by not using Longs internally.

### DIFF
--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/RandomTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/RandomTest.scala
@@ -160,16 +160,16 @@ object RandomTest extends JasmineTest {
 
     it("should correctly implement nextFloat") {
       val random = new Random(-3920005825473L)
-      expect(random.nextFloat()).toBeCloseTo(0.059591234, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.7007871, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.39173192, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.0647918, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.9029677, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.18226051, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.94444054, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.008844078, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.08891684, 7)
-      expect(random.nextFloat()).toBeCloseTo(0.06482434, 7)
+      expect(random.nextFloat()).toBe(0.059591234f)
+      expect(random.nextFloat()).toBe(0.7007871f)
+      expect(random.nextFloat()).toBe(0.39173192f)
+      expect(random.nextFloat()).toBe(0.0647918f)
+      expect(random.nextFloat()).toBe(0.9029677f)
+      expect(random.nextFloat()).toBe(0.18226051f)
+      expect(random.nextFloat()).toBe(0.94444054f)
+      expect(random.nextFloat()).toBe(0.008844078f)
+      expect(random.nextFloat()).toBe(0.08891684f)
+      expect(random.nextFloat()).toBe(0.06482434f)
     }
 
     it("should correctly implement nextBytes") {


### PR DESCRIPTION
According to a user report, calling `Math.random()`, which delegates to `java.util.Random.nextDouble()`, was a major bottleneck of an algorithm, compared to the raw `js.Math.random()`, to the point that it was unusably slow.

In this commit, we optimize `java.util.Random.next(bits: Int)`, as well `nextDouble()` and `nextFloat()`, essentially by *not* using Longs. We still implement the specified algorithm (which is defined in terms of Long operations) with clever bit and double manipulations.