### PR TITLE
Fix #1625: Add warnings when js.Dynamic.literal has duplicate keys.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSDynamicLiteralTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSDynamicLiteralTest.scala
@@ -99,4 +99,135 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
 
   }
 
+  @Test
+  def keyDuplicationWarning = {
+
+    // detects duplicate named keys
+    expr"""
+    lit(a = "1", b = "2", a = "3")
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "a" defined 2 times. Only the last occurrence is assigned.
+      |    lit(a = "1", b = "2", a = "3")
+      |       ^
+    """
+
+    // detects duplicate named keys (check the arrow indentation)
+    expr"""
+    lit(aaa = "1", b = "2", aaa = "3")
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "aaa" defined 2 times. Only the last occurrence is assigned.
+      |    lit(aaa = "1", b = "2", aaa = "3")
+      |       ^
+    """
+
+    // detects duplicate named keys (check the arrow indentation)
+    expr"""
+    lit(aaa = "1",
+        bb = "2",
+        bb = "3")
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "bb" defined 2 times. Only the last occurrence is assigned.
+      |    lit(aaa = "1",
+      |       ^
+    """
+
+    // detects duplicate named keys (check the arrow indentation)
+    expr"""
+    lit(aaa = "1",
+        b = "2",
+        aaa = "3")
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "aaa" defined 2 times. Only the last occurrence is assigned.
+      |    lit(aaa = "1",
+      |       ^
+    """
+
+    // detects triplicated named keys
+    expr"""
+    lit(a = "1", a = "2", a = "3")
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "a" defined 3 times. Only the last occurrence is assigned.
+      |    lit(a = "1", a = "2", a = "3")
+      |       ^
+    """
+
+    // detects two different duplicates named keys
+    expr"""
+    lit(a = "1", b = "2", a = "3", b = "4", c = "5", c = "6", c = "7")
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "a" defined 2 times, "b" defined 2 times, "c" defined 3 times. Only the last occurrence is assigned.
+      |    lit(a = "1", b = "2", a = "3", b = "4", c = "5", c = "6", c = "7")
+      |       ^
+    """
+
+    // detects duplicate keys when represented with arrows
+    expr"""
+    lit("a" -> "1", "b" -> "2", "a" -> "3")
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "a" defined 2 times. Only the last occurrence is assigned.
+      |    lit("a" -> "1", "b" -> "2", "a" -> "3")
+      |       ^
+    """
+
+    // detects duplicate keys when represented with tuples
+    expr"""
+    lit(("a", "1"), ("b", "2"), ("a", "3"))
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "a" defined 2 times. Only the last occurrence is assigned.
+      |    lit(("a", "1"), ("b", "2"), ("a", "3"))
+      |       ^
+    """
+
+    // detects duplicate keys when represented with mixed tuples and arrows
+    expr"""
+    lit("a" -> "1", ("b", "2"), ("a", "3"))
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Duplicate keys in object literal: "a" defined 2 times. Only the last occurrence is assigned.
+      |    lit("a" -> "1", ("b", "2"), ("a", "3"))
+      |       ^
+    """
+
+    // should not warn if the key is not literal
+    expr"""
+    val a = "x"
+    lit("a" -> "1", a -> "2", a -> "3")
+    """ hasWarns
+    """
+    """
+
+    // should not warn if the key/value pairs are not literal
+    """
+    class A {
+      val tup = "x" -> lit()
+      def foo = lit(tup, tup)
+    }
+    """ hasWarns
+    """
+    """
+
+    // should warn only for the literal keys when in
+    // the presence of non literal keys
+    """
+    class A {
+      val b = "b"
+      val tup = b -> lit()
+      lit("a" -> "2", tup, ("a", "3"), b -> "5", tup, b -> "6")
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:6: warning: Duplicate keys in object literal: "a" defined 2 times. Only the last occurrence is assigned.
+      |      lit("a" -> "2", tup, ("a", "3"), b -> "5", tup, b -> "6")
+      |         ^
+    """
+  }
+
 }


### PR DESCRIPTION
Check for every duplicate keys in

    js.Dynamic.literal(name1 = arg1, name2 = arg2, ...)

and emits a warning if one is found.

Check for every explicit duplicate key in

    js.Dynamic.literal(tup_1, tup_2, ...)

where tup_i is in the form (key, value) or key->value and key is a String literal.