### PR TITLE
Finish fix for #1759: Use `new` in *all* versions of Array.clone().

### DIFF
--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -775,7 +775,7 @@ initArray(
       return new ArrayClass(this.u["slice"](0));
     else
       // The underlying Array is a TypedArray
-      return new ArrayClass(this.u.constructor(this.u));
+      return new ArrayClass(new this.u.constructor(this.u));
   };
 //!else
   class ArrayClass extends ScalaJS.c.O {


### PR DESCRIPTION
The original fix in b153f86e883267efba51bd9320b8d6d616dc168f was missing one change, in the variant of Array.clone() used when targeting ES 5.