### PR TITLE
Adds 'commonLibraries' method to CrossProject.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossProject.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossProject.scala
@@ -272,6 +272,18 @@ final class CrossProject private (
   def settings(ss: Def.Setting[_]*): CrossProject =
     copy(jvm.settings(ss: _*), js.settings(ss: _*))
 
+  /** Define common libraries for both JS/JVM projects.  
+   *  JS projects will automatically be converted into the SJS format. 
+   */
+  def commonLibraries(modules: Seq[ModuleID]): CrossProject = {
+    cp.jsSettings(
+      libraryDependencies ++= modules.map { _.cross(ScalaJSCrossVersion.binary) }
+    ).
+    jvmSettings(
+      libraryDependencies ++= modules
+    )
+  } 
+
   override def toString(): String = s"CrossProject(jvm = $jvm, js = $js)"
 
   // Helpers


### PR DESCRIPTION
Proposing to add the method 'commonLibraries' to CrossProject.  This allows you to define libraries that should be on both the JVM and JS classpath.