### PR TITLE
Fix #1518: Don't assume aggregates in dev doc

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -18,7 +18,7 @@ Harmony project.
 Scala.js is entirely built with [sbt](http://www.scala-sbt.org/).
 To build a local version of the compiler and standard library, run
 
-    > package
+    > library/package
 
 To test your changes, run
 


### PR DESCRIPTION
Packaging the library is sufficient to build both the compiler and the
library, since compiling the library depends on the compiler. This
does not build the tools, but the build itself does. Therefore, this
seems like a reasonable introduction to the beginning developer.