### PR TITLE
Fix #1865: Upgrade to MiMa 0.1.8 and reenable it on 2.12.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -89,9 +89,6 @@ object Build extends sbt.Build {
       } else if (newScalaBinaryVersionsInThisRelease.contains(scalaBinaryV)) {
         // New in this release, no binary compatibility to comply to
         None
-      } else if (scalaBinaryV == "2.12.0-M3") {
-        // See #1865: MiMa is much too noisy with 2.12.0-M3 to be useful
-        None
       } else {
         val thisProjectID = projectID.value
         val previousCrossVersion = thisProjectID.crossVersion match {

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -7,7 +7,7 @@ addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.2")
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.1")
 
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.7")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
 


### PR DESCRIPTION
MiMa 0.1.8 fixes the issue https://github.com/typesafehub/migration-manager/issues/78 which was responsible for the high level of noise in 2.12 artifacts.