### PR TITLE
Fix #1560: StringReader.read should return -1 on EOF

### DIFF
--- a/javalib/src/main/scala/java/io/StringReader.scala
+++ b/javalib/src/main/scala/java/io/StringReader.scala
@@ -43,7 +43,7 @@ class StringReader(s: String) extends Reader {
         i += 1
       }
       pos += count
-      count
+      if (count == 0) -1 else count
     }
   }
 

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/ReadersTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/ReadersTest.scala
@@ -40,6 +40,7 @@ object ReadersTest extends JasmineTest {
       expect(r.read(buf, 2, 8)).toBe(4)
       expect(buf.map(_.toInt).toJSArray).toEqual(
         js.Array[Int](0,0,'a','s','d','f',0,0,0,0))
+      expect(r.read(buf, 2, 8)).toBe(-1) // #1560
     }
 
     it("should provide read(java.nio.CharBuffer)") {


### PR DESCRIPTION
Simple fix for issue #1560 - `StringReader.read(c:Array[Char],offset:Int,len:Int)` should return -1 if eof.