### PR TITLE
Fix #1868: Add an annotation `@js.native` for native JS types.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -29,6 +29,8 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val JSPackage_debugger      = getMemberMethod(ScalaJSJSPackage, newTermName("debugger"))
       lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackage, newTermName("native"))
 
+    lazy val JSNativeAnnotation = getRequiredClass("scala.scalajs.js.native")
+
     lazy val JSAnyClass       = getRequiredClass("scala.scalajs.js.Any")
     lazy val JSDynamicClass   = getRequiredClass("scala.scalajs.js.Dynamic")
     lazy val JSDictionaryClass = getRequiredClass("scala.scalajs.js.Dictionary")

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -404,6 +404,18 @@ abstract class PrepJSInterop extends plugins.PluginComponent
 
       val isJSNative = !sym.hasAnnotation(ScalaJSDefinedAnnotation)
 
+      if (isJSNative && !isJSAnonFun &&
+          !sym.hasAnnotation(JSNativeAnnotation)) {
+        reporter.warning(implDef.pos,
+            "Classes, traits and objects inheriting from js.Any should be " +
+            "annotated with @js.native, unless they have @ScalaJSDefined. " +
+            "The default will switch to Scala.js-defined in the next major " +
+            "version of Scala.js.")
+      } else if (!isJSNative && sym.hasAnnotation(JSNativeAnnotation)) {
+        reporter.error(implDef.pos,
+            "@ScalaJSDefined and @js.native cannot be used together")
+      }
+
       def strKind =
         if (sym.isTrait) "trait"
         else if (sym.isModuleClass) "object"

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
@@ -15,6 +15,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
   def noIsInstanceOnJSRaw: Unit = {
 
     """
+    @js.native
     trait JSRaw extends js.Object
 
     class A {
@@ -23,7 +24,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     }
     """ hasErrors
     """
-      |newSource1.scala:7: error: isInstanceOf[JSRaw] not supported because it is a raw JS trait
+      |newSource1.scala:8: error: isInstanceOf[JSRaw] not supported because it is a raw JS trait
       |      def x = a.isInstanceOf[JSRaw]
       |                            ^
     """
@@ -57,9 +58,9 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     """
 
     """
-    class NativeJSClass extends js.Object
-    trait NativeJSTrait extends js.Object
-    object NativeJSObject extends js.Object
+    @js.native class NativeJSClass extends js.Object
+    @js.native trait NativeJSTrait extends js.Object
+    @js.native object NativeJSObject extends js.Object
 
     @ScalaJSDefined class JSClass extends js.Object
     @ScalaJSDefined trait JSTrait extends js.Object
@@ -124,7 +125,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     import scala.scalajs.runtime
 
     object ScalaObject
-    object NativeJSObject extends js.Object
+    @js.native object NativeJSObject extends js.Object
     @ScalaJSDefined object JSObject extends js.Object
 
     object A {
@@ -151,9 +152,9 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     class ScalaClass
     trait ScalaTrait
 
-    class NativeJSClass extends js.Object
-    trait NativeJSTrait extends js.Object
-    object NativeJSObject extends js.Object
+    @js.native class NativeJSClass extends js.Object
+    @js.native trait NativeJSTrait extends js.Object
+    @js.native object NativeJSObject extends js.Object
 
     @ScalaJSDefined class JSClass extends js.Object
     @ScalaJSDefined trait JSTrait extends js.Object

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -375,6 +375,7 @@ class JSExportTest extends DirectTest with TestHelpers {
     @ScalaJSDefined trait Test2 extends js.Object
 
     @JSExport
+    @js.native
     trait Test3 extends js.Object
     """ hasErrors
     """
@@ -564,6 +565,7 @@ class JSExportTest extends DirectTest with TestHelpers {
     import scala.scalajs.js
 
     @JSExport
+    @js.native
     object A extends js.Object
     """ hasErrors
     """
@@ -576,6 +578,7 @@ class JSExportTest extends DirectTest with TestHelpers {
     import scala.scalajs.js
 
     @JSExport
+    @js.native
     trait A extends js.Object
     """ hasErrors
     """
@@ -588,6 +591,7 @@ class JSExportTest extends DirectTest with TestHelpers {
     import scala.scalajs.js
 
     @JSExport
+    @js.native
     class A extends js.Object {
       @JSExport
       def this(x: Int) = this()
@@ -597,7 +601,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:5: error: You may not export a native JS class or object
       |    @JSExport
       |     ^
-      |newSource1.scala:7: error: You may not export a constructor of a subclass of js.Any
+      |newSource1.scala:8: error: You may not export a constructor of a subclass of js.Any
       |      @JSExport
       |       ^
     """
@@ -610,13 +614,14 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
     import scala.scalajs.js
 
+    @js.native
     class A extends js.Object {
       @JSExport
       def foo: Int = js.native
     }
     """ hasErrors
     """
-      |newSource1.scala:6: error: You may not export a method of a subclass of js.Any
+      |newSource1.scala:7: error: You may not export a method of a subclass of js.Any
       |      @JSExport
       |       ^
     """

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -60,6 +60,7 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
   @Test
   def noExtendNativeTrait: Unit = {
     """
+    @js.native
     trait NativeTrait extends js.Object
 
     @ScalaJSDefined
@@ -76,16 +77,16 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: A Scala.js-defined JS class cannot directly extend a native JS trait.
+      |newSource1.scala:9: error: A Scala.js-defined JS class cannot directly extend a native JS trait.
       |    class A extends NativeTrait
       |          ^
-      |newSource1.scala:11: error: A Scala.js-defined JS trait cannot directly extend a native JS trait.
+      |newSource1.scala:12: error: A Scala.js-defined JS trait cannot directly extend a native JS trait.
       |    trait B extends NativeTrait
       |          ^
-      |newSource1.scala:14: error: A Scala.js-defined JS object cannot directly extend a native JS trait.
+      |newSource1.scala:15: error: A Scala.js-defined JS object cannot directly extend a native JS trait.
       |    object C extends NativeTrait
       |           ^
-      |newSource1.scala:17: error: A Scala.js-defined JS class cannot directly extend a native JS trait.
+      |newSource1.scala:18: error: A Scala.js-defined JS class cannot directly extend a native JS trait.
       |      val x = new NativeTrait {}
       |                  ^
     """

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Jasmine.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Jasmine.scala
@@ -2,6 +2,7 @@ package org.scalajs.jasmine
 
 import scala.scalajs.js
 
+@js.native
 object Jasmine extends js.GlobalScope {
   def jasmine: JasmineEnv = js.native
   def describe(name: String, suite: js.Function0[_]): Unit = js.native

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/JasmineEnv.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/JasmineEnv.scala
@@ -2,11 +2,13 @@ package org.scalajs.jasmine
 
 import scala.scalajs.js
 
+@js.native
 trait JasmineEnv extends js.Object {
   def Clock: JasmineEnv.Clock = js.native
 }
 
 object JasmineEnv {
+  @js.native
   trait Clock extends js.Object {
     def tick(time: Double): Unit = js.native
     def useMock(): Unit = js.native

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/JasmineExpectation.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/JasmineExpectation.scala
@@ -2,6 +2,7 @@ package org.scalajs.jasmine
 
 import scala.scalajs.js
 
+@js.native
 trait JasmineExpectation extends js.Object {
   def toBe(exp: js.Any): Unit = js.native
   def toEqual(exp: js.Any): Unit = js.native

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Results.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Results.scala
@@ -2,11 +2,13 @@ package org.scalajs.jasmine
 
 import scala.scalajs.js
 
+@js.native
 trait Result extends js.Object {
   def `type`: String = js.native
   val trace: js.Dynamic = js.native
 }
 
+@js.native
 trait ExpectationResult extends Result {
   def passed(): Boolean = js.native
   val message: String = js.native

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Spec.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Spec.scala
@@ -2,6 +2,7 @@ package org.scalajs.jasmine
 
 import scala.scalajs.js
 
+@js.native
 trait Spec extends js.Object {
   def results(): SpecResults = js.native
   val description: String = js.native

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/SpecResults.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/SpecResults.scala
@@ -2,6 +2,7 @@ package org.scalajs.jasmine
 
 import scala.scalajs.js
 
+@js.native
 trait SpecResults extends js.Object {
   def passed(): Boolean = js.native
   def getItems(): js.Array[Result] = js.native

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Suite.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/Suite.scala
@@ -2,6 +2,7 @@ package org.scalajs.jasmine
 
 import scala.scalajs.js
 
+@js.native
 trait Suite extends js.Object {
   def results(): SuiteResults = js.native
   val description: String = js.native

--- a/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/SuiteResults.scala
+++ b/jasmine-test-framework/src/main/scala/org/scalajs/jasmine/SuiteResults.scala
@@ -2,6 +2,7 @@ package org.scalajs.jasmine
 
 import scala.scalajs.js
 
+@js.native
 trait SuiteResults extends js.Object {
   val passedCount: Int = js.native
   val failedCount: Int = js.native

--- a/javalanglib/src/main/scala/java/lang/Class.scala
+++ b/javalanglib/src/main/scala/java/lang/Class.scala
@@ -2,6 +2,7 @@ package java.lang
 
 import scala.scalajs.js
 
+@js.native
 private trait ScalaJSClassData[A] extends js.Object {
   val name: String = js.native
   val isPrimitive: scala.Boolean = js.native

--- a/library/src/main/scala/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala/scala/scalajs/js/Any.scala
@@ -21,15 +21,28 @@ import scala.collection.generic.CanBuildFrom
 
 import annotation.ScalaJSDefined
 
-/** Supertype of all JavaScript values.
+/** Root of the hierarchy of JavaScript types.
  *
- *  Subtypes of [[Any js.Any]] are facade types to APIs implemented in
- *  JavaScript code. Their implementation is irrelevant and never emitted.
- *  As such, all members must be defined with their right-hand-side being
- *  [[native js.native]].
+ *  Subtypes of [[Any js.Any]] are JavaScript types, which have different
+ *  semantics and guarantees than Scala types (subtypes of [[AnyRef]] and
+ *  [[AnyVal]]). Operations on JavaScript types behave as the corresponding
+ *  operations in the JavaScript language.
  *
- *  In most cases, you should extend [[Object js.Object]] instead of this
- *  trait to define facade types.
+ *  By default, JavaScript types are native: they are facade types to APIs
+ *  implemented in JavaScript code. Their implementation is irrelevant and
+ *  never emitted. As such, all members must be defined with their
+ *  right-hand-side being [[native js.native]]. For forward source
+ *  compatibility with the next major version, the class/trait/object itself
+ *  should be annotated with [[native @js.native]].
+ *
+ *  In most cases, you should not directly extend this trait, but rather extend
+ *  [[Object js.Object]].
+ *
+ *  To implement a JavaScript type in Scala.js (therefore non-native), its
+ *  declaration must be annotated with
+ *  [[annotation.ScalaJSDefined @ScalaJSDefined]]. Scala.js-defined JS types
+ *  cannot directly extend native JS traits; and Scala.js-defined JS traits
+ *  cannot declare concrete term members.
  *
  *  It is not possible to define traits or classes that inherit both from this
  *  trait and a strict subtype of [[AnyRef]]. In fact, you should think of

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -36,6 +36,7 @@ import annotation._
  *
  *  @constructor Creates a new array of length 0.
  */
+@native
 class Array[A] extends Object {
   /** Creates a new array with the given length.
    *  @param arrayLength Initial length of the array.
@@ -161,6 +162,7 @@ class Array[A] extends Object {
 }
 
 /** Factory for [[js.Array]] objects. */
+@native
 object Array extends Object {
   // Do not expose this one - use new Array(len) instead
   // def apply[A](arrayLength: Int): Array[A] = native

--- a/library/src/main/scala/scala/scalajs/js/Date.scala
+++ b/library/src/main/scala/scala/scalajs/js/Date.scala
@@ -21,6 +21,7 @@ package scala.scalajs.js
  *
  * MDN
  */
+@native
 class Date extends Object {
 
   def this(value: Double) = this()
@@ -186,6 +187,7 @@ class Date extends Object {
 }
 
 /** Factory for [[js.Date]] objects. */
+@native
 object Date extends Object {
   def apply(): String = native
 

--- a/library/src/main/scala/scala/scalajs/js/Dictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dictionary.scala
@@ -48,6 +48,7 @@ import annotation.JSBracketAccess
  *  call methods of [[Object js.Object]] on it, given that the name of these
  *  methods could be used as keys in the dictionary.
  */
+@native
 sealed trait Dictionary[A] extends Any {
   /** Reads a field of this object by its name.
    *

--- a/library/src/main/scala/scala/scalajs/js/Dynamic.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dynamic.scala
@@ -24,6 +24,7 @@ import annotation.{JSBracketAccess, JSBracketCall}
  *  dynamically typed way. You can read and write any field, call any method,
  *  apply any JavaScript operator to values of this type.
  */
+@native
 sealed trait Dynamic extends Any with scala.Dynamic {
   /** Calls a method of this object. */
   @JSBracketCall

--- a/library/src/main/scala/scala/scalajs/js/Error.scala
+++ b/library/src/main/scala/scala/scalajs/js/Error.scala
@@ -14,6 +14,7 @@
  */
 package scala.scalajs.js
 
+@native
 class Error(message0: String = "") extends Object {
   val name: String = native
   /**
@@ -24,6 +25,7 @@ class Error(message0: String = "") extends Object {
   val message: String = native
 }
 
+@native
 object Error extends Object {
   def apply(message: String = ""): Error = native
 }
@@ -34,8 +36,10 @@ object Error extends Object {
  *
  * MDN
  */
+@native
 class EvalError(message: String = "") extends Error
 
+@native
 object EvalError extends Object {
   def apply(message: String = ""): EvalError = native
 }
@@ -52,8 +56,10 @@ object EvalError extends Object {
  *
  * MDN
  */
+@native
 class RangeError(message: String = "") extends Error
 
+@native
 object RangeError extends Object {
   def apply(message: String = ""): RangeError = native
 }
@@ -66,8 +72,10 @@ object RangeError extends Object {
  *
  * MDN
  */
+@native
 class ReferenceError(message: String = "") extends Error
 
+@native
 object ReferenceError extends Object {
   def apply(message: String = ""): ReferenceError = native
 }
@@ -80,8 +88,10 @@ object ReferenceError extends Object {
  *
  * MDN
  */
+@native
 class SyntaxError(message: String = "") extends Error
 
+@native
 object SyntaxError extends Object {
   def apply(message: String = ""): SyntaxError = native
 }
@@ -94,8 +104,10 @@ object SyntaxError extends Object {
  *
  * MDN
  */
+@native
 class TypeError(message: String = "") extends Error
 
+@native
 object TypeError extends Object {
   def apply(message: String = ""): TypeError = native
 }
@@ -107,8 +119,10 @@ object TypeError extends Object {
  *
  * MDN
  */
+@native
 class URIError(message: String = "") extends Error
 
+@native
 object URIError extends Object {
   def apply(message: String = ""): URIError = native
 }

--- a/library/src/main/scala/scala/scalajs/js/Function.scala
+++ b/library/src/main/scala/scala/scalajs/js/Function.scala
@@ -39,6 +39,7 @@ package scala.scalajs.js
  *
  * MDN
  */
+@native
 class Function(args: String*) extends Object {
   /**
    * length is a property of a function object, and indicates how many arguments
@@ -97,100 +98,124 @@ class Function(args: String*) extends Object {
   def bind(thisArg: Any, argArray: Any*): Dynamic = native
 }
 
+@native
 object Function extends Object {
   def apply(args: String*): Function = native
 }
 
 // scalastyle:off line.size.limit
 
+@native
 trait Function0[+R] extends Function {
   def apply(): R
 }
 
+@native
 trait Function1[-T1, +R] extends Function {
   def apply(arg1: T1): R
 }
 
+@native
 trait Function2[-T1, -T2, +R] extends Function {
   def apply(arg1: T1, arg2: T2): R
 }
 
+@native
 trait Function3[-T1, -T2, -T3, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3): R
 }
 
+@native
 trait Function4[-T1, -T2, -T3, -T4, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4): R
 }
 
+@native
 trait Function5[-T1, -T2, -T3, -T4, -T5, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): R
 }
 
+@native
 trait Function6[-T1, -T2, -T3, -T4, -T5, -T6, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): R
 }
 
+@native
 trait Function7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): R
 }
 
+@native
 trait Function8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): R
 }
 
+@native
 trait Function9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): R
 }
 
+@native
 trait Function10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): R
 }
 
+@native
 trait Function11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11): R
 }
 
+@native
 trait Function12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12): R
 }
 
+@native
 trait Function13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13): R
 }
 
+@native
 trait Function14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14): R
 }
 
+@native
 trait Function15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15): R
 }
 
+@native
 trait Function16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16): R
 }
 
+@native
 trait Function17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17): R
 }
 
+@native
 trait Function18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18): R
 }
 
+@native
 trait Function19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19): R
 }
 
+@native
 trait Function20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20): R
 }
 
+@native
 trait Function21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20, arg21: T21): R
 }
 
+@native
 trait Function22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, -T22, +R] extends Function {
   def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20, arg21: T21, arg22: T22): R
 }

--- a/library/src/main/scala/scala/scalajs/js/GlobalScope.scala
+++ b/library/src/main/scala/scala/scalajs/js/GlobalScope.scala
@@ -18,4 +18,5 @@ package scala.scalajs.js
  *
  *  @see [[http://www.scala-js.org/doc/calling-javascript.html Calling JavaScript from Scala.js]]
  */
+@native
 trait GlobalScope extends Any

--- a/library/src/main/scala/scala/scalajs/js/JSArrayOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSArrayOps.scala
@@ -27,6 +27,7 @@ import scala.scalajs.js.annotation._
  *  To enable the use of these functions on js.[[Array]]s, import the implicit
  *  conversion [[JSArrayOps.jsArrayOps]].
  */
+@native
 trait JSArrayOps[A] extends Object {
 
   /**

--- a/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
@@ -19,6 +19,7 @@ import scala.language.implicitConversions
 import scala.scalajs.js.annotation._
 
 /** Operations on JavaScript numbers. */
+@native
 trait JSNumberOps extends Any {
 
   def toString(radix: Int): String = native

--- a/library/src/main/scala/scala/scalajs/js/JSON.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSON.scala
@@ -20,6 +20,7 @@ package scala.scalajs.js
  *
  * MDN
  */
+@native
 object JSON extends Object {
   /**
    * Parse a string as JSON, optionally transforming the value produced by parsing.

--- a/library/src/main/scala/scala/scalajs/js/JSStringOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSStringOps.scala
@@ -23,6 +23,7 @@ import scala.scalajs.js.annotation._
  *  The methods with an equivalent signature in [[String]] but with a different
  *  meaning are prefixed by `js` in this trait.
  */
+@native
 trait JSStringOps extends Any {
 
   /**

--- a/library/src/main/scala/scala/scalajs/js/Math.scala
+++ b/library/src/main/scala/scala/scalajs/js/Math.scala
@@ -20,6 +20,7 @@ package scala.scalajs.js
  *
  * MDN
  */
+@native
 object Math extends Object {
   /**
    * Euler's constant and the base of natural logarithms, approximately 2.718.

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -15,6 +15,7 @@
 package scala.scalajs.js
 
 /** Base class of all JavaScript objects. */
+@native
 class Object extends Any {
   def this(value: Any) = this()
 
@@ -44,6 +45,7 @@ class Object extends Any {
 }
 
 /** The top-level `Object` JavaScript object. */
+@native
 object Object extends Object {
   def apply(): Object = native
   def apply(value: Any): Object = native

--- a/library/src/main/scala/scala/scalajs/js/PropertyDescriptor.scala
+++ b/library/src/main/scala/scala/scalajs/js/PropertyDescriptor.scala
@@ -10,6 +10,7 @@
 
 package scala.scalajs.js
 
+@native
 trait PropertyDescriptor extends Object {
   var configurable: Boolean = native
   var enumerable: Boolean = native

--- a/library/src/main/scala/scala/scalajs/js/RegExp.scala
+++ b/library/src/main/scala/scala/scalajs/js/RegExp.scala
@@ -20,6 +20,7 @@ package scala.scalajs.js
  *
  * MDN
  */
+@native
 class RegExp(pattern: String, flags: String = "") extends Object {
   /** Creates a new RegExp with the same pattern and flags as the given one. */
   def this(pattern: RegExp) = this("", "")
@@ -101,9 +102,11 @@ class RegExp(pattern: String, flags: String = "") extends Object {
   def test(string: String): Boolean = native
 }
 
+@native
 object RegExp extends Object {
   def apply(pattern: String, flags: String = ""): RegExp = native
 
+  @native
   trait ExecResult extends Array[UndefOr[String]] {
     var index: Int = native
     var input: String = native

--- a/library/src/main/scala/scala/scalajs/js/ThisFunction.scala
+++ b/library/src/main/scala/scala/scalajs/js/ThisFunction.scala
@@ -20,6 +20,7 @@ import scala.language.implicitConversions
  *
  *  @see [[http://www.scala-js.org/doc/calling-javascript.html Calling JavaScript from Scala.js]]
  */
+@native
 trait ThisFunction extends Function
 
 object ThisFunction {
@@ -74,90 +75,112 @@ object ThisFunction {
 
 // scalastyle:off line.size.limit
 
+@native
 trait ThisFunction0[-T0, +R] extends ThisFunction {
   def apply(thisArg: T0): R
 }
 
+@native
 trait ThisFunction1[-T0, -T1, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1): R
 }
 
+@native
 trait ThisFunction2[-T0, -T1, -T2, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2): R
 }
 
+@native
 trait ThisFunction3[-T0, -T1, -T2, -T3, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3): R
 }
 
+@native
 trait ThisFunction4[-T0, -T1, -T2, -T3, -T4, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4): R
 }
 
+@native
 trait ThisFunction5[-T0, -T1, -T2, -T3, -T4, -T5, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): R
 }
 
+@native
 trait ThisFunction6[-T0, -T1, -T2, -T3, -T4, -T5, -T6, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): R
 }
 
+@native
 trait ThisFunction7[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): R
 }
 
+@native
 trait ThisFunction8[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): R
 }
 
+@native
 trait ThisFunction9[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): R
 }
 
+@native
 trait ThisFunction10[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): R
 }
 
+@native
 trait ThisFunction11[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11): R
 }
 
+@native
 trait ThisFunction12[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12): R
 }
 
+@native
 trait ThisFunction13[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13): R
 }
 
+@native
 trait ThisFunction14[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14): R
 }
 
+@native
 trait ThisFunction15[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15): R
 }
 
+@native
 trait ThisFunction16[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16): R
 }
 
+@native
 trait ThisFunction17[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17): R
 }
 
+@native
 trait ThisFunction18[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18): R
 }
 
+@native
 trait ThisFunction19[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19): R
 }
 
+@native
 trait ThisFunction20[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20): R
 }
 
+@native
 trait ThisFunction21[-T0, -T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends ThisFunction {
   def apply(thisArg: T0, arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20, arg21: T21): R
 }

--- a/library/src/main/scala/scala/scalajs/js/URIUtils.scala
+++ b/library/src/main/scala/scala/scalajs/js/URIUtils.scala
@@ -11,6 +11,7 @@
 package scala.scalajs.js
 
 /** Methods related to URIs, provided by ECMAScript 5.1. */
+@native
 object URIUtils extends GlobalScope {
 
   /** Decodes a Uniform Resource Identifier (URI).

--- a/library/src/main/scala/scala/scalajs/js/UndefOr.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOr.scala
@@ -12,14 +12,13 @@ package scala.scalajs.js
 import scala.language.implicitConversions
 
 /** Value of type A or the JS undefined value.
- *  In a type system with union types, this would really be
- *  `A | js.prim.Undefined`. Since Scala does not have union types, but this
- *  particular union is crucial to many interoperability scenarios, it is
- *  provided as this trait.
  *
- *  An API similar to that of [[scala.Option]] is provided through the
- *  [[UndefOrOps]] implicit class, with the understanding that `undefined` is
- *  the None value.
+ *  `js.UndefOr[A]` is the type of a value that can be either `undefined` or
+ *  an `A`. It provides an API similar to that of [[scala.Option]] through the
+ *  [[UndefOrOps]] implicit class, where `undefined` take the role of [[None]].
+ *
+ *  By extension, this type is also suited to typing optional fields in native
+ *  JS types, i.e., fields that may not exist on the object.
  */
 @scala.scalajs.js.annotation.RawJSType // Don't do this at home!
 sealed trait UndefOr[+A]
@@ -231,7 +230,7 @@ final class UndefOrOps[A](val self: UndefOr[A]) extends AnyVal {
   @inline final def toLeft[X](right: => X): Either[A, X] =
     if (isEmpty) Right(right) else Left(this.forceGet)
 
-  /** Returns a [[scala.Some]] containing this $options's value
+  /** Returns a [[scala.Some]] containing this $option's value
    *  if this $option is nonempty, [[scala.None]] otherwise.
    */
   @inline final def toOption: Option[A] =

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -22,32 +22,25 @@ package scala.scalajs
  *
  *  == Overview ==
  *
- *  The trait [[js.Any]] is the super type of all JavaScript values.
- *
- *  All class, trait and object definitions that inherit, directly or
- *  indirectly, from [[js.Any]] do not have actual implementations in Scala.
- *  They are only the manifestation of static types representing libraries
- *  written directly in JavaScript. It is not possible to implement yourself
- *  a subclass of [[js.Any]]: all the method definitions will be ignored when
- *  compiling to JavaScript.
+ *  The trait [[js.Any]] is the root of the hierarchy of JavaScript types.
+ *  This package defines important subtypes of [[js.Any]] that are defined
+ *  in the standard library of ECMAScript 5.1 (or ES 6, with a label in the
+ *  documentation), such as [[Object js.Object]], [[Array js.Array]] and
+ *  [[RegExp js.RegExp]].
  *
  *  Implicit conversions to and from standard Scala types to their equivalent
  *  in JavaScript are provided. For example, from Scala functions to JavaScript
  *  functions and back.
  *
- *  The most important subclasses of [[js.Any]] are:
- *  - [[js.Dynamic]], a dynamically typed interface to JavaScript APIs
- *  - [[js.Object]], the superclass of all statically typed JavaScript classes,
- *    which has subclasses for all the classes standardized in ECMAScript 5.1,
- *    among which:
- *    - [[js.Array]]
- *    - [[js.Function]] (and subtraits with specific number of parameters)
- *    - [[js.ThisFunction]] and its subtraits for functions that take the
- *      JavaScript `this` as an explicit parameters
- *    - [[js.Dictionary]] to access the properties of an object in a
- *      dictionary-like way
- *    - [[js.Date]]
- *    - [[js.RegExp]]
+ *  The most important subtypes of [[js.Any]] declared in this package are:
+ *  - [[Object js.Object]], the superclass of most (all) JavaScript classes
+ *  - [[Array js.Array]]
+ *  - [[Function js.Function]] (and subtraits with specific number of
+ *    parameters)
+ *  - [[ThisFunction js.ThisFunction]] and its subtraits for functions that
+ *    take the JavaScript `this` as an explicit parameter
+ *  - [[Dictionary js.Dictionary]], a [[Map]]-like view of the properties of a
+ *    JS object
  *
  *  The trait [[js.Dynamic]] is a special subtrait of [[js.Any]]. It can
  *  represent any JavaScript value in a dynamically-typed way. It is possible
@@ -56,14 +49,17 @@ package scala.scalajs
  *
  *  There are no explicit definitions for JavaScript primitive types, as one
  *  could expect, because the corresponding Scala types stand in their stead:
- *  - [[Boolean]] is a primitive JavaScript boolean
- *  - [[Double]] is a primitive JavaScript number
- *  - [[String]] is a primitive JavaScript string
+ *  - [[Boolean]] is the type of primitive JavaScript booleans
+ *  - [[Double]] is the type of primitive JavaScript numbers
+ *  - [[String]] is the type of primitive JavaScript strings (or `null`)
  *  - [[Unit]] is the type of the JavaScript undefined value
  *  - [[Null]] is the type of the JavaScript null value
  *
- *  [[js.UndefOr]] gives a [[scala.Option]]-like interface where the JavaScript
- *  value `undefined` takes the role of `None`.
+ *  [[UndefOr js.UndefOr]] gives a [[scala.Option]]-like interface where the
+ *  JavaScript value `undefined` takes the role of `None`.
+ *
+ *  [[| A | B]] is an unboxed pseudo-union type, suitable to type values that
+ *  admit several unrelated types in facade types.
  */
 package object js {
   /** The undefined value. */

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -101,6 +101,21 @@ package object js {
   @inline def eval(x: String): Any =
     js.Dynamic.global.eval(x)
 
+  /** Marks the annotated class, trait or object as a native JS entity.
+   *
+   *  Native JS entities are not implemented in Scala.js. They are facade types
+   *  for native JS libraries.
+   *
+   *  In Scala.js 0.6.x, all types extending [[Any js.Any]] are native by
+   *  default (unless they are annotated with [[annotation.ScalaJSDefined]]),
+   *  but this will not be the case in the next major version anymore.
+   *
+   *  Only types extending [[Any js.Any]] can be annotated with `@js.native`.
+   *  The body of all concrete members in a native JS class, trait or object
+   *  must be `= js.native`.
+   */
+  class native extends scala.annotation.StaticAnnotation // scalastyle:ignore
+
   /** Denotes a method body as native JavaScript. For use in facade types:
    *
    *  {{{

--- a/library/src/main/scala/scala/scalajs/js/timers/Handles.scala
+++ b/library/src/main/scala/scala/scalajs/js/timers/Handles.scala
@@ -16,6 +16,7 @@ import scala.scalajs.js
  *
  *  May only be used to pass to [[clearTimeout]].
  */
+@js.native
 trait SetTimeoutHandle extends js.Any
 
 /** <span class="badge badge-non-std" style="float: right;">Non-Standard</span>
@@ -23,4 +24,5 @@ trait SetTimeoutHandle extends js.Any
  *
  *  May only be used to pass to [[clearInterval]].
  */
+@js.native
 trait SetIntervalHandle extends js.Any

--- a/library/src/main/scala/scala/scalajs/js/timers/RawTimers.scala
+++ b/library/src/main/scala/scala/scalajs/js/timers/RawTimers.scala
@@ -19,6 +19,7 @@ import scala.scalajs.js
  *  general it is more advisable to use the methods directly defined on
  *  [[timers]] as they are more Scala-like.
  */
+@js.native
 object RawTimers extends js.GlobalScope {
 
   /** Schedule [[handler]] for execution in [[interval]] milliseconds.

--- a/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBuffer.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBuffer.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  An ArrayBuffer is a block of contiguous, non-resizable memory.
  */
+@js.native
 class ArrayBuffer(length: Int) extends js.Object {
 
   /** Length of this buffer in bytes */

--- a/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBufferView.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBufferView.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  An ArrayBufferView allows accessing the data of an [[ArrayBuffer]]
  */
+@js.native
 trait ArrayBufferView extends js.Object {
   /** The underlying buffer of this ArrayBufferView */
   val buffer: ArrayBuffer = js.native

--- a/library/src/main/scala/scala/scalajs/js/typedarray/DataView.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/DataView.scala
@@ -6,6 +6,7 @@ import scala.scalajs.js
  *  A DataView allows for extraction of particular data types at specific
  *  offsets.
  */
+@js.native
 class DataView(buffer: ArrayBuffer, byteOffset: Int = 0,
     byteLength: Int = ???) extends ArrayBufferView {
 

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of single precision floats
  */
+@js.native
 class Float32Array private extends TypedArray[Float, Float32Array] {
 
   /** Constructs a Float32Array with the given length. Initialized to all 0 */
@@ -27,4 +28,5 @@ class Float32Array private extends TypedArray[Float, Float32Array] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Float32Array]] companion
  */
+@js.native
 object Float32Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of double precision floats
  */
+@js.native
 class Float64Array private extends TypedArray[Double, Float64Array] {
 
   /** Constructs a Float64Array with the given length. Initialized to all 0 */
@@ -27,4 +28,5 @@ class Float64Array private extends TypedArray[Double, Float64Array] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Float64Array]] companion
  */
+@js.native
 object Float64Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of signed 16-bit integers
  */
+@js.native
 class Int16Array private extends TypedArray[Short, Int16Array] {
 
   /** Constructs a Int16Array with the given length. Initialized to all 0 */
@@ -27,4 +28,5 @@ class Int16Array private extends TypedArray[Short, Int16Array] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Int16Array]] companion
  */
+@js.native
 object Int16Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of signed 32-bit integers
  */
+@js.native
 class Int32Array private extends TypedArray[Int, Int32Array] {
 
   /** Constructs a Int32Array with the given length. Initialized to all 0 */
@@ -27,4 +28,5 @@ class Int32Array private extends TypedArray[Int, Int32Array] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Int32Array]] companion
  */
+@js.native
 object Int32Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of signed 8-bit integers
  */
+@js.native
 class Int8Array private extends TypedArray[Byte, Int8Array] {
 
   /** Constructs a Int8Array with the given length. Initialized to all 0 */
@@ -27,4 +28,5 @@ class Int8Array private extends TypedArray[Byte, Int8Array] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Int8Array]] companion
  */
+@js.native
 object Int8Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
@@ -7,6 +7,7 @@ import scala.scalajs.js.annotation.JSBracketAccess
  *  A TypedArray allows to view an [[ArrayBuffer]] as an array of values of a
  *  particular numeric type.
  */
+@js.native
 trait TypedArray[T, Repr] extends ArrayBufferView {
 
   /** The number of elements in this TypedArray */
@@ -48,6 +49,7 @@ trait TypedArray[T, Repr] extends ArrayBufferView {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  Static information that exists for any concrete TypedArray
  */
+@js.native
 trait TypedArrayStatic extends js.Object {
   val BYTES_PER_ELEMENT: Int = js.native
 }

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of unsigned 16-bit integers
  */
+@js.native
 class Uint16Array private extends TypedArray[Int, Uint16Array] {
 
   /** Constructs a Uint16Array with the given length. Initialized to all 0 */
@@ -27,4 +28,5 @@ class Uint16Array private extends TypedArray[Int, Uint16Array] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Uint16Array]] companion
  */
+@js.native
 object Uint16Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of unsigned 32-bit integers
  */
+@js.native
 class Uint32Array private extends TypedArray[Double, Uint32Array] {
 
   /** Constructs a Uint32Array with the given length. Initialized to all 0 */
@@ -27,4 +28,5 @@ class Uint32Array private extends TypedArray[Double, Uint32Array] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Uint32Array]] companion
  */
+@js.native
 object Uint32Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
@@ -5,6 +5,7 @@ import scala.scalajs.js
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of unsigned 8-bit integers
  */
+@js.native
 class Uint8Array private extends TypedArray[Short, Uint8Array] {
 
   /** Constructs a Uint8Array with the given length. Initialized to all 0 */
@@ -27,4 +28,5 @@ class Uint8Array private extends TypedArray[Short, Uint8Array] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Uint8Array]] companion
  */
+@js.native
 object Uint8Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
@@ -6,6 +6,7 @@ import scala.scalajs.js
  *  A [[TypedArray]] of unsigned 8-bit integers whose values are clamped to
  *  their max/min rather than wrapped around if they overflow.
  */
+@js.native
 class Uint8ClampedArray private extends TypedArray[Int, Uint8ClampedArray] {
 
   /** Constructs a Uint8ClampedArray with the given length. Initialized to all 0 */
@@ -28,4 +29,5 @@ class Uint8ClampedArray private extends TypedArray[Int, Uint8ClampedArray] {
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  [[Uint8ClampedArray]] companion
  */
+@js.native
 object Uint8ClampedArray extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/runtime/EnvironmentInfo.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/EnvironmentInfo.scala
@@ -22,6 +22,7 @@ import StackTrace.JSStackTraceElem
  *  @groupname envInfo Scala.js environment configuration
  *  @groupprio envInfo 1
  */
+@js.native
 trait EnvironmentInfo extends js.Object {
 
   /** The global JavaScript scope (corresponds to js.Dynamic.global)

--- a/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
@@ -3,6 +3,7 @@ package scala.scalajs.runtime
 import scala.scalajs.js
 
 /** Information about link-time configuration of Scala.js. */
+@js.native
 trait LinkingInfo extends js.Object {
   /** Semantics configuration. */
   val semantics: LinkingInfo.Semantics = js.native
@@ -13,6 +14,7 @@ trait LinkingInfo extends js.Object {
 
 object LinkingInfo {
   /** Semantics configuration. */
+  @js.native
   trait Semantics extends js.Object {
     /** Compliance level of asInstanceOfs. */
     val asInstanceOfs: Int = js.native

--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
@@ -21,6 +21,7 @@ private[runtime] object RuntimeString {
   /** Operations on a primitive JS string that are shadowed by Scala methods,
    *  and that we need to implement these very Scala methods.
    */
+  @js.native
   private trait SpecialJSStringOps extends js.Any {
     def length: Int = js.native
     def charCodeAt(index: Int): Int = js.native

--- a/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
@@ -497,6 +497,7 @@ object StackTrace {
    * ---------------------------------------------------------------------------
    */
 
+  @js.native
   trait JSStackTraceElem extends js.Object {
     var declaringClass: String = js.native
     var methodName: String = js.native

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/Com.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/Com.scala
@@ -3,6 +3,7 @@ package org.scalajs.testinterface.internal
 import scala.scalajs.js
 import js.annotation.JSName
 
+@js.native
 @JSName("scalajsCom")
 object Com extends js.Object {
   def init(onReceive: js.Function1[String, Unit]): Unit = js.native

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -449,12 +449,14 @@ object InteroperabilityTest extends JasmineTest {
 
   }
 
+  @js.native
   trait InteroperabilityTestFieldEscape extends js.Object {
     var `def`: Int = js.native
     def `val`(): Int = js.native
     def `val`(n: Int): Int = js.native
   }
 
+  @js.native
   trait InteroperabilityTestJSName extends js.Object {
     @JSName("val")
     def value(): Int = js.native
@@ -462,11 +464,13 @@ object InteroperabilityTest extends JasmineTest {
     def value(n: Int): Int = js.native
   }
 
+  @js.native
   trait InteroperabilityTestProperty extends js.Object {
     def a_=(x: Int): Unit = js.native
     def a: Int = js.native
   }
 
+  @js.native
   trait InteroperabilityTestPropertyNamed extends js.Object {
     @JSName("b")
     def a_=(x: Int): Unit = js.native
@@ -475,6 +479,7 @@ object InteroperabilityTest extends JasmineTest {
     def b: Int = js.native
   }
 
+  @js.native
   trait InteroperabilityTestJSBracketAccess extends js.Object {
     @JSBracketAccess
     def apply(index: Int): Int = js.native
@@ -482,6 +487,7 @@ object InteroperabilityTest extends JasmineTest {
     def update(index: Int, v: Int): Unit = js.native
   }
 
+  @js.native
   trait InteroperabilityTestRawReceiver extends js.Object {
     val check: js.Function1[Int, Int] = js.native
   }
@@ -489,6 +495,7 @@ object InteroperabilityTest extends JasmineTest {
   /** Trait with different method signatures, all forwarded to the same
    *  JS raw function that returns the argument list for inspection
    */
+  @js.native
   trait InteroperabilityTestDefaultParam extends js.Object {
     @JSName("fun")
     def simple(x: Int, y: Int = 5): js.Any = js.native
@@ -498,26 +505,32 @@ object InteroperabilityTest extends JasmineTest {
     def multi(x: Int = 1)(ys: Int*)(z: Int = 1): js.Any = js.native
   }
 
+  @js.native
   trait InteroperabilityTestCharResult extends js.Object {
     def get(): Char = js.native
   }
 
+  @js.native
   trait InteroperabilityTestCharParam extends js.Object {
     def twice(c: Char): String = js.native
   }
 
+  @js.native
   trait InteroperabilityTestValueClassResult extends js.Object {
     def test(vc: Any): SomeValueClass = js.native
   }
 
+  @js.native
   trait InteroperabilityTestValueClassParam extends js.Object {
     def stringOf(vc: SomeValueClass): String = js.native
   }
 
+  @js.native
   trait InteroperabilityTestNoUnboxResultInStatement extends js.Object {
     def test(): String = js.native
   }
 
+  @js.native
   trait InteroperabilityTestAsInstanceOfResult extends js.Object {
     def testChar(): Char = js.native
     def testInt(): Int = js.native
@@ -537,6 +550,7 @@ object InteroperabilityTest extends JasmineTest {
  */
 
 @JSName("InteroperabilityTestInherit.Pattern")
+@js.native
 class InteroperabilityTestPattern protected () extends js.Object {
   def this(pattern: String) = this()
   val field: Int = js.native
@@ -544,65 +558,80 @@ class InteroperabilityTestPattern protected () extends js.Object {
   def getConstructorParam(): String = js.native
 }
 
+@js.native
 trait InteroperabilityTestTopLevel extends js.Object {
   val value: String = js.native
   def valueAsInt(): Int = js.native
 }
 
 @JSName("InteroperabilityTestTopLevelObject")
+@js.native
 object InteroperabilityTestTopLevel extends js.Object {
   def apply(value: String): InteroperabilityTestTopLevel = js.native
 }
 
+@js.native
 object InteroperabilityTestContainerObject extends js.Object {
+  @js.native
   class ContainedClass(_x: Int) extends js.Object {
     val x: Int = js.native
   }
 
+  @js.native
   object ContainedObject extends js.Object {
     val x: Int = js.native
   }
 
   @JSName("ContainedClassRenamed")
+  @js.native
   class ContainedClassWithJSName(_x: Int) extends js.Object {
     val x: Int = js.native
   }
 
   @JSName("ContainedObjectRenamed")
+  @js.native
   object ContainedObjectWithJSName extends js.Object {
     val x: Int = js.native
   }
 }
 
 @JSName("InteroperabilityTestContainerObjectRenamed")
+@js.native
 object InteroperabilityTestContainerObjectWithJSName extends js.Object {
+  @js.native
   class ContainedClass(_x: Int) extends js.Object {
     val x: Int = js.native
   }
 
+  @js.native
   object ContainedObject extends js.Object {
     val x: Int = js.native
   }
 
   @JSName("ContainedClassRenamed")
+  @js.native
   class ContainedClassWithJSName(_x: Int) extends js.Object {
     val x: Int = js.native
   }
 
   @JSName("ContainedObjectRenamed")
+  @js.native
   object ContainedObjectWithJSName extends js.Object {
     val x: Int = js.native
   }
 }
 
+@js.native
 trait InteroperabilityTestVariadicMethod extends js.Object {
   def foo(args: Any*): js.Array[Any] = js.native
 }
 
+@js.native
 class InteroperabilityTestVariadicCtor(inargs: Any*) extends js.Object {
   val args: js.Array[Any] = js.native
 }
 
+@js.native
 object InteroperabilityTestGlobalScope extends js.GlobalScope {
   var interoperabilityTestGlobalScopeValue: String = js.native
   def interoperabilityTestGlobalScopeValueAsInt(): Int = js.native
@@ -612,8 +641,10 @@ class SomeValueClass(val i: Int) extends AnyVal {
   override def toString(): String = s"SomeValueClass($i)"
 }
 
+@js.native
 class InteroperabilityTestCtor(x: Int = 5, y: Int = ???) extends js.Object {
   def values: js.Array[Int] = js.native
 }
 
+@js.native
 class InteroparabilityCtorInlineValue(val x: Int, var y: Int) extends js.Object

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -137,8 +137,10 @@ object ReflectionTest extends JasmineTest {
   class RenamedTestClass
 
   @JSName("ReflectionTestRawJSClass")
+  @js.native
   class ReflectionTestRawJSClass extends js.Object
 
+  @js.native
   trait ReflectionTestRawJSTrait extends js.Object
 
   class SomeParentClass

--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -102,11 +102,14 @@ object RuntimeTypesTest extends JasmineTest {
 
   }
 
+  @js.native
   trait ParentJSType extends js.Object
 
+  @js.native
   trait SomeJSInterface extends ParentJSType
 
   @JSName("SomeJSClass")
+  @js.native
   class SomeJSClass extends ParentJSType
 
 }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
@@ -99,6 +99,7 @@ object DictionaryTest extends JasmineTest {
 
   }
 
+  @js.native
   trait KeyHolder extends js.Object {
     def key: String = js.native
   }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -1346,7 +1346,9 @@ object SJSDefinedAutoExportedIgnoreClassObject extends SJSDefinedAutoExportIgnor
 @ScalaJSDefined
 class SJSDefinedAutoExportedIgnoreClassClass(val x: Int) extends SJSDefinedAutoExportIgnoreClass
 
+@js.native
 object NativeInvalidExportObject extends SJSDefinedAutoExportIgnoreClass
+@js.native
 class NativeInvalidExportClass extends SJSDefinedAutoExportIgnoreClass
 @ScalaJSDefined
 class SJSDefinedInvalidExportClass private () extends SJSDefinedAutoExportIgnoreClass

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
@@ -45,21 +45,25 @@ object JSNameTest extends JasmineTest {
 
   }
 
+  @js.native
   trait PropDefFacade extends js.Any {
     @JSName("jsDef")
     def internalDef: Int = js.native
   }
 
+  @js.native
   trait PropValFacade extends js.Any {
     @JSName("jsVal")
     val internalVal: String = js.native
   }
 
+  @js.native
   trait PropVarFacade extends js.Any {
     @JSName("jsVar")
     var internalVar: Double = js.native
   }
 
+  @js.native
   trait UndEqNamed extends js.Any {
     @JSName("a_=")
     def a: Int = js.native

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -151,11 +151,13 @@ object MiscInteropTest extends JasmineTest {
   @ScalaJSDefined
   class OtherwiseUnreferencedJSClass(val x: Int) extends js.Object
 
+  @js.native
   trait DirectSubtraitOfJSAny extends js.Any {
     def foo(x: Int): Int = js.native
   }
 
   @JSName("DirectSubclassOfJSAny")
+  @js.native
   class DirectSubclassOfJSAny extends js.Any {
     def bar(x: Int): Int = js.native
   }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -18,6 +18,7 @@ object ScalaJSDefinedTest extends JasmineTest {
 
   // Defined in test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
   @JSName("ScalaJSDefinedTestNativeParentClass")
+  @js.native
   class NativeParentClass(val x: Int) extends js.Object {
     def foo(s: String): String = js.native
 
@@ -31,12 +32,14 @@ object ScalaJSDefinedTest extends JasmineTest {
     def bar: Int = x * 2
   }
 
+  @js.native
   trait NativeTraitWithDeferred extends js.Object {
     val x: Int
   }
 
   // Defined in test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
   @JSName("ScalaJSDefinedTestNativeParentClassWithDeferred")
+  @js.native
   abstract class NativeParentClassWithDeferred extends NativeTraitWithDeferred {
     def foo(y: Int): Int = js.native // = bar(y + 4) + x
 
@@ -45,6 +48,7 @@ object ScalaJSDefinedTest extends JasmineTest {
 
   // Defined in test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
   @JSName("ScalaJSDefinedTestNativeParentClassWithVarargs")
+  @js.native
   class NativeParentClassWithVarargs(
       _x: Int, _args: Int*) extends js.Object {
     val x: Int = js.native

--- a/test-suite/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala
@@ -504,15 +504,18 @@ object UseAsTest extends JasmineTest {
 
   }
 
+  @js.native
   trait JSBasic extends js.Object {
     def m(a: Int, b: String): js.Object = js.native
   }
 
+  @js.native
   trait JSBasicJSName extends js.Object {
     @JSName("m")
     def foo(a: Int, b: String): js.Object = js.native
   }
 
+  @js.native
   trait JSNamedApply extends js.Object {
     @JSName("apply")
     def apply(x: Int): Int = js.native
@@ -520,28 +523,34 @@ object UseAsTest extends JasmineTest {
     def bar(x: Int): Int = js.native
   }
 
+  @js.native
   trait JSGeneric[T] extends js.Object {
     def arr: js.Array[T] = js.native
   }
 
+  @js.native
   trait JSGenericInt extends JSGeneric[Int]
 
+  @js.native
   trait JSTypeMember extends js.Object {
     type R
     def foo(x: R): Int = js.native
   }
 
+  @js.native
   trait JSOverload extends JSBasic {
     def m(b: String): Int = js.native
     def m(a: Int): js.Object = js.native
   }
 
+  @js.native
   trait JSGetters extends js.Object {
     def a: Int = js.native
     val b: String = js.native
     def c: js.Object = js.native
   }
 
+  @js.native
   trait JSSetters extends js.Object {
     def a_=(x: Int): Unit = js.native
 
@@ -552,6 +561,7 @@ object UseAsTest extends JasmineTest {
     def barJS_=(x: js.Array[Int]): Unit = js.native
   }
 
+  @js.native
   trait JSVars extends js.Object {
     var a: Int = js.native
     def b: String = js.native
@@ -561,54 +571,66 @@ object UseAsTest extends JasmineTest {
     var fooJS: js.Object = js.native
   }
 
+  @js.native
   trait JSDefaultArgs extends js.Object {
     def sum4(a: Int, b: Int = ???, c: Int = ???, d: Int = ???): Int = js.native
     def sum2(a: Int, b: Int = ???): Int = js.native
   }
 
+  @js.native
   trait JSRepeated extends js.Object {
     def rep(a: Int, b: String*): Unit = js.native
     def rep(a: Int*): Unit = js.native
   }
 
+  @js.native
   trait JSMulti extends js.Object {
     def multi(a: Int)(b: String): Int = js.native
   }
 
+  @js.native
   trait JSPolyMethod extends js.Object {
     def poly[T](a: T): js.Array[T] = js.native
   }
 
+  @js.native
   trait JSWithApply extends js.Object {
     def apply(a: String): Int = js.native
   }
 
+  @js.native
   trait JSWithBracketAccess extends js.Object {
     @JSBracketAccess
     def foo(a: String): Int = js.native
   }
 
+  @js.native
   trait JSWithBracketCall extends js.Object {
     @JSBracketCall
     def foo(name: String, b: String): Int = js.native
   }
 
+  @js.native
   trait JSNonClassParent extends js.Date
 
+  @js.native
   trait JSApplyString extends js.Object {
     def apply(): String = js.native
   }
 
+  @js.native
   trait JSBracketAccessInt extends js.Object {
     @JSBracketAccess
     def apply(x: Int): Int = js.native
   }
 
+  @js.native
   trait JSBracketCallInt1 extends js.Object {
     @JSBracketCall
     def foo(method: String): Int = js.native
   }
 
+  @js.native
   trait JSBracketCallInt2 extends js.Object {
     @JSBracketCall
     def bar(method: String): Int = js.native


### PR DESCRIPTION
Native JS classes, traits and objects, i.e., those that extend `js.Any` but do not have `@ScalaJSDefined`, should be annotated with `@js.native`.

A warning is emitted for declarations that extend `js.Any` but have neither `@js.native` nor `@ScalaJSDefined`. It is obviously an error to have both.

In the next major version, an unannotated declaration will be Scala.js-defined by default, instead of native, and `@ScalaJSDefined` will be deprecated. This commit encourages developers to update their codebase to forward source compatible code.