### PR TITLE
Fix #1643: Fix handling of negative integers in String.lastIndexOf.

### DIFF
--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
@@ -160,7 +160,8 @@ private[runtime] object RuntimeString {
     thiz.lastIndexOf(fromCodePoint(ch))
 
   def lastIndexOf(thiz: String, ch: Int, fromIndex: Int): Int =
-    thiz.lastIndexOf(fromCodePoint(ch), fromIndex)
+    if (fromIndex < 0) -1
+    else thiz.lastIndexOf(fromCodePoint(ch), fromIndex)
 
   @inline
   def lastIndexOf(thiz: String, str: String): Int =
@@ -168,7 +169,8 @@ private[runtime] object RuntimeString {
 
   @inline
   def lastIndexOf(thiz: String, str: String, fromIndex: Int): Int =
-    thiz.jsLastIndexOf(str, fromIndex)
+    if (fromIndex < 0) -1
+    else thiz.jsLastIndexOf(str, fromIndex)
 
   @inline
   def length(thiz: String): Int =

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/StringTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/StringTest.scala
@@ -98,6 +98,7 @@ object StringTest extends JasmineTest {
       expect("Scala.js".lastIndexOf("Scala.js")).toBe(0)
       expect("ananas".lastIndexOf("na")).toBe(3)
       expect("Scala.js".lastIndexOf("Java")).toBe(-1)
+      expect("Negative index".lastIndexOf("N", -5)).toBe(-1)
     }
 
     it("should respond to `lastIndexOf(int)`") {
@@ -106,6 +107,7 @@ object StringTest extends JasmineTest {
       expect("abc\uD834\uDF06def\uD834\uDF06def".lastIndexOf(0xD834)).toEqual(8)
       expect("abc\uD834\uDF06def\uD834\uDF06def".lastIndexOf(0xDF06)).toEqual(9)
       expect("abc\uD834\uDF06def\uD834\uDF06def".lastIndexOf(0x64)).toEqual(10)
+      expect("abc\uD834\uDF06def\uD834\uDF06def".lastIndexOf(0x64, -1)).toEqual(-1)
     }
 
     it("should respond to `toUpperCase`") {


### PR DESCRIPTION
There appears to be a difference in the underlying implementation between Scala and JS,
namely 

Scala:
```
> "/".lastIndexOf("/", -1)
res0: Int = -1
```

JS:
```
> "/".lastIndexOf("/", -1)
0
```

This can lead to infinite recursion in some Scala code where the behaviour depends on the correct handling of negative indexes

