### PR TITLE
Automatically generate Infos from the Trees in GenJSCode.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSFiles.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSFiles.scala
@@ -12,7 +12,7 @@ import scala.reflect.internal.pickling.PickleBuffer
 import java.io._
 
 import org.scalajs.core.ir
-import ir.Infos._
+import ir.Infos
 
 /** Send JS ASTs to files
  *
@@ -22,12 +22,12 @@ trait GenJSFiles extends SubComponent { self: GenJSCode =>
   import global._
   import jsAddons._
 
-  def genIRFile(cunit: CompilationUnit, sym: Symbol, tree: ir.Trees.ClassDef,
-      classInfo: ClassInfo): Unit = {
+  def genIRFile(cunit: CompilationUnit, sym: Symbol,
+      tree: ir.Trees.ClassDef): Unit = {
     val outfile = getFileFor(cunit, sym, ".sjsir")
     val output = outfile.bufferedOutput
     try {
-      ir.InfoSerializers.serialize(output, classInfo)
+      ir.InfoSerializers.serialize(output, Infos.generateClassInfo(tree))
       ir.Serializers.serialize(output, tree)
     } finally {
       output.close()


### PR DESCRIPTION
Previously, we used mutable builders, and we had to take care to
call the appropriate mutating methods when constructing immutable
Trees. This was extremely tedious, error-prone, and has been known
to be the cause of bugs in the past.

This commit completely removes all references to Infos from
GenJSCode and GenJSExports. Instead, we focus on building the
Trees. At the end of the process, GenJSFiles can automatically
generate the appropriate ClassInfo for the ClassDef that it needs
to serialize.

This considerably simplifies the code, at the cost of an
additional pass on the Trees to generate the Infos after the fact.