### PR TITLE
Fix #1748: Return canonical files from CrossType.sharedSrcDir().

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossType.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossType.scala
@@ -43,7 +43,7 @@ object CrossType {
       crossBase / projectType
 
     def sharedSrcDir(projectBase: File, conf: String): Option[File] =
-      Some(projectBase / ".." / "shared" / "src" / conf / "scala")
+      Some(projectBase.getParentFile / "shared" / "src" / conf / "scala")
   }
 
   object Pure extends CrossType {
@@ -51,7 +51,7 @@ object CrossType {
       crossBase / ("." + projectType)
 
     def sharedSrcDir(projectBase: File, conf: String): Option[File] =
-      Some(projectBase / ".." / "src" / conf / "scala")
+      Some(projectBase.getParentFile / "src" / conf / "scala")
   }
 
   object Dummy extends CrossType {


### PR DESCRIPTION
Some tools, such as scoverage, are not happy if they receive paths to source files that contain '..' in them. So we avoid creating such paths using `.getParentFile` instead of `/ ".."`.