### PR TITLE
Fix #1824: Add a union type `js.|[A, B]`, aka `A | B`.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Union.scala
+++ b/library/src/main/scala/scala/scalajs/js/Union.scala
@@ -1,0 +1,76 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.language.implicitConversions
+
+/** Value of type A or B (union type).
+ *
+ *  Scala does not have union types, but they are important to many
+ *  interoperability scenarios. This type provides a (partial) encoding of
+ *  union types using implicit evidences.
+ */
+@scala.scalajs.js.annotation.RawJSType // Don't do this at home!
+sealed trait |[A, B] // scalastyle:ignore
+
+object | { // scalastyle:ignore
+  /** Evidence that `A <: B`, taking top-level `|`-types into account. */
+  sealed trait Evidence[-A, +B]
+
+  /** A unique (and typically dead-code-eliminated away) instance of
+   *  `Evidence`.
+   */
+  private object ReusableEvidence extends Evidence[scala.Any, scala.Any]
+
+  abstract sealed class EvidenceLowestPrioImplicits {
+    /** If `A <: B2`, then `A <: B1 | B2`. */
+    implicit def right[A, B1, B2](implicit ev: Evidence[A, B2]): Evidence[A, B1 | B2] =
+      ReusableEvidence.asInstanceOf[Evidence[A, B1 | B2]]
+  }
+
+  abstract sealed class EvidenceLowPrioImplicits extends EvidenceLowestPrioImplicits {
+    /** `Int <: Double`, because that's true in Scala.js. */
+    implicit def intDouble: Evidence[Int, Double] =
+      ReusableEvidence.asInstanceOf[Evidence[Int, Double]]
+
+    /** If `A <: B1`, then `A <: B1 | B2`. */
+    implicit def left[A, B1, B2](implicit ev: Evidence[A, B1]): Evidence[A, B1 | B2] =
+      ReusableEvidence.asInstanceOf[Evidence[A, B1 | B2]]
+  }
+
+  object Evidence extends EvidenceLowPrioImplicits {
+    /** `A <: A`. */
+    implicit def base[A]: Evidence[A, A] =
+      ReusableEvidence.asInstanceOf[Evidence[A, A]]
+
+    /** If `A1 <: B` and `A2 <: B`, then `A1 | A2 <: B`. */
+    implicit def allSubtypes[A1, A2, B](
+        implicit ev1: Evidence[A1, B], ev2: Evidence[A2, B]): Evidence[A1 | A2, B] =
+      ReusableEvidence.asInstanceOf[Evidence[A1 | A2, B]]
+  }
+
+  /** Upcast `A` to `B1 | B2`.
+   *
+   *  This needs evidence that `A <: B1 | B2`.
+   */
+  implicit def from[A, B1, B2](a: A)(implicit ev: Evidence[A, B1 | B2]): B1 | B2 =
+    a.asInstanceOf[B1 | B2]
+
+  /** Operations on union types. */
+  implicit class UnionOps[A <: _ | _](val self: A) extends AnyVal {
+    /** Explicitly merge a union type to a supertype (which might not be a
+     *  union type itself).
+     *
+     *  This needs evidence that `A <: B`.
+     */
+    def merge[B](implicit ev: |.Evidence[A, B]): B =
+      self.asInstanceOf[B]
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
@@ -1,0 +1,178 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.library
+
+import scala.language.implicitConversions
+
+import scala.collection.mutable
+
+import scala.scalajs.js
+import js.|
+
+import org.scalajs.jasminetest.JasmineTest
+import org.scalajs.testsuite.Typechecking._
+
+import js.JSConverters._
+
+object UnionTypeTest extends JasmineTest {
+
+  private implicit def unionAsJSAny(x: _ | _): js.Any = x.asInstanceOf[js.Any]
+
+  describe("js.| (postive)") {
+
+    it("Left and right") {
+      val x1: Int | String = 4
+      expect(x1).toBe(4)
+
+      val x2: Int | String = "hello"
+      expect(x2).toBe("hello")
+    }
+
+    it("Left and right with subtyping") {
+      val list = List(1, 2, 3)
+
+      val x1: Seq[Int] | CharSequence = list
+      expect(x1.isInstanceOf[List[_]]).toBeTruthy
+      expect(x1.asInstanceOf[List[_]].toJSArray).toEqual(js.Array(1, 2, 3))
+
+      val x2: Seq[Int] | CharSequence = "hello"
+      expect(x2).toBe("hello")
+    }
+
+    it("Three types") {
+      val x1: Int | String | Boolean = 3
+      expect(x1).toBe(3)
+
+      val x2: Int | String | Boolean = "hello"
+      expect(x2).toBe("hello")
+
+      val x3: Int | String | Boolean = false
+      expect(x3).toBe(false)
+    }
+
+    it("Upcast") {
+      val x1: List[Int] | String = "hello"
+      val x2: Seq[Int] | CharSequence = x1
+      expect(x2).toBe("hello")
+    }
+
+    it("Int as Double") {
+      val x1: Double | String = 3
+      expect(x1).toBe(3)
+    }
+
+    it("Swap base types") {
+      val x1: Int | String = 3
+      val x2: String | Int = x1
+      expect(x2).toBe(3)
+    }
+
+    it("Permutations for 3 base types") {
+      val x: Int | String | Boolean = 3
+
+      val x1: Int | Boolean | String = x
+      val x2: String | Int | Boolean = x
+      val x3: String | Boolean | Int = x
+      val x4: Boolean | Int | String = x
+      val x5: Boolean | String | Int = x
+
+      expect(x1).toBe(3)
+      expect(x2).toBe(3)
+      expect(x3).toBe(3)
+      expect(x4).toBe(3)
+      expect(x5).toBe(3)
+    }
+
+    it("Permutations of 2 base types to 3 base types") {
+      val x1: Int | String = 3
+      val x2: Int | Boolean = false
+      val x3: Boolean | String = "hello"
+
+      val y1: Int | String | Boolean = x1
+      val y2: Int | String | Boolean = x2
+      val y3: Int | String | Boolean = x3
+
+      expect(y1).toBe(3)
+      expect(y2).toBe(false)
+      expect(y3).toBe("hello")
+    }
+
+    it("Partial upper bound") {
+      val x: Int | String | Boolean = "hello"
+
+      val x1: AnyVal | String = x
+      val x2: String | AnyVal = x
+
+      expect(x1).toBe("hello")
+      expect(x2).toBe("hello")
+
+      /* Note: the *total* upper bound does not work without an explicit
+       * `merge`, because the expected type is not an | type.
+       */
+    }
+
+    it("merge") {
+      val x1: Int | Boolean = 4
+      val y1: AnyVal = x1.merge
+      expect(y1.asInstanceOf[js.Any]).toBe(4)
+
+      val x2: String | java.nio.CharBuffer = "hello"
+      val y2: CharSequence = x2.merge
+      expect(y2.asInstanceOf[js.Any]).toBe("hello")
+
+      val x3: Int | String | Boolean | java.nio.CharBuffer = "hello"
+      val y3: CharSequence | AnyVal = x3.merge
+      expect(y3.asInstanceOf[js.Any]).toBe("hello")
+
+      val x4: List[Int] | Vector[Int] | mutable.Buffer[Int] = List(3, 5)
+      val y4: Seq[Int] = x4.merge
+      expect(y4.toJSArray).toEqual(js.Array(3, 5))
+    }
+
+  }
+
+  describe("js.| (negative)") {
+
+    /* Error messages vary a lot depending on the version of Scala, so we do
+     * not test them.
+     */
+
+    it("Neither left nor right") {
+      typeError(
+          "3: Boolean | String")
+    }
+
+    it("None of three types") {
+      typeError(
+          "3: Boolean | String | List[Int]")
+    }
+
+    it("Wrong type parameter on left or right") {
+      typeError(
+          "List(1, 2): List[String] | String")
+      typeError(
+          "List(1, 2): String | List[String]")
+    }
+
+    it("Left of |-type is not a subtype of rhs") {
+      typeError(
+          "(1: Int | List[String]): String | List[String]")
+    }
+
+    it("Right of |-type is not a subtype of rhs") {
+      typeError(
+          "(1: Int | List[String]): String | Int")
+    }
+
+    it("merge with an incorrect subtype") {
+      typeError(
+          "(List(1, 2): List[Int] | Set[Int]).merge: Seq[Int]")
+    }
+
+  }
+}


### PR DESCRIPTION
This is an unboxed union type, which is represent a value of type either A or B.