### PR TITLE
Fix #1812: Support exporting Scala.js-defined JS classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -459,16 +459,12 @@ abstract class GenJSCode extends plugins.PluginComponent
 
       gen(cd.impl)
 
-      // Generate exported module accessors
-      val exports = {
-        // Generate exported constructors or accessors
-        val exportedAccessors =
-          if (isStaticModule(sym)) genModuleAccessorExports(sym)
-          else Nil
-        if (exportedAccessors.nonEmpty)
-          currentClassInfoBuilder.setIsExported(true)
-        exportedAccessors
-      }
+      // Generate class-level exporters
+      val exports =
+        if (isStaticModule(sym)) genModuleAccessorExports(sym)
+        else genJSClassExports(sym)
+      if (exports.nonEmpty)
+        currentClassInfoBuilder.setIsExported(true)
 
       // Generate fields (and add to methods + ctors)
       val generatedMembers = {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -108,6 +108,16 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
       }
     }
 
+    def genJSClassExports(classSym: Symbol): List[js.JSClassExportDef] = {
+      for {
+        exp <- jsInterop.registeredExportsOf(classSym)
+      } yield {
+        implicit val pos = exp.pos
+        assert(!exp.isNamed, "Class cannot be exported named")
+        js.JSClassExportDef(exp.jsName)
+      }
+    }
+
     def genModuleAccessorExports(classSym: Symbol): List[js.ModuleExportDef] = {
       for {
         exp <- jsInterop.registeredExportsOf(classSym)

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -48,8 +48,8 @@ trait JSGlobalAddons extends JSDefinitions
     }
 
     private def assertValidForRegistration(sym: Symbol): Unit = {
-      assert(sym.isConstructor || sym.isModuleClass,
-          "Can only register constructors or module classes for export")
+      assert(sym.isConstructor || sym.isClass,
+          "Can only register constructors or classes for export")
     }
 
     def clearRegisteredExports(): Unit =

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -637,7 +637,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
 
         // private[Scope] methods must be final
         if (sym.isMethod && (sym.hasAccessBoundary && !sym.isProtected) &&
-            !sym.isFinal) {
+            !sym.isFinal && !sym.isClassConstructor) {
           reporter.error(tree.pos,
               "Qualified private members in Scala.js-defined JS classes " +
               "must be final")

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -8,7 +8,7 @@ import org.junit.Test
 class JSExportTest extends DirectTest with TestHelpers {
 
   override def preamble: String =
-    """import scala.scalajs.js.annotation._
+    """import scala.scalajs.js, js.annotation._
     """
 
   @Test
@@ -25,6 +25,9 @@ class JSExportTest extends DirectTest with TestHelpers {
 
     @JSExport
     class B__
+
+    @JSExport
+    @ScalaJSDefined class C__ extends js.Object
     """ hasErrors
     """
       |newSource1.scala:4: error: An exported name may not contain a double underscore (`__`)
@@ -36,6 +39,9 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:12: error: An exported name may not contain a double underscore (`__`)
       |    class B__
       |          ^
+      |newSource1.scala:15: error: An exported name may not contain a double underscore (`__`)
+      |    @ScalaJSDefined class C__ extends js.Object
+      |                          ^
     """
 
     // Inherited exports (objects)
@@ -51,6 +57,20 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:7: error: B may not have a double underscore (`__`) in its fully qualified name, since it is forced to be exported by a @JSExportDescendentObjects on trait A
       |      object B extends A
       |             ^
+    """
+
+    """
+    @JSExportDescendentObjects
+    @ScalaJSDefined trait A extends js.Object
+
+    package fo__o {
+      @ScalaJSDefined object B extends A
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: B may not have a double underscore (`__`) in its fully qualified name, since it is forced to be exported by a @JSExportDescendentObjects on trait A
+      |      @ScalaJSDefined object B extends A
+      |                             ^
     """
 
     // Inherited exports (classes)
@@ -72,6 +92,20 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:8: error: B may not have a double underscore (`__`) in its fully qualified name, since it is forced to be exported by a @JSExportDescendentClasses on trait A
       |        def this() = this(1)
       |            ^
+    """
+
+    """
+    @JSExportDescendentClasses
+    @ScalaJSDefined trait A extends js.Object
+
+    package fo__o {
+      @ScalaJSDefined class B(x: Int) extends A
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: B may not have a double underscore (`__`) in its fully qualified name, since it is forced to be exported by a @JSExportDescendentClasses on trait A
+      |      @ScalaJSDefined class B(x: Int) extends A
+      |                            ^
     """
   }
 
@@ -170,11 +204,17 @@ class JSExportTest extends DirectTest with TestHelpers {
       def method = {
         @JSExport
         class A
+
+        @JSExport
+        @ScalaJSDefined class B extends js.Object
       }
     }
     """ hasErrors
     """
       |newSource1.scala:5: error: You may not export a local class
+      |        @JSExport
+      |         ^
+      |newSource1.scala:8: error: You may not export a local class
       |        @JSExport
       |         ^
     """
@@ -185,11 +225,17 @@ class JSExportTest extends DirectTest with TestHelpers {
       def method = {
         @JSExport
         object A
+
+        @JSExport
+        @ScalaJSDefined object B extends js.Object
       }
     }
     """ hasErrors
     """
       |newSource1.scala:5: error: You may not export a local object
+      |        @JSExport
+      |         ^
+      |newSource1.scala:8: error: You may not export a local object
       |        @JSExport
       |         ^
     """
@@ -300,6 +346,9 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def this() = this(5)
     }
+
+    @JSExport
+    @ScalaJSDefined abstract class C extends js.Object
     """ hasErrors
     """
       |newSource1.scala:3: error: You may not export an abstract class
@@ -308,6 +357,9 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:7: error: You may not export an abstract class
       |      @JSExport
       |       ^
+      |newSource1.scala:11: error: You may not export an abstract class
+      |    @JSExport
+      |     ^
     """
 
   }
@@ -318,9 +370,21 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
     @JSExport
     trait Test
+
+    @JSExport
+    @ScalaJSDefined trait Test2 extends js.Object
+
+    @JSExport
+    trait Test3 extends js.Object
     """ hasErrors
     """
       |newSource1.scala:3: error: You may not export a trait
+      |    @JSExport
+      |     ^
+      |newSource1.scala:6: error: You may not export a trait
+      |    @JSExport
+      |     ^
+      |newSource1.scala:9: error: You may not export a trait
       |    @JSExport
       |     ^
     """
@@ -336,12 +400,24 @@ class JSExportTest extends DirectTest with TestHelpers {
 
     @JSExport
     protected[this] class B
+
+    @JSExport
+    @ScalaJSDefined private class C extends js.Object
+
+    @JSExport
+    @ScalaJSDefined protected[this] class D extends js.Object
     """ hasErrors
     """
       |newSource1.scala:3: error: You may only export public and protected classes
       |    @JSExport
       |     ^
       |newSource1.scala:6: error: You may only export public and protected classes
+      |    @JSExport
+      |     ^
+      |newSource1.scala:9: error: You may only export public and protected classes
+      |    @JSExport
+      |     ^
+      |newSource1.scala:12: error: You may only export public and protected classes
       |    @JSExport
       |     ^
     """
@@ -352,12 +428,24 @@ class JSExportTest extends DirectTest with TestHelpers {
 
     @JSExport
     protected[this] object B
+
+    @JSExport
+    @ScalaJSDefined private object C extends js.Object
+
+    @JSExport
+    @ScalaJSDefined protected[this] object D extends js.Object
     """ hasErrors
     """
       |newSource1.scala:3: error: You may only export public and protected objects
       |    @JSExport
       |     ^
       |newSource1.scala:6: error: You may only export public and protected objects
+      |    @JSExport
+      |     ^
+      |newSource1.scala:9: error: You may only export public and protected objects
+      |    @JSExport
+      |     ^
+      |newSource1.scala:12: error: You may only export public and protected objects
       |    @JSExport
       |     ^
     """
@@ -394,10 +482,16 @@ class JSExportTest extends DirectTest with TestHelpers {
     class A {
       @JSExport
       class Nested
+
+      @JSExport
+      @ScalaJSDefined class Nested2 extends js.Object
     }
     """ hasErrors
     """
       |newSource1.scala:4: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
+      |      @JSExport
+      |       ^
+      |newSource1.scala:7: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
       |      @JSExport
       |       ^
     """
@@ -406,10 +500,16 @@ class JSExportTest extends DirectTest with TestHelpers {
     object A {
       @JSExport
       class Nested
+
+      @JSExport
+      @ScalaJSDefined class Nested2 extends js.Object
     }
     """ hasErrors
     """
       |newSource1.scala:4: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
+      |      @JSExport
+      |       ^
+      |newSource1.scala:7: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
       |      @JSExport
       |       ^
     """
@@ -423,10 +523,16 @@ class JSExportTest extends DirectTest with TestHelpers {
     class A {
       @JSExport
       object Nested
+
+      @JSExport
+      @ScalaJSDefined object Nested2 extends js.Object
     }
     """ hasErrors
     """
       |newSource1.scala:4: error: You may not export a nested object
+      |      @JSExport
+      |       ^
+      |newSource1.scala:7: error: You may not export a nested object
       |      @JSExport
       |       ^
     """
@@ -435,10 +541,16 @@ class JSExportTest extends DirectTest with TestHelpers {
     object A {
       @JSExport
       object Nested
+
+      @JSExport
+      @ScalaJSDefined object Nested2 extends js.Object
     }
     """ hasErrors
     """
       |newSource1.scala:4: error: You may not export a nested object
+      |      @JSExport
+      |       ^
+      |newSource1.scala:7: error: You may not export a nested object
       |      @JSExport
       |       ^
     """
@@ -467,7 +579,7 @@ class JSExportTest extends DirectTest with TestHelpers {
     trait A extends js.Object
     """ hasErrors
     """
-      |newSource1.scala:5: error: You may not export a native JS class or object
+      |newSource1.scala:5: error: You may not export a trait
       |    @JSExport
       |     ^
     """
@@ -725,9 +837,30 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
     @JSExportNamed
     object A
+
+    @JSExportNamed
+    @ScalaJSDefined object B extends js.Object
     """ hasErrors
     """
       |newSource1.scala:3: error: You may not use @JSNamedExport on an object
+      |    @JSExportNamed
+      |     ^
+      |newSource1.scala:6: error: You may not use @JSNamedExport on an object
+      |    @JSExportNamed
+      |     ^
+    """
+
+  }
+
+  @Test
+  def noNamedExportSJSDefinedClass: Unit = {
+
+    """
+    @JSExportNamed
+    @ScalaJSDefined class A extends js.Object
+    """ hasErrors
+    """
+      |newSource1.scala:3: error: You may not use @JSNamedExport on a Scala.js-defined JS class
       |    @JSExportNamed
       |     ^
     """

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -322,6 +322,19 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     """
     object Enclosing {
       @ScalaJSDefined
+      class A private () extends js.Object
+
+      @ScalaJSDefined
+      class B private[this] () extends js.Object
+
+      @ScalaJSDefined
+      class C private[Enclosing] () extends js.Object
+    }
+    """.succeeds
+
+    """
+    object Enclosing {
+      @ScalaJSDefined
       class A extends js.Object {
         final private[Enclosing] def foo(i: Int): Int = i
       }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -586,14 +586,38 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportClass: Unit = {
+  def noExportClassWithOnlyPrivateCtors: Unit = {
     """
     @ScalaJSDefined
     @JSExport
-    class A extends js.Object
+    class A private () extends js.Object
     """ hasErrors
     """
-      |newSource1.scala:6: error: Implementation restriction: exporting a Scala.js-defined JS class is not supported
+      |newSource1.scala:6: error: You may not export a class that has only private constructors
+      |    @JSExport
+      |     ^
+    """
+
+    """
+    @ScalaJSDefined
+    @JSExport
+    class A private[this] () extends js.Object
+    """ hasErrors
+    """
+      |newSource1.scala:6: error: You may not export a class that has only private constructors
+      |    @JSExport
+      |     ^
+    """
+
+    """
+    @ScalaJSDefined
+    @JSExport
+    class A private[A] () extends js.Object
+
+    object A
+    """ hasErrors
+    """
+      |newSource1.scala:6: error: You may not export a class that has only private constructors
       |    @JSExport
       |     ^
     """

--- a/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
@@ -267,7 +267,7 @@ object Infos {
       case constructorDef: ConstructorExportDef =>
         builder.setIsExported(true)
         exportedConstructors ::= constructorDef
-      case _: ModuleExportDef =>
+      case _:JSClassExportDef | _:ModuleExportDef =>
         builder.setIsExported(true)
       case _ =>
     }

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -635,8 +635,11 @@ object Printers {
           printSig(args, NoType) // NoType as trick not to display a type
           printBlock(body)
 
+        case JSClassExportDef(fullName) =>
+          print("export class \"", escapeJS(fullName), "\"")
+
         case ModuleExportDef(fullName) =>
-          print("export \"", escapeJS(fullName), "\"")
+          print("export module \"", escapeJS(fullName), "\"")
 
         case _ =>
           print(s"<error, elem of class ${tree.getClass()}>")

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -445,6 +445,10 @@ object Serializers {
           writeByte(TagConstructorExportDef)
           writeString(fullName); writeTrees(args); writeTree(body)
 
+        case JSClassExportDef(fullName) =>
+          writeByte(TagJSClassExportDef)
+          writeString(fullName)
+
         case ModuleExportDef(fullName) =>
           writeByte(TagModuleExportDef)
           writeString(fullName)
@@ -736,6 +740,8 @@ object Serializers {
           } else {
             result
           }
+        case TagJSClassExportDef =>
+          JSClassExportDef(readString())
         case TagModuleExportDef =>
           ModuleExportDef(readString())
       }

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -97,6 +97,7 @@ private[ir] object Tags {
   final val TagJSSuperConstructorCall = TagJSSuperBracketCall + 1
   final val TagLoadJSConstructor = TagJSSuperConstructorCall + 1
   final val TagLoadJSModule = TagLoadJSConstructor + 1
+  final val TagJSClassExportDef = TagLoadJSModule + 1
 
   // Tags for Types
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -225,7 +225,7 @@ object Transformers {
         case ConstructorExportDef(fullName, args, body) =>
           ConstructorExportDef(fullName, args, transformStat(body))
 
-        case ModuleExportDef(_) =>
+        case _:JSClassExportDef | _:ModuleExportDef =>
           tree
 
         case _ =>

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -204,7 +204,7 @@ object Traversers {
       case _:Skip | _:Continue | _:Debugger | _:LoadModule |
           _:LoadJSConstructor | _:LoadJSModule | _:JSEnvInfo | _:JSLinkingInfo |
           _:Literal | _:UndefinedParam | _:VarRef | _:This | _:FieldDef |
-          _:ModuleExportDef | EmptyTree =>
+          _:JSClassExportDef | _:ModuleExportDef | EmptyTree =>
 
       case _ =>
         sys.error(s"Invalid tree in traverse() of class ${tree.getClass}")

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -799,6 +799,11 @@ object Trees {
     val tpe = NoType
   }
 
+  case class JSClassExportDef(fullName: String)(
+      implicit val pos: Position) extends Tree {
+    val tpe = NoType
+  }
+
   case class ModuleExportDef(fullName: String)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -589,6 +589,15 @@ object ExportsTest extends JasmineTest {
       expect(obj.x).toEqual(5)
     }
 
+    it("should offer exports for Scala.js-defined JS classes with implicit name") {
+      val constr = jsPackage.SJSDefinedExportedClass
+      expect(constr).toBeDefined
+      expect(js.typeOf(constr)).toEqual("function")
+      val obj = js.Dynamic.newInstance(constr)(5)
+      expect((obj: Any).isInstanceOf[SJSDefinedExportedClass]).toBeTruthy
+      expect(obj.x).toEqual(5)
+    }
+
     it("should offer exports for classes with explicit name") {
       val constr = js.Dynamic.global.TheExportedClass
       expect(constr).toBeDefined
@@ -597,11 +606,29 @@ object ExportsTest extends JasmineTest {
       expect(obj.x).toEqual(5)
     }
 
+    it("should offer exports for Scala.js-defined JS classes with explicit name") {
+      val constr = js.Dynamic.global.TheSJSDefinedExportedClass
+      expect(constr).toBeDefined
+      expect(js.typeOf(constr)).toEqual("function")
+      val obj = js.Dynamic.newInstance(constr)(5)
+      expect((obj: Any).isInstanceOf[SJSDefinedExportedClass]).toBeTruthy
+      expect(obj.x).toEqual(5)
+    }
+
     it("should offer exports for classes with qualified name") {
       val constr = js.Dynamic.global.qualified.testclass.ExportedClass
       expect(constr).toBeDefined
       expect(js.typeOf(constr)).toEqual("function")
       val obj = js.Dynamic.newInstance(constr)(5)
+      expect(obj.x).toEqual(5)
+    }
+
+    it("should offer exports for classes with qualified name") {
+      val constr = js.Dynamic.global.qualified.testclass.SJSDefinedExportedClass
+      expect(constr).toBeDefined
+      expect(js.typeOf(constr)).toEqual("function")
+      val obj = js.Dynamic.newInstance(constr)(5)
+      expect((obj: Any).isInstanceOf[SJSDefinedExportedClass]).toBeTruthy
       expect(obj.x).toEqual(5)
     }
 
@@ -963,6 +990,26 @@ object ExportsTest extends JasmineTest {
       expect(obj).toBe(AutoExportedClassObject.asInstanceOf[js.Any])
     }
 
+    it("should offer auto exports for Scala.js-defined JS objects extending a trait") {
+      val accessor =
+        js.Dynamic.global.org.scalajs.testsuite.jsinterop.SJSDefinedAutoExportedTraitObject
+      expect(accessor).toBeDefined
+      expect(js.typeOf(accessor)).toEqual("function")
+      val obj = accessor()
+      expect(obj).toBeDefined
+      expect(obj).toBe(SJSDefinedAutoExportedTraitObject)
+    }
+
+    it("should offer auto exports for Scala.js-defined JS objects extending a class") {
+      val accessor =
+        js.Dynamic.global.org.scalajs.testsuite.jsinterop.SJSDefinedAutoExportedClassObject
+      expect(accessor).toBeDefined
+      expect(js.typeOf(accessor)).toEqual("function")
+      val obj = accessor()
+      expect(obj).toBeDefined
+      expect(obj).toBe(SJSDefinedAutoExportedClassObject)
+    }
+
     it("should offer auto exports for objects extending a trait with ignoreInvalidDescendants") {
       val accessor =
         js.Dynamic.global.org.scalajs.testsuite.jsinterop.AutoExportIgnoreTraitObject
@@ -983,20 +1030,37 @@ object ExportsTest extends JasmineTest {
       expect(obj).toBe(AutoExportIgnoreClassObject.asInstanceOf[js.Any])
     }
 
+    it("should offer auto exports for Scala.js-defined JS objects extending " +
+        "a class with ignoreInvalidDescendants") {
+      val accessor =
+        js.Dynamic.global.org.scalajs.testsuite.jsinterop.SJSDefinedAutoExportedIgnoreClassObject
+      expect(accessor).toBeDefined
+      expect(js.typeOf(accessor)).toEqual("function")
+      val obj = accessor()
+      expect(obj).toBeDefined
+      expect(obj).toBe(SJSDefinedAutoExportedIgnoreClassObject)
+    }
+
     it("should ignore invalid descendants") {
       // This is just to check that everything here compiles
       object A extends AutoExportIgnoreTrait { var x = 1 }
       object B extends AutoExportIgnoreClass { var x = 2 }
 
+      @ScalaJSDefined
+      object C extends SJSDefinedAutoExportIgnoreClass { var x = 3 }
+
       // Check that the objects are usable
       expect(A.x).toEqual(1)
       expect(B.x).toEqual(2)
+      expect(C.x).toEqual(3)
 
       A.x = 3
       B.x = 4
+      C.x = 2
 
       expect(A.x).toEqual(3)
       expect(B.x).toEqual(4)
+      expect(C.x).toEqual(2)
     }
 
   }
@@ -1033,6 +1097,30 @@ object ExportsTest extends JasmineTest {
       expect(obj2.x).toBe(100)
     }
 
+    it("should offer auto exports for Scala.js-defined JS classes extending a trait") {
+      val ctor =
+        js.Dynamic.global.org.scalajs.testsuite.jsinterop.SJSDefinedAutoExportedTraitClass
+      expect(ctor).toBeDefined
+      expect(js.typeOf(ctor)).toEqual("function")
+
+      val obj = js.Dynamic.newInstance(ctor)(100)
+      expect((obj: Any).isInstanceOf[SJSDefinedAutoExportedTraitClass]).toBeTruthy
+      expect(obj).toBeDefined
+      expect(obj.x).toBe(100)
+    }
+
+    it("should offer auto exports for Scala.js-defined JS classes extending a class") {
+      val ctor =
+        js.Dynamic.global.org.scalajs.testsuite.jsinterop.SJSDefinedAutoExportedClassClass
+      expect(ctor).toBeDefined
+      expect(js.typeOf(ctor)).toEqual("function")
+
+      val obj = js.Dynamic.newInstance(ctor)(100)
+      expect((obj: Any).isInstanceOf[SJSDefinedAutoExportedClassClass]).toBeTruthy
+      expect(obj).toBeDefined
+      expect(obj.x).toBe(100)
+    }
+
     it("should offer auto exports for classes extending a trait with ignoreInvalidDescendants") {
       val ctor =
         js.Dynamic.global.org.scalajs.testsuite.jsinterop.AutoExportIgnoreTraitClass
@@ -1063,25 +1151,49 @@ object ExportsTest extends JasmineTest {
       expect(obj2.x).toBe(100)
     }
 
+    it("should offer auto exports for Scala.js-defined JS classes extending " +
+        "a class with ignoreInvalidDescendants") {
+      val ctor =
+        js.Dynamic.global.org.scalajs.testsuite.jsinterop.SJSDefinedAutoExportedIgnoreClassClass
+      expect(ctor).toBeDefined
+      expect(js.typeOf(ctor)).toEqual("function")
+
+      val obj = js.Dynamic.newInstance(ctor)(100)
+      expect((obj: Any).isInstanceOf[SJSDefinedAutoExportedIgnoreClassClass]).toBeTruthy
+      expect(obj).toBeDefined
+      expect(obj.x).toBe(100)
+    }
+
     it("should ignore invalid descendants") {
       trait HasBar { def bar: Int }
+
+      @ScalaJSDefined
+      trait SJSDefinedHasBar extends js.Any { def bar: Int }
 
       // This is just to check that everything here compiles
       class A extends AutoExportIgnoreTrait { def foo: Int = 1 }
       class B extends AutoExportIgnoreClass { def foo: Int = 2 }
 
+      @ScalaJSDefined
+      class C extends SJSDefinedAutoExportIgnoreClass { def foo: Int = 3 }
+
       val a = new A { override def foo: Int = 3 }
       val b = new B { override def foo: Int = 4 }
-      val c = new AutoExportIgnoreClass with HasBar { def bar: Int = 1 }
-      val d = new AutoExportIgnoreTrait with HasBar { def bar: Int = 1 }
+      val c = new C { override def foo: Int = 5 }
+      val d = new AutoExportIgnoreClass with HasBar { def bar: Int = 1 }
+      val e = new AutoExportIgnoreTrait with HasBar { def bar: Int = 1 }
+      val f = new SJSDefinedAutoExportIgnoreClass with SJSDefinedHasBar { def bar: Int = 1 }
 
       // Check the classes are usable
       expect((new A).foo).toEqual(1)
       expect((new B).foo).toEqual(2)
+      expect((new C).foo).toEqual(3)
       expect(a.foo).toEqual(3)
       expect(b.foo).toEqual(4)
-      expect(c.bar).toEqual(1)
+      expect(c.foo).toEqual(5)
       expect(d.bar).toEqual(1)
+      expect(e.bar).toEqual(1)
+      expect(f.bar).toEqual(1)
     }
 
   }
@@ -1124,6 +1236,12 @@ class ExportedClass(_x: Int) {
   @JSExport
   val x = _x
 }
+
+@JSExport
+@JSExport("TheSJSDefinedExportedClass")
+@JSExport("qualified.testclass.SJSDefinedExportedClass")
+@ScalaJSDefined
+class SJSDefinedExportedClass(val x: Int) extends js.Object
 
 @JSExport
 protected class ProtectedExportedClass(_x: Int) {
@@ -1176,6 +1294,26 @@ class AutoExportedClassClass(_x: Int) extends AutoExportTrait {
   def x: Int = _x
 }
 
+@JSExportDescendentClasses
+@JSExportDescendentObjects
+@ScalaJSDefined
+trait SJSDefinedAutoExportTrait extends js.Object
+
+@ScalaJSDefined
+object SJSDefinedAutoExportedTraitObject extends SJSDefinedAutoExportTrait
+@ScalaJSDefined
+class SJSDefinedAutoExportedTraitClass(val x: Int) extends SJSDefinedAutoExportTrait
+
+@JSExportDescendentClasses
+@JSExportDescendentObjects
+@ScalaJSDefined
+class SJSDefinedAutoExportClass extends js.Object
+
+@ScalaJSDefined
+object SJSDefinedAutoExportedClassObject extends SJSDefinedAutoExportClass
+@ScalaJSDefined
+class SJSDefinedAutoExportedClassClass(val x: Int) extends SJSDefinedAutoExportClass
+
 @JSExportDescendentClasses(ignoreInvalidDescendants = true)
 @JSExportDescendentObjects(ignoreInvalidDescendants = true)
 trait AutoExportIgnoreTrait
@@ -1197,6 +1335,21 @@ class AutoExportIgnoreClassClass(_x: Int) extends AutoExportIgnoreTrait {
   @JSExport
   def x: Int = _x
 }
+
+@JSExportDescendentClasses(ignoreInvalidDescendants = true)
+@JSExportDescendentObjects(ignoreInvalidDescendants = true)
+@ScalaJSDefined
+class SJSDefinedAutoExportIgnoreClass extends js.Object
+
+@ScalaJSDefined
+object SJSDefinedAutoExportedIgnoreClassObject extends SJSDefinedAutoExportIgnoreClass
+@ScalaJSDefined
+class SJSDefinedAutoExportedIgnoreClassClass(val x: Int) extends SJSDefinedAutoExportIgnoreClass
+
+object NativeInvalidExportObject extends SJSDefinedAutoExportIgnoreClass
+class NativeInvalidExportClass extends SJSDefinedAutoExportIgnoreClass
+@ScalaJSDefined
+class SJSDefinedInvalidExportClass private () extends SJSDefinedAutoExportIgnoreClass
 
 class SomeValueClass(val i: Int) extends AnyVal
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/IRChecker.scala
@@ -120,6 +120,8 @@ class IRChecker(unit: LinkingUnit, logger: Logger) {
         tree match {
           case member @ ConstructorExportDef(_, _, _) =>
             checkConstructorExportDef(member, classDef)
+          case member @ JSClassExportDef(_) =>
+            checkJSClassExportDef(member, classDef)
           case member @ ModuleExportDef(_) =>
             checkModuleExportDef(member, classDef)
           // Anything else is illegal
@@ -364,6 +366,14 @@ class IRChecker(unit: LinkingUnit, logger: Logger) {
     val thisType = ClassType(classDef.name.name)
     val bodyEnv = Env.fromSignature(thisType, params, NoType)
     typecheckStat(body, bodyEnv)
+  }
+
+  def checkJSClassExportDef(classExportDef: JSClassExportDef,
+      classDef: LinkedClass): Unit = {
+    implicit val ctx = ErrorContext(classExportDef)
+
+    if (classDef.kind != ClassKind.JSClass)
+      reportError(s"Exported JS class def can only appear in a JS class")
   }
 
   def checkModuleExportDef(moduleDef: ModuleExportDef,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Linker.scala
@@ -241,6 +241,9 @@ final class Linker(semantics: Semantics, outputMode: OutputMode,
       case e: ConstructorExportDef =>
         classExports += e
 
+      case e: JSClassExportDef =>
+        classExports += e
+
       case e: ModuleExportDef =>
         classExports += e
 


### PR DESCRIPTION
Unlike Scala classes, for which we export *constructors*, for Scala.js-defined JS classes we really export the *class* itself.