### PR TITLE
Make j.l.Math.random() a trivial forwarder to js.Math.random().

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -4,8 +4,6 @@ package lang
 import scala.scalajs.js
 
 object Math {
-  private lazy val internalRandom = new java.util.Random()
-
   final val E  = 2.718281828459045
   final val PI = 3.141592653589793
 
@@ -46,7 +44,7 @@ object Math {
   @inline def atan(a: scala.Double): scala.Double = js.Math.atan(a)
   @inline def atan2(y: scala.Double, x: scala.Double): scala.Double = js.Math.atan2(y, x)
 
-  def random(): scala.Double = internalRandom.nextDouble()
+  @inline def random(): scala.Double = js.Math.random()
 
   @inline def toDegrees(a: scala.Double): scala.Double = a * 180.0 / PI
   @inline def toRadians(a: scala.Double): scala.Double = a / 180.0 * PI


### PR DESCRIPTION
Since the seed of `j.l.Math.random()` cannot be predicted or reset, there cannot be any reasonable code relying on the particular PRNG algorithm behind `j.l.Math.random()`. Therefore, it is uselessly inefficient *not* to use `js.Math.random()` directly.