### PR TITLE
Fix #1496: Allow partial paths in jsDependencies.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -37,6 +37,20 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.optimizer.LinkedClass.this"),
 
+      /* Breaking changes: ClasspathContentHandler.handleJS takes an
+       * additional parameter.
+       */
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.classpath.builder.ClasspathContentHandler.handleJS"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.classpath.builder.AbstractJarLibClasspathBuilder.handleJS"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.classpath.builder.AbstractPartialClasspathBuilder.handleJS"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.classpath.builder.JarLibClasspathBuilder.handleJS"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.classpath.builder.PartialClasspathBuilder.handleJS"),
+
       /* In theory, this is a problem, but no one but us is going to
        * *implement* Analysis.ClassInfo.
        */

--- a/tools/jvm/src/test/scala/org/scalajs/core/tools/classpath/builder/test/ClasspathElementsTraverserTest.scala
+++ b/tools/jvm/src/test/scala/org/scalajs/core/tools/classpath/builder/test/ClasspathElementsTraverserTest.scala
@@ -14,7 +14,7 @@ class ClasspathElementsTraverserTest {
   class TestElementTraverser extends ClasspathElementsTraverser with PhysicalFileSystem {
     protected def handleDepManifest(m: => JSDependencyManifest): Unit = ???
     protected def handleIR(relPath: String, ir: => VirtualScalaJSIRFile): Unit = ???
-    protected def handleJS(js: => VirtualJSFile): Unit = ???
+    protected def handleJS(relPath: String, js: => VirtualJSFile): Unit = ???
 
     def test(f: File): String = traverseClasspathElements(Seq(f))
   }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/AbstractJarLibClasspathBuilder.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/AbstractJarLibClasspathBuilder.scala
@@ -38,10 +38,11 @@ trait AbstractJarLibClasspathBuilder extends JarTraverser {
     irFiles += ir
   }
 
-  override protected def handleJS(js: => VirtualJSFile): Unit = {
+  override protected def handleJS(relPath: String,
+      js: => VirtualJSFile): Unit = {
     val file = js
-    if (!jsFiles.contains(file.name))
-      jsFiles += file.name -> file
+    if (!jsFiles.contains(relPath))
+      jsFiles += relPath -> file
   }
 
   override protected def handleDepManifest(m: => JSDependencyManifest): Unit = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/AbstractPartialClasspathBuilder.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/AbstractPartialClasspathBuilder.scala
@@ -29,10 +29,11 @@ trait AbstractPartialClasspathBuilder extends ClasspathContentHandler
       irFiles += relPath -> ir
   }
 
-  override protected def handleJS(js: => VirtualJSFile): Unit = {
+  override protected def handleJS(relPath: String,
+      js: => VirtualJSFile): Unit = {
     val file = js
-    if (!otherJSFiles.contains(file.name))
-      otherJSFiles += file.name -> file
+    if (!otherJSFiles.contains(relPath))
+      otherJSFiles += relPath -> file
   }
 
   override protected def handleDepManifest(m: => JSDependencyManifest): Unit = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/ClasspathContentHandler.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/ClasspathContentHandler.scala
@@ -20,6 +20,6 @@ import scala.collection.immutable.Seq
 /** Base-trait used by traversers to handle content with callbacks */
 trait ClasspathContentHandler {
   protected def handleIR(relPath: String, ir: => VirtualScalaJSIRFile): Unit
-  protected def handleJS(js: => VirtualJSFile): Unit
+  protected def handleJS(relPath: String, js: => VirtualJSFile): Unit
   protected def handleDepManifest(m: => JSDependencyManifest): Unit
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/DirTraverser.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/DirTraverser.scala
@@ -45,7 +45,7 @@ trait DirTraverser extends ClasspathContentHandler with FileSystem {
 
           case _ if isJSFile(file) =>
             versions += getGlobalVersion(file)
-            handleJS(toJSFile(file))
+            handleJS(path, toJSFile(file))
 
           case _ if isIRFile(file) =>
             versions += getGlobalVersion(file)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/JarTraverser.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/JarTraverser.scala
@@ -30,9 +30,9 @@ trait JarTraverser extends ClasspathContentHandler with FileSystem {
     finally zipStream.close()
 
     for {
-      (_, jsFile) <- jsFiles
+      (relPath, jsFile) <- jsFiles
       if jsFile.content != "" // drop if this is just a lone sourcemap
-    } handleJS(jsFile)
+    } handleJS(relPath, jsFile)
 
     getGlobalVersion(jar)
   }


### PR DESCRIPTION
This comes with an important caveat: all `jsDependencies` in a dependency graph must agree on exactly which subpath to use to refer to a given .js file within its jar. But at least, it is an improvement over the status quo, where disambiguation is completely impossible.