### PR TITLE
Fix #1819: Accept any number in isFloat when non-strict floats.

### DIFF
--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
@@ -53,6 +53,22 @@ object InstanceTestsHijackedBoxedClassesTest extends JasmineTest {
       expect((-0.0: Any).isInstanceOf[Int]).toBeFalsy
     }
 
+    when("strict-floats").
+    it("isInstanceOf[Float] with strict-floats") {
+      expect((1.2: Any).isInstanceOf[Float]).toBeFalsy
+    }
+
+    unless("strict-floats").
+    it("isInstanceOf[Float] with non-strict-floats") {
+      expect((1.2: Any).isInstanceOf[Float]).toBeTruthy
+
+      // from the bug report
+      def test(x: Any): String = x match {
+        case f: Float => "ok"
+      }
+      expect(test(0.2)).toEqual("ok")
+    }
+
     it("should support asInstanceOf (positive)") {
       def swallow(x: Any): Unit = ()
       swallow((()         : Any).asInstanceOf[Unit])
@@ -79,6 +95,16 @@ object InstanceTestsHijackedBoxedClassesTest extends JasmineTest {
       expect(() => ('g'  : Any).asInstanceOf[Double] ).toThrow
 
       expect(() => (-0.0: Any).asInstanceOf[Int]).toThrow
+    }
+
+    whenAll("strict-floats", "compliant-asinstanceofs").
+    it("asInstanceOf[Float] with strict-floats") {
+      expect(() => (1.2: Any).asInstanceOf[Float]).toThrow
+    }
+
+    unless("strict-floats").
+    it("asInstanceOf[Float] with non-strict-floats") {
+      expect((1.2: Any).asInstanceOf[Float]).toBe(1.2)
     }
 
     it("should support isInstanceOf via java.lang.Class (positive)") {
@@ -115,6 +141,16 @@ object InstanceTestsHijackedBoxedClassesTest extends JasmineTest {
       test('f',   classOf[java.lang.Double])
 
       test(-0.0, classOf[java.lang.Integer])
+    }
+
+    when("strict-floats").
+    it("classOf[Float].isInstance() with strict-floats") {
+      expect(classOf[java.lang.Float].isInstance(1.2)).toBeFalsy
+    }
+
+    unless("strict-floats").
+    it("classOf[Float].isInstance() with non-strict-floats") {
+      expect(classOf[java.lang.Float].isInstance(1.2)).toBeTruthy
     }
 
   }

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -520,7 +520,11 @@ ScalaJS.isInt = function(v) {
 };
 
 ScalaJS.isFloat = function(v) {
+//!if floats == Strict
   return v !== v || ScalaJS.fround(v) === v;
+//!else
+  return typeof v === "number";
+//!endif
 };
 
 //!if asInstanceOfs != Unchecked

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/JSDesugaring.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/JSDesugaring.scala
@@ -1633,8 +1633,10 @@ object JSDesugaring {
               case 'F' =>
                 if (isStrongMode)
                   genCallHelper("uF", newExpr)
-                else
+                else if (semantics.strictFloats)
                   genFround(newExpr)
+                else
+                  js.UnaryOp(JSUnaryOp.+, newExpr)
               case 'D' =>
                 if (isStrongMode)
                   genCallHelper("uD", newExpr)

--- a/tools/strongmodeenv.js
+++ b/tools/strongmodeenv.js
@@ -140,7 +140,11 @@ function $isInt(v) {
 }
 
 function $isFloat(v) {
+//!if floats == Strict
   return (typeof v === "number") && (v !== v || $fround(v) === v);
+//!else
+  return typeof v === "number";
+//!endif
 }
 
 //!if asInstanceOfs != Unchecked
@@ -328,7 +332,11 @@ function $uD(value) {
 }
 //!else
 function $uF(value) {
+//!if floats == Strict
   return value === null ? 0 : $fround(value);
+//!else
+  return value === null ? 0 : +value;
+//!endif
 }
 function $uD(value) {
   return value === null ? 0 : +value;


### PR DESCRIPTION
When strict-floats are disabled, any number, i.e., any Double, now also matches as a Float, as per the specification.