### PR TITLE
Fix #1791: Provide conversions from Java boxed types to js.Any.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala/scala/scalajs/js/Any.scala
@@ -123,6 +123,24 @@ object Any extends LowPrioAnyImplicits {
   implicit def toFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R](f: Function21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]): scala.Function21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21)
   implicit def toFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R](f: Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]): scala.Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] = (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22) => f(x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22)
   // scalastyle:on line.size.limit
+
+  @inline implicit def fromJBoolean(value: java.lang.Boolean): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromJByte(value: java.lang.Byte): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromJShort(value: java.lang.Short): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromJInteger(value: java.lang.Integer): Any =
+    value.asInstanceOf[Any]
+
+  @inline implicit def fromJLong(value: java.lang.Long): Any =
+    if (value eq null) null
+    else value.doubleValue.asInstanceOf[Any]
+
+  @inline implicit def fromJFloat(value: java.lang.Float): Any =
+    value.asInstanceOf[Any]
+  @inline implicit def fromJDouble(value: java.lang.Double): Any =
+    value.asInstanceOf[Any]
 }
 
 trait LowPrioAnyImplicits {

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/PrimitivesTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/PrimitivesTest.scala
@@ -1,0 +1,42 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import org.scalajs.jasminetest.JasmineTest
+
+object PrimitivesTest extends JasmineTest {
+
+  describe("Interoperability for primitive types") {
+
+    it("should convert Java boxed types to js.Any") {
+      expect(new java.lang.Boolean(false)).toBe(false)
+      expect(null: java.lang.Boolean).toBeNull
+
+      expect(new java.lang.Byte(42.toByte)).toBe(42)
+      expect(null: java.lang.Byte).toBeNull
+
+      expect(new java.lang.Short(42.toShort)).toBe(42)
+      expect(null: java.lang.Short).toBeNull
+
+      expect(new java.lang.Integer(42)).toBe(42)
+      expect(null: java.lang.Integer).toBeNull
+
+      expect(new java.lang.Long(42L)).toBe(42)
+      expect(null: java.lang.Long).toBeNull
+
+      expect(new java.lang.Float(42.0f)).toBe(42)
+      expect(null: java.lang.Float).toBeNull
+
+      expect(new java.lang.Double(42.0)).toBe(42)
+      expect(null: java.lang.Double).toBeNull
+    }
+
+  }
+
+}


### PR DESCRIPTION
Java boxed types can be used as an accurate representation of `null | PrimType`. These conversions allow these types to be used where a js.Any is expected.