### PR TITLE
Revert "Fix #1299: Launch slaves in test adapter in anticipation"

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -4,4 +4,16 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 object BinaryIncompatibilities {
   val Tools = Seq(
   )
+
+  val TestAdapter = Seq(
+      // Private things, not an issue
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.testadapter.ScalaJSRunner.org$scalajs$testadapter$ScalaJSRunner$$awaitSlaveRunner"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.testadapter.ScalaJSRunner.org$scalajs$testadapter$ScalaJSRunner$$launchNewSlave"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.testadapter.ScalaJSRunner.org$scalajs$testadapter$ScalaJSRunner$$createSlaveRunner"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.testadapter.ScalaJSRunner.org$scalajs$testadapter$ScalaJSRunner$$createSlave")
+  )
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -386,7 +386,8 @@ object Build extends sbt.Build {
           name := "Scala.js sbt test adapter",
           libraryDependencies += "org.scala-sbt" % "test-interface" % "1.0",
           previousArtifact := Some(
-              "org.scala-js" % s"scalajs-sbt-test-adapter_${scalaBinaryVersion.value}" % previousVersion)
+              "org.scala-js" % s"scalajs-sbt-test-adapter_${scalaBinaryVersion.value}" % previousVersion),
+          binaryIssueFilters ++= BinaryIncompatibilities.TestAdapter
       )
   ).dependsOn(jsEnvs)
 

--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
@@ -16,13 +16,11 @@ import org.scalajs.core.tools.json._
 import org.scalajs.jsenv._
 
 import scala.collection.concurrent.TrieMap
-import scala.collection.JavaConverters._
 
 import scala.concurrent.duration._
 import scala.util.{Try, Failure, Success}
 
 import java.util.concurrent.atomic.AtomicInteger
-import java.util.concurrent.ConcurrentLinkedQueue
 
 import sbt.testing._
 
@@ -42,36 +40,14 @@ final class ScalaJSRunner private[testadapter] (
   /** Map of ThreadId -> Slave */
   private[this] val slaves = TrieMap.empty[Long, ComJSRunner]
 
-  /** Queue of unassigned but started slaves.
-   *
-   *  The slaves in this queue have been requested to start a runner,
-   *  but the corresponding messages have not been handled yet
-   */
-  private[this] val readySlaves = new ConcurrentLinkedQueue[ComJSRunner]
-
   /** An object used as lock for the loggers. Ensures output does not get
    *  interleaved.
    */
   private[testadapter] val loggerLock = new Object
 
-  // Constructor body, factored out to allow local vals
-  init()
-  private def init(): Unit = {
-    createMasterRunner()
+  // Constructor body
 
-    // Create anticipated slaves
-    val readySlaveCount = Runtime.getRuntime().availableProcessors()
-    val slaves = List.fill(readySlaveCount)(launchNewSlave())
-
-    // Wait for master runner to come up
-    awaitMasterRunner()
-
-    // Request slaves to start runner
-    for (slave <- slaves) {
-      createSlaveRunner(slave)
-      readySlaves.add(slave)
-    }
-  }
+  createRemoteRunner()
 
   // Public API
 
@@ -98,7 +74,7 @@ final class ScalaJSRunner private[testadapter] (
 
     // First we run the stopping sequence of the slaves
     val slavesDeadline = VMTermTimeout.fromNow
-    val slavesClosing = closeSlaves(slavesDeadline)
+    val slavesClosing = stopSlaves(slavesDeadline)
 
     /* Once all slaves are closing, we can schedule termination of the master.
      * We need a fresh deadline for the master, since we can only start its
@@ -118,7 +94,7 @@ final class ScalaJSRunner private[testadapter] (
 
     // Now we wait for everyone to be completely stopped
     val slavesStopped =
-      allSlaves.map(s => Try(s.awaitOrStop(slavesDeadline.timeLeft)))
+      slaves.values.toList.map(s => Try(s.awaitOrStop(slavesDeadline.timeLeft)))
     val masterStopped = Try(master.awaitOrStop(masterDeadline.timeLeft))
 
     // Cleanup
@@ -159,21 +135,13 @@ final class ScalaJSRunner private[testadapter] (
 
   // Slave Management
 
-  /** Gets a slave for a [[ScalaJSTask]] which has already a started runner */
   private[testadapter] def getSlave(): ComJSRunner = {
     val threadId = Thread.currentThread().getId()
 
     // Note that this is thread safe, since each thread can only operate on
     // the value associated to its thread id.
     if (!slaves.contains(threadId)) {
-      val slave = {
-        Option(readySlaves.poll()).fold {
-          createSlave()
-        } { slave =>
-          awaitSlaveRunner(slave)
-          slave
-        }
-      }
+      val slave = createSlave()
       slaves.put(threadId, slave)
       slave
     } else {
@@ -181,16 +149,11 @@ final class ScalaJSRunner private[testadapter] (
     }
   }
 
-  /** Starts the stopping sequence of all slaves by closing their Com channel.
-   *
-   *  Instead of throwing any exception, this method returns a [[Try]].
+  /** Starts the stopping sequence of all slaves.
+   *  The returned future will be completed when all slaves are closing.
    */
-  private def closeSlaves(deadline: Deadline): Try[Unit] = {
-    // Flush out messages on started, but unused slaves
-    readySlaves.iterator().asScala.foreach(awaitSlaveRunner)
-
-    // Now, work on all slaves
-    val slaves = allSlaves
+  private def stopSlaves(deadline: Deadline): Try[Unit] = {
+    val slaves = this.slaves.values.toList // .toList to make it strict
 
     // First launch the stopping sequence on all slaves
     val stopMessagesSent = for (slave <- slaves) yield Try {
@@ -213,9 +176,15 @@ final class ScalaJSRunner private[testadapter] (
   private def createSlave(): ComJSRunner = {
     // We don't want to create new slaves when we're closing/closed
     ensureNotDone()
-    val slave = launchNewSlave()
-    createSlaveRunner(slave)
-    awaitSlaveRunner(slave)
+
+    // Launch the slave
+    val slave = framework.createRunner(slaveLauncher)
+    slave.start()
+
+    // Create a runner on the slave
+    slave.send("newRunner")
+    ComUtils.receiveLoop(slave)(msgHandler(slave) orElse ComUtils.doneHandler)
+
     slave
   }
 
@@ -245,7 +214,7 @@ final class ScalaJSRunner private[testadapter] (
       throw new IllegalStateException("Runner is already done")
   }
 
-  private def createMasterRunner(): Unit = {
+  private def createRemoteRunner(): Unit = {
     assert(master == null)
 
     master = framework.createRunner(masterLauncher)
@@ -259,27 +228,9 @@ final class ScalaJSRunner private[testadapter] (
     }
 
     master.send("newRunner:" + jsonToString(data))
-  }
-
-  private def awaitMasterRunner(): Unit = {
     ComUtils.receiveResponse(master) {
       case ("ok", "") =>
     }
   }
-
-  private def launchNewSlave(): ComJSRunner = {
-    val slave = framework.createRunner(slaveLauncher)
-    slave.start()
-    slave
-  }
-
-  private def createSlaveRunner(slave: ComJSRunner): Unit =
-    slave.send("newRunner")
-
-  private def awaitSlaveRunner(slave: ComJSRunner): Unit =
-    ComUtils.receiveLoop(slave)(msgHandler(slave) orElse ComUtils.doneHandler)
-
-  private def allSlaves: List[ComJSRunner] =
-    slaves.values.toList ++ readySlaves.asScala
 
 }


### PR DESCRIPTION
This fixes #1556.

While in principle reducing latency for testing, the commit in
question has shown to launch too many concurrent slaves in some
cases. This happens especially if mutliple projects are tested at the
same time in sbt.

I do not see a way how we can determine the number of slaves we
provision in a way that interacts nicely with sbt's scheduling
(without going into very complicated heuristics). Since the old
adapter has shown to be good enough, we simply revert.

This reverts commit 6d61c347281b597af309bbf789f570feb5d90059.