### PR TITLE
Change the exception message used in UUID.fromString

### DIFF
--- a/javalib/src/main/scala/java/util/UUID.scala
+++ b/javalib/src/main/scala/java/util/UUID.scala
@@ -141,7 +141,7 @@ object UUID {
     import Integer.parseInt
 
     def fail(): Nothing =
-      throw new IllegalArgumentException("Illegal UUID string: "+name)
+      throw new IllegalArgumentException("Invalid UUID string: "+name)
 
     @inline def parseHex8(his: String, los: String): Int =
       (parseInt(his, 16) << 16) | parseInt(los, 16)


### PR DESCRIPTION
The OpenJDKs 6 and 7 and the Oracle JDKs 7 and 8 use "Invalid UUID string"
as prefix for the exception message that is used in UUID.fromString. The
Android SDK's message begins with "Invalid UUID" but skips " string". This
changes the message from "Illegal UUID string" to "Invalid UUID string" to
match the message used by the aforementioned JDKs.

I've checked the error messages of the different JDKs here:
https://travis-ci.org/fthomas/jdk-test/jobs/72487266
https://travis-ci.org/fthomas/jdk-test/jobs/72487267
https://travis-ci.org/fthomas/jdk-test/jobs/72487268
https://travis-ci.org/fthomas/jdk-test/jobs/72487269
https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/java/util/UUID.java