### PR TITLE
Fix #1818: Improve performance of Hashers.hashAsVersion

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -53,9 +53,12 @@ object Hashers {
     val size = 2 * (if (considerPos) 2 else 1) * 20
     val builder = new StringBuilder(size)
 
-    def append(hash: Array[Byte]) =
-      for (b <- hash) builder.append(f"$b%02X")
+    def hexDigit(digit: Int): Char = Character.forDigit(digit, 16)
 
+    def append(hash: Array[Byte]): Unit = {
+      for (b <- hash)
+        builder.append(hexDigit(b >> 4)).append(hexDigit(b & 0xF))
+    }
     append(hash.treeHash)
 
     if (considerPos)


### PR DESCRIPTION
Before the change the performance of `testSuite/test:fastOpt` where:
```
[debug] Linker: Read info: 19896 us
[debug] Linker: Check Infos: 374083 us
[debug] Linker: Compute reachability: 193762 us
[debug] Linker: Assemble LinkedClasses: 1023952 us 
[debug] Linker: Check IR: 2641108 us
[debug] Linker: cache stats: reused: 5164 -- invalidated: 0 -- trees read: 0
```
After the change it has a 13X improvement:
```
[debug] Linker: Read info: 26999 us
[debug] Linker: Check Infos: 418228 us
[debug] Linker: Compute reachability: 1427003 us
[debug] Linker: Assemble LinkedClasses: 78869 us
[debug] Linker: Check IR: 2693044 us
[debug] Linker: cache stats: reused: 5164 -- invalidated: 0 -- trees read: 0
```
