### PR TITLE
Fix #1690: Add JUnit framework and plugin.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -123,6 +123,6 @@ following incantations.
 `SCALA_VERSION` refers to the Scala version used by the separate project.
 
     > ++SCALA_VERSION
-    > ;compiler/publishLocal;library/publishLocal;javalibEx/publishLocal;testInterface/publishLocal;stubs/publishLocal
+    > ;compiler/publishLocal;library/publishLocal;javalibEx/publishLocal;testInterface/publishLocal;stubs/publishLocal;jasmineTestFramework/publishLocal;jUnitRuntime/publishLocal;jUnitPlugin/publishLocal
     > ++2.10.6
     > ;ir/publishLocal;tools/publishLocal;jsEnvs/publishLocal;testAdapter/publishLocal;sbtPlugin/publishLocal

--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -242,6 +242,7 @@
     # Then go into standalone project and test
     sbt ++2.11.7 compiler/publishLocal library/publishLocal javalibEx/publishLocal \
                  testInterface/publishLocal jasmineTestFramework/publishLocal stubs/publishLocal \
+                 jUnitPlugin/publishLocal jUnitRuntime/publishLocal \
         ++2.10.6 ir/publishLocal tools/publishLocal jsEnvs/publishLocal \
                  testAdapter/publishLocal sbtPlugin/publishLocal &&
     cd sbt-plugin-test &&

--- a/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
@@ -53,6 +53,15 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
     var absSourceMap: Option[URI] = None
   }
 
+  /** Checks and registers module exports on the symbol.
+   *  This bridge allows other plugins (such as ScalaJSJUnitPlugin) to register
+   *  new modules for export between jsinterop and jscode phases. It is meant to
+   *  be accessed using reflection. The calling code still must insert the
+   *  `@JSExport` annotation to the module.
+   */
+  def registerModuleExports(sym: Symbol): Unit =
+    PrepInteropComponent.registerModuleExports(sym)
+
   object PrepInteropComponent extends {
     val global: ScalaJSPlugin.this.global.type = ScalaJSPlugin.this.global
     val jsAddons: ScalaJSPlugin.this.jsAddons.type = ScalaJSPlugin.this.jsAddons

--- a/junit-plugin/src/main/resources/scalac-plugin.xml
+++ b/junit-plugin/src/main/resources/scalac-plugin.xml
@@ -1,0 +1,4 @@
+<plugin>
+  <name>scalajs-junit</name>
+  <classname>org.scalajs.junit.plugin.ScalaJSJUnitPlugin</classname>
+</plugin>

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/Compat210Component.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/Compat210Component.scala
@@ -1,0 +1,71 @@
+package org.scalajs.junit.plugin
+
+import scala.reflect.internal.Flags
+import scala.tools.nsc._
+
+/** Hacks to have our source code compatible with 2.10 and 2.11.
+ *  It exposes 2.11 API in a 2.10 compiler.
+ *
+ *  @author Nicolas Stucki
+ */
+trait Compat210Component {
+
+  val global: Global
+
+  import global._
+
+  def newValDef(sym: Symbol, rhs: Tree)(
+      mods: Modifiers = Modifiers(sym.flags),
+      name: TermName = sym.name.toTermName,
+      tpt: Tree = TypeTreeMemberType(sym)): ValDef = {
+    atPos(sym.pos)(ValDef(mods, name, tpt, rhs)) setSymbol sym
+  }
+
+  def newDefDef(sym: Symbol, rhs: Tree)(
+      mods: Modifiers = Modifiers(sym.flags),
+      name: TermName = sym.name.toTermName,
+      tparams: List[TypeDef] = sym.typeParams.map(sym =>
+          newTypeDef(sym, typeBoundsTree(sym))()),
+      vparamss: List[List[ValDef]] = mapParamss(sym)(sym =>
+          newValDef(sym, EmptyTree)()),
+      tpt: Tree = TypeTreeMemberType(sym)): DefDef = {
+    atPos(sym.pos)(DefDef(mods, name, tparams, vparamss, tpt, rhs)).setSymbol(sym)
+  }
+
+  def TypeTreeMemberType(sym: Symbol): TypeTree = {
+    val resType = {
+      if (sym.owner.isTerm) sym.tpe
+      else sym.owner.thisType.memberType(sym)
+    }.finalResultType
+    atPos(sym.pos.focus)(TypeTree(resType))
+  }
+
+  private def newTypeDef(sym: Symbol, rhs: Tree)(
+      mods: Modifiers = Modifiers(sym.flags),
+      name: TypeName = sym.name.toTypeName,
+      tparams: List[TypeDef] = sym.typeParams.map(sym =>
+          newTypeDef(sym, typeBoundsTree(sym))())): TypeDef = {
+    atPos(sym.pos)(TypeDef(mods, name, tparams, rhs)) setSymbol sym
+  }
+
+  private def typeBoundsTree(bounds: TypeBounds): TypeBoundsTree =
+    TypeBoundsTree(TypeTree(bounds.lo), TypeTree(bounds.hi))
+
+  private def typeBoundsTree(sym: Symbol): TypeBoundsTree =
+    atPos(sym.pos)(typeBoundsTree(sym.info.bounds))
+
+  implicit final class GenCompat(self: global.TreeGen) {
+    def mkClassDef(mods: Modifiers, name: TypeName,
+        tparams: List[TypeDef], templ: Template): ClassDef = {
+      val isInterface =
+        mods.isTrait && templ.body.forall(treeInfo.isInterfaceMember)
+      val mods1 = if (isInterface) mods | Flags.INTERFACE else mods
+      ClassDef(mods1, name, tparams, templ)
+    }
+  }
+
+  implicit final class DefinitionsCompat(
+      self: Compat210Component.this.global.definitions.type) {
+    lazy val StringTpe = definitions.StringClass.tpe
+  }
+}

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -1,0 +1,469 @@
+package org.scalajs.junit.plugin
+
+import scala.language.reflectiveCalls
+
+import scala.reflect.internal.Flags
+import scala.tools.nsc._
+import scala.tools.nsc.plugins.{
+  Plugin => NscPlugin, PluginComponent => NscPluginComponent
+}
+
+/** The Scala.js jUnit plugin is a way to overcome the lack of annotation
+ *  information of any test class (usually accessed through reflection).
+ *  This is all the information required by the Scala.js testing framework to
+ *  execute the tests.
+ *
+ *  As an example we take the following test class:
+ *  {{{
+ *  class Foo {
+ *    @Before def before(): Unit = {
+ *      // Initialize the instance before the tests
+ *    }
+ *    @Test def bar(): Unit = {
+ *      // assert some stuff
+ *    }
+ *    @Ignore("baz not implemented yet") @Test def baz(): Unit = {
+ *      // assert some other stuff
+ *    }
+ *  }
+ *
+ *  object Foo {
+ *    @BeforeClass def beforeClass(): Unit = {
+ *      // Initialize some global state for the tests.
+ *    }
+ *  }
+ *  }}}
+ *
+ *  Will generate the following bootstrapper module:
+ *
+ *  {{{
+ *  object Foo\$scalajs\$junit\$bootstrapper extends org.scalajs.junit.JUnitTestBootstrapper {
+ *
+ *    def metadata(): JUnitClassMetadata = {
+ *      new JUnitClassMetadata(
+ *        classAnnotations = List(),
+ *        moduleAnnotations = List(),
+ *        classMethods = List(
+ *            new JUnitMethodMetadata(name = "before",
+ *                annotations = List(new Before)),
+ *            new JUnitMethodMetadata(name = "bar",
+ *                annotations = List(new Test)),
+ *            new JUnitMethodMetadata(name = "baz",
+ *                annotations = List(new Test, new Ignore("baz not implemented yet")))
+ *        ),
+ *        moduleMethods(
+ *            new JUnitMethodMetadata(name = "beforeClass",
+ *                annotations = List(new BeforeClass)))
+ *      )
+ *    }
+ *
+ *    def newInstance(): AnyRef = new Foo()
+ *
+ *    def invoke(methodName: String): Unit = {
+ *      if (methodName == "0") Foo.beforeClass()
+ *      else throw new NoSuchMethodException(methodId)
+ *    }
+ *
+ *    def invoke(instance: AnyRef, methodName: String): Unit = {
+ *      if (methodName == "before") instance.asInstanceOf[Foo].before()
+ *      else if (methodName == "bar") instance.asInstanceOf[Foo].bar()
+ *      else if (methodName == "baz") instance.asInstanceOf[Foo].baz()
+ *      else throw new NoSuchMethodException(methodId)
+ *    }
+ *  }
+ *  }}}
+ *  The test framework will identify `Foo\$scalajs\$junit\$bootstrapper` as a test module
+ *  because it extends `JUnitTestBootstrapper`. It will know which methods to run based
+ *  on the info returned by Foo\$scalajs\$junit\$bootstrapper.metadata,
+ *  it will create new test instances using `Foo\$scalajs\$junit\$bootstrapper.newInstance()`
+ *  and it will invoke test methods using `invoke` on the bootstrapper.
+ */
+class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
+
+  val name: String = "Scala.js JUnit plugin"
+
+  val components: List[NscPluginComponent] =
+    List(ScalaJSJUnitPluginComponent)
+
+  val description: String = "Makes JUnit test classes invokable in Scala.js"
+
+  // `ScalaJSPlugin` instance reference. Only `registerModuleExports` is accessible.
+  private lazy val scalaJSPlugin = {
+    type ScalaJSPlugin = NscPlugin {
+      def registerModuleExports(sym: ScalaJSJUnitPluginComponent.global.Symbol): Unit
+    }
+    global.plugins.collectFirst {
+      case pl if pl.getClass.getName == "org.scalajs.core.compiler.ScalaJSPlugin" =>
+        pl.asInstanceOf[ScalaJSPlugin]
+    }.getOrElse {
+      throw new Exception(
+          "The Scala.js JUnit plugin only works with the Scala.js plugin enabled.")
+    }
+  }
+
+  object ScalaJSJUnitPluginComponent
+      extends plugins.PluginComponent with transform.Transform with Compat210Component {
+
+    val global: Global = ScalaJSJUnitPlugin.this.global
+    import global._
+
+    val phaseName: String = "junit-inject"
+    val runsAfter: List[String] = List("mixin")
+    override val runsBefore: List[String] = List("jscode")
+
+    protected def newTransformer(unit: CompilationUnit): Transformer =
+      new ScalaJSJUnitPluginTransformer
+
+    class ScalaJSJUnitPluginTransformer extends Transformer {
+
+      import rootMirror.getRequiredClass
+
+      private val TestClass =
+        getRequiredClass("org.junit.Test")
+
+      private val FixMethodOrderClass =
+        getRequiredClass("org.junit.FixMethodOrder")
+
+      private val annotationWhiteList = List(
+        TestClass,
+        getRequiredClass("org.junit.Before"),
+        getRequiredClass("org.junit.After"),
+        getRequiredClass("org.junit.BeforeClass"),
+        getRequiredClass("org.junit.AfterClass"),
+        getRequiredClass("org.junit.Ignore")
+      )
+
+      private val jUnitClassMetadataType =
+        getRequiredClass("org.scalajs.junit.JUnitClassMetadata").toType
+
+      private val jUnitTestMetadataType =
+        getRequiredClass("org.scalajs.junit.JUnitTestBootstrapper").toType
+
+      private def jUnitMethodMetadataTypeTree =
+        TypeTree(getRequiredClass("org.scalajs.junit.JUnitMethodMetadata").toType)
+
+      override def transform(tree: Tree): Tree = tree match {
+        case tree: PackageDef =>
+          def isClassWithJUnitAnnotation(sym: Symbol): Boolean = sym match {
+            case _:ClassSymbol | _:ModuleSymbol =>
+              val hasAnnotationInClass = sym.selfType.members.exists {
+                case mtdSym: MethodSymbol => hasAnnotation(mtdSym, TestClass)
+                case _ => false
+              }
+              if (hasAnnotationInClass) true
+              else sym.parentSymbols.headOption.fold(false)(isClassWithJUnitAnnotation)
+
+            case _ => false
+          }
+
+          val bootstrappers = tree.stats.groupBy { // Group the class with its module
+            case clDef: ClassDef => Some(clDef.name)
+            case _               => None
+          }.iterator.flatMap {
+            case (Some(_), xs) if xs.exists(x => isClassWithJUnitAnnotation(x.symbol)) =>
+              def isModule(cDef: ClassDef): Boolean =
+                cDef.mods.hasFlag(Flags.MODULE)
+              def isTestClass(cDef: ClassDef): Boolean = {
+                !cDef.mods.hasFlag(Flags.MODULE) &&
+                !cDef.mods.hasFlag(Flags.ABSTRACT) &&
+                !cDef.mods.hasFlag(Flags.TRAIT)
+              }
+              // Get the class definition and do the transformation
+              xs.collectFirst {
+                case clDef: ClassDef if isTestClass(clDef) =>
+                  // Get the module definition
+                  val modDefOption = xs collectFirst {
+                    case clDef: ClassDef if isModule(clDef) => clDef
+                  }
+                  // Create a new module for the JUnit entry point.
+                  mkBootstrapperClass(clDef, modDefOption)
+              }
+
+            case (_, xs) => None
+          }
+
+          val newStats = tree.stats.map(transform) ++ bootstrappers
+
+          treeCopy.PackageDef(tree: Tree, tree.pid, newStats.toList)
+
+        case _ =>
+          super.transform(tree)
+      }
+
+      def mkBootstrapperClass(clazz: ClassDef, modDefOption: Option[ClassDef]): ClassDef = {
+        val bootSym = clazz.symbol.cloneSymbol
+        val getJUnitMetadataDef = mkGetJUnitMetadataDef(clazz.symbol,
+            modDefOption.map(_.symbol))
+        val newInstanceDef = genNewInstanceDef(clazz.symbol, bootSym)
+        val invokeJUnitMethodDef = {
+          val annotatedMethods = modDefOption.fold(List.empty[MethodSymbol]) { mod =>
+            jUnitAnnotatedMethods(mod.symbol.asClass)
+          }
+          mkInvokeJUnitMethodOnModuleDef(annotatedMethods, bootSym,
+              modDefOption.map(_.symbol))
+        }
+        val invokeJUnitMethodOnInstanceDef = {
+          val annotatedMethods = jUnitAnnotatedMethods(clazz.symbol.asClass)
+          mkInvokeJUnitMethodOnInstanceDef(annotatedMethods, bootSym,
+              clazz.symbol)
+        }
+
+        val bootBody = {
+          List(getJUnitMetadataDef, newInstanceDef, invokeJUnitMethodDef,
+              invokeJUnitMethodOnInstanceDef)
+        }
+        val bootParents = List(
+          TypeTree(definitions.ObjectTpe),
+          TypeTree(jUnitTestMetadataType)
+        )
+        val bootImpl =
+          treeCopy.Template(clazz.impl, bootParents, clazz.impl.self, bootBody)
+
+        val bootName = newTypeName(clazz.name.toString + "$scalajs$junit$bootstrapper")
+        val bootClazz = gen.mkClassDef(Modifiers(Flags.MODULE),
+            bootName, Nil, bootImpl)
+        bootSym.flags += Flags.MODULE
+        bootSym.withoutAnnotations
+        bootSym.setName(bootName)
+        val newClazzInfo = {
+          val newParentsInfo = List(
+            definitions.ObjectTpe,
+            jUnitTestMetadataType
+          )
+          val decls = bootSym.info.decls
+          decls.enter(getJUnitMetadataDef.symbol)
+          decls.enter(newInstanceDef.symbol)
+          decls.enter(invokeJUnitMethodDef.symbol)
+          decls.enter(invokeJUnitMethodOnInstanceDef.symbol)
+          ClassInfoType(newParentsInfo, decls, bootSym.info.typeSymbol)
+        }
+        bootSym.setInfo(newClazzInfo)
+        scalaJSPlugin.registerModuleExports(bootSym)
+        bootClazz.setSymbol(bootSym)
+
+        bootClazz
+      }
+
+      def jUnitAnnotatedMethods(sym: Symbol): List[MethodSymbol] = {
+        sym.selfType.members.collect {
+          case m: MethodSymbol if hasJUnitMethodAnnotation(m) => m
+        }.toList
+      }
+
+      /** This method generates a method that invokes a test method in the module
+       *  given its name. These methods have no parameters.
+       *
+       *  Example:
+       *  {{{
+       *  object Foo {
+       *    @BeforeClass def bar(): Unit
+       *    @AfterClass def baz(): Unit
+       *  }
+       *  object Foo\$scalajs\$junit\$bootstrapper {
+       *    // This is the method generated by mkInvokeJUnitMethodOnModuleDef
+       *    def invoke(methodName: String): Unit = {
+       *      if (methodName == "bar") Foo.bar()
+       *      else if (methodName == "baz") Foo.baz()
+       *      else throw new NoSuchMethodException(methodName + " not found")
+       *    }
+       *  }
+       *  }}}
+       */
+      def mkInvokeJUnitMethodOnModuleDef(methods: List[MethodSymbol],
+          bootSym: Symbol, modClassSym: Option[Symbol]): DefDef = {
+        val invokeJUnitMethodSym = bootSym.newMethod(newTermName("invoke"))
+
+        val paramSyms = {
+          val params = List(("methodName", definitions.StringTpe))
+          mkParamSymbols(invokeJUnitMethodSym, params)
+        }
+
+        invokeJUnitMethodSym.setInfo(MethodType(paramSyms, definitions.UnitTpe))
+
+        def callLocally(methodSymbol: Symbol): Tree = {
+          val methodSymbolLocal = {
+            modClassSym.fold(methodSymbol) { sym =>
+              methodSymbol.cloneSymbol(newOwner = sym)
+            }
+          }
+          gen.mkMethodCall(methodSymbolLocal, Nil)
+        }
+
+        val invokeJUnitMethodRhs = mkMethodResolutionAndCall(invokeJUnitMethodSym,
+            methods, paramSyms.head, callLocally)
+
+        mkMethod(invokeJUnitMethodSym, invokeJUnitMethodRhs, paramSyms)
+      }
+
+      /** This method generates a method that invokes a test method in the class
+       *  given its name. These methods have no parameters.
+       *
+       *  Example:
+       *  {{{
+       *  class Foo {
+       *    @Test def bar(): Unit
+       *    @Test def baz(): Unit
+       *  }
+       *  object Foo\$scalajs\$junit\$bootstrapper {
+       *    // This is the method generated by mkInvokeJUnitMethodOnInstanceDef
+       *    def invoke(instance: AnyRef, methodName: String): Unit = {
+       *      if (methodName == "bar") instance.asInstanceOf[Foo].bar()
+       *      else if (methodName == "baz") instance.asInstanceOf[Foo].baz()
+       *      else throw new NoSuchMethodException(methodName + " not found")
+       *    }
+       *  }
+       *  }}}
+       */
+      def mkInvokeJUnitMethodOnInstanceDef(methods: List[MethodSymbol],
+          classSym: Symbol, refClassSym: Symbol): DefDef = {
+        val invokeJUnitMethodSym = classSym.newMethod(newTermName("invoke"))
+
+        val paramSyms = {
+          val params = List(("instance", definitions.ObjectTpe),
+            ("methodName", definitions.StringTpe))
+          mkParamSymbols(invokeJUnitMethodSym, params)
+        }
+
+        val instanceParamSym :: idParamSym :: Nil = paramSyms
+
+        invokeJUnitMethodSym.setInfo(MethodType(paramSyms, definitions.UnitTpe))
+
+        def callLocally(methodSymbol: Symbol): Tree = {
+          val instance = gen.mkAttributedIdent(instanceParamSym)
+          val castedInstance = gen.mkAttributedCast(instance, refClassSym.tpe)
+          gen.mkMethodCall(castedInstance, methodSymbol, Nil, Nil)
+        }
+
+        val invokeJUnitMethodRhs = mkMethodResolutionAndCall(invokeJUnitMethodSym,
+          methods, idParamSym, callLocally)
+
+        mkMethod(invokeJUnitMethodSym, invokeJUnitMethodRhs, paramSyms)
+      }
+
+      def mkGetJUnitMetadataDef(clSym: Symbol,
+          modSymOption: Option[Symbol]): DefDef = {
+        val methods = jUnitAnnotatedMethods(clSym)
+        val modMethods = modSymOption.map(jUnitAnnotatedMethods)
+
+        def liftAnnotations(methodSymbol: Symbol): List[Tree] = {
+          val annotations = methodSymbol.annotations
+
+          // Find and report unsupported JUnit annotations
+          annotations.foreach {
+            case ann if ann.atp.typeSymbol == TestClass && ann.original.isInstanceOf[Block] =>
+              reporter.error(ann.pos, "@Test(timeout = ...) is not " +
+                "supported in Scala.js JUnit Framework")
+
+            case ann if ann.atp.typeSymbol == FixMethodOrderClass =>
+              reporter.error(ann.pos, "@FixMethodOrder(...) is not supported " +
+                "in Scala.js JUnit Framework")
+
+            case _ => // all is well
+          }
+
+          // Collect lifted representations of the JUnit annotations
+          annotations.collect {
+            case ann if annotationWhiteList.contains(ann.tpe.typeSymbol) =>
+              val args = if (ann.args != null) ann.args else Nil
+              mkNewInstance(TypeTree(ann.tpe), args)
+          }
+        }
+
+        def defaultMethodMetadata(tpe: TypeTree)(mtdSym: MethodSymbol): Tree = {
+          val annotations = liftAnnotations(mtdSym)
+          mkNewInstance(tpe, List(
+              Literal(Constant(mtdSym.name.toString)),
+              mkList(annotations)))
+        }
+
+        def mkList(elems: List[Tree]): Tree = {
+          val array = ArrayValue(TypeTree(definitions.ObjectTpe), elems)
+          val wrappedArray = gen.mkMethodCall(
+              definitions.PredefModule,
+              definitions.wrapArrayMethodName(definitions.ObjectTpe),
+              Nil, List(array))
+          gen.mkMethodCall(definitions.List_apply, List(wrappedArray))
+        }
+
+        def mkMethodList(tpe: TypeTree)(testMethods: List[MethodSymbol]): Tree =
+          mkList(testMethods.map(defaultMethodMetadata(tpe)))
+
+        val getJUnitMethodRhs = {
+          mkNewInstance(
+              TypeTree(jUnitClassMetadataType),
+              List(
+                mkList(liftAnnotations(clSym)),
+                gen.mkNil,
+                mkMethodList(jUnitMethodMetadataTypeTree)(methods),
+                modMethods.fold(gen.mkNil)(mkMethodList(jUnitMethodMetadataTypeTree))
+          ))
+        }
+
+        val getJUnitMetadataSym = clSym.newMethod(newTermName("metadata"))
+        getJUnitMetadataSym.setInfo(MethodType(Nil, jUnitClassMetadataType))
+
+        typer.typedDefDef(newDefDef(getJUnitMetadataSym, getJUnitMethodRhs)())
+      }
+
+      private def hasJUnitMethodAnnotation(mtd: MethodSymbol): Boolean =
+        annotationWhiteList.exists(hasAnnotation(mtd, _))
+
+      private def hasAnnotation(mtd: MethodSymbol, tpe: TypeSymbol): Boolean =
+        mtd.annotations.exists(_.atp.typeSymbol == tpe)
+
+      private def mkNewInstance[T: TypeTag](params: List[Tree]): Apply =
+        mkNewInstance(TypeTree(typeOf[T]), params)
+
+      private def mkNewInstance(tpe: TypeTree, params: List[Tree]): Apply =
+        Apply(Select(New(tpe), nme.CONSTRUCTOR), params)
+
+      /* Generate a method that creates a new instance of the test class, this
+       * method will be located in the bootstrapper class.
+       */
+      private def genNewInstanceDef(classSym: Symbol, bootSymbol: Symbol): DefDef = {
+        val mkNewInstanceDefRhs =
+          mkNewInstance(TypeTree(classSym.typeConstructor), Nil)
+        val mkNewInstanceDefSym = bootSymbol.newMethodSymbol(newTermName("newInstance"))
+        mkNewInstanceDefSym.setInfo(MethodType(Nil, definitions.ObjectTpe))
+
+        typer.typedDefDef(newDefDef(mkNewInstanceDefSym, mkNewInstanceDefRhs)())
+      }
+
+      private def mkParamSymbols(method: MethodSymbol,
+          params: List[(String, Type)]): List[Symbol] = {
+        params.map {
+          case (pName, tpe) =>
+            val sym = method.newValueParameter(newTermName(pName))
+            sym.setInfo(tpe)
+            sym
+        }
+      }
+
+      private def mkMethod(methodSym: MethodSymbol, methodRhs: Tree,
+          paramSymbols: List[Symbol]): DefDef = {
+        val paramValDefs = List(paramSymbols.map(newValDef(_, EmptyTree)()))
+        typer.typedDefDef(newDefDef(methodSym, methodRhs)(vparamss = paramValDefs))
+      }
+
+      private def mkMethodResolutionAndCall(methodSym: MethodSymbol,
+          methods: List[Symbol], idParamSym: Symbol, genCall: Symbol => Tree): Tree = {
+        val tree = methods.foldRight[Tree](mkMethodNotFound(idParamSym)) { (methodSymbol, acc) =>
+            val mName = Literal(Constant(methodSymbol.name.toString))
+            val paramIdent = gen.mkAttributedIdent(idParamSym)
+            val cond = gen.mkMethodCall(paramIdent, definitions.Object_equals, Nil, List(mName))
+            val call = genCall(methodSymbol)
+            If(cond, call, acc)
+        }
+        atOwner(methodSym)(typer.typed(tree))
+      }
+
+      private def mkMethodNotFound(paramSym: Symbol) = {
+        val paramIdent = gen.mkAttributedIdent(paramSym)
+        val msg = gen.mkMethodCall(paramIdent, definitions.String_+, Nil,
+          List(Literal(Constant(" not found"))))
+        val exception = mkNewInstance[NoSuchMethodException](List(msg))
+        Throw(exception)
+      }
+    }
+  }
+}

--- a/junit-runtime/src/main/scala/com/novocode/junit/Ansi.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/Ansi.scala
@@ -1,0 +1,45 @@
+package com.novocode.junit
+
+object Ansi {
+
+  private[this] final val NORMAL = "\u001B[0m"
+
+  def c(s: String, colorSequence: String): String =
+    if (colorSequence == null) s
+    else colorSequence + s + NORMAL
+
+  def filterAnsi(s: String): String = {
+    if (s == null) {
+      null
+    } else {
+      var r: String = ""
+      val len = s.length
+      var i = 0
+      while (i < len) {
+        val c = s.charAt(i)
+        if (c == '\u001B') {
+          i += 1
+          while (i < len && s.charAt(i) != 'm')
+            i += 1
+        } else {
+          r += c
+        }
+        i += 1
+      }
+      r
+    }
+  }
+
+  final val INFO = "\u001B[34m" // BLUE
+  final val ERRCOUNT = "\u001B[31m" // RED
+  final val IGNCOUNT = "\u001B[33m" // YELLOW
+  final val ERRMSG = "\u001B[31m" // RED
+  final val NNAME1 = "\u001B[33m" // YELLOW
+  final val NNAME2 = "\u001B[36m" // CYAN
+  final val NNAME3 = "\u001B[33m" // YELLOW
+  final val ENAME1 = "\u001B[33m" // YELLOW
+  final val ENAME2 = "\u001B[31m" // RED
+  final val ENAME3 = "\u001B[33m" // YELLOW
+  final val TESTFILE1 = "\u001B[35m" // MAGENTA
+  final val TESTFILE2 = "\u001B[33m" // YELLOW
+}

--- a/junit-runtime/src/main/scala/com/novocode/junit/JUnitFramework.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/JUnitFramework.scala
@@ -1,0 +1,93 @@
+package com.novocode.junit
+
+import org.scalajs.junit.{JUnitMasterRunner, JUnitSlaveRunner}
+import sbt.testing._
+
+final class JUnitFramework extends Framework {
+
+  val name: String = "Scala.js JUnit test framework"
+
+  private object JUnitFingerprint extends AnnotatedFingerprint {
+    override def annotationName(): String = "org.junit.Test"
+
+    override def isModule(): Boolean = false
+  }
+
+  def fingerprints(): Array[Fingerprint] = {
+    Array(JUnitFingerprint)
+  }
+
+  def runner(args: Array[String], remoteArgs: Array[String],
+      testClassLoader: ClassLoader): JUnitMasterRunner = {
+    new JUnitMasterRunner(args, remoteArgs, testClassLoader,
+        parseRunSettings(args))
+  }
+
+  def slaveRunner(args: Array[String], remoteArgs: Array[String],
+      testClassLoader: ClassLoader, send: String => Unit): JUnitSlaveRunner = {
+    new JUnitSlaveRunner(args, remoteArgs, testClassLoader, send,
+        parseRunSettings(args))
+  }
+
+  def arrayString(arr: Array[String]): String = arr.mkString("Array(", ", ", ")")
+
+  def parseRunSettings(args: Array[String]): RunSettings = {
+    var quiet = false
+    var verbose = false
+    var noColor = false
+    var decodeScalaNames = false
+    var logAssert = false
+    var logExceptionClass = true
+    var ignoreRunners = "org.junit.runners.Suite"
+    var runListener: String = null
+    for (str <- args) {
+      str match {
+        case "-q" => quiet = true
+        case "-v" => verbose = true
+        case "-n" => noColor = true
+        case "-s" => decodeScalaNames = true
+        case "-a" => logAssert = true
+        case "-c" => logExceptionClass = false
+
+        case s if s.startsWith("-tests=") =>
+          throw new UnsupportedOperationException("-tests")
+
+        case s if s.startsWith("--tests=") =>
+            throw new UnsupportedOperationException("--tests")
+
+        case s if s.startsWith("--ignore-runners=") =>
+          ignoreRunners = s.substring(17)
+
+        case s if s.startsWith("--run-listener=") =>
+          runListener = s.substring(15)
+
+        case s if s.startsWith("--include-categories=") =>
+            throw new UnsupportedOperationException("--include-categories")
+
+        case s if s.startsWith("--exclude-categories=") =>
+            throw new UnsupportedOperationException("--exclude-categories")
+
+        case s if s.startsWith("-D") && s.contains("=") =>
+            throw new UnsupportedOperationException("-Dkey=value")
+
+        case s if !s.startsWith("-") && !s.startsWith("+") =>
+            throw new UnsupportedOperationException(s)
+
+        case _ =>
+      }
+    }
+    for (s <- args) {
+      s match {
+        case "+q" => quiet = false
+        case "+v" => verbose = false
+        case "+n" => noColor = false
+        case "+s" => decodeScalaNames = false
+        case "+a" => logAssert = false
+        case "+c" => logExceptionClass = false
+        case _    =>
+      }
+    }
+    new RunSettings(!noColor, decodeScalaNames, quiet, verbose, logAssert,
+        ignoreRunners, logExceptionClass)
+  }
+}

--- a/junit-runtime/src/main/scala/com/novocode/junit/RichLogger.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/RichLogger.scala
@@ -1,0 +1,161 @@
+package com.novocode.junit
+
+import sbt.testing._
+
+import scala.collection.mutable
+
+import Ansi._
+
+final class RichLogger private (loggers: Array[Logger], settings: RunSettings) {
+
+  private[this] val currentTestClassName = new mutable.Stack[String]()
+
+  def this(loggers: Array[Logger], settings: RunSettings,
+      testClassName: String) = {
+    this(loggers, settings)
+    currentTestClassName.push(testClassName)
+  }
+
+  def pushCurrentTestClassName(s: String): Unit =
+    currentTestClassName.push(s)
+
+  def popCurrentTestClassName(): Unit = {
+    if (currentTestClassName.size > 1)
+      currentTestClassName.pop()
+  }
+
+  def debug(s: String): Unit = {
+    for (l <- loggers)
+      l.debug(filterAnsiIfNeeded(l, s))
+  }
+
+  def error(s: String): Unit = {
+    for (l <- loggers)
+      l.error(filterAnsiIfNeeded(l, s))
+  }
+
+  def error(s: String, t: Throwable): Unit = {
+    error(s)
+    if (t != null && (settings.logAssert || !t.isInstanceOf[AssertionError]))
+      logStackTrace(t)
+  }
+
+  def info(s: String): Unit = {
+    for (l <- loggers)
+      l.info(filterAnsiIfNeeded(l, s))
+  }
+
+  def warn(s: String): Unit = {
+    for (l <- loggers)
+      l.warn(filterAnsiIfNeeded(l, s))
+  }
+
+  private def filterAnsiIfNeeded(l: Logger, s: String): String =
+    if (l.ansiCodesSupported() && settings.color) s
+    else filterAnsi(s)
+
+  private def logStackTrace(t: Throwable): Unit = {
+    val trace = t.getStackTrace.dropWhile { p =>
+      p.getFileName.contains("StackTrace.scala") ||
+      p.getFileName.contains("Throwables.scala")
+    }
+    val testClassName = currentTestClassName.head
+    val testFileName = {
+      if (settings.color) findTestFileName(trace, testClassName)
+      else null
+    }
+    val i = trace.indexWhere(p => p.getFileName.contains("JUnitExecuteTest.scala")) - 1
+    val m = if (i > 0) i else trace.length - 1
+    logStackTracePart(trace, m, trace.length - m - 1, t, testClassName, testFileName)
+  }
+
+  private def logStackTracePart(trace: Array[StackTraceElement], m: Int,
+      framesInCommon: Int, t: Throwable, testClassName: String,
+      testFileName: String): Unit = {
+    val m0 = m
+    var m2 = m
+    var top = 0
+    var i = top
+    while (i <= m2) {
+      if (trace(i).toString.startsWith("org.junit.") ||
+          trace(i).toString.startsWith("org.hamcrest.")) {
+        if (i == top) {
+          top += 1
+        } else {
+          m2 = i - 1
+          var break = false
+          while (m2 > top && !break) {
+            val s = trace(m2).toString
+            if (!s.startsWith("java.lang.reflect.") &&
+                !s.startsWith("sun.reflect.")) {
+              break = true
+            } else {
+              m2 -= 1
+            }
+          }
+          i = m2 // break
+        }
+      }
+      i += 1
+    }
+
+    for (i <- top to m2) {
+      error("    at " +
+        stackTraceElementToString(trace(i), testClassName, testFileName))
+    }
+    if (m0 != m2) {
+      // skip junit-related frames
+      error("    ...")
+    } else if (framesInCommon != 0) {
+      // skip frames that were in the previous trace too
+      error("    ... " + framesInCommon + " more")
+    }
+    logStackTraceAsCause(trace, t.getCause, testClassName, testFileName)
+  }
+
+  private def logStackTraceAsCause(causedTrace: Array[StackTraceElement],
+      t: Throwable, testClassName: String, testFileName: String): Unit = {
+    if (t != null) {
+      val trace = t.getStackTrace
+      var m = trace.length - 1
+      var n = causedTrace.length - 1
+      while (m >= 0 && n >= 0 && trace(m) == causedTrace(n)) {
+        m -= 1
+        n -= 1
+      }
+      error("Caused by: " + t)
+      logStackTracePart(trace, m, trace.length - 1 - m, t, testClassName, testFileName)
+    }
+  }
+
+  private def findTestFileName(trace: Array[StackTraceElement], testClassName: String): String = {
+    trace.collectFirst {
+      case e if testClassName.equals(e.getClassName) => e.getFileName
+    }.orNull
+  }
+
+  private def stackTraceElementToString(e: StackTraceElement,
+      testClassName: String, testFileName: String): String = {
+    val highlight = settings.color && {
+      testClassName == e.getClassName ||
+      (testFileName != null && testFileName == e.getFileName)
+    }
+    var r = ""
+    r += settings.decodeName(e.getClassName + '.' + e.getMethodName)
+    r += '('
+
+    if (e.isNativeMethod) {
+      r += c("Native Method", if (highlight) TESTFILE2 else null)
+    } else if (e.getFileName == null) {
+      r += c("Unknown Source", if (highlight) TESTFILE2 else null)
+    } else {
+      r += c(e.getFileName, if (highlight) TESTFILE1 else null)
+      if (e.getLineNumber >= 0) {
+        r += ':'
+        r += c(String.valueOf(e.getLineNumber), if (highlight) TESTFILE2 else null)
+      }
+    }
+    r += ')'
+    r
+  }
+}

--- a/junit-runtime/src/main/scala/com/novocode/junit/RunSettings.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/RunSettings.scala
@@ -1,0 +1,60 @@
+package com.novocode.junit
+
+import com.novocode.junit.Ansi._
+
+import java.util.HashSet
+
+import scala.util.Try
+
+class RunSettings private (val color: Boolean, val decodeScalaNames: Boolean,
+    val quiet: Boolean, val verbose: Boolean, val logAssert: Boolean,
+    val logExceptionClass: Boolean) {
+
+  private val ignoreRunnersSet = new HashSet[String]
+
+  def this(color: Boolean, decodeScalaNames: Boolean, quiet: Boolean,
+      verbose: Boolean, logAssert: Boolean, ignoreRunners: String,
+      logExceptionClass: Boolean) = {
+    this(color, decodeScalaNames, quiet, verbose, logAssert, logExceptionClass)
+    for (s <- ignoreRunners.split(","))
+      ignoreRunnersSet.add(s.trim)
+  }
+
+  def decodeName(name: String): String =
+    if (decodeScalaNames) RunSettings.decodeScalaName(name) else name
+
+  def buildColoredMessage(t: Throwable, c1: String): String = {
+    if (t == null) "null" else {
+      if (!logExceptionClass || (!logAssert && t.isInstanceOf[AssertionError])) {
+        t.getMessage
+      } else {
+        val b = new StringBuilder()
+        val cn = decodeName(t.getClass.getName)
+        val pos1 = cn.indexOf('$')
+        val pos2 = {
+          if (pos1 == -1) cn.lastIndexOf('.')
+          else cn.lastIndexOf('.', pos1)
+        }
+        if (pos2 == -1) b.append(c(cn, c1))
+        else {
+          b.append(cn.substring(0, pos2))
+          b.append('.')
+          b.append(c(cn.substring(pos2 + 1), c1))
+        }
+        b.append(": ").append(t.getMessage)
+        b.toString()
+      }
+    }
+  }
+
+  def buildInfoMessage(t: Throwable): String =
+    buildColoredMessage(t, NNAME2)
+
+  def buildErrorMessage(t: Throwable): String =
+    buildColoredMessage(t, ENAME2)
+}
+
+object RunSettings {
+  private[RunSettings] def decodeScalaName(name: String): String =
+    Try(scala.reflect.NameTransformer.decode(name)).getOrElse(name)
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/BaseDescription.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/BaseDescription.scala
@@ -1,0 +1,109 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+import java.util.Arrays
+import scala.annotation.tailrec
+import org.hamcrest.internal.ArrayIterator
+import org.hamcrest.internal.SelfDescribingValueIterator
+
+abstract class BaseDescription extends Description {
+  override def appendText(text: String): Description = {
+    append(text)
+    this
+  }
+
+  override def appendDescriptionOf(value: SelfDescribing): Description = {
+    value.describeTo(this)
+    this
+  }
+
+  override def appendValue(value: AnyRef): Description = {
+    value match {
+      case null =>
+        append("null")
+
+      case value: String =>
+        append(toJavaSyntax(value))
+
+      case value: java.lang.Character =>
+        append('"')
+        append(toJavaSyntax(value))
+        append('"')
+
+      case value: Array[AnyRef] =>
+        appendValueList("[", ", ", "]", new ArrayIterator(value))
+
+      case _ =>
+        append('<')
+        append(descriptionOf(value))
+        append('>')
+    }
+    this
+  }
+
+  private def descriptionOf(value: AnyRef): String = {
+    try {
+      String.valueOf(value)
+    } catch {
+      case _: Exception =>
+        s"${value.getClass.getName}@${Integer.toHexString(value.hashCode)}"
+    }
+  }
+
+  override def appendValueList[T](start: String, separator: String, end: String,
+      values: T*): Description = {
+    appendValueList(start, separator, end, Arrays.asList(values))
+  }
+
+  override def appendValueList[T](start: String, separator: String, end: String,
+      values:  java.lang.Iterable[T]): Description = {
+    appendValueList(start, separator, end, values.iterator())
+  }
+
+  private def appendValueList[T](start: String, separator: String, end: String,
+      values: java.util.Iterator[T]): Description = {
+    appendList(start, separator, end, new SelfDescribingValueIterator[T](values))
+  }
+
+  override def appendList(start: String, separator: String, end: String,
+      values: java.lang.Iterable[SelfDescribing]): Description = {
+    appendList(start, separator, end, values.iterator())
+  }
+
+  private def appendList(start: String, separator: String, end: String,
+      i: java.util.Iterator[SelfDescribing]): Description = {
+    @tailrec
+    def appendElems(separate: Boolean): Unit = {
+      if (i.hasNext) {
+        if (separate) append(separator)
+        appendDescriptionOf(i.next)
+        appendElems(true)
+      }
+    }
+    append(start)
+    appendElems(false)
+    append(end)
+    this
+  }
+
+  protected def append(str: String): Unit = {
+    str.foreach(append)
+  }
+
+  protected def append(c: Char): Unit
+
+  private def toJavaSyntax(unformatted: String): String =
+    s""""${unformatted.map(toJavaSyntax)}"""" // Note the four "
+
+  private def toJavaSyntax(ch: Char): String = {
+    ch match {
+      case '"'  => "\\\""
+      case '\n' => "\\n"
+      case '\r' => "\\r"
+      case '\t' => "\\t"
+      case _    => ch.toString
+    }
+  }
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/BaseMatcher.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/BaseMatcher.scala
@@ -1,0 +1,11 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+abstract class BaseMatcher[T] extends Matcher[T] {
+  override def describeMismatch(item: AnyRef, description: Description): Unit =
+    description.appendText("was ").appendValue(item)
+
+  override def toString(): String = StringDescription.toString(this)
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/CoreMatchers.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/CoreMatchers.scala
@@ -1,0 +1,117 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+import org.hamcrest.core._
+
+object CoreMatchers {
+  // Commented matchers where implemented using reflexion. It is possible that
+  // some of them could be reimplemented from scratch without using reflexion.
+
+  //  def allOf[T](matchers: java.lang.Iterable[Matcher[T]]): Matcher[T] =
+  //    AllOf.allOf(matchers)
+
+  //  def allOf[T](matchers: Matcher[T]*): Matcher[T] =
+  //    AllOf.allOf(matchers)
+
+  //  def anyOf[T](matchers: java.lang.Iterable[Matcher[T]]): AnyOf[T] =
+  //    AnyOf.anyOf(matchers)
+
+  //  def anyOf[T](matchers: Matcher[T]*) : AnyOf = AnyOf.anyOf(matchers)
+
+  //  def both[LHS](matcher: Matcher[LHS]):
+  //      CombinableMatcher.CombinableBothMatcher[LHS] = {
+  //    CombinableMatcher.both(matcher)
+  //  }
+
+  //  def either[LHS](matcher: Matcher[LHS]):
+  //      CombinableMatcher.CombinableEitherMatcher[LHS] = {
+  //    CombinableMatcher.either(matcher)
+  //  }
+
+  //  def describedAs[T](description: String, matcher: Matcher[T],
+  //      values: AnyRef*): Matcher[T] = {
+  //    DescribedAs.describedAs(description, matcher, values)
+  //  }
+
+  //  def everyItem[U](itemMatcher: Matcher[U]): Matcher[java.lang.Iterable[U]] =
+  //    Every.everyItem(itemMatcher)
+
+  def is[T](matcher: Matcher[T]): Matcher[T] = Is.is(matcher)
+
+  def is[T](value: T): Matcher[T] = Is.is(value)
+
+  def isA[T](typ: java.lang.Class[T]): Matcher[T] = Is.isA(typ)
+
+  //  def anything(): Matcher[AnyRef] = IsAnything.anything()
+
+  //  def anything(description: String): Matcher[AnyRef] =
+  //    IsAnything.anything(description)
+
+  //  def hasItem[T](itemMatcher: Matcher[T]): Match[Iterable[T]] =
+  //    IsCollectionContaining.hasItem(itemMatcher)
+
+  //  def hasItem[T](item: T): Matcher[Iterable[T]] =
+  //    IsCollectionContaining.hasItem(item)
+
+  //  def hasItems[T](itemMatchers:Matcher[T]*): Matcher[T] =
+  //    IsCollectionContaining.hasItems(itemMatchers)
+
+  //  def hasItems[T](items: T*): Matcher[java.lang.Iterable[T]] =
+  //    IsCollectionContaining.hasItems(items)
+
+  //  def equalTo[T](operand: T): Matcher[T] =
+  //    IsEqual.equalTo(operand)
+
+  //  def equalToObject[T](operand: AnyRef): Matcher[AnyRef] =
+  //    IsEqual.equalToObject(operand)
+
+  def any[T](typ: Class[T]): Matcher[T] =
+    core.IsInstanceOf.any(typ)
+
+  def instanceOf[T](typ: Class[_]): Matcher[T] =
+    core.IsInstanceOf.instanceOf(typ)
+
+  def not[T](matcher: Matcher[T]): Matcher[T] =
+    core.IsNot.not(matcher)
+
+  def not[T](value: T): Matcher[T] =
+    core.IsNot.not(value)
+
+  def notNullValue(): Matcher[AnyRef] =
+    core.IsNull.notNullValue()
+
+  def notNullValue[T](typ: java.lang.Class[T]): Matcher[T] =
+    core.IsNull.notNullValue(typ)
+
+  def nullValue(): Matcher[AnyRef] =
+     core.IsNull.nullValue()
+
+  def nullValue[T](typ: java.lang.Class[T]): Matcher[T] =
+    core.IsNull.nullValue(typ)
+
+  //  def sameInstance[T](target: T): Matcher[T] =
+  //    IsSame.sameInstance(target)
+
+  //  def theInstance[T](target: T): Matcher[T] =
+  //    IsSame.theInstance(target)
+
+  //  def containsString(substring: String): Matcher[String] =
+  //    StringContains.containsString(substring)
+
+  //  def containsStringIgnoringCase(substring: String): Matcher[String] =
+  //    StringContains.containsStringIgnoringCase(substring)
+
+  //  def startsWith(prefix: String): Matcher[String] =
+  //    core.StringStartsWith.startsWith(prefix)
+
+  //  def startsWithIgnoringCase(prefix: String): Matcher[String] =
+  //    core.StringStartsWith.startsWithIgnoringCase(prefix)
+
+  //  def endsWith(suffix: String): Matcher[String] =
+  //    core.StringEndsWith.endsWith(suffix)
+
+  //  def endsWithIgnoringCase(suffix: String): Matcher[String] =
+  //    core.StringEndsWith.endsWithIgnoringCase(suffix)
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/Description.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/Description.scala
@@ -1,0 +1,50 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+object Description {
+  val NONE: Description = new NullDescription
+
+  final class NullDescription extends Description {
+    override def appendDescriptionOf(value: SelfDescribing): Description = this
+
+    override def appendList(start: String, separator: String, end: String,
+        values: java.lang.Iterable[SelfDescribing]): Description = {
+      this
+    }
+
+    override def appendText(text: String): Description = this
+
+    override def appendValue(value: AnyRef): Description = this
+
+    override def appendValueList[T](start: String, separator: String,
+        end: String, values: T*): Description = {
+      this
+    }
+
+    override def appendValueList[T](start: String, separator: String,
+        end: String, values: java.lang.Iterable[T]): Description = {
+      this
+    }
+
+    override def toString(): String = ""
+  }
+}
+
+trait Description {
+  def appendText(text: String): Description
+
+  def appendDescriptionOf(value: SelfDescribing): Description
+
+  def appendValue(value: AnyRef): Description
+
+  def appendValueList[T](start: String, separator: String, end: String,
+      values: T*): Description
+
+  def appendValueList[T](start: String, separator: String, end: String,
+      values: java.lang.Iterable[T]): Description
+
+  def appendList(start: String, separator: String, end: String,
+      values: java.lang.Iterable[SelfDescribing]): Description
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/DiagnosingMatcher.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/DiagnosingMatcher.scala
@@ -1,0 +1,16 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+abstract class DiagnosingMatcher[T <: AnyRef] extends BaseMatcher[T] {
+  override final def matches(item: AnyRef): Boolean =
+    matches(item, Description.NONE)
+
+  override final def describeMismatch(item: AnyRef,
+      mismatchDescription: Description): Unit = {
+    matches(item, mismatchDescription)
+  }
+
+  protected def matches(item: AnyRef, mismatchDescription: Description): Boolean
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/Matcher.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/Matcher.scala
@@ -1,0 +1,10 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+trait Matcher[+T] extends SelfDescribing {
+  def matches(item: AnyRef): Boolean
+
+  def describeMismatch(item: AnyRef, mismatchDescription: Description): Unit
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/MatcherAssert.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/MatcherAssert.scala
@@ -1,0 +1,28 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+object MatcherAssert {
+  def assertThat[T](actual: T, matcher: Matcher[T]): Unit =
+    assertThat("", actual, matcher)
+
+  def assertThat[T](reason: String, actual: T, matcher: Matcher[T]): Unit = {
+    val _actual = actual.asInstanceOf[AnyRef]
+    if (!matcher.matches(_actual)) {
+      val description = new StringDescription
+      description
+        .appendText(s"$reason\nExpected: ")
+        .appendDescriptionOf(matcher)
+        .appendText("\n     but: ")
+      matcher.describeMismatch(_actual, description)
+
+      throw new AssertionError(description.toString)
+    }
+  }
+
+  def assertThat(reason: String, assertion: Boolean): Unit = {
+    if (!assertion)
+      throw new AssertionError(reason)
+  }
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/SelfDescribing.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/SelfDescribing.scala
@@ -1,0 +1,8 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+trait SelfDescribing {
+  def describeTo(description: Description): Unit
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/StringDescription.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/StringDescription.scala
@@ -1,0 +1,39 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest
+
+import java.io.IOException
+import java.lang.StringBuilder
+
+object StringDescription {
+  def toString(selfDescribing: SelfDescribing): String =
+    new StringDescription().appendDescriptionOf(selfDescribing).toString()
+
+  def asString(selfDescribing: SelfDescribing): String =
+    toString(selfDescribing)
+}
+
+class StringDescription(out: Appendable = new StringBuilder())
+    extends BaseDescription {
+  override protected def append(str: String): Unit = {
+    try {
+      out.append(str)
+    } catch {
+      case e: IOException =>
+        throw new RuntimeException("Could not write description", e)
+    }
+  }
+
+  override protected def append(c: Char): Unit = {
+    try {
+      out.append(c)
+    } catch {
+      case e: IOException =>
+        throw new RuntimeException("Could not write description", e)
+    }
+  }
+
+  override def toString(): String =
+    out.toString()
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/core/Is.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/core/Is.scala
@@ -1,0 +1,36 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest.core
+
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+
+import org.hamcrest.core.IsEqual.equalTo
+import org.hamcrest.core.IsInstanceOf.instanceOf
+
+class Is[T](matcher: Matcher[T]) extends BaseMatcher[T] {
+
+  override def matches(arg: AnyRef): Boolean =
+    matcher.matches(arg)
+
+  override def describeTo(description: Description): Unit =
+    description.appendText("is ").appendDescriptionOf(matcher)
+
+  override def describeMismatch(item: AnyRef,
+      mismatchDescription: Description): Unit = {
+    matcher.describeMismatch(item, mismatchDescription)
+  }
+}
+
+object Is {
+  def is[T](matcher: Matcher[T]): Matcher[T] =
+    new Is[T](matcher)
+
+  def is[T](value: T): Matcher[T] =
+    is(equalTo(value))
+
+  def isA[T](typ: Class[T]): Matcher[T] =
+    is(instanceOf(typ))
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/core/IsEqual.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/core/IsEqual.scala
@@ -1,0 +1,33 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest.core
+
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+
+class IsEqual[T](expectedValue: AnyRef) extends BaseMatcher[T] {
+
+  override def matches(actualValue: AnyRef): Boolean =
+    IsEqual.areEqual(actualValue, expectedValue)
+
+  override def describeTo(description: Description): Unit =
+    description.appendValue(expectedValue)
+}
+
+object IsEqual {
+  private[IsEqual] def areEqual(actual: AnyRef, expected: AnyRef): Boolean = {
+    (actual, expected) match {
+      case (null, _)                              => expected == null
+      case (actual: Array[_], expected: Array[_]) => actual.toList == expected.toList
+      case _                                      => actual.equals(expected)
+    }
+  }
+
+  def equalTo[T](operand: T): Matcher[T] =
+    new IsEqual[T](operand.asInstanceOf[AnyRef])
+
+  def equalToObject(operand: AnyRef): Matcher[AnyRef] =
+    new IsEqual[AnyRef](operand)
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/core/IsInstanceOf.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/core/IsInstanceOf.scala
@@ -1,0 +1,53 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest.core
+
+import org.hamcrest.Description
+import org.hamcrest.DiagnosingMatcher
+import org.hamcrest.Matcher
+
+class IsInstanceOf private (expectedClass: Class[_], matchableClass: Class[_])
+    extends DiagnosingMatcher[AnyRef] {
+
+  def this(expectedClass: Class[_]) =
+    this(expectedClass, IsInstanceOf.matchableClass(expectedClass))
+
+  override protected def matches(item: AnyRef, mismatch: Description): Boolean = {
+    if (null == item) {
+      mismatch.appendText("null")
+      false
+    } else if (!matchableClass.isInstance(item)) {
+      mismatch.appendValue(item).appendText(" is a " + item.getClass.getName)
+      false
+    } else true
+  }
+
+  override def describeTo(description: Description): Unit =
+    description.appendText("an instance of ").appendText(expectedClass.getName)
+}
+
+object IsInstanceOf {
+
+  private[IsInstanceOf] def matchableClass(expectedClass: Class[_]): Class[_] = {
+    expectedClass match {
+      case java.lang.Byte.TYPE      => classOf[java.lang.Byte]
+      case java.lang.Boolean.TYPE   => classOf[java.lang.Boolean]
+      case java.lang.Integer.TYPE   => classOf[java.lang.Integer]
+      case java.lang.Long.TYPE      => classOf[java.lang.Long]
+      case java.lang.Character.TYPE => classOf[java.lang.Character]
+      case java.lang.Short.TYPE     => classOf[java.lang.Character]
+      case java.lang.Float.TYPE     => classOf[java.lang.Float]
+      case java.lang.Double.TYPE    => classOf[java.lang.Double]
+      case _                        => expectedClass
+    }
+  }
+
+  // @SuppressWarnings("unchecked")
+  def instanceOf[T](typ: Class[_]): Matcher[T] =
+    new IsInstanceOf(typ).asInstanceOf[Matcher[T]]
+
+  // @SuppressWarnings("unchecked")
+  def any[T](typ: Class[_]): Matcher[T] =
+     new IsInstanceOf(typ).asInstanceOf[Matcher[T]]
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/core/IsNot.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/core/IsNot.scala
@@ -1,0 +1,26 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest.core
+
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+
+import org.hamcrest.core.IsEqual.equalTo
+
+class IsNot[T](matcher: Matcher[T]) extends BaseMatcher[T] {
+  override def matches(arg: AnyRef): Boolean =
+    !matcher.matches(arg)
+
+  override def describeTo(description: Description): Unit =
+    description.appendText("not ").appendDescriptionOf(matcher)
+}
+
+object IsNot {
+  def not[T](matcher: Matcher[T]): Matcher[T] =
+    new IsNot[T](matcher)
+
+  def not[T](value: T): Matcher[T] =
+    not(equalTo(value))
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/core/IsNull.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/core/IsNull.scala
@@ -1,0 +1,32 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest.core
+
+import org.hamcrest.BaseMatcher
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+
+import org.hamcrest.core.IsNot.not
+
+class IsNull[T] extends BaseMatcher[T] {
+  override def matches(o: AnyRef): Boolean =
+    o == null
+
+  override def describeTo(description: Description): Unit =
+      description.appendText("null")
+}
+
+object IsNull {
+  def nullValue(): Matcher[AnyRef] =
+    new IsNull[AnyRef]
+
+  def notNullValue(): Matcher[AnyRef] =
+    not(nullValue())
+
+  def nullValue[T](tpe: Class[T]): Matcher[T] =
+      new IsNull[T]()
+
+  def notNullValue[T](typ: Class[T]): Matcher[T] =
+    not(nullValue(typ))
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/internal/ArrayIterator.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/internal/ArrayIterator.scala
@@ -1,0 +1,32 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest.internal
+
+import java.{util => ju}
+
+class ArrayIterator private (array: Array[_], private var currentIndex: Int = 0)
+    extends ju.Iterator[AnyRef] {
+
+  def this(array: AnyRef) = {
+    this(
+      array match {
+        case arr: Array[_] => arr
+        case _ => throw new IllegalArgumentException("not an array")
+      },
+      0
+    )
+  }
+
+  override def hasNext: Boolean =
+    currentIndex < array.length
+
+  override def next(): AnyRef = {
+    val _currentIndex = currentIndex
+    currentIndex = _currentIndex + 1
+    array(_currentIndex).asInstanceOf[AnyRef]
+  }
+
+  override def remove(): Unit =
+    throw new UnsupportedOperationException("cannot remove items from an array")
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/internal/SelfDescribingValue.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/internal/SelfDescribingValue.scala
@@ -1,0 +1,12 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest.internal
+
+import org.hamcrest.Description
+import org.hamcrest.SelfDescribing
+
+class SelfDescribingValue[T](value: T) extends SelfDescribing {
+  override def describeTo(description: Description): Unit =
+    description.appendValue(value.asInstanceOf[AnyRef])
+}

--- a/junit-runtime/src/main/scala/org/hamcrest/internal/SelfDescribingValueIterator.scala
+++ b/junit-runtime/src/main/scala/org/hamcrest/internal/SelfDescribingValueIterator.scala
@@ -1,0 +1,20 @@
+/*
+ * Ported from https://github.com/hamcrest/JavaHamcrest/
+ */
+package org.hamcrest.internal
+
+import org.hamcrest.SelfDescribing
+
+import java.{util => ju}
+
+class SelfDescribingValueIterator[T](values: ju.Iterator[T])
+    extends ju.Iterator[SelfDescribing] {
+  override def hasNext(): Boolean =
+    values.hasNext
+
+  override def next(): SelfDescribing =
+    new SelfDescribingValue(values.next)
+
+  override def remove(): Unit =
+    values.remove()
+}

--- a/junit-runtime/src/main/scala/org/junit/After.scala
+++ b/junit-runtime/src/main/scala/org/junit/After.scala
@@ -1,0 +1,11 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import java.lang.annotation._
+
+class After extends scala.annotation.Annotation
+    with java.lang.annotation.Annotation {
+  def annotationType(): Class[_ <: Annotation] = classOf[After]
+}

--- a/junit-runtime/src/main/scala/org/junit/AfterClass.scala
+++ b/junit-runtime/src/main/scala/org/junit/AfterClass.scala
@@ -1,0 +1,11 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import java.lang.annotation._
+
+class AfterClass extends scala.annotation.Annotation
+    with java.lang.annotation.Annotation {
+  def annotationType(): Class[_ <: Annotation] = classOf[AfterClass]
+}

--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -1,0 +1,324 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import org.junit.internal.InexactComparisonCriteria
+import org.junit.internal.ExactComparisonCriteria
+import org.hamcrest.Matcher
+import org.hamcrest.MatcherAssert
+
+object Assert {
+  def assertTrue(message: String, condition: Boolean): Unit = {
+    if (!condition)
+      fail(message)
+  }
+
+  def assertTrue(condition: Boolean): Unit =
+    assertTrue(null, condition)
+
+  def assertFalse(message: String, condition: Boolean): Unit =
+    assertTrue(message, !condition)
+
+  def assertFalse(condition: Boolean): Unit =
+    assertFalse(null, condition)
+
+  def fail(message: String): Unit =
+    if (message eq null) throw new AssertionError()
+    else throw new AssertionError(message)
+
+  def fail(): Unit =
+    fail(null)
+
+  def assertEquals(message: String, expected: Any, actual: Any): Unit = {
+    if (!equalsRegardingNull(expected, actual)) {
+      (expected, actual) match {
+        case (expectedString: String, actualString: String) =>
+          val cleanMsg: String = if (message == null) "" else message
+          throw new ComparisonFailure(cleanMsg, expectedString, actualString)
+
+        case _ =>
+          failNotEquals(message, expected, actual)
+      }
+    }
+  }
+
+  @inline
+  private def equalsRegardingNull(expected: Any, actual: Any): Boolean =
+    if (expected == null) actual == null
+    else isEquals(expected, actual)
+
+  @inline
+  private def isEquals(expected: Any, actual: Any): Boolean =
+    expected.equals(actual)
+
+  def assertEquals(expected: Any, actual: Any): Unit =
+    assertEquals(null, expected, actual)
+
+  def assertNotEquals(message: String, unexpected: AnyRef,
+      actual: AnyRef): Unit = {
+    if (equalsRegardingNull(unexpected, actual))
+      failEquals(message, actual)
+  }
+
+  def assertNotEquals(unexpected: AnyRef, actual: AnyRef): Unit =
+    assertNotEquals(null, unexpected, actual)
+
+  private def failEquals(message: String, actual: Any): Unit = {
+    val checkedMessage = {
+      if (message != null) message
+      else "Values should be different"
+    }
+    fail(s"$checkedMessage. Actual: $actual")
+  }
+
+  def assertNotEquals(message: String, unexpected: Long, actual: Long): Unit = {
+    if (unexpected == actual)
+      failEquals(message, actual)
+  }
+
+  def assertNotEquals(unexpected: Long, actual: Long): Unit =
+    assertNotEquals(null, unexpected, actual)
+
+  def assertNotEquals(message: String, unexpected: Double, actual: Double,
+      delta: Double): Unit = {
+    if (!doubleIsDifferent(unexpected, actual, delta))
+      failEquals(message, actual)
+  }
+
+  def assertNotEquals(unexpected: Double, actual: Double, delta: Double): Unit =
+    assertNotEquals(null, unexpected, actual, delta)
+
+  def assertNotEquals(unexpected: Float, actual: Float, delta: Float): Unit =
+    assertNotEquals(null, unexpected, actual, delta)
+
+  def assertArrayEquals(message: String, expecteds: Array[AnyRef],
+      actuals: Array[AnyRef]): Unit = {
+    internalArrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[AnyRef],
+      actuals: Array[AnyRef]): Unit = {
+    assertArrayEquals(null, expecteds, actuals)
+  }
+
+  def assertArrayEquals(message: String, expecteds: Array[Boolean],
+      actuals: Array[Boolean]): Unit = {
+    internalArrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[Boolean],
+      actuals: Array[Boolean]): Unit = {
+    assertArrayEquals(null, expecteds, actuals)
+  }
+
+  def assertArrayEquals(message: String, expecteds: Array[Byte],
+      actuals: Array[Byte]): Unit = {
+    internalArrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[Byte], actuals: Array[Byte]): Unit =
+    assertArrayEquals(null, expecteds, actuals)
+
+  def assertArrayEquals(message: String, expecteds: Array[Char],
+      actuals: Array[Char]): Unit = {
+    internalArrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[Char], actuals: Array[Char]): Unit =
+    assertArrayEquals(null, expecteds, actuals)
+
+  def assertArrayEquals(message: String, expecteds: Array[Short],
+      actuals: Array[Short]): Unit = {
+    internalArrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[Short],
+      actuals: Array[Short]): Unit = {
+    assertArrayEquals(null, expecteds, actuals)
+  }
+
+  def assertArrayEquals(message: String, expecteds: Array[Int],
+      actuals: Array[Int]): Unit = {
+    internalArrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[Int], actuals: Array[Int]): Unit =
+    assertArrayEquals(null, expecteds, actuals)
+
+  def assertArrayEquals(message: String, expecteds: Array[Long],
+      actuals: Array[Long]): Unit = {
+    internalArrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[Long], actuals: Array[Long]): Unit =
+    assertArrayEquals(null, expecteds, actuals)
+
+  def assertArrayEquals(message: String, expecteds: Array[Double],
+      actuals: Array[Double], delta: Double): Unit = {
+    new InexactComparisonCriteria(delta).arrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[Double], actuals: Array[Double],
+      delta: Double): Unit = {
+    assertArrayEquals(null, expecteds, actuals, delta)
+  }
+
+  def assertArrayEquals(message: String, expecteds: Array[Float],
+      actuals: Array[Float], delta: Float): Unit = {
+    new InexactComparisonCriteria(delta).arrayEquals(message, expecteds, actuals)
+  }
+
+  def assertArrayEquals(expecteds: Array[Float], actuals: Array[Float],
+      delta: Float): Unit = {
+    assertArrayEquals(null, expecteds, actuals, delta)
+  }
+
+  private def internalArrayEquals(message: String, expecteds: AnyRef,
+      actuals: AnyRef): Unit = {
+    new ExactComparisonCriteria().arrayEquals(message, expecteds, actuals)
+  }
+
+  def assertEquals(message: String, expected: Double, actual: Double,
+      delta: Double): Unit = {
+    if (doubleIsDifferent(expected, actual, delta)) {
+      failNotEquals(message, expected, actual)
+    }
+  }
+
+  def assertEquals(message: String, expected: Float, actual: Float,
+      delta: Float): Unit = {
+    if (floatIsDifferent(expected, actual, delta)) {
+      failNotEquals(message, expected, actual)
+    }
+  }
+
+  def assertNotEquals(message: String, unexpected: Float, actual: Float,
+      delta: Float): Unit = {
+    if (!floatIsDifferent(unexpected, actual, delta))
+      failEquals(message, actual)
+  }
+
+  private def doubleIsDifferent(d1: Double, d2: Double,
+      delta: Double): Boolean = {
+    java.lang.Double.compare(d1, d2) != 0 && Math.abs(d1 - d2) > delta
+  }
+
+  private def floatIsDifferent(f1: Float, f2: Float, delta: Float): Boolean =
+    java.lang.Float.compare(f1, f2) != 0 && Math.abs(f1 - f2) > delta
+
+  def assertEquals(expected: Double, actual: Double, delta: Double): Unit =
+    assertEquals(null, expected, actual, delta)
+
+  def assertEquals(expected: Float, actual: Float, delta: Float): Unit =
+    assertEquals(null, expected, actual, delta)
+
+  def assertNotNull(message: String, obj: AnyRef): Unit =
+    assertTrue(message, obj != null)
+
+  def assertNotNull(obj: AnyRef): Unit =
+    assertNotNull(null, obj)
+
+  def assertNull(message: String, obj: AnyRef): Unit = {
+    if (obj != null)
+      failNotNull(message, obj)
+  }
+
+  def assertNull(obj: AnyRef): Unit =
+    assertNull(null, obj)
+
+  private def failNotNull(message: String, actual: AnyRef): Unit = {
+    val formatted = if (message != null) message + " " else ""
+    fail(s"${formatted}expected null, but was:<$actual}>")
+  }
+
+  def assertSame(message: String, expected: AnyRef, actual: AnyRef): Unit = {
+    if (expected ne actual)
+      failNotSame(message, expected, actual)
+  }
+
+  def assertSame(expected: AnyRef, actual: AnyRef): Unit =
+    assertSame(null, expected, actual)
+
+  def assertNotSame(message: String, unexpected: AnyRef, actual: AnyRef): Unit = {
+    if (unexpected eq actual)
+      failSame(message)
+  }
+
+  def assertNotSame(unexpected: AnyRef, actual: AnyRef): Unit =
+    assertNotSame(null, unexpected, actual)
+
+  private def failSame(message: String): Unit = {
+    if (message == null)
+      fail("expected not same")
+    else
+      fail(s"$message expected not same")
+  }
+
+  private def failNotSame(message: String, expected: AnyRef,
+      actual: AnyRef): Unit = {
+    if (message == null)
+      fail(s"expected same:<$expected> was not:<$actual>")
+    else
+      fail(s"$message expected same:<$expected> was not:<$actual>")
+  }
+
+  @inline
+  private def failNotEquals(message: String, expected: Any, actual: Any): Unit =
+    fail(format(message, expected, actual))
+
+  private[junit] def format(message: String, expected: Any, actual: Any): String = {
+    val formatted = if (message != null && message != "") message + " " else ""
+    val expectedString = String.valueOf(expected)
+    val actualString = String.valueOf(actual)
+    if (expectedString == actualString) {
+      val expectedFormatted = formatClassAndValue(expected, expectedString)
+      val actualFormatted = formatClassAndValue(actual, actualString)
+      s"${formatted}expected: $expectedFormatted but was: $actualFormatted"
+    } else {
+      s"${formatted}expected:<$expectedString> but was:<$actualString>"
+    }
+  }
+
+  private def formatClassAndValue(value: Any, valueString: String): String = {
+    val className = if (value == null) "null" else value.getClass.getName
+    s"$className<$valueString>"
+  }
+
+  def assertThat[T](actual: T, matcher: Matcher[T]): Unit =
+    assertThat("", actual, matcher)
+
+  def assertThat[T](reason: String, actual: T, matcher: Matcher[T]): Unit =
+    MatcherAssert.assertThat(reason, actual, matcher)
+
+  def assertThrows(expectedThrowable: Class[_ <: Throwable],
+      runnable: ThrowingRunnable): Unit = {
+    expectThrows(expectedThrowable, runnable)
+  }
+
+  def expectThrows[T <: Throwable](expectedThrowable: Class[T], runnable: ThrowingRunnable): T = {
+    try {
+      runnable.run()
+    } catch {
+      case actualThrown: Throwable =>
+        if (expectedThrowable.isInstance(actualThrown)) {
+          actualThrown.asInstanceOf[T]
+        } else {
+          val mismatchMessage = format("unexpected exception type thrown;",
+            expectedThrowable.getSimpleName, actualThrown.getClass.getSimpleName)
+
+          val assertionError = new AssertionError(mismatchMessage)
+          assertionError.initCause(actualThrown)
+          throw assertionError
+        }
+    }
+    val message =
+      s"expected ${expectedThrowable.getSimpleName} to be thrown," +
+      " but nothing was thrown"
+    throw new AssertionError(message)
+  }
+
+  trait ThrowingRunnable {
+    def run(): Unit
+  }
+}

--- a/junit-runtime/src/main/scala/org/junit/Assume.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assume.scala
@@ -1,0 +1,43 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import org.hamcrest.CoreMatchers.is
+import org.hamcrest.CoreMatchers.notNullValue
+import org.hamcrest.CoreMatchers.nullValue
+import org.hamcrest.Matcher
+
+object Assume {
+
+  def assumeTrue(b: Boolean): Unit =
+    assumeThat(b, is(true))
+
+  def assumeFalse(b: Boolean): Unit =
+    assumeTrue(!b)
+
+  def assumeTrue(message: String, b: Boolean): Unit =
+    if (!b) throw new AssumptionViolatedException(message)
+
+  def assumeFalse(message: String, b: Boolean): Unit =
+    assumeTrue(message, !b)
+
+  def assumeNotNull(objects: AnyRef*): Unit =
+    objects.foreach(assumeThat(_, notNullValue()))
+
+  def assumeThat[T](actual: T, matcher: Matcher[T]): Unit = {
+    if (!matcher.matches(actual.asInstanceOf[AnyRef]))
+      throw new AssumptionViolatedException(actual, matcher)
+  }
+
+  def assumeThat[T](message: String, actual: T, matcher: Matcher[T]): Unit = {
+    if (!matcher.matches(actual.asInstanceOf[AnyRef]))
+      throw new AssumptionViolatedException(message, actual, matcher)
+  }
+
+  def assumeNoException(e: Throwable): Unit =
+    assumeThat(e, nullValue())
+
+  def assumeNoException(message: String, e: Throwable): Unit =
+    assumeThat(message, e, nullValue())
+}

--- a/junit-runtime/src/main/scala/org/junit/AssumptionViolatedException.scala
+++ b/junit-runtime/src/main/scala/org/junit/AssumptionViolatedException.scala
@@ -1,0 +1,29 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import org.hamcrest.Matcher
+
+// @SuppressWarnings("deprecation")
+class AssumptionViolatedException protected (fAssumption: String,
+    fValueMatcher: Boolean, fMatcher: Matcher[_], fValue: AnyRef)
+    extends org.junit.internal.AssumptionViolatedException(fAssumption,
+        fValueMatcher, fMatcher, fValue) {
+
+  @Deprecated
+  def this(actual: Any,  matcher: Matcher[_]) =
+    this(null, true, fMatcher = matcher, fValue = actual.asInstanceOf[AnyRef])
+
+  @Deprecated
+  def this(message: String, expected: Any, matcher: Matcher[_]) =
+    this(message, true, fMatcher = matcher, fValue = expected.asInstanceOf[AnyRef])
+
+  def this(message: String) =
+    this(message, false, null, null)
+
+  def this(assumption: String, t: Throwable) = {
+    this(assumption, false, null, null)
+    initCause(t)
+  }
+}

--- a/junit-runtime/src/main/scala/org/junit/Before.scala
+++ b/junit-runtime/src/main/scala/org/junit/Before.scala
@@ -1,0 +1,8 @@
+package org.junit
+
+import java.lang.annotation._
+
+class Before extends scala.annotation.Annotation
+    with java.lang.annotation.Annotation {
+  def annotationType(): Class[_ <: Annotation] = classOf[Before]
+}

--- a/junit-runtime/src/main/scala/org/junit/BeforeClass.scala
+++ b/junit-runtime/src/main/scala/org/junit/BeforeClass.scala
@@ -1,0 +1,11 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import java.lang.annotation._
+
+class BeforeClass extends scala.annotation.Annotation
+    with java.lang.annotation.Annotation {
+  def annotationType(): Class[_ <: Annotation] = classOf[BeforeClass]
+}

--- a/junit-runtime/src/main/scala/org/junit/ClassRule.scala
+++ b/junit-runtime/src/main/scala/org/junit/ClassRule.scala
@@ -1,0 +1,7 @@
+package org.junit
+
+import java.lang.annotation._
+
+trait ClassRule extends Annotation {
+  def annotationType(): Class[_ <: Annotation] = classOf[ClassRule]
+}

--- a/junit-runtime/src/main/scala/org/junit/ComparisonFailure.scala
+++ b/junit-runtime/src/main/scala/org/junit/ComparisonFailure.scala
@@ -1,0 +1,94 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+object ComparisonFailure {
+  private final val MAX_CONTEXT_LENGTH = 20
+
+  private class ComparisonCompactor(private val expected: String,
+      private val actual: String) {
+
+    private val ELLIPSIS: String = "..."
+    private val DIFF_END: String = "]"
+    private val DIFF_START: String = "["
+
+    def compact(message: String): String = {
+      if (expected == null || actual == null || expected.equals(actual)) {
+        Assert.format(message, expected, actual)
+      } else {
+        val extractor = new DiffExtractor()
+        val compactedPrefix = extractor.compactPrefix()
+        val compactedSuffix = extractor.compactSuffix()
+        Assert.format(message,
+          compactedPrefix + extractor.expectedDiff() + compactedSuffix,
+          compactedPrefix + extractor.actualDiff() + compactedSuffix)
+      }
+    }
+
+    private[junit] def sharedPrefix(): String = {
+      val end: Int = Math.min(expected.length, actual.length)
+      (0 until end).find(i => expected.charAt(i) != actual.charAt(i))
+        .fold(expected.substring(0, end))(expected.substring(0, _))
+    }
+
+    private def sharedSuffix(prefix: String): String = {
+      var suffixLength = 0
+      var maxSuffixLength = Math.min(expected.length() - prefix.length(),
+        actual.length() - prefix.length()) - 1
+      while (suffixLength <= maxSuffixLength) {
+        if (expected.charAt(expected.length() - 1 - suffixLength)
+          != actual.charAt(actual.length() - 1 - suffixLength)) {
+          maxSuffixLength = suffixLength - 1 // break
+        }
+        suffixLength += 1
+      }
+      expected.substring(expected.length() - suffixLength)
+    }
+
+    private class DiffExtractor {
+
+      private val _sharedPrefix: String = sharedPrefix()
+      private val _sharedSuffix: String = sharedSuffix(_sharedPrefix)
+
+      def expectedDiff(): String = extractDiff(expected)
+
+      def actualDiff(): String = extractDiff(actual)
+
+      def compactPrefix(): String = {
+        if (_sharedPrefix.length() <= MAX_CONTEXT_LENGTH)
+          _sharedPrefix
+        else
+          ELLIPSIS + _sharedPrefix.substring(_sharedPrefix.length() - MAX_CONTEXT_LENGTH)
+      }
+
+      def compactSuffix(): String = {
+        if (_sharedSuffix.length() <= MAX_CONTEXT_LENGTH)
+          _sharedSuffix
+        else
+          _sharedSuffix.substring(0, MAX_CONTEXT_LENGTH) + ELLIPSIS
+      }
+
+      private def extractDiff(source: String): String = {
+        val sub = source.substring(_sharedPrefix.length(),
+          source.length() - _sharedSuffix.length())
+        DIFF_START + sub + DIFF_END
+      }
+    }
+  }
+}
+
+class ComparisonFailure(message: String, fExpected: String, fActual: String)
+    extends AssertionError(message) {
+
+  import ComparisonFailure._
+
+  override def getMessage(): String = {
+    val cc = new ComparisonCompactor(fExpected, fActual)
+    cc.compact(super.getMessage)
+  }
+
+  def getActual(): String = fActual
+
+  def getExpected(): String = fExpected
+}

--- a/junit-runtime/src/main/scala/org/junit/FixMethodOrder.scala
+++ b/junit-runtime/src/main/scala/org/junit/FixMethodOrder.scala
@@ -1,0 +1,16 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import java.lang.annotation._
+
+import org.junit.runners.MethodSorters
+
+class FixMethodOrder(val value: MethodSorters)
+    extends Annotation {
+
+  def this() = this(MethodSorters.DEFAULT)
+
+  def annotationType(): Class[_ <: Annotation] = classOf[FixMethodOrder]
+}

--- a/junit-runtime/src/main/scala/org/junit/Ignore.scala
+++ b/junit-runtime/src/main/scala/org/junit/Ignore.scala
@@ -1,0 +1,14 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import java.lang.annotation._
+
+class Ignore(val value: java.lang.String)
+    extends scala.annotation.Annotation with java.lang.annotation.Annotation {
+
+  def this() = this("")
+
+  def annotationType(): Class[_ <: Annotation] = classOf[Ignore]
+}

--- a/junit-runtime/src/main/scala/org/junit/Rule.scala
+++ b/junit-runtime/src/main/scala/org/junit/Rule.scala
@@ -1,0 +1,7 @@
+package org.junit
+
+import java.lang.annotation._
+
+trait Rule extends Annotation {
+  def annotationType(): Class[_ <: Annotation] = classOf[Rule]
+}

--- a/junit-runtime/src/main/scala/org/junit/Test.scala
+++ b/junit-runtime/src/main/scala/org/junit/Test.scala
@@ -1,0 +1,22 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+import java.lang.annotation._
+
+class Test(val expected: Class[_ <: Throwable],
+    val timeout: Long)
+    extends scala.annotation.Annotation with Annotation {
+
+  def this(expected: Class[_ <: Throwable]) = this(expected, 0L)
+  def this(timeout: Long) = this(classOf[Test.None], timeout)
+  def this() = this(0L)
+
+  def annotationType(): Class[_ <: Annotation] =
+    classOf[Test]
+}
+
+object Test {
+  final class None private () extends Throwable
+}

--- a/junit-runtime/src/main/scala/org/junit/internal/ArrayComparisonFailure.scala
+++ b/junit-runtime/src/main/scala/org/junit/internal/ArrayComparisonFailure.scala
@@ -1,0 +1,29 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.internal
+
+object ArrayComparisonFailure
+
+class ArrayComparisonFailure(fMessage: String) extends AssertionError {
+  private var fIndices: List[Int] = Nil
+
+  def this(message: String, cause: AssertionError, index: Int) = {
+    this(message)
+    initCause(cause)
+    addDimension(index)
+  }
+
+  def addDimension(index: Int): Unit = {
+    fIndices = index :: fIndices
+  }
+
+  override def getMessage(): String = {
+    val message = if (fMessage != null) fMessage else ""
+    val indices = fIndices.map(index => s"[$index]").mkString
+    val causeMessage = getCause.getMessage
+    s"${message}arrays first differed at element $indices; $causeMessage"
+  }
+
+  override def toString(): String = getMessage
+}

--- a/junit-runtime/src/main/scala/org/junit/internal/AssumptionViolatedException.scala
+++ b/junit-runtime/src/main/scala/org/junit/internal/AssumptionViolatedException.scala
@@ -1,0 +1,66 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.internal;
+
+import org.hamcrest.Description
+import org.hamcrest.Matcher
+import org.hamcrest.SelfDescribing
+import org.hamcrest.StringDescription
+
+class AssumptionViolatedException protected(
+    fAssumption: String,
+    fValueMatcher: Boolean,
+    fMatcher: Matcher[_],
+    fValue: AnyRef) extends RuntimeException with SelfDescribing {
+
+  //  @deprecated
+  //  def this(assumption: String, hasValue: Boolean, value: AnyRef, matcher: Matcher[AnyRef]) {
+  //    this(assumption, hasValue, matcher, value)
+  //    if (value.isInstanceOf[Throwable]) {
+  //      initCause(value.asInstanceOf[Throwable])
+  //    }
+  //  }
+
+  //  @deprecated
+  //  def this(value: AnyRef, matcher: Matcher[AnyRef]) {
+  //    this(null, true, matcher, value)
+  //  }
+
+  //  @deprecated
+  //  def this(assumption: String, value: AnyRef, matcher: Matcher[AnyRef]) {
+  //    this(assumption, true, matcher, value)
+  //  }
+
+  //  @deprecated
+  //  def this(assumption: String) {
+  //    this(assumption, false, fMatcher = null, null)
+  //  }
+
+  //  @deprecated
+  //  def this(assumption: String, e: Throwable) {
+  //    this(assumption, false, fMatcher = null, null)
+  //    initCause(e)
+  //  }
+
+  override def getMessage(): String =
+    StringDescription.asString(this)
+
+  def describeTo(description: Description): Unit = {
+    if (fAssumption != null)
+      description.appendText(fAssumption)
+
+    if (fValueMatcher) {
+      if (fAssumption != null)
+        description.appendText(": ")
+
+      description.appendText("got: ")
+      description.appendValue(fValue)
+
+      if (fMatcher != null) {
+        description.appendText(", expected: ")
+        description.appendDescriptionOf(fMatcher)
+      }
+    }
+  }
+}

--- a/junit-runtime/src/main/scala/org/junit/internal/ComparisonCriteria.scala
+++ b/junit-runtime/src/main/scala/org/junit/internal/ComparisonCriteria.scala
@@ -1,0 +1,77 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.internal
+
+import org.junit.Assert
+
+abstract class ComparisonCriteria {
+
+  def arrayEquals(message: String, expecteds: AnyRef, actuals: AnyRef): Unit =
+    arrayEquals(message, expecteds, actuals, true)
+
+  private def arrayEquals(message: String, expecteds: AnyRef, actuals: AnyRef,
+      outer: Boolean): Unit = {
+    if (expecteds != actuals &&
+        !java.util.Arrays.deepEquals(Array(expecteds), Array(actuals))) {
+
+      val header = if (message == null) "" else s"$message: "
+
+      val exceptionMessage = if (outer) header else ""
+      val expectedsLength =
+        assertArraysAreSameLength(expecteds, actuals, exceptionMessage)
+
+      for (i <- 0 until expectedsLength) {
+        val expected = get(expecteds, i)
+        val actual = get(actuals, i)
+
+        if (isArray(expected) && isArray(actual)) {
+          try {
+            arrayEquals(message, expected, actual, false)
+          } catch {
+            case e: ArrayComparisonFailure =>
+              e.addDimension(i)
+              throw e
+            case e: AssertionError =>
+              throw new ArrayComparisonFailure(header, e, i)
+          }
+        } else {
+          try {
+            assertElementsEqual(expected, actual)
+          } catch {
+            case e: AssertionError =>
+              throw new ArrayComparisonFailure(header, e, i)
+          }
+        }
+      }
+    }
+  }
+
+  private def isArray(expected: AnyRef): Boolean =
+    expected.isInstanceOf[Array[_]]
+
+  private def assertArraysAreSameLength(expecteds: AnyRef, actuals: AnyRef,
+        header: String): Int = {
+    if (expecteds == null)
+      Assert.fail(header + "expected array was null")
+    if (actuals == null)
+      Assert.fail(header + "actual array was null")
+    val actualsLength = actuals.asInstanceOf[Array[_]].length
+    val expectedsLength = expecteds.asInstanceOf[Array[_]].length
+    if (actualsLength != expectedsLength) {
+      Assert.fail(header +
+          "array lengths differed, expected.length=" + expectedsLength +
+          " actual.length=" + actualsLength)
+    }
+    expectedsLength
+  }
+
+  @inline
+  private def get(arr: AnyRef, i: Int): AnyRef =
+    arr.asInstanceOf[Array[_]](i).asInstanceOf[AnyRef]
+
+  private def length(arr: AnyRef): Int =
+    arr.asInstanceOf[Array[_]].length
+
+  protected def assertElementsEqual(expected: AnyRef, actual: AnyRef): Unit
+}

--- a/junit-runtime/src/main/scala/org/junit/internal/ExactComparisonCriteria.scala
+++ b/junit-runtime/src/main/scala/org/junit/internal/ExactComparisonCriteria.scala
@@ -1,0 +1,13 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.internal
+
+import org.junit.Assert
+
+class ExactComparisonCriteria extends ComparisonCriteria {
+  override protected def assertElementsEqual(expected: AnyRef,
+      actual: AnyRef): Unit = {
+    Assert.assertEquals(expected, actual)
+  }
+}

--- a/junit-runtime/src/main/scala/org/junit/internal/InexactComparisonCriteria.scala
+++ b/junit-runtime/src/main/scala/org/junit/internal/InexactComparisonCriteria.scala
@@ -1,0 +1,22 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.internal
+
+import org.junit.Assert
+
+class InexactComparisonCriteria private (val fDelta: AnyRef)
+    extends ComparisonCriteria {
+
+  def this(delta: Double) =
+    this(delta: java.lang.Double)
+
+  def this(delta: Float) =
+    this(delta: java.lang.Float)
+
+  override protected def assertElementsEqual(expected: AnyRef,
+      actual: AnyRef): Unit = {
+    Assert.assertEquals(expected.asInstanceOf[Double],
+      actual.asInstanceOf[Double], fDelta.asInstanceOf[Double])
+  }
+}

--- a/junit-runtime/src/main/scala/org/junit/runner/RunWith.scala
+++ b/junit-runtime/src/main/scala/org/junit/runner/RunWith.scala
@@ -1,0 +1,10 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.runner
+
+import java.lang.annotation._
+
+class RunWith(value: Class[_ <: Runner]) extends Annotation {
+  override def annotationType(): Class[_ <: Annotation] = classOf[RunWith]
+}

--- a/junit-runtime/src/main/scala/org/junit/runner/Runner.scala
+++ b/junit-runtime/src/main/scala/org/junit/runner/Runner.scala
@@ -1,0 +1,6 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.runner
+
+abstract class Runner

--- a/junit-runtime/src/main/scala/org/junit/runners/BlockJUnit4ClassRunner.scala
+++ b/junit-runtime/src/main/scala/org/junit/runners/BlockJUnit4ClassRunner.scala
@@ -1,0 +1,12 @@
+package org.junit.runners
+
+import org.junit.runners.model.FrameworkMethod
+
+/* In the Scala.js JUnit framework (com.novocode.junit.JUnitFramework) there
+ * is a custom runner that executes the tests. Therefore the implementation of
+ * the original runner is not used. But we still want to be able the compile a
+ * class that explicitly specifies the default runner using @RunWith(JUnit4).
+ * For this we need only a dummy implementation because we just need to
+ * identify the runner using classOf[...].
+ */
+class BlockJUnit4ClassRunner(testClass: Class[_]) extends ParentRunner[FrameworkMethod](testClass)

--- a/junit-runtime/src/main/scala/org/junit/runners/JUnit4.scala
+++ b/junit-runtime/src/main/scala/org/junit/runners/JUnit4.scala
@@ -1,0 +1,3 @@
+package org.junit.runners
+
+final class JUnit4(klass: Class[_]) extends BlockJUnit4ClassRunner(klass)

--- a/junit-runtime/src/main/scala/org/junit/runners/MethodSorters.scala
+++ b/junit-runtime/src/main/scala/org/junit/runners/MethodSorters.scala
@@ -1,0 +1,25 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.runners
+
+object MethodSorters {
+
+  private lazy val _NAME_ASCENDING = new MethodSorters((x, y) => x.compareTo(y))
+  private lazy val _JVM = new MethodSorters((x, y) => 0)
+  private lazy val _DEFAULT = new MethodSorters((x, y) => 0)
+
+  def NAME_ASCENDING: MethodSorters = _NAME_ASCENDING
+
+  def JVM: MethodSorters = _JVM
+
+  def DEFAULT: MethodSorters = _DEFAULT
+}
+
+class MethodSorters private (f: (String, String) => Int) {
+  lazy val comparator: Ordering[String] = {
+    new Ordering[String] {
+      def compare(x: String, y: String): Int = f(x, y)
+    }
+  }
+}

--- a/junit-runtime/src/main/scala/org/junit/runners/ParentRunner.scala
+++ b/junit-runtime/src/main/scala/org/junit/runners/ParentRunner.scala
@@ -1,0 +1,6 @@
+package org.junit.runners
+
+import org.junit.runner.Runner
+
+// Dummy for classOf[...]
+abstract class ParentRunner[T](testClass: Class[_]) extends Runner

--- a/junit-runtime/src/main/scala/org/junit/runners/model/FrameworkMethod.scala
+++ b/junit-runtime/src/main/scala/org/junit/runners/model/FrameworkMethod.scala
@@ -1,0 +1,4 @@
+package org.junit.runners.model
+
+// Dummy for classOf[...]
+class FrameworkMethod

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitBaseRunner.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitBaseRunner.scala
@@ -1,0 +1,61 @@
+package org.scalajs.junit
+
+import com.novocode.junit.RunSettings
+import sbt.testing._
+
+abstract class JUnitBaseRunner(
+    val args: Array[String],
+    val remoteArgs: Array[String],
+    private[junit] val testClassLoader: ClassLoader,
+    private[junit] val runSettings: RunSettings) extends Runner {
+
+  protected def newTask(taskDef: TaskDef): Task =
+    new JUnitTask(taskDef, this)
+
+  protected var doneCount = 0
+  protected var passedCount = 0
+  protected var failedCount = 0
+  protected var ignoredCount = 0
+  protected var skippedCount = 0
+  protected var totalCount = 0
+
+  private[junit] def taskDoneCount: Int = doneCount
+  private[junit] def taskPassedCount: Int = passedCount
+  private[junit] def taskFailedCount: Int = failedCount
+  private[junit] def taskIgnoredCount: Int = ignoredCount
+  private[junit] def taskSkippedCount: Int = skippedCount
+  private[junit] def taskTotalCount: Int = totalCount
+
+  private[junit] def taskDone(): Unit = doneCount += 1
+  private[junit] def taskPassed(): Unit = passedCount += 1
+  private[junit] def taskFailed(): Unit = failedCount += 1
+  private[junit] def taskIgnored(): Unit = ignoredCount += 1
+  private[junit] def taskSkipped(): Unit = skippedCount += 1
+  private[junit] def taskRegisterTotal(count: Int = 1): Unit = totalCount += count
+
+  def serializeTask(task: Task, serializer: TaskDef => String): String =
+    serializer(task.taskDef)
+
+  def deserializeTask(task: String, deserializer: String => TaskDef): Task =
+    newTask(deserializer(task))
+}
+
+object JUnitBaseRunner {
+  object Done {
+    def deserialize(str: String): Done = {
+      val split = str.split(':')
+      if (split.length != 6) {
+        throw new IllegalArgumentException(str)
+      } else {
+        Done(split(0).toInt, split(1).toInt, split(2).toInt, split(3).toInt,
+            split(4).toInt, split(5).toInt)
+      }
+    }
+  }
+
+  case class Done(done: Int, passed: Int, failed: Int, ignored: Int,
+      skipped: Int, total: Int) {
+    def serialize(): String =
+      Seq(done, passed, failed, ignored, skipped, total).mkString(":")
+  }
+}

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitEvent.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitEvent.scala
@@ -1,0 +1,10 @@
+package org.scalajs.junit
+
+import sbt.testing._
+
+final class JUnitEvent(taskDef: TaskDef, val status: Status, val selector: Selector,
+    val throwable: OptionalThrowable = new OptionalThrowable,
+    val duration: Long = -1L) extends Event {
+  def fullyQualifiedName: String = taskDef.fullyQualifiedName
+  def fingerprint: Fingerprint = taskDef.fingerprint
+}

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitExecuteTest.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitExecuteTest.scala
@@ -1,0 +1,242 @@
+package org.scalajs.junit
+
+import java.io.ByteArrayOutputStream
+
+import com.novocode.junit.Ansi._
+import com.novocode.junit.RichLogger
+import org.junit._
+import sbt.testing._
+
+final class JUnitExecuteTest(taskDef: TaskDef, runner: JUnitBaseRunner,
+    classMetadata: JUnitTestBootstrapper, richLogger: RichLogger,
+    eventHandler: EventHandler) {
+
+  lazy val packageName = fullyQualifiedName.split('.').init.mkString(".")
+  lazy val className = fullyQualifiedName.split('.').last
+
+  def fullyQualifiedName: String = taskDef.fullyQualifiedName()
+
+  def executeTests(): Unit = {
+    val jUnitMetadata = classMetadata.metadata()
+
+    val assumptionViolated = try {
+      for (method <- jUnitMetadata.beforeClassMethod)
+        classMetadata.invoke(method.name)
+      false
+    } catch {
+      case _: AssumptionViolatedException | _:internal.AssumptionViolatedException =>
+        true
+    }
+
+    if (assumptionViolated) {
+      logFormattedInfo(null, "ignored")
+      taskSkipped()
+    } else {
+      def runWithOrWithoutQuietMode[T](block: => T): T = {
+        if (runner.runSettings.quiet) {
+          scala.Console.withOut(new ByteArrayOutputStream()) {
+            block
+          }
+        } else {
+          block
+        }
+      }
+
+      runWithOrWithoutQuietMode {
+        for (method <- jUnitMetadata.testMethods) {
+          method.getIgnoreAnnotation match {
+            case Some(ign) =>
+              logFormattedInfo(method.name, "ignored")
+              ignoreTest(method.name)
+
+            case None =>
+              executeTestMethod(classMetadata, method)
+          }
+        }
+      }
+
+      for (method <- jUnitMetadata.afterClassMethod)
+        classMetadata.invoke(method.name)
+    }
+  }
+
+  private[this] def executeTestMethod(classMetadata: JUnitTestBootstrapper,
+      method: JUnitMethodMetadata) = {
+    val jUnitMetadata = classMetadata.metadata()
+    val testClassInstance = classMetadata.newInstance()
+
+    val t0 = System.nanoTime
+    def timeInSeconds() = (System.nanoTime - t0).toDouble / 1000000000
+
+    val beforeMethodsAssertionFaild = {
+      try {
+        for (method <- jUnitMetadata.beforeMethod)
+          classMetadata.invoke(testClassInstance, method.name)
+        false
+      } catch {
+        case ex: AssumptionViolatedException =>
+          logFormattedInfo(method.name, "started")
+          logAssertionWarning(method.name, ex, timeInSeconds())
+          true
+
+        case ex: internal.AssumptionViolatedException =>
+          logFormattedInfo(method.name, "started")
+          logAssertionWarning(method.name, ex, timeInSeconds())
+          true
+      }
+    }
+
+    if (!beforeMethodsAssertionFaild) {
+      val testAnnotation = method.getTestAnnotation.get
+      val testMethodFailed = {
+        try {
+          classMetadata.invoke(testClassInstance, method.name)
+          executedWithoutExceptions(method.name, testAnnotation, timeInSeconds())
+          false
+        } catch {
+          case ex: Throwable =>
+            executedWithExceptions(method.name, testAnnotation, timeInSeconds(), ex)
+            true
+        }
+      }
+
+      if (!testMethodFailed) {
+        try {
+          for (method <- jUnitMetadata.afterMethod)
+            classMetadata.invoke(testClassInstance, method.name)
+
+          if (testAnnotation.timeout != 0 && testAnnotation.timeout <= timeInSeconds) {
+            richLogger.warn("Timeout: took " + timeInSeconds + " sec, expected " +
+              (testAnnotation.timeout.toDouble / 1000) + " sec")
+          }
+        } catch {
+          case ex: Throwable =>
+            logFormattedError(method.name, "failed: on @AfterClass method", Some(ex))
+            val selector = new NestedTestSelector(fullyQualifiedName, method.name)
+            eventHandler.handle(new JUnitEvent(taskDef, Status.Failure, selector))
+        }
+      }
+    }
+  }
+
+  private[this] def executedWithoutExceptions(methodName: String,
+    testAnnotation: org.junit.Test, timeInSeconds: Double) = {
+    if (testAnnotation.expected == classOf[org.junit.Test.None]) {
+      if (runner.runSettings.verbose)
+        logFormattedInfo(methodName, "started")
+      taskPassed(methodName)
+    } else {
+      val msg = {
+        s"failed: Expected exception: ${testAnnotation.expected} " +
+        s"took $timeInSeconds sec"
+      }
+      logFormattedError(methodName, msg, None)
+      taskFailed(methodName)
+    }
+    runner.taskRegisterTotal()
+  }
+
+  private[this] def executedWithExceptions(methodName: String,
+      testAnnotation: org.junit.Test, timeInSeconds: Double, ex: Throwable) = {
+    if (classOf[AssumptionViolatedException].isInstance(ex) ||
+        classOf[internal.AssumptionViolatedException].isInstance(ex)) {
+      logFormattedInfo(methodName, "started")
+      logAssertionWarning(methodName, ex, timeInSeconds)
+      taskSkipped()
+    } else if (testAnnotation.expected.isInstance(ex)) {
+      if (runner.runSettings.verbose)
+        logFormattedInfo(methodName, "started")
+      taskPassed(methodName)
+    } else if (testAnnotation.expected == classOf[org.junit.Test.None]) {
+      val failedMsg = new StringBuilder
+      failedMsg ++= "failed: "
+      if (ex.isInstanceOf[AssertionError] && runner.runSettings.logAssert) {
+        failedMsg ++= "java.lang." ++= c("AssertionError", ERRMSG) ++= ": "
+        failedMsg ++= ex.getMessage
+      } else if (runner.runSettings.logExceptionClass) {
+        failedMsg ++= ex.getMessage
+      } else {
+        failedMsg ++= ex.getClass.toString ++= " expected<"
+        failedMsg ++= testAnnotation.expected.toString ++= "> but was<"
+        failedMsg ++= ex.getClass.toString += '>'
+      }
+      failedMsg += ','
+      val msg = s"$failedMsg took $timeInSeconds sec"
+      val exOpt = {
+        if (!ex.isInstanceOf[AssertionError] || runner.runSettings.logAssert) Some(ex)
+        else None
+      }
+      logFormattedError(methodName, msg, exOpt)
+      taskFailed(methodName)
+    } else {
+      val msg = s"failed: ${ex.getClass}, took $timeInSeconds sec"
+      logFormattedError(methodName, msg, Some(ex))
+      taskFailed(methodName)
+    }
+    runner.taskRegisterTotal()
+  }
+
+  private def ignoreTest(methodName: String) = {
+    runner.taskIgnored()
+    runner.taskRegisterTotal()
+    val selector = new NestedTestSelector(fullyQualifiedName, methodName)
+    eventHandler.handle(new JUnitEvent(taskDef, Status.Ignored, selector))
+  }
+
+  private def taskSkipped(): Unit = {
+    runner.taskSkipped()
+    val selector = new TestSelector(fullyQualifiedName)
+    eventHandler.handle(new JUnitEvent(taskDef, Status.Skipped, selector))
+  }
+
+  private def taskFailed(methodName: String): Unit = {
+    runner.taskFailed()
+    val selector = new NestedTestSelector(fullyQualifiedName, methodName)
+    eventHandler.handle(new JUnitEvent(taskDef, Status.Failure, selector))
+  }
+
+  private def taskPassed(methodName: String): Unit = {
+    runner.taskPassed()
+    val selector = new NestedTestSelector(fullyQualifiedName, methodName)
+    eventHandler.handle(new JUnitEvent(taskDef, Status.Success, selector))
+  }
+
+  private[this] def logAssertionWarning(methodName: String, ex: Throwable,
+      timeInSeconds: Double): Unit = {
+    val msg = {
+      "failed: org.junit." + c("AssumptionViolatedException", ERRMSG) +
+        ": " + ex.getMessage + ", took " + timeInSeconds + " sec"
+    }
+    logFormattedWarn("Test assumption in test ", methodName, msg)
+  }
+
+  private[this] def logFormattedInfo(method: String, msg: String): Unit = {
+    val fMethod = if (method != null) c(method, NNAME2) else null
+    richLogger.info(
+        formatLayout("Test ", packageName, c(className, NNAME1), fMethod, msg))
+  }
+
+  private[this] def logFormattedWarn(prefix: String, method: String,
+      msg: String): Unit = {
+    val fMethod = if (method != null) c(method, ERRMSG) else null
+    richLogger.warn(
+        formatLayout(prefix, packageName, c(className, NNAME1), fMethod, msg))
+  }
+
+  private[this] def logFormattedError(method: String, msg: String,
+      exOpt: Option[Throwable]): Unit = {
+    val fMethod = if (method != null) c(method, ERRMSG) else null
+    val formattedMsg = formatLayout("Test ", packageName, c(className, NNAME1),
+        fMethod, msg)
+    exOpt match {
+      case Some(ex) => richLogger.error(formattedMsg, ex)
+      case None     => richLogger.error(formattedMsg)
+    }
+  }
+
+  private[this] def formatLayout(prefix: String, packageName: String,
+      className: String, method: String, msg: String): String = {
+    if (method != null) s"$prefix$packageName.$className.$method $msg"
+    else s"$prefix$packageName.$className $msg"
+  }
+}

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitMasterRunner.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitMasterRunner.scala
@@ -1,0 +1,50 @@
+package org.scalajs.junit
+
+import com.novocode.junit.RunSettings
+import sbt.testing._
+import java.util.concurrent.atomic.AtomicInteger
+
+final class JUnitMasterRunner(
+    args: Array[String],
+    remoteArgs: Array[String],
+    testClassLoader: ClassLoader,
+    runSettings: RunSettings)
+    extends JUnitBaseRunner(args, remoteArgs, testClassLoader, runSettings) {
+
+  private[this] var registeredCount = 0
+  private[this] var slaveCount = 0
+
+  def tasks(taskDefs: Array[TaskDef]): Array[Task] = {
+    registeredCount += taskDefs.length
+    taskDefs.map(newTask)
+  }
+
+  def done(): String = {
+    val slaves = slaveCount
+    val registered = registeredCount
+    val done = doneCount
+
+    if (slaves > 0)
+      throw new IllegalStateException(s"There are still $slaves slaves running")
+
+    if (registered != done) {
+      val msg = s"$registered task(s) were registered, $done were executed"
+      throw new IllegalStateException(msg)
+    } else {
+      ""
+    }
+  }
+
+  def receiveMessage(msg: String): Option[String] = msg(0) match {
+    case 'd' =>
+      val slaveDone = JUnitBaseRunner.Done.deserialize(msg.tail)
+      doneCount += slaveDone.done
+      passedCount += slaveDone.passed
+      failedCount += slaveDone.failed
+      ignoredCount += slaveDone.skipped
+      skippedCount += slaveDone.skipped
+      totalCount += slaveDone.total
+      slaveCount -= 1
+      None
+  }
+}

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitSlaveRunner.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitSlaveRunner.scala
@@ -1,0 +1,27 @@
+package org.scalajs.junit
+
+import com.novocode.junit.RunSettings
+import sbt.testing._
+
+final class JUnitSlaveRunner(
+    args: Array[String],
+    remoteArgs: Array[String],
+    testClassLoader: ClassLoader,
+    send: String => Unit,
+    runSettings: RunSettings)
+    extends JUnitBaseRunner(args, remoteArgs, testClassLoader, runSettings) {
+
+  def tasks(taskDefs: Array[TaskDef]): Array[Task] = {
+    taskDefs.map(newTask)
+  }
+
+  def done(): String = {
+    send("d" + JUnitBaseRunner.Done(doneCount, passedCount, failedCount,
+        ignoredCount, skippedCount, totalCount).serialize)
+    ""
+  }
+
+  def receiveMessage(msg: String): Option[String] = {
+    None // <- ignored
+  }
+}

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTask.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTask.scala
@@ -1,0 +1,63 @@
+package org.scalajs.junit
+
+import com.novocode.junit.{Ansi, RichLogger}
+import Ansi._
+import sbt.testing._
+import org.scalajs.testinterface.TestUtils
+import scala.util.{Try, Success, Failure}
+
+final class JUnitTask(val taskDef: TaskDef, runner: JUnitBaseRunner)
+    extends sbt.testing.Task {
+
+  def tags: Array[String] = Array.empty
+
+  def execute(eventHandler: EventHandler, loggers: Array[Logger],
+      continuation: Array[Task] => Unit): Unit = {
+    continuation(execute(eventHandler, loggers))
+  }
+
+  def execute(eventHandler: EventHandler, loggers: Array[Logger]): Array[Task] = {
+    val richLogger = new RichLogger(loggers, runner.runSettings,
+        taskDef.fullyQualifiedName)
+
+    if (runner.runSettings.verbose)
+      richLogger.info(c("Test run started", INFO))
+
+    val bootstrapperName = taskDef.fullyQualifiedName + "$scalajs$junit$bootstrapper"
+
+    val startTime = System.nanoTime
+
+    Try(TestUtils.loadModule(bootstrapperName, runner.testClassLoader)) match {
+      case Success(classMetadata: JUnitTestBootstrapper) =>
+        new JUnitExecuteTest(taskDef, runner, classMetadata,
+            richLogger, eventHandler).executeTests()
+
+      case Success(_) =>
+        richLogger.error("Error while loading test class: " +
+            taskDef.fullyQualifiedName + ", expected " + bootstrapperName +
+            " to extend JUnitTestBootstrapper")
+
+      case Failure(exception) =>
+        richLogger.error("Error while loading test class: " +
+            taskDef.fullyQualifiedName, exception)
+    }
+
+    runner.taskDone()
+
+    if (runner.runSettings.verbose) {
+      val time = System.nanoTime - startTime
+      val failed = runner.taskFailedCount
+      val ignored = runner.taskIgnoredCount
+      val total = runner.taskTotalCount
+      val msg = Seq(
+        c("Test run finished:", INFO),
+        c(s"$failed failed,", if (failed == 0) INFO else ERRCOUNT),
+        c(s"$ignored ignored,", if (ignored == 0) INFO else IGNCOUNT),
+        c(s"$total total,", INFO),
+        c(s"${time.toDouble / 1000000000}s", INFO))
+      richLogger.info(msg.mkString(" "))
+    }
+
+    Array()
+  }
+}

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTestBootstrapper.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTestBootstrapper.scala
@@ -1,0 +1,69 @@
+package org.scalajs.junit
+
+import java.lang.annotation.Annotation
+
+import org.junit.FixMethodOrder
+
+import scala.scalajs.js.annotation.JSExportDescendentObjects
+
+@JSExportDescendentObjects
+trait JUnitTestBootstrapper {
+  def metadata(): JUnitClassMetadata
+  def newInstance(): AnyRef
+  def invoke(methodName: String): Unit
+  def invoke(instance: AnyRef, methodName: String): Unit
+}
+
+final class JUnitMethodMetadata(val name: String, annotations: List[Annotation]) {
+
+  def hasTestAnnotation: Boolean =
+    annotations.exists(_.isInstanceOf[org.junit.Test])
+
+  def hasBeforeAnnotation: Boolean =
+    annotations.exists(_.isInstanceOf[org.junit.Before])
+
+  def hasAfterAnnotation: Boolean =
+    annotations.exists(_.isInstanceOf[org.junit.After])
+
+  def hasBeforeClassAnnotation: Boolean =
+    annotations.exists(_.isInstanceOf[org.junit.BeforeClass])
+
+  def hasAfterClassAnnotation: Boolean =
+    annotations.exists(_.isInstanceOf[org.junit.AfterClass])
+
+  def getTestAnnotation: Option[org.junit.Test] =
+    annotations.collectFirst { case test: org.junit.Test => test }
+
+  def getIgnoreAnnotation: Option[org.junit.Ignore] =
+    annotations.collectFirst { case ign: org.junit.Ignore => ign }
+}
+
+final class JUnitClassMetadata(classAnnotations: List[Annotation],
+    moduleAnnotations: List[Annotation], classMethods: List[JUnitMethodMetadata],
+    moduleMethods: List[JUnitMethodMetadata]) {
+
+  def testMethods: List[JUnitMethodMetadata] = {
+    val fixMethodOrderAnnotation = getFixMethodOrderAnnotation
+    val methodSorter = fixMethodOrderAnnotation.value
+    val tests = classMethods.filter(_.hasTestAnnotation)
+    tests.sortWith((a, b) => methodSorter.comparator.lt(a.name, b.name))
+  }
+
+  def beforeMethod: List[JUnitMethodMetadata] =
+    classMethods.filter(_.hasBeforeAnnotation)
+
+  def afterMethod: List[JUnitMethodMetadata] =
+    classMethods.filter(_.hasAfterAnnotation)
+
+  def beforeClassMethod: List[JUnitMethodMetadata] =
+    moduleMethods.filter(_.hasBeforeClassAnnotation)
+
+  def afterClassMethod: List[JUnitMethodMetadata] =
+    moduleMethods.filter(_.hasAfterClassAnnotation)
+
+  def getFixMethodOrderAnnotation: FixMethodOrder = {
+    classAnnotations.collectFirst {
+      case fmo: FixMethodOrder => fmo
+    }.getOrElse(new FixMethodOrder)
+  }
+}

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -75,17 +75,21 @@ lazy val testFrameworkJS = testFramework.js
 lazy val testFrameworkJVM = testFramework.jvm
 
 lazy val multiTest = crossProject.
+  jsConfigure(_.enablePlugins(ScalaJSJUnitPlugin)).
   settings(
     testFrameworks ++= Seq(
         TestFramework("sbttest.framework.DummyFramework"),
-        TestFramework("inexistent.Foo", "another.strange.Bar")
+        TestFramework("inexistent.Foo", "another.strange.Bar"),
+        TestFramework("org.scalajs.jasminetest.JasmineFramework")
     )
   ).
   jsSettings(baseSettings: _*).
   jsSettings(
     name := "Multi test framework test JS",
     // Make FrameworkDetector resilient to other output - #1572
-    jsDependencies in Test += ProvidedJS / "consoleWriter.js"
+    jsDependencies in Test += ProvidedJS / "consoleWriter.js",
+    testOptions += Tests.Argument(
+      TestFramework("com.novocode.junit.JUnitFramework"), "-v", "-a")
   ).
   jvmSettings(versionSettings: _*).
   jvmSettings(

--- a/sbt-plugin-test/multiTest/js/src/test/scala/sbttest/multitest/JUnitUtil.scala
+++ b/sbt-plugin-test/multiTest/js/src/test/scala/sbttest/multitest/JUnitUtil.scala
@@ -1,0 +1,22 @@
+package sbttest.multitest
+
+import org.scalajs.junit.JUnitTestBootstrapper
+import org.junit.Assert.fail
+
+import scalajs.js
+
+object JUnitUtil {
+  private final val bootstrapperSuffix = "$scalajs$junit$bootstrapper"
+
+  def loadBootstrapper(classFullName: String): JUnitTestBootstrapper = {
+    val fullName = s"$classFullName$bootstrapperSuffix"
+    try {
+      fullName.split('.').foldLeft(js.Dynamic.global) { (obj, n) =>
+        obj.selectDynamic(n)
+      }.apply().asInstanceOf[JUnitTestBootstrapper]
+    } catch {
+      case ex: Throwable =>
+        throw new AssertionError(s"could not load $fullName: ${ex.getMessage}")
+    }
+  }
+}

--- a/sbt-plugin-test/multiTest/js/src/test/scala/sbttest/multitest/ScalaJSJUnitBootstrapTest.scala
+++ b/sbt-plugin-test/multiTest/js/src/test/scala/sbttest/multitest/ScalaJSJUnitBootstrapTest.scala
@@ -1,0 +1,22 @@
+package sbttest.multitest
+
+import org.junit.Test
+import org.junit.Assert.assertTrue
+
+import org.scalajs.jasminetest.JasmineTest
+
+class JUnitBootstrapTest {
+  @Test def testClassBootstrap(): Unit = {
+    // This tests that the Scala.js JUnit runtime is working
+    assertTrue(true)
+  }
+}
+
+object JUnitBootstrapTestFromJasmine extends JasmineTest {
+  describe("org.scalajs.testsuite.junit.JUnitBootstrapTest") {
+    it("should bootstrap JUnit test classes") {
+      // This should not fail
+      JUnitUtil.loadBootstrapper("sbttest.multitest.JUnitBootstrapTest")
+    }
+  }
+}

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
@@ -1,0 +1,42 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.sbtplugin
+
+import sbt._
+import sbt.Keys._
+
+object ScalaJSJUnitPlugin extends AutoPlugin {
+  override def requires: Plugins = ScalaJSPlugin
+
+  import ScalaJSPlugin.autoImport._
+
+  override def projectSettings: Seq[Setting[_]] = Seq(
+    /* The `scala-js-test-plugin` configuration adds a plugin only to the `test`
+     * configuration. It is a refinement of the `plugin` configuration which adds
+     * it to both `compile` and `test`.
+     */
+    ivyConfigurations += config("scala-js-test-plugin").hide,
+    libraryDependencies ++= Seq(
+        "org.scala-js" % "scalajs-junit-test-plugin" % scalaJSVersion %
+        "scala-js-test-plugin" cross CrossVersion.full,
+        "org.scala-js" %% "scalajs-junit-test-runtime" % scalaJSVersion  % "test"),
+    scalacOptions in Test ++= {
+      val report = update.value
+      val jars = report.select(configurationFilter("scala-js-test-plugin"))
+      for {
+        jar <- jars
+        jarPath = jar.getPath
+        // This is a hack to filter out the dependencies of the plugins
+        if jarPath.contains("plugin")
+      } yield {
+        s"-Xplugin:$jarPath"
+      }
+    }
+  )
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,11 +12,15 @@ FULL_VERSIONS="2.10.2 2.10.3 2.10.4 2.10.5 2.10.6 2.11.0 2.11.1 2.11.2 2.11.4 2.
 BIN_VERSIONS="2.10.6 2.11.7 2.12.0-M3"
 SBT_VERSION="2.10.6"
 
-LIBS="library javalibEx ir irJS tools toolsJS jsEnvs testAdapter stubs testInterface cli"
+COMPILER="compiler jUnitPlugin"
+LIBS="library javalibEx ir irJS tools toolsJS jsEnvs testAdapter stubs testInterface cli jUnitRuntime"
 
 # Publish compiler
 for v in $FULL_VERSIONS; do
-    ARGS="++$v compiler/publishSigned"
+    ARGS="++$v"
+    for p in $COMPILER; do
+        ARGS="$ARGS $p/publishSigned"
+    done
     $CMD $ARGS
 done
 

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAbstractClassTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAbstractClassTest.scala
@@ -1,0 +1,39 @@
+package org.scalajs.testsuite.junit
+
+import org.junit.Assert._
+import org.junit.Test
+
+abstract class JUnitAbstractClassTest {
+  @Test def test1(): Unit = ()
+}
+
+class JUnitAbstractClassExtended1Test extends JUnitAbstractClassTest
+
+class JUnitAbstractClassExtended2Test extends JUnitAbstractClassTest {
+  @Test def test2(): Unit = ()
+}
+
+class JUnitAbstractClassTestCheck {
+  @Test def testAbstractClass1(): Unit = {
+    val boot = JUnitUtil.loadBootstrapper(
+        "org.scalajs.testsuite.junit.JUnitAbstractClassExtended1Test")
+    try {
+      boot.invoke(boot.newInstance(), "test1")
+    } catch {
+      case e: Throwable =>
+        fail(s"Could not invoke a test: ${e.getMessage}")
+    }
+  }
+
+  @Test def testAbstractClass2(): Unit = {
+    val boot = JUnitUtil.loadBootstrapper(
+        "org.scalajs.testsuite.junit.JUnitAbstractClassExtended2Test")
+    try {
+      boot.invoke(boot.newInstance(), "test1")
+      boot.invoke(boot.newInstance(), "test2")
+    } catch {
+      case e: Throwable =>
+        fail(s"Could not invoke a test: ${e.getMessage}")
+    }
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsParamTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsParamTest.scala
@@ -1,0 +1,25 @@
+package org.scalajs.testsuite.junit
+
+import org.junit.Test
+
+class JUnitAnnotationsParamTest {
+  @Test
+  def test0(): Unit = ()
+
+  @Test(expected = classOf[Exception])
+  def testException(): Unit =
+    throw new Exception("error message")
+
+  @Test(expected = classOf[Exception])
+  def testException2(): Unit =
+    throw new IndexOutOfBoundsException("error message")
+
+  @Test(timeout = 0L)
+  def testTimeOut0(): Unit = ()
+
+  @Test(timeout = 10000L)
+  def testTimeOut1(): Unit = ()
+
+  @Test(expected = classOf[Exception], timeout = 10000L)
+  def test3(): Unit = throw new Exception
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsTest.scala
@@ -1,0 +1,41 @@
+package org.scalajs.testsuite.junit
+
+import org.junit._
+import org.junit.Assert._
+
+object JUnitAnnotationsTest {
+  @BeforeClass
+  def beforeClassTest(): Unit = ()
+
+  @AfterClass
+  def afterClassTest(): Unit = ()
+}
+
+class JUnitAnnotationsTest {
+  @Before
+  def beforeTest(): Unit = ()
+
+  @After
+  def afterTest(): Unit = ()
+
+  @Test
+  def test1(): Unit = ()
+
+  @Test
+  def test2(): Unit = ()
+
+  @Test
+  def test3(): Unit = ()
+
+  @Ignore
+  @Test
+  def testIgnore(): Unit = {
+    assertTrue(false)
+  }
+
+  @Ignore("This is the @Ignore message.")
+  @Test
+  def testIgnoreWithMessage(): Unit = {
+    assertTrue(false)
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
@@ -1,0 +1,329 @@
+package org.scalajs.testsuite.junit
+
+import org.junit.Test
+
+import org.junit.Assert._
+import org.hamcrest.CoreMatchers._
+
+class JUnitAssertionsTest {
+
+  private final val NotEquals = false
+  private final val ShallNotPass = false
+
+  private def testIfAsserts(assertion: => Unit, shouldPass: Boolean = true): Unit = {
+    try {
+      assertion
+      if (!shouldPass)
+        fail("Assertion should have failed")
+    } catch {
+      case assErr: AssertionError =>
+        if (shouldPass)
+          throw assErr
+    }
+  }
+
+  @Test
+  def testAssertTrueFalse(): Unit = {
+    testIfAsserts(assertTrue("'true' did not assertTrue", condition = true))
+    testIfAsserts(assertTrue(true))
+
+    testIfAsserts(assertFalse("'false' did not assertFalse", condition = false))
+    testIfAsserts(assertFalse(false))
+
+    testIfAsserts(assertTrue("'true' did not assertTrue", condition = false), ShallNotPass)
+    testIfAsserts(assertTrue(false), ShallNotPass)
+
+    testIfAsserts(assertFalse("'false' did not assertFalse", condition = true), ShallNotPass)
+    testIfAsserts(assertFalse(true), ShallNotPass)
+  }
+
+  @Test
+  def testAssertNull(): Unit = {
+    testIfAsserts(assertNull("'null' did not assertNull", null))
+    testIfAsserts(assertNull(null))
+
+    testIfAsserts(assertNotNull("'new Object' did not assertNotNull", new Object))
+    testIfAsserts(assertNotNull(new Object))
+
+    testIfAsserts(assertNull("'null' did not assertNull", new Object), ShallNotPass)
+    testIfAsserts(assertNull(new Object), ShallNotPass)
+
+    testIfAsserts(assertNotNull("'null' did not assertNotNull", null), ShallNotPass)
+    testIfAsserts(assertNotNull(null), ShallNotPass)
+  }
+
+  @Test
+  def testAssertSame(): Unit = {
+    // Setup
+    val obj = new Object()
+    val str = "abcd"
+    val nullRef: AnyRef = null
+
+    def testAssertion(expected: AnyRef, actual: AnyRef, equals: Boolean = true): Unit = {
+      testIfAsserts(assertSame("References where not equal", expected, actual), equals)
+      testIfAsserts(assertSame(expected, actual), equals)
+      testIfAsserts(assertNotSame("References where equal", expected, actual), !equals)
+      testIfAsserts(assertNotSame(expected, actual), !equals)
+    }
+
+    // Tests
+    testAssertion(obj, obj)
+    testAssertion(str, str)
+    testAssertion(nullRef, nullRef)
+
+    testAssertion(new Object, new Object, NotEquals)
+  }
+
+  @Test
+  def testAssertEquals(): Unit = {
+
+    // Setup
+    val obj = new Object()
+    val str = "abcd"
+    val nullRef: AnyRef = null
+
+    // Object equality tests
+    def testAssertion(expected: AnyRef, actual: AnyRef, equals: Boolean = true): Unit = {
+      testIfAsserts(assertEquals(s"Asserting $expected == $actual", expected, actual), equals)
+      testIfAsserts(assertEquals(expected, actual), equals)
+      testIfAsserts(assertNotEquals(s"Asserting $expected != $actual", expected, actual), !equals)
+      testIfAsserts(assertNotEquals(expected, actual), !equals)
+    }
+
+    testAssertion(nullRef, nullRef)
+    testAssertion(obj, obj)
+    testAssertion(str, str)
+    testAssertion(new Object, null, NotEquals)
+    testAssertion(null, new Object, NotEquals)
+    testAssertion(new Object, new Object, NotEquals)
+
+    testAssertion("", "")
+    testAssertion("42", "42")
+    testAssertion("asdfasfsafs", "asdfasfsafs")
+    testAssertion(List(1, 2, 3), List(1, 2, 3))
+    testAssertion(List(1L, 2L, 3L), List(1L, 2L, 3L))
+    testAssertion(Vector(1L, 2L, 3L), List(1L, 2L, 3L))
+    testAssertion((1, 2, 3), (1, 2, 3))
+    testAssertion("", "d", equals = false)
+    testAssertion("42", "1", equals = false)
+    testAssertion("asdfasfsafs", "asdfuhafs", NotEquals)
+    testAssertion(List(1, 2, 3), List(1, 2, 4), NotEquals)
+    testAssertion(List(1L, 2L, 3L), List(1L, 2L, 4L), NotEquals)
+    testAssertion(Vector(1L, 2L, 3L), List(1L, 2L, 4L), NotEquals)
+    testAssertion((1, 2, 3), (1, 2, 4), NotEquals)
+  }
+
+  @Test
+  def testAssertEqualsByte(): Unit = {
+    def testByteAssertion(expected: Byte, actual: Byte, equals: Boolean = true): Unit = {
+      testIfAsserts(assertEquals(s"Asserting $expected == $actual", expected, actual), equals)
+      testIfAsserts(assertEquals(expected, actual), equals)
+      testIfAsserts(assertNotEquals(s"Asserting $expected != $actual", expected, actual), !equals)
+      testIfAsserts(assertNotEquals(expected, actual), !equals)
+    }
+    testByteAssertion(0, 0)
+    testByteAssertion(42, 42)
+    testByteAssertion(-42, -42)
+    testByteAssertion(Byte.MinValue, Byte.MinValue)
+    testByteAssertion(Byte.MaxValue, Byte.MaxValue)
+    testByteAssertion(1, 2, NotEquals)
+
+  }
+
+  @Test
+  def testAssertEqualsChar(): Unit = {
+    def testCharAssertion(expected: Char, actual: Char, equals: Boolean = true): Unit = {
+      testIfAsserts(assertEquals(s"Asserting $expected == $actual", expected, actual), equals)
+      testIfAsserts(assertEquals(expected, actual), equals)
+      testIfAsserts(assertNotEquals(s"Asserting $expected != $actual", expected, actual), !equals)
+      testIfAsserts(assertNotEquals(expected, actual), !equals)
+    }
+
+    testCharAssertion('a', 'a')
+    testCharAssertion('@', '@')
+    testCharAssertion('\n', '\n')
+    testCharAssertion('a', '\0', NotEquals)
+    testCharAssertion('a', '@', NotEquals)
+    testCharAssertion('a', '\n', NotEquals)
+  }
+
+  @Test
+  def testAssertEqualsShort(): Unit = {
+    def testShortAssertion(expected: Short, actual: Short, equals: Boolean = true): Unit = {
+      testIfAsserts(assertEquals(s"Asserting $expected == $actual", expected, actual), equals)
+      testIfAsserts(assertEquals(expected, actual), equals)
+      testIfAsserts(assertNotEquals(s"Asserting $expected != $actual", expected, actual), !equals)
+      testIfAsserts(assertNotEquals(expected, actual), !equals)
+    }
+    testShortAssertion(0, 0)
+    testShortAssertion(42, 42)
+    testShortAssertion(-42, -42)
+    testShortAssertion(Short.MinValue, Short.MinValue)
+    testShortAssertion(Short.MaxValue, Short.MaxValue)
+    testShortAssertion(1, 2, NotEquals)
+  }
+
+  @Test
+  def testAssertEqualsInt(): Unit = {
+    def testIntAssertion(expected: Int, actual: Int, equals: Boolean = true): Unit = {
+      testIfAsserts(assertEquals(s"Asserting $expected == $actual", expected, actual), equals)
+      testIfAsserts(assertEquals(expected, actual), equals)
+      testIfAsserts(assertNotEquals(s"Asserting $expected != $actual", expected, actual), !equals)
+      testIfAsserts(assertNotEquals(expected, actual), !equals)
+    }
+
+    testIntAssertion(0, 0)
+    testIntAssertion(42, 42)
+    testIntAssertion(-42, -42)
+    testIntAssertion(Int.MinValue, Int.MinValue)
+    testIntAssertion(Int.MaxValue, Int.MaxValue)
+    testIntAssertion(1, 2, NotEquals)
+  }
+
+  @Test
+  def testAssertEqualsLong(): Unit = {
+    def testLongAssertion(expected: Long, actual: Long, equals: Boolean = true): Unit = {
+      testIfAsserts(assertEquals(s"Asserting $expected == $actual", expected, actual), equals)
+      testIfAsserts(assertEquals(expected, actual), equals)
+      testIfAsserts(assertNotEquals(s"Asserting $expected != $actual", expected, actual), !equals)
+      testIfAsserts(assertNotEquals(expected, actual), !equals)
+    }
+
+    testLongAssertion(0L, 0L)
+    testLongAssertion(42L, 42L)
+    testLongAssertion(-42L, -42L)
+    testLongAssertion(Long.MinValue, Long.MinValue)
+    testLongAssertion(Long.MaxValue, Long.MaxValue)
+    testLongAssertion(1L, 2L, NotEquals)
+  }
+
+  @Test
+  def testAssertEqualsDouble(): Unit = {
+    def testDoubleAssertion(expected: Double, actual: Double, delta: Double, equals: Boolean = true): Unit = {
+      testIfAsserts(assertEquals(s"Asserting $expected == $actual", expected, actual, delta), equals)
+      testIfAsserts(assertEquals(expected, actual, delta), equals)
+      testIfAsserts(assertNotEquals(s"Asserting $expected != $actual", expected, actual, delta), !equals)
+      testIfAsserts(assertNotEquals(expected, actual, delta), !equals)
+    }
+
+    testDoubleAssertion(1d, 1d, 0d)
+    testDoubleAssertion(1d, 2d, 1d)
+    testDoubleAssertion(1d, 2d, 10d)
+    testDoubleAssertion(1d, 1.1d, 0.2d)
+    testDoubleAssertion(1d, 2d, 0d, NotEquals)
+    testDoubleAssertion(1d, 2d, 0.5d, NotEquals)
+//    testDoubleAssertion(Double.NegativeInfinity, Double.NegativeInfinity, 1.0d)
+  }
+
+  @Test
+  def testAssertEqualsFloat(): Unit = {
+    def testFloatAssertion(expected: Float, actual: Float, delta: Float,
+        equals: Boolean = true): Unit = {
+      testIfAsserts(assertEquals(s"Asserting $expected == $actual", expected, actual, delta), equals)
+      testIfAsserts(assertEquals(expected, actual, delta), equals)
+      testIfAsserts(assertNotEquals(s"Asserting $expected != $actual", expected, actual, delta), !equals)
+      testIfAsserts(assertNotEquals(expected, actual, delta), !equals)
+    }
+
+    testFloatAssertion(1f, 1f, 0f)
+    testFloatAssertion(1f, 2f, 1f)
+    testFloatAssertion(1f, 2f, 10f)
+    testFloatAssertion(1f, 1.1f, 0.2f)
+    testFloatAssertion(1f, 2f, 0f, NotEquals)
+    testFloatAssertion(1f, 2f, 0.5f, NotEquals)
+  }
+
+  @Test
+  def testAssertArrayEquals(): Unit = {
+    // setup
+    val (obj1, obj2): (AnyRef, AnyRef) = ("0", "1")
+    val arr1 = Array(obj1)
+
+    val message = "Should be different up to != operator"
+
+    def testAnyRefAssertion(expected: Array[AnyRef], actual: Array[AnyRef],
+                            equals: Boolean = true): Unit = {
+      testIfAsserts(assertArrayEquals(message, expected, actual), equals)
+      testIfAsserts(assertArrayEquals(expected, actual), equals)
+    }
+    def testIntAssertion(expected: Array[Int], actual: Array[Int],
+                         equals: Boolean = true): Unit = {
+      testIfAsserts(assertArrayEquals(message, expected, actual), equals)
+      testIfAsserts(assertArrayEquals(expected, actual), equals)
+    }
+    def testLongAssertion(expected: Array[Long], actual: Array[Long],
+                          equals: Boolean = true): Unit = {
+      testIfAsserts(assertArrayEquals(message, expected, actual), equals)
+      testIfAsserts(assertArrayEquals(expected, actual), equals)
+    }
+
+
+    // Array tests
+    testAnyRefAssertion(arr1, arr1)
+    testAnyRefAssertion(Array(obj1), Array(obj1))
+    testAnyRefAssertion(Array(obj1, obj2, obj2), Array(obj1, obj2, obj2))
+    testAnyRefAssertion(Array(obj1), Array("0"))
+    testAnyRefAssertion(Array(Array(1), Array(2, Array(3))),
+        Array(Array(1), Array(2, Array(3))))
+    testIntAssertion(Array(1, 2, 3), Array(1, 2, 3))
+    testLongAssertion(Array(1L, 2L, 3L), Array(1L, 2L, 3L))
+
+    testAnyRefAssertion(Array(obj1), Array(obj2), NotEquals)
+    testAnyRefAssertion(Array(obj1, obj2, obj2), Array(obj1, obj2, obj1), NotEquals)
+    testAnyRefAssertion(Array(obj1), Array("4"), NotEquals)
+    testAnyRefAssertion(Array(Array(2), Array(2, Array(3))), Array(Array(1),
+        Array(2, Array(3))), NotEquals)
+    testAnyRefAssertion(Array(Array(1, 2), Array(2, Array(3))),
+        Array(Array(1), Array(2, Array(3))), NotEquals)
+    testAnyRefAssertion(Array(Array(1), Array(2, Array(3))),
+        Array(Array(1, 4), Array(2, Array(3))), NotEquals)
+    testIntAssertion(Array(1, 2, 3), Array(1, 3, 3), NotEquals)
+    testLongAssertion(Array(1L, 2L, 3L), Array(1L, 1L, 3L), NotEquals)
+  }
+
+  @Test
+  def testAssertArrayEqualsDouble(): Unit = {
+    def testDoubleAssertion(expected: Array[Double], actual: Array[Double],
+        delta: Double, equals: Boolean = true): Unit = {
+      val message = "Should be different up to != operator"
+      testIfAsserts(assertArrayEquals(message, expected, actual, delta), equals)
+      testIfAsserts(assertArrayEquals(expected, actual, delta), equals)
+    }
+
+    testDoubleAssertion(Array(1d, 2d, 3d), Array(1d, 2d, 4d), 1d)
+    testDoubleAssertion(Array(1d, 2d, 3d), Array(1d, 2d, 3.5d), 1d)
+    testDoubleAssertion(Array(1d, 2d, 3d), Array(1d, 2d, 3.5d), 0.1d, NotEquals)
+    testDoubleAssertion(Array(1d, 2d, 3d), Array(1d, 2d, 3.5d), 0.1d, NotEquals)
+  }
+
+  @Test
+  def testAssertArrayEqualsFloats(): Unit = {
+    def testFloatAssertion(expected: Array[Float], actual: Array[Float],
+        delta: Float, equals: Boolean = true): Unit = {
+      val message = "Should be different up to != operator"
+      testIfAsserts(assertArrayEquals(message, expected, actual, delta), equals)
+      testIfAsserts(assertArrayEquals(expected, actual, delta), equals)
+    }
+
+    testFloatAssertion(Array(1f, 2f, 3f), Array(1f, 2f, 4f), 1f)
+    testFloatAssertion(Array(1f, 2f, 3f), Array(1f, 2f, 3.5f), 1f)
+    testFloatAssertion(Array(1f, 2f, 3f), Array(1f, 2f, 4f), 0.11f, NotEquals)
+    testFloatAssertion(Array(1f, 2f, 3f), Array(1f, 2f, 3.5f), 0.11f, NotEquals)
+  }
+
+  @Test
+  def testAssertThat(): Unit = {
+    testIfAsserts(assertThat("42", instanceOf(classOf[String])))
+    testIfAsserts(assertThat("42", instanceOf[String](classOf[Int])), ShallNotPass)
+
+    testIfAsserts(assertThat(42, instanceOf(classOf[Int])))
+    testIfAsserts(assertThat(42, instanceOf[Int](classOf[Long])), ShallNotPass)
+    testIfAsserts(assertThat(42, instanceOf[Int](classOf[String])), ShallNotPass)
+
+    testIfAsserts(assertThat(Float.MaxValue, instanceOf(classOf[Float])))
+    testIfAsserts(assertThat(Double.MaxValue, instanceOf(classOf[Double])))
+
+    testIfAsserts(assertThat(0, instanceOf[Int](classOf[Double])), ShallNotPass)
+  }
+
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAssumptionsTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitAssumptionsTest.scala
@@ -1,0 +1,81 @@
+package org.scalajs.testsuite.junit
+
+import org.hamcrest.CoreMatchers._
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit._
+import org.junit.internal.AssumptionViolatedException
+
+class JUnitAssumptionsTest {
+
+  private val ShallNotPass = false
+
+  def testIfAssumePass(assumption: => Unit, shouldPass: Boolean = true): Unit = {
+    try {
+      assumption
+      if (!shouldPass)
+        fail("Assumption should have failed")
+    } catch {
+      case assVio: AssumptionViolatedException =>
+        if (shouldPass)
+          throw assVio
+    }
+  }
+
+  @Test
+  def testAssumeTrue(): Unit = {
+    testIfAssumePass(assumeTrue("true be assumed to be true", true))
+    testIfAssumePass(assumeTrue(true))
+    testIfAssumePass(assumeTrue("false be assumed to be true", false), ShallNotPass)
+    testIfAssumePass(assumeTrue(false), ShallNotPass)
+
+    testIfAssumePass(assumeFalse("false be assumed to be false", false))
+    testIfAssumePass(assumeFalse(false))
+    testIfAssumePass(assumeFalse("true be assumed to be false", true), ShallNotPass)
+    testIfAssumePass(assumeFalse(true), ShallNotPass)
+  }
+
+  @Test
+  def testAssumeNotNull(): Unit = {
+    testIfAssumePass(assumeNotNull())
+    testIfAssumePass(assumeNotNull(new Object))
+    testIfAssumePass(assumeNotNull("", new Object, " "))
+
+    testIfAssumePass(assumeNotNull(null), ShallNotPass)
+    testIfAssumePass(assumeNotNull(new Object, null), ShallNotPass)
+    testIfAssumePass(assumeNotNull(null, new Object), ShallNotPass)
+  }
+
+  @Test
+  def testAssumeThat(): Unit = {
+    testIfAssumePass(assumeThat(null, nullValue()))
+    testIfAssumePass(assumeThat(null, notNullValue()), ShallNotPass)
+
+    testIfAssumePass(assumeThat(new Object, notNullValue()))
+    testIfAssumePass(assumeThat(new Object, nullValue()), ShallNotPass)
+
+    testIfAssumePass(assumeThat(new Object, notNullValue(classOf[AnyRef])))
+
+    testIfAssumePass(assumeThat(1, is(1)))
+    testIfAssumePass(assumeThat(1, is(2)), ShallNotPass)
+
+    testIfAssumePass(assumeThat(1, not(is(2))))
+    testIfAssumePass(assumeThat(1, not(is(1))), ShallNotPass)
+
+    testIfAssumePass(assumeThat(1, is(not(2))))
+    testIfAssumePass(assumeThat(1, is(not(1))), ShallNotPass)
+
+    testIfAssumePass(assumeThat(1, not(2)))
+    testIfAssumePass(assumeThat(1, not(1)), ShallNotPass)
+  }
+
+  @Test
+  def testAssumesNoException(): Unit = {
+    testIfAssumePass(assumeNoException("assumeNoException(null) should succeed", null))
+    testIfAssumePass(assumeNoException(null))
+
+    testIfAssumePass(assumeNoException("assumeNoException(new Throwable) should succeed",
+        new Throwable), ShallNotPass)
+    testIfAssumePass(assumeNoException(new Throwable), ShallNotPass)
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitBootstrapTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitBootstrapTest.scala
@@ -1,0 +1,22 @@
+package org.scalajs.testsuite.junit
+
+import org.junit.Test
+import org.junit.Assert.assertTrue
+
+import org.scalajs.jasminetest.JasmineTest
+
+class JUnitBootstrapTest {
+  @Test def testClassBootstrap(): Unit = {
+    // This tests that the Scala.js JUnit runtime is working
+    assertTrue(true)
+  }
+}
+
+object JUnitBootstrapTestFromJasmine extends JasmineTest {
+  describe("org.scalajs.testsuite.junit.JUnitBootstrapTest") {
+    it("should bootstrap JUnit test classes") {
+      // This should not fail
+      JUnitUtil.loadBootstrapper("org.scalajs.testsuite.junit.JUnitBootstrapTest")
+    }
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitMixinTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitMixinTest.scala
@@ -1,0 +1,23 @@
+package org.scalajs.testsuite.junit
+
+import org.junit.Assert._
+import org.junit.Test
+
+trait JUnitMixinTestTrait {
+  @Test def mixinTest(): Unit = ()
+}
+
+class JUnitMixinTest extends JUnitMixinTestTrait
+
+class JUnitMixinTestCheck {
+  @Test def jUnitMixinTest(): Unit = {
+    val boot = JUnitUtil.loadBootstrapper(
+        "org.scalajs.testsuite.junit.JUnitMixinTest")
+    try {
+      boot.invoke(boot.newInstance(), "mixinTest")
+    } catch {
+      case _: Throwable =>
+        fail("Could not invoke JUnitMixinTest.mixinTest as a test.")
+    }
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitNamesTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitNamesTest.scala
@@ -1,0 +1,25 @@
+package org.scalajs.testsuite.junit
+
+import org.junit.Test
+import org.junit.Assert._
+
+class JUnitNamesTest {
+  @Test def +(): Unit = ()
+  @Test def `*`(): Unit = ()
+  @Test def `∆ƒ`(): Unit = ()
+}
+
+class JUnitNamesTestCheck {
+  @Test def jUnitNamesTest(): Unit = {
+    val boot = JUnitUtil.loadBootstrapper(
+        "org.scalajs.testsuite.junit.JUnitNamesTest")
+    try {
+      boot.invoke(boot.newInstance(), "$plus")
+      boot.invoke(boot.newInstance(), "$times")
+      boot.invoke(boot.newInstance(), "$u2206ƒ")
+    } catch {
+      case _: Throwable =>
+        fail("Could not invoke method on JUnitNamesTest.")
+    }
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitPackageTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitPackageTest.scala
@@ -1,0 +1,28 @@
+package org.scalajs.testsuite.junit
+
+import org.junit.Test
+import org.junit.Assert._
+
+package Outer {
+  class JUnitPackageTestOuter {
+    @Test def fun(): Unit = ()
+  }
+
+  package Inner {
+    class JUnitPackageTestInner {
+      @Test def fun(): Unit = ()
+    }
+  }
+}
+
+class JUnitPackageTest {
+  @Test def testOuterTransformation(): Unit = {
+    JUnitUtil.loadBootstrapper(
+      "org.scalajs.testsuite.junit.Outer.JUnitPackageTestOuter")
+  }
+
+  @Test def testInnerTransformation(): Unit = {
+    JUnitUtil.loadBootstrapper(
+      "org.scalajs.testsuite.junit.Outer.Inner.JUnitPackageTestInner")
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitSubClassTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitSubClassTest.scala
@@ -1,0 +1,51 @@
+package org.scalajs.testsuite.junit
+
+import org.junit.Assert._
+import org.junit.Test
+
+class JUnitSubClassTest {
+  @Test def test1(): Unit = ()
+}
+
+class JUnitSubClassExtended1Test extends JUnitSubClassTest
+
+class JUnitSubClassExtended2Test extends JUnitSubClassTest {
+  @Test def test2(): Unit = ()
+}
+
+class JUnitSubClassTestCheck {
+
+  @Test def testSubClass0(): Unit = {
+    val boot = JUnitUtil.loadBootstrapper(
+        "org.scalajs.testsuite.junit.JUnitSubClassTest")
+    try {
+      boot.invoke(boot.newInstance(), "test1")
+    } catch {
+      case e: Throwable =>
+        fail(s"Could not invoke a test: ${e.getMessage}")
+    }
+  }
+
+  @Test def testSubClass1(): Unit = {
+    val boot = JUnitUtil.loadBootstrapper(
+        "org.scalajs.testsuite.junit.JUnitSubClassExtended1Test")
+    try {
+      boot.invoke(boot.newInstance(), "test1")
+    } catch {
+      case e: Throwable =>
+        fail(s"Could not invoke a test: ${e.getMessage}")
+    }
+  }
+
+  @Test def testSubClass2(): Unit = {
+    val boot = JUnitUtil.loadBootstrapper(
+        "org.scalajs.testsuite.junit.JUnitSubClassExtended2Test")
+    try {
+      boot.invoke(boot.newInstance(), "test1")
+      boot.invoke(boot.newInstance(), "test2")
+    } catch {
+      case e: Throwable =>
+        fail(s"Could not invoke a test: ${e.getMessage}")
+    }
+  }
+}

--- a/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
@@ -1,0 +1,22 @@
+package org.scalajs.testsuite.junit
+
+import org.scalajs.junit.JUnitTestBootstrapper
+import org.junit.Assert.fail
+
+import scalajs.js
+
+object JUnitUtil {
+  private final val BootstrapperSuffix = "$scalajs$junit$bootstrapper"
+
+  def loadBootstrapper(classFullName: String): JUnitTestBootstrapper = {
+    val fullName = s"$classFullName$BootstrapperSuffix"
+    try {
+      fullName.split('.').foldLeft(js.Dynamic.global) { (obj, n) =>
+        obj.selectDynamic(n)
+      }.apply().asInstanceOf[JUnitTestBootstrapper]
+    } catch {
+      case ex: Throwable =>
+        throw new AssertionError(s"could not load $fullName: ${ex.getMessage}")
+    }
+  }
+}


### PR DESCRIPTION
* Add junit-runntime:
 * Adapt JUnit classes
 * Adapt sbt junit-interface
 * Adapt hamcrest Matchers (partial support)
 * Custom sbt JUnit test framework.
* Add junit-plugin: Transforms classes containing method with @Test
  to retain data that would usually be accessed through reflection.
* Create new sbt confuiguration for plugins that are only added in
  test configurations ('scala-js-test-plugin').
* Add JUnit framework to test-suite
* Add JUnit plugin test in sbt-plugin-test