### PR TITLE
Fix #1990: Do not duplicate % for 1-arg console.log on Node.js >= 2.1.0.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -281,11 +281,24 @@ class NodeJSEnv private (
           """
           // Hack console log to duplicate double % signs
           (function() {
+            function startsWithAnyOf(s, prefixes) {
+              for (var i = 0; i < prefixes.length; i++) {
+                // ES5 does not have .startsWith() on strings
+                if (s.substring(0, prefixes[i].length) === prefixes[i])
+                  return true;
+              }
+              return false;
+            }
+            var nodeWillDeduplicateEvenForOneArgument = startsWithAnyOf(
+                process.version, ["v0.", "v1.", "v2.0."]);
             var oldLog = console.log;
             var newLog = function() {
               var args = arguments;
               if (args.length >= 1 && args[0] !== void 0 && args[0] !== null) {
-                args[0] = args[0].toString().replace(/%/g, "%%");
+                var argStr = args[0].toString();
+                if (args.length > 1 || nodeWillDeduplicateEvenForOneArgument)
+                  argStr = argStr.replace(/%/g, "%%");
+                args[0] = argStr;
               }
               oldLog.apply(console, args);
             };


### PR DESCRIPTION
As of io.js v2.1.0 (which later merged back into Node.js v4), console.log() does not deduplicate % signs anymore if only one argument is given to console.log().

This commit detects the version of Node.js, and will only duplicate % signs on old versions, or if there is more than one argument given to log(). This precisely restores the previous behavior of our patching of console.log() on recent versions.