### PR TITLE
Fix #1756: Use the linking info in ScalaJSClassEmitter.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -14,7 +14,9 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.optimizer.OptimizerCore.org$scalajs$core$tools$optimizer$OptimizerCore$$treeNotInlined0$3"),
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.scalajs.core.tools.optimizer.OptimizerCore.org$scalajs$core$tools$optimizer$OptimizerCore$$inline")
+          "org.scalajs.core.tools.optimizer.OptimizerCore.org$scalajs$core$tools$optimizer$OptimizerCore$$inline"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.optimizer.Emitter.org$scalajs$core$tools$optimizer$Emitter$$ClassesWhoseDataReferToTheirInstanceTests")
   )
 
   val JSEnvs = Seq(

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Emitter.scala
@@ -185,13 +185,7 @@ final class Emitter(semantics: Semantics, outputMode: OutputMode) {
       }
     }
 
-    val needInstanceTests = {
-      linkedClass.hasInstanceTests || {
-        linkedClass.hasRuntimeTypeInfo &&
-        ClassesWhoseDataReferToTheirInstanceTests.contains(linkedClass.encodedName)
-      }
-    }
-    if (needInstanceTests) {
+    if (classEmitter.needInstanceTests(linkedClass)) {
       addTree(classTreeCache.instanceTests.getOrElseUpdate(js.Block(
           classEmitter.genInstanceTests(linkedClass),
           classEmitter.genArrayInstanceTests(linkedClass)
@@ -251,13 +245,7 @@ final class Emitter(semantics: Semantics, outputMode: OutputMode) {
 
     emitFromLibUntil("///INSERT IS AND AS FUNCTIONS HERE///")
     for (linkedClass <- orderedClasses) {
-      val needInstanceTests = {
-        linkedClass.hasInstanceTests || {
-          linkedClass.hasRuntimeTypeInfo &&
-          ClassesWhoseDataReferToTheirInstanceTests.contains(linkedClass.encodedName)
-        }
-      }
-      if (needInstanceTests) {
+      if (classEmitter.needInstanceTests(linkedClass)) {
         val classTreeCache = getClassTreeCache(linkedClass)
         addTree(classTreeCache.instanceTests.getOrElseUpdate(js.Block(
             classEmitter.genInstanceTests(linkedClass),
@@ -415,11 +403,6 @@ final class Emitter(semantics: Semantics, outputMode: OutputMode) {
 }
 
 object Emitter {
-  private val ClassesWhoseDataReferToTheirInstanceTests = {
-    Definitions.AncestorsOfHijackedClasses +
-    Definitions.ObjectClass + Definitions.StringClass
-  }
-
   private final class DesugaredClassCache {
     val constructor = new OneTimeCache[js.Tree]
     val exportedMembers = new OneTimeCache[js.Tree]


### PR DESCRIPTION
The issue was caused by the following pattern:

```scala
class A
class B extends A
println(classOf[B])
```

In this case, `B` is retained by the linker because its runtime type info are required. But `A` is discarded because it is not used in any way, despite it being a superclass of `B`. This is normal.

The problem is that the Rhino runner, when lazy loading `B`, did not use the fact that `linkedClassB.hasInstances` is false, and therefore generated the (empty) class. This empty class *did*
reference its parent class `A`, so when the script was evaluated, it would look for `A`. However it could not find `A` at all because it has been completely eliminated by the linker.

This commit fixes this by making `ScalaJSClassEmitter` leverage the linking info available in the `LinkedClass` it prints to emit only the necessary parts, basically with the same tests as those used
by `Emitter`.