### PR TITLE
Fix #1844: Add JSDependency.toString method.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependency.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependency.scala
@@ -79,6 +79,19 @@ final class JSDependency(
     acc = mixLast(acc, minifiedResourceName.##)
     finalizeHash(acc, 4)
   }
+
+  override def toString(): String = {
+    val b = new StringBuilder
+    b ++= s"JSDependency($resourceName"
+    if (commonJSName.nonEmpty)
+      b ++= s", commonJSName=$dependencies"
+    if (minifiedResourceName.nonEmpty)
+      b ++= s", minifiedResourceName=$minifiedResourceName"
+    if (dependencies.nonEmpty)
+      b ++= s", dependencies=$dependencies"
+    b ++= ")"
+    b.result()
+  }
 }
 
 object JSDependency {


### PR DESCRIPTION
Before it would print:
```scala
> show jasmineTestFramework/jsDependencies
[info] List(ProvidedJSModuleID(org.scalajs.core.tools.jsdep.JSDependency@8247f992,None), JarJSModuleID(org.webjars:jasmine:1.3.1,org.scalajs.core.tools.jsdep.JSDependency@69106ac6))
```

Now it prints:
```scala
> show jasmineTestFramework/jsDependencies
[info] List(ProvidedJSModuleID(JSDependency(jasmine-polyfills.js),None), JarJSModuleID(org.webjars:jasmine:1.3.1,JSDependency(jasmine.js, dependencies=List(jasmine-polyfills.js))))
```