### PR TITLE
Fix #1685: Publish the jar of the CLI project.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -197,20 +197,22 @@
 
   <task id="tools-cli-stubs"><![CDATA[
     export JAVA_HOME=$HOME/apps/java-$java
-    sbt ++$scala tools/package tools/test cli/assembly stubs/package \
-        jsEnvs/test \
+    sbt ++$scala tools/package tools/test cli/package cli/assembly \
+        stubs/package jsEnvs/test \
         ir/mimaReportBinaryIssues tools/mimaReportBinaryIssues \
         jsEnvs/mimaReportBinaryIssues testAdapter/mimaReportBinaryIssues \
-        stubs/mimaReportBinaryIssues
+        stubs/mimaReportBinaryIssues cli/mimaReportBinaryIssues
   ]]></task>
 
   <task id="tools-cli-stubs-sbtplugin"><![CDATA[
     export JAVA_HOME=$HOME/apps/java-$java
-    sbt ++$scala tools/package tools/test cli/assembly stubs/package \
-        sbtPlugin/package jsEnvs/test \
+    sbt ++$scala tools/package tools/test cli/package cli/assembly \
+        stubs/package jsEnvs/test \
+        sbtPlugin/package \
         ir/mimaReportBinaryIssues tools/mimaReportBinaryIssues \
         jsEnvs/mimaReportBinaryIssues testAdapter/mimaReportBinaryIssues \
-        sbtPlugin/mimaReportBinaryIssues stubs/mimaReportBinaryIssues
+        stubs/mimaReportBinaryIssues cli/mimaReportBinaryIssues \
+        sbtPlugin/mimaReportBinaryIssues
     sbt ++$scala library/scalastyle javalanglib/scalastyle javalib/scalastyle \
         javalibEx/scalastyle ir/scalastyle compiler/scalastyle \
         compiler/test:scalastyle tools/scalastyle tools/test:scalastyle \

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -33,7 +33,7 @@ import java.net.URI
 
 object Scalajsld {
 
-  case class Options(
+  private case class Options(
     cp: Seq[File] = Seq.empty,
     output: File = null,
     jsoutput: Option[File] = None,
@@ -49,7 +49,7 @@ object Scalajsld {
     stdLib: Option[File] = None,
     logLevel: Level = Level.Info)
 
-  implicit object OutputModeRead extends scopt.Read[OutputMode] {
+  private implicit object OutputModeRead extends scopt.Read[OutputMode] {
     val arity = 1
     val reads = { (s: String) =>
       OutputMode.All.find(_.toString() == s).getOrElse(

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
@@ -29,7 +29,7 @@ import java.util.zip.{ZipFile, ZipEntry}
 
 object Scalajsp {
 
-  case class Options(
+  private case class Options(
     infos: Boolean = false,
     desugar: Boolean = false,
     showReflProxy: Boolean = false,
@@ -84,14 +84,15 @@ object Scalajsp {
     }
   }
 
-  def printSupported(): Unit = {
+  private def printSupported(): Unit = {
     import ScalaJSVersions._
     println(s"Emitted Scala.js IR version is: $binaryEmitted")
     println("Supported Scala.js IR versions are")
     binarySupported.foreach(v => println(s"* $v"))
   }
 
-  def displayFileContent(vfile: VirtualScalaJSIRFile, opts: Options): Unit = {
+  private def displayFileContent(vfile: VirtualScalaJSIRFile,
+      opts: Options): Unit = {
     if (opts.infos)
       new InfoPrinter(stdout).printClassInfo(vfile.info)
     else {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -749,11 +749,14 @@ object Build extends sbt.Build {
   lazy val cli: Project = Project(
       id = "cli",
       base = file("cli"),
-      settings = commonSettings ++ assemblySettings ++ Seq(
+      settings = commonSettings ++ publishSettings ++ assemblySettings ++ Seq(
           name := "Scala.js CLI",
           libraryDependencies ++= Seq(
               "com.github.scopt" %% "scopt" % "3.2.0"
           ),
+
+          // TODO Enable this when going towards 0.6.5:
+          //previousArtifactSetting,
 
           // assembly options
           mainClass in assembly := None, // don't want an executable JAR

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,7 +12,7 @@ FULL_VERSIONS="2.10.2 2.10.3 2.10.4 2.10.5 2.11.0 2.11.1 2.11.2 2.11.4 2.11.5 2.
 BIN_VERSIONS="2.10.5 2.11.6 2.12.0-M1"
 SBT_VERSION="2.10.5"
 
-LIBS="library javalibEx ir irJS tools toolsJS jsEnvs testAdapter stubs testInterface"
+LIBS="library javalibEx ir irJS tools toolsJS jsEnvs testAdapter stubs testInterface cli"
 
 # Publish compiler
 for v in $FULL_VERSIONS; do


### PR DESCRIPTION
This provides a tool- and language-agnostic entry point to the tools, which can be used by simple tasks for build tools other than sbt. Publishing the CLI allows these tools to fetch the appropriate jar through normal Maven dependencies.