### PR TITLE
Make fullOptJS work for ES6 modes (but not using Closure).

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -89,12 +89,16 @@
         'set Seq(testSuite, noIrCheckTest).map(pr => postLinkJSEnv in pr := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters")).value.withSourceMap(false))' \
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala testSuite/test noIrCheckTest/test \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala testSuite/test noIrCheckTest/test \
         testSuite/clean noIrCheckTest/clean &&
     sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
         'set postLinkJSEnv in testSuite := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters")).value.withSourceMap(false)' \
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala testSuite/test \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala testSuite/test \
         testSuite/clean &&
     sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
         'set postLinkJSEnv in testSuite := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters")).value.withSourceMap(false)' \
@@ -104,6 +108,8 @@
             .withStrictFloats(true)
          }' \
         'set scalaJSStage in Global := FastOptStage' \
+        ++$scala testSuite/test \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala testSuite/test \
         testSuite/clean &&
     sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
@@ -116,23 +122,14 @@
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala testSuite/test \
-        testSuite/clean &&
-    sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
-        'set postLinkJSEnv in testSuite := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters")).value.withSourceMap(false)' \
-        'set scalaJSSemantics in testSuite ~= { _.optimized }' \
-        'set scalaJSStage in Global := FastOptStage' \
-        ++$scala testSuite/test \
-        testSuite/clean &&
-    sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
-        'set postLinkJSEnv in testSuite := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters")).value.withSourceMap(false)' \
-        'set scalaJSSemantics in testSuite ~= { _.optimized }' \
-        'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
-        'set scalaJSStage in Global := FastOptStage' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala testSuite/test \
         testSuite/clean &&
     sbt 'set Seq(testSuite, noIrCheckTest).map(pr => scalaJSOutputMode in pr := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode)' \
         'set Seq(testSuite, noIrCheckTest).map(pr => postLinkJSEnv in pr := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters", "--strong-mode")).value.withSourceMap(false))' \
         'set scalaJSStage in Global := FastOptStage' \
+        ++$scala testSuite/test noIrCheckTest/test \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala testSuite/test noIrCheckTest/test \
         testSuite/clean noIrCheckTest/clean &&
     sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
@@ -140,6 +137,8 @@
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala testSuite/test \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala testSuite/test \
         testSuite/clean &&
     sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
         'set postLinkJSEnv in testSuite := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters", "--strong-mode")).value.withSourceMap(false)' \
@@ -149,6 +148,8 @@
             .withStrictFloats(true)
          }' \
         'set scalaJSStage in Global := FastOptStage' \
+        ++$scala testSuite/test \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala testSuite/test \
         testSuite/clean &&
     sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
@@ -161,18 +162,7 @@
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala testSuite/test \
-        testSuite/clean &&
-    sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
-        'set postLinkJSEnv in testSuite := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters", "--strong-mode")).value.withSourceMap(false)' \
-        'set scalaJSSemantics in testSuite ~= { _.optimized }' \
-        'set scalaJSStage in Global := FastOptStage' \
-        ++$scala testSuite/test \
-        testSuite/clean &&
-    sbt 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
-        'set postLinkJSEnv in testSuite := NodeJSEnv(executable = "/home/jenkins/apps/iojs-2.0/bin/iojs", args = Seq("--harmony-rest-parameters", "--strong-mode")).value.withSourceMap(false)' \
-        'set scalaJSSemantics in testSuite ~= { _.optimized }' \
-        'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
-        'set scalaJSStage in Global := FastOptStage' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala testSuite/test \
         testSuite/clean &&
     sbt 'set scalaJSStage in Global := FastOptStage' \

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala
@@ -59,6 +59,18 @@ class ScalaJSClosureOptimizer {
   def optimizeIR(optimizer: ScalaJSOptimizer,
       irFiles: Traversable[VirtualScalaJSIRFile], cfg: Config,
       logger: Logger): Unit = {
+    optimizer.outputMode match {
+      case OutputMode.ECMAScript51Global | OutputMode.ECMAScript51Isolated =>
+        optimizeIRUsingClosure(optimizer, irFiles, cfg, logger)
+      case OutputMode.ECMAScript6 | OutputMode.ECMAScript6StrongMode =>
+        optimizer.optimizeIRInternal(irFiles, cfg, cfg.output,
+            cfg.relativizeSourceMapBase, logger)
+    }
+  }
+
+  private def optimizeIRUsingClosure(optimizer: ScalaJSOptimizer,
+      irFiles: Traversable[VirtualScalaJSIRFile], cfg: Config,
+      logger: Logger): Unit = {
 
     // Build Closure IR via ScalaJSOptimizer
     val builder = new ClosureAstBuilder(cfg.relativizeSourceMapBase)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSOptimizer.scala
@@ -80,6 +80,25 @@ class ScalaJSOptimizer(val semantics: Semantics, val outputMode: OutputMode,
 
   def optimizeIR(irFiles: Traversable[VirtualScalaJSIRFile],
       cfg: Config, logger: Logger): Unit = {
+    optimizeIRInternal(irFiles, cfg, cfg.output,
+        cfg.relativizeSourceMapBase, logger)
+  }
+
+  /** Factorization of optimizeIR and ClosureOptimizer.optimizeIR for the
+   *  ES6 cases.
+   *
+   *  Yes, this is a virtually nonsensical factorization, which highlights a
+   *  deeper design issue with the responsibilities of writing the prelude
+   *  and postlude. This responsibility needs to be moved to [[Emitter]].
+   *  In 0.6.3 we make this factorization just good enough to avoid code
+   *  duplication, in a binary compatible way.
+   *
+   *  TODO Fix this technical debt
+   */
+  private[optimizer] def optimizeIRInternal(
+      irFiles: Traversable[VirtualScalaJSIRFile],
+      cfg: OptimizerConfig, output: WritableVirtualJSFile,
+      relativizeSourceMapBase: Option[URI], logger: Logger): Unit = {
 
     val builder = {
       import cfg._


### PR DESCRIPTION
For ES6 modes, `ScalaJSClosureOptimizer` simply forwards to the underlying `ScalaJSOptimizer`. This allows to run `fullOptJS` even with these modes. At this point, this is mostly useful to get the optimized `Semantics`.