### PR TITLE
Fix #1736: Add a scalajsp input task in the sbt plugin.

### DIFF
--- a/cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
@@ -153,6 +153,7 @@ object Scalajsp {
   private val stdout =
     new BufferedWriter(new OutputStreamWriter(Console.out, "UTF-8"))
 
+  // !!! CODE DUPLICATION with ScalaJSPluginInternal.filterOutReflProxies
   private def filterOutReflProxies(tree: ClassDef): ClassDef = {
     import ir.Trees._
     import ir.Definitions.isReflProxyName

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -185,6 +185,11 @@ object ScalaJSPlugin extends AutoPlugin {
         "Private class loader to load jetty8 without polluting classpath. Only use this " +
         "as the `jettyClassLoader` argument of the PhantomJSEnv",
         KeyRanks.Invisible)
+
+    /** Prints the content of a .sjsir file in human readable form. */
+    val scalajsp = InputKey[Unit]("scalajsp",
+        "Prints the content of a .sjsir file in human readable form.",
+        CTask)
   }
 
   import autoImport._

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalajspUtils.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalajspUtils.scala
@@ -1,0 +1,121 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package org.scalajs.sbtplugin
+
+import java.io.{File, FileNotFoundException}
+
+import scala.collection.mutable
+
+import sbt._
+import sbt.complete._
+
+import org.scalajs.core.tools.io._
+import org.scalajs.core.tools.jsdep.JSDependencyManifest
+import org.scalajs.core.tools.classpath.builder._
+
+private[sbtplugin] object ScalajspUtils {
+
+  /** Pairs (relPath, loadIR), "elements" of a ClasspathIRTraverser. */
+  private type RelPathAndIRFile = (String, () => VirtualScalaJSIRFile)
+
+  /** Lists all the .sjsir files on a classpath. */
+  def listSjsirFilesOnClasspath(cp: Seq[File]): List[String] =
+    new ClasspathIRTraverser(cp).map(_._1).toList
+
+  /** Creates an [[ExampleSource]] with per-directory tab completion. */
+  def relPathsExamples(relPaths: List[String]): ExampleSource =
+    new ScalaJSIRFilesOnClasspathExamples(relPaths)
+
+  /** Loads an .sjsir file by its relative path on a classpath. */
+  def loadIRFile(cp: Seq[File], relPath: String): VirtualScalaJSIRFile = {
+    new ClasspathIRTraverser(cp) collectFirst {
+      case (fileRelPath, loadIR) if fileRelPath == relPath => loadIR()
+    } getOrElse {
+      throw new FileNotFoundException(relPath)
+    }
+  }
+
+  /** An [[ExampleSource]] showing .sjsir files on a classpath. */
+  private class ScalaJSIRFilesOnClasspathExamples(allRelPaths: List[String],
+      prefix: String = "") extends ExampleSource {
+
+    override def apply(): Iterable[String] = {
+      val allExamples = (for {
+        relPath <- allRelPaths
+        if relPath.startsWith(prefix)
+      } yield {
+        // Returned examples must not include the prefix
+        val remaining = relPath.substring(prefix.length)
+
+        /* For files in subdirectories wrt. the current prefix, do not show
+         * the entire remaining path. Instead, show only the remaining path
+         * to the subdirectory, '/' included. This means that:
+         *
+         * > scalajsp hello<tab>
+         *
+         * will complete to
+         *
+         * > scalajsp helloworld/
+         *
+         * and further tabs are necessary to show to files and directories
+         * under the helloworld/ subdirectory.
+         */
+        val nextSlashPos = remaining.indexOf('/')
+        if (nextSlashPos == -1) remaining
+        else remaining.substring(0, nextSlashPos + 1)
+      }).distinct
+
+      val (dirs, files) = allExamples.partition(_.endsWith("/"))
+      dirs.sorted ++ files.sorted
+    }
+
+    override def withAddedPrefix(addedPrefix: String): ExampleSource =
+      new ScalaJSIRFilesOnClasspathExamples(allRelPaths, prefix + addedPrefix)
+  }
+
+  /** A [[Traversable]] listing the .sjsir files in a classpath. */
+  private class ClasspathIRTraverser(cp: Seq[File])
+      extends ClasspathElementsTraverser
+      with PhysicalFileSystem
+      with Traversable[RelPathAndIRFile] {
+
+    private var f: RelPathAndIRFile => Any = null
+
+    override protected def handleIR(relPath: String,
+        ir: => VirtualScalaJSIRFile): Unit = {
+      f((relPath, () => ir))
+    }
+
+    override protected def handleJS(relPath: String,
+        js: => VirtualJSFile): Unit = {
+    }
+
+    override protected def handleDepManifest(
+        m: => JSDependencyManifest): Unit = {
+    }
+
+    override def foreach[U](f: RelPathAndIRFile => U): Unit = {
+      this.f = f
+      try traverseClasspathElements(cp)
+      finally this.f = null
+    }
+
+    /* Backport performance improvement from
+     * https://github.com/scala/scala/commit/56c1af90999f0a9a55a90f3dd3bf6d04ddda5943
+     */
+    override def collectFirst[B](
+        pf: PartialFunction[RelPathAndIRFile, B]): Option[B] = {
+      this.foreach(pf.runWith(b => return Some(b))) // scalastyle:ignore
+      None
+    }
+
+  }
+
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/DirTraverser.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/DirTraverser.scala
@@ -39,9 +39,11 @@ trait DirTraverser extends ClasspathContentHandler with FileSystem {
         path match {
           case JSDependencyManifest.ManifestFileName =>
             versions += getGlobalVersion(file)
-            val reader = toReader(file)
-            try handleDepManifest(JSDependencyManifest.read(reader))
-            finally reader.close()
+            handleDepManifest({
+              val reader = toReader(file)
+              try JSDependencyManifest.read(reader)
+              finally reader.close()
+            })
 
           case _ if isJSFile(file) =>
             versions += getGlobalVersion(file)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/JarTraverser.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/classpath/builder/JarTraverser.scala
@@ -74,7 +74,7 @@ trait JarTraverser extends ClasspathContentHandler with FileSystem {
       getOrCreateJSFile(relPath, fullPath, shortName)
         .withSourceMap(Some(entryContent))
     } else if (longName.endsWith(".sjsir")) {
-      val vf = new MemVirtualSerializedScalaJSIRFile(fullPath) {
+      def vf = new MemVirtualSerializedScalaJSIRFile(fullPath) {
         override val name = shortName
       }.withContent(entryBinaryContent)
        .withVersion(entryVersion)


### PR DESCRIPTION
It accepts relative paths to .sjsir files on the classpath.