### PR TITLE
Fix #1571: Make FrameworkDetector resilient to other output

### DIFF
--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -72,7 +72,9 @@ lazy val multiTest = crossProject.
   ).
   jsSettings(baseSettings: _*).
   jsSettings(
-    name := "Multi test framework test JS"
+    name := "Multi test framework test JS",
+    // Make FrameworkDetector resilient to other output - #1572
+    jsDependencies in Test += ProvidedJS / "consoleWriter.js"
   ).
   jvmSettings(versionSettings: _*).
   jvmSettings(

--- a/sbt-plugin-test/multiTest/js/src/test/resources/consoleWriter.js
+++ b/sbt-plugin-test/multiTest/js/src/test/resources/consoleWriter.js
@@ -1,0 +1,2 @@
+// Make FrameworkDetector resilient to other output - #1572
+console.log("Breaking message")


### PR DESCRIPTION
Sometimes project may have jsDependencies which prints something in javascirpt console. It disturbs `FrameworkDetector`. Fix adds distinctive prefix to all messages produced by `FrameworkDetector`s javascript part.