### PR TITLE
Fix #1542: Introduce ...rest parameters in the IR.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -123,7 +123,8 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
       val trgSym = fun.symbol
 
       val inArg =
-        js.ParamDef(js.Ident("namedParams"), jstpe.AnyType, mutable = false)
+        js.ParamDef(js.Ident("namedParams"), jstpe.AnyType,
+            mutable = false, rest = false)
       val inArgRef = inArg.ref
 
       val methodIdent = encodeMethodSym(sym)
@@ -776,8 +777,10 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
   private def genFormalArgs(count: Int)(implicit pos: Position): List[js.ParamDef] =
     (1 to count map genFormalArg).toList
 
-  private def genFormalArg(index: Int)(implicit pos: Position): js.ParamDef =
-    js.ParamDef(js.Ident("arg$" + index), jstpe.AnyType, mutable = false)
+  private def genFormalArg(index: Int)(implicit pos: Position): js.ParamDef = {
+    js.ParamDef(js.Ident("arg$" + index), jstpe.AnyType,
+        mutable = false, rest = false)
+  }
 
   private def hasRepeatedParam(sym: Symbol) =
     enteringPhase(currentRun.uncurryPhase) {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -224,11 +224,11 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
 
       val getTree =
         if (getter.isEmpty) js.EmptyTree
-        else genApplyForSym(getter.head)
+        else genApplyForSym(0, getter.head)
 
       val setTree =
         if (setters.isEmpty) js.EmptyTree
-        else genExportSameArgc(setters.map(ExportedSymbol), 0) // we only have 1 argument
+        else genExportSameArgc(1, setters.map(ExportedSymbol), 0) // we only have 1 argument
 
       js.PropertyDef(js.StringLiteral(jsName), getTree, genFormalArg(1), setTree)
     }
@@ -262,8 +262,6 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
           normalMeths.map(_.params.size)
       ).max
 
-      val formalArgs = genFormalArgs(maxArgc)
-
       // Calculates possible arg counts for normal method
       def argCounts(ex: Exported) = ex match {
         case ExportedSymbol(sym) =>
@@ -295,6 +293,15 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
       val methodByArgCount =
         methodArgCounts.groupBy(_._1).mapValues(_.map(_._2).toSet)
 
+      // Minimum number of arguments that must be given
+      val minArgc = methodByArgCount.keys.min
+
+      val hasVarArg = varArgMeths.nonEmpty
+
+      // List of formal parameters
+      val needsRestParam = maxArgc != minArgc || hasVarArg
+      val formalArgs = genFormalArgs(minArgc, needsRestParam)
+
       // Create tuples: (methods, argCounts). This will be the cases we generate
       val caseDefinitions =
         methodByArgCount.groupBy(_._2).mapValues(_.keySet)
@@ -316,19 +323,17 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
 
         // body of case to disambiguates methods with current count
         caseBody =
-          genExportSameArgc(methods.toList, 0, Some(argcs.min))
+          genExportSameArgc(minArgc, methods.toList, 0, Some(argcs.min))
 
         // argc in reverse order
         argcList = argcs.toList.sortBy(- _)
-      } yield (argcList.map(js.IntLiteral(_)), caseBody)
-
-      val hasVarArg = varArgMeths.nonEmpty
+      } yield (argcList.map(argc => js.IntLiteral(argc - minArgc)), caseBody)
 
       def defaultCase = {
         if (!hasVarArg)
           genThrowTypeError()
         else
-          genExportSameArgc(varArgMeths, 0)
+          genExportSameArgc(minArgc, varArgMeths, 0)
       }
 
       val body = {
@@ -337,9 +342,11 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
         else if (cases.size == 1 && !hasVarArg)
           cases.head._2
         else {
+          assert(needsRestParam,
+              "Trying to read rest param length but needsRestParam is false")
           js.Match(
               js.Unbox(js.JSBracketSelect(
-                  js.VarRef(js.Ident("arguments"))(jstpe.AnyType),
+                  genRestArgRef(),
                   js.StringLiteral("length")),
                   'I'),
               cases.toList, defaultCase)(jstpe.AnyType)
@@ -353,17 +360,18 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
     /**
      * Resolve method calls to [[alts]] while assuming they have the same
      * parameter count.
+     * @param minArgc The minimum number of arguments that must be given
      * @param alts Alternative methods
      * @param paramIndex Index where to start disambiguation
      * @param maxArgc only use that many arguments
      */
-    private def genExportSameArgc(alts: List[Exported],
+    private def genExportSameArgc(minArgc: Int, alts: List[Exported],
         paramIndex: Int, maxArgc: Option[Int] = None): js.Tree = {
 
       implicit val pos = alts.head.pos
 
       if (alts.size == 1)
-        alts.head.body
+        alts.head.genBody(minArgc)
       else if (maxArgc.exists(_ <= paramIndex) ||
         !alts.exists(_.params.size > paramIndex)) {
         // We reach here in three cases:
@@ -400,7 +408,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
 
         if (altsByTypeTest.size == 1) {
           // Testing this parameter is not doing any us good
-          genExportSameArgc(alts, paramIndex+1, maxArgc)
+          genExportSameArgc(minArgc, alts, paramIndex+1, maxArgc)
         } else {
           // Sort them so that, e.g., isInstanceOf[String]
           // comes before isInstanceOf[Object]
@@ -413,8 +421,9 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
             val (typeTest, subAlts) = elem
             implicit val pos = subAlts.head.pos
 
-            val param = genFormalArg(paramIndex+1)
-            val genSubAlts = genExportSameArgc(subAlts, paramIndex+1, maxArgc)
+            val paramRef = genFormalArgRef(paramIndex+1, minArgc)
+            val genSubAlts = genExportSameArgc(minArgc,
+                subAlts, paramIndex+1, maxArgc)
 
             def hasDefaultParam = subAlts.exists {
               case ExportedSymbol(p) =>
@@ -428,10 +437,10 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
               case HijackedTypeTest(boxedClassName, _) =>
                 val tpe = jstpe.ClassType(boxedClassName)
                 currentMethodInfoBuilder.addUsedInstanceTest(tpe)
-                Some(js.IsInstanceOf(param.ref, tpe))
+                Some(js.IsInstanceOf(paramRef, tpe))
 
               case InstanceOfTypeTest(tpe) =>
-                Some(genIsInstanceOf(param.ref, tpe))
+                Some(genIsInstanceOf(paramRef, tpe))
 
               case NoTypeTest =>
                 None
@@ -442,7 +451,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
             } { cond =>
               val condOrUndef = if (!hasDefaultParam) cond else {
                 js.If(cond, js.BooleanLiteral(true),
-                    js.BinaryOp(js.BinaryOp.===, param.ref, js.Undefined()))(
+                    js.BinaryOp(js.BinaryOp.===, paramRef, js.Undefined()))(
                     jstpe.BooleanType)
               }
               js.If(condOrUndef, genSubAlts, elsep)(jstpe.AnyType)
@@ -457,7 +466,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
      * and potentially the argument array. Also inserts default parameters if
      * required.
      */
-    private def genApplyForSym(sym: Symbol): js.Tree = {
+    private def genApplyForSym(minArgc: Int, sym: Symbol): js.Tree = {
       implicit val pos = sym.pos
 
       // the (single) type of the repeated parameter if any
@@ -473,56 +482,14 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
 
       // optional repeated parameter list
       val jsVarArg = repeatedTpe map { tpe =>
-        // Copy arguments that go to vararg into an array, put it in a wrapper
-
-        val countIdent = freshLocalIdent("count")
-        val count = js.VarRef(countIdent)(jstpe.IntType)
-
-        val counterIdent = freshLocalIdent("i")
-        val counter = js.VarRef(counterIdent)(jstpe.IntType)
-
-        val arrayIdent = freshLocalIdent("varargs")
-        val array = js.VarRef(arrayIdent)(jstpe.AnyType)
-
-        val arguments = js.VarRef(js.Ident("arguments"))(jstpe.AnyType)
-        val argLen = js.Unbox(
-            js.JSBracketSelect(arguments, js.StringLiteral("length")), 'I')
-        val argOffset = js.IntLiteral(normalArgc)
-
-        val jsArrayCtor =
-          js.JSBracketSelect(
-              js.JSBracketSelect(js.JSEnvInfo(), js.StringLiteral("global")),
-              js.StringLiteral("Array"))
-
-        js.Block(
-            // var i = 0
-            js.VarDef(counterIdent, jstpe.IntType, mutable = true,
-                rhs = js.IntLiteral(0)),
-            // val count = arguments.length - <normalArgc>
-            js.VarDef(countIdent, jstpe.IntType, mutable = false,
-                rhs = js.BinaryOp(js.BinaryOp.Int_-, argLen, argOffset)),
-            // val varargs = new Array(count)
-            js.VarDef(arrayIdent, jstpe.AnyType, mutable = false,
-                rhs = js.JSNew(jsArrayCtor, List(count))),
-            // while (i < count)
-            js.While(js.BinaryOp(js.BinaryOp.Num_<, counter, count), js.Block(
-                // varargs[i] = arguments[<normalArgc> + i];
-                js.Assign(
-                    js.JSBracketSelect(array, counter),
-                    js.JSBracketSelect(arguments,
-                        js.BinaryOp(js.BinaryOp.Int_+, argOffset, counter))),
-                // i = i + 1 (++i won't work, desugar eliminates it)
-                js.Assign(counter, js.BinaryOp(js.BinaryOp.Int_+,
-                    counter, js.IntLiteral(1)))
-            )),
-            // new WrappedArray(varargs)
-            genNew(WrappedArrayClass, WrappedArray_ctor, List(array))
-        )
+        // new WrappedArray(varargs)
+        genNew(WrappedArrayClass, WrappedArray_ctor, List(
+            genVarargRef(normalArgc, minArgc)))
       }
 
       // normal arguments
-      val jsArgs = genFormalArgs(normalArgc)
-      val jsArgRefs = jsArgs.map(_.ref)
+      val jsArgRefs = (1 to normalArgc).toList.map(
+          i => genFormalArgRef(i, minArgc))
 
       // Generate JS code to prepare arguments (default getters and unboxes)
       val jsArgPrep = genPrepareArgs(jsArgRefs, sym)
@@ -534,7 +501,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
     /** Generate the necessary JavaScript code to prepare the arguments of an
      *  exported method (unboxing and default parameter handling)
      */
-    private def genPrepareArgs(jsArgs: List[js.VarRef], sym: Symbol)(
+    private def genPrepareArgs(jsArgs: List[js.Tree], sym: Symbol)(
         implicit pos: Position): List[js.VarDef] = {
 
       val result = new mutable.ListBuffer[js.VarDef]
@@ -596,7 +563,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
         }
 
         result +=
-          js.VarDef(js.Ident("prep"+jsArg.ident.name, jsArg.ident.originalName),
+          js.VarDef(js.Ident("prep"+i),
               verifiedOrDefault.tpe, mutable = false, verifiedOrDefault)
       }
 
@@ -625,7 +592,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
     private sealed abstract class Exported {
       def pos: Position
       def params: List[Type]
-      def body: js.Tree
+      def genBody(minArgc: Int): js.Tree
       def name: String
       def typeInfo: String
       def hasRepeatedParam: Boolean
@@ -634,14 +601,15 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
     private case class ExportedSymbol(sym: Symbol) extends Exported {
       def pos: Position = sym.pos
       def params: List[Type] = sym.tpe.params.map(_.tpe)
-      def body: js.Tree = genApplyForSym(sym)
+      def genBody(minArgc: Int): js.Tree = genApplyForSym(minArgc, sym)
       def name: String = sym.name.toString
       def typeInfo: String = sym.tpe.toString
       def hasRepeatedParam: Boolean = GenJSExports.this.hasRepeatedParam(sym)
     }
 
     private case class ExportedBody(params: List[Type], body: js.Tree,
-      name: String, pos: Position) extends Exported {
+        name: String, pos: Position) extends Exported {
+      def genBody(minArgc: Int): js.Tree = body
       def typeInfo: String = params.mkString("(", ", ", ")")
       val hasRepeatedParam: Boolean = false
     }
@@ -774,13 +742,44 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
     js.Throw(js.StringLiteral(msg))
   }
 
-  private def genFormalArgs(count: Int)(implicit pos: Position): List[js.ParamDef] =
-    (1 to count map genFormalArg).toList
+  private def genFormalArgs(minArgc: Int, needsRestParam: Boolean)(
+      implicit pos: Position): List[js.ParamDef] = {
+    val fixedParams = (1 to minArgc map genFormalArg).toList
+    if (needsRestParam) fixedParams :+ genRestFormalArg()
+    else fixedParams
+  }
 
   private def genFormalArg(index: Int)(implicit pos: Position): js.ParamDef = {
     js.ParamDef(js.Ident("arg$" + index), jstpe.AnyType,
         mutable = false, rest = false)
   }
+
+  private def genRestFormalArg()(implicit pos: Position): js.ParamDef = {
+    js.ParamDef(js.Ident("arg$rest"), jstpe.AnyType,
+        mutable = false, rest = true)
+  }
+
+  private def genFormalArgRef(index: Int, minArgc: Int)(
+      implicit pos: Position): js.Tree = {
+    if (index <= minArgc)
+      js.VarRef(js.Ident("arg$" + index))(jstpe.AnyType)
+    else
+      js.JSBracketSelect(genRestArgRef(), js.IntLiteral(index - 1 - minArgc))
+  }
+
+  private def genVarargRef(fixedParamCount: Int, minArgc: Int)(
+      implicit pos: Position): js.Tree = {
+    val restParam = genRestArgRef()
+    assert(fixedParamCount >= minArgc)
+    if (fixedParamCount == minArgc) restParam
+    else {
+      js.JSBracketMethodApply(restParam, js.StringLiteral("slice"), List(
+          js.IntLiteral(fixedParamCount - minArgc)))
+    }
+  }
+
+  private def genRestArgRef()(implicit pos: Position): js.Tree =
+    js.VarRef(js.Ident("arg$rest"))(jstpe.AnyType)
 
   private def hasRepeatedParam(sym: Symbol) =
     enteringPhase(currentRun.uncurryPhase) {

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -96,11 +96,18 @@ object Hashers {
           mixBoolean(mutable)
           mixTree(rhs)
 
-        case ParamDef(ident, ptpe, mutable) =>
+        case ParamDef(ident, ptpe, mutable, rest) =>
           mixTag(TagParamDef)
           mixIdent(ident)
           mixType(ptpe)
           mixBoolean(mutable)
+          /* TODO Remove this test in the next major release.
+           * In 0.6.x we need this test so that the hash of a non-rest ParamDef
+           * emitted in 0.6.3 format is the same as an (implicitly non-rest)
+           * ParamDef emitted in 0.6.0 format.
+           */
+          if (rest)
+            mixBoolean(rest)
 
         case Skip() =>
           mixTag(TagSkip)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -136,9 +136,11 @@ object Printers {
           if (rhs != EmptyTree)
             print(" = ", rhs)
 
-        case ParamDef(ident, ptpe, mutable) =>
+        case ParamDef(ident, ptpe, mutable, rest) =>
           if (mutable)
             print("var ")
+          if (rest)
+            print("...")
           print(ident, ": ", ptpe)
 
         // Control flow constructs

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -646,7 +646,7 @@ object Serializers {
 
         case TagVarRef =>
           val result = VarRef(readIdent())(readType())
-          if (true /*useHacks060*/ && result.ident.name == "arguments")
+          if (useHacks060 && result.ident.name == "arguments")
             foundArguments = true
           result
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -117,9 +117,9 @@ object Serializers {
           writeByte(TagVarDef)
           writeIdent(ident); writeType(vtpe); writeBoolean(mutable); writeTree(rhs)
 
-        case ParamDef(ident, ptpe, mutable) =>
+        case ParamDef(ident, ptpe, mutable, rest) =>
           writeByte(TagParamDef)
-          writeIdent(ident); writeType(ptpe); writeBoolean(mutable)
+          writeIdent(ident); writeType(ptpe); writeBoolean(mutable); writeBoolean(rest)
 
         case Skip() =>
           writeByte(TagSkip)
@@ -551,6 +551,8 @@ object Serializers {
   }
 
   private final class Deserializer(stream: InputStream, sourceVersion: String) {
+    private[this] val useHacks060 = sourceVersion == "0.6.0"
+
     private[this] val input = new DataInputStream(stream)
 
     private[this] val files =
@@ -560,6 +562,8 @@ object Serializers {
       Array.fill(input.readInt())(input.readUTF())
 
     private[this] var lastPosition: Position = Position.NoPosition
+
+    private[this] var foundArguments: Boolean = false
 
     def deserialize(): Tree = {
       readTree()
@@ -572,8 +576,10 @@ object Serializers {
       val result = (tag: @switch) match {
         case TagEmptyTree => EmptyTree
 
-        case TagVarDef     => VarDef(readIdent(), readType(), readBoolean(), readTree())
-        case TagParamDef   => ParamDef(readIdent(), readType(), readBoolean())
+        case TagVarDef   => VarDef(readIdent(), readType(), readBoolean(), readTree())
+        case TagParamDef =>
+          ParamDef(readIdent(), readType(), readBoolean(),
+              rest = if (useHacks060) false else readBoolean())
 
         case TagSkip     => Skip()
         case TagBlock    => Block(readTrees())
@@ -638,7 +644,12 @@ object Serializers {
         case TagStringLiteral  => StringLiteral(readString())
         case TagClassOf        => ClassOf(readReferenceType())
 
-        case TagVarRef  => VarRef(readIdent())(readType())
+        case TagVarRef =>
+          val result = VarRef(readIdent())(readType())
+          if (true /*useHacks060*/ && result.ident.name == "arguments")
+            foundArguments = true
+          result
+
         case TagThis    => This()(readType())
         case TagClosure =>
           Closure(readParamDefs(), readParamDefs(), readTree(), readTrees())
@@ -661,14 +672,26 @@ object Serializers {
           // read and discard the length
           val len = readInt()
           assert(len >= 0)
-          MethodDef(readBoolean(), readPropertyName(),
+          val result = MethodDef(readBoolean(), readPropertyName(),
               readParamDefs(), readType(), readTree())(
               new OptimizerHints(readInt()), optHash)
+          if (foundArguments) {
+            foundArguments = false
+            new RewriteArgumentsTransformer().transformMethodDef(result)
+          } else {
+            result
+          }
         case TagPropertyDef =>
           PropertyDef(readPropertyName(), readTree(),
               readTree().asInstanceOf[ParamDef], readTree())
         case TagConstructorExportDef =>
-          ConstructorExportDef(readString(), readParamDefs(), readTree())
+          val result = ConstructorExportDef(readString(), readParamDefs(), readTree())
+          if (foundArguments) {
+            foundArguments = false
+            new RewriteArgumentsTransformer().transformConstructorExportDef(result)
+          } else {
+            result
+          }
         case TagModuleExportDef =>
           ModuleExportDef(readString())
       }
@@ -807,5 +830,59 @@ object Serializers {
     def readString(): String = {
       strings(input.readInt())
     }
+  }
+
+  private class RewriteArgumentsTransformer extends Transformers.Transformer {
+    import RewriteArgumentsTransformer._
+
+    private[this] var paramToIndex: Map[String, Int] = _
+
+    def transformMethodDef(tree: MethodDef): MethodDef = {
+      /* Ideally, we would re-hash the new MethodDef here, but we cannot do
+       * that because it prevents the JS version of the tools to link.
+       * Since the hashes of exported methods are not used by our pipeline
+       * anyway, we simply put None.
+       */
+      val MethodDef(static, name, args, resultType, body) = tree
+      setupParamToIndex(args)
+      MethodDef(static, name, List(argumentsParamDef(tree.pos)),
+          resultType, transform(body, isStat = resultType == NoType))(
+          tree.optimizerHints, None)(tree.pos)
+    }
+
+    def transformConstructorExportDef(
+        tree: ConstructorExportDef): ConstructorExportDef = {
+      val ConstructorExportDef(name, args, body) = tree
+      setupParamToIndex(args)
+      ConstructorExportDef(name, List(argumentsParamDef(tree.pos)),
+          transformStat(body))(tree.pos)
+    }
+
+    private def setupParamToIndex(params: List[ParamDef]): Unit =
+      paramToIndex = params.map(_.name.name).zipWithIndex.toMap
+
+    private def argumentsParamDef(implicit pos: Position): ParamDef =
+      ParamDef(Ident(ArgumentsName), AnyType, mutable = false, rest = true)
+
+    private def argumentsRef(implicit pos: Position): VarRef =
+      VarRef(Ident(ArgumentsName))(AnyType)
+
+    override def transform(tree: Tree, isStat: Boolean): Tree = tree match {
+      case VarRef(Ident(name, origName)) =>
+        implicit val pos = tree.pos
+        paramToIndex.get(name).fold {
+          if (name == "arguments") argumentsRef
+          else tree
+        } { paramIndex =>
+          JSBracketSelect(argumentsRef, IntLiteral(paramIndex))
+        }
+
+      case _ =>
+        super.transform(tree, isStat)
+    }
+  }
+
+  private object RewriteArgumentsTransformer {
+    private final val ArgumentsName = "$arguments"
   }
 }

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -92,7 +92,7 @@ object Trees {
     def ref(implicit pos: Position): VarRef = VarRef(name)(vtpe)
   }
 
-  case class ParamDef(name: Ident, ptpe: Type, mutable: Boolean)(implicit val pos: Position) extends Tree {
+  case class ParamDef(name: Ident, ptpe: Type, mutable: Boolean, rest: Boolean)(implicit val pos: Position) extends Tree {
     val tpe = NoType
 
     def ref(implicit pos: Position): VarRef = VarRef(name)(ptpe)

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -2,10 +2,22 @@ import com.typesafe.tools.mima.core._
 import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
+  val IR = Seq(
+      // Breaking: ParamDef has an additinal `rest` parameter
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.ir.Trees#ParamDef.apply"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.ir.Trees#ParamDef.copy"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.ir.Trees#ParamDef.this")
+  )
+
   val Tools = Seq(
       // Private, not an issue
       ProblemFilters.exclude[MissingMethodProblem](
-          "org.scalajs.core.tools.sem.Semantics.this")
+          "org.scalajs.core.tools.sem.Semantics.this"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.optimizer.IRChecker#Env.withArgumentsVar")
   )
 
   val TestAdapter = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -213,7 +213,9 @@ object Build extends sbt.Build {
   val commonIrProjectSettings = (
       commonSettings ++ publishSettings
   ) ++ Seq(
-      name := "Scala.js IR"
+      name := "Scala.js IR",
+
+      binaryIssueFilters ++= BinaryIncompatibilities.IR
   )
 
   lazy val irProject: Project = Project(

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -56,7 +56,8 @@ object JavaLangObject {
         MethodDef(
           static = false,
           Ident("equals__O__Z", Some("equals__O__Z")),
-          List(ParamDef(Ident("that", Some("that")), AnyType, mutable = false)),
+          List(ParamDef(Ident("that", Some("that")), AnyType,
+            mutable = false, rest = false)),
           BooleanType,
           {
             BinaryOp(BinaryOp.===,

--- a/project/JavaLangString.scala
+++ b/project/JavaLangString.scala
@@ -37,7 +37,8 @@ object JavaLangString {
         MethodDef(
           static = false,
           Ident("equals__O__Z", Some("equals__O__Z")),
-          List(ParamDef(Ident("that", Some("that")), AnyType, mutable = false)),
+          List(ParamDef(Ident("that", Some("that")), AnyType,
+            mutable = false, rest = false)),
           BooleanType,
           {
             BinaryOp(BinaryOp.===,
@@ -62,7 +63,8 @@ object JavaLangString {
         MethodDef(
           static = false,
           Ident("compareTo__T__I", Some("compareTo__T__I")),
-          List(ParamDef(Ident("that", Some("that")), ThisType, mutable = false)),
+          List(ParamDef(Ident("that", Some("that")), ThisType,
+            mutable = false, rest = false)),
           IntType,
           {
             Apply(
@@ -77,7 +79,8 @@ object JavaLangString {
         MethodDef(
           static = false,
           Ident("compareTo__O__I", Some("compareTo__O__I")),
-          List(ParamDef(Ident("that", Some("that")), AnyType, mutable = false)),
+          List(ParamDef(Ident("that", Some("that")), AnyType,
+            mutable = false, rest = false)),
           IntType,
           {
             Apply(
@@ -102,7 +105,8 @@ object JavaLangString {
         MethodDef(
           static = false,
           Ident("charAt__I__C", Some("charAt__I__C")),
-          List(ParamDef(Ident("i", Some("i")), IntType, mutable = false)),
+          List(ParamDef(Ident("i", Some("i")), IntType,
+            mutable = false, rest = false)),
           IntType,
           {
             Apply(
@@ -134,8 +138,10 @@ object JavaLangString {
           Ident("subSequence__I__I__jl_CharSequence",
             Some("subSequence__I__I__jl_CharSequence")),
           List(
-            ParamDef(Ident("begin", Some("begin")), IntType, mutable = false),
-            ParamDef(Ident("end", Some("end")), IntType, mutable = false)
+            ParamDef(Ident("begin", Some("begin")), IntType,
+              mutable = false, rest = false),
+            ParamDef(Ident("end", Some("end")), IntType,
+              mutable = false, rest = false)
           ),
           ClassType("jl_CharSequence"),
           {


### PR DESCRIPTION
The magic `arguments` variable is now banned from the IR. It is replaced by its cleaner ES6 replacement: ...rest parameters.

Rest params are only allowed in exported methods and constructors, and only as last parameter. They are desugared into a loop preceding the normal body of the method, copying the elements from `arguments`. But until desugaring, we do not have to deal with it.

When eventually targeting ES6, a rest parameter need not be desugared at all.

To preserve backward binary compatibility, a deserialization hack identifies uses of `arguments`, and replaces it by a rest param. All normal parameters are also removed, and replaced by indexed access into the rest parameter.