### PR TITLE
Fix #1487: Implement java.util.ConcurrentHashMap.

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -1,0 +1,75 @@
+package java.util
+
+import scala.collection.JavaConversions._
+
+import java.lang.{reflect => jlr}
+
+abstract class AbstractCollection[E] protected () extends Collection[E] {
+  def iterator(): Iterator[E]
+  def size(): Int
+
+  def isEmpty(): Boolean = size == 0
+
+  def contains(o: Any): Boolean =
+    iterator.exists(o === _)
+
+  def toArray(): Array[AnyRef] =
+    toArray(new Array[AnyRef](size))
+
+  def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
+    val toFill: Array[T] =
+      if (a.size >= size) a
+      else jlr.Array.newInstance(a.getClass.getComponentType, size).asInstanceOf[Array[T]]
+
+    val iter = iterator
+    for (i <- 0 until size)
+      toFill(i) = iter.next().asInstanceOf[T]
+    if (toFill.size > size)
+      toFill(size) = null.asInstanceOf[T]
+    toFill
+  }
+
+  def add(e: E): Boolean =
+    throw new UnsupportedOperationException()
+
+  def remove(o: Any): Boolean = {
+    val iter = iterator()
+    while (iter.hasNext) {
+      if (iter.next().equals(o)) {
+        iter.remove()
+        return true
+      }
+    }
+    false
+  }
+
+  def containsAll(c: Collection[_]): Boolean =
+    c.iterator.forall(this.contains(_))
+
+  def addAll(c: Collection[_ <: E]): Boolean =
+    throw new UnsupportedOperationException()
+
+  def removeAll(c: Collection[_]): Boolean =
+    removeWhere(c.contains(_))
+
+  def retainAll(c: Collection[_]): Boolean =
+    removeWhere(!c.contains(_))
+
+  def clear(): Unit =
+    removeWhere(_ => true)
+
+  private def removeWhere(p: Any => Boolean): Boolean = {
+    val iter = iterator()
+    var changed = false
+    while (iter.hasNext) {
+      if (p(iter.next())) {
+        iter.remove()
+        changed = true
+      }
+    }
+    changed
+  }
+
+  override def toString(): String =
+    iterator.mkString("[", ",", "]")
+}

--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -1,0 +1,3 @@
+package java.util
+
+abstract class AbstractList[E] extends AbstractCollection[E] with List[E]

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -1,0 +1,174 @@
+package java.util
+
+import scala.collection.JavaConversions._
+
+object AbstractMap {
+
+  private def entryEquals[K, V](entry: Map.Entry[K, V], other: Any): Boolean = {
+    other match {
+      case other: Map.Entry[_, _] =>
+        entry.getKey === other.getKey && entry.getValue === other.getValue
+      case _ => false
+    }
+  }
+
+  private def entryHashCode[K, V](entry: Map.Entry[K, V]): Int = {
+    val keyHash =
+      if (entry.getKey == null) 0
+      else entry.getKey.hashCode
+    val valueHash =
+      if (entry.getValue == null) 0
+      else entry.getValue.hashCode
+
+    keyHash ^ valueHash
+  }
+
+  class SimpleEntry[K, V](private var key: K,
+      private var value: V) extends Map.Entry[K, V] with Serializable {
+
+    def this(entry: Map.Entry[_ <: K, _ <: V]) =
+      this(entry.getKey, entry.getValue)
+
+    def getKey(): K = key
+
+    def getValue(): V = value
+
+    def setValue(value: V): V = {
+      val oldValue = this.value
+      this.value = value
+      oldValue
+    }
+
+    override def equals(o: Any): Boolean =
+      entryEquals(this, o)
+
+    override def hashCode(): Int =
+      entryHashCode(this)
+
+    override def toString(): String =
+      getKey + "=" + getValue
+  }
+
+  class SimpleImmutableEntry[K, V](key: K,
+      value: V) extends Map.Entry[K, V] with Serializable {
+
+    def this(entry: Map.Entry[_ <: K, _ <: V]) =
+      this(entry.getKey, entry.getValue)
+
+    def getKey(): K = key
+
+    def getValue(): V = value
+
+    def setValue(value: V): V =
+      throw new UnsupportedOperationException()
+
+    override def equals(o: Any): Boolean =
+      entryEquals(this, o)
+
+    override def hashCode(): Int =
+      entryHashCode(this)
+
+    override def toString(): String =
+      getKey + "=" + getValue
+  }
+}
+
+abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] { self =>
+
+  def size(): Int = entrySet.size
+
+  def isEmpty(): Boolean = size == 0
+
+  def containsValue(value: Any): Boolean =
+    entrySet.iterator.exists(value === _.getValue)
+
+  def containsKey(key: Any): Boolean =
+    entrySet.iterator.exists(entry => entry === key)
+
+  def get(key: Any): V = {
+    entrySet.iterator.find(_.getKey === key).fold[V] {
+      null.asInstanceOf[V]
+    } { entry =>
+      entry.getValue
+    }
+  }
+
+  def put(key: K, value: V): V =
+    throw new UnsupportedOperationException()
+
+  def remove(key: Any): V = {
+    val iter = entrySet.iterator
+    while (iter.hasNext) {
+      val item = iter.next()
+      if (key === item.getKey) {
+        iter.remove()
+        return item.getValue
+      }
+    }
+    null.asInstanceOf[V]
+  }
+
+  def putAll[K2 <: K, V2 <: V](m: Map[K2, V2]): Unit =
+    m.entrySet.iterator.foreach(e => put(e.getKey, e.getValue))
+
+  def clear(): Unit =
+    entrySet.clear()
+
+  def keySet(): Set[K] = {
+    new AbstractSet[K] {
+      override def size(): Int = self.size
+
+      def iterator(): Iterator[K] = {
+        new Iterator[K] {
+          val iter = entrySet.iterator()
+
+          def hasNext(): Boolean = iter.hasNext()
+
+          def next(): K = iter.next().getKey()
+
+          def remove(): Unit = iter.remove()
+        }
+      }
+    }
+  }
+
+  def values(): Collection[V] = {
+    new AbstractCollection[V] {
+      override def size(): Int = self.size
+
+      def iterator(): Iterator[V] = {
+        new Iterator[V] {
+          val iter = entrySet.iterator()
+
+          def hasNext(): Boolean = iter.hasNext()
+
+          def next(): V = iter.next().getValue()
+
+          def remove(): Unit = iter.remove()
+        }
+      }
+    }
+  }
+
+  def entrySet(): Set[Map.Entry[K, V]]
+
+  override def equals(o: Any): Boolean = {
+    if (o.asInstanceOf[AnyRef] eq this) true
+    else {
+      o match {
+        case m: Map[_, _] =>
+          (self.size == m.size &&
+              entrySet.forall(item => m.get(item.getKey) === item.getValue))
+        case _ => false
+      }
+    }
+  }
+
+  override def hashCode(): Int =
+    entrySet.foldLeft(0)((prev, item) => item.hashCode + prev)
+
+  override def toString(): String = {
+    entrySet.iterator.map(
+        e => e.getKey + "=" + e.getValue).mkString("{", ", ", "}")
+  }
+}

--- a/javalib/src/main/scala/java/util/AbstractSet.scala
+++ b/javalib/src/main/scala/java/util/AbstractSet.scala
@@ -1,0 +1,40 @@
+package java.util
+
+import scala.annotation.tailrec
+
+import scala.collection.JavaConversions._
+
+abstract class AbstractSet[E] protected () extends AbstractCollection[E]
+                                              with Set[E] {
+  override def equals(that: Any): Boolean = {
+    if (that.asInstanceOf[AnyRef] eq this) true
+    else {
+      that match {
+        case that: Collection[_] => that.size == this.size && containsAll(that)
+        case _                   => false
+      }
+    }
+  }
+
+  override def hashCode(): Int =
+    asScalaIterator(iterator).foldLeft(0)((prev, item) => item.hashCode + prev)
+
+  override def removeAll(c: Collection[_]): Boolean = {
+    @tailrec
+    def remAll(iter: Iterator[_], comp: Collection[_],
+        remFun: (Iterator[_], Any) => Unit, res: Boolean = false): Boolean = {
+      if (iter.hasNext) {
+        val elem = iter.next()
+        if (comp.contains(elem)) {
+          remFun(iter, elem)
+          remAll(iter, comp, remFun, true)
+        } else remAll(iter, comp, remFun, res)
+      } else res
+    }
+
+    if (size > c.size)
+      remAll(c.iterator, this, (i, _) => i.remove())
+    else
+      remAll(iterator, c, (_, e) => remove(e))
+  }
+}

--- a/javalib/src/main/scala/java/util/Collection.scala
+++ b/javalib/src/main/scala/java/util/Collection.scala
@@ -1,0 +1,19 @@
+package java.util
+
+trait Collection[E] extends Iterable[E] {
+  def size(): Int
+  def isEmpty(): Boolean
+  def contains(o: Any): Boolean
+  def iterator(): Iterator[E]
+  def toArray(): Array[AnyRef]
+  def toArray[T <: AnyRef](a: Array[T]): Array[T]
+  def add(e: E): Boolean
+  def remove(o: Any): Boolean
+  def containsAll(c: Collection[_]): Boolean
+  def addAll(c: Collection[_ <: E]): Boolean
+  def removeAll(c: Collection[_]): Boolean
+  def retainAll(c: Collection[_]): Boolean
+  def clear(): Unit
+  def equals(o: Any): Boolean
+  def hashCode(): Int
+}

--- a/javalib/src/main/scala/java/util/Dictionary.scala
+++ b/javalib/src/main/scala/java/util/Dictionary.scala
@@ -1,0 +1,11 @@
+package java.util
+
+abstract class Dictionary[K, V] {
+  def size(): Int
+  def isEmpty(): Boolean
+  def keys(): Enumeration[K]
+  def elements(): Enumeration[V]
+  def get(key: Any): V
+  def put(key: K, value: V): V
+  def remove(key: Any): V
+}

--- a/javalib/src/main/scala/java/util/Enumeration.scala
+++ b/javalib/src/main/scala/java/util/Enumeration.scala
@@ -1,0 +1,6 @@
+package java.util
+
+trait Enumeration[E] {
+  def hasMoreElements(): Boolean
+  def nextElement(): E
+}

--- a/javalib/src/main/scala/java/util/HashSet.scala
+++ b/javalib/src/main/scala/java/util/HashSet.scala
@@ -1,0 +1,83 @@
+package java.util
+
+import scala.collection.mutable
+import scala.collection.JavaConversions._
+
+class HashSet[E] extends AbstractSet[E] with Set[E]
+                                        with Cloneable
+                                        with Serializable { self =>
+  def this(initialCapacity: Int, loadFactor: Float) =
+    this()
+
+  def this(initialCapacity: Int) =
+    this()
+
+  def this(c: Collection[_ <: E]) = {
+    this()
+    addAll(c)
+  }
+
+  protected val inner: mutable.Set[Box[E]] =
+    new mutable.HashSet[Box[E]]()
+
+  override def contains(o: Any): Boolean =
+    inner.contains(Box(o.asInstanceOf[E]))
+
+  override def remove(o: Any): Boolean =
+    inner.remove(Box(o.asInstanceOf[E]))
+
+  override def containsAll(c: Collection[_]): Boolean =
+    c.iterator.forall(e => contains(e))
+
+  override def removeAll(c: Collection[_]): Boolean = {
+    val iter = c.iterator
+    var changed = false
+    while (iter.hasNext)
+      changed = remove(iter.next()) || changed
+    changed
+  }
+
+  override def retainAll(c: Collection[_]): Boolean = {
+    val iter = iterator
+    var changed = false
+    while (iter.hasNext) {
+      val value = iter.next
+      if (!c.contains(value))
+        changed = remove(value) || changed
+    }
+    changed
+  }
+
+  override def add(e: E): Boolean = 
+    inner.add(Box(e))
+
+  override def addAll(c: Collection[_ <: E]): Boolean = {
+    val iter = c.iterator()
+    var changed = false
+    while (iter.hasNext)
+      changed = add(iter.next()) || changed
+    changed
+  }
+
+  override def clear(): Unit = inner.clear()
+
+  override def size(): Int = inner.size
+
+  def iterator(): Iterator[E] = {
+    new Iterator[E] {
+      private val iter = inner.iterator
+
+      var actual: Option[E] = None
+
+      def hasNext(): Boolean = iter.hasNext
+
+      def next(): E = {
+        actual = Some(iter.next().inner)
+        actual.get
+      }
+
+      def remove(): Unit = actual.map(self.remove(_))
+    }
+  }
+
+}

--- a/javalib/src/main/scala/java/util/Iterable.scala
+++ b/javalib/src/main/scala/java/util/Iterable.scala
@@ -1,0 +1,5 @@
+package java.util
+
+trait Iterable[T] {
+  def iterator(): Iterator[T]
+}

--- a/javalib/src/main/scala/java/util/Iterator.scala
+++ b/javalib/src/main/scala/java/util/Iterator.scala
@@ -1,0 +1,7 @@
+package java.util
+
+trait Iterator[E] {
+  def hasNext(): Boolean
+  def next(): E
+  def remove(): Unit
+}

--- a/javalib/src/main/scala/java/util/LinkedHashSet.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashSet.scala
@@ -1,0 +1,22 @@
+package java.util
+
+import scala.collection.mutable
+
+class LinkedHashSet[E] extends HashSet[E] with Set[E]
+                                          with Cloneable
+                                          with Serializable {
+  def this(initialCapacity: Int, loadFactor: Float) =
+    this()
+
+  def this(initialCapacity: Int) =
+    this()
+
+  def this(c: java.util.Collection[_ <: E]) = {
+    this()
+    addAll(c)
+  }
+
+  override protected val inner: mutable.Set[Box[E]] =
+    new mutable.LinkedHashSet[Box[E]]()
+
+}

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -1,0 +1,3 @@
+package java.util
+
+trait List[E] extends Collection[E]

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -1,0 +1,30 @@
+package java.util
+
+trait Map[K, V] {
+  def size(): Int
+  def isEmpty(): Boolean
+  def containsKey(key: Any): Boolean
+  def containsValue(value: Any): Boolean
+  def get(key: Any): V
+  def put(key: K, value: V): V
+  def remove(key: Any): V
+  def putAll[K2 <: K, V2 <: V](m: Map[K2, V2]): Unit
+  def clear(): Unit
+  def keySet(): Set[K]
+  def values(): Collection[V]
+  def entrySet(): Set[Map.Entry[K, V]]
+  def equals(o: Any): Boolean
+  def hashCode(): Int
+}
+
+object Map {
+
+  trait Entry[K, V] {
+    def getKey(): K
+    def getValue(): V
+    def setValue(value: V): V
+    def equals(o: Any): Boolean
+    def hashCode(): Int
+  }
+
+}

--- a/javalib/src/main/scala/java/util/Set.scala
+++ b/javalib/src/main/scala/java/util/Set.scala
@@ -1,0 +1,3 @@
+package java.util
+
+trait Set[E] extends Collection[E]

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -1,0 +1,210 @@
+package java.util.concurrent
+
+import java.lang.{reflect => jlr}
+import java.io.Serializable
+import java.util._
+
+import scala.collection.JavaConversions._
+
+class ConcurrentHashMap[K >: Null, V >: Null]
+    extends AbstractMap[K, V] with ConcurrentMap[K, V] with Serializable { self =>
+
+  def this(initialCapacity: Int) =
+    this()
+
+  def this(initialCapacity: Int, loadFactor: Float) =
+    this()
+
+  def this(initialCapacity: Int, loadFactor: Float, concurrencyLevel: Int) =
+    this()
+
+  def this(initialMap: java.util.Map[_ <: K, _ <: V]) = {
+    this()
+    putAll(initialMap)
+  }
+
+  private val inner = new scala.collection.mutable.HashMap[Box[K], V]()
+
+  override def isEmpty(): Boolean = inner.isEmpty
+
+  override def size(): Int = inner.size
+
+  override def get(key: Any): V =
+    inner.get(Box(key.asInstanceOf[K])).getOrElse(null)
+
+  override def containsKey(key: Any): Boolean =
+    inner.exists { case (ik, _) => key === ik() }
+
+  override def containsValue(value: Any): Boolean =
+    inner.exists { case (_, iv) => value === iv }
+
+  override def put(key: K, value: V): V = {
+    if (key != null && value != null)
+      inner.put(Box(key), value).getOrElse(null)
+    else
+      throw new NullPointerException()
+  }
+
+  def putIfAbsent(key: K, value: V): V = {
+    if (key != null && value != null)
+      inner.getOrElseUpdate(Box(key), value)
+    else
+      throw new NullPointerException()
+  }
+
+  override def putAll[K1 <: K, V1 <: V](m: Map[K1, V1]): Unit = {
+    for (e <- m.entrySet())
+      put(e.getKey, e.getValue)
+  }
+
+  override def remove(key: Any): V =
+    inner.remove(Box(key.asInstanceOf[K])).getOrElse(null)
+
+  override def remove(key: Any, value: Any): Boolean = {
+    val old = inner(Box(key.asInstanceOf[K]))
+    if (value === old)
+      inner.remove(Box(key.asInstanceOf[K])).isDefined
+    else
+      false
+  }
+
+  override def replace(key: K, oldValue: V, newValue: V): Boolean = {
+    if (key != null && oldValue != null && newValue != null) {
+      val old = inner(Box(key))
+      if (oldValue === old) {
+        put(key, newValue)
+        true
+      } else {
+        false
+      }
+    } else {
+      throw new NullPointerException()
+    }
+  }
+
+  override def replace(key: K, value: V): V = {
+    if (key != null && value != null) {
+      if (inner(Box(key)) != null) put(key, value)
+      else null
+    } else {
+      throw new NullPointerException()
+    }
+  }
+
+  override def clear(): Unit =
+    inner.clear()
+
+  override def keySet(): ConcurrentHashMap.KeySetView[K, V] =
+    new ConcurrentHashMap.KeySetView[K, V](this)
+
+  def entrySet(): Set[Map.Entry[K, V]] = {
+    new AbstractSet[Map.Entry[K, V]] {
+      override def size(): Int = self.size
+
+      def iterator(): Iterator[Map.Entry[K, V]] = {
+        new Iterator[Map.Entry[K, V]] {
+          private val keysCopy = inner.keysIterator
+
+          private var lastKey: Box[K] = null
+
+          def hasNext(): Boolean = keysCopy.hasNext
+
+          def next(): Map.Entry[K, V] = {
+            val k = keysCopy.next()
+            val v = inner(k)
+            lastKey = k
+            new AbstractMap.SimpleImmutableEntry(k(), v)
+          }
+
+          def remove(): Unit = {
+            if (lastKey != null) {
+              inner.remove(lastKey)
+              lastKey = null
+            } else {
+              throw new IllegalStateException()
+            }
+          }
+        }
+      }
+    }
+  }
+
+  def keys(): Enumeration[K] =
+    asJavaEnumeration(inner.keys.iterator.map(_.inner))
+
+  def elements(): Enumeration[V] =
+    asJavaEnumeration(inner.values.iterator)
+}
+
+object ConcurrentHashMap {
+
+  class KeySetView[K >: Null, V >: Null] private[ConcurrentHashMap] (
+      chm: ConcurrentHashMap[K, V]) extends Set[K] with Serializable {
+
+    def size(): Int = chm.size
+
+    def isEmpty(): Boolean = chm.isEmpty
+
+    def contains(o: Any): Boolean = chm.containsKey(o)
+
+    def iterator(): Iterator[K] = {
+      new Iterator[K] {
+        val iter = chm.entrySet.iterator()
+
+        def hasNext(): Boolean = iter.hasNext()
+
+        def next(): K = iter.next().getKey()
+
+        def remove(): Unit = iter.remove()
+      }
+    }
+
+    def toArray(): Array[AnyRef] =
+      chm.keys().asInstanceOf[Enumeration[AnyRef]].toArray[AnyRef]
+
+    def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
+      val toFill: Array[T] =
+        if (a.size >= size) a
+        else jlr.Array.newInstance(a.getClass.getComponentType, size).asInstanceOf[Array[T]]
+
+      val iter = iterator
+      for (i <- 0 until size)
+        toFill(i) = iter.next().asInstanceOf[T]
+      if (toFill.size > size)
+        toFill(size) = null.asInstanceOf[T]
+      toFill
+    }
+
+    def add(e: K): Boolean =
+      throw new UnsupportedOperationException()
+
+    def remove(o: Any): Boolean = chm.remove(o) != null
+
+    def containsAll(c: Collection[_]): Boolean =
+      c.forall(item => chm.contains(item.asInstanceOf[K]))
+
+    def addAll(c: Collection[_ <: K]): Boolean =
+      throw new UnsupportedOperationException()
+
+    def removeAll(c: Collection[_]): Boolean =
+      removeWhere(c.contains(_))
+
+    def retainAll(c: Collection[_]): Boolean =
+      removeWhere(!c.contains(_))
+
+    def clear(): Unit = chm.clear()
+
+    private def removeWhere(p: Any => Boolean): Boolean = {
+      val iter = chm.entrySet.iterator
+      var changed = false
+      while (iter.hasNext) {
+        if (p(iter.next().getKey())) {
+          iter.remove()
+          changed = true
+        }
+      }
+      changed
+    }
+  }
+
+}

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentMap.scala
@@ -1,0 +1,10 @@
+package java.util.concurrent
+
+import java.util._
+
+trait ConcurrentMap[K, V] extends Map[K, V] {
+  def putIfAbsent(key: K, value: V): V
+  def remove(key: Any, value: Any): Boolean
+  def replace(key: K, oldValue: V, newValue: V): Boolean
+  def replace(key: K, value: V): V
+}

--- a/javalib/src/main/scala/java/util/package.scala
+++ b/javalib/src/main/scala/java/util/package.scala
@@ -1,0 +1,27 @@
+package java
+
+package object util {
+
+  implicit private[util] class CompareNullablesOps(val self: Any) extends AnyVal {
+    @inline
+    def ===(that: Any): Boolean =
+      if (self.asInstanceOf[AnyRef] eq null) that.asInstanceOf[AnyRef] eq null
+      else self.equals(that)
+  }
+
+  private[util] final case class Box[+K](inner: K) {
+    def apply(): K = inner
+
+    override def equals(o: Any): Boolean = {
+      o match {
+        case o: Box[_] => inner === o.inner
+        case _         => false
+      }
+    }
+
+    override def hashCode(): Int =
+      if (inner == null) 0
+      else inner.hashCode
+  }
+
+}

--- a/scalalib/overrides-2.10/scala/collection/JavaConversions.scala
+++ b/scalalib/overrides-2.10/scala/collection/JavaConversions.scala
@@ -1,0 +1,132 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://www.scala-lang.org/           **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.collection
+
+import java.{ lang => jl, util => ju }, java.util.{ concurrent => juc }
+import convert._
+
+/**   A collection of implicit conversions supporting interoperability between
+ *    Scala and Java collections.
+ *
+ *    The following conversions are supported:
+ *{{{
+ *    scala.collection.Iterable <=> java.lang.Iterable
+ *    scala.collection.Iterable <=> java.util.Collection
+ *    scala.collection.Iterator <=> java.util.{ Iterator, Enumeration }
+ *    scala.collection.mutable.Buffer <=> java.util.List
+ *    scala.collection.mutable.Set <=> java.util.Set
+ *    scala.collection.mutable.Map <=> java.util.{ Map, Dictionary }
+ *    scala.collection.mutable.ConcurrentMap (deprecated since 2.10) <=> java.util.concurrent.ConcurrentMap
+ *    scala.collection.concurrent.Map <=> java.util.concurrent.ConcurrentMap
+ *}}}
+ *    In all cases, converting from a source type to a target type and back
+ *    again will return the original source object, eg.
+ *
+ *{{{
+ *    import scala.collection.JavaConversions._
+ *
+ *    val sl = new scala.collection.mutable.ListBuffer[Int]
+ *    val jl : java.util.List[Int] = sl
+ *    val sl2 : scala.collection.mutable.Buffer[Int] = jl
+ *    assert(sl eq sl2)
+ *}}}
+ *  In addition, the following one way conversions are provided:
+ *
+ *{{{
+ *    scala.collection.Seq         => java.util.List
+ *    scala.collection.mutable.Seq => java.util.List
+ *    scala.collection.Set         => java.util.Set
+ *    scala.collection.Map         => java.util.Map
+ *    java.util.Properties         => scala.collection.mutable.Map[String, String]
+ *}}}
+ *
+ *  @author Miles Sabin
+ *  @author Martin Odersky
+ *  @since  2.8
+ */
+object JavaConversions extends WrapAsScala with WrapAsJava {
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type ConcurrentMapWrapper[A, B]  = Wrappers.ConcurrentMapWrapper[A, B]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type DictionaryWrapper[A, B]     = Wrappers.DictionaryWrapper[A, B]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type IterableWrapper[A]          = Wrappers.IterableWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type IteratorWrapper[A]          = Wrappers.IteratorWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JCollectionWrapper[A]       = Wrappers.JCollectionWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JConcurrentMapWrapper[A, B] = Wrappers.JConcurrentMapWrapper[A, B]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JDictionaryWrapper[A, B]    = Wrappers.JDictionaryWrapper[A, B]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JEnumerationWrapper[A]      = Wrappers.JEnumerationWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JIterableWrapper[A]         = Wrappers.JIterableWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JIteratorWrapper[A]         = Wrappers.JIteratorWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JListWrapper[A]             = Wrappers.JListWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JMapWrapper[A, B]           = Wrappers.JMapWrapper[A, B]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JPropertiesWrapper          = Wrappers.JPropertiesWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type JSetWrapper[A]              = Wrappers.JSetWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type MapWrapper[A, B]            = Wrappers.MapWrapper[A, B]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type MutableBufferWrapper[A]     = Wrappers.MutableBufferWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type MutableMapWrapper[A, B]     = Wrappers.MutableMapWrapper[A, B]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type MutableSeqWrapper[A]        = Wrappers.MutableSeqWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type MutableSetWrapper[A]        = Wrappers.MutableSetWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type SeqWrapper[A]               = Wrappers.SeqWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type SetWrapper[A]               = Wrappers.SetWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type ToIteratorWrapper[A]        = Wrappers.ToIteratorWrapper[A]
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val DictionaryWrapper            = Wrappers.DictionaryWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val IterableWrapper              = Wrappers.IterableWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val IteratorWrapper              = Wrappers.IteratorWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JCollectionWrapper           = Wrappers.JCollectionWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JConcurrentMapWrapper        = Wrappers.JConcurrentMapWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JDictionaryWrapper           = Wrappers.JDictionaryWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JEnumerationWrapper          = Wrappers.JEnumerationWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JIterableWrapper             = Wrappers.JIterableWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JIteratorWrapper             = Wrappers.JIteratorWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JListWrapper                 = Wrappers.JListWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JMapWrapper                  = Wrappers.JMapWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JPropertiesWrapper           = Wrappers.JPropertiesWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JSetWrapper                  = Wrappers.JSetWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val MutableBufferWrapper         = Wrappers.MutableBufferWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val MutableMapWrapper            = Wrappers.MutableMapWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val MutableSeqWrapper            = Wrappers.MutableSeqWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val MutableSetWrapper            = Wrappers.MutableSetWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val SeqWrapper                   = Wrappers.SeqWrapper
+
+  // Note to implementors: the cavalcade of deprecated methods herein should
+  // serve as a warning to any who follow: don't overload implicit methods.
+
+  @deprecated("use bufferAsJavaList instead", "2.9.0")
+  def asJavaList[A](b : mutable.Buffer[A]): ju.List[A] = bufferAsJavaList[A](b)
+
+  @deprecated("use mutableSeqAsJavaList instead", "2.9.0")
+  def asJavaList[A](b : mutable.Seq[A]): ju.List[A] = mutableSeqAsJavaList[A](b)
+
+  @deprecated("use seqAsJavaList instead", "2.9.0")
+  def asJavaList[A](b : Seq[A]): ju.List[A] = seqAsJavaList[A](b)
+
+  @deprecated("use mutableSetAsJavaSet instead", "2.9.0")
+  def asJavaSet[A](s : mutable.Set[A]): ju.Set[A] = mutableSetAsJavaSet[A](s)
+
+  @deprecated("use setAsJavaSet instead", "2.9.0")
+  def asJavaSet[A](s: Set[A]): ju.Set[A] = setAsJavaSet[A](s)
+
+  @deprecated("use mutableMapAsJavaMap instead", "2.9.0")
+  def asJavaMap[A, B](m : mutable.Map[A, B]): ju.Map[A, B] = mutableMapAsJavaMap[A, B](m)
+
+  @deprecated("use mapAsJavaMap instead", "2.9.0")
+  def asJavaMap[A, B](m : Map[A, B]): ju.Map[A, B] = mapAsJavaMap[A, B](m)
+
+  @deprecated("use iterableAsScalaIterable instead", "2.9.0")
+  def asScalaIterable[A](i : jl.Iterable[A]): Iterable[A] = iterableAsScalaIterable[A](i)
+
+  @deprecated("use collectionAsScalaIterable instead", "2.9.0")
+  def asScalaIterable[A](i : ju.Collection[A]): Iterable[A] = collectionAsScalaIterable[A](i)
+
+  @deprecated("use mapAsScalaMap instead", "2.9.0")
+  def asScalaMap[A, B](m: ju.Map[A, B]): mutable.Map[A, B] = mapAsScalaMap[A, B](m)
+
+  @deprecated("use propertiesAsScalaMap instead", "2.9.0")
+  def asScalaMap(p: ju.Properties): mutable.Map[String, String] = propertiesAsScalaMap(p)
+}
+
+

--- a/scalalib/overrides-2.10/scala/collection/JavaConversions.scala
+++ b/scalalib/overrides-2.10/scala/collection/JavaConversions.scala
@@ -73,24 +73,24 @@ object JavaConversions extends WrapAsScala with WrapAsJava {
   @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type SeqWrapper[A]               = Wrappers.SeqWrapper[A]
   @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type SetWrapper[A]               = Wrappers.SetWrapper[A]
   @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") type ToIteratorWrapper[A]        = Wrappers.ToIteratorWrapper[A]
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val DictionaryWrapper            = Wrappers.DictionaryWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val IterableWrapper              = Wrappers.IterableWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val IteratorWrapper              = Wrappers.IteratorWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JCollectionWrapper           = Wrappers.JCollectionWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JConcurrentMapWrapper        = Wrappers.JConcurrentMapWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JDictionaryWrapper           = Wrappers.JDictionaryWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JEnumerationWrapper          = Wrappers.JEnumerationWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JIterableWrapper             = Wrappers.JIterableWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JIteratorWrapper             = Wrappers.JIteratorWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JListWrapper                 = Wrappers.JListWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JMapWrapper                  = Wrappers.JMapWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JPropertiesWrapper           = Wrappers.JPropertiesWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val JSetWrapper                  = Wrappers.JSetWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val MutableBufferWrapper         = Wrappers.MutableBufferWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val MutableMapWrapper            = Wrappers.MutableMapWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val MutableSeqWrapper            = Wrappers.MutableSeqWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val MutableSetWrapper            = Wrappers.MutableSetWrapper
-  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") val SeqWrapper                   = Wrappers.SeqWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def DictionaryWrapper            = Wrappers.DictionaryWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def IterableWrapper              = Wrappers.IterableWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def IteratorWrapper              = Wrappers.IteratorWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JCollectionWrapper           = Wrappers.JCollectionWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JConcurrentMapWrapper        = Wrappers.JConcurrentMapWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JDictionaryWrapper           = Wrappers.JDictionaryWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JEnumerationWrapper          = Wrappers.JEnumerationWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JIterableWrapper             = Wrappers.JIterableWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JIteratorWrapper             = Wrappers.JIteratorWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JListWrapper                 = Wrappers.JListWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JMapWrapper                  = Wrappers.JMapWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JPropertiesWrapper           = Wrappers.JPropertiesWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def JSetWrapper                  = Wrappers.JSetWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def MutableBufferWrapper         = Wrappers.MutableBufferWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def MutableMapWrapper            = Wrappers.MutableMapWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def MutableSeqWrapper            = Wrappers.MutableSeqWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def MutableSetWrapper            = Wrappers.MutableSetWrapper
+  @deprecated("Use a member of scala.collection.convert.Wrappers", "2.10.0") def SeqWrapper                   = Wrappers.SeqWrapper
 
   // Note to implementors: the cavalcade of deprecated methods herein should
   // serve as a warning to any who follow: don't overload implicit methods.

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/ConcurrentHashMapTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/ConcurrentHashMapTest.scala
@@ -1,0 +1,595 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.javalib
+
+import scala.language.implicitConversions
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+import org.scalajs.jasminetest.JasmineTest
+
+import java.util.AbstractMap
+import java.util.concurrent.ConcurrentHashMap
+
+object ConcurrentHashMapTest extends JasmineTest {
+
+  describe("java.util.concurrent.ConcurrentHashMap") {
+
+    def expectNullPointerException(f: => Unit): Unit = {
+      expect({
+        try {
+          f
+          false
+        } catch {
+          case err: NullPointerException => true
+        }
+      }).toBeTruthy
+    }
+
+    it("should store strings") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      expect(chm.size()).toEqual(0)
+      chm.put("ONE", "one")
+      expect(chm.size()).toEqual(1)
+      expect(chm.get("ONE")).toEqual("one")
+      chm.put("TWO", "two")
+      expect(chm.size()).toEqual(2)
+      expect(chm.get("TWO")).toEqual("two")
+    }
+
+    it("should store integers") {
+      val chm = new ConcurrentHashMap[Int, Int]()
+
+      chm.put(100, 12345)
+      expect(chm.size()).toEqual(1)
+      val one = chm.get(100)
+      expect(one).toEqual(12345)
+    }
+
+    it("should store doubles also in corner cases") {
+      val chm = new ConcurrentHashMap[Double, Double]()
+
+      chm.put(1.2345, 11111.0)
+      expect(chm.size()).toEqual(1)
+      val one = chm.get(1.2345)
+      expect(one).toEqual(11111.0)
+
+      chm.put(Double.NaN, 22222.0)
+      expect(chm.size()).toEqual(2)
+      val two = chm.get(Double.NaN)
+      expect(two).toEqual(22222.0)
+
+      chm.put(+0.0, 33333.0)
+      expect(chm.size()).toEqual(3)
+      val three = chm.get(+0.0)
+      expect(three).toEqual(33333.0)
+
+      chm.put(-0.0, 44444.0)
+      expect(chm.size()).toEqual(4)
+      val four = chm.get(-0.0)
+      expect(four).toEqual(44444.0)
+    }
+
+    it("should store custom objects") {
+      case class TestObj(num: Int)
+
+      val chm = new ConcurrentHashMap[TestObj, TestObj]()
+
+      chm.put(TestObj(100), TestObj(12345))
+      expect(chm.size()).toEqual(1)
+      val one = chm.get(TestObj(100))
+      expect(one.num).toEqual(12345)
+    }
+
+    it("should remove stored elements") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      expect(chm.size()).toEqual(1)
+      expect(chm.remove("ONE")).toEqual("one")
+      val newOne = chm.get("ONE")
+      expect(chm.get("ONE")).toBeNull
+    }
+
+    it("should remove stored elements on double corner cases") {
+      val chm = new ConcurrentHashMap[Double, String]()
+
+      chm.put(1.2345, "11111.0")
+      chm.put(Double.NaN, "22222.0")
+      chm.put(+0.0, "33333.0")
+      chm.put(-0.0, "44444.0")
+
+      expect(chm.get(1.2345)).toEqual("11111.0")
+      expect(chm.get(Double.NaN)).toEqual("22222.0")
+      expect(chm.get(+0.0)).toEqual("33333.0")
+      expect(chm.get(-0.0)).toEqual("44444.0")
+
+      expect(chm.remove(-0.0)).toEqual("44444.0")
+      expect(chm.get(-0.0)).toBeNull
+
+      chm.put(-0.0, "55555.0")
+
+      expect(chm.remove(+0.0)).toEqual("33333.0")
+      expect(chm.get(+0.0)).toBeNull
+
+      chm.put(+0.0, "66666.0")
+
+      expect(chm.remove(Double.NaN)).toEqual("22222.0")
+      expect(chm.get(Double.NaN)).toBeNull
+
+      chm.put(Double.NaN, "77777.0")
+
+      chm.clear()
+
+      expect(chm.isEmpty).toBeTruthy
+    }
+
+    it("should not put null keys or null values") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      expectNullPointerException(chm.put(null, "one"))
+      expectNullPointerException(chm.put("ONE", null))
+      expectNullPointerException(chm.put(null, null))
+    }
+
+    it("should be cleared with one operation") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+      expect(chm.size()).toEqual(2)
+      chm.clear()
+      expect(chm.size()).toEqual(0)
+    }
+
+    it("should check contained key presence") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      expect(chm.containsKey("ONE")).toBeTruthy
+      expect(chm.containsKey("TWO")).toBeFalsy
+      expect(chm.containsKey(null)).toBeFalsy
+    }
+
+    it("should check contained value presence") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      expect(chm.containsValue("one")).toBeTruthy
+      expect(chm.containsValue("two")).toBeFalsy
+      expect(chm.containsValue(null)).toBeFalsy
+    }
+
+    it("should give proper Enumerator over elements") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      val elements = chm.elements
+      expect(elements.hasNext).toBeTruthy
+      expect(elements.nextElement).toEqual("one")
+      expect(elements.hasNext).toBeFalsy
+    }
+
+    it("should give proper Collection over values") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      val values = chm.values
+      expect(values.size).toEqual(1)
+      val iter = values.iterator
+      expect(iter.hasNext).toBeTruthy
+      expect(iter.next).toEqual("one")
+      expect(iter.hasNext).toBeFalsy
+    }
+
+    it("should give proper EntrySet over key values pairs") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      val entrySet = chm.entrySet
+
+      expect(entrySet.size).toEqual(1)
+
+      val iter = entrySet.iterator
+      expect(iter.hasNext).toBeTruthy
+      val next = iter.next
+      expect(iter.hasNext).toBeFalsy
+      expect(next.getKey).toEqual("ONE")
+      expect(next.getValue).toEqual("one")
+    }
+
+    it("should give proper KeySet over keys") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      val keySet = chm.keySet
+
+      expect(keySet.size).toEqual(1)
+
+      val iter = keySet.iterator
+      expect(iter.hasNext).toBeTruthy
+      expect(iter.next).toEqual("ONE")
+      expect(iter.hasNext).toBeFalsy
+    }
+
+    it("should put a whole map into") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      val m = mutable.Map[String, String](
+          "X" -> "y")
+      chm.putAll(mutableMapAsJavaMap(m))
+      expect(chm.size).toEqual(1)
+      expect(chm.get("X")).toEqual("y")
+
+      val nullMap = mutable.Map[String, String](
+          (null: String) -> "y",
+          "X" -> "y")
+
+      expectNullPointerException(chm.putAll(mutableMapAsJavaMap(nullMap)))
+    }
+
+    it("should replace contained items") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      expect(chm.replace("ONE", "two")).toEqual("one")
+      expectNullPointerException(chm.replace("ONE", null))
+      expectNullPointerException(chm.replace(null, "one"))
+      expect(chm.get("ONE")).toEqual("two")
+
+      expect(chm.replace("ONE", "one", "two")).toBeFalsy
+      expectNullPointerException(chm.replace(null, "two", "one"))
+      expectNullPointerException(chm.replace("ONE", null, "one"))
+      expectNullPointerException(chm.replace("ONE", "two", null))
+
+      expect(chm.replace("ONE", "two", "one")).toBeTruthy
+      expect(chm.get("ONE")).toEqual("one")
+    }
+
+  }
+
+  case class SimpleQuerableMap[K, V](inner: mutable.HashMap[K, V])
+      extends AbstractMap[K, V] {
+    def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
+      setAsJavaSet(inner.map {
+        case (k, v) => new AbstractMap.SimpleImmutableEntry(k, v)
+      }.toSet)
+    }
+  }
+
+  describe("java.util.AbstractMap.values") {
+
+    it("should mirror the related map size") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+
+      val values = chm.values
+      expect(values.size).toEqual(2)
+
+      chm.put("THREE", "three")
+
+      expect(values.size).toEqual(3)
+
+      chm.remove("ONE")
+
+      expect(values.size).toEqual(2)
+
+      expect(values.isEmpty).toBeFalsy
+
+      chm.clear()
+
+      expect(values.size).toEqual(0)
+
+      expect(values.isEmpty).toBeTruthy
+
+      val hm1 = mutable.HashMap(
+        "ONE" -> "one",
+        "TWO" -> "two")
+      val hm2 = mutable.HashMap(
+        "ONE" -> null,
+        "TWO" -> "two")
+      val hm3 = mutable.HashMap(
+        (null: String) -> "one",
+        "TWO" -> "two")
+      val hm4 = mutable.HashMap(
+        (null: String) -> null,
+        "TWO" -> "two")
+
+      expect(SimpleQuerableMap(hm1).values.size).toEqual(2)
+      expect(SimpleQuerableMap(hm2).values.size).toEqual(2)
+      expect(SimpleQuerableMap(hm3).values.size).toEqual(2)
+      expect(SimpleQuerableMap(hm4).values.size).toEqual(2)
+    }
+
+    it("should check single and multiple objects presence") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+
+      val values = chm.values
+      expect(values.contains("one")).toBeTruthy
+      expect(values.contains("two")).toBeTruthy
+      expect(values.contains("three")).toBeFalsy
+      expect(values.contains(null)).toBeFalsy
+
+      chm.put("THREE", "three")
+
+      expect(values.contains("three")).toBeTruthy
+
+      val coll1 = asJavaCollection(Set("one", "two", "three"))
+      expect(values.containsAll(coll1)).toBeTruthy
+
+      val coll2 = asJavaCollection(Set("one", "two", "three", "four"))
+      expect(values.containsAll(coll2)).toBeFalsy
+
+      val coll3 = asJavaCollection(Set("one", "two", "three", null))
+      expect(values.containsAll(coll2)).toBeFalsy
+
+      val numChm = new ConcurrentHashMap[Double, Double]()
+
+      val numValues = numChm.values
+      numChm.put(1, +0.0)
+      expect(numValues.contains(+0.0)).toBeTruthy
+      expect(numValues.contains(-0.0)).toBeFalsy
+      expect(numValues.contains(Double.NaN)).toBeFalsy
+
+      numChm.put(2, -0.0)
+      expect(numValues.contains(+0.0)).toBeTruthy
+      expect(numValues.contains(-0.0)).toBeTruthy
+      expect(numValues.contains(Double.NaN)).toBeFalsy
+
+      numChm.put(3, Double.NaN)
+      expect(numValues.contains(+0.0)).toBeTruthy
+      expect(numValues.contains(-0.0)).toBeTruthy
+      expect(numValues.contains(Double.NaN)).toBeTruthy
+
+      val hm1 = mutable.HashMap(
+        1.0 -> null,
+        2.0 -> 2.0)
+      val hm2 = mutable.HashMap(
+        (null: Any) -> 1.0,
+        2.0 -> 2.0)
+      val hm3 = mutable.HashMap(
+        (null: Any) -> null,
+        2.0 -> 2.0)
+
+      expect(SimpleQuerableMap(hm1).values.contains(1.0)).toBeFalsy
+      expect(SimpleQuerableMap(hm2).values.contains(1.0)).toBeTruthy
+      expect(SimpleQuerableMap(hm3).values.contains(1.0)).toBeFalsy
+
+      expect(SimpleQuerableMap(hm1).values.contains(null)).toBeTruthy
+      expect(SimpleQuerableMap(hm2).values.contains(null)).toBeFalsy
+      expect(SimpleQuerableMap(hm3).values.contains(null)).toBeTruthy
+    }
+
+    it("should side effect clear/remove/retain on the related map") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+
+      val values = chm.values
+      expect(values.isEmpty).toBeFalsy
+      expect(chm.isEmpty).toBeFalsy
+
+      values.clear()
+
+      expect(values.isEmpty).toBeTruthy
+      expect(chm.isEmpty).toBeTruthy
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+
+      expect(chm.containsKey("ONE")).toBeTruthy
+
+      values.remove("one")
+
+      expect(chm.containsKey("ONE")).toBeFalsy
+
+      chm.put("ONE", "one")
+      chm.put("THREE", "three")
+
+      expect(chm.containsKey("ONE")).toBeTruthy
+      expect(chm.containsKey("TWO")).toBeTruthy
+      expect(chm.containsKey("THREE")).toBeTruthy
+
+      values.removeAll(asJavaCollection(List("one", "two")))
+
+      expect(chm.containsKey("ONE")).toBeFalsy
+      expect(chm.containsKey("TWO")).toBeFalsy
+      expect(chm.containsKey("THREE")).toBeTruthy
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+      chm.put("THREE", "three")
+
+      expect(chm.containsKey("ONE")).toBeTruthy
+      expect(chm.containsKey("TWO")).toBeTruthy
+      expect(chm.containsKey("THREE")).toBeTruthy
+
+      values.retainAll(asJavaCollection(List("one", "two")))
+
+      expect(chm.containsKey("ONE")).toBeTruthy
+      expect(chm.containsKey("TWO")).toBeTruthy
+      expect(chm.containsKey("THREE")).toBeFalsy
+    }
+
+  }
+
+  describe("java.util.AbstractMap.keySet") {
+
+    it("should mirror the related map size") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+
+      val keySet = chm.keySet
+      expect(keySet.size).toEqual(2)
+
+      chm.put("THREE", "three")
+
+      expect(keySet.size).toEqual(3)
+
+      chm.remove("ONE")
+
+      expect(keySet.size).toEqual(2)
+
+      expect(keySet.isEmpty).toBeFalsy
+
+      chm.clear()
+
+      expect(keySet.size).toEqual(0)
+
+      expect(keySet.isEmpty).toBeTruthy
+
+      val hm1 = mutable.HashMap(
+        "ONE" -> "one",
+        "TWO" -> "two")
+      val hm2 = mutable.HashMap(
+        "ONE" -> null,
+        "TWO" -> "two")
+      val hm3 = mutable.HashMap(
+        (null: String) -> "one",
+        "TWO" -> "two")
+      val hm4 = mutable.HashMap(
+        (null: String) -> null,
+        "TWO" -> "two")
+
+      expect(SimpleQuerableMap(hm1).keySet.size).toEqual(2)
+      expect(SimpleQuerableMap(hm2).keySet.size).toEqual(2)
+      expect(SimpleQuerableMap(hm3).keySet.size).toEqual(2)
+      expect(SimpleQuerableMap(hm4).keySet.size).toEqual(2)
+    }
+
+    it("should check single and multiple objects presence") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+
+      val keySet = chm.keySet
+      expect(keySet.contains("ONE")).toBeTruthy
+      expect(keySet.contains("TWO")).toBeTruthy
+      expect(keySet.contains("THREE")).toBeFalsy
+      expect(keySet.contains(null)).toBeFalsy
+
+      chm.put("THREE", "three")
+
+      expect(keySet.contains("THREE")).toBeTruthy
+
+      val coll1 =
+          asJavaCollection(Set("ONE", "TWO", "THREE"))
+      expect(keySet.containsAll(coll1)).toBeTruthy
+
+      val coll2 =
+          asJavaCollection(Set("ONE", "TWO", "THREE", "FOUR"))
+      expect(keySet.containsAll(coll2)).toBeFalsy
+
+      val coll3 =
+          asJavaCollection(Set("ONE", "TWO", "THREE", null))
+      expect(keySet.containsAll(coll2)).toBeFalsy
+
+      val numChm = new ConcurrentHashMap[Double, Double]()
+
+      val numkeySet = numChm.keySet
+      numChm.put(+0.0, 1)
+      expect(numkeySet.contains(+0.0)).toBeTruthy
+      expect(numkeySet.contains(-0.0)).toBeFalsy
+      expect(numkeySet.contains(Double.NaN)).toBeFalsy
+
+      numChm.put(-0.0, 2)
+      expect(numkeySet.contains(+0.0)).toBeTruthy
+      expect(numkeySet.contains(-0.0)).toBeTruthy
+      expect(numkeySet.contains(Double.NaN)).toBeFalsy
+
+      numChm.put(Double.NaN, 3)
+      expect(numkeySet.contains(+0.0)).toBeTruthy
+      expect(numkeySet.contains(-0.0)).toBeTruthy
+      expect(numkeySet.contains(Double.NaN)).toBeTruthy
+
+      val hm1 = mutable.HashMap(
+        1.0 -> null,
+        2.0 -> 2.0)
+      val hm2 = mutable.HashMap(
+        (null: Any) -> 1.0,
+        2.0 -> 2.0)
+      val hm3 = mutable.HashMap(
+        (null: Any) -> null,
+        2.0 -> 2.0)
+
+      expect(SimpleQuerableMap(hm1).keySet.contains(1.0)).toBeTruthy
+      expect(SimpleQuerableMap(hm2).keySet.contains(1.0)).toBeFalsy
+      expect(SimpleQuerableMap(hm3).keySet.contains(1.0)).toBeFalsy
+
+      expect(SimpleQuerableMap(hm1).keySet.contains(null)).toBeFalsy
+      expect(SimpleQuerableMap(hm2).keySet.contains(null)).toBeTruthy
+      expect(SimpleQuerableMap(hm3).keySet.contains(null)).toBeTruthy
+    }
+
+    it("should side effect clear/remove/retain on the related map") {
+      val chm = new ConcurrentHashMap[String, String]()
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+
+      val keySet = chm.keySet
+      expect(keySet.isEmpty).toBeFalsy
+      expect(chm.isEmpty).toBeFalsy
+
+      keySet.clear()
+
+      expect(keySet.isEmpty).toBeTruthy
+
+      expect(chm.isEmpty).toBeTruthy
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+
+      expect(chm.containsKey("ONE")).toBeTruthy
+
+      keySet.remove("ONE")
+
+      expect(chm.containsKey("ONE")).toBeFalsy
+
+      chm.put("ONE", "one")
+      chm.put("THREE", "three")
+
+      expect(chm.containsKey("ONE")).toBeTruthy
+      expect(chm.containsKey("TWO")).toBeTruthy
+      expect(chm.containsKey("THREE")).toBeTruthy
+
+      keySet.removeAll(asJavaCollection(List("ONE", "TWO")))
+
+      expect(chm.containsKey("ONE")).toBeFalsy
+      expect(chm.containsKey("TWO")).toBeFalsy
+      expect(chm.containsKey("THREE")).toBeTruthy
+
+      chm.put("ONE", "one")
+      chm.put("TWO", "two")
+      chm.put("THREE", "three")
+
+      expect(chm.containsKey("ONE")).toBeTruthy
+      expect(chm.containsKey("TWO")).toBeTruthy
+      expect(chm.containsKey("THREE")).toBeTruthy
+
+      keySet.retainAll(asJavaCollection(List("ONE", "TWO")))
+
+      expect(chm.containsKey("ONE")).toBeTruthy
+      expect(chm.containsKey("TWO")).toBeTruthy
+      expect(chm.containsKey("THREE")).toBeFalsy
+    }
+
+  }
+
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/HashSetTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/HashSetTest.scala
@@ -1,0 +1,239 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.javalib
+
+import scala.language.implicitConversions
+
+import scala.collection.JavaConversions._
+import scala.collection.mutable
+
+import org.scalajs.jasminetest.JasmineTest
+
+import java.util.{HashSet, LinkedHashSet}
+
+object HashSetTest extends JasmineTest {
+
+  trait HashSetGen {
+    def apply[T](): HashSet[T]
+  }
+
+  def genHashSetTests(newHashSet: HashSetGen): Unit = {
+    it("should check hashSet size") {
+      val hs = newHashSet[String]()
+
+      expect(hs.size()).toEqual(0)
+      expect(hs.add("ONE")).toBeTruthy
+      expect(hs.size()).toEqual(1)
+      expect(hs.add("TWO")).toBeTruthy
+      expect(hs.size()).toEqual(2)
+    }
+
+    it("should store integers") {
+      val hs = newHashSet[Int]()
+
+      expect(hs.add(100)).toBeTruthy
+      expect(hs.size()).toEqual(1)
+      expect(hs.contains(100)).toBeTruthy
+      expect(hs.iterator.next()).toEqual(100)
+    }
+
+    it("should store objects with same HashCode but different types") {
+      val hs = newHashSet[Any]()
+
+      expect(hs.add(true)).toBeTruthy
+      expect(hs.add(1231)).toBeTruthy
+      expect(hs.size()).toEqual(2)
+    }
+
+    it("should store doubles also in corner cases") {
+      val hs = newHashSet[Double]()
+
+      expect(hs.add(11111.0)).toBeTruthy
+      expect(hs.size()).toEqual(1)
+      expect(hs.contains(11111.0)).toBeTruthy
+      expect(hs.iterator.next()).toEqual(11111.0)
+
+      expect(hs.add(Double.NaN)).toBeTruthy
+      expect(hs.size()).toEqual(2)
+      expect(hs.contains(Double.NaN)).toBeTruthy
+      expect(hs.contains(+0.0)).toBeFalsy
+      expect(hs.contains(-0.0)).toBeFalsy
+
+      expect(hs.remove(Double.NaN)).toBeTruthy
+      expect(hs.add(+0.0)).toBeTruthy
+      expect(hs.size()).toEqual(2)
+      expect(hs.contains(Double.NaN)).toBeFalsy
+      expect(hs.contains(+0.0)).toBeTruthy
+      expect(hs.contains(-0.0)).toBeFalsy
+
+      expect(hs.remove(+0.0)).toBeTruthy
+      expect(hs.add(-0.0)).toBeTruthy
+      expect(hs.size()).toEqual(2)
+      expect(hs.contains(Double.NaN)).toBeFalsy
+      expect(hs.contains(+0.0)).toBeFalsy
+      expect(hs.contains(-0.0)).toBeTruthy
+
+      expect(hs.add(+0.0)).toBeTruthy
+      expect(hs.add(Double.NaN)).toBeTruthy
+      expect(hs.contains(Double.NaN)).toBeTruthy
+      expect(hs.contains(+0.0)).toBeTruthy
+      expect(hs.contains(-0.0)).toBeTruthy
+    }
+
+    it("should store custom objects") {
+      case class TestObj(num: Int)
+
+      val hs = newHashSet[TestObj]()
+
+      expect(hs.add(TestObj(100))).toBeTruthy
+      expect(hs.size()).toEqual(1)
+      expect(hs.contains(TestObj(100))).toBeTruthy
+      expect(hs.iterator.next().num).toEqual(100)
+    }
+
+    it("should remove stored elements") {
+      val hs = newHashSet[String]()
+
+      expect(hs.size()).toEqual(0)
+      expect(hs.add("ONE")).toBeTruthy
+      expect(hs.add("ONE")).toBeFalsy
+      expect(hs.size()).toEqual(1)
+      expect(hs.add("TWO")).toBeTruthy
+      expect(hs.size()).toEqual(2)
+      expect(hs.remove("ONE")).toBeTruthy
+      expect(hs.remove("ONE")).toBeFalsy
+      expect(hs.size()).toEqual(1)
+      expect(hs.remove("TWO")).toBeTruthy
+      expect(hs.size()).toEqual(0)
+
+      expect(hs.add("ONE")).toBeTruthy
+      expect(hs.add("TWO")).toBeTruthy
+      expect(hs.size()).toEqual(2)
+      val l1 = List[String]("ONE", "TWO")
+      expect(hs.removeAll(asJavaCollection(l1))).toBeTruthy
+      expect(hs.size()).toEqual(0)
+
+      expect(hs.add("ONE")).toBeTruthy
+      expect(hs.add("TWO")).toBeTruthy
+      expect(hs.size()).toEqual(2)
+      val l2 = List[String]("ONE", "THREE")
+      expect(hs.retainAll(asJavaCollection(l2))).toBeTruthy
+      expect(hs.size()).toEqual(1)
+      expect(hs.contains("ONE")).toBeTruthy
+      expect(hs.contains("TWO")).toBeFalsy
+    }
+
+    it("should be cleared with one operation") {
+      val hs = newHashSet[String]()
+
+      expect(hs.add("ONE")).toBeTruthy
+      expect(hs.add("TWO")).toBeTruthy
+      expect(hs.size()).toEqual(2)
+
+      hs.clear()
+      expect(hs.size()).toEqual(0)
+      expect(hs.isEmpty).toBeTruthy
+    }
+
+    it("should check contained elems presence") {
+      val hs = newHashSet[String]()
+
+      expect(hs.add("ONE")).toBeTruthy
+      expect(hs.contains("ONE")).toBeTruthy
+      expect(hs.contains("TWO")).toBeFalsy
+      expect(hs.contains(null)).toBeFalsy
+      expect(hs.add(null)).toBeTruthy
+      expect(hs.contains(null)).toBeTruthy
+    }
+
+    it("should put a whole Collection into") {
+      val hs = newHashSet[String]()
+
+      val l = List[String]("ONE", "TWO", (null: String))
+      expect(hs.addAll(asJavaCollection(l))).toBeTruthy
+      expect(hs.size).toEqual(3)
+      expect(hs.contains("ONE")).toBeTruthy
+      expect(hs.contains("TWO")).toBeTruthy
+      expect(hs.contains(null)).toBeTruthy
+    }
+
+    it("should iterate over elements") {
+      val hs = newHashSet[String]()
+
+      val l = List[String]("ONE", "TWO", (null: String))
+      expect(hs.addAll(asJavaCollection(l))).toBeTruthy
+      expect(hs.size).toEqual(3)
+
+      val iter = hs.iterator()
+      val result = {
+        for {
+          i <- 0 until 3
+        } yield {
+          expect(iter.hasNext()).toBeTruthy
+          iter.next()
+        }
+      }
+      expect(iter.hasNext()).toBeFalsy
+      expect(result.containsAll(l)).toBeTruthy
+      expect(l.containsAll(result)).toBeTruthy
+    }
+
+  }
+
+  describe("java.util.HashSet") {
+    genHashSetTests(new HashSetGen {
+      def apply[T]() = new HashSet[T]()
+    })
+  }
+
+  describe("java.util.LinkedHashSet") {
+
+    genHashSetTests(new HashSetGen {
+      def apply[T]() = new LinkedHashSet[T]()
+    })
+
+    it("should iterate over elements in an ordered manner") {
+      val hs = new LinkedHashSet[String]()
+
+      val l1 = List[String]("ONE", "TWO", (null: String))
+      expect(hs.addAll(asJavaCollection(l1))).toBeTruthy
+      expect(hs.size).toEqual(3)
+
+      val iter1 = hs.iterator()
+      val result1 = {
+        for {
+          i <- 0 until 3
+        } yield {
+          expect(iter1.hasNext()).toBeTruthy
+          val value = iter1.next()
+          expect(value).toEqual(l1(i))
+        }
+      }
+      expect(iter1.hasNext()).toBeFalsy
+      expect(result1.equals(l1))
+
+      val l2 = l1 :+ "THREE"
+      expect(hs.add(l2(3))).toBeTruthy
+
+      val iter2 = hs.iterator()
+      val result2 = {
+        for {
+          i <- 0 until 4
+        } yield {
+          expect(iter2.hasNext()).toBeTruthy
+          val value = iter2.next()
+          expect(value).toEqual(l2(i))
+        }
+      }
+      expect(iter2.hasNext()).toBeFalsy
+      expect(result2.equals(l2))
+    }
+
+  }
+
+}


### PR DESCRIPTION
This is an implementation of ConcurrentHashMap in java.util.concurrent.
To keep it working nicely I had to stub a bit of the java.util.Collection related interfaces, please consider them just a stub to let scala.collection.JavaConversions works, I will ask for some discussion and/or review about the actual implementation.

Another issue is about the keySet method, unfortunately, the signature of this method changed in Java 8, I wait for suggestions on how to manage that.