### PR TITLE
Fix #1903: Remove noWarnMissing option from Linker

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
@@ -452,7 +452,7 @@ object RhinoJSEnv {
         considerPositions = true)
     linker.link(cp.scalaJSIR, logger,
         reachOptimizerSymbols = false,
-        bypassLinkingErrors = true, noWarnMissing = Nil, checkIR = false)
+        bypassLinkingErrors = true, checkIR = false)
   }
 
   /** Communication channel between the Rhino thread and the rest of the JVM */

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/BlacklistedTests.txt
@@ -885,6 +885,24 @@ run/t7791-script-linenums.scala
 # Suffers from bug in Node.js (https://github.com/joyent/node/issues/7528)
 run/range-unit.scala
 
+# Using Manifests (which use Class.getInterfaces)
+run/valueclasses-manifest-existential.scala
+run/existentials3-old.scala
+run/t2236-old.scala
+run/interop_manifests_are_classtags.scala
+run/valueclasses-manifest-generic.scala
+run/valueclasses-manifest-basic.scala
+run/t1195-old.scala
+run/t3758-old.scala
+run/t4110-old.scala
+
+# Using ScalaRunTime.stringOf
+run/value-class-extractor-seq.scala
+run/t3493.scala
+
+# Using Class.forName
+run/private-inline.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/NoDCEWarn.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/NoDCEWarn.txt
@@ -1,8 +1,0 @@
-Ljava_math_MathContext$
-Ljava_math_BigDecimal$
-Ljava_math_BigDecimal
-Ljava_math_BigInteger$
-jl_Class$
-jl_Class.getClassLoader__jl_ClassLoader
-jl_Class.getPackage__jl_Package
-jl_Class.getInterfaces__Ajl_Class

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/WhitelistedTests.txt
@@ -1024,7 +1024,6 @@ run/Course-2002-13.scala
 run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
-run/existentials3-old.scala
 run/runtime-richChar.scala
 run/t6272.scala
 run/t7215.scala
@@ -1047,7 +1046,6 @@ run/t889.scala
 run/QueueTest.scala
 run/t4537
 run/t3699.scala
-run/valueclasses-manifest-basic.scala
 run/t1192.scala
 run/macro-expand-tparams-bounds
 run/macro-expand-nullary-generic
@@ -1055,7 +1053,6 @@ run/t1434.scala
 run/t6443-varargs.scala
 run/macro-term-declared-in-trait
 run/t4080.scala
-run/t2236-old.scala
 run/matcharraytail.scala
 run/infiniteloop.scala
 run/t5733.scala
@@ -1083,7 +1080,6 @@ run/t5867.scala
 run/search.scala
 run/t3112.scala
 run/hashsetremove.scala
-run/interop_manifests_are_classtags.scala
 run/t6443.scala
 run/macro-expand-tparams-prefix
 run/contrib674.scala
@@ -1289,7 +1285,6 @@ run/t5907.scala
 run/t266.scala
 run/missingparams.scala
 run/t2255.scala
-run/private-inline.scala
 run/t3488.scala
 run/t3950.scala
 run/typealias_overriding.scala
@@ -1324,7 +1319,6 @@ run/enrich-gentraversable.scala
 run/macro-expand-override
 run/t4054.scala
 run/t4753.scala
-run/valueclasses-manifest-generic.scala
 run/macro-typecheck-macrosdisabled
 run/t2308a.scala
 run/duplicate-meth.scala
@@ -1568,13 +1562,11 @@ neg/cyclics.scala
 neg/t5060.scala
 neg/scopes.scala
 run/t4013.scala
-run/value-class-extractor-seq.scala
 run/macro-expand-tparams-explicit
 run/tuples.scala
 run/t5753_2
 run/t0528.scala
 run/t5105.scala
-run/t1195-old.scala
 run/t7341.scala
 run/t3670.scala
 run/t2594_tcpoly.scala
@@ -1588,7 +1580,6 @@ run/t3004.scala
 run/viewtest.scala
 run/t6481.scala
 run/t0005.scala
-run/t4110-old.scala
 run/t4766.scala
 run/t5500b.scala
 run/t7407b.scala
@@ -2379,13 +2370,10 @@ run/t3242b.scala
 run/indexedSeq-apply.scala
 run/t107.scala
 run/t2337.scala
-run/t3758-old.scala
 run/t2754.scala
-run/valueclasses-manifest-existential.scala
 run/flat-flat-flat.scala
 run/t6673.scala
 run/interpolationMultiline2.scala
-run/t3493.scala
 run/t0631.scala
 run/t2800.scala
 run/t6506.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/BlacklistedTests.txt
@@ -893,6 +893,24 @@ run/t7791-script-linenums.scala
 # Suffers from bug in Node.js (https://github.com/joyent/node/issues/7528)
 run/range-unit.scala
 
+# Using Manifests (which use Class.getInterfaces)
+run/valueclasses-manifest-existential.scala
+run/existentials3-old.scala
+run/t2236-old.scala
+run/interop_manifests_are_classtags.scala
+run/valueclasses-manifest-generic.scala
+run/valueclasses-manifest-basic.scala
+run/t1195-old.scala
+run/t3758-old.scala
+run/t4110-old.scala
+
+# Using ScalaRunTime.stringOf
+run/value-class-extractor-seq.scala
+run/t3493.scala
+
+# Using Class.forName
+run/private-inline.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/NoDCEWarn.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/NoDCEWarn.txt
@@ -1,8 +1,0 @@
-Ljava_math_MathContext$
-Ljava_math_BigDecimal$
-Ljava_math_BigDecimal
-Ljava_math_BigInteger$
-jl_Class$
-jl_Class.getClassLoader__jl_ClassLoader
-jl_Class.getPackage__jl_Package
-jl_Class.getInterfaces__Ajl_Class

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/WhitelistedTests.txt
@@ -1024,7 +1024,6 @@ run/Course-2002-13.scala
 run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
-run/existentials3-old.scala
 run/runtime-richChar.scala
 run/t6272.scala
 run/t7215.scala
@@ -1047,7 +1046,6 @@ run/t889.scala
 run/QueueTest.scala
 run/t4537
 run/t3699.scala
-run/valueclasses-manifest-basic.scala
 run/t1192.scala
 run/macro-expand-tparams-bounds
 run/macro-expand-nullary-generic
@@ -1055,7 +1053,6 @@ run/t1434.scala
 run/t6443-varargs.scala
 run/macro-term-declared-in-trait
 run/t4080.scala
-run/t2236-old.scala
 run/matcharraytail.scala
 run/infiniteloop.scala
 run/t5733.scala
@@ -1083,7 +1080,6 @@ run/t5867.scala
 run/search.scala
 run/t3112.scala
 run/hashsetremove.scala
-run/interop_manifests_are_classtags.scala
 run/t6443.scala
 run/macro-expand-tparams-prefix
 run/contrib674.scala
@@ -1289,7 +1285,6 @@ run/t5907.scala
 run/t266.scala
 run/missingparams.scala
 run/t2255.scala
-run/private-inline.scala
 run/t3488.scala
 run/t3950.scala
 run/typealias_overriding.scala
@@ -1324,7 +1319,6 @@ run/enrich-gentraversable.scala
 run/macro-expand-override
 run/t4054.scala
 run/t4753.scala
-run/valueclasses-manifest-generic.scala
 run/macro-typecheck-macrosdisabled
 run/t2308a.scala
 run/duplicate-meth.scala
@@ -1568,13 +1562,11 @@ neg/cyclics.scala
 neg/t5060.scala
 neg/scopes.scala
 run/t4013.scala
-run/value-class-extractor-seq.scala
 run/macro-expand-tparams-explicit
 run/tuples.scala
 run/t5753_2
 run/t0528.scala
 run/t5105.scala
-run/t1195-old.scala
 run/t7341.scala
 run/t3670.scala
 run/t2594_tcpoly.scala
@@ -1588,7 +1580,6 @@ run/t3004.scala
 run/viewtest.scala
 run/t6481.scala
 run/t0005.scala
-run/t4110-old.scala
 run/t4766.scala
 run/t5500b.scala
 run/t7407b.scala
@@ -2379,13 +2370,10 @@ run/t3242b.scala
 run/indexedSeq-apply.scala
 run/t107.scala
 run/t2337.scala
-run/t3758-old.scala
 run/t2754.scala
-run/valueclasses-manifest-existential.scala
 run/flat-flat-flat.scala
 run/t6673.scala
 run/interpolationMultiline2.scala
-run/t3493.scala
 run/t0631.scala
 run/t2800.scala
 run/t6506.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BlacklistedTests.txt
@@ -908,6 +908,24 @@ run/t7791-script-linenums.scala
 # Suffers from bug in Node.js (https://github.com/joyent/node/issues/7528)
 run/range-unit.scala
 
+# Using Manifests (which use Class.getInterfaces)
+run/valueclasses-manifest-existential.scala
+run/existentials3-old.scala
+run/t2236-old.scala
+run/interop_manifests_are_classtags.scala
+run/valueclasses-manifest-generic.scala
+run/valueclasses-manifest-basic.scala
+run/t1195-old.scala
+run/t3758-old.scala
+run/t4110-old.scala
+
+# Using ScalaRunTime.stringOf
+run/value-class-extractor-seq.scala
+run/t3493.scala
+
+# Using Class.forName
+run/private-inline.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/NoDCEWarn.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/NoDCEWarn.txt
@@ -1,8 +1,0 @@
-Ljava_math_MathContext$
-Ljava_math_BigDecimal$
-Ljava_math_BigDecimal
-Ljava_math_BigInteger$
-jl_Class$
-jl_Class.getClassLoader__jl_ClassLoader
-jl_Class.getPackage__jl_Package
-jl_Class.getInterfaces__Ajl_Class

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/WhitelistedTests.txt
@@ -1024,7 +1024,6 @@ run/Course-2002-13.scala
 run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
-run/existentials3-old.scala
 run/runtime-richChar.scala
 run/t6272.scala
 run/t7215.scala
@@ -1047,7 +1046,6 @@ run/t889.scala
 run/QueueTest.scala
 run/t4537
 run/t3699.scala
-run/valueclasses-manifest-basic.scala
 run/t1192.scala
 run/macro-expand-tparams-bounds
 run/macro-expand-nullary-generic
@@ -1055,7 +1053,6 @@ run/t1434.scala
 run/t6443-varargs.scala
 run/macro-term-declared-in-trait
 run/t4080.scala
-run/t2236-old.scala
 run/matcharraytail.scala
 run/infiniteloop.scala
 run/t5733.scala
@@ -1083,7 +1080,6 @@ run/t5867.scala
 run/search.scala
 run/t3112.scala
 run/hashsetremove.scala
-run/interop_manifests_are_classtags.scala
 run/t6443.scala
 run/macro-expand-tparams-prefix
 run/contrib674.scala
@@ -1289,7 +1285,6 @@ run/t5907.scala
 run/t266.scala
 run/missingparams.scala
 run/t2255.scala
-run/private-inline.scala
 run/t3488.scala
 run/t3950.scala
 run/typealias_overriding.scala
@@ -1324,7 +1319,6 @@ run/enrich-gentraversable.scala
 run/macro-expand-override
 run/t4054.scala
 run/t4753.scala
-run/valueclasses-manifest-generic.scala
 run/macro-typecheck-macrosdisabled
 run/t2308a.scala
 run/duplicate-meth.scala
@@ -1568,13 +1562,11 @@ neg/cyclics.scala
 neg/t5060.scala
 neg/scopes.scala
 run/t4013.scala
-run/value-class-extractor-seq.scala
 run/macro-expand-tparams-explicit
 run/tuples.scala
 run/t5753_2
 run/t0528.scala
 run/t5105.scala
-run/t1195-old.scala
 run/t7341.scala
 run/t3670.scala
 run/t2594_tcpoly.scala
@@ -1588,7 +1580,6 @@ run/t3004.scala
 run/viewtest.scala
 run/t6481.scala
 run/t0005.scala
-run/t4110-old.scala
 run/t4766.scala
 run/t5500b.scala
 run/t7407b.scala
@@ -2379,13 +2370,10 @@ run/t3242b.scala
 run/indexedSeq-apply.scala
 run/t107.scala
 run/t2337.scala
-run/t3758-old.scala
 run/t2754.scala
-run/valueclasses-manifest-existential.scala
 run/flat-flat-flat.scala
 run/t6673.scala
 run/interpolationMultiline2.scala
-run/t3493.scala
 run/t0631.scala
 run/t2800.scala
 run/t6506.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/BlacklistedTests.txt
@@ -935,6 +935,24 @@ run/t7791-script-linenums.scala
 # Suffers from bug in Node.js (https://github.com/joyent/node/issues/7528)
 run/range-unit.scala
 
+# Using Manifests (which use Class.getInterfaces)
+run/valueclasses-manifest-existential.scala
+run/existentials3-old.scala
+run/t2236-old.scala
+run/interop_manifests_are_classtags.scala
+run/valueclasses-manifest-generic.scala
+run/valueclasses-manifest-basic.scala
+run/t1195-old.scala
+run/t3758-old.scala
+run/t4110-old.scala
+
+# Using ScalaRunTime.stringOf
+run/value-class-extractor-seq.scala
+run/t3493.scala
+
+# Using Class.forName
+run/private-inline.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/NoDCEWarn.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/NoDCEWarn.txt
@@ -1,8 +1,0 @@
-Ljava_math_MathContext$
-Ljava_math_BigDecimal$
-Ljava_math_BigDecimal
-Ljava_math_BigInteger$
-jl_Class$
-jl_Class.getClassLoader__jl_ClassLoader
-jl_Class.getPackage__jl_Package
-jl_Class.getInterfaces__Ajl_Class

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/WhitelistedTests.txt
@@ -1087,7 +1087,6 @@ run/Course-2002-13.scala
 run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
-run/existentials3-old.scala
 run/runtime-richChar.scala
 run/t6272.scala
 run/t7215.scala
@@ -1110,7 +1109,6 @@ run/t889.scala
 run/QueueTest.scala
 run/t4537
 run/t3699.scala
-run/valueclasses-manifest-basic.scala
 run/t1192.scala
 run/macro-expand-tparams-bounds
 run/macro-expand-nullary-generic
@@ -1118,7 +1116,6 @@ run/t1434.scala
 run/t6443-varargs.scala
 run/macro-term-declared-in-trait
 run/t4080.scala
-run/t2236-old.scala
 run/matcharraytail.scala
 run/infiniteloop.scala
 run/t5733.scala
@@ -1145,7 +1142,6 @@ run/t5867.scala
 run/search.scala
 run/t3112.scala
 run/hashsetremove.scala
-run/interop_manifests_are_classtags.scala
 run/t6443.scala
 run/macro-expand-tparams-prefix
 run/contrib674.scala
@@ -1349,7 +1345,6 @@ run/t5907.scala
 run/t266.scala
 run/missingparams.scala
 run/t2255.scala
-run/private-inline.scala
 run/t3488.scala
 run/t3950.scala
 run/typealias_overriding.scala
@@ -1383,7 +1378,6 @@ run/enrich-gentraversable.scala
 run/macro-expand-override
 run/t4054.scala
 run/t4753.scala
-run/valueclasses-manifest-generic.scala
 run/macro-typecheck-macrosdisabled
 run/t2308a.scala
 run/duplicate-meth.scala
@@ -1626,13 +1620,11 @@ neg/cyclics.scala
 neg/t5060.scala
 neg/scopes.scala
 run/t4013.scala
-run/value-class-extractor-seq.scala
 run/macro-expand-tparams-explicit
 run/tuples.scala
 run/t5753_2
 run/t0528.scala
 run/t5105.scala
-run/t1195-old.scala
 run/t7341.scala
 run/t3670.scala
 run/t2594_tcpoly.scala
@@ -1646,7 +1638,6 @@ run/t3004.scala
 run/viewtest.scala
 run/t6481.scala
 run/t0005.scala
-run/t4110-old.scala
 run/t4766.scala
 run/t5500b.scala
 run/t7407b.scala
@@ -2437,13 +2428,10 @@ run/t3242b.scala
 run/indexedSeq-apply.scala
 run/t107.scala
 run/t2337.scala
-run/t3758-old.scala
 run/t2754.scala
-run/valueclasses-manifest-existential.scala
 run/flat-flat-flat.scala
 run/t6673.scala
 run/interpolationMultiline2.scala
-run/t3493.scala
 run/t0631.scala
 run/t2800.scala
 run/t6506.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/BlacklistedTests.txt
@@ -937,6 +937,24 @@ run/t7791-script-linenums.scala
 # Suffers from bug in Node.js (https://github.com/joyent/node/issues/7528)
 run/range-unit.scala
 
+# Using Manifests (which use Class.getInterfaces)
+run/valueclasses-manifest-existential.scala
+run/existentials3-old.scala
+run/t2236-old.scala
+run/interop_manifests_are_classtags.scala
+run/valueclasses-manifest-generic.scala
+run/valueclasses-manifest-basic.scala
+run/t1195-old.scala
+run/t3758-old.scala
+run/t4110-old.scala
+
+# Using ScalaRunTime.stringOf
+run/value-class-extractor-seq.scala
+run/t3493.scala
+
+# Using Class.forName
+run/private-inline.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/NoDCEWarn.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/NoDCEWarn.txt
@@ -1,8 +1,0 @@
-Ljava_math_MathContext$
-Ljava_math_BigDecimal$
-Ljava_math_BigDecimal
-Ljava_math_BigInteger$
-jl_Class$
-jl_Class.getClassLoader__jl_ClassLoader
-jl_Class.getPackage__jl_Package
-jl_Class.getInterfaces__Ajl_Class

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/WhitelistedTests.txt
@@ -1099,7 +1099,6 @@ run/Course-2002-13.scala
 run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
-run/existentials3-old.scala
 run/runtime-richChar.scala
 run/t6272.scala
 run/t7215.scala
@@ -1122,7 +1121,6 @@ run/t889.scala
 run/QueueTest.scala
 run/t4537
 run/t3699.scala
-run/valueclasses-manifest-basic.scala
 run/t1192.scala
 run/macro-expand-tparams-bounds
 run/macro-expand-nullary-generic
@@ -1130,7 +1128,6 @@ run/t1434.scala
 run/t6443-varargs.scala
 run/macro-term-declared-in-trait
 run/t4080.scala
-run/t2236-old.scala
 run/matcharraytail.scala
 run/infiniteloop.scala
 run/t5733.scala
@@ -1157,7 +1154,6 @@ run/t5867.scala
 run/search.scala
 run/t3112.scala
 run/hashsetremove.scala
-run/interop_manifests_are_classtags.scala
 run/t6443.scala
 run/macro-expand-tparams-prefix
 run/contrib674.scala
@@ -1361,7 +1357,6 @@ run/t5907.scala
 run/t266.scala
 run/missingparams.scala
 run/t2255.scala
-run/private-inline.scala
 run/t3488.scala
 run/t3950.scala
 run/typealias_overriding.scala
@@ -1395,7 +1390,6 @@ run/enrich-gentraversable.scala
 run/macro-expand-override
 run/t4054.scala
 run/t4753.scala
-run/valueclasses-manifest-generic.scala
 run/macro-typecheck-macrosdisabled
 run/t2308a.scala
 run/duplicate-meth.scala
@@ -1638,13 +1632,11 @@ neg/cyclics.scala
 neg/t5060.scala
 neg/scopes.scala
 run/t4013.scala
-run/value-class-extractor-seq.scala
 run/macro-expand-tparams-explicit
 run/tuples.scala
 run/t5753_2
 run/t0528.scala
 run/t5105.scala
-run/t1195-old.scala
 run/t7341.scala
 run/t3670.scala
 run/t2594_tcpoly.scala
@@ -1658,7 +1650,6 @@ run/t3004.scala
 run/viewtest.scala
 run/t6481.scala
 run/t0005.scala
-run/t4110-old.scala
 run/t4766.scala
 run/t5500b.scala
 run/t7407b.scala
@@ -2449,13 +2440,10 @@ run/t3242b.scala
 run/indexedSeq-apply.scala
 run/t107.scala
 run/t2337.scala
-run/t3758-old.scala
 run/t2754.scala
-run/valueclasses-manifest-existential.scala
 run/flat-flat-flat.scala
 run/t6673.scala
 run/interpolationMultiline2.scala
-run/t3493.scala
 run/t0631.scala
 run/t2800.scala
 run/t6506.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
@@ -962,6 +962,24 @@ run/t7791-script-linenums.scala
 # Suffers from bug in Node.js (https://github.com/joyent/node/issues/7528)
 run/range-unit.scala
 
+# Using Manifests (which use Class.getInterfaces)
+run/valueclasses-manifest-existential.scala
+run/existentials3-old.scala
+run/t2236-old.scala
+run/interop_manifests_are_classtags.scala
+run/valueclasses-manifest-generic.scala
+run/valueclasses-manifest-basic.scala
+run/t1195-old.scala
+run/t3758-old.scala
+run/t4110-old.scala
+
+# Using ScalaRunTime.stringOf
+run/value-class-extractor-seq.scala
+run/t3493.scala
+
+# Using Class.forName
+run/private-inline.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/NoDCEWarn.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/NoDCEWarn.txt
@@ -1,8 +1,0 @@
-Ljava_math_MathContext$
-Ljava_math_BigDecimal$
-Ljava_math_BigDecimal
-Ljava_math_BigInteger$
-jl_Class$
-jl_Class.getClassLoader__jl_ClassLoader
-jl_Class.getPackage__jl_Package
-jl_Class.getInterfaces__Ajl_Class

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
@@ -1120,7 +1120,6 @@ run/Course-2002-13.scala
 run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
-run/existentials3-old.scala
 run/runtime-richChar.scala
 run/t6272.scala
 run/t7215.scala
@@ -1143,7 +1142,6 @@ run/t889.scala
 run/QueueTest.scala
 run/t4537
 run/t3699.scala
-run/valueclasses-manifest-basic.scala
 run/t1192.scala
 run/macro-expand-tparams-bounds
 run/macro-expand-nullary-generic
@@ -1151,7 +1149,6 @@ run/t1434.scala
 run/t6443-varargs.scala
 run/macro-term-declared-in-trait
 run/t4080.scala
-run/t2236-old.scala
 run/matcharraytail.scala
 run/infiniteloop.scala
 run/t5733.scala
@@ -1178,7 +1175,6 @@ run/t5867.scala
 run/search.scala
 run/t3112.scala
 run/hashsetremove.scala
-run/interop_manifests_are_classtags.scala
 run/t6443.scala
 run/macro-expand-tparams-prefix
 run/contrib674.scala
@@ -1382,7 +1378,6 @@ run/t5907.scala
 run/t266.scala
 run/missingparams.scala
 run/t2255.scala
-run/private-inline.scala
 run/t3488.scala
 run/t3950.scala
 run/typealias_overriding.scala
@@ -1416,7 +1411,6 @@ run/enrich-gentraversable.scala
 run/macro-expand-override
 run/t4054.scala
 run/t4753.scala
-run/valueclasses-manifest-generic.scala
 run/macro-typecheck-macrosdisabled
 run/t2308a.scala
 run/duplicate-meth.scala
@@ -1667,13 +1661,11 @@ neg/cyclics.scala
 neg/t5060.scala
 neg/scopes.scala
 run/t4013.scala
-run/value-class-extractor-seq.scala
 run/macro-expand-tparams-explicit
 run/tuples.scala
 run/t5753_2
 run/t0528.scala
 run/t5105.scala
-run/t1195-old.scala
 run/t7341.scala
 run/t3670.scala
 run/t2594_tcpoly.scala
@@ -1687,7 +1679,6 @@ run/t3004.scala
 run/viewtest.scala
 run/t6481.scala
 run/t0005.scala
-run/t4110-old.scala
 run/t4766.scala
 run/t5500b.scala
 run/t7407b.scala
@@ -2477,13 +2468,10 @@ run/t3242b.scala
 run/indexedSeq-apply.scala
 run/t107.scala
 run/t2337.scala
-run/t3758-old.scala
 run/t2754.scala
-run/valueclasses-manifest-existential.scala
 run/flat-flat-flat.scala
 run/t6673.scala
 run/interpolationMultiline2.scala
-run/t3493.scala
 run/t0631.scala
 run/t2800.scala
 run/t6506.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M2/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M2/BlacklistedTests.txt
@@ -966,6 +966,21 @@ run/range-unit.scala
 # Using scalap
 run/scalapInvokedynamic.scala
 
+# Using Manifests (which use Class.getInterfaces)
+run/valueclasses-manifest-existential.scala
+run/existentials3-old.scala
+run/t2236-old.scala
+run/interop_manifests_are_classtags.scala
+run/valueclasses-manifest-generic.scala
+run/valueclasses-manifest-basic.scala
+run/t1195-old.scala
+run/t3758-old.scala
+run/t4110-old.scala
+
+# Using ScalaRunTime.stringOf
+run/value-class-extractor-seq.scala
+run/t3493.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M2/NoDCEWarn.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M2/NoDCEWarn.txt
@@ -1,8 +1,0 @@
-Ljava_math_MathContext$
-Ljava_math_BigDecimal$
-Ljava_math_BigDecimal
-Ljava_math_BigInteger$
-jl_Class$
-jl_Class.getClassLoader__jl_ClassLoader
-jl_Class.getPackage__jl_Package
-jl_Class.getInterfaces__Ajl_Class

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M2/WhitelistedTests.txt
@@ -1119,7 +1119,6 @@ run/Course-2002-13.scala
 run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
-run/existentials3-old.scala
 run/runtime-richChar.scala
 run/t6272.scala
 run/t7215.scala
@@ -1142,7 +1141,6 @@ run/t889.scala
 run/QueueTest.scala
 run/t4537
 run/t3699.scala
-run/valueclasses-manifest-basic.scala
 run/t1192.scala
 run/macro-expand-tparams-bounds
 run/macro-expand-nullary-generic
@@ -1150,7 +1148,6 @@ run/t1434.scala
 run/t6443-varargs.scala
 run/macro-term-declared-in-trait
 run/t4080.scala
-run/t2236-old.scala
 run/matcharraytail.scala
 run/infiniteloop.scala
 run/t5733.scala
@@ -1177,7 +1174,6 @@ run/t5867.scala
 run/search.scala
 run/t3112.scala
 run/hashsetremove.scala
-run/interop_manifests_are_classtags.scala
 run/t6443.scala
 run/macro-expand-tparams-prefix
 run/contrib674.scala
@@ -1413,7 +1409,6 @@ run/enrich-gentraversable.scala
 run/macro-expand-override
 run/t4054.scala
 run/t4753.scala
-run/valueclasses-manifest-generic.scala
 run/macro-typecheck-macrosdisabled
 run/t2308a.scala
 run/duplicate-meth.scala
@@ -1664,13 +1659,11 @@ neg/cyclics.scala
 neg/t5060.scala
 neg/scopes.scala
 run/t4013.scala
-run/value-class-extractor-seq.scala
 run/macro-expand-tparams-explicit
 run/tuples.scala
 run/t5753_2
 run/t0528.scala
 run/t5105.scala
-run/t1195-old.scala
 run/t7341.scala
 run/t3670.scala
 run/t2594_tcpoly.scala
@@ -1684,7 +1677,6 @@ run/t3004.scala
 run/viewtest.scala
 run/t6481.scala
 run/t0005.scala
-run/t4110-old.scala
 run/t4766.scala
 run/t5500b.scala
 run/t7407b.scala
@@ -2474,13 +2466,10 @@ run/t3242b.scala
 run/indexedSeq-apply.scala
 run/t107.scala
 run/t2337.scala
-run/t3758-old.scala
 run/t2754.scala
-run/valueclasses-manifest-existential.scala
 run/flat-flat-flat.scala
 run/t6673.scala
 run/interpolationMultiline2.scala
-run/t3493.scala
 run/t0631.scala
 run/t2800.scala
 run/t6506.scala

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -42,21 +42,6 @@ class MainGenericRunner {
 
   val optMode = OptMode.fromId(sys.props("scalajs.partest.optMode"))
 
-  def noWarnMissing = {
-    import ScalaJSOptimizer._
-
-    for {
-      fname <- sys.props.get("scalajs.partest.noWarnFile").toList
-      line  <- Source.fromFile(fname).getLines
-      if !line.startsWith("#")
-    } yield line.split('.') match {
-      case Array(className) =>
-        NoWarnMissing.Class(className)
-      case Array(className, methodName) =>
-        NoWarnMissing.Method(className, methodName)
-    }
-  }
-
   def readSemantics() = {
     val opt = sys.props.get("scalajs.partest.compliantSems")
     opt.fold(Semantics.Defaults) { str =>
@@ -109,8 +94,7 @@ class MainGenericRunner {
         classpath,
         Config(output)
           .withWantSourceMap(false)
-          .withCheckIR(true)
-          .withNoWarnMissing(noWarnMissing),
+          .withCheckIR(true),
         logger)
   }
 
@@ -125,9 +109,8 @@ class MainGenericRunner {
     fullOptimizer.optimizeCP(fastOptimizer,
         classpath,
         Config(output)
-          .withCheckIR(true)
           .withWantSourceMap(false)
-          .withNoWarnMissing(noWarnMissing),
+          .withCheckIR(true),
         logger)
   }
 

--- a/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -33,8 +33,8 @@ trait ScalaJSDirectCompiler extends DirectCompiler {
 }
 
 class ScalaJSRunner(testFile: File, suiteRunner: SuiteRunner,
-    scalaJSOverridePath: String, options: ScalaJSPartestOptions,
-    noWarnFile: File) extends nest.Runner(testFile, suiteRunner) {
+    scalaJSOverridePath: String,
+    options: ScalaJSPartestOptions) extends nest.Runner(testFile, suiteRunner) {
 
   private val compliantSems: List[String] = {
     scalaJSConfigFile("sem").fold(List.empty[String]) { file =>
@@ -58,7 +58,6 @@ class ScalaJSRunner(testFile: File, suiteRunner: SuiteRunner,
   override def newCompiler = new DirectCompiler(this) with ScalaJSDirectCompiler
   override def extraJavaOptions = {
     super.extraJavaOptions ++ Seq(
-        s"-Dscalajs.partest.noWarnFile=${noWarnFile.getAbsolutePath}",
         s"-Dscalajs.partest.optMode=${options.optMode.id}",
         s"-Dscalajs.partest.compliantSems=${compliantSems.mkString(",")}"
     )
@@ -89,7 +88,7 @@ trait ScalaJSSuiteRunner extends SuiteRunner {
 
   override def runTest(testFile: File): TestState = {
     // Mostly copy-pasted from SuiteRunner.runTest(), unfortunately :-(
-    val runner = new ScalaJSRunner(testFile, this, listDir, options, noWarnFile)
+    val runner = new ScalaJSRunner(testFile, this, listDir, options)
 
     // when option "--failed" is provided execute test only if log
     // is present (which means it failed before)
@@ -125,12 +124,6 @@ trait ScalaJSSuiteRunner extends SuiteRunner {
 
   private lazy val whitelistedTestFileNames =
     readTestList(s"$listDir/WhitelistedTests.txt")
-
-  private lazy val noWarnFile: File = {
-    val url = getClass.getResource(s"$listDir/NoDCEWarn.txt")
-    assert(url != null, "Need NoDCEWarn.txt file")
-    new File(url.toURI).getAbsolutePath()
-  }
 
   private def readTestList(resourceName: String): Set[String] = {
     val source = scala.io.Source.fromURL(getClass.getResource(resourceName))

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -245,7 +245,6 @@ object ScalaJSPluginInternal {
             s.log,
             reachOptimizerSymbols = true, // better be safe than sorry here
             bypassLinkingErrors = opts.bypassLinkingErrors,
-            noWarnMissing = Nil,
             checkIR = opts.checkScalaJSIR)
         new LinkingUnitClasspath(cp.jsLibs, linkingUnit, cp.requiresDOM,
             cp.version)

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala
@@ -167,8 +167,7 @@ object ScalaJSClosureOptimizer {
       val output: WritableVirtualJSFile,
       /** Cache file */
       val cache: Option[WritableVirtualTextFile],
-      /** Whether to only warn if the linker has errors. Implicitly true, if
-       *  noWarnMissing is nonEmpty */
+      /** Whether to only warn if the linker has errors. */
       val bypassLinkingErrors: Boolean,
       /** If true, performs expensive checks of the IR for the used parts. */
       val checkIR: Boolean,
@@ -186,46 +185,9 @@ object ScalaJSClosureOptimizer {
       val prettyPrint: Boolean,
       /** Base path to relativize paths in the source map */
       val relativizeSourceMapBase: Option[URI],
-      /** Elements we won't warn even if they don't exist */
-      val noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing],
       /** Custom js code that wraps the output */
       val customOutputWrapper: (String, String)
-  ) extends OptimizerConfig with ScalaJSOptimizer.OptimizerConfig
-      /* for binary compatibility */ with Product with Serializable with Equals {
-
-    /* NOTE: This class was previously a case class and hence many useless
-     * methods were implemented for binary compatibility :(
-     */
-
-    // For binary compatibility
-    @deprecated("Use Config(output) and .withXYZ() methods", "0.6.5")
-    def this(
-        output: WritableVirtualJSFile,
-        cache: Option[WritableVirtualTextFile] = None,
-        bypassLinkingErrors: Boolean = false,
-        checkIR: Boolean = false,
-        unCache: Boolean = true,
-        disableOptimizer: Boolean = false,
-        batchMode: Boolean = false,
-        wantSourceMap: Boolean = false,
-        prettyPrint: Boolean = false,
-        relativizeSourceMapBase: Option[URI] = None,
-        noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing] = Nil) = {
-
-      this(
-          output = output,
-          cache = cache,
-          bypassLinkingErrors = bypassLinkingErrors,
-          checkIR = checkIR,
-          unCache = unCache,
-          disableOptimizer = disableOptimizer,
-          batchMode = batchMode,
-          wantSourceMap = wantSourceMap,
-          prettyPrint = prettyPrint,
-          relativizeSourceMapBase = relativizeSourceMapBase,
-          noWarnMissing = noWarnMissing,
-          customOutputWrapper = ("", ""))
-    }
+  ) extends OptimizerConfig with ScalaJSOptimizer.OptimizerConfig {
 
     def withCache(cache: Option[WritableVirtualTextFile]): Config =
       copyWith(cache = cache)
@@ -254,29 +216,23 @@ object ScalaJSClosureOptimizer {
     def withRelativizeSourceMapBase(relativizeSourceMapBase: Option[URI]): Config =
       copyWith(relativizeSourceMapBase = relativizeSourceMapBase)
 
-    def withNoWarnMissing(noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing]): Config =
-      copyWith(noWarnMissing = noWarnMissing)
-
     def withCustomOutputWrapper(customOutputWrapper: (String, String)): Config =
       copyWith(customOutputWrapper = customOutputWrapper)
 
-    @deprecated("Not a case class anymore", "0.6.5")
-    def copy(
-        output: WritableVirtualJSFile = this.output,
-        cache: Option[WritableVirtualTextFile] = this.cache,
-        bypassLinkingErrors: Boolean = this.bypassLinkingErrors,
-        checkIR: Boolean = this.checkIR,
-        unCache: Boolean = this.unCache,
-        disableOptimizer: Boolean = this.disableOptimizer,
-        batchMode: Boolean = this.batchMode,
-        wantSourceMap: Boolean = this.wantSourceMap,
-        prettyPrint: Boolean = this.prettyPrint,
-        relativizeSourceMapBase: Option[URI] = this.relativizeSourceMapBase,
-        noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing] = this.noWarnMissing): Config = {
-
-      copyWith(output, cache, bypassLinkingErrors, checkIR, unCache,
-          disableOptimizer, batchMode, wantSourceMap, prettyPrint,
-          relativizeSourceMapBase, noWarnMissing)
+    override def toString(): String = {
+        s"""Config(
+           |  output                  = $output
+           |  cache                   = $cache
+           |  bypassLinkingErrors     = $bypassLinkingErrors
+           |  checkIR                 = $checkIR
+           |  unCache                 = $unCache
+           |  disableOptimizer        = $disableOptimizer
+           |  batchMode               = $batchMode
+           |  wantSourceMap           = $wantSourceMap
+           |  prettyPrint             = $prettyPrint
+           |  relativizeSourceMapBase = $relativizeSourceMapBase
+           |  customOutputWrapper     = $customOutputWrapper
+           |)""".stripMargin
     }
 
     private def copyWith(
@@ -290,48 +246,15 @@ object ScalaJSClosureOptimizer {
         wantSourceMap: Boolean = this.wantSourceMap,
         prettyPrint: Boolean = this.prettyPrint,
         relativizeSourceMapBase: Option[URI] = this.relativizeSourceMapBase,
-        noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing] = this.noWarnMissing,
         customOutputWrapper: (String, String) = this.customOutputWrapper): Config = {
 
       new Config(output, cache, bypassLinkingErrors, checkIR, unCache,
           disableOptimizer, batchMode, wantSourceMap, prettyPrint,
-          relativizeSourceMapBase, noWarnMissing, customOutputWrapper)
+          relativizeSourceMapBase, customOutputWrapper)
     }
-
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def canEqual(that: Any): Boolean = true
-
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def productArity: Int = productArray.length
-
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def productElement(n: Int): Any = productArray(n)
-
-    private def productArray: Array[Any] = {
-      Array[Any](output, cache, bypassLinkingErrors, checkIR, unCache,
-          disableOptimizer, batchMode, wantSourceMap, prettyPrint,
-          relativizeSourceMapBase, noWarnMissing, customOutputWrapper)
-    }
-
-    // For binary compatibility
-    override def equals(other: Any): Boolean = super.equals(other)
-
-    // For binary compatibility
-    override def hashCode(): Int = super.hashCode()
-
-    // For binary compatibility
-    override def toString(): String =
-      productArray.mkString("Config(", ", ", ")")
   }
 
-  object Config extends runtime.AbstractFunction11[WritableVirtualJSFile,
-      Option[WritableVirtualTextFile], Boolean, Boolean, Boolean,
-      Boolean, Boolean, Boolean, Boolean, Option[URI],
-      Seq[ScalaJSOptimizer.NoWarnMissing], Config] {
-
+  object Config {
     def apply(output: WritableVirtualJSFile): Config = {
       new Config(
           output = output,
@@ -344,41 +267,7 @@ object ScalaJSClosureOptimizer {
           wantSourceMap = false,
           prettyPrint = false,
           relativizeSourceMapBase = None,
-          noWarnMissing = Nil,
           customOutputWrapper = ("", ""))
-    }
-
-    // For binary compatibility
-    @deprecated("Use Config(output) and .withXYZ() methods", "0.6.5")
-    def apply(
-        output: WritableVirtualJSFile,
-        cache: Option[WritableVirtualTextFile] = None,
-        bypassLinkingErrors: Boolean = false,
-        checkIR: Boolean = false,
-        unCache: Boolean = true,
-        disableOptimizer: Boolean = false,
-        batchMode: Boolean = false,
-        wantSourceMap: Boolean = false,
-        prettyPrint: Boolean = false,
-        relativizeSourceMapBase: Option[URI] = None,
-        noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing] = Nil): Config = {
-
-      new Config(output, cache, bypassLinkingErrors, checkIR, unCache,
-          disableOptimizer, batchMode, wantSourceMap, prettyPrint,
-          relativizeSourceMapBase, noWarnMissing, customOutputWrapper = ("", ""))
-    }
-
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def unapply(config: Config): Option[(WritableVirtualJSFile,
-        Option[WritableVirtualTextFile], Boolean, Boolean, Boolean,
-        Boolean, Boolean, Boolean, Boolean, Option[URI],
-        Seq[ScalaJSOptimizer.NoWarnMissing])] = {
-
-      Some((config.output, config.cache, config.bypassLinkingErrors,
-          config.checkIR, config.unCache, config.disableOptimizer,
-          config.batchMode, config.wantSourceMap, config.prettyPrint,
-          config.relativizeSourceMapBase, config.noWarnMissing))
     }
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSOptimizer.scala
@@ -116,7 +116,7 @@ class ScalaJSOptimizer(val semantics: Semantics, val outputMode: OutputMode,
       logTime(logger, "Linker") {
         linker.link(irFiles, logger,
             reachOptimizerSymbols = !cfg.disableOptimizer,
-            cfg.bypassLinkingErrors, cfg.noWarnMissing, cfg.checkIR)
+            cfg.bypassLinkingErrors, cfg.checkIR)
       }
     } catch {
       case th: Throwable =>
@@ -139,7 +139,7 @@ class ScalaJSOptimizer(val semantics: Semantics, val outputMode: OutputMode,
           refiner.refine(rawOptimized, logger)
         }
       } else {
-        if (cfg.noWarnMissing.isEmpty && !cfg.disableOptimizer)
+        if (!cfg.disableOptimizer)
           logger.warn("Not running the optimizer because there where linking errors.")
         linkResult
       }
@@ -171,16 +171,6 @@ class ScalaJSOptimizer(val semantics: Semantics, val outputMode: OutputMode,
 
 object ScalaJSOptimizer {
 
-  sealed abstract class NoWarnMissing {
-    def className: String
-  }
-
-  object NoWarnMissing {
-    final case class Class(className: String) extends NoWarnMissing
-    final case class Method(className: String, methodName: String)
-        extends NoWarnMissing
-  }
-
   type OptimizerFactory = (Semantics, OutputMode, Boolean) => GenIncOptimizer
 
   /** Configurations relevant to the optimizer */
@@ -189,9 +179,7 @@ object ScalaJSOptimizer {
      *  optimizer to decide whether a position change should trigger re-inlining
      */
     val wantSourceMap: Boolean
-    /** Whether to only warn if the linker has errors. Implicitly true, if
-     *  noWarnMissing is nonEmpty
-     */
+    /** Whether to only warn if the linker has errors. */
     val bypassLinkingErrors: Boolean
     /** If true, performs expensive checks of the IR for the used parts. */
     val checkIR: Boolean
@@ -203,8 +191,6 @@ object ScalaJSOptimizer {
     val disableOptimizer: Boolean
     /** If true, nothing is performed incrementally */
     val batchMode: Boolean
-    /** Elements we won't warn even if they don't exist */
-    val noWarnMissing: Seq[NoWarnMissing]
   }
 
   /** Configuration for the output of the Scala.js optimizer. */
@@ -217,9 +203,7 @@ object ScalaJSOptimizer {
       val wantSourceMap: Boolean,
       /** Base path to relativize paths in the source map. */
       val relativizeSourceMapBase: Option[URI],
-      /** Whether to only warn if the linker has errors. Implicitly true, if
-       *  noWarnMissing is nonEmpty
-       */
+      /** Whether to only warn if the linker has errors. */
       val bypassLinkingErrors: Boolean,
       /** If true, performs expensive checks of the IR for the used parts. */
       val checkIR: Boolean,
@@ -231,35 +215,9 @@ object ScalaJSOptimizer {
       val disableOptimizer: Boolean,
       /** If true, nothing is performed incrementally */
       val batchMode: Boolean,
-      /** Elements we won't warn even if they don't exist */
-      val noWarnMissing: Seq[NoWarnMissing],
       /** Custom js code that wraps the output */
       val customOutputWrapper: (String, String)
-  ) extends OptimizerConfig
-      /* for binary compatibility */ with Product with Serializable with Equals {
-
-    /* NOTE: This class was previously a case class and hence many useless
-     * methods were implemented for binary compatibility :(
-     */
-
-    // For binary compatibility
-    @deprecated("Use Config(output) and .withXYZ() methods", "0.6.5")
-    def this(
-        output: WritableVirtualJSFile,
-        cache: Option[WritableVirtualTextFile] = None,
-        wantSourceMap: Boolean = false,
-        relativizeSourceMapBase: Option[URI] = None,
-        bypassLinkingErrors: Boolean = false,
-        checkIR: Boolean = false,
-        unCache: Boolean = true,
-        disableOptimizer: Boolean = false,
-        batchMode: Boolean = false,
-        noWarnMissing: Seq[NoWarnMissing] = Nil) = {
-
-      this(output, cache, wantSourceMap, relativizeSourceMapBase,
-          bypassLinkingErrors, checkIR, unCache, disableOptimizer, batchMode,
-          noWarnMissing, customOutputWrapper = ("", ""))
-    }
+  ) extends OptimizerConfig {
 
     def withCache(cache: Option[WritableVirtualTextFile]): Config =
       copyWith(cache = cache)
@@ -285,29 +243,22 @@ object ScalaJSOptimizer {
     def withRelativizeSourceMapBase(relativizeSourceMapBase: Option[URI]): Config =
       copyWith(relativizeSourceMapBase = relativizeSourceMapBase)
 
-    def withNoWarnMissing(noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing]): Config =
-      copyWith(noWarnMissing = noWarnMissing)
-
     def withCustomOutputWrapper(customOutputWrapper: (String, String)): Config =
       copyWith(customOutputWrapper = customOutputWrapper)
 
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def copy(
-        output: WritableVirtualJSFile = this.output,
-        cache: Option[WritableVirtualTextFile] = this.cache,
-        wantSourceMap: Boolean = this.wantSourceMap,
-        relativizeSourceMapBase: Option[URI] = this.relativizeSourceMapBase,
-        bypassLinkingErrors: Boolean = this.bypassLinkingErrors,
-        checkIR: Boolean = this.checkIR,
-        unCache: Boolean = this.unCache,
-        disableOptimizer: Boolean = this.disableOptimizer,
-        batchMode: Boolean = this.batchMode,
-        noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing] = this.noWarnMissing): Config = {
-
-      copyWith(output, cache, wantSourceMap, relativizeSourceMapBase,
-          bypassLinkingErrors, checkIR, unCache, disableOptimizer, batchMode,
-          noWarnMissing)
+    override def toString(): String = {
+        s"""Config(
+           |  output                  = $output
+           |  cache                   = $cache
+           |  wantSourceMap           = $wantSourceMap
+           |  relativizeSourceMapBase = $relativizeSourceMapBase
+           |  bypassLinkingErrors     = $bypassLinkingErrors
+           |  checkIR                 = $checkIR
+           |  unCache                 = $unCache
+           |  disableOptimizer        = $disableOptimizer
+           |  batchMode               = $batchMode
+           |  customOutputWrapper     = $customOutputWrapper
+           |)""".stripMargin
     }
 
     private def copyWith(
@@ -320,48 +271,15 @@ object ScalaJSOptimizer {
         unCache: Boolean = this.unCache,
         disableOptimizer: Boolean = this.disableOptimizer,
         batchMode: Boolean = this.batchMode,
-        noWarnMissing: Seq[ScalaJSOptimizer.NoWarnMissing] = this.noWarnMissing,
         customOutputWrapper: (String, String) = this.customOutputWrapper): Config = {
 
       new Config(output, cache, wantSourceMap, relativizeSourceMapBase,
           bypassLinkingErrors, checkIR, unCache, disableOptimizer, batchMode,
-          noWarnMissing, customOutputWrapper)
+          customOutputWrapper)
     }
-
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def canEqual(that: Any): Boolean = true
-
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def productArity: Int = productArray.length
-
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def productElement(n: Int): Any = productArray(n)
-
-    // For binary compatibility
-    private def productArray: Array[Any] = {
-      Array[Any](output, cache, wantSourceMap, relativizeSourceMapBase,
-          bypassLinkingErrors, checkIR, unCache, disableOptimizer, batchMode,
-          noWarnMissing, customOutputWrapper)
-    }
-
-    // For binary compatibility
-    override def equals(other: Any): Boolean = super.equals(other)
-
-    // For binary compatibility
-    override def hashCode(): Int = super.hashCode()
-
-    // For binary compatibility
-    override def toString(): String =
-      productArray.mkString("Config(", ", ", ")")
   }
 
-  object Config extends runtime.AbstractFunction10[WritableVirtualJSFile,
-      Option[WritableVirtualTextFile], Boolean, Option[URI], Boolean, Boolean,
-      Boolean, Boolean, Boolean, Seq[NoWarnMissing], Config] {
-
+  object Config {
     def apply(output: WritableVirtualJSFile): Config = {
       new Config(
           output = output,
@@ -373,39 +291,7 @@ object ScalaJSOptimizer {
           unCache = true,
           disableOptimizer = false,
           batchMode = false,
-          noWarnMissing = Nil,
           customOutputWrapper = ("", ""))
-    }
-
-    // For binary compatibility
-    @deprecated("Use Config(output) and .withXYZ() methods", "0.6.5")
-    def apply(
-        output: WritableVirtualJSFile,
-        cache: Option[WritableVirtualTextFile] = None,
-        wantSourceMap: Boolean = false,
-        relativizeSourceMapBase: Option[URI] = None,
-        bypassLinkingErrors: Boolean = false,
-        checkIR: Boolean = false,
-        unCache: Boolean = true,
-        disableOptimizer: Boolean = false,
-        batchMode: Boolean = false,
-        noWarnMissing: Seq[NoWarnMissing] = Nil): Config = {
-
-      new Config(output, cache, wantSourceMap, relativizeSourceMapBase,
-          bypassLinkingErrors, checkIR, unCache, disableOptimizer, batchMode,
-          noWarnMissing, customOutputWrapper = ("", ""))
-    }
-
-    // For binary compatibility
-    @deprecated("Not a case class anymore", "0.6.5")
-    def unapply(config: Config): Option[(WritableVirtualJSFile,
-        Option[WritableVirtualTextFile], Boolean, Option[URI], Boolean, Boolean,
-        Boolean, Boolean, Boolean, Seq[NoWarnMissing])] = {
-
-      Some((config.output, config.cache, config.wantSourceMap,
-          config.relativizeSourceMapBase, config.bypassLinkingErrors,
-          config.checkIR, config.unCache, config.disableOptimizer, config.batchMode,
-          config.noWarnMissing))
     }
   }
 }


### PR DESCRIPTION
This breaks binary compatibility of the external tools API (as scheduled for 0.6.6).