### PR TITLE
Fix #1737: Add configuration to include tests from require-jdk[7|8] folders.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -932,12 +932,14 @@ object Build extends sbt.Build {
           })),
 
           sources in Test ++= {
-            if (!scalaVersion.value.startsWith("2.10") &&
-                scalacOptions.value.contains("-Xexperimental")) {
-              (((sourceDirectory in Test).value / "require-sam") ** "*.scala").get
-            } else {
-              Nil
-            }
+            def listAllScalaFilesIf(testDir: String, condition: Boolean): Seq[File] =
+              if (condition) (((sourceDirectory in Test).value / testDir) ** "*.scala").get
+              else Nil
+            val javaVersion = System.getProperty("java.version")
+            listAllScalaFilesIf("require-jdk7", javaVersion.matches("1\\.[78].*")) ++
+            listAllScalaFilesIf("require-jdk8", javaVersion.startsWith("1.8")) ++
+            listAllScalaFilesIf("require-sam", !scalaVersion.value.startsWith("2.10") &&
+              scalacOptions.value.contains("-Xexperimental"))
           },
 
           /* Generate a scala source file that throws exceptions in

--- a/test-suite/src/test/require-jdk7/org/scalajs/testsuite/OnJDK7OrHigher.scala
+++ b/test-suite/src/test/require-jdk7/org/scalajs/testsuite/OnJDK7OrHigher.scala
@@ -1,0 +1,22 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite
+
+import org.scalajs.jasminetest.JasmineTest
+
+object OnJDK7OrHigher extends JasmineTest {
+
+  describe("require-jdk7 tests") {
+    it("should only be running JDK7 or JDK8") {
+      // This method did not exist id JDK6 and hence this class will not link
+      // java.util.Collections.emptyIterator[Int]()
+      // TODO remove comment one the implementation is added
+    }
+  }
+
+}

--- a/test-suite/src/test/require-jdk8/org/scalajs/testsuite/OnJDK8OrHigher.scala
+++ b/test-suite/src/test/require-jdk8/org/scalajs/testsuite/OnJDK8OrHigher.scala
@@ -1,0 +1,22 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite
+
+import org.scalajs.jasminetest.JasmineTest
+
+object OnJDK8OrHigher extends JasmineTest {
+
+  describe("require-jdk8 tests") {
+    it("should only be running JDK8") {
+      // This method did not exist id JDK7 and hence this class will not link
+      // java.util.Collections.asLifoQueue[Int](null)
+      // TODO remove comment one the implementation is added
+    }
+  }
+
+}


### PR DESCRIPTION
Configuration loads tests in `testSuite/src/test/require-jdk7` when in JDK7 or JDK8.
Configuration loads tests in `testSuite/src/test/require-jdk8` when in JDK8.
Add placeholders for JDK version test.