### PR TITLE
Fix #1693: Implement java.util.concurrent.CopyOnWriteArrayList.

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
+++ b/javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
@@ -1,0 +1,63 @@
+package java.util
+
+abstract private[util] class AbstractRandomAccessListIterator[E](private var i: Int,
+    start: Int, protected var end: Int) extends ListIterator[E] with SizeChangeEvent {
+
+  private var last = -1
+
+  def hasNext(): Boolean =
+    i < end
+
+  def next(): E = {
+    last = i
+    i += 1
+    get(last)
+  }
+
+  def hasPrevious(): Boolean =
+    start < i
+
+  def previous(): E = {
+    i -= 1
+    last = i
+    get(last)
+  }
+
+  def nextIndex(): Int = i
+
+  def previousIndex(): Int = i - 1
+
+  def remove(): Unit = {
+    checkThatHasLast()
+    remove(last)
+    if (last < i)
+      i -= 1
+    last = -1
+    changeSize(-1)
+  }
+
+  def set(e: E): Unit = {
+    checkThatHasLast()
+    set(last, e)
+  }
+
+  def add(e: E): Unit = {
+    add(i, e)
+    changeSize(1)
+    last = -1
+    i += 1
+  }
+
+  protected def get(index: Int): E
+
+  protected def remove(index: Int): Unit
+
+  protected def set(index: Int, e: E): Unit
+
+  protected def add(index: Int, e: E): Unit
+
+  private def checkThatHasLast(): Unit = {
+    if (last == -1)
+      throw new IllegalStateException
+  }
+}

--- a/javalib/src/main/scala/java/util/SizeChangeEvent.scala
+++ b/javalib/src/main/scala/java/util/SizeChangeEvent.scala
@@ -1,0 +1,13 @@
+package java.util
+
+private[util] trait SizeChangeEvent {
+  protected var end: Int
+
+  @inline
+  protected final def changeSize(delta: Int): Unit = {
+    end += delta
+    onSizeChanged(delta)
+  }
+
+  protected def onSizeChanged(delta: Int): Unit = () // override if needed
+}

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -1,0 +1,338 @@
+package java.util.concurrent
+
+import java.lang.{reflect => jlr}
+
+import scala.annotation.tailrec
+import scala.collection.JavaConversions._
+
+import scala.scalajs._
+
+import java.util._
+
+class CopyOnWriteArrayList[E] private (private var inner: js.Array[E])
+    extends List[E] with RandomAccess with Cloneable with Serializable {
+  self =>
+
+  // requiresCopyOnWrite is false if and only if no other object
+  // (like the iterator) may have a reference to inner
+  private var requiresCopyOnWrite = false
+
+  def this() = {
+    this(new js.Array[E])
+  }
+
+  def this(c: Collection[_ <: E]) = {
+    this()
+    addAll(c)
+  }
+
+  def this(toCopyIn: Array[E]) = {
+    this()
+    toCopyIn.foreach(add)
+  }
+
+  def size(): Int =
+    inner.size
+
+  def isEmpty: Boolean =
+    size == 0
+
+  def contains(o: scala.Any): Boolean =
+    iterator.exists(o === _)
+
+  def indexOf(o: scala.Any): Int =
+    indexOf(o.asInstanceOf[E], 0)
+
+  def indexOf(e: E, index: Int): Int = {
+    checkIndexInBounds(index)
+    index + listIterator(index).indexWhere(_ === e)
+  }
+
+  def lastIndexOf(o: scala.Any): Int =
+    lastIndexOf(o.asInstanceOf[E], 0)
+
+  def lastIndexOf(e: E, index: Int): Int = {
+    @tailrec
+    def findIndex(iter: ListIterator[E]): Int = {
+      if (!iter.hasPrevious) -1
+      else if (iter.previous() === e) iter.nextIndex
+      else findIndex(iter)
+    }
+    findIndex(listIterator(size))
+  }
+
+  override def clone(): AnyRef =
+    new CopyOnWriteArrayList[E](this)
+
+  def toArray(): Array[AnyRef] =
+    toArray(new Array[AnyRef](size))
+
+  def toArray[T](a: Array[T]): Array[T] = {
+    val componentType = a.getClass.getComponentType
+    val toFill: Array[T] =
+      if (a.size >= size) a
+      else jlr.Array.newInstance(componentType, size).asInstanceOf[Array[T]]
+
+    val iter = iterator
+    for (i <- 0 until size)
+      toFill(i) = iter.next().asInstanceOf[T]
+    if (toFill.size > size)
+      toFill(size) = null.asInstanceOf[T]
+    toFill
+  }
+
+  def get(index: Int): E = {
+    checkIndexInBounds(index)
+    innerGet(index)
+  }
+
+  def set(index: Int, element: E): E = {
+    checkIndexInBounds(index)
+    copyIfNeeded()
+    val oldValue = innerGet(index)
+    innerSet(index, element)
+    oldValue
+  }
+
+  def add(e: E): Boolean = {
+    copyIfNeeded()
+    innerPush(e)
+    true
+  }
+
+  def add(index: Int, element: E): Unit = {
+    checkIndexOnBounds(index)
+    copyIfNeeded()
+    innerSplice(index, 0, element)
+  }
+
+  def remove(index: Int): E = {
+    checkIndexInBounds(index)
+    copyIfNeeded()
+    innerSplice(index, 1)(0)
+  }
+
+  def remove(o: scala.Any): Boolean = {
+    val index = indexOf(o)
+    if (index == -1) false else {
+      remove(index)
+      true
+    }
+  }
+
+  def addIfAbsent(e: E): Boolean = {
+    if (contains(e)) false else {
+      copyIfNeeded()
+      innerPush(e)
+      true
+    }
+  }
+
+  def containsAll(c: Collection[_]): Boolean =
+    c.iterator.forall(this.contains(_))
+
+  def removeAll(c: Collection[_]): Boolean = {
+    copyIfNeeded()
+    c.foldLeft(false)((prev, elem) => remove(elem) || prev)
+  }
+
+  def retainAll(c: Collection[_]): Boolean = {
+    val iter = iterator()
+    clear()
+    var modified = false
+    for (elem <- iter) {
+      if (c.contains(elem))
+        innerPush(elem)
+      else
+        modified = true
+    }
+    modified
+  }
+
+  def addAllAbsent(c: Collection[_ <: E]): Int = {
+    val elemsToAdd = c.iterator().filter(!contains(_)).toList
+    copyIfNeeded()
+    elemsToAdd.foreach(innerPush(_))
+    elemsToAdd.size
+  }
+
+  def clear(): Unit = {
+    inner = new js.Array[E]
+    requiresCopyOnWrite = false
+  }
+
+  def addAll(c: Collection[_ <: E]): Boolean =
+    addAll(size, c)
+
+  def addAll(index: Int, c: Collection[_ <: E]): Boolean = {
+    checkIndexOnBounds(index)
+    copyIfNeeded()
+    innerSplice(index, 0, c.asInstanceOf[Collection[E]].toSeq: _*)
+    c.nonEmpty
+  }
+
+  override def toString: String =
+    iterator().mkString("[", ",", "]")
+
+  override def equals(obj: Any): Boolean = {
+    if (obj.asInstanceOf[AnyRef] eq this) {
+      true
+    } else {
+      obj match {
+        case obj: List[_] =>
+          val oIter = obj.listIterator
+          this.forall(oIter.hasNext && _ === oIter.next()) && !oIter.hasNext
+        case _ => false
+      }
+    }
+  }
+
+  override def hashCode(): Int = {
+    iterator().foldLeft(1) {
+      (prev, elem) => 31 * prev + (if (elem == null) 0 else elem.hashCode)
+    }
+  }
+
+  def iterator(): Iterator[E] =
+    listIterator()
+
+  def listIterator(): ListIterator[E] =
+    listIterator(0)
+
+  def listIterator(index: Int): ListIterator[E] = {
+    checkIndexOnBounds(index)
+    new CopyOnWriteArrayListIterator[E](innerSnapshot(), index, 0, size)
+  }
+
+  def subList(fromIndex: Int, toIndex: Int): List[E] = {
+    if (fromIndex < 0 || fromIndex > toIndex || toIndex > size)
+      throw new IndexOutOfBoundsException
+    new CopyOnWriteArrayListView(fromIndex, toIndex)
+  }
+
+  protected def innerGet(index: Int): E =
+    inner(index)
+
+  protected def innerSet(index: Int, elem: E): Unit =
+    inner(index) = elem
+
+  protected def innerPush(elem: E): Unit =
+    inner.push(elem)
+
+  protected def innerSplice(index: Int, deleteCount: Int, items: E*): js.Array[E] =
+    inner.splice(index, deleteCount, items: _*)
+
+  protected def copyIfNeeded(): Unit = {
+    if (requiresCopyOnWrite) {
+      inner = inner.jsSlice()
+      requiresCopyOnWrite = false
+    }
+  }
+
+  protected def innerSnapshot(): js.Array[E] = {
+    requiresCopyOnWrite = true
+    inner
+  }
+
+  private class CopyOnWriteArrayListView(fromIndex: Int, private var toIndex: Int)
+      extends CopyOnWriteArrayList[E](null: js.Array[E]) {
+    viewSelf =>
+
+    override def size(): Int =
+      toIndex - fromIndex
+
+    override def clear(): Unit = {
+      copyIfNeeded()
+      self.innerSplice(fromIndex, size)
+      changeSize(-size)
+    }
+
+    override def listIterator(index: Int): ListIterator[E] = {
+      checkIndexOnBounds(index)
+      new CopyOnWriteArrayListIterator[E](innerSnapshot(), fromIndex + index,
+          fromIndex, toIndex) {
+        override protected def onSizeChanged(delta: Int): Unit = changeSize(delta)
+      }
+    }
+
+    override def subList(fromIndex: Int, toIndex: Int): List[E] = {
+      if (fromIndex < 0 || fromIndex > toIndex || toIndex > size)
+        throw new IndexOutOfBoundsException
+
+      new CopyOnWriteArrayListView(viewSelf.fromIndex + fromIndex,
+          viewSelf.fromIndex + toIndex) {
+        override protected def changeSize(delta: Int): Unit = {
+          super.changeSize(delta)
+          viewSelf.changeSize(delta)
+        }
+      }
+    }
+
+    override def clone(): AnyRef =
+      new CopyOnWriteArrayList[E](this)
+
+    override protected def innerGet(index: Int): E =
+      self.innerGet(fromIndex + index)
+
+    override protected def innerSet(index: Int, elem: E): Unit =
+      self.innerSet(fromIndex + index, elem)
+
+    override protected def innerSplice(index: Int, deleteCount: Int,
+        items: E*): js.Array[E] = {
+      changeSize(items.size - deleteCount)
+      self.innerSplice(fromIndex + index, deleteCount, items: _*)
+    }
+
+    override protected def innerPush(elem: E): Unit = {
+      if (toIndex < self.size) {
+        innerSplice(size, 0, elem)
+      } else {
+        changeSize(1)
+        self.innerPush(elem)
+      }
+    }
+
+    override protected def copyIfNeeded(): Unit =
+      self.copyIfNeeded()
+
+    override protected def innerSnapshot(): js.Array[E] =
+      self.innerSnapshot()
+
+    protected def changeSize(delta: Int): Unit =
+      toIndex += delta
+  }
+
+  protected def checkIndexInBounds(index: Int): Unit = {
+    if (index < 0 || index >= size)
+      throw new IndexOutOfBoundsException(index.toString)
+  }
+
+  protected def checkIndexOnBounds(index: Int): Unit = {
+    if (index < 0 || index > size)
+      throw new IndexOutOfBoundsException(index.toString)
+  }
+}
+
+private class CopyOnWriteArrayListIterator[E](arraySnapshot: js.Array[E], i: Int, start: Int, end: Int)
+    extends AbstractRandomAccessListIterator[E](i, start, end) {
+  override def remove(): Unit =
+    throw new UnsupportedOperationException
+
+  override def set(e: E): Unit =
+    throw new UnsupportedOperationException
+
+  override def add(e: E): Unit =
+    throw new UnsupportedOperationException
+
+  protected def get(index: Int): E =
+    arraySnapshot(index)
+
+  protected def remove(index: Int): Unit =
+    throw new UnsupportedOperationException
+
+  protected def set(index: Int, e: E): Unit =
+    throw new UnsupportedOperationException
+
+  protected def add(index: Int, e: E): Unit =
+    throw new UnsupportedOperationException
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/AbstractCollectionTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/AbstractCollectionTest.scala
@@ -2,7 +2,8 @@ package org.scalajs.testsuite.javalib
 
 import java.{util => ju}
 
-object AbstractCollectionTest extends AbstractCollectionTest(new AbstractCollectionFactory)
+object AbstractCollectionTest
+    extends AbstractCollectionTest(new AbstractCollectionFactory)
 
 abstract class AbstractCollectionTest[F <: AbstractCollectionFactory](factory: F)
     extends CollectionTest {

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/CollectionTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/CollectionTest.scala
@@ -204,4 +204,5 @@ object CollectionFactory {
 trait CollectionFactory {
   def implementationName: String
   def empty[E]: ju.Collection[E]
+  def allowsMutationThroughIterator: Boolean = true
 }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/CollectionsTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/CollectionsTest.scala
@@ -910,6 +910,9 @@ object CollectionsTest extends JasmineTest with ListTest with SortedSetTest
 
           def empty[E]: ju.List[E] =
             ju.Collections.synchronizedList(factory.empty[E])
+
+          override def allowsMutationThroughIterator: Boolean =
+            factory.allowsMutationThroughIterator
         }
       )
     }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/CopyOnWriteArrayListTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/CopyOnWriteArrayListTest.scala
@@ -1,0 +1,101 @@
+/*                    __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.javalib
+
+import java.{util => ju}
+
+import scala.collection.JavaConversions._
+
+object CopyOnWriteArrayListTest extends CopyOnWriteArrayListTest(new CopyOnWriteArrayListFactory)
+
+abstract class CopyOnWriteArrayListTest[F <: CopyOnWriteArrayListFactory](listFactory: F) extends ListTest {
+
+  describe(listFactory.implementationName) {
+    testApi()
+  }
+
+  def testApi(): Unit = {
+    testListApi(listFactory)
+
+    it ("should implement addIfAbsent") {
+      val list = listFactory.empty[Int]
+
+      expect(list.addIfAbsent(0)).toBeTruthy
+      expect(list.size).toEqual(1)
+      expect(list.get(0)).toEqual(0)
+
+      expect(list.addIfAbsent(0)).toBeFalsy
+      expect(list.size).toEqual(1)
+      expect(list.get(0)).toEqual(0)
+
+      expect(list.addIfAbsent(1)).toBeTruthy
+      expect(list.size).toEqual(2)
+      expect(list.get(0)).toEqual(0)
+      expect(list.get(1)).toEqual(1)
+    }
+
+    it ("should implement addAllAbsent") {
+      val list = listFactory.empty[Int]
+
+      expect(list.addAllAbsent(0 until 3)).toEqual(3)
+      expect(list.size).toEqual(3)
+      for (i <- 0 until 3)
+        expect(list.get(i)).toEqual(i)
+
+      expect(list.addAllAbsent(0 until 2)).toEqual(0)
+      expect(list.size).toEqual(3)
+      for (i <- 0 until 3)
+        expect(list.get(i)).toEqual(i)
+
+      expect(list.addAllAbsent(3 until 6)).toEqual(3)
+      expect(list.size).toEqual(6)
+      for (i <- 0 until 6)
+        expect(list.get(i)).toEqual(i)
+
+      expect(list.addAllAbsent(0 until 10)).toEqual(4)
+      expect(list.size).toEqual(10)
+      for (i <- 0 until 10)
+        expect(list.get(i)).toEqual(i)
+
+      expect(list.addAllAbsent(Seq(42, 42, 42))).toEqual(3)
+      expect(list.size).toEqual(13)
+      for (i <- 0 until 10)
+        expect(list.get(i)).toEqual(i)
+      for (i <- 10 until 13)
+        expect(list.get(i)).toEqual(42)
+    }
+
+    it ("should implement a snapshot iterator") {
+      val list = listFactory.empty[Int]
+      list.addAll(0 to 10)
+
+      val iter = list.iterator()
+      list.clear()
+      val iter2 = list.iterator()
+      list.addAll(0 to 5)
+
+      for (i <- 0 to 10) {
+        expect(iter.hasNext).toBeTruthy
+        if (iter.hasNext)
+          expect(iter.next()).toEqual(i)
+      }
+      expect(iter2.hasNext).toBeFalsy
+    }
+  }
+}
+
+class CopyOnWriteArrayListFactory extends ListFactory {
+
+  override def allowsMutationThroughIterator: Boolean = false
+
+  override def implementationName: String =
+    "java.util.concurrent.CopyOnWriteArrayList"
+
+  override def empty[E]: ju.concurrent.CopyOnWriteArrayList[E] =
+    new ju.concurrent.CopyOnWriteArrayList[E]
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/ListTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/ListTest.scala
@@ -218,9 +218,9 @@ trait ListTest extends CollectionTest {
 
     it("should add elements at a given index") {
       val al = factory.empty[String]
-      al.add(0, "one") // ("one")
-      al.add(0, "two") // ("two", "one")
-      al.add(1, "three") // ("two", "three", "one")
+      al.add(0, "one") // ["one"]
+      al.add(0, "two") // ["two", "one"]
+      al.add(1, "three") // ["two", "three", "one"]
 
       expect(al.get(0)).toEqual("two")
       expect(al.get(1)).toEqual("three")
@@ -349,71 +349,75 @@ trait ListTest extends CollectionTest {
       testListIterator(al, Seq("one", "two", "ten", "six"))
       testListIterator(al1, Seq("ten"))
 
-      val iter = al1.listIterator
-      iter.add("three")
-      iter.next()
-      iter.add("zero")
+      if (factory.allowsMutationThroughIterator) {
+        val iter = al1.listIterator
+        iter.add("three")
+        iter.next()
+        iter.add("zero")
 
-      testListIterator(al, Seq("one", "two", "three", "ten", "zero", "six"))
-      testListIterator(al1, Seq("three", "ten", "zero"))
+        testListIterator(al, Seq("one", "two", "three", "ten", "zero", "six"))
+        testListIterator(al1, Seq("three", "ten", "zero"))
+      }
     }
 
-    it("should iterate and modify elements with a listIterator") {
-      val s = Seq("one", "two", "three")
-      val ll = factory.empty[String]
+    if (factory.allowsMutationThroughIterator) {
+      it("should iterate and modify elements with a listIterator") {
+        val s = Seq("one", "two", "three")
+        val ll = factory.empty[String]
 
-      for (e <- s)
-        ll.add(e)
+        for (e <- s)
+          ll.add(e)
 
-      val iter = ll.listIterator(1)
+        val iter = ll.listIterator(1)
 
-      expect(iter.hasNext()).toBeTruthy
-      expect(iter.hasPrevious()).toBeTruthy
+        expect(iter.hasNext()).toBeTruthy
+        expect(iter.hasPrevious()).toBeTruthy
 
-      expect(iter.previous()).toEqual("one")
+        expect(iter.previous()).toEqual("one")
 
-      expect(iter.hasNext()).toBeTruthy
-      expect(iter.hasPrevious()).toBeFalsy
+        expect(iter.hasNext()).toBeTruthy
+        expect(iter.hasPrevious()).toBeFalsy
 
-      expect(iter.next()).toEqual("one")
+        expect(iter.next()).toEqual("one")
 
-      expect(iter.next()).toEqual("two")
-      expect(iter.next()).toEqual("three")
+        expect(iter.next()).toEqual("two")
+        expect(iter.next()).toEqual("three")
 
-      expect(iter.hasNext()).toBeFalsy
-      expect(iter.hasPrevious()).toBeTruthy
+        expect(iter.hasNext()).toBeFalsy
+        expect(iter.hasPrevious()).toBeTruthy
 
-      iter.add("four")
+        iter.add("four")
 
-      expect(iter.hasNext()).toBeFalsy
-      expect(iter.hasPrevious()).toBeTruthy
+        expect(iter.hasNext()).toBeFalsy
+        expect(iter.hasPrevious()).toBeTruthy
 
-      expect(iter.previous()).toEqual("four")
+        expect(iter.previous()).toEqual("four")
 
-      iter.remove()
+        iter.remove()
 
-      expect(iter.hasNext()).toBeFalsy
-      expect(iter.hasPrevious()).toBeTruthy
-      expect(iter.previous()).toEqual("three")
-      iter.set("THREE")
-      expect(iter.previous()).toEqual("two")
-      iter.set("TWO")
-      expect(iter.previous()).toEqual("one")
-      iter.set("ONE")
-      expect(iter.hasNext()).toBeTruthy
-      expect(iter.hasPrevious()).toBeFalsy
+        expect(iter.hasNext()).toBeFalsy
+        expect(iter.hasPrevious()).toBeTruthy
+        expect(iter.previous()).toEqual("three")
+        iter.set("THREE")
+        expect(iter.previous()).toEqual("two")
+        iter.set("TWO")
+        expect(iter.previous()).toEqual("one")
+        iter.set("ONE")
+        expect(iter.hasNext()).toBeTruthy
+        expect(iter.hasPrevious()).toBeFalsy
 
-      expect(iter.next()).toEqual("ONE")
-      iter.remove()
-      expect(iter.next()).toEqual("TWO")
-      iter.remove()
-      expect(iter.next()).toEqual("THREE")
-      iter.remove()
+        expect(iter.next()).toEqual("ONE")
+        iter.remove()
+        expect(iter.next()).toEqual("TWO")
+        iter.remove()
+        expect(iter.next()).toEqual("THREE")
+        iter.remove()
 
-      expect(iter.hasNext()).toBeFalsy
-      expect(iter.hasPrevious()).toBeFalsy
+        expect(iter.hasNext()).toBeFalsy
+        expect(iter.hasPrevious()).toBeFalsy
 
-      expect(ll.isEmpty()).toBeTruthy
+        expect(ll.isEmpty()).toBeTruthy
+      }
     }
   }
 }


### PR DESCRIPTION
* Implement `java.util.concurrent.CopyOnWriteArrayList` without copy on each write.
  Only make a copy if there might be an iterator using the array (simplification due to single-threading).
* Implement tests for `CopyOnWriteArrayList`.