### PR TITLE
Fix #1759: Use `new` when copying a TypedArray in Array.clone().

### DIFF
--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -793,7 +793,7 @@ initArray(
         return new ArrayClass(this.u["slice"](0));
       else
         // The underlying Array is a TypedArray
-        return new ArrayClass(this.u.constructor(this.u));
+        return new ArrayClass(new this.u.constructor(this.u));
     };
   };
 //!endif

--- a/tools/strongmodeenv.js
+++ b/tools/strongmodeenv.js
@@ -769,7 +769,7 @@ class $TypeData {
           return new ArrayClass(this.u["slice"](0));
         else
           // The underlying Array is a TypedArray
-          return new ArrayClass(this.u.constructor(this.u));
+          return new ArrayClass(new this.u.constructor(this.u));
       };
     };
 


### PR DESCRIPTION
The ES6 spec says that it is illegal to call a `TypedArray` constructor without `new`.

This does not come with any new test because we already have the tests that would trigger this error. But this we don't have any testing runtime that triggers it: the latest versions of Node.js and io.js are too lenient about this, and are fine with the absence of `new`.