### PR TITLE
Fix #1564: Allow filtering of JS dependency manifests

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -3,6 +3,10 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val Tools = Seq(
+      // Protected, but in final class. Made private
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.classpath.PartialClasspath.resolveDependencies"),
+
       // Private, not an issue
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.sem.Semantics.this")

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -1,3 +1,5 @@
+import org.scalajs.core.tools.jsdep.ManifestFilters
+
 name := "Scala.js sbt test"
 
 version := scalaJSVersion
@@ -37,6 +39,8 @@ lazy val jetty9 = project.settings(baseSettings: _*).
     name := "Scala.js sbt test with jetty9 on classpath",
     jsDependencies ++= Seq(
         RuntimeDOM,
+        // The jsDependenciesTest relies on this jQuery dependency
+        // If you change it, make sure we still test properly
         "org.webjars" % "jquery" % "1.10.2" / "jquery.js"
     ),
     // A test for packageJSDependencies, although we don't use it
@@ -98,8 +102,13 @@ lazy val jsDependenciesTest = project.settings(versionSettings: _*).
 
         // cause a duplicate commonJSName if the following are not considered equal
         "org.webjars" % "mustachejs" % "0.8.2" / "mustache.js" commonJSName "Mustache",
-        "org.webjars" % "mustachejs" % "0.8.2" / "0.8.2/mustache.js" commonJSName "Mustache"
-    )
+        "org.webjars" % "mustachejs" % "0.8.2" / "0.8.2/mustache.js" commonJSName "Mustache",
+
+        // cause an ambiguity with jQuery dependency from jetty9 project (if we don't filter)
+        ProvidedJS / "js/customJQuery/jquery.js" dependsOn "1.10.2/jquery.js"
+    ),
+    jsManifestFilter := ManifestFilters.reinterpretResourceNames("jetty9")(
+        "jquery.js" -> "1.10.2/jquery.js")
   ).
   settings(inConfig(Compile)(Seq(
     skip in packageJSDependencies := false,
@@ -114,10 +123,11 @@ lazy val jsDependenciesTest = project.settings(versionSettings: _*).
           "META-INF/resources/webjars/historyjs/1.8.0/scripts/compressed/history.js",
           "META-INF/resources/webjars/jquery/1.10.2/jquery.js",
           "js/foo.js",
-          "js/some-jquery-plugin.js"),
+          "js/some-jquery-plugin.js",
+          "js/customJQuery/jquery.js"),
           s"Bad set of relPathes: ${relPaths.toSet}")
 
-      val jQueryIndex = relPaths.indexWhere(_ endsWith "/jquery.js")
+      val jQueryIndex = relPaths.indexWhere(_ endsWith "1.10.2/jquery.js")
       val jQueryPluginIndex = relPaths.indexWhere(_ endsWith "/some-jquery-plugin.js")
       assert(jQueryPluginIndex > jQueryIndex,
           "the jQuery plugin appears before jQuery")

--- a/sbt-plugin-test/jsDependenciesTest/src/main/resources/js/customJQuery/jquery.js
+++ b/sbt-plugin-test/jsDependenciesTest/src/main/resources/js/customJQuery/jquery.js
@@ -1,0 +1,1 @@
+// js/customJQuery/jquery.js

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -163,6 +163,9 @@ object ScalaJSPlugin extends AutoPlugin {
     val jsDependencyFilter = SettingKey[PartialClasspath.DependencyFilter]("jsDependencyFilter",
         "The filter applied to the raw JavaScript dependencies before execution", CSetting)
 
+    val jsManifestFilter = SettingKey[PartialClasspath.ManifestFilter]("jsManifestFilter",
+        "The filter applied to JS dependency manifests before resolution", CSetting)
+
     val checkScalaJSSemantics = SettingKey[Boolean]("checkScalaJSSemantics",
         "Whether to check that the current semantics meet compliance " +
         "requirements of dependencies.", CSetting)

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -114,7 +114,7 @@ object ScalaJSPluginInternal {
       scalaJSPreLinkClasspath := {
         val cp = fullClasspath.value
         val pcp = PartialClasspathBuilder.build(Attributed.data(cp).toList)
-        val ccp = pcp.resolve(jsDependencyFilter.value)
+        val ccp = pcp.resolve(jsDependencyFilter.value, jsManifestFilter.value)
 
         if (checkScalaJSSemantics.value)
           ccp.checkCompliance(scalaJSSemantics.value)
@@ -508,6 +508,7 @@ object ScalaJSPluginInternal {
 
       jsDependencies := Seq(),
       jsDependencyFilter := identity,
+      jsManifestFilter := identity,
 
       scalaJSSemantics := Semantics.Defaults,
       scalaJSOutputMode := OutputMode.ECMAScript51Isolated,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ManifestFilters.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ManifestFilters.scala
@@ -1,0 +1,47 @@
+package org.scalajs.core.tools.jsdep
+
+import scala.collection.immutable.Traversable
+
+/** Holds useful JSDependencyManifest filters */
+object ManifestFilters {
+
+  type ManifestFilter =
+    Traversable[JSDependencyManifest] => Traversable[JSDependencyManifest]
+
+  /** Creates a manifest filter that maps resource names of a certain
+   *  origin as if they were written differently
+   *  @param moduleNames Modules for which the mapping should be applied
+   *  @param nameMappings resource name mappings
+   */
+  def reinterpretResourceNames(moduleNames: String*)(
+      nameMappings: (String, String)*): ManifestFilter = {
+    val modSet = moduleNames.toSet
+    val nameMap = nameMappings.toMap
+
+    val mapper = { (origin: Origin) => (oldName: String) =>
+      if (modSet(origin.moduleName))
+        nameMap.getOrElse(oldName, oldName)
+      else
+        oldName
+    }
+
+    reinterpretResourceNames(mapper)
+  }
+
+  /** Creates a manifest filter that maps resource names of a certain
+   *  origin as if they were written differently
+   *  @param mappings Maps manifest origin to old resource name to new
+   *      resource name
+   */
+  def reinterpretResourceNames(
+      mappings: Origin => String => String): ManifestFilter = { manifests =>
+    for (manifest <- manifests) yield {
+      val mapping = mappings(manifest.origin)
+      val filteredJSDeps = for (jsDependency <- manifest.libDeps)
+        yield new JSDependency(mapping(jsDependency.resourceName),
+            jsDependency.dependencies.map(mapping), jsDependency.commonJSName)
+      new JSDependencyManifest(manifest.origin, filteredJSDeps,
+          manifest.requiresDOM, manifest.compliantSemantics)
+    }
+  }
+}


### PR DESCRIPTION
This allows to resolve relative path conflicts in manifests inherited
from dependencies as the test shows. The typical example (for which we
provide a convenience filter) is a dependency that does not declare
specific enough relative paths.

Binary compatibility of PartialClasspath.resolve is a bit funky here:
The default parameter for the one argument version is now provided by
the parameter of the two argument version. However, since the values
equal, this is fine. Also, argument names need not be deprecated, since
the overloading resolution works properly, if filter is used.