### PR TITLE
Fix #1913: Add Thread.{interrupt,isInterrupted,interrupted}.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Thread.scala
+++ b/javalanglib/src/main/scala/java/lang/Thread.scala
@@ -6,9 +6,16 @@ package java.lang
  * So we use a binary signature that no Java source file can ever produce.
  */
 class Thread private (dummy: Unit) extends Runnable {
+  private var interruptedState = false
   private[this] var name: String = "main" // default name of the main thread
 
   def run(): Unit = ()
+
+  def interrupt(): Unit =
+    interruptedState = true
+
+  def isInterrupted(): scala.Boolean =
+    interruptedState
 
   final def setName(name: String): Unit =
     this.name = name
@@ -26,4 +33,10 @@ object Thread {
   private[this] val SingleThread = new Thread(())
 
   def currentThread(): Thread = SingleThread
+
+  def interrupted(): scala.Boolean = {
+    val ret = currentThread.isInterrupted
+    currentThread.interruptedState = false
+    ret
+  }
 }

--- a/test-suite/src/test/scala/org/scalajs/testsuite/javalib/lang/ThreadTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/javalib/lang/ThreadTest.scala
@@ -25,11 +25,23 @@ object ThreadTest extends JasmineTest {
     }
 
     it("Thread.currentThread().getStackTrace() should exist and not crash") {
-      java.lang.Thread.currentThread().getStackTrace()
+      Thread.currentThread().getStackTrace()
     }
 
     it("getId()") {
       expect(Thread.currentThread().getId > 0).toBeTruthy
+    }
+
+    it("interrupt() exist and the status is properly reflected") {
+      val t = Thread.currentThread()
+      expect(t.isInterrupted()).toBeFalsy
+      expect(Thread.interrupted()).toBeFalsy
+      expect(t.isInterrupted()).toBeFalsy
+      t.interrupt()
+      expect(t.isInterrupted()).toBeTruthy
+      expect(Thread.interrupted()).toBeTruthy
+      expect(t.isInterrupted()).toBeFalsy
+      expect(Thread.interrupted()).toBeFalsy
     }
   }
 


### PR DESCRIPTION
Added the method ```interrupt``` to Thread class, just to achieve better source to source compatibility.