### PR TITLE
fixing project source path issue - makes sbt-coverage work

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossType.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossType.scala
@@ -43,7 +43,7 @@ object CrossType {
       crossBase / projectType
 
     def sharedSrcDir(projectBase: File, conf: String): Option[File] =
-      Some(projectBase / ".." / "shared" / "src" / conf / "scala")
+      Some(projectBase.getParentFile / "shared" / "src" / conf / "scala")
   }
 
   object Pure extends CrossType {
@@ -51,7 +51,7 @@ object CrossType {
       crossBase / ("." + projectType)
 
     def sharedSrcDir(projectBase: File, conf: String): Option[File] =
-      Some(projectBase / ".." / "src" / conf / "scala")
+      Some(projectBase.getParentFile / "src" / conf / "scala")
   }
 
   object Dummy extends CrossType {


### PR DESCRIPTION
Getting the project source directories this way allows sbt-coverage to work.

Thanks!
Russ