### PR TITLE
Fix #1804: Do binary compat checks only for published artifacts.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -52,7 +52,7 @@ object Build extends sbt.Build {
     CrossVersion.binaryMapped(v => s"sjs${previousSJSBinaryVersion}_$v")
 
   val newScalaBinaryVersionsInThisRelease: Set[String] =
-    Set("2.12.0-M1")
+    Set()
 
   val previousArtifactSetting: Setting[_] = {
     previousArtifact := {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -51,6 +51,8 @@ object Build extends sbt.Build {
   val previousBinaryCrossVersion =
     CrossVersion.binaryMapped(v => s"sjs${previousSJSBinaryVersion}_$v")
 
+  val scalaVersionsUsedForPublishing: Set[String] =
+    Set("2.10.5", "2.11.7", "2.12.0-M1")
   val newScalaBinaryVersionsInThisRelease: Set[String] =
     Set()
 
@@ -58,7 +60,10 @@ object Build extends sbt.Build {
     previousArtifact := {
       val scalaV = scalaVersion.value
       val scalaBinaryV = scalaBinaryVersion.value
-      if (newScalaBinaryVersionsInThisRelease.contains(scalaBinaryV)) {
+      if (!scalaVersionsUsedForPublishing.contains(scalaV)) {
+        // This artifact will not be published. Binary compatibility is irrelevant.
+        None
+      } else if (newScalaBinaryVersionsInThisRelease.contains(scalaBinaryV)) {
         // New in this release, no binary compatibility to comply to
         None
       } else {


### PR DESCRIPTION
It is irrelevant, and wrong, to check binary compatibility checks with Scala versions that are not actually used to *publish* the artifacts. Doing them caused some checks to fail when testing with earlier versions of the Scala compiler, because more recent versions produce less private boilerplate members.