### PR TITLE
Fix #1966: ChronoUnit and ChronoField

### DIFF
--- a/javalib/src/main/scala/java/time/temporal/ChronoField.scala
+++ b/javalib/src/main/scala/java/time/temporal/ChronoField.scala
@@ -1,9 +1,10 @@
 package java.time.temporal
 
 final class ChronoField private (name: String, ordinal: Int,
-    _range: ValueRange, dateBased: Boolean, baseUnit: ChronoUnit,
-    rangeUnit: ChronoUnit) extends Enum[ChronoField](name, ordinal)
-    with TemporalField {
+    _range: ValueRange, baseUnit: ChronoUnit, rangeUnit: ChronoUnit, flags: Int)
+    extends Enum[ChronoField](name, ordinal) with TemporalField {
+
+  import ChronoField._
 
   // Not implemented:
   // def String getDisplayName(locale: java.util.Locale)
@@ -14,9 +15,9 @@ final class ChronoField private (name: String, ordinal: Int,
 
   def range(): ValueRange = _range
 
-  def isDateBased(): Boolean = dateBased
+  def isDateBased(): Boolean = (flags & isDateBasedFlag) != 0
 
-  def isTimeBased(): Boolean = !dateBased
+  def isTimeBased(): Boolean = (flags & isTimeBasedFlag) != 0
 
   def checkValidValue(value: Long): Long =
     _range.checkValidValue(value, this)
@@ -40,95 +41,98 @@ object ChronoField {
 
   import ChronoUnit._
 
+  private final val isTimeBasedFlag = 1
+  private final val isDateBasedFlag = 2
+
   final val NANO_OF_SECOND = new ChronoField("NanoOfSecond", 0,
-      ValueRange.of(0, 999999999), false, NANOS, SECONDS)
+      ValueRange.of(0, 999999999), NANOS, SECONDS, isTimeBasedFlag)
 
   final val NANO_OF_DAY = new ChronoField("NanoOfDay", 1,
-      ValueRange.of(0, 86399999999999L), false, NANOS, DAYS)
+      ValueRange.of(0, 86399999999999L), NANOS, DAYS, isTimeBasedFlag)
 
   final val MICRO_OF_SECOND = new ChronoField("MicroOfSecond", 2,
-      ValueRange.of(0, 999999), false, MICROS, SECONDS)
+      ValueRange.of(0, 999999), MICROS, SECONDS, isTimeBasedFlag)
 
   final val MICRO_OF_DAY = new ChronoField("MicroOfDay", 3,
-      ValueRange.of(0, 86399999999L), false, MICROS, DAYS)
+      ValueRange.of(0, 86399999999L), MICROS, DAYS, isTimeBasedFlag)
 
   final val MILLI_OF_SECOND = new ChronoField("MilliOfSecond", 4,
-      ValueRange.of(0, 999), false, MILLIS, SECONDS)
+      ValueRange.of(0, 999), MILLIS, SECONDS, isTimeBasedFlag)
 
   final val MILLI_OF_DAY = new ChronoField("MilliOfDay", 5,
-      ValueRange.of(0, 86399999), false, MILLIS, DAYS)
+      ValueRange.of(0, 86399999), MILLIS, DAYS, isTimeBasedFlag)
 
   final val SECOND_OF_MINUTE = new ChronoField("SecondOfMinute", 6,
-      ValueRange.of(0, 59), false, SECONDS, MINUTES)
+      ValueRange.of(0, 59), SECONDS, MINUTES, isTimeBasedFlag)
 
   final val SECOND_OF_DAY = new ChronoField("SecondOfDay", 7,
-      ValueRange.of(0, 86399), false, SECONDS, DAYS)
+      ValueRange.of(0, 86399), SECONDS, DAYS, isTimeBasedFlag)
 
   final val MINUTE_OF_HOUR = new ChronoField("MinuteOfHour", 8,
-      ValueRange.of(0, 59), false, MINUTES, HOURS)
+      ValueRange.of(0, 59), MINUTES, HOURS, isTimeBasedFlag)
 
   final val MINUTE_OF_DAY = new ChronoField("MinuteOfDay", 9,
-      ValueRange.of(0, 1439), false, MINUTES, DAYS)
+      ValueRange.of(0, 1439), MINUTES, DAYS, isTimeBasedFlag)
 
   final val HOUR_OF_AMPM = new ChronoField("HourOfAmPm", 10,
-      ValueRange.of(0, 11), false, HOURS, HALF_DAYS)
+      ValueRange.of(0, 11), HOURS, HALF_DAYS, isTimeBasedFlag)
 
   final val CLOCK_HOUR_OF_AMPM = new ChronoField("ClockHourOfAmPm", 11,
-      ValueRange.of(1, 12), false, HOURS, HALF_DAYS)
+      ValueRange.of(1, 12), HOURS, HALF_DAYS, isTimeBasedFlag)
 
   final val HOUR_OF_DAY = new ChronoField("HourOfDay", 12,
-      ValueRange.of(0, 23), false, HOURS, DAYS)
+      ValueRange.of(0, 23), HOURS, DAYS, isTimeBasedFlag)
 
   final val CLOCK_HOUR_OF_DAY = new ChronoField("ClockHourOfDay", 13,
-      ValueRange.of(1, 24), false, HOURS, DAYS)
+      ValueRange.of(1, 24), HOURS, DAYS, isTimeBasedFlag)
 
   final val AMPM_OF_DAY = new ChronoField("AmPmOfDay", 14,
-      ValueRange.of(0, 1), false, HALF_DAYS, DAYS)
+      ValueRange.of(0, 1), HALF_DAYS, DAYS, isTimeBasedFlag)
 
   final val DAY_OF_WEEK = new ChronoField("DayOfWeek", 15,
-      ValueRange.of(1, 7), true, DAYS, WEEKS)
+      ValueRange.of(1, 7), DAYS, WEEKS, isDateBasedFlag)
 
   final val ALIGNED_DAY_OF_WEEK_IN_MONTH = new ChronoField("AlignedDayOfWeekInMonth",
-      16, ValueRange.of(1, 7), true, DAYS, WEEKS)
+      16, ValueRange.of(1, 7), DAYS, WEEKS, isDateBasedFlag)
 
   final val ALIGNED_DAY_OF_WEEK_IN_YEAR = new ChronoField("AlignedDayOfWeekInYear",
-      17, ValueRange.of(1, 7), true, DAYS, WEEKS)
+      17, ValueRange.of(1, 7), DAYS, WEEKS, isDateBasedFlag)
 
   final val DAY_OF_MONTH = new ChronoField("DayOfMonth", 18,
-      ValueRange.of(1, 28, 31), true, DAYS, MONTHS)
+      ValueRange.of(1, 28, 31), DAYS, MONTHS, isDateBasedFlag)
 
   final val DAY_OF_YEAR = new ChronoField("DayOfYear", 19,
-      ValueRange.of(1, 365, 366), true, DAYS, YEARS)
+      ValueRange.of(1, 365, 366), DAYS, YEARS, isDateBasedFlag)
 
   final val EPOCH_DAY = new ChronoField("EpochDay", 20,
-      ValueRange.of(-365249999634L, 365249999634L), true, DAYS, FOREVER)
+      ValueRange.of(-365249999634L, 365249999634L), DAYS, FOREVER, isDateBasedFlag)
 
   final val ALIGNED_WEEK_OF_MONTH = new ChronoField("AlignedWeekOfMonth", 21,
-      ValueRange.of(1, 4, 5), true, WEEKS, MONTHS)
+      ValueRange.of(1, 4, 5), WEEKS, MONTHS, isDateBasedFlag)
 
   final val ALIGNED_WEEK_OF_YEAR = new ChronoField("AlignedWeekOfYear", 22,
-      ValueRange.of(1, 53), true, WEEKS, YEARS)
+      ValueRange.of(1, 53), WEEKS, YEARS, isDateBasedFlag)
 
   final val MONTH_OF_YEAR = new ChronoField("MonthOfYear", 23,
-      ValueRange.of(1, 12), true, MONTHS, YEARS)
+      ValueRange.of(1, 12), MONTHS, YEARS, isDateBasedFlag)
 
   final val PROLEPTIC_MONTH = new ChronoField("ProlepticMonth", 24,
-      ValueRange.of(-11999999988L, 11999999999L), true, MONTHS, FOREVER)
+      ValueRange.of(-11999999988L, 11999999999L), MONTHS, FOREVER, isDateBasedFlag)
 
   final val YEAR_OF_ERA = new ChronoField("YearOfEra", 25,
-      ValueRange.of(1, 999999999, 1000000000), true, YEARS, ERAS)
+      ValueRange.of(1, 999999999, 1000000000), YEARS, ERAS, isDateBasedFlag)
 
   final val YEAR = new ChronoField("Year", 26,
-      ValueRange.of(-999999999, 999999999), true, YEARS, FOREVER)
+      ValueRange.of(-999999999, 999999999), YEARS, FOREVER, isDateBasedFlag)
 
-  final val ERA = new ChronoField("Era", 27, ValueRange.of(0, 1), true, ERAS,
-      FOREVER)
+  final val ERA = new ChronoField("Era", 27, ValueRange.of(0, 1), ERAS, FOREVER,
+      isDateBasedFlag)
 
   final val INSTANT_SECONDS = new ChronoField("InstantSeconds", 28,
-      ValueRange.of(Long.MinValue, Long.MaxValue), false, SECONDS, FOREVER)
+      ValueRange.of(Long.MinValue, Long.MaxValue), SECONDS, FOREVER, 0)
 
   final val OFFSET_SECONDS = new ChronoField("OffsetSeconds", 29,
-      ValueRange.of(-64800, 64800), false, SECONDS, FOREVER)
+      ValueRange.of(-64800, 64800), SECONDS, FOREVER, 0)
 
   private val fields = Array(NANO_OF_SECOND, NANO_OF_DAY, MICRO_OF_SECOND,
       MICRO_OF_DAY, MILLI_OF_SECOND, MILLI_OF_DAY, SECOND_OF_MINUTE,

--- a/javalib/src/main/scala/java/time/temporal/ChronoUnit.scala
+++ b/javalib/src/main/scala/java/time/temporal/ChronoUnit.scala
@@ -3,16 +3,17 @@ package java.time.temporal
 import java.time.Duration
 
 final class ChronoUnit private (name: String, ordinal: Int, duration: Duration,
-    dateBased: Boolean) extends Enum[ChronoUnit](name, ordinal)
-    with TemporalUnit {
+    flags: Int) extends Enum[ChronoUnit](name, ordinal) with TemporalUnit {
+
+  import ChronoUnit._
 
   def getDuration(): Duration = duration
 
-  def isDurationEstimated(): Boolean = dateBased
+  def isDurationEstimated(): Boolean = (flags & isTimeBasedFlag) == 0
 
-  def isDateBased(): Boolean = dateBased
+  def isDateBased(): Boolean = (flags & isDateBasedFlag) != 0
 
-  def isTimeBased(): Boolean = !dateBased
+  def isTimeBased(): Boolean = (flags & isTimeBasedFlag) != 0
 
   override def isSupportedBy(temporal: Temporal): Boolean =
     temporal.isSupported(this)
@@ -24,41 +25,54 @@ final class ChronoUnit private (name: String, ordinal: Int, duration: Duration,
 }
 
 object ChronoUnit {
-  final val NANOS = new ChronoUnit("Nanos", 0, Duration.OneNano, false)
+  private final val isTimeBasedFlag = 1
+  private final val isDateBasedFlag = 2
 
-  final val MICROS = new ChronoUnit("Micros", 1, Duration.OneMicro, false)
+  final val NANOS =
+    new ChronoUnit("Nanos", 0, Duration.OneNano, isTimeBasedFlag)
 
-  final val MILLIS = new ChronoUnit("Millis", 2, Duration.OneMilli, false)
+  final val MICROS =
+    new ChronoUnit("Micros", 1, Duration.OneMicro, isTimeBasedFlag)
 
-  final val SECONDS = new ChronoUnit("Seconds", 3, Duration.OneSecond, false)
+  final val MILLIS =
+    new ChronoUnit("Millis", 2, Duration.OneMilli, isTimeBasedFlag)
 
-  final val MINUTES = new ChronoUnit("Minutes", 4, Duration.OneMinute, false)
+  final val SECONDS =
+    new ChronoUnit("Seconds", 3, Duration.OneSecond, isTimeBasedFlag)
 
-  final val HOURS = new ChronoUnit("Hours", 5, Duration.OneHour, false)
+  final val MINUTES =
+    new ChronoUnit("Minutes", 4, Duration.OneMinute, isTimeBasedFlag)
 
-  final val HALF_DAYS = new ChronoUnit("HalfDays", 6, Duration.ofHours(12), false)
+  final val HOURS =
+    new ChronoUnit("Hours", 5, Duration.OneHour, isTimeBasedFlag)
 
-  final val DAYS = new ChronoUnit("Days", 7, Duration.OneDay, true)
+  final val HALF_DAYS =
+    new ChronoUnit("HalfDays", 6, Duration.ofHours(12), isTimeBasedFlag)
 
-  final val WEEKS = new ChronoUnit("Weeks", 8, Duration.OneWeek, true)
+  final val DAYS = new ChronoUnit("Days", 7, Duration.OneDay, isDateBasedFlag)
 
-  final val MONTHS = new ChronoUnit("Months", 9, Duration.OneMonth, true)
+  final val WEEKS =
+    new ChronoUnit("Weeks", 8, Duration.OneWeek, isDateBasedFlag)
 
-  final val YEARS = new ChronoUnit("Years", 10, Duration.OneYear, true)
+  final val MONTHS =
+    new ChronoUnit("Months", 9, Duration.OneMonth, isDateBasedFlag)
+
+  final val YEARS =
+    new ChronoUnit("Years", 10, Duration.OneYear, isDateBasedFlag)
 
   final val DECADES = new ChronoUnit("Decades", 11,
-      Duration.OneYear.multipliedBy(10), true)
+      Duration.OneYear.multipliedBy(10), isDateBasedFlag)
 
   final val CENTURIES = new ChronoUnit("Centuries", 12,
-      Duration.OneYear.multipliedBy(100), true)
+      Duration.OneYear.multipliedBy(100), isDateBasedFlag)
 
-  final val MILLENNIA = new ChronoUnit("Millenia", 13,
-      Duration.OneYear.multipliedBy(1000), true)
+  final val MILLENNIA = new ChronoUnit("Millennia", 13,
+      Duration.OneYear.multipliedBy(1000), isDateBasedFlag)
 
   final val ERAS = new ChronoUnit("Eras", 14,
-      Duration.OneYear.multipliedBy(1000000000), true)
+      Duration.OneYear.multipliedBy(1000000000), isDateBasedFlag)
 
-  final val FOREVER = new ChronoUnit("Forever", 15, Duration.Max, true)
+  final val FOREVER = new ChronoUnit("Forever", 15, Duration.Max, 0)
 
   private val units =
     Array(NANOS, MICROS, MILLIS, SECONDS, MINUTES, HOURS, HALF_DAYS, DAYS,

--- a/test-suite/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/temporal/ChronoFieldTest.scala
+++ b/test-suite/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/temporal/ChronoFieldTest.scala
@@ -8,6 +8,72 @@ object ChronoFieldTest extends JasmineTest {
   import ChronoField._
 
   describe("java.time.temporal.ChronoField") {
+    it("should respond to `isDateBased`") {
+      expect(NANO_OF_SECOND.isDateBased).toBeFalsy
+      expect(NANO_OF_DAY.isDateBased).toBeFalsy
+      expect(MICRO_OF_SECOND.isDateBased).toBeFalsy
+      expect(MICRO_OF_DAY.isDateBased).toBeFalsy
+      expect(MILLI_OF_SECOND.isDateBased).toBeFalsy
+      expect(MILLI_OF_DAY.isDateBased).toBeFalsy
+      expect(SECOND_OF_MINUTE.isDateBased).toBeFalsy
+      expect(SECOND_OF_DAY.isDateBased).toBeFalsy
+      expect(MINUTE_OF_HOUR.isDateBased).toBeFalsy
+      expect(MINUTE_OF_DAY.isDateBased).toBeFalsy
+      expect(HOUR_OF_AMPM.isDateBased).toBeFalsy
+      expect(CLOCK_HOUR_OF_AMPM.isDateBased).toBeFalsy
+      expect(HOUR_OF_DAY.isDateBased).toBeFalsy
+      expect(CLOCK_HOUR_OF_DAY.isDateBased).toBeFalsy
+      expect(AMPM_OF_DAY.isDateBased).toBeFalsy
+      expect(DAY_OF_WEEK.isDateBased).toBeTruthy
+      expect(ALIGNED_DAY_OF_WEEK_IN_MONTH.isDateBased).toBeTruthy
+      expect(ALIGNED_DAY_OF_WEEK_IN_YEAR.isDateBased).toBeTruthy
+      expect(DAY_OF_MONTH.isDateBased).toBeTruthy
+      expect(DAY_OF_YEAR.isDateBased).toBeTruthy
+      expect(EPOCH_DAY.isDateBased).toBeTruthy
+      expect(ALIGNED_WEEK_OF_MONTH.isDateBased).toBeTruthy
+      expect(ALIGNED_WEEK_OF_YEAR.isDateBased).toBeTruthy
+      expect(MONTH_OF_YEAR.isDateBased).toBeTruthy
+      expect(PROLEPTIC_MONTH.isDateBased).toBeTruthy
+      expect(YEAR_OF_ERA.isDateBased).toBeTruthy
+      expect(YEAR.isDateBased).toBeTruthy
+      expect(ERA.isDateBased).toBeTruthy
+      expect(INSTANT_SECONDS.isDateBased).toBeFalsy
+      expect(OFFSET_SECONDS.isDateBased).toBeFalsy
+    }
+
+    it("should respond to `isTimeBased`") {
+      expect(NANO_OF_SECOND.isTimeBased).toBeTruthy
+      expect(NANO_OF_DAY.isTimeBased).toBeTruthy
+      expect(MICRO_OF_SECOND.isTimeBased).toBeTruthy
+      expect(MICRO_OF_DAY.isTimeBased).toBeTruthy
+      expect(MILLI_OF_SECOND.isTimeBased).toBeTruthy
+      expect(MILLI_OF_DAY.isTimeBased).toBeTruthy
+      expect(SECOND_OF_MINUTE.isTimeBased).toBeTruthy
+      expect(SECOND_OF_DAY.isTimeBased).toBeTruthy
+      expect(MINUTE_OF_HOUR.isTimeBased).toBeTruthy
+      expect(MINUTE_OF_DAY.isTimeBased).toBeTruthy
+      expect(HOUR_OF_AMPM.isTimeBased).toBeTruthy
+      expect(CLOCK_HOUR_OF_AMPM.isTimeBased).toBeTruthy
+      expect(HOUR_OF_DAY.isTimeBased).toBeTruthy
+      expect(CLOCK_HOUR_OF_DAY.isTimeBased).toBeTruthy
+      expect(AMPM_OF_DAY.isTimeBased).toBeTruthy
+      expect(DAY_OF_WEEK.isTimeBased).toBeFalsy
+      expect(ALIGNED_DAY_OF_WEEK_IN_MONTH.isTimeBased).toBeFalsy
+      expect(ALIGNED_DAY_OF_WEEK_IN_YEAR.isTimeBased).toBeFalsy
+      expect(DAY_OF_MONTH.isTimeBased).toBeFalsy
+      expect(DAY_OF_YEAR.isTimeBased).toBeFalsy
+      expect(EPOCH_DAY.isTimeBased).toBeFalsy
+      expect(ALIGNED_WEEK_OF_MONTH.isTimeBased).toBeFalsy
+      expect(ALIGNED_WEEK_OF_YEAR.isTimeBased).toBeFalsy
+      expect(MONTH_OF_YEAR.isTimeBased).toBeFalsy
+      expect(PROLEPTIC_MONTH.isTimeBased).toBeFalsy
+      expect(YEAR_OF_ERA.isTimeBased).toBeFalsy
+      expect(YEAR.isTimeBased).toBeFalsy
+      expect(ERA.isTimeBased).toBeFalsy
+      expect(INSTANT_SECONDS.isTimeBased).toBeFalsy
+      expect(OFFSET_SECONDS.isTimeBased).toBeFalsy
+    }
+
     it("should respond to `values`") {
       val fields = ChronoField.values()
 

--- a/test-suite/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/temporal/ChronoUnitTest.scala
+++ b/test-suite/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/temporal/ChronoUnitTest.scala
@@ -8,6 +8,49 @@ object ChronoUnitTest extends JasmineTest {
   import ChronoUnit._
 
   describe("java.time.temporal.ChronoUnit") {
+    it("should respond to `isDurationEstimated`") {
+      for (u <- ChronoUnit.values())
+        expect(u.isDurationEstimated != u.isTimeBased).toBeTruthy
+    }
+
+    it("should respond to `isDateBased`") {
+      expect(NANOS.isDateBased).toBeFalsy
+      expect(MICROS.isDateBased).toBeFalsy
+      expect(MILLIS.isDateBased).toBeFalsy
+      expect(SECONDS.isDateBased).toBeFalsy
+      expect(MINUTES.isDateBased).toBeFalsy
+      expect(HOURS.isDateBased).toBeFalsy
+      expect(HALF_DAYS.isDateBased).toBeFalsy
+      expect(DAYS.isDateBased).toBeTruthy
+      expect(WEEKS.isDateBased).toBeTruthy
+      expect(MONTHS.isDateBased).toBeTruthy
+      expect(YEARS.isDateBased).toBeTruthy
+      expect(DECADES.isDateBased).toBeTruthy
+      expect(CENTURIES.isDateBased).toBeTruthy
+      expect(MILLENNIA.isDateBased).toBeTruthy
+      expect(ERAS.isDateBased).toBeTruthy
+      expect(FOREVER.isDateBased).toBeFalsy
+    }
+
+    it("should respond to `isTimeBased`") {
+      expect(NANOS.isTimeBased).toBeTruthy
+      expect(MICROS.isTimeBased).toBeTruthy
+      expect(MILLIS.isTimeBased).toBeTruthy
+      expect(SECONDS.isTimeBased).toBeTruthy
+      expect(MINUTES.isTimeBased).toBeTruthy
+      expect(HOURS.isTimeBased).toBeTruthy
+      expect(HALF_DAYS.isTimeBased).toBeTruthy
+      expect(DAYS.isTimeBased).toBeFalsy
+      expect(WEEKS.isTimeBased).toBeFalsy
+      expect(MONTHS.isTimeBased).toBeFalsy
+      expect(YEARS.isTimeBased).toBeFalsy
+      expect(DECADES.isTimeBased).toBeFalsy
+      expect(CENTURIES.isTimeBased).toBeFalsy
+      expect(MILLENNIA.isTimeBased).toBeFalsy
+      expect(ERAS.isTimeBased).toBeFalsy
+      expect(FOREVER.isTimeBased).toBeFalsy
+    }
+
     it("should respond to `values`") {
       val units = ChronoUnit.values()
 
@@ -43,7 +86,7 @@ object ChronoUnitTest extends JasmineTest {
       expect(valueOf("YEARS") == YEARS).toBeTruthy
       expect(valueOf("DECADES") == DECADES).toBeTruthy
       expect(valueOf("CENTURIES") == CENTURIES).toBeTruthy
-      expect(valueOf("MILLENIA") == MILLENNIA).toBeTruthy
+      expect(valueOf("MILLENNIA") == MILLENNIA).toBeTruthy
       expect(valueOf("ERAS") == ERAS).toBeTruthy
       expect(valueOf("FOREVER") == FOREVER).toBeTruthy
     }


### PR DESCRIPTION
This fixes the behavior of `isDateBased` and `isTimeBased` on `ChronoUnit.FOREVER` as well as `ChronoField.INSTANT_SECONDS` and `ChronoField.OFFSET_SECONDS`.

Fixes #1966.

~~Also fixes the behavior of `LocalTime.isSupported` on null argument (should return `false` instead of throw an exception).~~