### PR TITLE
Remove run/bigDecimalTest.scala from blacklist in 2.11.{0-5}.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/BlacklistedTests.txt
@@ -63,7 +63,6 @@ run/lazy-concurrent.scala
 run/t5880.scala
 run/mapConserve.scala
 run/t3667.scala
-run/bigDecimalTest.scala
 run/t3038d.scala
 run/numbereq.scala
 run/shutdownhooks.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/BlacklistedTests.txt
@@ -63,7 +63,6 @@ run/lazy-concurrent.scala
 run/t5880.scala
 run/mapConserve.scala
 run/t3667.scala
-run/bigDecimalTest.scala
 run/t3038d.scala
 run/numbereq.scala
 run/shutdownhooks.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BlacklistedTests.txt
@@ -63,7 +63,6 @@ run/lazy-concurrent.scala
 run/t5880.scala
 run/mapConserve.scala
 run/t3667.scala
-run/bigDecimalTest.scala
 run/t3038d.scala
 run/numbereq.scala
 run/shutdownhooks.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/BlacklistedTests.txt
@@ -63,7 +63,6 @@ run/lazy-concurrent.scala
 run/t5880.scala
 run/mapConserve.scala
 run/t3667.scala
-run/bigDecimalTest.scala
 run/t3038d.scala
 run/numbereq.scala
 run/shutdownhooks.scala


### PR DESCRIPTION
It was left in the blacklist while at the same time being in the whitelist.