### PR TITLE
Fix #1955: Recognize an additional shape of Match in the back-end.

### DIFF
--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -12,7 +12,9 @@ import scala.annotation.tailrec
 import scala.scalajs.js
 import org.scalajs.jasminetest.JasmineTest
 
-object RegressionTest extends JasmineTest {
+import org.scalajs.testsuite.utils.ExpectExceptions
+
+object RegressionTest extends JasmineTest with ExpectExceptions {
 
   class Bug218Foo[T](val x: T) extends AnyVal
 
@@ -433,6 +435,15 @@ object RegressionTest extends JasmineTest {
       expect(x).toEqual(5)
     }
 
+    it("switch-match with a guard and a result type of BoxedUnit - #1955") {
+      val bug = new Bug1955
+      bug.bug(2, true)
+      expect(bug.result).toEqual(0)
+      bug.bug(1, true)
+      expect(bug.result).toEqual(579)
+      expectThrows[MatchError](bug.bug(2, false))
+    }
+
     it("null.asInstanceOf[Unit] should succeed - #1691") {
       def getNull(): Any = null
       val x = getNull().asInstanceOf[Unit]: Any
@@ -442,6 +453,24 @@ object RegressionTest extends JasmineTest {
     it("lambda parameter with a dash - #1790") {
       val f = (`a-b`: Int) => `a-b` + 1
       expect(f(5)).toEqual(6)
+    }
+  }
+
+  class Bug1955 {
+    var result: Int = 0
+
+    def doSomething[A](a: Int, b: Int, r: A): A = {
+      result = a + b
+      r
+    }
+
+    def bug(x: Int, e: Boolean): Unit = {
+      x match {
+        case 1 => doSomething(123, 456, ())
+        case 2 if e =>
+      }
+
+      if (false) ()
     }
   }
 }


### PR DESCRIPTION
After mixin, scalac gives us the following tree for the bug()
method:

```scala
    def bug(e: Boolean): Unit = {
      {
        case <synthetic> val x1: Int = 1;
        (x1: Int) match {
          case 1 => Bug.this.doSomething(123, 456, scala.runtime.BoxedUnit.UNIT)
          case 2 => {
            if (e)
              ()
            else
              default4();
            scala.runtime.BoxedUnit.UNIT
          }
          case _ => default4(){
            throw new MatchError(scala.Int.box(x1))
          }
        }
      };
      ()
    };
```

in which the `case 2 =>` has the BoxedUnit.UNIT *after* the
if/else, instead of inside the branches, as one might expect.
We now recognize this shape, and rewrite it by injecting
`scala.runtime.BoxedUnit.UNIT` in the two branches of the if,
so that it fits the shape we can deal with.