### PR TITLE
Remove JDK 6 from CI, essentially dropping support of JDK 6.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -266,19 +266,11 @@
     <!-- Main test tasks -->
     <run task="main">
       <v n="scala">2.10.2</v>
-      <v n="java">1.6</v>
-    </run>
-    <run task="main">
-      <v n="scala">2.10.2</v>
       <v n="java">1.7</v>
     </run>
     <run task="main">
       <v n="scala">2.10.2</v>
       <v n="java">1.8</v>
-    </run>
-    <run task="main">
-      <v n="scala">2.11.7</v>
-      <v n="java">1.6</v>
     </run>
     <run task="main">
       <v n="scala">2.11.7</v>
@@ -296,17 +288,12 @@
     <!-- Bootstrap test tasks -->
     <run task="bootstrap">
       <v n="scala">2.10.2</v>
-      <v n="java">1.6</v>
-    </run>
-    <run task="bootstrap">
-      <v n="scala">2.10.2</v>
       <v n="java">1.7</v>
     </run>
     <run task="bootstrap">
       <v n="scala">2.10.2</v>
       <v n="java">1.8</v>
     </run>
-    <!-- Tools do not compile on JDK6, Scala 2.11.x (see #1235) -->
     <run task="bootstrap">
       <v n="scala">2.11.7</v>
       <v n="java">1.7</v>
@@ -323,17 +310,12 @@
     <!-- Tools / CLI / Stubs / sbtPlugin test tasks -->
     <run task="tools-cli-stubs-sbtplugin">
       <v n="scala">2.10.5</v>
-      <v n="java">1.6</v>
-    </run>
-    <run task="tools-cli-stubs-sbtplugin">
-      <v n="scala">2.10.5</v>
       <v n="java">1.7</v>
     </run>
     <run task="tools-cli-stubs-sbtplugin">
       <v n="scala">2.10.5</v>
       <v n="java">1.8</v>
     </run>
-    <!-- Tools do not compile on JDK6, Scala 2.11.x (see #1235) -->
     <run task="tools-cli-stubs">
       <v n="scala">2.11.7</v>
       <v n="java">1.7</v>
@@ -370,10 +352,6 @@
     </run>
     <run task="main">
       <v n="scala">2.10.5</v>
-      <v n="java">1.6</v>
-    </run>
-    <run task="main">
-      <v n="scala">2.10.5</v>
       <v n="java">1.7</v>
     </run>
     <run task="main">
@@ -390,10 +368,6 @@
     </run>
     <run task="main">
       <v n="scala">2.11.2</v>
-      <v n="java">1.6</v>
-    </run>
-    <run task="main">
-      <v n="scala">2.11.2</v>
       <v n="java">1.7</v>
     </run>
     <run task="main">
@@ -402,10 +376,6 @@
     </run>
     <run task="main">
       <v n="scala">2.11.4</v>
-      <v n="java">1.6</v>
-    </run>
-    <run task="main">
-      <v n="scala">2.11.4</v>
       <v n="java">1.7</v>
     </run>
     <run task="main">
@@ -414,19 +384,11 @@
     </run>
     <run task="main">
       <v n="scala">2.11.5</v>
-      <v n="java">1.6</v>
-    </run>
-    <run task="main">
-      <v n="scala">2.11.5</v>
       <v n="java">1.7</v>
     </run>
     <run task="main">
       <v n="scala">2.11.5</v>
       <v n="java">1.8</v>
-    </run>
-    <run task="main">
-      <v n="scala">2.11.6</v>
-      <v n="java">1.6</v>
     </run>
     <run task="main">
       <v n="scala">2.11.6</v>
@@ -445,10 +407,6 @@
     <run task="bootstrap">
       <v n="scala">2.10.4</v>
       <v n="java">1.7</v>
-    </run>
-    <run task="bootstrap">
-      <v n="scala">2.10.5</v>
-      <v n="java">1.6</v>
     </run>
     <run task="bootstrap">
       <v n="scala">2.10.5</v>
@@ -614,10 +572,6 @@
       <v n="scala">2.11.7</v>
       <v n="java">1.8</v>
     </run>
-    <!--
-        Partest does sometimes not compile on JDK6 (see #1227) we
-        therefore do not run any JDK6 partests.
-      -->
   </matrix>
 
 </ci>


### PR DESCRIPTION
We have been dragging support for JDK 6 for a very long time already. Even though some parts of our architecture did not even work correctly on that platform (e.g., partests).

This commit removes all traces of JDK 6 from our CI matrix, essentially dropping support of JDK 6.