### PR TITLE
Fix #1718: Validate the regex directly in Pattern.compile().

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -16,7 +16,7 @@ final class Matcher private[regex] (
   def pattern(): Pattern = pattern0
 
   // Configuration (updated manually)
-  private var regexp = new js.RegExp(pattern0.jspattern, pattern0.jsflags)
+  private var regexp = pattern0.newJSRegExp()
   private var inputstr = input0.subSequence(regionStart0, regionEnd0).toString
 
   // Match result (updated by successful matches)
@@ -155,7 +155,7 @@ final class Matcher private[regex] (
   def usePattern(pattern: Pattern): Matcher = {
     val prevLastIndex = regexp.lastIndex
     pattern0 = pattern
-    regexp = new js.RegExp(pattern.jspattern, pattern.jsflags)
+    regexp = pattern.newJSRegExp()
     regexp.lastIndex = prevLastIndex
     lastMatch = null
     this

--- a/library/src/main/scala/scala/scalajs/js/RegExp.scala
+++ b/library/src/main/scala/scala/scalajs/js/RegExp.scala
@@ -21,6 +21,9 @@ package scala.scalajs.js
  * MDN
  */
 class RegExp(pattern: String, flags: String = "") extends Object {
+  /** Creates a new RegExp with the same pattern and flags as the given one. */
+  def this(pattern: RegExp) = this("", "")
+
   /**
    * The source property returns a String containing the text of the pattern,
    * excluding the forward slashes. It is a read-only property of an individual

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/RegexTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/RegexTest.scala
@@ -135,6 +135,10 @@ object RegexTest extends JasmineTest {
       expect(splitNoQuote.mkString).toEqual("Scala$1&$2.js")
     }
 
+    it("Pattern.compile should throw for invalid patterns - #1718") {
+      expect(() => Pattern.compile("*")).toThrow
+    }
+
   }
 
   describe("java.util.regex.Matcher") {
@@ -194,6 +198,18 @@ object RegexTest extends JasmineTest {
 
       expect(matcher0.matches()).toBeTruthy
       expect(matcher1.matches()).toBeFalsy
+    }
+
+    it("Several matches from the same pattern should be independent") {
+      val pattern = Pattern.compile("S[a-z]+")
+      val matcher0 = pattern.matcher("Scalable")
+      val matcher1 = pattern.matcher("Scalable")
+
+      expect(matcher0.find()).toBeTruthy
+      expect(matcher0.find()).toBeFalsy
+
+      expect(matcher1.find()).toBeTruthy
+      expect(matcher1.find()).toBeFalsy
     }
 
     it("should respond to `reset`") {


### PR DESCRIPTION
Since this requires the creation of a `js.RegExp` at the time `Pattern.compile()` is called anyway, we also store that native `RegExp` in the `Pattern` instance. `RegExp`'s for the `Matcher`s are created from that model `RegExp`, instead of from pattern and flags every time. This *might* be optimized in JS VMs to reuse the internally compiled representation for the regex.