### PR TITLE
Fix #1647: Require explicit @JSExport("apply")

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -829,4 +829,65 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
   }
 
+  @Test
+  def noExportImplicitApply: Unit = {
+
+    """
+    class A {
+      @JSExport
+      def apply(): Int = 1
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:4: warning: Member cannot be exported to function application. It is available under the name apply instead. Add @JSExport("apply") to silence this warning. This will be enforced in 1.0.
+      |      @JSExport
+      |       ^
+    """
+
+    """
+    @JSExportAll
+    class A {
+      def apply(): Int = 1
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:5: warning: Member cannot be exported to function application. It is available under the name apply instead. Add @JSExport("apply") to silence this warning. This will be enforced in 1.0.
+      |      def apply(): Int = 1
+      |          ^
+    """
+
+    """
+    @JSExportAll
+    class A {
+      @JSExportNamed("apply")
+      @JSExport("foo")
+      def apply(): Int = 1
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:7: warning: Member cannot be exported to function application. It is available under the name apply instead. Add @JSExport("apply") to silence this warning. This will be enforced in 1.0.
+      |      def apply(): Int = 1
+      |          ^
+    """
+
+    """
+    @JSExportAll
+    class A {
+      @JSExport("apply")
+      def apply(): Int = 1
+    }
+    """.hasNoWarns
+
+  }
+
+  @Test
+  def exportObjectAsToString: Unit = {
+
+    """
+    @JSExport("toString")
+    object ExportAsToString
+    """.succeeds
+
+  }
+
 }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/util/TestHelpers.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/util/TestHelpers.scala
@@ -41,6 +41,13 @@ trait TestHelpers extends DirectTest {
           expected.stripMargin.trim, reps.trim)
     }
 
+    def hasNoWarns(): Unit = {
+      val reps = repResult {
+        assertTrue("snippet should compile", compileString(preamble + code))
+      }
+      assertTrue("should not have warnings", reps.isEmpty)
+    }
+
     def fails(): Unit =
       assertFalse("snippet shouldn't compile", compileString(preamble + code))
 


### PR DESCRIPTION
Exporting a method named apply (without explicit name) should cause it
to be callable using call synatx in JavaScript. This is not doable. We
therefore require explicitly specifying the name of the method to be
"apply". This will cause the method to callable under the name apply.

As a side effect, the clean up in this commit also fixes #1723 (export
object under the name toString).