### PR TITLE
Add scalastyle

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,0 +1,3 @@
+addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "0.6.0")
+
+resolvers += "sonatype-releases" at "https://oss.sonatype.org/content/repositories/releases/"

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -1,0 +1,147 @@
+<scalastyle>
+    <name>Scalastyle standard configuration</name>
+    <check level="warning" class="org.scalastyle.file.FileTabChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.FileLengthChecker" enabled="false">
+        <parameters>
+            <parameter name="maxFileLength"><![CDATA[800]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.file.HeaderMatchesChecker" enabled="false">
+        <parameters>
+            <parameter name="header"><![CDATA[// Copyright (C) 2011-2012 the original author or authors.
+// See the LICENCE.txt file distributed with this work for additional
+// information regarding copyright ownership.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.]]></parameter>
+        </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.RedundantIfChecker" level="warning"></check>
+    <check enabled="true" class="org.scalastyle.scalariform.SimplifyBooleanExpressionChecker " level="warning"></check>
+    <check enabled="true" class="org.scalastyle.scalariform.UppercaseLChecker" level="warning"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesAfterPlusChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.file.WhitespaceEndOfLineChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.SpacesBeforePlusChecker" enabled="false"></check>
+    <!--Indentation checker, whilst useful gives false positives on the file headers, so disabled for now-->
+    <check level="warning" class="org.scalastyle.file.IndentationChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
+        <parameters>
+            <parameter name="maxLineLength"><![CDATA[160]]></parameter>
+            <parameter name="tabSize"><![CDATA[4]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ClassNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[[A-Z][A-Za-z]*]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PackageObjectNamesChecker" enabled="true">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[a-z][A-Za-z]*$]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.EqualsHashCodeChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.scalariform.IllegalImportsChecker" enabled="true">
+        <parameters>
+            <parameter name="illegalImports"><![CDATA[sun._,java.awt._]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.ParameterNumberChecker" enabled="true">
+        <parameters>
+            <parameter name="maxParameters"><![CDATA[8]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MagicNumberChecker" enabled="false">
+        <parameters>
+            <parameter name="ignore"><![CDATA[-1,0,1,2,3]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceBeforeLeftBracketChecker"
+           enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoWhitespaceAfterLeftBracketChecker"
+           enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.ReturnChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NullChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoCloneChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.scalariform.NoFinalizeChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.CovariantEqualsChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.scalariform.StructuralTypeChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.file.RegexChecker" enabled="false">
+        <parameters>
+            <parameter name="regex"><![CDATA[:[!\w]]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfTypesChecker" enabled="true">
+        <parameters>
+            <parameter name="maxTypes"><![CDATA[30]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.CyclomaticComplexityChecker" enabled="false">
+        <parameters>
+            <parameter name="maximum"><![CDATA[17]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.IfBraceChecker" enabled="false">
+        <parameters>
+            <parameter name="singleLineAllowed"><![CDATA[true]]></parameter>
+            <parameter name="doubleLineAllowed"><![CDATA[false]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodLengthChecker" enabled="false">
+        <parameters>
+            <parameter name="maxLength"><![CDATA[60]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.NumberOfMethodsInTypeChecker" enabled="false">
+        <parameters>
+            <parameter name="maxMethods"><![CDATA[50]]></parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.PublicMethodsHaveTypeChecker" enabled="false"></check>
+    <check level="warning" class="org.scalastyle.file.NewLineAtEofChecker" enabled="true"></check>
+    <check level="warning" class="org.scalastyle.file.NoNewLineAtEofChecker" enabled="false"></check>
+    <check enabled="true" class="org.scalastyle.scalariform.EmptyClassChecker" level="warning"/>
+    <check enabled="false" class="org.scalastyle.scalariform.ForBraceChecker" level="warning"/>
+    <check enabled="false" class="org.scalastyle.scalariform.LowercasePatternMatchChecker" level="warning"/>
+    <check enabled="false" class="org.scalastyle.scalariform.VarFieldChecker" level="warning"></check>
+    <check enabled="false" class="org.scalastyle.scalariform.MultipleStringLiteralsChecker" level="warning">
+        <parameters>
+            <parameter name="allowed">1</parameter>
+            <parameter name="ignoreRegex">^\&quot;\&quot;$</parameter>
+        </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.DisallowSpaceBeforeTokenChecker" level="warning">
+        <parameters>
+            <parameter name="tokens">COLON, COMMA, RPAREN</parameter>
+        </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.DisallowSpaceAfterTokenChecker" level="warning">
+        <parameters>
+            <parameter name="tokens">LPAREN</parameter>
+        </parameters>
+    </check>
+    <check enabled="true" class="org.scalastyle.scalariform.EnsureSingleSpaceAfterTokenChecker" level="warning">
+        <parameters>
+            <parameter name="tokens">COLON, IF</parameter>
+        </parameters>
+    </check>
+    <check level="warning" class="org.scalastyle.scalariform.MethodNamesChecker" enabled="false">
+        <parameters>
+            <parameter name="regex"><![CDATA[^[A-Za-z_][A-Za-z0-9_+]*$]]></parameter>
+        </parameters>
+    </check>
+</scalastyle>


### PR DESCRIPTION
Discussed on the mailing list, I think this might save a bit of time and effort if contributors run their stuff through scalastyle before submitting pull requests.

You could start with a relaxed set of rules and tighten things up in future...

Here's the output:

```
>Loading global plugins from /home/mark/.sbt/0.13/plugins
>Loading project definition from /home/mark/scalaProjects/scala-js/project/project
>Loading project definition from /home/mark/scalaProjects/scala-js/project
>Set current project to Scala.js (in build file:/home/mark/scalaProjects/scala-js/)
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 19 ms
[success] created output: /home/mark/scalaProjects/scala-js/javalib-ex-test-suite/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 15 ms
[success] created output: /home/mark/scalaProjects/scala-js/all/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/jasmine-test-framework/src/main/scala/org/scalajs/jasminetest/JasmineTask.scala:57:12: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/jasmine-test-framework/src/main/scala/org/scalajs/jasminetest/JasmineRunner.scala:32:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/jasmine-test-framework/src/main/scala/org/scalajs/jasminetest/JasmineRunner.scala:88:19: Use braces in for comprehensions
>Processed 16 file(s)
>Found 0 errors
>Found 3 warnings
>Found 0 infos
>Finished in 57 ms
[success] created output: /home/mark/scalaProjects/scala-js/jasmine-test-framework/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 5 ms
[success] created output: /home/mark/scalaProjects/scala-js/no-ir-check-test/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 2 ms
[success] created output: /home/mark/scalaProjects/scala-js/examples/helloworld/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 5 ms
[success] created output: /home/mark/scalaProjects/scala-js/test-suite/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala:140:8: Use braces in for comprehensions
>Processed 2 file(s)
>Found 0 errors
>Found 1 warnings
>Found 0 infos
>Finished in 4 ms
[success] created output: /home/mark/scalaProjects/scala-js/cli/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 1 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 4 ms
[success] created output: /home/mark/scalaProjects/scala-js/examples/testing/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 2 ms
[success] created output: /home/mark/scalaProjects/scala-js/examples/reversi/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 14 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 19 ms
[success] created output: /home/mark/scalaProjects/scala-js/sbt-plugin/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 2 ms
[success] created output: /home/mark/scalaProjects/scala-js/partest-suite/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 3 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 14 ms
[success] created output: /home/mark/scalaProjects/scala-js/tools/js/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala:81:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala:86: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala:100: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala:112: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala:114: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala:112:14: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala:70:21: Avoid using return
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala:71:39: Avoid using return
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala:72:41: Avoid using return
[warn] /home/mark/scalaProjects/scala-js/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala:75:6: Avoid using return
>Processed 4 file(s)
>Found 0 errors
>Found 10 warnings
>Found 0 infos
>Finished in 23 ms
[success] created output: /home/mark/scalaProjects/scala-js/partest/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 9 ms
[success] created output: /home/mark/scalaProjects/scala-js/examples/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala:70:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala:154:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala:196:31: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala:201:27: Use braces in for comprehensions
>Processed 12 file(s)
>Found 0 errors
>Found 4 warnings
>Found 0 infos
>Finished in 21 ms
[success] created output: /home/mark/scalaProjects/scala-js/test-adapter/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 4 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 11 ms
[success] created output: /home/mark/scalaProjects/scala-js/javalib-ex/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/Utils.scala:16:43: Space before token )
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala:100:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala:15:35: No space after token :
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala:142:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala:156:12: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala:204:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala:225:17: Space before token :
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/LazyScalaJSScope.scala:40:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala:34:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala:54:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala:67:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala:84:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala:90:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala:154:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala:237:12: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala:94:18: Avoid using finalize method.
>Processed 23 file(s)
>Found 0 errors
>Found 16 warnings
>Found 0 infos
>Finished in 47 ms
[success] created output: /home/mark/scalaProjects/scala-js/js-envs/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala:470:14: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala:543:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Trees.scala: Number of types declared in the file exceeds 30
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Trees.scala:138:12: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Trees.scala:138:23: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Trees.scala:138:34: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Trees.scala:139:12: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Trees.scala:139:28: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Trees.scala:417:12: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Trees.scala:417:28: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala:114:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala:117:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Infos.scala:57:8: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Infos.scala:326:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:95:14: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:219:14: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:357:14: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:359:14: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:375:14: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:636:12: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:642:12: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:422:18: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:422:34: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Printers.scala:422:54: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala:176:14: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala:176:23: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala:176:36: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala:176:49: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala:176:64: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala:177:13: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala:177:25: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala:177:36: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:192:12: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:192:21: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:192:34: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:192:47: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:192:62: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:193:11: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:193:23: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:193:34: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:193:43: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala:193:56: No space after token :
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala:57:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala:432:12: Use braces in for comprehensions
>Processed 15 file(s)
>Found 0 errors
>Found 44 warnings
>Found 0 infos
>Finished in 88 ms
[success] created output: /home/mark/scalaProjects/scala-js/ir/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Math.scala:66:6: Avoid using return
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Math.scala:82:4: Avoid using return
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Throwables.scala: Number of types declared in the file exceeds 30
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/System.scala:143:12: No space after token :
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/System.scala:143:30: No space after token :
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/System.scala:143:47: No space after token :
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Character.scala:283: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Character.scala:286: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Character.scala:289: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Character.scala:36:24: Space before token :
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Character.scala:37:24: Space before token :
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Character.scala:38:24: Space before token :
[warn] /home/mark/scalaProjects/scala-js/javalanglib/src/main/scala/java/lang/Void.scala:3:12: Redundant braces after class definition
>Processed 35 file(s)
>Found 0 errors
>Found 13 warnings
>Found 0 infos
>Finished in 73 ms
[success] created output: /home/mark/scalaProjects/scala-js/javalanglib/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
>Processed 0 file(s)
>Found 0 errors
>Found 0 warnings
>Found 0 infos
>Finished in 2 ms
[success] created output: /home/mark/scalaProjects/scala-js/ir/.js/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala:7:9: Object name does not match the regular expression '[A-Z][A-Za-z]*'
>Processed 2 file(s)
>Found 0 errors
>Found 1 warnings
>Found 0 infos
>Finished in 3 ms
[success] created output: /home/mark/scalaProjects/scala-js/stubs/target
>scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ParIncOptimizer.scala:84:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala:71:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala:60:13: No space after token :
[warn] /home/mark/scalaProjects/scala-js/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ClosureAstTransformer.scala:101:12: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ClosureAstTransformer.scala:179:12: Use braces in for comprehensions
>Processed 12 file(s)
>Found 0 errors
>Found 5 warnings
>Found 0 infos
>Finished in 23 ms
[success] created output: /home/mark/scalaProjects/scala-js/tools/jvm/target
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Dynamic.scala:89:9: Object name does not match the regular expression '[A-Z][A-Za-z]*'
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:32: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:33: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:34: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:35: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:36: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:37: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:38: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:39: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:40: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:41: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:42: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:43: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:44: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:45: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:46: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:47: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:48: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:54: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:55: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:56: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:57: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:58: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:59: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:60: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:61: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:62: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:63: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:64: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:65: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:66: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:67: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:68: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:69: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:70: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:71: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:127: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:131: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:135: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:139: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:143: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:147: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:151: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:154: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:155: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:158: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:159: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:107:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:111:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:115:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:119:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:123:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:127:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:131:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:135:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:139:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:143:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:147:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:151:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:155:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:159:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/ThisFunction.scala:23:6: Redundant braces after class definition
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferOps.scala:23:31: There should be no space after a left bracket '['
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/typedarray/package.scala:129:42: There should be no space after a left bracket '['
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/typedarray/package.scala:171:42: There should be no space after a left bracket '['
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:84: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:85: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:86: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:87: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:88: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:89: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:90: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:91: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:92: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:93: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:94: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:95: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:96: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:97: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:98: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:99: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:106: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:107: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:108: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:109: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:110: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:111: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:112: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:113: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:114: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:115: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:116: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:117: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:118: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:119: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:120: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:121: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:122: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Any.scala:123: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Dictionary.scala:81:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:161: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:165: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:169: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:173: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:177: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:181: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:185: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:189: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:192: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:193: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:141:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:145:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:149:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:153:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:157:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:161:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:165:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:169:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:173:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:177:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:181:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:185:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:189:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/js/Function.scala:193:6: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/niocharset/UTF_16_Common.scala:131:10: Avoid using return
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/package.scala:21:10: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/IntegerReflectiveCall.scala:15:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/IntegerReflectiveCall.scala:16:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/IntegerReflectiveCall.scala:60:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:42: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:47: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:52: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:53: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:57: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:58: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:62: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:63: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:67: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:68: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:72: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:73: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:77: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:78: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:82: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:83: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:87: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:88: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:92: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:93: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:97: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:98: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:102: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:103: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:107: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:108: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:112: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:113: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:117: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:118: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:53:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:58:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:63:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:68:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:73:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:78:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:83:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:88:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:93:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:98:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:103:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:108:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:113:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala:118:15: The number of parameters should not exceed 8
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/BooleanReflectiveCall.scala:22:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala:40:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala:41:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala:135:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:454:14: Avoid using return
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:64:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:65:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:66:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:540:32: Space after token (
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:541:32: Space after token (
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:542:32: Space after token (
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:543:32: Space after token (
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:393:4: No space after token if
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala:399:4: No space after token if
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/EnvironmentInfo.scala:49:43: There should be no space after a left bracket '['
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/LongReflectiveCall.scala:35:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/LongReflectiveCall.scala:36:14: Space before token :
[warn] /home/mark/scalaProjects/scala-js/library/src/main/scala/scala/scalajs/runtime/LongReflectiveCall.scala:37:14: Space before token :
>Processed 82 file(s)
>Found 0 errors
>Found 191 warnings
>Found 0 infos
>Finished in 265 ms
[success] created output: /home/mark/scalaProjects/scala-js/library/target
[success] Total time: 19 s, completed Mar 24, 2015 9:58:34 PM

[info] scalastyle using config /home/mark/scalaProjects/scala-js/scalastyle-config.xml
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/nio/GenBuffer.scala:129:10: Avoid using return
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/nio/charset/Charset.scala:72:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/nio/charset/Charset.scala:79:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/nio/charset/Charset.scala:87:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/nio/charset/Charset.scala:90:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/nio/charset/Charset.scala:94:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/nio/charset/Charset.scala:98:8: Use braces in for comprehensions
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/nio/charset/StandardCharsets.scala:3:12: Redundant braces after class definition
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/net/URI.scala:360: File line length exceeds 160 characters
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/util/Throwables.scala:12:34: Whitespace at end of line
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/util/Throwables.scala:26:30: Whitespace at end of line
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/util/Throwables.scala:100:60: Whitespace at end of line
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/util/Throwables.scala:83:32: No space after token if
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/util/Throwables.scala:95:9: No space after token if
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/util/Date.scala:116:15: No space after token if
[warn] /home/mark/scalaProjects/scala-js/javalib/src/main/scala/java/util/Random.scala:130:6: Avoid using return
[info] Processed 98 file(s)
[info] Found 0 errors
[info] Found 16 warnings

```
