### PR TITLE
Fix #1820: Allow nested native JS stuff in native JS objects.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -28,6 +28,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
   import jsAddons._
   import definitions._
   import jsDefinitions._
+  import jsInterop.jsNameOf
 
   trait JSExportsPhase { this: JSCodePhase =>
 

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -51,6 +51,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JavaScriptExceptionClass = getClassIfDefined("scala.scalajs.js.JavaScriptException")
 
     lazy val JSNameAnnotation          = getRequiredClass("scala.scalajs.js.annotation.JSName")
+    lazy val JSFullNameAnnotation      = getRequiredClass("scala.scalajs.js.annotation.JSFullName")
     lazy val JSBracketAccessAnnotation = getRequiredClass("scala.scalajs.js.annotation.JSBracketAccess")
     lazy val JSBracketCallAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSBracketCall")
     lazy val JSExportAnnotation        = getRequiredClass("scala.scalajs.js.annotation.JSExport")

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -125,6 +125,31 @@ trait JSGlobalAddons extends JSDefinitions
     def isJSBracketCall(sym: Symbol): Boolean =
       sym.hasAnnotation(JSBracketCallAnnotation)
 
+    /** Gets the unqualified JS name of a symbol.
+     *
+     *  If it is not explicitly specified with an `@JSName` annotation, the
+     *  JS name is inferred from the Scala name.
+     */
+    def jsNameOf(sym: Symbol): String = {
+      sym.getAnnotation(JSNameAnnotation).flatMap(_.stringArg(0)) getOrElse {
+        val base = sym.unexpandedName.decoded.stripSuffix("_=")
+        if (!sym.isMethod) base.stripSuffix(" ")
+        else base
+      }
+    }
+
+    /** Gets the fully qualified JS name of a static class of module Symbol.
+     *
+     *  This is the JS name of the symbol qualified by the fully qualified JS
+     *  name of its original owner if the latter is a native JS object.
+     */
+    def fullJSNameOf(sym: Symbol): String = {
+      assert(sym.isClass, s"fullJSNameOf called for non-class symbol $sym")
+      sym.getAnnotation(JSFullNameAnnotation).flatMap(_.stringArg(0)) getOrElse {
+        jsNameOf(sym)
+      }
+    }
+
   }
 
 }

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSFullName.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSFullName.scala
@@ -1,0 +1,16 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js.annotation
+
+/** IMPLEMENTATION DETAIL: Saves the fully qualified JS name of a symbol.
+ *
+ *  Do not use this annotation yourself.
+ */
+class JSFullName(fullName: String) extends scala.annotation.StaticAnnotation

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -123,6 +123,74 @@ object InteroperabilityTest extends JasmineTest {
       expect(obj.valueAsInt).toEqual(7357)
     }
 
+    it("should access native JS classes and objects nested in JS objects") {
+      js.eval("""
+        var InteroperabilityTestContainerObject = {
+          ContainedClass: function(x) {
+            this.x = x;
+          },
+          ContainedObject: {
+            x: 42
+          },
+          ContainedClassRenamed: function(x) {
+            this.x = x * 2;
+          },
+          ContainedObjectRenamed: {
+            x: 4242
+          }
+        };
+      """)
+
+      // Use alias for convenience: see end of file for definition
+      val TopLevel = InteroperabilityTestContainerObject
+
+      val obj1 = new TopLevel.ContainedClass(34)
+      expect(obj1.x).toEqual(34)
+
+      val obj2 = TopLevel.ContainedObject
+      expect(obj2.x).toEqual(42)
+
+      val obj3 = new TopLevel.ContainedClassWithJSName(65)
+      expect(obj3.x).toEqual(130)
+
+      val obj4 = TopLevel.ContainedObjectWithJSName
+      expect(obj4.x).toEqual(4242)
+    }
+
+    it("should access native JS classes and objects nested in @JSName'd JS objects") {
+      js.eval("""
+        var InteroperabilityTestContainerObjectRenamed = {
+          ContainedClass: function(x) {
+            this.x = x;
+          },
+          ContainedObject: {
+            x: 42
+          },
+          ContainedClassRenamed: function(x) {
+            this.x = x * 2;
+          },
+          ContainedObjectRenamed: {
+            x: 4242
+          }
+        };
+      """)
+
+      // Use alias for convenience: see end of file for definition
+      val TopLevel = InteroperabilityTestContainerObjectWithJSName
+
+      val obj1 = new TopLevel.ContainedClass(34)
+      expect(obj1.x).toEqual(34)
+
+      val obj2 = TopLevel.ContainedObject
+      expect(obj2.x).toEqual(42)
+
+      val obj3 = new TopLevel.ContainedClassWithJSName(65)
+      expect(obj3.x).toEqual(130)
+
+      val obj4 = TopLevel.ContainedObjectWithJSName
+      expect(obj4.x).toEqual(4242)
+    }
+
     it("should allow to call JS methods with variadic parameters") {
       val obj = js.eval("""
         var obj = {
@@ -463,7 +531,9 @@ object InteroperabilityTest extends JasmineTest {
 }
 
 /*
- * Helper classes, traits and objects defined here since they cannot be nested.
+ * Helper classes, traits and objects defined here since they cannot be nested
+ * without requiring explicit @JSName's, which would defeat the purpose of
+ * their tests.
  */
 
 @JSName("InteroperabilityTestInherit.Pattern")
@@ -482,6 +552,47 @@ trait InteroperabilityTestTopLevel extends js.Object {
 @JSName("InteroperabilityTestTopLevelObject")
 object InteroperabilityTestTopLevel extends js.Object {
   def apply(value: String): InteroperabilityTestTopLevel = js.native
+}
+
+object InteroperabilityTestContainerObject extends js.Object {
+  class ContainedClass(_x: Int) extends js.Object {
+    val x: Int = js.native
+  }
+
+  object ContainedObject extends js.Object {
+    val x: Int = js.native
+  }
+
+  @JSName("ContainedClassRenamed")
+  class ContainedClassWithJSName(_x: Int) extends js.Object {
+    val x: Int = js.native
+  }
+
+  @JSName("ContainedObjectRenamed")
+  object ContainedObjectWithJSName extends js.Object {
+    val x: Int = js.native
+  }
+}
+
+@JSName("InteroperabilityTestContainerObjectRenamed")
+object InteroperabilityTestContainerObjectWithJSName extends js.Object {
+  class ContainedClass(_x: Int) extends js.Object {
+    val x: Int = js.native
+  }
+
+  object ContainedObject extends js.Object {
+    val x: Int = js.native
+  }
+
+  @JSName("ContainedClassRenamed")
+  class ContainedClassWithJSName(_x: Int) extends js.Object {
+    val x: Int = js.native
+  }
+
+  @JSName("ContainedObjectRenamed")
+  object ContainedObjectWithJSName extends js.Object {
+    val x: Int = js.native
+  }
 }
 
 trait InteroperabilityTestVariadicMethod extends js.Object {

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -8,6 +8,7 @@
 package org.scalajs.testsuite.compiler
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation.JSName
 import org.scalajs.jasminetest.JasmineTest
 
 import scala.util.{ Try, Failure }
@@ -105,6 +106,7 @@ object RuntimeTypesTest extends JasmineTest {
 
   trait SomeJSInterface extends ParentJSType
 
+  @JSName("SomeJSClass")
   class SomeJSClass extends ParentJSType
 
 }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -109,6 +109,7 @@ object MiscInteropTest extends JasmineTest {
     def foo(x: Int): Int = js.native
   }
 
+  @JSName("DirectSubclassOfJSAny")
   class DirectSubclassOfJSAny extends js.Any {
     def bar(x: Int): Int = js.native
   }


### PR DESCRIPTION
Native JS objects can now contain nested native JS traits, classes and objects. For classes and objects, their full JS name is qualified by the full JS name of the enclosing native JS object, since they appear as members of this object. In this example:

```scala
object Foo extends js.Object {
  @JSName("Babar")
  object/class Bar extends js.Object
}
```

the full JS name of Bar is "Foo.Babar", not just "Babar".

This prompted to revisit native JS objects and classes in Scala objects. For those, an explicit `@JSName` is required, and is their full JS name (it is not qualified by their enclosing Scala object). For classes, this is a warning, since we previously erroneously allowed that.

Native JS stuff is not allowed in Scala.js-defined JS objects.

Altogether, these changes to the rules prompted a major refactoring of the checks performed by PrepJSInterop.