### PR TITLE
Speed up the publish script: invoke sbt once per compiler version.

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -15,11 +15,10 @@ SBT_VERSION="2.10.5"
 LIBS="library javalibEx ir irJS tools toolsJS jsEnvs testAdapter stubs testInterface"
 
 # Publish compiler
-ARGS=""
 for v in $FULL_VERSIONS; do
-    ARGS="$ARGS ++$v compiler/publishSigned"
+    ARGS="++$v compiler/publishSigned"
+    $CMD $ARGS
 done
-$CMD $ARGS
 
 # Package libraries
 for v in $BIN_VERSIONS; do


### PR DESCRIPTION
Instead of publishing the compilers for all full versions in the same sbt instance, this change spawns a new sbt for each version. For some reason, this dramatically speeds up the script.