### PR TITLE
Fix #1878: Make comparison between Int and Float work on Floats.

### DIFF
--- a/test-suite/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -104,5 +104,24 @@ object FloatTest extends JasmineTest {
       test(1.973497969450596E-21, 1.973498047135062E-21)
     }
 
+    it("Int should be cast to Float when comparing to Float - #1878") {
+      val intMax: Int = Int.MaxValue
+      val float: Float = (Int.MaxValue - 1).toFloat
+
+      expect(intMax == float).toBeTruthy
+      expect(intMax != float).toBeFalsy
+      expect(intMax < float).toBeFalsy
+      expect(intMax <= float).toBeTruthy
+      expect(intMax > float).toBeFalsy
+      expect(intMax >= float).toBeTruthy
+
+      expect(float == intMax).toBeTruthy
+      expect(float != intMax).toBeFalsy
+      expect(float < intMax).toBeFalsy
+      expect(float <= intMax).toBeTruthy
+      expect(float > intMax).toBeFalsy
+      expect(float >= intMax).toBeTruthy
+    }
+
   }
 }


### PR DESCRIPTION
Previously, such comparisons would work at the Double level,
contrary to their specification. This can cause discrepancies in
the rare cases where the imprecision of casting the Int to Float
makes it equal to the other operand.