### PR TITLE
Fix #1956: Remove unCache option from optimizers

### DIFF
--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSClosureOptimizer.scala
@@ -171,10 +171,6 @@ object ScalaJSClosureOptimizer {
       val bypassLinkingErrors: Boolean,
       /** If true, performs expensive checks of the IR for the used parts. */
       val checkIR: Boolean,
-      /** If true, the optimizer removes trees that have not been used in the
-       *  last run from the cache. Otherwise, all trees that has been used once,
-       *  are kept in memory. */
-      val unCache: Boolean,
       /** If true, no optimizations are performed */
       val disableOptimizer: Boolean,
       /** If true, nothing is performed incrementally */
@@ -197,9 +193,6 @@ object ScalaJSClosureOptimizer {
 
     def withCheckIR(checkIR: Boolean): Config =
       copyWith(checkIR = checkIR)
-
-    def withUnCache(unCache: Boolean): Config =
-      copyWith(unCache = unCache)
 
     def withDisableOptimizer(disableOptimizer: Boolean): Config =
       copyWith(disableOptimizer = disableOptimizer)
@@ -225,7 +218,6 @@ object ScalaJSClosureOptimizer {
            |  cache                   = $cache
            |  bypassLinkingErrors     = $bypassLinkingErrors
            |  checkIR                 = $checkIR
-           |  unCache                 = $unCache
            |  disableOptimizer        = $disableOptimizer
            |  batchMode               = $batchMode
            |  wantSourceMap           = $wantSourceMap
@@ -240,7 +232,6 @@ object ScalaJSClosureOptimizer {
         cache: Option[WritableVirtualTextFile] = this.cache,
         bypassLinkingErrors: Boolean = this.bypassLinkingErrors,
         checkIR: Boolean = this.checkIR,
-        unCache: Boolean = this.unCache,
         disableOptimizer: Boolean = this.disableOptimizer,
         batchMode: Boolean = this.batchMode,
         wantSourceMap: Boolean = this.wantSourceMap,
@@ -248,7 +239,7 @@ object ScalaJSClosureOptimizer {
         relativizeSourceMapBase: Option[URI] = this.relativizeSourceMapBase,
         customOutputWrapper: (String, String) = this.customOutputWrapper): Config = {
 
-      new Config(output, cache, bypassLinkingErrors, checkIR, unCache,
+      new Config(output, cache, bypassLinkingErrors, checkIR,
           disableOptimizer, batchMode, wantSourceMap, prettyPrint,
           relativizeSourceMapBase, customOutputWrapper)
     }
@@ -261,7 +252,6 @@ object ScalaJSClosureOptimizer {
           cache = None,
           bypassLinkingErrors = false,
           checkIR = false,
-          unCache = true,
           disableOptimizer = false,
           batchMode = false,
           wantSourceMap = false,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/ScalaJSOptimizer.scala
@@ -183,10 +183,6 @@ object ScalaJSOptimizer {
     val bypassLinkingErrors: Boolean
     /** If true, performs expensive checks of the IR for the used parts. */
     val checkIR: Boolean
-    /** If true, the optimizer removes trees that have not been used in the
-     *  last run from the cache. Otherwise, all trees that has been used once,
-     *  are kept in memory. */
-    val unCache: Boolean
     /** If true, no optimizations are performed */
     val disableOptimizer: Boolean
     /** If true, nothing is performed incrementally */
@@ -207,10 +203,6 @@ object ScalaJSOptimizer {
       val bypassLinkingErrors: Boolean,
       /** If true, performs expensive checks of the IR for the used parts. */
       val checkIR: Boolean,
-      /** If true, the optimizer removes trees that have not been used in the
-       *  last run from the cache. Otherwise, all trees that has been used once,
-       *  are kept in memory. */
-      val unCache: Boolean,
       /** If true, no optimizations are performed */
       val disableOptimizer: Boolean,
       /** If true, nothing is performed incrementally */
@@ -227,9 +219,6 @@ object ScalaJSOptimizer {
 
     def withCheckIR(checkIR: Boolean): Config =
       copyWith(checkIR = checkIR)
-
-    def withUnCache(unCache: Boolean): Config =
-      copyWith(unCache = unCache)
 
     def withDisableOptimizer(disableOptimizer: Boolean): Config =
       copyWith(disableOptimizer = disableOptimizer)
@@ -254,7 +243,6 @@ object ScalaJSOptimizer {
            |  relativizeSourceMapBase = $relativizeSourceMapBase
            |  bypassLinkingErrors     = $bypassLinkingErrors
            |  checkIR                 = $checkIR
-           |  unCache                 = $unCache
            |  disableOptimizer        = $disableOptimizer
            |  batchMode               = $batchMode
            |  customOutputWrapper     = $customOutputWrapper
@@ -268,13 +256,12 @@ object ScalaJSOptimizer {
         relativizeSourceMapBase: Option[URI] = this.relativizeSourceMapBase,
         bypassLinkingErrors: Boolean = this.bypassLinkingErrors,
         checkIR: Boolean = this.checkIR,
-        unCache: Boolean = this.unCache,
         disableOptimizer: Boolean = this.disableOptimizer,
         batchMode: Boolean = this.batchMode,
         customOutputWrapper: (String, String) = this.customOutputWrapper): Config = {
 
       new Config(output, cache, wantSourceMap, relativizeSourceMapBase,
-          bypassLinkingErrors, checkIR, unCache, disableOptimizer, batchMode,
+          bypassLinkingErrors, checkIR, disableOptimizer, batchMode,
           customOutputWrapper)
     }
   }
@@ -288,7 +275,6 @@ object ScalaJSOptimizer {
           relativizeSourceMapBase = None,
           bypassLinkingErrors = false,
           checkIR = false,
-          unCache = true,
           disableOptimizer = false,
           batchMode = false,
           customOutputWrapper = ("", ""))


### PR DESCRIPTION
The option was completely unused. This breaks binary compatibility of
the tools as planned for the 0.6.6 release.