### PR TITLE
Fix #1894: Add js.ConstructorTag[T].

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -90,6 +90,9 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSThisFunctionModule = JSThisFunctionClass.companionModule
       def JSThisFunction_fromFunction(arity: Int): TermSymbol = getMemberMethod(JSThisFunctionModule, newTermName("fromFunction"+arity))
 
+    lazy val JSConstructorTagModule = getRequiredModule("scala.scalajs.js.ConstructorTag")
+      lazy val JSConstructorTag_materialize = getMemberMethod(JSConstructorTagModule, newTermName("materialize"))
+
     lazy val RawJSTypeAnnot = getRequiredClass("scala.scalajs.js.annotation.RawJSType")
     lazy val ExposedJSMemberAnnot = getRequiredClass("scala.scalajs.js.annotation.ExposedJSMember")
 
@@ -107,6 +110,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val Runtime_genTraversableOnce2jsArray = getMemberMethod(RuntimePackageModule, newTermName("genTraversableOnce2jsArray"))
       lazy val Runtime_jsTupleArray2jsObject      = getMemberMethod(RuntimePackageModule, newTermName("jsTupleArray2jsObject"))
       lazy val Runtime_constructorOf              = getMemberMethod(RuntimePackageModule, newTermName("constructorOf"))
+      lazy val Runtime_newConstructorTag          = getMemberMethod(RuntimePackageModule, newTermName("newConstructorTag"))
       lazy val Runtime_propertiesOf               = getMemberMethod(RuntimePackageModule, newTermName("propertiesOf"))
       lazy val Runtime_environmentInfo            = getMemberMethod(RuntimePackageModule, newTermName("environmentInfo"))
       lazy val Runtime_linkingInfo                = getMemberMethod(RuntimePackageModule, newTermName("linkingInfo"))

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
@@ -80,11 +80,11 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
       val h = js.constructorOf[JSClass { def bar: Int }]
 
       def foo[A <: js.Any] = js.constructorOf[A]
-      def bar[A <: js.Any : scala.reflect.ClassTag] = js.constructorOf[A]
+      def bar[A <: js.Any: scala.reflect.ClassTag] = js.constructorOf[A]
     }
     """ hasErrors
     """
-      |newSource1.scala:12: error: non-trait class required but NativeJSTrait found
+      |newSource1.scala:12: error: non-trait class type required but NativeJSTrait found
       |      val a = js.constructorOf[NativeJSTrait]
       |                               ^
       |newSource1.scala:13: error: class type required but NativeJSObject.type found
@@ -96,7 +96,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
       |newSource1.scala:16: error: class type required but NativeJSClass{def bar: Int} found
       |      val d = js.constructorOf[NativeJSClass { def bar: Int }]
       |                               ^
-      |newSource1.scala:18: error: non-trait class required but JSTrait found
+      |newSource1.scala:18: error: non-trait class type required but JSTrait found
       |      val e = js.constructorOf[JSTrait]
       |                               ^
       |newSource1.scala:19: error: class type required but JSObject.type found
@@ -112,8 +112,95 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
       |      def foo[A <: js.Any] = js.constructorOf[A]
       |                                              ^
       |newSource1.scala:25: error: class type required but A found
-      |      def bar[A <: js.Any : scala.reflect.ClassTag] = js.constructorOf[A]
-      |                                                                       ^
+      |      def bar[A <: js.Any: scala.reflect.ClassTag] = js.constructorOf[A]
+      |                                                                      ^
+    """
+
+  }
+
+  @Test
+  def jsConstructorTagErrors: Unit = {
+
+    """
+    class ScalaClass
+    trait ScalaTrait
+    object ScalaObject
+
+    object A {
+      val a = js.constructorTag[ScalaClass]
+      val b = js.constructorTag[ScalaTrait]
+      val c = js.constructorTag[ScalaObject.type]
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: type arguments [ScalaClass] do not conform to method constructorTag's type parameter bounds [T <: scala.scalajs.js.Any]
+      |      val a = js.constructorTag[ScalaClass]
+      |                               ^
+      |newSource1.scala:9: error: type arguments [ScalaTrait] do not conform to method constructorTag's type parameter bounds [T <: scala.scalajs.js.Any]
+      |      val b = js.constructorTag[ScalaTrait]
+      |                               ^
+      |newSource1.scala:10: error: type arguments [ScalaObject.type] do not conform to method constructorTag's type parameter bounds [T <: scala.scalajs.js.Any]
+      |      val c = js.constructorTag[ScalaObject.type]
+      |                               ^
+    """
+
+    """
+    @js.native class NativeJSClass extends js.Object
+    @js.native trait NativeJSTrait extends js.Object
+    @js.native object NativeJSObject extends js.Object
+
+    @ScalaJSDefined class JSClass extends js.Object
+    @ScalaJSDefined trait JSTrait extends js.Object
+    @ScalaJSDefined object JSObject extends js.Object
+
+    object A {
+      val a = js.constructorTag[NativeJSTrait]
+      val b = js.constructorTag[NativeJSObject.type]
+
+      val c = js.constructorTag[NativeJSClass with NativeJSTrait]
+      val d = js.constructorTag[NativeJSClass { def bar: Int }]
+
+      val e = js.constructorTag[JSTrait]
+      val f = js.constructorTag[JSObject.type]
+
+      val g = js.constructorTag[JSClass with JSTrait]
+      val h = js.constructorTag[JSClass { def bar: Int }]
+
+      def foo[A <: js.Any] = js.constructorTag[A]
+      def bar[A <: js.Any: scala.reflect.ClassTag] = js.constructorTag[A]
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:12: error: non-trait class type required but NativeJSTrait found
+      |      val a = js.constructorTag[NativeJSTrait]
+      |                               ^
+      |newSource1.scala:13: error: class type required but NativeJSObject.type found
+      |      val b = js.constructorTag[NativeJSObject.type]
+      |                               ^
+      |newSource1.scala:15: error: class type required but NativeJSClass with NativeJSTrait found
+      |      val c = js.constructorTag[NativeJSClass with NativeJSTrait]
+      |                               ^
+      |newSource1.scala:16: error: class type required but NativeJSClass{def bar: Int} found
+      |      val d = js.constructorTag[NativeJSClass { def bar: Int }]
+      |                               ^
+      |newSource1.scala:18: error: non-trait class type required but JSTrait found
+      |      val e = js.constructorTag[JSTrait]
+      |                               ^
+      |newSource1.scala:19: error: class type required but JSObject.type found
+      |      val f = js.constructorTag[JSObject.type]
+      |                               ^
+      |newSource1.scala:21: error: class type required but JSClass with JSTrait found
+      |      val g = js.constructorTag[JSClass with JSTrait]
+      |                               ^
+      |newSource1.scala:22: error: class type required but JSClass{def bar: Int} found
+      |      val h = js.constructorTag[JSClass { def bar: Int }]
+      |                               ^
+      |newSource1.scala:24: error: class type required but A found
+      |      def foo[A <: js.Any] = js.constructorTag[A]
+      |                                              ^
+      |newSource1.scala:25: error: class type required but A found
+      |      def bar[A <: js.Any: scala.reflect.ClassTag] = js.constructorTag[A]
+      |                                                                      ^
     """
 
   }

--- a/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
+++ b/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
@@ -1,0 +1,39 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+/** Stores the JS constructor function of a JS class.
+ *
+ *  A `ConstructorTag[T]` holds the constructor function of a JS class, as
+ *  retrieved by `js.constructorOf[T]`. Similarly to
+ *  [[ClassTag scala.reflect.ClassTag]]s, `ConstructorTag`s can be implicitly
+ *  materialized when `T` is statically known to be a JS class, i.e., a valid
+ *  type argument to `js.constructorOf`.
+ */
+final class ConstructorTag[T <: Any] private[scalajs] (
+    val constructor: Dynamic) extends AnyVal {
+
+  /** Instantiates the class `T` with the specified arguments.
+   *
+   *  Note that, unlike [[Dynamic.newInstance js.Dynamic.newInstance]], this
+   *  method accepts `scala.Any`s as parameters.
+   */
+  def newInstance(args: scala.Any*): T =
+    Dynamic.newInstance(constructor)(args.asInstanceOf[Seq[Any]]: _*).asInstanceOf[T]
+}
+
+object ConstructorTag {
+  /** Implicitly materializes a [[ConstructorTag]].
+   *
+   *  This method has the same preconditions as
+   *  [[constructorOf js.constructorOf]].
+   */
+  implicit def materialize[T <: Any]: ConstructorTag[T] = sys.error("stub")
+}

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -81,6 +81,10 @@ package object js {
    */
   def constructorOf[T <: js.Any]: js.Dynamic = sys.error("stub")
 
+  /** Makes explicit an implicitly available `ConstructorTag[T]`. */
+  def constructorTag[T <: js.Any](implicit tag: ConstructorTag[T]): ConstructorTag[T] =
+    tag
+
   /** Invokes any available debugging functionality.
    *  If no debugging functionality is available, this statement has no effect.
    *

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -103,6 +103,12 @@ package object runtime {
    */
   def constructorOf(clazz: Class[_ <: js.Any]): js.Dynamic = sys.error("stub")
 
+  /** Public access to `new ConstructorTag` for the codegen of
+   *  `js.ConstructorTag.materialize`.
+   */
+  def newConstructorTag[T <: js.Any](constructor: js.Dynamic): js.ConstructorTag[T] =
+    new js.ConstructorTag[T](constructor)
+
   /** Returns an array of the enumerable properties in an object's prototype
    *  chain.
    *


### PR DESCRIPTION
Similarly to `ClassTag[T]`, `js.ConstructorTag[T]` is an implicitly materializable wrapper for `js.constructorOf[T]`.