### PR TITLE
Fix #1586: Make Emitter agree with Optimizer on the id of a method.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Emitter.scala
@@ -29,7 +29,7 @@ final class Emitter(semantics: Semantics, outputMode: OutputMode) {
     this(semantics, OutputMode.ECMAScript51Global)
 
   private var classEmitter: javascript.ScalaJSClassEmitter = _
-  private val classCaches = mutable.Map.empty[String, ClassCache]
+  private val classCaches = mutable.Map.empty[List[String], ClassCache]
 
   private[this] var statsClassesReused: Int = 0
   private[this] var statsClassesInvalidated: Int = 0
@@ -80,7 +80,7 @@ final class Emitter(semantics: Semantics, outputMode: OutputMode) {
     def addTree(tree: js.Tree): Unit = builder.addJSTree(tree)
 
     val className = linkedClass.encodedName
-    val classCache = getClassCache(className)
+    val classCache = getClassCache(linkedClass.ancestors)
     val classTreeCache = classCache.getCache(linkedClass.version)
     val kind = linkedClass.kind
 
@@ -141,8 +141,8 @@ final class Emitter(semantics: Semantics, outputMode: OutputMode) {
 
   // Helpers
 
-  private def getClassCache(encodedName: String) =
-    classCaches.getOrElseUpdate(encodedName, new ClassCache)
+  private def getClassCache(ancestors: List[String]) =
+    classCaches.getOrElseUpdate(ancestors, new ClassCache)
 
   // Caching
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/LinkedClass.scala
@@ -24,6 +24,14 @@ import ir.Definitions
  *  [[staticMethods]], [[memberMethods]], [[abstractMethods]] and
  *  [[exportedMembers]] as they have their individual versions. (The collections
  *  themselves are not versioned).
+ *
+ *  Moreover, the [[version]] is relative to the identity of a LinkedClass.
+ *  The definition of identity varies as linked classes progress through the
+ *  linking pipeline, but it only gets stronger, i.e., if two linked classes
+ *  are id-different at phase P, then they must also be id-different at phase
+ *  P+1. The converse is not true. This guarantees that versions can be used
+ *  reliably to determine at phase P+1 whether a linked class coming from phase
+ *  P must be reprocessed.
  */
 final class LinkedClass(
     // Stuff from Tree

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/LinkedMember.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/LinkedMember.scala
@@ -13,7 +13,16 @@ import org.scalajs.core.ir
 import ir.Trees._
 import ir.Infos
 
-/** A MethodDef or a PropertyDef after linking */
+/** A MethodDef or a PropertyDef after linking.
+ *
+ *  Note that the [[version]] is relative to the identity of a LinkedMember.
+ *  The definition of identity varies as linked members progress through the
+ *  linking pipeline, but it only gets stronger, i.e., if two linked members
+ *  are id-different at phase P, then they must also be id-different at phase
+ *  P+1. The converse is not true. This guarantees that versions can be used
+ *  reliably to determine at phase P+1 whether a linked member coming from
+ *  phase P must be reprocessed.
+ */
 final case class LinkedMember[+T <: Tree](
     info: Infos.MethodInfo,
     tree: T,


### PR DESCRIPTION
For the optimizer, the identity of a method is its name + the list
of all classes in the hierarchy of its enclosing class.
Previously, the Emitter only used the enclosing class, but not its
hierarchy. This caused problems with the versioning of methods.

This commit solves the issue by making the Emitter agree with the
Optimizer that the identity of a method depends on the entire hierarchy.