### PR TITLE
Fix #1675: Implement {Integer,Long}.{highest,lowest}OneBit.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -108,6 +108,9 @@ object Integer {
     else (1 << 31) >>> Integer.numberOfLeadingZeros(i)
   }
 
+  @inline def lowestOneBit(i: Int): Int =
+    i & -i
+
   def reverseBytes(i: scala.Int): scala.Int = {
     val byte3 = i >>> 24
     val byte2 = (i >>> 8) & 0xFF00

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -161,6 +161,18 @@ object Long {
   @inline def compare(x: scala.Long, y: scala.Long): scala.Int =
     if (x == y) 0 else if (x < y) -1 else 1
 
+  def highestOneBit(i: scala.Long): scala.Long = {
+    val hi = (i >>> 32).toInt
+    if (hi != 0) Integer.highestOneBit(hi).toLong << 32
+    else Integer.highestOneBit(i.toInt).toLong & 0xffffffffL
+  }
+
+  def lowestOneBit(i: scala.Long): scala.Long = {
+    val lo = i.toInt
+    if (lo != 0) Integer.lowestOneBit(lo).toLong & 0xffffffffL
+    else Integer.lowestOneBit((i >>> 32).toInt).toLong << 32
+  }
+
   def bitCount(i: scala.Long): scala.Int = {
     val lo = i.toInt
     val hi = (i >>> 32).toInt

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/IntegerTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/IntegerTest.scala
@@ -166,7 +166,18 @@ object IntegerTest extends JasmineTest {
       expect(Integer.highestOneBit(-256)).toEqual(Integer.MIN_VALUE)
       expect(Integer.highestOneBit(1)).toEqual(1)
       expect(Integer.highestOneBit(0x88)).toEqual(0x80)
-      expect(Integer.highestOneBit(Integer.MAX_VALUE)).toEqual(0x40000000)
+      expect(Integer.highestOneBit(Int.MaxValue)).toEqual(0x40000000)
+      expect(Integer.highestOneBit(Int.MinValue)).toEqual(Int.MinValue)
+    }
+
+    it("should provide `lowestOneBit`") {
+      expect(Integer.lowestOneBit(0)).toEqual(0)
+      expect(Integer.lowestOneBit(-1)).toEqual(1)
+      expect(Integer.lowestOneBit(-256)).toEqual(256)
+      expect(Integer.lowestOneBit(12)).toEqual(4)
+      expect(Integer.lowestOneBit(0x88)).toEqual(0x8)
+      expect(Integer.lowestOneBit(Int.MaxValue)).toEqual(1)
+      expect(Integer.lowestOneBit(Int.MinValue)).toEqual(Int.MinValue)
     }
 
     it("should provide `toString` without radix") {

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/LongTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/LongTest.scala
@@ -185,6 +185,28 @@ object LongTest extends JasmineTest {
       expect(JLong.toString(0x7fffffffffffffffL, 16)).toEqual("7fffffffffffffff")
     }
 
+    it("should provide `highestOneBit`") {
+      expect(JLong.highestOneBit(0L) == 0L).toBeTruthy
+      expect(JLong.highestOneBit(-1L) == Long.MinValue).toBeTruthy
+      expect(JLong.highestOneBit(-256L) == Long.MinValue).toBeTruthy
+      expect(JLong.highestOneBit(1L) == 1L).toBeTruthy
+      expect(JLong.highestOneBit(0x88L) == 0x80L).toBeTruthy
+      expect(JLong.highestOneBit(Long.MaxValue) == 0x4000000000000000L).toBeTruthy
+      expect(JLong.highestOneBit(Long.MinValue) == Long.MinValue).toBeTruthy
+      expect(JLong.highestOneBit(0x32100012300L) == 0x20000000000L).toBeTruthy
+    }
+
+    it("should provide `lowestOneBit`") {
+      expect(JLong.lowestOneBit(0L) == 0L).toBeTruthy
+      expect(JLong.lowestOneBit(-1L) == 1L).toBeTruthy
+      expect(JLong.lowestOneBit(-256L) == 256L).toBeTruthy
+      expect(JLong.lowestOneBit(12L) == 4L).toBeTruthy
+      expect(JLong.lowestOneBit(0x88L) == 0x8L).toBeTruthy
+      expect(JLong.lowestOneBit(Long.MaxValue) == 1L).toBeTruthy
+      expect(JLong.lowestOneBit(Long.MinValue) == Long.MinValue).toBeTruthy
+      expect(JLong.lowestOneBit(0x32100012300L) == 0x100L).toBeTruthy
+    }
+
     it("should implement toBinaryString") {
       // scalastyle:off disallow.space.before.token disallow.space.after.token line.size.limit
       expect(JLong.toBinaryString(              0L)).toEqual("0")


### PR DESCRIPTION
`Integer.highestOneBit` was already there. This commit completes the set.