### PR TITLE
Port java.util.concurrent.ConcurrentLinkedQueue.

### DIFF
--- a/javalib/src/main/scala/java/util/LinkedList.scala
+++ b/javalib/src/main/scala/java/util/LinkedList.scala
@@ -211,16 +211,20 @@ class LinkedList[E]() extends AbstractSequentialList[E]
   }
 
   def peekFirst(): E =
-    head.value
+    if (head eq null) null.asInstanceOf[E]
+    else head.value
 
   def peekLast(): E =
-    peekFirst()
+    if (last eq null) null.asInstanceOf[E]
+    else last.value
 
   def pollFirst(): E =
-    removeFirst()
+    if (isEmpty()) null.asInstanceOf[E]
+    else removeFirst()
 
   def pollLast(): E =
-    removeLast()
+    if (isEmpty) null.asInstanceOf[E]
+    else removeLast()
 
   def push(e: E): Unit =
     addFirst(e)

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
@@ -1,0 +1,153 @@
+package java.util.concurrent
+
+import java.util._
+import scala.collection.JavaConversions._
+
+class ConcurrentLinkedQueue[E]()
+    extends AbstractQueue[E] with Queue[E] with Serializable {
+
+  def this(c: Collection[_ <: E]) = {
+    this()
+    addAll(c)
+  }
+
+  import ConcurrentLinkedQueue._
+
+  private var head: Node[E] = null
+  private var last: Node[E] = null
+
+  private var _size: Double = 0
+
+  override def add(e: E): Boolean = {
+    if (e == null) {
+      throw new NullPointerException()
+    } else {
+      val oldLast = last
+
+      last = new Node(e)
+
+      _size += 1
+
+      if (oldLast ne null)
+        oldLast.next = last
+      else
+        head = last
+
+      true
+    }
+  }
+
+  override def offer(e: E): Boolean =
+    add(e)
+
+  override def poll(): E = {
+    if (isEmpty()) null.asInstanceOf[E]
+    else {
+      val oldHead = head
+      head = oldHead.next
+
+      if (head eq null)
+        last = null
+
+      _size -= 1
+      oldHead.value
+    }
+  }
+
+  override def peek(): E =
+    if (isEmpty()) null.asInstanceOf[E]
+    else head.value
+
+  override def isEmpty(): Boolean =
+    _size == 0
+
+  override def size(): Int =
+    _size.toInt
+
+  private def getNodeAt(index: Int): Node[E] = {
+    var current: Node[E] = head
+    for (_ <- 0 until index)
+      current = current.next
+    current
+  }
+
+  private def removeNode(node: Node[E]): Unit = {
+    if (node eq head) {
+      poll()
+    } else if (head ne null) {
+      var prev = head
+      var current: Node[E] = head.next
+
+      while ((current ne null) && (current ne node)) {
+        prev = current
+        current = current.next
+      }
+
+      if (current eq null) {
+        null.asInstanceOf[E]
+      } else {
+        _size -= 1
+
+        prev.next = current.next
+        if (current eq last)
+          last = prev
+      }
+    }
+  }
+
+  override def iterator(): Iterator[E] = {
+    new Iterator[E] {
+
+      private var nextNode: Node[Node[E]] = {
+        val originalHead: Node[Node[E]] =
+          if (head ne null) new Node(head)
+          else null
+
+        var current = originalHead
+        while (current ne null) {
+          val newNode: Node[Node[E]] =
+            if (current.value.next ne null) new Node(current.value.next)
+            else null
+
+          current.next = newNode
+          current = newNode
+        }
+
+        originalHead
+      }
+
+      private var lastNode: Node[Node[E]] = null
+
+      def hasNext(): Boolean =
+        nextNode ne null
+
+      def next(): E = {
+        if (nextNode eq null)
+          throw new NoSuchElementException()
+
+        lastNode = nextNode
+        nextNode = nextNode.next
+
+        lastNode.value.value
+      }
+
+      def remove(): Unit = {
+        if (lastNode eq null)
+          throw new IllegalStateException()
+
+        removeNode(lastNode.value)
+
+        lastNode = null
+      }
+    }
+  }
+
+}
+
+object ConcurrentLinkedQueue {
+
+  private final class Node[T](
+      var value: T,
+      var next: Node[T] = null)
+
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/ConcurrentLinkedQueueTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/ConcurrentLinkedQueueTest.scala
@@ -1,0 +1,184 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package  org.scalajs.testsuite.javalib
+
+import scala.language.implicitConversions
+
+import scala.collection.JavaConversions._
+
+import org.scalajs.jasminetest.JasmineTest
+
+import scala.scalajs.runtime.UndefinedBehaviorError
+
+import java.util.concurrent.ConcurrentLinkedQueue
+
+object ConcurrentLinkedQueueTest extends ConcurrentLinkedQueueTest(new ConcurrentLinkedQueueFactory)
+
+abstract class ConcurrentLinkedQueueTest[F <: ConcurrentLinkedQueueFactory](
+    listFactory: F) extends AbstractCollectionTest(listFactory) {
+
+  override def testApi(): Unit = {
+
+    super.testApi()
+
+    it("should store and remove ordered integers") {
+      val pq = new ConcurrentLinkedQueue[Int]()
+
+      expect(pq.size()).toEqual(0)
+      expect(pq.add(111)).toBeTruthy
+      expect(pq.size()).toEqual(1)
+      expect(pq.add(222)).toBeTruthy
+      expect(pq.size()).toEqual(2)
+      expect(pq.poll()).toEqual(111)
+      expect(pq.size()).toEqual(1)
+      expect(pq.poll()).toEqual(222)
+      expect(pq.add(222)).toBeTruthy
+      expect(pq.add(222)).toBeTruthy
+      expect(pq.remove(222)).toBeTruthy
+      expect(pq.remove(222)).toBeTruthy
+      expect(pq.remove(222)).toBeFalsy
+    }
+
+    it("should store and remove strings") {
+      val pq = new ConcurrentLinkedQueue[String]()
+
+      expect(pq.size()).toEqual(0)
+      expect(pq.add("aaa")).toBeTruthy
+      expect(pq.size()).toEqual(1)
+      expect(pq.add("bbb")).toBeTruthy
+      expect(pq.size()).toEqual(2)
+      expect(pq.poll()).toEqual("aaa")
+      expect(pq.size()).toEqual(1)
+      expect(pq.poll()).toEqual("bbb")
+      expect(pq.add("bbb")).toBeTruthy
+      expect(pq.add("bbb")).toBeTruthy
+      expect(pq.remove("bbb")).toBeTruthy
+      expect(pq.remove("bbb")).toBeTruthy
+      expect(pq.remove("bbb")).toBeFalsy
+      expect(pq.poll()).toBeNull
+    }
+
+    it("should store Double even in corner cases") {
+      val pq = new ConcurrentLinkedQueue[Double]()
+
+      expect(pq.add(1.0)).toBeTruthy
+      expect(pq.add(+0.0)).toBeTruthy
+      expect(pq.add(-0.0)).toBeTruthy
+      expect(pq.add(Double.NaN)).toBeTruthy
+
+      expect(pq.poll.equals(1.0)).toBeTruthy
+
+      expect(pq.poll.equals(+0.0)).toBeTruthy
+
+      expect(pq.poll.equals(-0.0)).toBeTruthy
+
+      expect(pq.peek.isNaN).toBeTruthy
+
+      expect(pq.remove(Double.NaN)).toBeTruthy
+
+      expect(pq.isEmpty).toBeTruthy
+    }
+
+    it("could be instantiated with a prepopulated Collection") {
+      val l = asJavaCollection(Set(1, 5, 2, 3, 4))
+      val pq = new ConcurrentLinkedQueue[Int](l)
+
+      expect(pq.size()).toEqual(5)
+      for (i <- l) {
+        expect(pq.poll()).toEqual(i)
+      }
+      expect(pq.isEmpty).toBeTruthy
+    }
+
+    it("should be cleared in a single operation") {
+      val l = asJavaCollection(Set(1, 5, 2, 3, 4))
+      val pq = new ConcurrentLinkedQueue[Int](l)
+
+      expect(pq.size()).toEqual(5)
+      pq.clear()
+      expect(pq.size()).toEqual(0)
+    }
+
+    it("should add multiple elemnt in one operation") {
+      val l = asJavaCollection(Set(1, 5, 2, 3, 4))
+      val pq = new ConcurrentLinkedQueue[Int]()
+
+      expect(pq.size()).toEqual(0)
+      pq.addAll(l)
+      expect(pq.size()).toEqual(5)
+      pq.add(6)
+      expect(pq.size()).toEqual(6)
+    }
+
+    it("should check contained values even in double corner cases") {
+      val pq = new ConcurrentLinkedQueue[Double]()
+
+      expect(pq.add(11111.0)).toBeTruthy
+      expect(pq.size()).toEqual(1)
+      expect(pq.contains(11111.0)).toBeTruthy
+      expect(pq.iterator.next()).toEqual(11111.0)
+
+      expect(pq.add(Double.NaN)).toBeTruthy
+      expect(pq.size()).toEqual(2)
+      expect(pq.contains(Double.NaN)).toBeTruthy
+      expect(pq.contains(+0.0)).toBeFalsy
+      expect(pq.contains(-0.0)).toBeFalsy
+
+      expect(pq.remove(Double.NaN)).toBeTruthy
+      expect(pq.add(+0.0)).toBeTruthy
+      expect(pq.size()).toEqual(2)
+      expect(pq.contains(Double.NaN)).toBeFalsy
+      expect(pq.contains(+0.0)).toBeTruthy
+      expect(pq.contains(-0.0)).toBeFalsy
+
+      expect(pq.remove(+0.0)).toBeTruthy
+      expect(pq.add(-0.0)).toBeTruthy
+      expect(pq.size()).toEqual(2)
+      expect(pq.contains(Double.NaN)).toBeFalsy
+      expect(pq.contains(+0.0)).toBeFalsy
+      expect(pq.contains(-0.0)).toBeTruthy
+
+      expect(pq.add(+0.0)).toBeTruthy
+      expect(pq.add(Double.NaN)).toBeTruthy
+      expect(pq.contains(Double.NaN)).toBeTruthy
+      expect(pq.contains(+0.0)).toBeTruthy
+      expect(pq.contains(-0.0)).toBeTruthy
+    }
+
+    it("should provide a weakly consistent iterator") {
+      val queue = new ConcurrentLinkedQueue[Int]()
+      queue.add(1)
+      queue.add(2)
+      val iter1 = queue.iterator()
+      expect(iter1.next()).toEqual(1)
+      expect(iter1.hasNext).toBeTruthy
+      queue.remove(2)
+      expect(iter1.hasNext).toBeTruthy
+      expect(iter1.next()).toEqual(2)
+      expect(iter1.hasNext).toBeFalsy
+
+      val queue2 = new ConcurrentLinkedQueue[Int]()
+      queue2.add(1)
+      queue2.add(2)
+      queue2.add(3)
+      val iter2 = queue2.iterator()
+      expect(iter2.next()).toEqual(1)
+      iter2.remove()
+      expect(iter2.next()).toEqual(2)
+      expect(iter2.next()).toEqual(3)
+    }
+  }
+}
+
+class ConcurrentLinkedQueueFactory extends AbstractCollectionFactory {
+  override def implementationName: String =
+    "java.util.concurrent.ConcurrentLinkedQueue"
+
+  override def empty[E]: ConcurrentLinkedQueue[E] =
+    new ConcurrentLinkedQueue[E]()
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/LinkedListTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/LinkedListTest.scala
@@ -35,6 +35,8 @@ abstract class LinkedListTest[F <: LinkedListFactory](listFactory: F) extends Ab
       ll.addLast(2)
       expect(ll.peekFirst()).toEqual(2)
 
+      ll.clear()
+
       ll.addFirst(1)
       ll.removeLast()
       ll.addFirst(2)
@@ -122,6 +124,29 @@ abstract class LinkedListTest[F <: LinkedListFactory](listFactory: F) extends Ab
       expect(llDouble.pop()).toEqual(-0.987)
       expect(llDouble.pop()).toEqual(+10000.987)
       expect(llString.isEmpty()).toBeTruthy
+    }
+
+    it("should poll and peek elements") {
+      val pq = new LinkedList[String]()
+
+      expect(pq.add("one")).toBeTruthy
+      expect(pq.add("two")).toBeTruthy
+      expect(pq.add("three")).toBeTruthy
+
+      expect(pq.peek.equals("one")).toBeTruthy
+      expect(pq.poll.equals("one")).toBeTruthy
+
+      expect(pq.peekFirst.equals("two")).toBeTruthy
+      expect(pq.pollFirst.equals("two")).toBeTruthy
+
+      expect(pq.peekLast.equals("three")).toBeTruthy
+      expect(pq.pollLast.equals("three")).toBeTruthy
+
+      expect(pq.peekFirst).toBeNull
+      expect(pq.pollFirst).toBeNull
+
+      expect(pq.peekLast).toBeNull
+      expect(pq.pollLast).toBeNull
     }
 
     it("should remove occurrences of provided elements") {


### PR DESCRIPTION
ConcurrentLinkedQueue backed by a java.util.LinkedList,
there is also a fix of peek and poll methods of LinkedList that were bugged