### PR TITLE
Fix #1717: Handle JS properties named apply

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -408,6 +408,13 @@ abstract class PrepJSInterop extends plugins.PluginComponent
       if (sym.isAccessor)
         sym.accessed.getAnnotation(JSNameAnnotation).foreach(sym.addAnnotation)
 
+      if (jsInterop.isJSGetter(sym) && sym.name == nme.apply &&
+          !sym.hasAnnotation(JSNameAnnotation)) {
+        reporter.error(sym.pos, s"A member named apply represents function " +
+            "application in JavaScript. A parameterless member should be " +
+            "exported as a property. You must add @JSName(\"apply\")")
+      }
+
       if (jsInterop.isJSSetter(sym))
         checkSetterSignature(sym, tree.pos, exported = false)
 

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -401,6 +401,13 @@ abstract class PrepJSInterop extends plugins.PluginComponent
         }
       }
 
+      /* If this is an accessor, copy a potential @JSName annotation from
+       * the field since otherwise it will get lost for traits (since they
+       * have no fields).
+       */
+      if (sym.isAccessor)
+        sym.accessed.getAnnotation(JSNameAnnotation).foreach(sym.addAnnotation)
+
       if (jsInterop.isJSSetter(sym))
         checkSetterSignature(sym, tree.pos, exported = false)
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
@@ -387,4 +387,75 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
+  @Test
+  def noApplyProperty: Unit = {
+
+    // def apply
+
+    """
+    trait A extends js.Object {
+      def apply: Int = js.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: A member named apply represents function application in JavaScript. A parameterless member should be exported as a property. You must add @JSName("apply")
+      |      def apply: Int = js.native
+      |          ^
+    """
+
+    """
+    import js.annotation.JSName
+
+    trait A extends js.Object {
+      @JSName("apply")
+      def apply: Int = js.native
+    }
+    """.succeeds
+
+    // val apply
+
+    """
+    trait A extends js.Object {
+      val apply: Int = js.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: A member named apply represents function application in JavaScript. A parameterless member should be exported as a property. You must add @JSName("apply")
+      |      val apply: Int = js.native
+      |          ^
+    """
+
+    """
+    import js.annotation.JSName
+
+    trait A extends js.Object {
+      @JSName("apply")
+      val apply: Int = js.native
+    }
+    """.succeeds
+
+    // var apply
+
+    """
+    trait A extends js.Object {
+      var apply: Int = js.native
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: A member named apply represents function application in JavaScript. A parameterless member should be exported as a property. You must add @JSName("apply")
+      |      var apply: Int = js.native
+      |          ^
+    """
+
+    """
+    import js.annotation.JSName
+
+    trait A extends js.Object {
+      @JSName("apply")
+      var apply: Int = js.native
+    }
+    """.succeeds
+
+  }
+
 }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
@@ -1,0 +1,71 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSName
+
+import org.scalajs.jasminetest.JasmineTest
+
+object JSNameTest extends JasmineTest {
+
+  describe("@JSName") {
+
+    it("should work with defs that are properties") {
+      val obj = js.Dynamic.literal(jsDef = 1).asInstanceOf[PropDefFacade]
+      expect(obj.internalDef).toEqual(1)
+    }
+
+    it("should work with vals") {
+      val obj = js.Dynamic.literal(jsVal = "hi").asInstanceOf[PropValFacade]
+      expect(obj.internalVal).toEqual("hi")
+    }
+
+    it("should work with vars") {
+      val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarFacade]
+      expect(obj.internalVar).toEqual(0.1)
+      obj.internalVar = 0.2
+      expect(obj.internalVar).toEqual(0.2)
+    }
+
+    it("should allow names ending in _=") {
+      val d = js.Dynamic.literal("a_=" -> 1)
+      val f = d.asInstanceOf[UndEqNamed]
+
+      expect(f.a).toEqual(1)
+      f.a = 2
+      expect(d.selectDynamic("a_=")).toEqual(2)
+      expect(f.a).toEqual(2)
+    }
+
+  }
+
+  trait PropDefFacade extends js.Any {
+    @JSName("jsDef")
+    def internalDef: Int = js.native
+  }
+
+  trait PropValFacade extends js.Any {
+    @JSName("jsVal")
+    val internalVal: String = js.native
+  }
+
+  trait PropVarFacade extends js.Any {
+    @JSName("jsVar")
+    var internalVar: Double = js.native
+  }
+
+  trait UndEqNamed extends js.Any {
+    @JSName("a_=")
+    def a: Int = js.native
+
+    @JSName("a_=")
+    def a_=(x: Int): Unit = js.native
+  }
+
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -103,15 +103,6 @@ object MiscInteropTest extends JasmineTest {
       expect(f.bar(5)).toEqual(7)
     }
 
-    it("should allow names ending in _=") {
-      val d = js.Dynamic.literal("a_=" -> 1)
-      val f = d.asInstanceOf[UndEqNamed]
-
-      expect(f.a).toEqual(1)
-      f.a = 2
-      expect(d.selectDynamic("a_=")).toEqual(2)
-      expect(f.a).toEqual(2)
-    }
   }
 
   trait DirectSubtraitOfJSAny extends js.Any {
@@ -120,14 +111,6 @@ object MiscInteropTest extends JasmineTest {
 
   class DirectSubclassOfJSAny extends js.Any {
     def bar(x: Int): Int = js.native
-  }
-
-  trait UndEqNamed extends js.Any {
-    @JSName("a_=")
-    def a: Int = js.native
-
-    @JSName("a_=")
-    def a_=(x: Int): Unit = js.native
   }
 
 }


### PR DESCRIPTION
A property in a facade type named apply needs to be explicitly made a
property (as opposed to a function application) by adding @JSName.

The changes in #1647 (@JSExport on method named apply) will align the
export behavior with this change.