### PR TITLE
Fix #1553: Implement missing methods in Integer, Char, Long and String

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -213,6 +213,17 @@ object Character {
     else -1
   }
 
+  // ported from https://github.com/gwtproject/gwt/blob/master/user/super/com/google/gwt/emul/java/lang/Character.java
+  def forDigit(digit: Int, radix: Int): Char = {
+    if (radix < MIN_RADIX || radix > MAX_RADIX || digit < 0 || digit >= radix) {
+      0
+    } else {
+      val overBaseTen = digit - 10
+      val result = if (overBaseTen < 0) '0' + digit else 'a' + overBaseTen
+      result.toChar
+    }
+  }
+
   def isISOControl(c: scala.Char): scala.Boolean = isISOControl(c.toInt)
   def isISOControl(codePoint: scala.Int): scala.Boolean = {
     (0x00 <= codePoint && codePoint <= 0x1F) || (0x7F <= codePoint && codePoint <= 0x9F)

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -103,6 +103,11 @@ object Integer {
     ((t2 + (t2 >> 4) & 0xF0F0F0F) * 0x1010101) >> 24
   }
 
+  def highestOneBit(i: Int): Int = {
+    if (i == 0) 0
+    else (1 << 31) >>> Integer.numberOfLeadingZeros(i)
+  }
+
   def reverseBytes(i: scala.Int): scala.Int = {
     val byte3 = i >>> 24
     val byte2 = (i >>> 8) & 0xFF00

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -144,6 +144,15 @@ object Integer {
   def toHexString(i: scala.Int): String = toStringBase(i, 16)
   def toOctalString(i: scala.Int): String = toStringBase(i, 8)
 
+  def toString(i: Int, radix: Int): String = {
+    if (radix == 10 || radix < Character.MIN_RADIX || radix > Character.MAX_RADIX) {
+      Integer.toString(i)
+    } else {
+      import js.JSNumberOps.enableJSNumberOps
+      i.toString(radix)
+    }
+  }
+
   @inline private[this] def toStringBase(i: scala.Int, base: scala.Int): String = {
     import js.JSNumberOps._
     i.toUint.toString(base)

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -114,6 +114,42 @@ object Long {
     }
   }
 
+  // Ported from https://github.com/gwtproject/gwt/blob/master/user/super/com/google/gwt/emul/java/lang/Long.java
+  def toString(value: scala.Long, intRadix: Int): String = {
+    if (intRadix == 10 || intRadix < Character.MIN_RADIX || intRadix > Character.MAX_RADIX) {
+      toString(value)
+    } else if (Integer.MIN_VALUE <= value && (value <= Integer.MAX_VALUE)) {
+      Integer.toString(value.toInt, intRadix)
+    } else {
+      // Character.forDigit checks the digit range which is not the requirement here - hence the apparent duplication
+      def forDigit(digit: Int): Char = {
+        val overBaseTen = digit - 10
+        val result = if (overBaseTen < 0) '0' + digit else 'a' + overBaseTen
+        result.toChar
+      }
+
+      // If the value is zero or positive, we can reduce code by negating the value for the string conversion
+      // but not adding a '-' at the end
+
+      var _value: scala.Long = if (value >= 0) -value else value
+      var res = ""
+      var radix: scala.Long = intRadix
+      val negRadix: scala.Long = -radix
+
+      while (_value <= negRadix) {
+        res = forDigit(-(_value % radix).toInt) + res
+        _value /= radix
+      }
+      res = forDigit(-(_value % radix).toInt) + res
+
+      // But real negative values do need the '-' sign
+      if (value < 0) {
+        res = '-' + res
+      }
+      res
+    }
+  }
+
   @inline def compare(x: scala.Long, y: scala.Long): scala.Int =
     if (x == y) 0 else if (x < y) -1 else 1
 

--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
@@ -166,6 +166,29 @@ private[runtime] object RuntimeString {
     Pattern.matches(regex, thiz)
   }
 
+  // Both regionMatches ported from https://github.com/gwtproject/gwt/blob/master/user/super/com/google/gwt/emul/java/lang/String.java
+  def regionMatches(thiz: String, ignoreCase: Boolean,
+      toffset: Int, other: String, ooffset: Int, len: Int): Boolean = {
+    checkNull(thiz)
+    if (other == null) {
+      throw new NullPointerException()
+    } else if (toffset < 0 || ooffset < 0 || toffset + len > thiz.length || ooffset + len > other.length) {
+      false
+    } else if (len <= 0) {
+      true
+    } else {
+      val left = thiz.substring(toffset, toffset + len)
+      val right = other.substring(ooffset, ooffset + len)
+      if (ignoreCase) left.equalsIgnoreCase(right) else left == right
+    }
+  }
+
+  @inline
+  def regionMatches(thiz: String, toffset: Int,
+      other: String, ooffset: Int, len: Int): Boolean = {
+    regionMatches(thiz, false, toffset, other, ooffset, len)
+  }
+
   @inline
   def replace(thiz: String, oldChar: Char, newChar: Char): String =
     thiz.replace(oldChar.toString, newChar.toString)

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/CharacterTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/CharacterTest.scala
@@ -34,7 +34,15 @@ object CharacterTest extends JasmineTest {
       expect(Character.digit('Z', 36)).toEqual(35)
       expect(Character.digit('\uFF22', 20)).toEqual(11)
     }
-    
+
+    it("should provide `forDigit`") {
+      // Ported from https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/CharacterTest.java
+      for (i <- 0 until 36) {
+        expect(Character.digit(Character.forDigit(i, 36), 36)).toEqual(i)
+      }
+      expect(Character.forDigit(9, 10) == '9').toBeTruthy
+    }
+
     it("should provide isDigit") {
       expect(Character.isDigit('a')).toBeFalsy
       expect(Character.isDigit('0')).toBeTruthy

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/IntegerTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/IntegerTest.scala
@@ -166,5 +166,32 @@ object IntegerTest extends JasmineTest {
       expect(Integer.highestOneBit(0x88)).toEqual(0x80)
       expect(Integer.highestOneBit(Integer.MAX_VALUE)).toEqual(0x40000000)
     }
+
+    it("should provide `toString` without radix") {
+      //Spec ported from https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/IntegerTest.java
+      expect(new Integer(12345).toString).toEqual("12345")
+      expect(new Integer("-12345").toString).toEqual("-12345")
+      expect(Integer.toString(-80765)).toEqual("-80765")
+      expect(Integer.toString(Integer.MAX_VALUE)).toEqual("2147483647")
+      expect(Integer.toString(-Integer.MAX_VALUE)).toEqual("-2147483647")
+      expect(Integer.toString(Integer.MIN_VALUE)).toEqual("-2147483648")
+      expect(Integer.toString(0)).toEqual("0")
+    }
+
+    it("should provide `toString` with radix") {
+      //Spec ported from https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/IntegerTest.java
+      expect(Integer.toString(2147483647, 8)).toEqual("17777777777")
+      expect(Integer.toString(2147483647, 16)).toEqual("7fffffff")
+      expect(Integer.toString(2147483647, 2)).toEqual("1111111111111111111111111111111")
+      expect(Integer.toString(2147483647, 10)).toEqual("2147483647")
+      expect(Integer.toString(-2147483647, 8)).toEqual("-17777777777")
+      expect(Integer.toString(-2147483647, 16)).toEqual("-7fffffff")
+      expect(Integer.toString(-2147483647, 2)).toEqual("-1111111111111111111111111111111")
+      expect(Integer.toString(-2147483647, 10)).toEqual("-2147483647")
+      expect(Integer.toString(-2147483648, 8)).toEqual("-20000000000")
+      expect(Integer.toString(-2147483648, 16)).toEqual("-80000000")
+      expect(Integer.toString(-2147483648, 2)).toEqual("-10000000000000000000000000000000")
+      expect(Integer.toString(-2147483648, 10)).toEqual("-2147483648")
+    }
   }
 }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/IntegerTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/IntegerTest.scala
@@ -157,5 +157,14 @@ object IntegerTest extends JasmineTest {
       test("-90000", -0x90000)
     }
 
+    it("should provide `highestOneBit`") {
+      //Spec ported from https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/IntegerTest.java
+      expect(Integer.highestOneBit(0)).toEqual(0)
+      expect(Integer.highestOneBit(-1)).toEqual(Integer.MIN_VALUE)
+      expect(Integer.highestOneBit(-256)).toEqual(Integer.MIN_VALUE)
+      expect(Integer.highestOneBit(1)).toEqual(1)
+      expect(Integer.highestOneBit(0x88)).toEqual(0x80)
+      expect(Integer.highestOneBit(Integer.MAX_VALUE)).toEqual(0x40000000)
+    }
   }
 }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/LongTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/LongTest.scala
@@ -116,12 +116,37 @@ object LongTest extends JasmineTest {
       test("-90000", -0x90000L)
     }
 
-    it("should implement toString") {
+    it("should implement toString without radix") {
       expect(Int.MaxValue.toLong.toString).toEqual("2147483647")
       expect((-50L).toString).toEqual("-50")
       expect((-1000000000L).toString).toEqual("-1000000000")
       expect((Int.MaxValue.toLong+1L).toString).toEqual("2147483648")
       expect(Int.MinValue.toLong.toString).toEqual("-2147483648")
+
+      // ported from https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/JLongTest.java
+      expect(new JLong(89000000005L).toString).toEqual("89000000005")
+      expect(new JLong(JLong.MIN_VALUE).toString).toEqual("-9223372036854775808")
+      expect(new JLong(JLong.MAX_VALUE).toString).toEqual("9223372036854775807")
+      expect(JLong.toString(-80765L)).toEqual("-80765")
+      expect(JLong.toString(80765L)).toEqual("80765")
+      expect(JLong.toString(Integer.MIN_VALUE.toLong)).toEqual("-2147483648")
+      expect(JLong.toString(Integer.MAX_VALUE.toLong)).toEqual("2147483647")
+      expect(JLong.toString(-89000000005L)).toEqual("-89000000005")
+      expect(JLong.toString(89000000005L)).toEqual("89000000005")
+      expect(JLong.toString(JLong.MIN_VALUE)).toEqual("-9223372036854775808")
+      expect(JLong.toString(JLong.MAX_VALUE)).toEqual("9223372036854775807")
+    }
+
+    it("should implement toString with radix") {
+      // ported from https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/JLongTest.java
+      expect(JLong.toString(100000000L, 10)).toEqual("100000000")
+      expect(JLong.toString(8589934591L, 8)).toEqual("77777777777")
+      expect(JLong.toString(68719476735L, 16)).toEqual("fffffffff")
+      expect(JLong.toString(8796093022207L, 2)).toEqual("1111111111111111111111111111111111111111111")
+      expect(JLong.toString(0x8000000000000000L, 10)).toEqual("-9223372036854775808")
+      expect(JLong.toString(0x7fffffffffffffffL, 10)).toEqual("9223372036854775807")
+      expect(JLong.toString(0x8000000000000000L, 16)).toEqual("-8000000000000000")
+      expect(JLong.toString(0x7fffffffffffffffL, 16)).toEqual("7fffffffffffffff")
     }
 
     it("should implement toBinaryString") {

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/StringTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/StringTest.scala
@@ -248,5 +248,49 @@ object StringTest extends JasmineTest {
               -94, 22, -41))
     }
 
+    it("should respond to `regionMatches`") {
+      // Ported from https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/StringTest.java
+      val test = "abcdef"
+
+      expect(test.regionMatches(1, "bcd", 0, 3)).toBeTruthy()
+      expect(test.regionMatches(1, "bcdx", 0, 3)).toBeTruthy()
+      expect(test.regionMatches(1, "bcdx", 0, 4)).toBeFalsy()
+      expect(test.regionMatches(1, "bcdx", 1, 3)).toBeFalsy()
+      expect(test.regionMatches(true, 0, "XAbCd", 1, 4)).toBeTruthy()
+      expect(test.regionMatches(true, 1, "BcD", 0, 3)).toBeTruthy()
+      expect(test.regionMatches(true, 1, "bCdx", 0, 3)).toBeTruthy()
+      expect(test.regionMatches(true, 1, "bCdx", 0, 4)).toBeFalsy()
+      expect(test.regionMatches(true, 1, "bCdx", 1, 3)).toBeFalsy()
+      expect(test.regionMatches(true, 0, "xaBcd", 1, 4)).toBeTruthy()
+
+      val testU = test.toUpperCase()
+      expect(testU.regionMatches(true, 0, "XAbCd", 1, 4)).toBeTruthy()
+      expect(testU.regionMatches(true, 1, "BcD", 0, 3)).toBeTruthy()
+      expect(testU.regionMatches(true, 1, "bCdx", 0, 3)).toBeTruthy()
+      expect(testU.regionMatches(true, 1, "bCdx", 0, 4)).toBeFalsy()
+      expect(testU.regionMatches(true, 1, "bCdx", 1, 3)).toBeFalsy()
+      expect(testU.regionMatches(true, 0, "xaBcd", 1, 4)).toBeTruthy()
+
+      expect(() => test.regionMatches(-1, null, -1, -1)).toThrow()
+      expect(() => test.regionMatches(true, -1, null, -1, -1)).toThrow()
+
+      // If len is negative, you must return true in some cases.
+      // see http://docs.oracle.com/javase/8/docs/api/java/lang/String.html#regionMatches-boolean-int-java.lang.String-int-int-
+
+      // four cases that are false, irrelevant of sign of len nor the value of the other string
+      expect(test.regionMatches(-1, test, 0, -4)).toBeFalsy
+      expect(test.regionMatches(0, test, -1, -4)).toBeFalsy
+      expect(test.regionMatches(100, test, 0, -4)).toBeFalsy
+      expect(test.regionMatches(0, test, 100, -4)).toBeFalsy
+
+      // the strange cases that are true
+      expect(test.regionMatches(0, test, 0, -4)).toBeTruthy
+      expect(test.regionMatches(1, "bcdx", 0, -4)).toBeTruthy
+      expect(test.regionMatches(1, "bcdx", 1, -3)).toBeTruthy
+      expect(test.regionMatches(true, 1, "bCdx", 0, -4)).toBeTruthy
+      expect(test.regionMatches(true, 1, "bCdx", 1, -3)).toBeTruthy
+      expect(testU.regionMatches(true, 1, "bCdx", 0, -4)).toBeTruthy
+      expect(testU.regionMatches(true, 1, "bCdx", 1, -3)).toBeTruthy
+    }
   }
 }


### PR DESCRIPTION
As per review comments in https://github.com/scala-js/scala-js/pull/1549