### PR TITLE
Fix #1722: Disable optimizations in Rhino all the time.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
@@ -131,6 +131,9 @@ final class RhinoJSEnv private (
     try {
       val scope = context.initStandardObjects()
 
+      // Rhino has trouble optimizing some big things, e.g., env.js or ScalaTest
+      context.setOptimizationLevel(-1)
+
       if (withDOM)
         setupDOM(context, scope)
 
@@ -183,9 +186,6 @@ final class RhinoJSEnv private (
     val path = "/META-INF/resources/webjars/envjs/1.2/" + name
     val resource = getClass.getResource(path)
     assert(resource != null, s"need $name as resource")
-
-    // Rhino can't optimize envjs
-    context.setOptimizationLevel(-1)
 
     // Don't print envjs header
     scope.addFunction("print", args => ())


### PR DESCRIPTION
We already disabled optimizations when including env.js. This commit generalizes this to any codebase.

This enables Rhino to correctly execute codebases that use ScalaTest. Since Rhino is slow anyway, and its only benefit is the out-of-the-box experience, it's better to make it work out-of-the-box with ScalaTest as well.