### PR TITLE
Fix #1813: Support calling the super ctor of a JS class with : _*.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -3398,13 +3398,6 @@ abstract class GenJSCode extends plugins.PluginComponent
             s"Scala.js-defined JS class at $pos")
         genApplyMethod(genReceiver, sym, genScalaArgs)
       } else if (sym.isClassConstructor) {
-        // Implementation restriction
-        if (genJSArgs.exists(_.isInstanceOf[js.JSSpread])) {
-          reporter.error(pos,
-              "Implementation restriction: cannot call the super " +
-              "constructor of a Scala.js-defined JS class with :_*")
-        }
-
         js.JSSuperConstructorCall(genJSArgs)
       } else if (isScalaJSDefinedJSClass(sym.owner) && !isExposed(sym)) {
         // Reroute to the static method

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -674,6 +674,18 @@ abstract class GenJSCode extends plugins.PluginComponent
         constructorTrees.partition(_.symbol.isPrimaryConstructor)
 
       // Implementation restriction
+      val sym = primaryCtorTree.symbol
+      val hasBadParam = enteringPhase(currentRun.uncurryPhase) {
+        sym.paramss.flatten.exists(p => p.hasDefault || isRepeated(p))
+      }
+      if (hasBadParam) {
+        reporter.error(pos,
+            "Implementation restriction: the constructor of a " +
+            "Scala.js-defined JS classes cannot have default parameters nor " +
+            "repeated parameters.")
+      }
+
+      // Implementation restriction
       for (tree <- secondaryCtorTrees) {
         reporter.error(tree.pos,
             "Implementation restriction: Scala.js-defined JS classes cannot " +

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -421,16 +421,6 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noSuperConstructorCallWithSpread: Unit = {
-    """
-    class A(args: Int*) extends js.Object
-
-    @ScalaJSDefined
-    class B(x: Int, y: Int) extends A(Seq(x, y): _*)
-    """.fails
-  }
-
-  @Test
   def noUseJsNative: Unit = {
     """
     @ScalaJSDefined

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -387,6 +387,25 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
   }
 
   @Test
+  def noDefaultOrRepeatedParam: Unit = {
+    """
+    @ScalaJSDefined
+    class A(x: Int, y: Int = 4) extends js.Object
+
+    @ScalaJSDefined
+    class B(x: Int, args: Int*) extends js.Object
+    """ hasErrors
+    """
+      |newSource1.scala:6: error: Implementation restriction: the constructor of a Scala.js-defined JS classes cannot have default parameters nor repeated parameters.
+      |    class A(x: Int, y: Int = 4) extends js.Object
+      |          ^
+      |newSource1.scala:9: error: Implementation restriction: the constructor of a Scala.js-defined JS classes cannot have default parameters nor repeated parameters.
+      |    class B(x: Int, args: Int*) extends js.Object
+      |          ^
+    """
+  }
+
+  @Test
   def noSecondaryCtor: Unit = {
     """
     @ScalaJSDefined
@@ -407,7 +426,7 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     class A(args: Int*) extends js.Object
 
     @ScalaJSDefined
-    class B(args: Int*) extends A(args: _*)
+    class B(x: Int, y: Int) extends A(Seq(x, y): _*)
     """.fails
   }
 

--- a/test-suite/scalajs-test-suite-2.10-fastopt.html
+++ b/test-suite/scalajs-test-suite-2.10-fastopt.html
@@ -8,6 +8,7 @@
 <body>
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine.js"></script>
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine-html.js"></script>
+<script type="text/javascript" src="./src/test/resources/ScalaJSDefinedTestNatives.js"></script>
 <script type="text/javascript" src="./target/scala-2.10/scalajs-test-suite-test-fastopt.js"></script>
 <script type="text/javascript" src="run-jasmine-tests.js"></script>
 

--- a/test-suite/scalajs-test-suite-2.10.html
+++ b/test-suite/scalajs-test-suite-2.10.html
@@ -8,6 +8,7 @@
 <body>
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine.js"></script>
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine-html.js"></script>
+<script type="text/javascript" src="./src/test/resources/ScalaJSDefinedTestNatives.js"></script>
 <script type="text/javascript" src="./target/scala-2.10/scalajs-test-suite-test-opt.js"></script>
 <script type="text/javascript" src="run-jasmine-tests.js"></script>
 

--- a/test-suite/scalajs-test-suite-2.11-fastopt.html
+++ b/test-suite/scalajs-test-suite-2.11-fastopt.html
@@ -8,6 +8,7 @@
 <body>
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine.js"></script>
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine-html.js"></script>
+<script type="text/javascript" src="./src/test/resources/ScalaJSDefinedTestNatives.js"></script>
 <script type="text/javascript" src="./target/scala-2.11/scalajs-test-suite-test-fastopt.js"></script>
 <script type="text/javascript" src="run-jasmine-tests.js"></script>
 

--- a/test-suite/scalajs-test-suite-2.11.html
+++ b/test-suite/scalajs-test-suite-2.11.html
@@ -8,6 +8,7 @@
 <body>
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine.js"></script>
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine-html.js"></script>
+<script type="text/javascript" src="./src/test/resources/ScalaJSDefinedTestNatives.js"></script>
 <script type="text/javascript" src="./target/scala-2.11/scalajs-test-suite-test-opt.js"></script>
 <script type="text/javascript" src="run-jasmine-tests.js"></script>
 

--- a/test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
+++ b/test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
@@ -30,4 +30,14 @@
   };
   $g.ScalaJSDefinedTestNativeParentClassWithDeferred =
     ScalaJSDefinedTestNativeParentClassWithDeferred;
+
+  var ScalaJSDefinedTestNativeParentClassWithVarargs = function(x) {
+    $g.Object.call(this);
+    this.x = x;
+    this.args = [];
+    for (var i = 1; i != arguments.length; ++i)
+      this.args.push(arguments[i]);
+  };
+  $g.ScalaJSDefinedTestNativeParentClassWithVarargs =
+    ScalaJSDefinedTestNativeParentClassWithVarargs;
 }).call(this);

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -43,6 +43,14 @@ object ScalaJSDefinedTest extends JasmineTest {
     def bar(y: Int): Int
   }
 
+  // Defined in test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
+  @JSName("ScalaJSDefinedTestNativeParentClassWithVarargs")
+  class NativeParentClassWithVarargs(
+      _x: Int, _args: Int*) extends js.Object {
+    val x: Int = js.native
+    val args: js.Array[Int] = js.native
+  }
+
   @ScalaJSDefined
   trait SimpleTrait extends js.Any {
     def foo(x: Int): Int
@@ -709,6 +717,23 @@ object ScalaJSDefinedTest extends JasmineTest {
       expect(dyn.dependent(4, 8)).toEqual(-4)
       expect(dyn.dependent(8)).toEqual(-1)
     }
+
+    /* TODO This is disabled because the ECMAScript 6 output cannot be parsed
+     * by io.js at the moment.
+    it("call super constructor with : _*") {
+      @ScalaJSDefined
+      class CallSuperCtorWithSpread(x: Int, y: Int, z: Int)
+          extends NativeParentClassWithVarargs(x, Seq(y, z): _*)
+
+      val foo = new CallSuperCtorWithSpread(4, 8, 23)
+      expect(foo.x).toEqual(4)
+      expect(foo.args).toEqual(js.Array(8, 23))
+
+      val dyn = foo.asInstanceOf[js.Dynamic]
+      expect(dyn.x).toEqual(4)
+      expect(dyn.args).toEqual(js.Array(8, 23))
+    }
+    */
 
     it("override native method") {
       @ScalaJSDefined

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
@@ -232,6 +232,9 @@ object Printers {
           print(fun)
           printArgs(args)
 
+        case Spread(items) =>
+          print("...", items)
+
         case Delete(prop) =>
           print("delete ", prop)
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
@@ -147,6 +147,15 @@ object Trees {
    */
   case class Apply(fun: Tree, args: List[Tree])(implicit val pos: Position) extends Tree
 
+  /** `...items`, the "spread" operator of ECMAScript 6.
+   *
+   *  It is only valid in ECMAScript 6, in the `args`/`items` of a [[New]],
+   *  [[Apply]], or [[ArrayConstr]].
+   *
+   *  @param items An iterable whose items will be spread
+   */
+  case class Spread(items: Tree)(implicit val pos: Position) extends Tree
+
   case class Delete(prop: Tree)(implicit val pos: Position) extends Tree {
     require(prop match {
       case _:DotSelect | _:BracketSelect => true


### PR DESCRIPTION
The only test for this is currently disabled (commented out), because the ECMAScript 6 output emitted for this code cannot be parsed by io.js at the moment.