### PR TITLE
Fix #1790: Don't crash for a lambda param containing a dash.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -3861,7 +3861,7 @@ abstract class GenJSCode extends plugins.PluginComponent
         val paramName = param.name
         val js.Ident(name, origName) = paramName
         val newOrigName = origName.getOrElse(name)
-        val newNameIdent = freshLocalIdent(newOrigName)(paramName.pos)
+        val newNameIdent = freshLocalIdent(name)(paramName.pos)
         val patchedParam = js.ParamDef(newNameIdent, jstpe.AnyType,
             mutable = false, rest = param.rest)(param.pos)
         val paramLocal = js.VarDef(paramName, param.ptpe, mutable = false,

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -438,5 +438,10 @@ object RegressionTest extends JasmineTest {
       val x = getNull().asInstanceOf[Unit]: Any
       expect(x.asInstanceOf[js.Any]).toBeNull
     }
+
+    it("lambda parameter with a dash - #1790") {
+      val f = (`a-b`: Int) => `a-b` + 1
+      expect(f(5)).toEqual(6)
+    }
   }
 }


### PR DESCRIPTION
This boils down to not using the original name of a parameter to derive the identifier for its boxed parameter. Use its identifier instead.