### PR TITLE
Fix #1774: Make Rhino tolerant to Unchecked asInstanceOfs.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -26,6 +26,9 @@
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala helloworld/run \
         helloworld/clean &&
+    sbt 'set scalaJSSemantics in helloworld ~= (_.withAsInstanceOfs(org.scalajs.core.tools.sem.CheckedBehavior.Unchecked))' \
+        ++$scala helloworld/run \
+        helloworld/clean &&
     sbt 'set inScope(ThisScope in helloworld)(postLinkJSEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
         'set scalaJSStage in Global := FastOptStage' \
         ++$scala helloworld/run \

--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
@@ -148,9 +148,13 @@ class ScalaJSCoreLib private[rhino] (semantics: Semantics,
       new LazyScalaJSScope(this, scope, base, isStatics, dummy = 0)
 
     for (Info(name, isStatics) <- scalaJSLazyFields) {
-      val base = ScalaJS.get(name, ScalaJS).asInstanceOf[Scriptable]
-      val lazified = makeLazyScalaJSScope(base, isStatics)
-      ScalaJS.put(name, ScalaJS, lazified)
+      val base = ScalaJS.get(name, ScalaJS)
+      // Depending on the Semantics, some fields could be entirely absent
+      if (base != Scriptable.NOT_FOUND) {
+        val lazified = makeLazyScalaJSScope(
+            base.asInstanceOf[Scriptable], isStatics)
+        ScalaJS.put(name, ScalaJS, lazified)
+      }
     }
   }
 


### PR DESCRIPTION
When asInstanceOfs are Unchecked, the global ScalaJS object has two fields less (namely `as` and `asArrayOf`) which must therefore not be turned into `LazyScalaJSScope`s.