### PR TITLE
Fix #1870: Add js.constructorOf[JSClass] to retrieve its constructor.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -3147,7 +3147,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       implicit val pos = tree.pos
 
       def receiver = genExpr(receiver0)
-      val genArgs = genPrimitiveJSArgs(tree.symbol, args)
+      def genArgs = genPrimitiveJSArgs(tree.symbol, args)
 
       if (code == DYNNEW) {
         // js.Dynamic.newInstance(clazz)(actualArgs:_*)
@@ -3252,6 +3252,27 @@ abstract class GenJSCode extends plugins.PluginComponent
       } else if (code == ARR_CREATE) {
         // js.Array.create(elements: _*)
         js.JSArrayConstr(genArgs)
+      } else if (code == CONSTRUCTOROF) {
+        def fail() = {
+          reporter.error(pos,
+              "runtime.constructorOf() must be called with a constant " +
+              "classOf[T] representing a class extending js.Any " +
+              "(not a trait nor an object)")
+          js.Undefined()
+        }
+        args match {
+          case List(Literal(value)) if value.tag == ClazzTag =>
+            val kind = toTypeKind(value.typeValue)
+            kind match {
+              case REFERENCE(classSym) if isRawJSType(classSym.tpe) &&
+                  !classSym.isTrait && !classSym.isModuleClass =>
+                genPrimitiveJSClass(classSym)
+              case _ =>
+                fail()
+            }
+          case _ =>
+            fail()
+        }
       } else (genArgs match {
         case Nil =>
           code match {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -24,9 +24,10 @@ trait JSDefinitions { self: JSGlobalAddons =>
   class JSDefinitionsClass {
 
     lazy val ScalaJSJSPackage = getPackage(newTermNameCached("scala.scalajs.js")) // compat 2.10/2.11
-      lazy val JSPackage_typeOf   = getMemberMethod(ScalaJSJSPackage, newTermName("typeOf"))
-      lazy val JSPackage_debugger = getMemberMethod(ScalaJSJSPackage, newTermName("debugger"))
-      lazy val JSPackage_native   = getMemberMethod(ScalaJSJSPackage, newTermName("native"))
+      lazy val JSPackage_typeOf        = getMemberMethod(ScalaJSJSPackage, newTermName("typeOf"))
+      lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackage, newTermName("constructorOf"))
+      lazy val JSPackage_debugger      = getMemberMethod(ScalaJSJSPackage, newTermName("debugger"))
+      lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackage, newTermName("native"))
 
     lazy val JSAnyClass       = getRequiredClass("scala.scalajs.js.Any")
     lazy val JSDynamicClass   = getRequiredClass("scala.scalajs.js.Dynamic")
@@ -102,6 +103,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val Runtime_unwrapJavaScriptException  = getMemberMethod(RuntimePackageModule, newTermName("unwrapJavaScriptException"))
       lazy val Runtime_genTraversableOnce2jsArray = getMemberMethod(RuntimePackageModule, newTermName("genTraversableOnce2jsArray"))
       lazy val Runtime_jsTupleArray2jsObject      = getMemberMethod(RuntimePackageModule, newTermName("jsTupleArray2jsObject"))
+      lazy val Runtime_constructorOf              = getMemberMethod(RuntimePackageModule, newTermName("constructorOf"))
       lazy val Runtime_propertiesOf               = getMemberMethod(RuntimePackageModule, newTermName("propertiesOf"))
       lazy val Runtime_environmentInfo            = getMemberMethod(RuntimePackageModule, newTermName("environmentInfo"))
       lazy val Runtime_linkingInfo                = getMemberMethod(RuntimePackageModule, newTermName("linkingInfo"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
@@ -51,8 +51,9 @@ abstract class JSPrimitives {
   val UNITVAL = 349  // () value, which is undefined
   val UNITTYPE = 350 // BoxedUnit.TYPE (== classOf[Unit])
 
-  val ENV_INFO = 353     // __ScalaJSEnv via helper
-  val LINKING_INFO = 354 // $linkingInfo
+  val CONSTRUCTOROF = 352 // runtime.constructorOf(clazz)
+  val ENV_INFO = 353      // __ScalaJSEnv via helper
+  val LINKING_INFO = 354  // $linkingInfo
 
   /** Initialize the map of primitive methods (for GenJSCode) */
   def init(): Unit = initWithPrimitives(addPrimitive)
@@ -88,8 +89,6 @@ abstract class JSPrimitives {
 
     addPrimitive(JSArray_create, ARR_CREATE)
 
-    val ntModule = getRequiredModule("scala.reflect.NameTransformer")
-
     addPrimitive(JSPackage_typeOf, TYPEOF)
     addPrimitive(JSPackage_debugger, DEBUGGER)
     addPrimitive(JSPackage_native, JS_NATIVE)
@@ -100,6 +99,7 @@ abstract class JSPrimitives {
     addPrimitive(BoxedUnit_UNIT, UNITVAL)
     addPrimitive(BoxedUnit_TYPE, UNITTYPE)
 
+    addPrimitive(Runtime_constructorOf, CONSTRUCTOROF)
     addPrimitive(Runtime_environmentInfo, ENV_INFO)
     addPrimitive(Runtime_linkingInfo, LINKING_INFO)
   }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
@@ -3,10 +3,12 @@ package org.scalajs.core.compiler.test
 import org.scalajs.core.compiler.test.util._
 import org.junit.Test
 
+// scalastyle:off line.size.limit
+
 class DiverseErrorsTest extends DirectTest with TestHelpers  {
 
   override def preamble: String =
-    """import scala.scalajs.js
+    """import scala.scalajs.js, js.annotation._
     """
 
   @Test
@@ -24,6 +26,175 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
       |newSource1.scala:7: error: isInstanceOf[JSRaw] not supported because it is a raw JS trait
       |      def x = a.isInstanceOf[JSRaw]
       |                            ^
+    """
+
+  }
+
+  @Test
+  def jsConstructorOfErrors: Unit = {
+
+    """
+    class ScalaClass
+    trait ScalaTrait
+    object ScalaObject
+
+    object A {
+      val a = js.constructorOf[ScalaClass]
+      val b = js.constructorOf[ScalaTrait]
+      val c = js.constructorOf[ScalaObject.type]
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: type arguments [ScalaClass] do not conform to method constructorOf's type parameter bounds [T <: scala.scalajs.js.Any]
+      |      val a = js.constructorOf[ScalaClass]
+      |                              ^
+      |newSource1.scala:9: error: type arguments [ScalaTrait] do not conform to method constructorOf's type parameter bounds [T <: scala.scalajs.js.Any]
+      |      val b = js.constructorOf[ScalaTrait]
+      |                              ^
+      |newSource1.scala:10: error: type arguments [ScalaObject.type] do not conform to method constructorOf's type parameter bounds [T <: scala.scalajs.js.Any]
+      |      val c = js.constructorOf[ScalaObject.type]
+      |                              ^
+    """
+
+    """
+    class NativeJSClass extends js.Object
+    trait NativeJSTrait extends js.Object
+    object NativeJSObject extends js.Object
+
+    @ScalaJSDefined class JSClass extends js.Object
+    @ScalaJSDefined trait JSTrait extends js.Object
+    @ScalaJSDefined object JSObject extends js.Object
+
+    object A {
+      val a = js.constructorOf[NativeJSTrait]
+      val b = js.constructorOf[NativeJSObject.type]
+
+      val c = js.constructorOf[NativeJSClass with NativeJSTrait]
+      val d = js.constructorOf[NativeJSClass { def bar: Int }]
+
+      val e = js.constructorOf[JSTrait]
+      val f = js.constructorOf[JSObject.type]
+
+      val g = js.constructorOf[JSClass with JSTrait]
+      val h = js.constructorOf[JSClass { def bar: Int }]
+
+      def foo[A <: js.Any] = js.constructorOf[A]
+      def bar[A <: js.Any : scala.reflect.ClassTag] = js.constructorOf[A]
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:12: error: non-trait class required but NativeJSTrait found
+      |      val a = js.constructorOf[NativeJSTrait]
+      |                               ^
+      |newSource1.scala:13: error: class type required but NativeJSObject.type found
+      |      val b = js.constructorOf[NativeJSObject.type]
+      |                                             ^
+      |newSource1.scala:15: error: class type required but NativeJSClass with NativeJSTrait found
+      |      val c = js.constructorOf[NativeJSClass with NativeJSTrait]
+      |                               ^
+      |newSource1.scala:16: error: class type required but NativeJSClass{def bar: Int} found
+      |      val d = js.constructorOf[NativeJSClass { def bar: Int }]
+      |                               ^
+      |newSource1.scala:18: error: non-trait class required but JSTrait found
+      |      val e = js.constructorOf[JSTrait]
+      |                               ^
+      |newSource1.scala:19: error: class type required but JSObject.type found
+      |      val f = js.constructorOf[JSObject.type]
+      |                                       ^
+      |newSource1.scala:21: error: class type required but JSClass with JSTrait found
+      |      val g = js.constructorOf[JSClass with JSTrait]
+      |                               ^
+      |newSource1.scala:22: error: class type required but JSClass{def bar: Int} found
+      |      val h = js.constructorOf[JSClass { def bar: Int }]
+      |                               ^
+      |newSource1.scala:24: error: class type required but A found
+      |      def foo[A <: js.Any] = js.constructorOf[A]
+      |                                              ^
+      |newSource1.scala:25: error: class type required but A found
+      |      def bar[A <: js.Any : scala.reflect.ClassTag] = js.constructorOf[A]
+      |                                                                       ^
+    """
+
+  }
+
+  @Test
+  def runtimeConstructorOfErrors: Unit = {
+
+    """
+    import scala.scalajs.runtime
+
+    object ScalaObject
+    object NativeJSObject extends js.Object
+    @ScalaJSDefined object JSObject extends js.Object
+
+    object A {
+      val a = runtime.constructorOf(classOf[ScalaObject.type].asInstanceOf[Class[_ <: js.Any]])
+      val b = runtime.constructorOf(classOf[NativeJSObject.type])
+      val c = runtime.constructorOf(classOf[JSObject.type])
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:10: error: class type required but ScalaObject.type found
+      |      val a = runtime.constructorOf(classOf[ScalaObject.type].asInstanceOf[Class[_ <: js.Any]])
+      |                                                       ^
+      |newSource1.scala:11: error: class type required but NativeJSObject.type found
+      |      val b = runtime.constructorOf(classOf[NativeJSObject.type])
+      |                                                          ^
+      |newSource1.scala:12: error: class type required but JSObject.type found
+      |      val c = runtime.constructorOf(classOf[JSObject.type])
+      |                                                    ^
+    """
+
+    """
+    import scala.scalajs.runtime
+
+    class ScalaClass
+    trait ScalaTrait
+
+    class NativeJSClass extends js.Object
+    trait NativeJSTrait extends js.Object
+    object NativeJSObject extends js.Object
+
+    @ScalaJSDefined class JSClass extends js.Object
+    @ScalaJSDefined trait JSTrait extends js.Object
+    @ScalaJSDefined object JSObject extends js.Object
+
+    object A {
+      val a = runtime.constructorOf(classOf[ScalaClass].asInstanceOf[Class[_ <: js.Any]])
+      val b = runtime.constructorOf(classOf[ScalaTrait].asInstanceOf[Class[_ <: js.Any]])
+
+      val c = runtime.constructorOf(classOf[NativeJSTrait])
+      val d = runtime.constructorOf(classOf[JSTrait])
+
+      def jsClassClass = classOf[JSClass]
+      val e = runtime.constructorOf(jsClassClass)
+
+      val f = runtime.constructorOf(NativeJSObject.getClass)
+      val g = runtime.constructorOf(JSObject.getClass)
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:17: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |      val a = runtime.constructorOf(classOf[ScalaClass].asInstanceOf[Class[_ <: js.Any]])
+      |                                   ^
+      |newSource1.scala:18: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |      val b = runtime.constructorOf(classOf[ScalaTrait].asInstanceOf[Class[_ <: js.Any]])
+      |                                   ^
+      |newSource1.scala:20: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |      val c = runtime.constructorOf(classOf[NativeJSTrait])
+      |                                   ^
+      |newSource1.scala:21: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |      val d = runtime.constructorOf(classOf[JSTrait])
+      |                                   ^
+      |newSource1.scala:24: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |      val e = runtime.constructorOf(jsClassClass)
+      |                                   ^
+      |newSource1.scala:26: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |      val f = runtime.constructorOf(NativeJSObject.getClass)
+      |                                   ^
+      |newSource1.scala:27: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |      val g = runtime.constructorOf(JSObject.getClass)
+      |                                   ^
     """
 
   }

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -77,6 +77,14 @@ package object js {
   /** Returns the type of `x` as identified by `typeof x` in JavaScript. */
   def typeOf(x: Any): String = sys.error("stub")
 
+  /** Returns the constructor function of a JavaScript class.
+   *
+   *  The specified type parameter `T` must be a class type (i.e., valid for
+   *  `classOf[T]`) and represent a class extending `js.Any` (not a trait nor
+   *  an object).
+   */
+  def constructorOf[T <: js.Any]: js.Dynamic = sys.error("stub")
+
   /** Invokes any available debugging functionality.
    *  If no debugging functionality is available, this statement has no effect.
    *

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -92,6 +92,17 @@ package object runtime {
   def newJSObjectWithVarargs(ctor: js.Dynamic, args: js.Array[_]): js.Any =
     js.Dynamic.newInstance(ctor)(args.asInstanceOf[js.Array[js.Any]]: _*)
 
+  /** Dummy method used to preserve the type parameter of
+   *  `js.constructorOf[T]` through erasure.
+   *
+   *  An early phase of the compiler reroutes calls to `js.constructorOf[T]`
+   *  into `runtime.constructorOf(classOf[T])`.
+   *
+   *  The `clazz` parameter must be a literal `classOf[T]` constant such that
+   *  `T` represents a class extending `js.Any` (not a trait nor an object).
+   */
+  def constructorOf(clazz: Class[_ <: js.Any]): js.Dynamic = sys.error("stub")
+
   /** Returns an array of the enumerable properties in an object's prototype
    *  chain.
    *


### PR DESCRIPTION
The method `js.constructorOf[JSClass]` returns the JavaScript constructor function for the class `JSClass`. The latter must be a class (not trait nor object) extending js.Any. It may be a native JS class or a Scala.js-defined JS class. The restrictions on what types can be used are enforced at compile-time.