### PR TITLE
Implement date-related java.time classes

### DIFF
--- a/javalib/src/main/scala/java/time/DayOfWeek.scala
+++ b/javalib/src/main/scala/java/time/DayOfWeek.scala
@@ -1,0 +1,79 @@
+package java.time
+
+import java.time.temporal._
+
+final class DayOfWeek private (name: String, value: Int)
+    extends Enum[DayOfWeek](name, value - 1) with TemporalAccessor
+    with TemporalAdjuster {
+
+  def getValue(): Int = value
+
+  // Not implemented
+  // def getDisplayName(style: TextStyle, locale: ju.Locale): String
+
+  def isSupported(field: TemporalField): Boolean = field match {
+    case _: ChronoField  => field == ChronoField.DAY_OF_WEEK
+    case null            => false
+    case _               => field.isSupportedBy(this)
+  }
+
+  // Implemented by TemporalAccessor
+  // def range(field: TemporalField): ValueRange
+
+  // Implemented by TemporalAccessor
+  // def get(field: TemporalField): Int
+
+  def getLong(field: TemporalField): Long = field match {
+    case ChronoField.DAY_OF_WEEK => ordinal + 1
+
+    case _: ChronoField =>
+      throw new UnsupportedTemporalTypeException(s"Field not supported: $field")
+
+    case _ => field.getFrom(this)
+  }
+
+  def plus(days: Long): DayOfWeek = {
+    val offset = (days % 7 + 7) % 7
+    DayOfWeek.of((ordinal + offset.toInt) % 7 + 1)
+  }
+
+  def minus(days: Long): DayOfWeek = plus(-(days % 7))
+
+  // Not implemented
+  // def query[R](query: TemporalQuery[R]): R
+
+  def adjustInto(temporal: Temporal): Temporal =
+    temporal.`with`(ChronoField.DAY_OF_WEEK, ordinal + 1)
+}
+
+object DayOfWeek {
+  final val MONDAY = new DayOfWeek("MONDAY", 1)
+
+  final val TUESDAY = new DayOfWeek("TUESDAY", 2)
+
+  final val WEDNESDAY = new DayOfWeek("WEDNESDAY", 3)
+
+  final val THURSDAY = new DayOfWeek("THURSDAY", 4)
+
+  final val FRIDAY = new DayOfWeek("FRIDAY", 5)
+
+  final val SATURDAY = new DayOfWeek("SATURDAY", 6)
+
+  final val SUNDAY = new DayOfWeek("SUNDAY", 7)
+
+  private val days =
+    Seq(MONDAY, TUESDAY, WEDNESDAY, THURSDAY, FRIDAY, SATURDAY, SUNDAY)
+
+  def values(): Array[DayOfWeek] = days.toArray
+
+  def valueOf(name: String): DayOfWeek = days.find(_.name == name).getOrElse {
+    throw new IllegalArgumentException(s"No such weekday: $name")
+  }
+
+  def of(dayOfWeek: Int): DayOfWeek = days.lift(dayOfWeek - 1).getOrElse {
+    throw new DateTimeException(s"Invalid value for weekday: $dayOfWeek")
+  }
+
+  def from(temporal: TemporalAccessor): DayOfWeek =
+    DayOfWeek.of(temporal.get(ChronoField.DAY_OF_WEEK))
+}

--- a/javalib/src/main/scala/java/time/LocalDate.scala
+++ b/javalib/src/main/scala/java/time/LocalDate.scala
@@ -1,0 +1,421 @@
+package java.time
+
+import scala.scalajs.js
+
+import java.time.chrono.{IsoEra, Era, IsoChronology, ChronoLocalDate}
+import java.time.temporal._
+
+final class LocalDate private (year: Int, month: Month, dayOfMonth: Int)
+    extends ChronoLocalDate with Serializable {
+  import Preconditions.requireDateTime
+  import ChronoField._
+  import ChronoUnit._
+  import LocalDate._
+
+  requireDateTime(year >= minYear && year <= maxYear,
+      s"Invalid value for year: $year")
+
+  private val _isLeapYear = iso.isLeapYear(year)
+
+  requireDateTime(dayOfMonth > 0 && dayOfMonth <= month.maxLength,
+      s"Invalid value for dayOfMonth: $dayOfMonth")
+  requireDateTime(_isLeapYear || dayOfMonth <= month.minLength,
+      s"Invalid value for dayOfMonth: $dayOfMonth")
+
+  private lazy val dayOfYear =
+    month.firstDayOfYear(_isLeapYear) + dayOfMonth - 1
+  private lazy val epochDay = {
+    val year1 = year - 1970
+    val daysBeforeYear = daysBeforeYears(MathJDK8Bridge.floorMod(year1, 400))._2
+    val offset =
+      MathJDK8Bridge.floorDiv(year1, 400).toLong * daysInFourHundredYears
+    offset + daysBeforeYear + dayOfYear - 1
+  }
+  private lazy val dayOfWeek =
+    MathJDK8Bridge.floorMod(epochDay + 3, 7).toInt + 1
+
+  // Implemented by ChronoLocalDate
+  // def isSupported(field: TemporalField): Boolean
+  // def isSupported(unit: TemporalUnit): Boolean
+
+  // Implemented by TemporalAccessor
+  // def range(field: TemporalField): ValueRange
+  // def get(field: TemporalField): Int
+
+  def getLong(field: TemporalField): Long = field match {
+    case DAY_OF_WEEK                  => dayOfWeek
+    case ALIGNED_DAY_OF_WEEK_IN_MONTH => (dayOfMonth - 1) % 7 + 1
+    case ALIGNED_DAY_OF_WEEK_IN_YEAR  => (getLong(DAY_OF_YEAR) - 1) % 7 + 1
+    case DAY_OF_MONTH                 => dayOfMonth
+    case DAY_OF_YEAR                  => dayOfYear
+    case EPOCH_DAY                    => epochDay
+    case ALIGNED_WEEK_OF_MONTH        => (dayOfMonth - 1) / 7 + 1
+    case ALIGNED_WEEK_OF_YEAR         => (dayOfYear - 1) / 7 + 1
+    case MONTH_OF_YEAR                => getMonthValue
+    case PROLEPTIC_MONTH              => year.toLong * 12 + getMonthValue - 1
+    case YEAR_OF_ERA                  => if (year > 0) year else 1 - year
+    case YEAR                         => year
+    case ERA                          => if (year > 0) 1 else 0
+
+    case _: ChronoField =>
+      throw new UnsupportedTemporalTypeException(s"Unsupported field: $field")
+
+    case _ => field.getFrom(this)
+  }
+
+  def getChronology(): IsoChronology = iso
+
+  override def getEra(): Era = if (year > 0) IsoEra.CE else IsoEra.BCE
+
+  def getYear(): Int = year
+
+  def getMonthValue(): Int = month.getValue
+
+  def getMonth(): Month = month
+
+  def getDayOfMonth(): Int = dayOfMonth
+
+  def getDayOfYear(): Int = dayOfYear
+
+  def getDayOfWeek(): DayOfWeek = DayOfWeek.of(dayOfWeek)
+
+  override def isLeapYear(): Boolean = _isLeapYear
+
+  def lengthOfMonth(): Int = month.length(_isLeapYear)
+
+  def lengthOfYear(): Int = if (_isLeapYear) 366 else 365
+
+  override def `with`(adjuster: TemporalAdjuster): LocalDate =
+    adjuster.adjustInto(this).asInstanceOf[LocalDate]
+
+  override def `with`(field: TemporalField, value: Long): LocalDate = {
+    val msg = s"Invalid value for $field: $value"
+    field match {
+      case DAY_OF_WEEK | ALIGNED_DAY_OF_WEEK_IN_MONTH |
+          ALIGNED_DAY_OF_WEEK_IN_YEAR =>
+        requireDateTime(value > 0 && value <= 7, msg)
+        plus(value.toInt - get(field), DAYS)
+
+      case DAY_OF_MONTH =>
+        requireDateTime(value > 0 && value <= 31, msg)
+        withDayOfMonth(value.toInt)
+
+      case DAY_OF_YEAR =>
+        requireDateTime(value > 0 && value <= 366, msg)
+        withDayOfYear(value.toInt)
+
+      case EPOCH_DAY =>
+        ofEpochDay(value)
+
+      case ALIGNED_WEEK_OF_MONTH =>
+        requireDateTime(value > 0 && value <= 5, msg)
+        plus(value.toInt - get(field), WEEKS)
+
+      case ALIGNED_WEEK_OF_YEAR =>
+        requireDateTime(value > 0 && value <= 53, msg)
+        plus(value.toInt - get(field), WEEKS)
+
+      case MONTH_OF_YEAR =>
+        requireDateTime(value > 0 && value <= 12, msg)
+        withMonth(value.toInt)
+
+      case PROLEPTIC_MONTH =>
+        requireDateTime(value >= -11999999988L && value <= 11999999999L, msg)
+        val year = MathJDK8Bridge.floorDiv(value, 12).toInt
+        val month = MathJDK8Bridge.floorMod(value, 12).toInt + 1
+        val day = dayOfMonth min Month.of(month).length(iso.isLeapYear(year))
+        LocalDate.of(year, month, day)
+
+      case YEAR_OF_ERA =>
+        requireDateTime(value > 0 && value <= maxYear + 1, msg)
+        if (getEra == IsoEra.CE) withYear(value.toInt)
+        else withYear(1 - value.toInt)
+
+      case YEAR =>
+        requireDateTime(value >= minYear && value <= maxYear, msg)
+        withYear(value.toInt)
+
+      case ERA =>
+        requireDateTime(value >= 0 && value <= 1, msg)
+        val yearOfEra = get(YEAR_OF_ERA)
+        if (getEra == IsoEra.BCE && value == 1) withYear(yearOfEra)
+        else if (getEra == IsoEra.CE && value == 0) withYear(1 - yearOfEra)
+        else this
+
+      case _: ChronoField =>
+        throw new UnsupportedTemporalTypeException(s"Unsupported field: $field")
+
+      case _ => field.adjustInto(this, value)
+    }
+  }
+
+  def withYear(year: Int): LocalDate = {
+    if (dayOfMonth == 29 && month == Month.FEBRUARY && !iso.isLeapYear(year))
+      LocalDate.of(year, 2, 28)
+    else
+      LocalDate.of(year, month, dayOfMonth)
+  }
+
+  def withMonth(month: Int): LocalDate = {
+    val m = Month.of(month)
+    LocalDate.of(year, m, dayOfMonth min m.length(isLeapYear))
+  }
+
+  def withDayOfMonth(dayOfMonth: Int): LocalDate =
+    LocalDate.of(year, month, dayOfMonth)
+
+  def withDayOfYear(dayOfYear: Int): LocalDate =
+    LocalDate.ofYearDay(year, dayOfYear)
+
+  override def plus(amount: TemporalAmount): LocalDate =
+    amount.addTo(this).asInstanceOf[LocalDate]
+
+  override def plus(amount: Long, unit: TemporalUnit): LocalDate = unit match {
+    case DAYS   => plusDays(amount)
+    case WEEKS  => plusWeeks(amount)
+    case MONTHS => plusMonths(amount)
+    case YEARS  => plusYears(amount)
+
+    case DECADES =>
+      val years = MathJDK8Bridge.multiplyExact(amount, 10)
+      plusYears(years)
+
+    case CENTURIES =>
+      val years = MathJDK8Bridge.multiplyExact(amount, 100)
+      plusYears(years)
+
+    case MILLENNIA =>
+      val years = MathJDK8Bridge.multiplyExact(amount, 1000)
+      plusYears(years)
+
+    case ERAS =>
+      `with`(ERA, MathJDK8Bridge.addExact(get(ERA), amount))
+
+    case _: ChronoUnit =>
+      throw new UnsupportedTemporalTypeException(s"Unsupported unit: $unit")
+
+    case _ => unit.addTo(this, amount)
+  }
+
+  def plusYears(years: Long): LocalDate = {
+    val year1 = year + years
+    requireDateTime(year1 >= minYear && year1 <= maxYear,
+        s"Invalid value for year: $year1")
+    val leap = iso.isLeapYear(year1)
+    val day1 =
+      if (month == Month.FEBRUARY && dayOfMonth == 29 && !leap) 28
+      else dayOfMonth
+    LocalDate.of(year1.toInt, month, day1)
+  }
+
+  def plusMonths(months: Long): LocalDate = {
+    val month1 = getMonthValue + MathJDK8Bridge.floorMod(months, 12).toInt
+    val year1 = year + MathJDK8Bridge.floorDiv(months, 12) +
+        (if (month1 > 12) 1 else 0)
+    requireDateTime(year1 >= minYear && year1 <= maxYear,
+        s"Invalid value for year: $year1")
+    val month2 = Month.of(if (month1 > 12) month1 - 12 else month1)
+    val day = dayOfMonth min month2.length(iso.isLeapYear(year1))
+    LocalDate.of(year1.toInt, month2, day)
+  }
+
+  def plusWeeks(weeks: Long): LocalDate =
+    plusDays(MathJDK8Bridge.multiplyExact(weeks, 7))
+
+  def plusDays(days: Long): LocalDate = {
+    val epochDay1 = MathJDK8Bridge.addExact(epochDay, days)
+    LocalDate.ofEpochDay(epochDay1)
+  }
+
+  override def minus(amount: TemporalAmount): LocalDate =
+    amount.subtractFrom(this).asInstanceOf[LocalDate]
+
+  override def minus(amount: Long, unit: TemporalUnit): LocalDate =
+    if (amount != Long.MinValue) plus(-amount, unit)
+    else plus(Long.MaxValue, unit).plus(1, unit)
+
+  def minusYears(years: Long): LocalDate = plusYears(-years)
+
+  def minusMonths(months: Long): LocalDate = plusMonths(-months)
+
+  def minusWeeks(weeks: Long): LocalDate = plusWeeks(-weeks)
+
+  def minusDays(days: Long): LocalDate =
+    if (days != Long.MinValue) plusDays(-days)
+    else plusDays(Long.MaxValue).plusDays(1)
+
+  // Not implemented
+  // def query[R](query: TemporalQuery[R]): R
+
+  // Implemented by ChronoLocalDate
+  // def adjustInto(temporal: Temporal): Temporal
+
+  def until(end: Temporal, unit: TemporalUnit): Long = {
+    import scala.math.Ordering.Implicits._
+
+    val other = LocalDate.from(end)
+    unit match {
+      case DAYS  => other.toEpochDay - epochDay
+      case WEEKS => (other.toEpochDay - epochDay) / 7
+
+      case MONTHS =>
+        val dmonths =
+          (other.getYear - year).toLong * 12 + other.getMonthValue - getMonthValue
+        if (other.getDayOfMonth < dayOfMonth && dmonths > 0) dmonths - 1
+        else if (other.getDayOfMonth > dayOfMonth && dmonths < 0) dmonths + 1
+        else dmonths
+
+      case YEARS =>
+        val dyears = other.getYear - year
+        if ((other.getMonthValue, other.getDayOfMonth) < (getMonthValue, dayOfMonth) &&
+            dyears > 0)
+          dyears - 1
+        else if ((other.getMonthValue, other.getDayOfMonth) > (getMonthValue, dayOfMonth) &&
+            dyears < 0)
+          dyears + 1
+        else
+          dyears
+
+      case DECADES   => until(end, YEARS) / 10
+      case CENTURIES => until(end, YEARS) / 100
+      case MILLENNIA => until(end, YEARS) / 1000
+
+      case ERAS =>
+        val year1 = other.getYear
+        if (year <= 0 && year1 > 0) 1
+        else if (year > 0 && year1 <= 0) -1
+        else 0
+
+      case _: ChronoUnit =>
+        throw new UnsupportedTemporalTypeException(s"Unsupported unit: $unit")
+
+      case _ => unit.between(this, other)
+    }
+  }
+
+  def until(end: ChronoLocalDate): Period = {
+    val other = LocalDate.from(end)
+    if (equals(other)) Period.ZERO
+    else if (isBefore(other)) {
+      val months = until(other, MONTHS)
+      val date1 = plus(months, MONTHS)
+      val days = date1.until(other, DAYS).toInt
+      val years = (months / 12).toInt
+      val months1 = (months % 12).toInt
+      Period.of(years, months1, days)
+    } else {
+      other.until(this).negated
+    }
+  }
+
+  // Not implemented
+  // def format(formatter: java.time.format.DateTimeFormatter): String
+
+  // TODO
+  // def atTime(time: LocalTime): LocalDateTime
+  // def atTime(hour: Int, minute: Int): LocalDateTime
+  // def atTime(hour: Int, minute: Int, second: Int): LocalDateTime
+  // def atTime(hour: Int, minute: Int, second: Int, nanoOfSecond: Int):
+  //     LocalDateTime
+
+  // Not implemented
+  // def atTime(time: OffsetTime): OffsetDateTime
+
+
+  // TODO
+  // def atStartOfDay(): LocalDateTime
+
+  // Not implemented
+  // def atStartOfDay(id: ZoneId): ZonedDateTime
+
+  override def toEpochDay(): Long = epochDay
+
+  // Implemented by ChronoLocalDate
+  // def compare(other: ChronoLocalDate): Int
+  // def isAfter(other: ChronoLocalDate): Boolean
+  // def isBefore(other: ChronoLocalDate): Boolean
+  // def isEqual(other: ChronoLocalDate): Boolean
+
+  override def equals(other: Any): Boolean = other match {
+    case other: LocalDate => isEqual(other)
+    case _                => false
+  }
+
+  override def hashCode(): Int = epochDay.hashCode
+
+  override def toString(): String = {
+    if (year >= 0 && year < 10000)
+      f"$year%04d-$getMonthValue%02d-$dayOfMonth%02d"
+    else
+      f"$year%+05d-$getMonthValue%02d-$dayOfMonth%02d"
+  }
+}
+
+object LocalDate {
+  import Preconditions.requireDateTime
+
+  private final val iso = IsoChronology.INSTANCE
+
+  private val daysBeforeYears = Stream.iterate(1970 -> 0) { case (year, day) =>
+    if (iso.isLeapYear(year)) (year + 1) -> (day + 366)
+    else (year + 1) -> (day + 365)
+  }.take(400).toVector
+
+  private final val daysInFourHundredYears = 146097
+  private final val minYear = -999999999
+  private final val maxYear = 999999999
+
+  final val MIN = new LocalDate(minYear, Month.JANUARY, 1)
+
+  final val MAX = new LocalDate(maxYear, Month.DECEMBER, 31)
+
+  def now(): LocalDate = {
+    val d = new js.Date()
+    of(d.getFullYear, d.getMonth + 1, d.getDate)
+  }
+
+  // Not implemented
+  // def now(zone: ZoneId): LocalDate
+  // def now(clock: Clock): LocalDate
+
+  def of(year: Int, month: Month, dayOfMonth: Int): LocalDate =
+    new LocalDate(year, month, dayOfMonth)
+
+  def of(year: Int, month: Int, dayOfMonth: Int): LocalDate =
+    new LocalDate(year, Month.of(month), dayOfMonth)
+
+  def ofYearDay(year: Int, dayOfYear: Int): LocalDate = {
+    requireDateTime(dayOfYear > 0 && dayOfYear <= 366,
+        s"Invalid value for dayOfYear: $dayOfYear")
+    val leap = iso.isLeapYear(year)
+    requireDateTime(dayOfYear <= 365 || leap,
+        s"Invalid value for dayOfYear: $dayOfYear")
+    val month = Month.values().takeWhile(_.firstDayOfYear(leap) <= dayOfYear).last
+    val dayOfMonth = dayOfYear - month.firstDayOfYear(leap) + 1
+    of(year, month, dayOfMonth)
+  }
+
+  def ofEpochDay(epochDay: Long): LocalDate = {
+    val quot = MathJDK8Bridge.floorDiv(epochDay, daysInFourHundredYears)
+    val rem = MathJDK8Bridge.floorMod(epochDay, daysInFourHundredYears).toInt
+    val (year1, start) = daysBeforeYears.takeWhile(_._2 <= rem).last
+    val year2 = year1 + quot * 400
+    requireDateTime(year2 >= minYear && year2 <= maxYear,
+        s"Invalid value for year: $year2")
+    val dayOfYear = rem - start + 1
+    LocalDate.ofYearDay(year2.toInt, dayOfYear.toInt)
+  }
+
+  def from(temporal: TemporalAccessor): LocalDate = temporal match {
+    case temporal: LocalDate =>
+      temporal
+
+    case _ =>
+      ofEpochDay(temporal.getLong(ChronoField.EPOCH_DAY))
+  }
+
+  // TODO
+  // def parse(text: CharSequence): LocalDate
+  // def parse(text: CharSequence,
+  //     formatter: java.time.format.DateTimeFormatter): LocalDate
+}

--- a/javalib/src/main/scala/java/time/Month.scala
+++ b/javalib/src/main/scala/java/time/Month.scala
@@ -1,0 +1,109 @@
+package java.time
+
+import java.time.temporal._
+
+final class Month private (name: String, value: Int, defaultLength: Int)
+    extends Enum[Month](name, value - 1) with TemporalAccessor
+    with TemporalAdjuster {
+  import Month._
+
+  private lazy val defaultFirstDayOfYear =
+    months.take(value - 1).foldLeft(1)(_ + _.minLength)
+
+  def getValue(): Int = value
+
+  // Not implemented
+  // def getDisplayName(style: TextStyle, locale: Locale): Locale
+
+  def isSupported(field: TemporalField): Boolean = field match {
+    case _: ChronoField => field == ChronoField.MONTH_OF_YEAR
+    case null           => false
+    case _              => field.isSupportedBy(this)
+  }
+
+  // Implemented by TemporalAccessor
+  // def range(field: TemporalField): ValueRange
+
+  // Implemented by TemporalAccessor
+  // def get(field: TemporalField): Int
+
+  def getLong(field: TemporalField): Long = field match {
+    case ChronoField.MONTH_OF_YEAR => ordinal + 1
+
+    case _: ChronoField =>
+      throw new UnsupportedTemporalTypeException(s"Field not supported: $field")
+
+    case _ => field.getFrom(this)
+  }
+
+  def plus(months: Long): Month = {
+    val offset = if (months < 0) months % 12 + 12 else months % 12
+    of((ordinal + offset.toInt) % 12 + 1)
+  }
+
+  def minus(months: Long): Month = {
+    val offset = if (months < 0) months % 12 else months % 12 - 12
+    of((ordinal - offset.toInt) % 12 + 1)
+  }
+
+  def length(leapYear: Boolean): Int = if (leapYear) maxLength else minLength
+
+  def minLength(): Int = defaultLength
+
+  def maxLength(): Int =
+    if (value == 2) defaultLength + 1 else defaultLength
+
+  def firstDayOfYear(leapYear: Boolean): Int =
+    if (leapYear && value > 2) defaultFirstDayOfYear + 1
+    else defaultFirstDayOfYear
+
+  def firstMonthOfQuarter(): Month = of((ordinal / 3) * 3 + 1)
+
+  // Not implemented
+  // def query[R](query: TemporalQuery[R]): R
+
+  def adjustInto(temporal: Temporal): Temporal =
+    temporal.`with`(ChronoField.MONTH_OF_YEAR, value)
+}
+
+object Month {
+  final lazy val JANUARY = new Month("JANUARY", 1, 31)
+
+  final lazy val FEBRUARY = new Month("FEBRUARY", 2, 28)
+
+  final lazy val MARCH = new Month("MARCH", 3, 31)
+
+  final lazy val APRIL = new Month("APRIL", 4, 30)
+
+  final lazy val MAY = new Month("MAY", 5, 31)
+
+  final lazy val JUNE = new Month("JUNE", 6, 30)
+
+  final lazy val JULY = new Month("JULY", 7, 31)
+
+  final lazy val AUGUST = new Month("AUGUST", 8, 31)
+
+  final lazy val SEPTEMBER = new Month("SEPTEMBER", 9, 30)
+
+  final lazy val OCTOBER = new Month("OCTOBER", 10, 31)
+
+  final lazy val NOVEMBER = new Month("NOVEMBER", 11, 30)
+
+  final lazy val DECEMBER = new Month("DECEMBER", 12, 31)
+
+  private lazy val months = Seq(JANUARY, FEBRUARY, MARCH, APRIL, MAY, JUNE,
+      JULY, AUGUST, SEPTEMBER, OCTOBER, NOVEMBER, DECEMBER)
+
+  def values(): Array[Month] = months.toArray
+
+  def valueOf(name: String): Month = months.find(_.name == name).getOrElse {
+    throw new IllegalArgumentException(s"No such month: $name")
+  }
+
+  def of(month: Int): Month = months.lift(month - 1).getOrElse {
+    throw new DateTimeException(s"Invalid value for month: $month")
+  }
+
+  def from(temporal: TemporalAccessor): Month =
+    Month.of(temporal.get(ChronoField.MONTH_OF_YEAR))
+}

--- a/javalib/src/main/scala/java/time/Period.scala
+++ b/javalib/src/main/scala/java/time/Period.scala
@@ -1,0 +1,194 @@
+package java.time
+
+import scala.collection.JavaConverters._
+
+import java.time.chrono.{IsoChronology, ChronoPeriod}
+import java.time.temporal._
+import java.{util => ju}
+
+final class Period private (years: Int, months: Int, days: Int)
+    extends ChronoPeriod with Serializable {
+  import ChronoUnit._
+
+  def get(unit: TemporalUnit): Long = unit match {
+    case YEARS  => years
+    case MONTHS => months
+    case DAYS   => days
+
+    case _ =>
+      throw new UnsupportedTemporalTypeException(s"Unsupported unit: $unit")
+  }
+
+  def getUnits(): ju.List[TemporalUnit] =
+    Seq[TemporalUnit](YEARS, MONTHS, DAYS).asJava
+
+  def getChronology(): IsoChronology = IsoChronology.INSTANCE
+
+  override def isZero(): Boolean =
+    years == 0 && months == 0 && days == 0
+
+  override def isNegative(): Boolean =
+    years < 0 || months < 0 || days < 0
+
+  def getYears(): Int = years
+
+  def getMonths(): Int = months
+
+  def getDays(): Int = days
+
+  def withYears(years: Int): Period = new Period(years, months, days)
+
+  def withMonths(months: Int): Period = new Period(years, months, days)
+
+  def withDays(days: Int): Period = new Period(years, months, days)
+
+  def plus(amount: TemporalAmount): Period = {
+    val other = Period.from(amount)
+    val years1 = MathJDK8Bridge.addExact(years, other.getYears)
+    val months1 = MathJDK8Bridge.addExact(months, other.getMonths)
+    val days1 = MathJDK8Bridge.addExact(days, other.getDays)
+    new Period(years1, months1, days1)
+  }
+
+  def plusYears(yearsToAdd: Long): Period = {
+    val years1 = MathJDK8Bridge.addExact(years, yearsToAdd)
+    new Period(MathJDK8Bridge.toIntExact(years1), months, days)
+  }
+
+  def plusMonths(monthsToAdd: Long): Period = {
+    val months1 = MathJDK8Bridge.addExact(months, monthsToAdd)
+    new Period(years, MathJDK8Bridge.toIntExact(months1), days)
+  }
+
+  def plusDays(daysToAdd: Long): Period = {
+    val days1 = MathJDK8Bridge.addExact(days, daysToAdd)
+    new Period(years, months, MathJDK8Bridge.toIntExact(days1))
+  }
+
+  def minus(amount: TemporalAmount): Period = {
+    val other = Period.from(amount)
+    val years1 = MathJDK8Bridge.subtractExact(years, other.getYears)
+    val months1 = MathJDK8Bridge.subtractExact(months, other.getMonths)
+    val days1 = MathJDK8Bridge.subtractExact(days, other.getDays)
+    new Period(years1, months1, days1)
+  }
+
+  def minusYears(yearsToSubtract: Long): Period = {
+    val years1 = MathJDK8Bridge.subtractExact(years, yearsToSubtract)
+    new Period(MathJDK8Bridge.toIntExact(years1), months, days)
+  }
+
+  def minusMonths(monthsToSubtract: Long): Period = {
+    val months1 = MathJDK8Bridge.subtractExact(months, monthsToSubtract)
+    new Period(years, MathJDK8Bridge.toIntExact(months1), days)
+  }
+
+  def minusDays(daysToSubtract: Long): Period = {
+    val days1 = MathJDK8Bridge.subtractExact(days, daysToSubtract)
+    new Period(years, months, MathJDK8Bridge.toIntExact(days1))
+  }
+
+  def multipliedBy(scalar: Int): Period = {
+    val years1 = MathJDK8Bridge.multiplyExact(years, scalar)
+    val months1 = MathJDK8Bridge.multiplyExact(months, scalar)
+    val days1 = MathJDK8Bridge.multiplyExact(days, scalar)
+    new Period(years1, months1, days1)
+  }
+
+  override def negated(): Period = multipliedBy(-1)
+
+  def normalized(): Period = {
+    val quot = months / 12
+    val months1 = months % 12
+    val years1 = MathJDK8Bridge.addExact(years, quot)
+    if (years1 > 0 && months1 < 0)
+      new Period(years1 - 1, months1 + 12, days)
+    else if (years1 < 0 && months1 > 0)
+      new Period(years1 + 1, months1 - 12, days)
+    else
+      new Period(years1, months1, days)
+  }
+
+  def toTotalMonths(): Long = years.toLong * 12 + months
+
+  def addTo(temporal: Temporal): Temporal = {
+    // TODO: Check chronology (needs TemporalQuery)
+    val t1 = {
+      if (months == 0 && years != 0) temporal.plus(years, YEARS)
+      else if (months != 0) temporal.plus(toTotalMonths, MONTHS)
+      else temporal
+    }
+    if (days != 0) t1.plus(days, DAYS) else t1
+  }
+
+  def subtractFrom(temporal: Temporal): Temporal = {
+    // TODO: Check chronology (needs TemporalQueries)
+    val t1 = {
+      if (months == 0 && years != 0) temporal.minus(years, YEARS)
+      else if (months != 0) temporal.minus(toTotalMonths, MONTHS)
+      else temporal
+    }
+    if (days != 0) t1.minus(days, DAYS) else t1
+  }
+
+  override def equals(other: Any): Boolean = other match {
+    case that: Period =>
+      years == that.getYears && months == that.getMonths && days == that.getDays
+
+    case _ => false
+  }
+
+  override def hashCode(): Int =
+    31 * (31 * years.hashCode + months.hashCode) + days.hashCode
+
+  override def toString(): String = {
+    if (isZero) "P0D"
+    else {
+      val yearPart = if (years != 0) years.toString + "Y" else ""
+      val monthPart = if (months != 0) months.toString + "M" else ""
+      val dayPart = if (days != 0) days.toString + "D" else ""
+      "P" + yearPart + monthPart + dayPart
+    }
+  }
+}
+
+object Period {
+  final lazy val ZERO = of(0, 0, 0)
+
+  def ofYears(years: Int): Period = of(years, 0, 0)
+
+  def ofMonths(months: Int): Period = of(0, months, 0)
+
+  def ofWeeks(weeks: Int): Period = ofDays(weeks * 7)
+
+  def ofDays(days: Int): Period = of(0, 0, days)
+
+  def of(years: Int, months: Int, days: Int): Period =
+    new Period(years, months, days)
+
+  def from(amount: TemporalAmount): Period = amount match {
+    case amount: Period => amount
+
+    case _ =>
+      amount.getUnits().asScala.foldLeft(ZERO) { (p, unit) =>
+        unit match {
+          case ChronoUnit.YEARS =>
+            p.withYears(MathJDK8Bridge.toIntExact(amount.get(unit)))
+
+          case ChronoUnit.MONTHS =>
+            p.withMonths(MathJDK8Bridge.toIntExact(amount.get(unit)))
+
+          case ChronoUnit.DAYS =>
+            p.withDays(MathJDK8Bridge.toIntExact(amount.get(unit)))
+
+          case _ =>
+            throw new DateTimeException(s"Unit not allowed: $unit")
+        }
+      }
+  }
+
+  def between(start: LocalDate, end: LocalDate): Period = start.until(end)
+
+  // TODO
+  // def parse(text: CharSequence): Period
+}

--- a/javalib/src/main/scala/java/time/chrono/AbstractChronology.scala
+++ b/javalib/src/main/scala/java/time/chrono/AbstractChronology.scala
@@ -1,0 +1,18 @@
+package java.time.chrono
+
+abstract class AbstractChronology protected () extends Chronology {
+  // Not implemented
+  // def resolveDate(fieldValues: ju.Map[TemporalField, Long],
+  //     resolverStyle: java.time.format.ResolverStyle): ChronoLocalDate
+
+  def compareTo(other: Chronology): Int = getId().compareTo(other.getId())
+
+  override def equals(that: Any): Boolean = that match {
+    case c: Chronology => compareTo(c) == 0
+    case _             => false
+  }
+
+  override def hashCode(): Int = getId().hashCode()
+
+  override def toString: String = getId()
+}

--- a/javalib/src/main/scala/java/time/chrono/ChronoLocalDate.scala
+++ b/javalib/src/main/scala/java/time/chrono/ChronoLocalDate.scala
@@ -1,0 +1,117 @@
+package java.time.chrono
+
+import java.time.temporal._
+import java.{util => ju}
+
+trait ChronoLocalDate
+    extends Temporal with TemporalAdjuster with Comparable[ChronoLocalDate] {
+  import ChronoField._
+
+  def getChronology(): Chronology
+
+  def getEra(): Era = getChronology().eraOf(get(ERA))
+
+  def isLeapYear(): Boolean = getChronology().isLeapYear(get(YEAR))
+
+  def lengthOfMonth(): Int
+
+  def lengthOfYear(): Int
+
+  def isSupported(field: TemporalField): Boolean = field match {
+    case _: ChronoField => field.isDateBased
+    case null           => false
+    case _              => field.isSupportedBy(this)
+  }
+
+  def isSupported(unit: TemporalUnit): Boolean = unit match {
+    case _: ChronoUnit => unit.isDateBased
+    case null          => false
+    case _             => unit.isSupportedBy(this)
+  }
+
+  override def `with`(adjuster: TemporalAdjuster): ChronoLocalDate =
+    adjuster.adjustInto(this).asInstanceOf[ChronoLocalDate]
+
+  def `with`(field: TemporalField, value: Long): ChronoLocalDate = field match {
+    case _: ChronoField =>
+      throw new UnsupportedTemporalTypeException(s"Unsupported field: $field")
+
+    case _ => field.adjustInto(this, value)
+  }
+
+  override def plus(amount: TemporalAmount): ChronoLocalDate =
+    amount.addTo(this).asInstanceOf[ChronoLocalDate]
+
+  def plus(amount: Long, unit: TemporalUnit): ChronoLocalDate = unit match {
+    case _: ChronoUnit =>
+      throw new UnsupportedTemporalTypeException(s"Unsupported unit: $unit")
+
+    case _ => unit.addTo(this, amount)
+  }
+
+  override def minus(amount: TemporalAmount): ChronoLocalDate =
+    amount.subtractFrom(this).asInstanceOf[ChronoLocalDate]
+
+  override def minus(amount: Long, unit: TemporalUnit): ChronoLocalDate =
+    if (amount != Long.MinValue) plus(-amount, unit)
+    else plus(Long.MaxValue, unit).plus(1, unit)
+
+  // Not implemented
+  // def query[R](query: TemporalQuery[R]): R
+
+  def adjustInto(temporal: Temporal): Temporal =
+    temporal.`with`(EPOCH_DAY, toEpochDay)
+
+  def until(end: Temporal, unit: TemporalUnit): Long
+
+  def until(end: ChronoLocalDate): ChronoPeriod
+
+  // Not implemented
+  // def format(formatter: java.time.format.DateFormatter): String
+
+  // TODO
+  // def atTime(localTime: LocalTime): ChronoLocalDateTime[_]
+
+  def toEpochDay(): Long = getLong(EPOCH_DAY)
+
+  def compareTo(other: ChronoLocalDate): Int = {
+    val r = toEpochDay.compareTo(other.toEpochDay)
+    if (r == 0) getChronology().compareTo(other.getChronology)
+    else r
+  }
+
+  def isAfter(other: ChronoLocalDate): Boolean =
+    toEpochDay > other.toEpochDay
+
+  def isBefore(other: ChronoLocalDate): Boolean =
+    toEpochDay < other.toEpochDay
+
+  def isEqual(other: ChronoLocalDate): Boolean =
+    other.toEpochDay == toEpochDay
+
+  override def equals(other: Any): Boolean = other match {
+    case other: ChronoLocalDate =>
+      isEqual(other) && getChronology == other.getChronology
+
+    case _ => false
+  }
+
+  override def hashCode: Int = super.hashCode
+}
+
+object ChronoLocalDate {
+  private val tlo = new ju.Comparator[ChronoLocalDate] {
+    def compare(date1: ChronoLocalDate, date2: ChronoLocalDate): Int =
+      date1.toEpochDay.compareTo(date2.toEpochDay)
+  }
+
+  def timeLineOrder(): ju.Comparator[ChronoLocalDate] = tlo
+
+  def from(temporal: TemporalAccessor): ChronoLocalDate = temporal match {
+    case temporal: ChronoLocalDate => temporal
+
+    case _ =>
+      // TODO: Get correct chronology (needs TemporalQuery)
+      IsoChronology.INSTANCE.date(temporal)
+  }
+}

--- a/javalib/src/main/scala/java/time/chrono/ChronoPeriod.scala
+++ b/javalib/src/main/scala/java/time/chrono/ChronoPeriod.scala
@@ -1,0 +1,32 @@
+package java.time.chrono
+
+import scala.collection.JavaConverters._
+
+import java.time.temporal.{Temporal, TemporalAmount}
+
+trait ChronoPeriod extends TemporalAmount {
+  def getChronology(): Chronology
+
+  def isZero(): Boolean = getUnits.asScala.forall(get(_) == 0)
+
+  def isNegative(): Boolean = getUnits.asScala.exists(get(_) < 0)
+
+  def plus(amount: TemporalAmount): ChronoPeriod
+
+  def minus(amount: TemporalAmount): ChronoPeriod
+
+  def multipliedBy(scalar: Int): ChronoPeriod
+
+  def negated(): ChronoPeriod = multipliedBy(-1)
+
+  def normalized(): ChronoPeriod
+
+  def addTo(temporal: Temporal): Temporal
+
+  def subtractFrom(temporal: Temporal): Temporal
+}
+
+object ChronoPeriod {
+  def between(start: ChronoLocalDate, end: ChronoLocalDate): ChronoPeriod =
+    start.until(end)
+}

--- a/javalib/src/main/scala/java/time/chrono/Chronology.scala
+++ b/javalib/src/main/scala/java/time/chrono/Chronology.scala
@@ -1,0 +1,80 @@
+package java.time.chrono
+
+import scala.collection.JavaConverters._
+import scala.scalajs.js
+
+import java.time.{Period, DateTimeException}
+import java.time.temporal.{ValueRange, ChronoField, TemporalAccessor}
+import java.{util => ju}
+
+trait Chronology extends Comparable[Chronology] {
+  def getId(): String
+
+  def getCalendarType(): String
+
+  def date(era: Era, yearOfEra: Int, month: Int, dayOfMonth: Int): ChronoLocalDate =
+    date(prolepticYear(era, yearOfEra), month, dayOfMonth)
+
+  def date(prolepticYear: Int, month: Int, dayOfMonth: Int): ChronoLocalDate
+
+  def dateYearDay(era: Era, yearOfEra: Int, dayOfYear: Int): ChronoLocalDate =
+    dateYearDay(prolepticYear(era, yearOfEra), dayOfYear)
+
+  def dateYearDay(prolepticYear: Int, dayOfYear: Int): ChronoLocalDate
+
+  def dateEpochDay(epochDay: Long): ChronoLocalDate
+
+  def dateNow(): ChronoLocalDate = {
+    val d = new js.Date()
+    date(d.getFullYear, d.getMonth, d.getDate)
+  }
+
+  // Not implemented
+  // def dateNow(zone: ZoneId): ChronoLocalDate
+  // def dateNow(clock: Clock): ChronoLocalDate
+
+  def date(temporal: TemporalAccessor): ChronoLocalDate
+
+  // TODO
+  // def localDateTime(temporal: TemporalAccessor): ChronoLocalDateTime[_]
+
+  // Not implemented
+  // def zonedDateTime(temporal: TemporalAccessor): ChronoZonedDateTime[_]
+  // def zonedDateTime(instant: Instant, zone: ZoneId): ChronoZonedDateTime[_]
+
+  def isLeapYear(prolepticYear: Long): Boolean
+
+  def prolepticYear(era: Era, yearOfEra: Int): Int
+
+  def eraOf(eraValue: Int): Era
+
+  def eras(): ju.List[Era]
+
+  def range(field: ChronoField): ValueRange
+
+  // Not implemented
+  // def getDisplayName(style: java.time.format.TextStyle,
+  //     locale: ju.Locale): String
+
+  // Not implemented
+  // def resolveDate(fieldValues: ju.Map[TemporalField, Long],
+  //     resolverStyle: java.time.format.ResolverStyle): ChronoLocalDate
+
+  def period(years: Int, months: Int, days: Int): ChronoPeriod =
+    Period.of(years, months, days)
+}
+
+object Chronology {
+  // Not implemented
+  // def from(temporal: TemporalAccessor): Chronology
+  // def ofLocale(locale: ju.Locale): Chronology
+
+  def of(id: String): Chronology = {
+    getAvailableChronologies().asScala.find(_.getId == id).getOrElse {
+      throw new DateTimeException(s"Unknown chronology: $id")
+    }
+  }
+
+  def getAvailableChronologies(): ju.Set[Chronology] =
+    Set[Chronology](IsoChronology.INSTANCE).asJava
+}

--- a/javalib/src/main/scala/java/time/chrono/Era.scala
+++ b/javalib/src/main/scala/java/time/chrono/Era.scala
@@ -1,0 +1,35 @@
+package java.time.chrono
+
+import java.time.temporal._
+
+trait Era extends TemporalAccessor with TemporalAdjuster {
+  def getValue(): Int
+
+  def isSupported(field: TemporalField): Boolean = field match {
+    case _: ChronoField  => field == ChronoField.ERA
+    case null            => false
+    case _               => field.isSupportedBy(this)
+  }
+
+  // Implemented by TemporalAccessor
+  // def range(field: TemporalField): ValueRange
+
+  def getLong(field: TemporalField): Long = field match {
+    case ChronoField.ERA => getValue()
+
+    case _: ChronoField =>
+      throw new UnsupportedTemporalTypeException(s"Field not supported: $field")
+
+    case _ => field.getFrom(this)
+  }
+
+  // Not implemented
+  // def query[R](query: TemporalQuery[R]): R
+
+  def adjustInto(temporal: Temporal): Temporal =
+    temporal.`with`(ChronoField.ERA, getValue())
+
+  // Not implemented
+  // def getDisplayName(style: java.time.format.TextStyle,
+  //     locale: ju.Locale): String
+}

--- a/javalib/src/main/scala/java/time/chrono/IsoChronology.scala
+++ b/javalib/src/main/scala/java/time/chrono/IsoChronology.scala
@@ -1,0 +1,70 @@
+package java.time.chrono
+
+import scala.collection.JavaConverters._
+
+import java.time.{Period, LocalDate}
+import java.time.temporal.{ValueRange, ChronoField, TemporalAccessor}
+import java.{util => ju}
+
+final class IsoChronology private () extends AbstractChronology with Serializable {
+  def getId(): String = "ISO"
+
+  def getCalendarType(): String = "iso8601"
+
+  override def date(era: Era, yearOfEra: Int, month: Int, dayOfMonth: Int): LocalDate =
+    date(prolepticYear(era, yearOfEra), month, dayOfMonth)
+
+  def date(prolepticYear: Int, month: Int, dayOfMonth: Int): LocalDate =
+    LocalDate.of(prolepticYear, month, dayOfMonth)
+
+  override def dateYearDay(era: Era, yearOfEra: Int, dayOfYear: Int): LocalDate =
+    dateYearDay(prolepticYear(era, yearOfEra), dayOfYear)
+
+  def dateYearDay(prolepticYear: Int, dayOfYear: Int): LocalDate =
+    LocalDate.ofYearDay(prolepticYear, dayOfYear)
+
+  def dateEpochDay(epochDay: Long): LocalDate = LocalDate.ofEpochDay(epochDay)
+
+  def date(temporal: TemporalAccessor): LocalDate = LocalDate.from(temporal)
+
+  // TODO
+  // def localDateTime(temporal: TemporalAccessor): LocalDateTime
+
+  // Not implemented
+  // def zonedDateTime(temporal: TemporalAccessor): ZonedDateTime
+  // def zonedDateTime(instant: Instant, zone: ZoneId): ZonedDateTime
+
+  override def dateNow(): LocalDate = LocalDate.now()
+
+  // Not implemented
+  // def dateNow(zone: ZoneId): ChronoLocalDate
+  // def dateNow(clock: Clock): ChronoLocalDate
+
+  def isLeapYear(prolepticYear: Long): Boolean = {
+    (prolepticYear % 400 == 0) ||
+    (prolepticYear % 4 == 0 && prolepticYear % 100 != 0)
+  }
+
+  def prolepticYear(era: Era, yearOfEra: Int): Int = era match {
+    case IsoEra.CE  => yearOfEra
+    case IsoEra.BCE => 1 - yearOfEra
+    case _          => throw new ClassCastException("Era must be IsoEra")
+  }
+
+  def eraOf(eraValue: Int): IsoEra = IsoEra.of(eraValue)
+
+  def eras(): ju.List[Era] = Seq[Era](IsoEra.BCE, IsoEra.CE).asJava
+
+  // Not implemented
+  // def resolveDate(fieldValues: ju.Map[TemporalField, Long],
+  //     resolverStyle: java.time.format.ResolverStyle): ChronoLocalDate
+
+  def range(field: ChronoField): ValueRange = field.range()
+
+  override def period(years: Int, months: Int, days: Int): Period =
+    Period.of(years, months, days)
+}
+
+object IsoChronology {
+  final val INSTANCE = new IsoChronology()
+}

--- a/javalib/src/main/scala/java/time/chrono/IsoEra.scala
+++ b/javalib/src/main/scala/java/time/chrono/IsoEra.scala
@@ -1,0 +1,26 @@
+package java.time.chrono
+
+import java.time.DateTimeException
+
+final class IsoEra private (name: String, ordinal: Int)
+    extends Enum[IsoEra](name, ordinal) with Era {
+  def getValue: Int = ordinal
+}
+
+object IsoEra {
+  final val BCE = new IsoEra("BCE", 0)
+
+  final val CE = new IsoEra("CE", 1)
+
+  private val eras = Seq(BCE, CE)
+
+  def values(): Array[IsoEra] = eras.toArray
+
+  def valueOf(name: String): IsoEra = eras.find(_.name == name).getOrElse {
+    throw new IllegalArgumentException(s"No such era: $name")
+  }
+
+  def of(isoEra: Int): IsoEra = eras.lift(isoEra).getOrElse {
+    throw new DateTimeException(s"Invalid value for isoEra: $isoEra")
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/DayOfWeekTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/DayOfWeekTest.scala
@@ -1,0 +1,119 @@
+package org.scalajs.testsuite.javalib.time
+
+import java.time.temporal.ChronoField
+import java.time._
+
+import org.scalajs.testsuite.javalib.time.temporal.TemporalAccessorTest
+
+object DayOfWeekTest extends TemporalAccessorTest {
+  import DayOfWeek._
+
+  describe("java.time.DayOfWeek") {
+    testTemporalAccessorApi(values():_*)
+
+    it("should respond to `getValue`") {
+      expect(MONDAY.getValue).toEqual(1)
+      expect(TUESDAY.getValue).toEqual(2)
+      expect(WEDNESDAY.getValue).toEqual(3)
+      expect(THURSDAY.getValue).toEqual(4)
+      expect(FRIDAY.getValue).toEqual(5)
+      expect(SATURDAY.getValue).toEqual(6)
+      expect(SUNDAY.getValue).toEqual(7)
+    }
+
+    it("should respond to `isSupported`") {
+      for {
+        d <- values
+        f <- ChronoField.values
+      } {
+        if (f == ChronoField.DAY_OF_WEEK)
+          expect(d.isSupported(f)).toBeTruthy
+        else
+          expect(d.isSupported(f)).toBeFalsy
+      }
+    }
+
+    it("should respond to `getLong`") {
+      for (d <- values())
+        expect(d.getLong(ChronoField.DAY_OF_WEEK)).toEqual(d.getValue)
+    }
+
+    it("should respond to `plus`") {
+      expect(SATURDAY.plus(Long.MinValue) == FRIDAY).toBeTruthy
+      expect(THURSDAY.plus(-7) == THURSDAY).toBeTruthy
+      expect(WEDNESDAY.plus(-3) == SUNDAY).toBeTruthy
+      expect(TUESDAY.plus(-1) == MONDAY).toBeTruthy
+      expect(MONDAY.plus(0) == MONDAY).toBeTruthy
+      expect(THURSDAY.plus(1) == FRIDAY).toBeTruthy
+      expect(FRIDAY.plus(3) == MONDAY).toBeTruthy
+      expect(SATURDAY.plus(7) == SATURDAY).toBeTruthy
+      expect(SUNDAY.plus(Long.MaxValue) == SUNDAY).toBeTruthy
+    }
+
+    it("should respond to `minus`") {
+      expect(SATURDAY.minus(Long.MinValue) == SUNDAY).toBeTruthy
+      expect(THURSDAY.minus(-7) == THURSDAY).toBeTruthy
+      expect(FRIDAY.minus(-3) == MONDAY).toBeTruthy
+      expect(TUESDAY.minus(-1) == WEDNESDAY).toBeTruthy
+      expect(MONDAY.minus(0) == MONDAY).toBeTruthy
+      expect(THURSDAY.minus(1) == WEDNESDAY).toBeTruthy
+      expect(WEDNESDAY.minus(3) == SUNDAY).toBeTruthy
+      expect(SATURDAY.minus(7) == SATURDAY).toBeTruthy
+      expect(SUNDAY.plus(Long.MaxValue) == SUNDAY).toBeTruthy
+    }
+
+    it("should be comparable") {
+      expect(WEDNESDAY.compareTo(WEDNESDAY)).toEqual(0)
+      expect(MONDAY.compareTo(SUNDAY)).toBeLessThan(0)
+      expect(SATURDAY.compareTo(TUESDAY)).toBeGreaterThan(0)
+    }
+
+    it("should respond to `values`") {
+      val days = values()
+
+      expect(days.length).toEqual(7)
+      expect(days(0) == MONDAY).toBeTruthy
+      expect(days(1) == TUESDAY).toBeTruthy
+      expect(days(2) == WEDNESDAY).toBeTruthy
+      expect(days(3) == THURSDAY).toBeTruthy
+      expect(days(4) == FRIDAY).toBeTruthy
+      expect(days(5) == SATURDAY).toBeTruthy
+      expect(days(6) == SUNDAY).toBeTruthy
+    }
+
+    it("should respond to `valueOf`") {
+      expect(valueOf("MONDAY") == MONDAY).toBeTruthy
+      expect(valueOf("TUESDAY") == TUESDAY).toBeTruthy
+      expect(valueOf("WEDNESDAY") == WEDNESDAY).toBeTruthy
+      expect(valueOf("THURSDAY") == THURSDAY).toBeTruthy
+      expect(valueOf("FRIDAY") == FRIDAY).toBeTruthy
+      expect(valueOf("SATURDAY") == SATURDAY).toBeTruthy
+      expect(valueOf("SUNDAY") == SUNDAY).toBeTruthy
+
+      expectThrows[IllegalArgumentException](valueOf(""))
+    }
+
+    it("should respond to `of`") {
+      expect(of(1) == MONDAY).toBeTruthy
+      expect(of(2) == TUESDAY).toBeTruthy
+      expect(of(3) == WEDNESDAY).toBeTruthy
+      expect(of(4) == THURSDAY).toBeTruthy
+      expect(of(5) == FRIDAY).toBeTruthy
+      expect(of(6) == SATURDAY).toBeTruthy
+      expect(of(7) == SUNDAY).toBeTruthy
+
+      for (n <- Seq(Int.MinValue, 0, 8, Int.MaxValue))
+        expectThrows[DateTimeException](of(n))
+    }
+
+    it("should respond to `from`") {
+      for (d <- values)
+        expect(from(d) == d).toBeTruthy
+      for (d <- Seq(LocalDate.MIN, LocalDate.of(2012, 2, 29), LocalDate.MAX))
+        expect(from(d) == d.getDayOfWeek).toBeTruthy
+
+      expectThrows[DateTimeException](from(LocalTime.MIN))
+      expectThrows[DateTimeException](from(Month.JANUARY))
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/DurationTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/DurationTest.scala
@@ -1,7 +1,7 @@
 package org.scalajs.testsuite.javalib.time
 
 import java.time.temporal.{ChronoUnit, UnsupportedTemporalTypeException}
-import java.time.{LocalTime, DateTimeException, Duration}
+import java.time._
 
 import org.scalajs.jasminetest.JasmineTest
 import org.scalajs.testsuite.utils.ExpectExceptions
@@ -124,7 +124,7 @@ object DurationTest extends JasmineTest with ExpectExceptions {
 
       for {
         d <- Seq(ZERO, d0, d1, d2, d3)
-        n <- Seq(-100000000000000l, 1l, 0l, 1l, 100000000000000l)
+        n <- Seq(-100000000000000L, 1L, 0L, 1L, 100000000000000L)
       } {
         expect(d.plus(n, NANOS) == d.plusNanos(n)).toBeTruthy
         expect(d.plus(n, MICROS) == d.plusNanos(n * 1000)).toBeTruthy
@@ -294,11 +294,11 @@ object DurationTest extends JasmineTest with ExpectExceptions {
       val d2 = ofSeconds(Long.MaxValue, 999999998)
       val d3 = ofSeconds(Long.MinValue, 1)
 
-      expect(d1.plusNanos(-5000000000l) == ofSeconds(-4, 1)).toBeTruthy
+      expect(d1.plusNanos(-5000000000L) == ofSeconds(-4, 1)).toBeTruthy
       expect(d1.plusNanos(-1000) == ofSeconds(0, 999999001)).toBeTruthy
       expect(d1.plusNanos(0) == d1).toBeTruthy
       expect(d1.plusNanos(1000) == ofSeconds(1, 1001)).toBeTruthy
-      expect(d1.plusNanos(5000000000l) == ofSeconds(6, 1)).toBeTruthy
+      expect(d1.plusNanos(5000000000L) == ofSeconds(6, 1)).toBeTruthy
       expect(d2.plusNanos(1) == dmax).toBeTruthy
       expect(d3.plusNanos(-1) == dmin).toBeTruthy
       expect(dmax.plusNanos(0) == dmax).toBeTruthy
@@ -329,7 +329,7 @@ object DurationTest extends JasmineTest with ExpectExceptions {
 
       for {
         d <- Seq(ZERO, d0, d1, d2, d3)
-        n <- Seq(-100000000000000l, 1l, 0l, 1l, 100000000000000l)
+        n <- Seq(-100000000000000L, 1L, 0L, 1L, 100000000000000L)
       } {
         expect(d.minus(n, NANOS) == d.minusNanos(n)).toBeTruthy
         expect(d.minus(n, MICROS) == d.minusNanos(n * 1000)).toBeTruthy
@@ -500,11 +500,11 @@ object DurationTest extends JasmineTest with ExpectExceptions {
       val d3 = ofSeconds(Long.MinValue, 1)
 
 
-      expect(d1.minusNanos(5000000000l) == ofSeconds(-4, 1)).toBeTruthy
+      expect(d1.minusNanos(5000000000L) == ofSeconds(-4, 1)).toBeTruthy
       expect(d1.minusNanos(1000) == ofSeconds(0, 999999001)).toBeTruthy
       expect(d1.minusNanos(0) == d1).toBeTruthy
       expect(d1.minusNanos(-1000) == ofSeconds(1, 1001)).toBeTruthy
-      expect(d1.minusNanos(-5000000000l) == ofSeconds(6, 1)).toBeTruthy
+      expect(d1.minusNanos(-5000000000L) == ofSeconds(6, 1)).toBeTruthy
       expect(d2.minusNanos(-1) == dmax).toBeTruthy
       expect(d3.minusNanos(1) == dmin).toBeTruthy
       expect(dmax.minusNanos(0) == dmax).toBeTruthy
@@ -718,7 +718,7 @@ object DurationTest extends JasmineTest with ExpectExceptions {
       expect(ofNanos(1).toNanos == 1).toBeTruthy
       expect(ofNanos(1000).toNanos == 1000).toBeTruthy
       expect(ofNanos(Int.MaxValue).toNanos == Int.MaxValue).toBeTruthy
-      expect(ofSeconds(9223372036l, 854775807).toNanos == Long.MaxValue).toBeTruthy
+      expect(ofSeconds(9223372036L, 854775807).toNanos == Long.MaxValue).toBeTruthy
 
       expectThrows[ArithmeticException](dmin.toNanos)
       expectThrows[ArithmeticException](dmax.toNanos)
@@ -777,7 +777,7 @@ object DurationTest extends JasmineTest with ExpectExceptions {
     }
 
     it("should respond to `ofDays`") {
-      val maxDays = 106751991167300l
+      val maxDays = 106751991167300L
       val maxSecs = maxDays * 86400
 
       expect(ofDays(-maxDays) == ofSeconds(-maxSecs)).toBeTruthy
@@ -791,7 +791,7 @@ object DurationTest extends JasmineTest with ExpectExceptions {
     }
 
     it("should respond to `ofHours`") {
-      val maxHrs = 2562047788015215l
+      val maxHrs = 2562047788015215L
       val maxSecs = maxHrs * 3600
 
       expect(ofHours(-maxHrs) == ofSeconds(-maxSecs)).toBeTruthy
@@ -805,7 +805,7 @@ object DurationTest extends JasmineTest with ExpectExceptions {
     }
 
     it("should respond to `ofMinutes`") {
-      val maxMins = 153722867280912930l
+      val maxMins = 153722867280912930L
       val maxSecs = maxMins * 60
 
       expect(ofMinutes(-maxMins) == ofSeconds(-maxSecs)).toBeTruthy
@@ -834,27 +834,27 @@ object DurationTest extends JasmineTest with ExpectExceptions {
 
     it("should respond to `ofMillis`") {
       expect(ofMillis(Long.MinValue) ==
-        ofSeconds(-9223372036854776l, 192000000)).toBeTruthy
+        ofSeconds(-9223372036854776L, 192000000)).toBeTruthy
       expect(ofMillis(-1000) == ofSeconds(-1)).toBeTruthy
       expect(ofMillis(-1) == ofSeconds(0, -1000000)).toBeTruthy
       expect(ofMillis(0) == ZERO).toBeTruthy
       expect(ofMillis(1) == ofSeconds(0, 1000000)).toBeTruthy
       expect(ofMillis(1000) == ofSeconds(1)).toBeTruthy
-      expect(ofMillis(Long.MaxValue) == ofSeconds(9223372036854775l, 807000000)).toBeTruthy
+      expect(ofMillis(Long.MaxValue) == ofSeconds(9223372036854775L, 807000000)).toBeTruthy
     }
 
     it("should respond to `ofNanos`") {
-      expect(ofNanos(Long.MinValue) == ofSeconds(-9223372037l, 145224192)).toBeTruthy
+      expect(ofNanos(Long.MinValue) == ofSeconds(-9223372037L, 145224192)).toBeTruthy
       expect(ofNanos(-1000000000) == ofSeconds(-1)).toBeTruthy
       expect(ofNanos(-1) == ofSeconds(0, -1)).toBeTruthy
       expect(ofNanos(0) == ZERO).toBeTruthy
       expect(ofNanos(1) == ofSeconds(0, 1)).toBeTruthy
       expect(ofNanos(1000000000) == ofSeconds(1)).toBeTruthy
-      expect(ofNanos(Long.MaxValue) == ofSeconds(9223372036l, 854775807)).toBeTruthy
+      expect(ofNanos(Long.MaxValue) == ofSeconds(9223372036L, 854775807)).toBeTruthy
     }
 
     it("should respont to `of`") {
-      for(n <- Seq(-100000000000000l, -1l, 0l, 1l, 100000000000000l)) {
+      for (n <- Seq(-100000000000000L, -1L, 0L, 1L, 100000000000000L)) {
         expect(of(n, NANOS) == ofNanos(n)).toBeTruthy
         expect(of(n, MICROS) == ofNanos(n * 1000)).toBeTruthy
         expect(of(n, MILLIS) == ofMillis(n)).toBeTruthy
@@ -865,14 +865,14 @@ object DurationTest extends JasmineTest with ExpectExceptions {
         expect(of(n, DAYS) == ofDays(n)).toBeTruthy
       }
 
-      for(s <- Seq(-1, 1)) {
-        expectThrows[ArithmeticException](of(106751991167301l * s, DAYS))
-        expectThrows[ArithmeticException](of(213503982334602l * s, HALF_DAYS))
-        expectThrows[ArithmeticException](of(2562047788015216l * s, HOURS))
-        expectThrows[ArithmeticException](of(153722867280912931l * s, MINUTES))
+      for (s <- Seq(-1, 1)) {
+        expectThrows[ArithmeticException](of(106751991167301L * s, DAYS))
+        expectThrows[ArithmeticException](of(213503982334602L * s, HALF_DAYS))
+        expectThrows[ArithmeticException](of(2562047788015216L * s, HOURS))
+        expectThrows[ArithmeticException](of(153722867280912931L * s, MINUTES))
       }
 
-      for(n <- Seq(-10, 0, 10)) {
+      for (n <- Seq(-10, 0, 10)) {
         expectThrows[UnsupportedTemporalTypeException](of(n, WEEKS))
         expectThrows[UnsupportedTemporalTypeException](of(n, MONTHS))
         expectThrows[UnsupportedTemporalTypeException](of(n, YEARS))
@@ -889,7 +889,7 @@ object DurationTest extends JasmineTest with ExpectExceptions {
       expect(from(ZERO) == ZERO).toBeTruthy
       expect(from(dmax) == dmax).toBeTruthy
 
-      // TODO: Add tests for other classes
+      expectThrows[UnsupportedTemporalTypeException](from(Period.ZERO))
     }
 
     it("should respond to `between`") {
@@ -899,9 +899,9 @@ object DurationTest extends JasmineTest with ExpectExceptions {
       expect(between(MIN, MAX) == ofNanos(86399999999999L)).toBeTruthy
       expect(between(MIN, LocalTime.of(0, 0, 0, 1)) == ofNanos(1)).toBeTruthy
 
-      // TODO: Add tests for other Temporals
+      expectThrows[DateTimeException](between(MIN, LocalDate.of(2012, 2, 29)))
+      expectThrows[DateTimeException](between(LocalDate.of(2012, 2, 29),
+        LocalDate.of(2012, 3, 1)))
     }
-
-
   }
 }

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/LocalDateTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/LocalDateTest.scala
@@ -1,0 +1,796 @@
+package org.scalajs.testsuite.javalib.time
+
+import java.time._
+import java.time.chrono.{IsoEra, IsoChronology}
+import java.time.temporal._
+
+import org.scalajs.testsuite.javalib.time.temporal.TemporalTest
+
+object LocalDateTest extends TemporalTest {
+  import LocalDate._
+  import ChronoField._
+  import ChronoUnit._
+
+  val someDate = of(2011, 2, 28)
+  val leapDate = of(2012, 2, 29)
+  val samples = Seq(MIN, someDate, leapDate, MAX)
+
+  describe("java.time.LocalDate") {
+    testTemporalApi(samples: _*)
+
+    it("should respond to `isSupported`") {
+      for {
+        d <- samples
+        f <- ChronoField.values
+      } {
+        expect(d.isSupported(f) == f.isDateBased).toBeTruthy
+      }
+
+      for {
+        d <- samples
+        u <- ChronoUnit.values
+      } {
+        expect(d.isSupported(u) == u.isDateBased).toBeTruthy
+      }
+    }
+
+    it("should respond to `getLong`") {
+      for (d <- samples) {
+        expect(d.getLong(DAY_OF_WEEK) == d.getDayOfWeek.getValue).toBeTruthy
+        expect(d.getLong(DAY_OF_MONTH) == d.getDayOfMonth).toBeTruthy
+        expect(d.getLong(DAY_OF_YEAR) == d.getDayOfYear).toBeTruthy
+        expect(d.getLong(EPOCH_DAY) == d.toEpochDay).toBeTruthy
+        expect(d.getLong(MONTH_OF_YEAR) == d.getMonthValue).toBeTruthy
+        expect(d.getLong(YEAR) == d.getYear).toBeTruthy
+        expect(d.getLong(ERA) == d.getEra.getValue).toBeTruthy
+      }
+
+      expect(MIN.getLong(ALIGNED_DAY_OF_WEEK_IN_MONTH) == 1).toBeTruthy
+      expect(MIN.getLong(ALIGNED_DAY_OF_WEEK_IN_YEAR) == 1).toBeTruthy
+      expect(MIN.getLong(ALIGNED_WEEK_OF_MONTH) == 1).toBeTruthy
+      expect(MIN.getLong(ALIGNED_WEEK_OF_YEAR) == 1).toBeTruthy
+      expect(MIN.getLong(PROLEPTIC_MONTH) == -11999999988L).toBeTruthy
+      expect(MIN.getLong(YEAR_OF_ERA) == 1000000000).toBeTruthy
+
+      expect(someDate.getLong(ALIGNED_DAY_OF_WEEK_IN_MONTH) == 7).toBeTruthy
+      expect(someDate.getLong(ALIGNED_DAY_OF_WEEK_IN_YEAR) == 3).toBeTruthy
+      expect(someDate.getLong(ALIGNED_WEEK_OF_MONTH) == 4).toBeTruthy
+      expect(someDate.getLong(ALIGNED_WEEK_OF_YEAR) == 9).toBeTruthy
+      expect(someDate.getLong(PROLEPTIC_MONTH) == 24133).toBeTruthy
+      expect(someDate.getLong(YEAR_OF_ERA) == 2011).toBeTruthy
+
+      expect(leapDate.getLong(ALIGNED_DAY_OF_WEEK_IN_MONTH) == 1).toBeTruthy
+      expect(leapDate.getLong(ALIGNED_DAY_OF_WEEK_IN_YEAR) == 4).toBeTruthy
+      expect(leapDate.getLong(ALIGNED_WEEK_OF_MONTH) == 5).toBeTruthy
+      expect(leapDate.getLong(ALIGNED_WEEK_OF_YEAR) == 9).toBeTruthy
+      expect(leapDate.getLong(PROLEPTIC_MONTH) == 24145).toBeTruthy
+      expect(leapDate.getLong(YEAR_OF_ERA) == 2012).toBeTruthy
+
+      expect(MAX.getLong(ALIGNED_DAY_OF_WEEK_IN_MONTH) == 3).toBeTruthy
+      expect(MAX.getLong(ALIGNED_DAY_OF_WEEK_IN_YEAR) == 1).toBeTruthy
+      expect(MAX.getLong(ALIGNED_WEEK_OF_MONTH) == 5).toBeTruthy
+      expect(MAX.getLong(ALIGNED_WEEK_OF_YEAR) == 53).toBeTruthy
+      expect(MAX.getLong(PROLEPTIC_MONTH) == 11999999999L).toBeTruthy
+      expect(MAX.getLong(YEAR_OF_ERA) == 999999999).toBeTruthy
+    }
+
+    it("should respond to `getChronology`") {
+      for (d <- samples)
+        expect(d.getChronology == IsoChronology.INSTANCE).toBeTruthy
+    }
+
+    it("should respond to `getEra`") {
+      expect(MIN.getEra == IsoEra.BCE).toBeTruthy
+      expect(someDate.getEra == IsoEra.CE).toBeTruthy
+      expect(leapDate.getEra == IsoEra.CE).toBeTruthy
+      expect(MAX.getEra == IsoEra.CE).toBeTruthy
+    }
+
+    it("should respond to `getYear`") {
+      expect(MIN.getYear).toEqual(-999999999)
+      expect(someDate.getYear).toEqual(2011)
+      expect(leapDate.getYear).toEqual(2012)
+      expect(MAX.getYear).toEqual(999999999)
+    }
+
+    it("should respond to `getMonthValue`") {
+      for (d <- samples)
+        expect(d.getMonthValue == d.getMonth.getValue).toBeTruthy
+    }
+
+    it("should respond to `getMonth`") {
+      expect(MIN.getMonth == Month.JANUARY).toBeTruthy
+      expect(someDate.getMonth == Month.FEBRUARY).toBeTruthy
+      expect(leapDate.getMonth == Month.FEBRUARY).toBeTruthy
+      expect(MAX.getMonth == Month.DECEMBER).toBeTruthy
+    }
+
+    it("should respond to `getDayOfMonth`") {
+      expect(MIN.getDayOfMonth).toEqual(1)
+      expect(someDate.getDayOfMonth).toEqual(28)
+      expect(leapDate.getDayOfMonth).toEqual(29)
+      expect(MAX.getDayOfMonth).toEqual(31)
+    }
+
+    it("should respond to `getDayOfYear`") {
+      expect(MIN.getDayOfYear).toEqual(1)
+      expect(someDate.getDayOfYear).toEqual(59)
+      expect(leapDate.getDayOfYear).toEqual(60)
+      expect(of(2012, 12, 31).getDayOfYear).toEqual(366)
+      expect(MAX.getDayOfYear).toEqual(365)
+    }
+
+    it("should respond to `getDayOfWeek`") {
+      expect(MIN.getDayOfWeek == DayOfWeek.MONDAY).toBeTruthy
+      expect(someDate.getDayOfWeek == DayOfWeek.MONDAY).toBeTruthy
+      expect(leapDate.getDayOfWeek == DayOfWeek.WEDNESDAY).toBeTruthy
+      expect(MAX.getDayOfWeek == DayOfWeek.FRIDAY).toBeTruthy
+    }
+
+    it("should respond to `isLeapYear`") {
+      expect(MIN.isLeapYear).toBeFalsy
+      expect(of(-400, 6, 30).isLeapYear).toBeTruthy
+      expect(of(-100, 3, 1).isLeapYear).toBeFalsy
+      expect(of(0, 1, 1).isLeapYear).toBeTruthy
+      expect(of(1900, 9, 30).isLeapYear).toBeFalsy
+      expect(of(2000, 1, 1).isLeapYear).toBeTruthy
+      expect(someDate.isLeapYear).toBeFalsy
+      expect(leapDate.isLeapYear).toBeTruthy
+      expect(MAX.isLeapYear).toBeFalsy
+    }
+
+    it("should respond to `lengthOfMonth`") {
+      for (d <- samples ++ Seq(of(2001, 2, 1), of(2012, 9, 30)))
+        expect(d.lengthOfMonth).toEqual(d.getMonth.length(d.isLeapYear))
+    }
+
+    it("should respond to `lengthOfYear`") {
+      for (d <- samples)
+        expect(d.lengthOfYear).toEqual(if (d.isLeapYear) 366 else 365)
+    }
+
+    it("should respond to `with`") {
+      testTemporal(MAX.`with`(DAY_OF_WEEK, 1))(of(999999999, 12, 27))
+      testTemporal(MAX.`with`(DAY_OF_WEEK, 5))(MAX)
+      testTemporal(MIN.`with`(DAY_OF_WEEK, 1))(MIN)
+      testTemporal(MIN.`with`(DAY_OF_WEEK, 7))(of(-999999999, 1, 7))
+      testTemporal(someDate.`with`(DAY_OF_WEEK, 1))(someDate)
+      testTemporal(someDate.`with`(DAY_OF_WEEK, 7))(of(2011, 3, 6))
+      testTemporal(leapDate.`with`(DAY_OF_WEEK, 1))(of(2012, 2, 27))
+      testTemporal(leapDate.`with`(DAY_OF_WEEK, 7))(of(2012, 3, 4))
+      testTemporal(MAX.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 1))(of(999999999, 12, 29))
+      testTemporal(MAX.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 3))(MAX)
+      testTemporal(MIN.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 1))(MIN)
+      testTemporal(MIN.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 7))(of(-999999999, 1, 7))
+      testTemporal(someDate.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 1))(of(2011, 2, 22))
+      testTemporal(someDate.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 7))(someDate)
+      testTemporal(leapDate.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 1))(leapDate)
+      testTemporal(leapDate.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 7))(of(2012, 3, 6))
+      testTemporal(MAX.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 1))(MAX)
+      testTemporal(MIN.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 1))(MIN)
+      testTemporal(MIN.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 7))(of(-999999999, 1, 7))
+      testTemporal(someDate.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 1))(of(2011, 2, 26))
+      testTemporal(someDate.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 7))(of(2011, 3, 4))
+      testTemporal(leapDate.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 1))(of(2012, 2, 26))
+      testTemporal(leapDate.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 7))(of(2012, 3, 3))
+      testTemporal(someDate.`with`(DAY_OF_MONTH, 1))(of(2011, 2, 1))
+      testTemporal(leapDate.`with`(DAY_OF_MONTH, 28))(of(2012, 2, 28))
+      testTemporal(someDate.`with`(DAY_OF_YEAR, 1))(of(2011, 1, 1))
+      testTemporal(someDate.`with`(DAY_OF_YEAR, 365))(of(2011, 12, 31))
+      testTemporal(leapDate.`with`(DAY_OF_YEAR, 366))(of(2012, 12, 31))
+      for {
+        d1 <- samples
+        d2 <- samples
+      } {
+        testTemporal(d1.`with`(EPOCH_DAY, d2.toEpochDay))(d2)
+      }
+      testTemporal(MAX.`with`(ALIGNED_WEEK_OF_MONTH, 1))(of(999999999, 12, 3))
+      testTemporal(MAX.`with`(ALIGNED_WEEK_OF_MONTH, 5))(MAX)
+      testTemporal(MIN.`with`(ALIGNED_WEEK_OF_MONTH, 1))(MIN)
+      testTemporal(MIN.`with`(ALIGNED_WEEK_OF_MONTH, 5))(of(-999999999, 1, 29))
+      testTemporal(someDate.`with`(ALIGNED_WEEK_OF_MONTH, 1))(of(2011, 2, 7))
+      testTemporal(someDate.`with`(ALIGNED_WEEK_OF_MONTH, 5))(of(2011, 3, 7))
+      testTemporal(leapDate.`with`(ALIGNED_WEEK_OF_MONTH, 1))(of(2012, 2, 1))
+      testTemporal(leapDate.`with`(ALIGNED_WEEK_OF_MONTH, 5))(leapDate)
+      testTemporal(MAX.`with`(ALIGNED_WEEK_OF_YEAR, 1))(of(999999999, 1, 1))
+      testTemporal(MAX.`with`(ALIGNED_WEEK_OF_YEAR, 53))(MAX)
+      testTemporal(MIN.`with`(ALIGNED_WEEK_OF_YEAR, 1))(MIN)
+      testTemporal(MIN.`with`(ALIGNED_WEEK_OF_YEAR, 53))(of(-999999999, 12, 31))
+      testTemporal(someDate.`with`(ALIGNED_WEEK_OF_YEAR, 1))(of(2011, 1, 3))
+      testTemporal(someDate.`with`(ALIGNED_WEEK_OF_YEAR, 53))(of(2012, 1, 2))
+      testTemporal(leapDate.`with`(ALIGNED_WEEK_OF_YEAR, 1))(of(2012, 1, 4))
+      testTemporal(leapDate.`with`(ALIGNED_WEEK_OF_YEAR, 53))(of(2013, 1, 2))
+      testTemporal(MAX.`with`(MONTH_OF_YEAR, 2))(of(999999999, 2, 28))
+      testTemporal(MAX.`with`(MONTH_OF_YEAR, 11))(of(999999999, 11, 30))
+      testTemporal(someDate.`with`(MONTH_OF_YEAR, 1))(of(2011, 1, 28))
+      testTemporal(leapDate.`with`(MONTH_OF_YEAR, 2))(leapDate)
+      testTemporal(MAX.`with`(PROLEPTIC_MONTH, 1))(of(0, 2, 29))
+      testTemporal(MIN.`with`(PROLEPTIC_MONTH, -1))(of(-1, 12, 1))
+      testTemporal(someDate.`with`(PROLEPTIC_MONTH, -11999999988L))(of(-999999999, 1, 28))
+      testTemporal(leapDate.`with`(PROLEPTIC_MONTH, 11999999999L))(of(999999999, 12, 29))
+      testTemporal(MIN.`with`(YEAR_OF_ERA, 1000000000))(MIN)
+      testTemporal(MIN.`with`(YEAR_OF_ERA, 1))(of(0, 1, 1))
+      testTemporal(MAX.`with`(YEAR_OF_ERA, 999999999))(MAX)
+      testTemporal(MAX.`with`(YEAR_OF_ERA, 1))(of(1, 12, 31))
+      testTemporal(leapDate.`with`(YEAR_OF_ERA, 2011))(someDate)
+      testTemporal(MIN.`with`(YEAR, -999999999))(MIN)
+      testTemporal(MIN.`with`(YEAR, 999999999))(of(999999999, 1, 1))
+      testTemporal(MAX.`with`(YEAR, -999999999))(of(-999999999, 12, 31))
+      testTemporal(MAX.`with`(YEAR, 999999999))(MAX)
+      testTemporal(leapDate.`with`(YEAR, 2011))(someDate)
+      testTemporal(MIN.`with`(ERA, 0))(MIN)
+      testTemporal(MAX.`with`(ERA, 0))(of(-999999998, 12, 31))
+      testTemporal(MAX.`with`(ERA, 1))(MAX)
+      testTemporal(someDate.`with`(ERA, 1))(someDate)
+      testTemporal(leapDate.`with`(ERA, 0))(of(-2011, 2, 28))
+
+      expectThrows[DateTimeException](MAX.`with`(DAY_OF_WEEK, 6))
+      expectThrows[DateTimeException](MAX.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, 4))
+      expectThrows[DateTimeException](MAX.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, 2))
+      expectThrows[DateTimeException](someDate.`with`(DAY_OF_MONTH, 29))
+      expectThrows[DateTimeException](leapDate.`with`(DAY_OF_MONTH, 30))
+      expectThrows[DateTimeException](someDate.`with`(DAY_OF_YEAR, 366))
+      expectThrows[DateTimeException](someDate.`with`(YEAR_OF_ERA, 1000000000))
+      expectThrows[DateTimeException](MIN.`with`(ERA, 1))
+
+      for (d <- samples) {
+        for (n <- Seq(Long.MinValue, 0L, 8L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(DAY_OF_WEEK, n))
+          expectThrows[DateTimeException](d.`with`(ALIGNED_DAY_OF_WEEK_IN_MONTH, n))
+          expectThrows[DateTimeException](d.`with`(ALIGNED_DAY_OF_WEEK_IN_YEAR, n))
+        }
+        for (n <- Seq(Long.MinValue, 0L, 32L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(DAY_OF_MONTH, n))
+        }
+        for (n <- Seq(Long.MinValue, 0L, 367L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(DAY_OF_YEAR, n))
+        }
+        for (n <- Seq(Long.MinValue, -365243219163L, 365241780472L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(EPOCH_DAY, n))
+        }
+        for (n <- Seq(Long.MinValue, 0L, 6L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(ALIGNED_WEEK_OF_MONTH, n))
+        }
+        for (n <- Seq(Long.MinValue, 0L, 54L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(ALIGNED_WEEK_OF_YEAR, n))
+        }
+        for (n <- Seq(Long.MinValue, 0L, 13L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(MONTH_OF_YEAR, n))
+        }
+        for (n <- Seq(Long.MinValue, -11999999989L, 12000000000L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(PROLEPTIC_MONTH, n))
+        }
+        for (n <- Seq(Long.MinValue, 0L, 1000000001L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(YEAR_OF_ERA, n))
+        }
+        for (n <- Seq(Long.MinValue, -1000000000L, 1000000000L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(YEAR, n))
+        }
+        for (n <- Seq(Long.MinValue, -1L, 2L, Long.MaxValue)) {
+          expectThrows[DateTimeException](d.`with`(ERA, n))
+        }
+      }
+    }
+
+    it("should respond to `withYear`") {
+      testTemporal(MIN.withYear(-999999999))(MIN)
+      testTemporal(MIN.withYear(999999999))(of(999999999, 1, 1))
+      testTemporal(MAX.withYear(-999999999))(of(-999999999, 12, 31))
+      testTemporal(MAX.withYear(999999999))(MAX)
+
+      val years = Seq(Int.MinValue, -1000000000, 1000000000, Int.MaxValue)
+      for {
+        d <- samples
+        n <- years
+      } {
+        expectThrows[DateTimeException](d.withYear(n))
+      }
+    }
+
+    it("should respond to `withMonth`") {
+      testTemporal(MAX.withMonth(2))(of(999999999, 2, 28))
+      testTemporal(MAX.withMonth(11))(of(999999999, 11, 30))
+      testTemporal(someDate.withMonth(1))(of(2011, 1, 28))
+      testTemporal(leapDate.withMonth(2))(leapDate)
+
+      val months = Seq(Int.MinValue, 0, 13, Int.MaxValue)
+      for {
+        d <- samples
+        n <- months
+      } {
+        expectThrows[DateTimeException](d.withMonth(n))
+      }
+    }
+
+    it("should respond to `withDayOfMonth`") {
+      testTemporal(someDate.withDayOfMonth(1))(of(2011, 2, 1))
+      testTemporal(leapDate.withDayOfMonth(28))(of(2012, 2, 28))
+
+      expectThrows[DateTimeException](someDate.withDayOfMonth(29))
+      expectThrows[DateTimeException](leapDate.withDayOfMonth(30))
+      expectThrows[DateTimeException](of(0, 4, 30).withDayOfMonth(31))
+      val days = Seq(Int.MinValue, 0, 32, Int.MaxValue)
+      for {
+        d <- samples
+        n <- days
+      } {
+        expectThrows[DateTimeException](d.withDayOfMonth(n))
+      }
+    }
+
+    it("should respond to `withDayOfYear`") {
+      testTemporal(someDate.withDayOfYear(1))(of(2011, 1, 1))
+      testTemporal(someDate.withDayOfYear(365))(of(2011, 12, 31))
+      testTemporal(leapDate.withDayOfYear(366))(of(2012, 12, 31))
+
+      expectThrows[DateTimeException](someDate.withDayOfYear(366))
+      val days = Seq(Int.MinValue, 0, 367, Int.MaxValue)
+      for {
+        d <- samples
+        n <- days
+      } {
+        expectThrows[DateTimeException](d.withDayOfMonth(n))
+      }
+    }
+
+    it("should respond to `plus`") {
+      val values = Seq(Long.MinValue, Int.MinValue.toLong, -1000L, -366L, -365L,
+          -100L, -12L, -10L, -7L, -1L, 0L, 1L, 7L, 10L, 12L, 100L,
+          365L, 366L, 1000L, Int.MaxValue.toLong, Long.MaxValue)
+
+      for {
+        d <- samples
+        n <- values
+      } {
+        testTemporal(d.plus(n, DAYS))(d.plusDays(n))
+        testTemporal(d.plus(n, WEEKS))(d.plusWeeks(n))
+        testTemporal(d.plus(n, MONTHS))(d.plusMonths(n))
+        testTemporal(d.plus(n, YEARS))(d.plusYears(n))
+        testTemporal(d.plus(n, DECADES))(d.plusYears(Math.multiplyExact(n, 10)))
+        testTemporal(d.plus(n, CENTURIES))(d.plusYears(Math.multiplyExact(n, 100)))
+        testTemporal(d.plus(n, MILLENNIA))(d.plusYears(Math.multiplyExact(n, 1000)))
+        testTemporal(d.plus(n, ERAS))(d.`with`(ERA, Math.addExact(n, d.get(ERA))))
+      }
+    }
+
+    it("should respond to `plusYears`") {
+      for (d <- samples)
+        testTemporal(d.plusYears(0))(d)
+      testTemporal(someDate.plusYears(-2))(of(2009, 2, 28))
+      testTemporal(someDate.plusYears(-1))(of(2010, 2, 28))
+      testTemporal(someDate.plusYears(1))(of(2012, 2, 28))
+      testTemporal(someDate.plusYears(2))(of(2013, 2, 28))
+      testTemporal(leapDate.plusYears(-2))(of(2010, 2, 28))
+      testTemporal(leapDate.plusYears(-1))(someDate)
+      testTemporal(leapDate.plusYears(1))(of(2013, 2, 28))
+      testTemporal(leapDate.plusYears(2))(of(2014, 2, 28))
+      testTemporal(MIN.plusYears(1999999998))(of(999999999, 1, 1))
+      testTemporal(MAX.plusYears(-1999999998))(of(-999999999, 12, 31))
+      expectThrows[DateTimeException](MIN.plusYears(-1))
+      expectThrows[DateTimeException](MIN.plusYears(1999999999))
+      expectThrows[DateTimeException](MAX.plusYears(-1999999999))
+      expectThrows[DateTimeException](MAX.plusYears(1))
+      expectThrows[DateTimeException](MIN.plusYears(Long.MinValue))
+      expectThrows[DateTimeException](MAX.plusYears(Long.MaxValue))
+    }
+
+    it("should respond to `plusMonths`") {
+      for (d <- samples)
+        testTemporal(d.plusMonths(0))(d)
+      testTemporal(someDate.plusMonths(-12))(of(2010, 2, 28))
+      testTemporal(someDate.plusMonths(-1))(of(2011, 1, 28))
+      testTemporal(someDate.plusMonths(1))(of(2011, 3, 28))
+      testTemporal(someDate.plusMonths(12))(of(2012, 2, 28))
+      testTemporal(leapDate.plusMonths(-12))(someDate)
+      testTemporal(leapDate.plusMonths(-1))(of(2012, 1, 29))
+      testTemporal(leapDate.plusMonths(1))(of(2012, 3, 29))
+      testTemporal(leapDate.plusMonths(12))(of(2013, 2, 28))
+      testTemporal(of(2011, 1, 31).plusMonths(1))(someDate)
+      testTemporal(of(2011, 3, 31).plusMonths(-1))(someDate)
+      testTemporal(of(2011, 3, 31).plusMonths(1))(of(2011, 4, 30))
+      testTemporal(of(2012, 1, 31).plusMonths(1))(leapDate)
+      testTemporal(of(2012, 3, 31).plusMonths(-1))(leapDate)
+      testTemporal(of(2012, 3, 31).plusMonths(1))(of(2012, 4, 30))
+      testTemporal(MIN.plusMonths(23999999987L))(of(999999999, 12, 1))
+      testTemporal(MAX.plusMonths(-23999999987L))(of(-999999999, 1, 31))
+      expectThrows[DateTimeException](MIN.plusMonths(-1))
+      expectThrows[DateTimeException](MIN.plusMonths(23999999988L))
+      expectThrows[DateTimeException](MAX.plusMonths(-23999999988L))
+      expectThrows[DateTimeException](MAX.plusMonths(1))
+      expectThrows[DateTimeException](MIN.plusMonths(Long.MinValue))
+      expectThrows[DateTimeException](MAX.plusMonths(Long.MaxValue))
+    }
+
+    it("should respond to `plusWeeks`") {
+      for (d <- samples)
+        testTemporal(d.plusWeeks(0))(d)
+      testTemporal(someDate.plusWeeks(-53))(of(2010, 2, 22))
+      testTemporal(someDate.plusWeeks(-52))(of(2010, 3, 1))
+      testTemporal(someDate.plusWeeks(-1))(of(2011, 2, 21))
+      testTemporal(someDate.plusWeeks(1))(of(2011, 3, 7))
+      testTemporal(someDate.plusWeeks(52))(of(2012, 2, 27))
+      testTemporal(someDate.plusWeeks(53))(of(2012, 3, 5))
+      testTemporal(leapDate.plusWeeks(-53))(of(2011, 2, 23))
+      testTemporal(leapDate.plusWeeks(-52))(of(2011, 3, 2))
+      testTemporal(leapDate.plusWeeks(-1))(of(2012, 2, 22))
+      testTemporal(leapDate.plusWeeks(1))(of(2012, 3, 7))
+      testTemporal(leapDate.plusWeeks(52))(of(2013, 2, 27))
+      testTemporal(leapDate.plusWeeks(53))(of(2013, 3, 6))
+      testTemporal(MIN.plusWeeks(104354999947L))(of(999999999, 12, 27))
+      testTemporal(MAX.plusWeeks(-104354999947L))(of(-999999999, 1, 5))
+      expectThrows[DateTimeException](MIN.plusWeeks(-1))
+      expectThrows[DateTimeException](MIN.plusWeeks(104354999948L))
+      expectThrows[DateTimeException](MAX.plusWeeks(-1043549999478L))
+      expectThrows[DateTimeException](MAX.plusWeeks(1))
+      expectThrows[ArithmeticException](MIN.plusWeeks(Long.MinValue))
+      expectThrows[ArithmeticException](MAX.plusWeeks(Long.MaxValue))
+    }
+
+    it("should respond to `plusDays`") {
+      for (d <- samples)
+        testTemporal(d.plusDays(0))(d)
+      testTemporal(someDate.plusDays(-365))(of(2010, 2, 28))
+      testTemporal(someDate.plusDays(-1))(of(2011, 2, 27))
+      testTemporal(someDate.plusDays(1))(of(2011, 3, 1))
+      testTemporal(someDate.plusDays(365))(of(2012, 2, 28))
+      testTemporal(someDate.plusDays(366))(leapDate)
+      testTemporal(leapDate.plusDays(-366))(someDate)
+      testTemporal(leapDate.plusDays(-365))(of(2011, 3, 1))
+      testTemporal(leapDate.plusDays(-1))(of(2012, 2, 28))
+      testTemporal(leapDate.plusDays(1))(of(2012, 3, 1))
+      testTemporal(leapDate.plusDays(365))(of(2013, 2, 28))
+      testTemporal(leapDate.plusDays(366))(of(2013, 3, 1))
+      testTemporal(MIN.plusDays(730484999633L))(MAX)
+      testTemporal(MAX.plusDays(-730484999633L))(MIN)
+      expectThrows[DateTimeException](MIN.plusDays(-1))
+      expectThrows[DateTimeException](MIN.plusDays(730484999634L))
+      expectThrows[DateTimeException](MAX.plusDays(-730484999634L))
+      expectThrows[DateTimeException](MAX.plusDays(1))
+      expectThrows[ArithmeticException](ofEpochDay(-1).plusDays(Long.MinValue))
+      expectThrows[ArithmeticException](ofEpochDay(1).plusDays(Long.MaxValue))
+    }
+
+    it("should respond to `minusYears`") {
+      for (d <- samples)
+        testTemporal(d.minusYears(0))(d)
+      testTemporal(someDate.minusYears(2))(of(2009, 2, 28))
+      testTemporal(someDate.minusYears(1))(of(2010, 2, 28))
+      testTemporal(someDate.minusYears(-1))(of(2012, 2, 28))
+      testTemporal(someDate.minusYears(-2))(of(2013, 2, 28))
+      testTemporal(leapDate.minusYears(2))(of(2010, 2, 28))
+      testTemporal(leapDate.minusYears(1))(someDate)
+      testTemporal(leapDate.minusYears(-1))(of(2013, 2, 28))
+      testTemporal(leapDate.minusYears(-2))(of(2014, 2, 28))
+      testTemporal(MIN.minusYears(-1999999998))(of(999999999, 1, 1))
+      testTemporal(MAX.minusYears(1999999998))(of(-999999999, 12, 31))
+      expectThrows[DateTimeException](MIN.minusYears(1))
+      expectThrows[DateTimeException](MIN.minusYears(-1999999999))
+      expectThrows[DateTimeException](MAX.minusYears(1999999999))
+      expectThrows[DateTimeException](MAX.minusYears(-1))
+      expectThrows[DateTimeException](MIN.minusYears(Long.MaxValue))
+      expectThrows[DateTimeException](MAX.minusYears(Long.MinValue))
+    }
+
+    it("should respond to `minusMonths`") {
+      for (d <- samples)
+        testTemporal(d.minusMonths(0))(d)
+      testTemporal(someDate.minusMonths(12))(of(2010, 2, 28))
+      testTemporal(someDate.minusMonths(1))(of(2011, 1, 28))
+      testTemporal(someDate.minusMonths(-1))(of(2011, 3, 28))
+      testTemporal(someDate.minusMonths(-12))(of(2012, 2, 28))
+      testTemporal(leapDate.minusMonths(12))(someDate)
+      testTemporal(leapDate.minusMonths(1))(of(2012, 1, 29))
+      testTemporal(leapDate.minusMonths(-1))(of(2012, 3, 29))
+      testTemporal(leapDate.minusMonths(-12))(of(2013, 2, 28))
+      testTemporal(of(2011, 1, 31).minusMonths(-1))(someDate)
+      testTemporal(of(2011, 3, 31).minusMonths(1))(someDate)
+      testTemporal(of(2011, 3, 31).minusMonths(-1))(of(2011, 4, 30))
+      testTemporal(of(2012, 1, 31).minusMonths(-1))(leapDate)
+      testTemporal(of(2012, 3, 31).minusMonths(1))(leapDate)
+      testTemporal(of(2012, 3, 31).minusMonths(-1))(of(2012, 4, 30))
+      testTemporal(MIN.minusMonths(-23999999987L))(of(999999999, 12, 1))
+      testTemporal(MAX.minusMonths(23999999987L))(of(-999999999, 1, 31))
+      expectThrows[DateTimeException](MIN.minusMonths(1))
+      expectThrows[DateTimeException](MIN.minusMonths(-23999999988L))
+      expectThrows[DateTimeException](MAX.minusMonths(23999999988L))
+      expectThrows[DateTimeException](MAX.minusMonths(-1))
+      expectThrows[DateTimeException](MIN.minusMonths(Long.MaxValue))
+      expectThrows[DateTimeException](MAX.minusMonths(Long.MinValue))
+    }
+
+    it("should respond to `minusWeeks`") {
+      for (d <- samples)
+        testTemporal(d.minusWeeks(0))(d)
+      testTemporal(someDate.minusWeeks(53))(of(2010, 2, 22))
+      testTemporal(someDate.minusWeeks(52))(of(2010, 3, 1))
+      testTemporal(someDate.minusWeeks(1))(of(2011, 2, 21))
+      testTemporal(someDate.minusWeeks(-1))(of(2011, 3, 7))
+      testTemporal(someDate.minusWeeks(-52))(of(2012, 2, 27))
+      testTemporal(someDate.minusWeeks(-53))(of(2012, 3, 5))
+      testTemporal(leapDate.minusWeeks(53))(of(2011, 2, 23))
+      testTemporal(leapDate.minusWeeks(52))(of(2011, 3, 2))
+      testTemporal(leapDate.minusWeeks(1))(of(2012, 2, 22))
+      testTemporal(leapDate.minusWeeks(-1))(of(2012, 3, 7))
+      testTemporal(leapDate.minusWeeks(-52))(of(2013, 2, 27))
+      testTemporal(leapDate.minusWeeks(-53))(of(2013, 3, 6))
+      testTemporal(MIN.minusWeeks(-104354999947L))(of(999999999, 12, 27))
+      testTemporal(MAX.minusWeeks(104354999947L))(of(-999999999, 1, 5))
+      expectThrows[DateTimeException](MIN.minusWeeks(1))
+      expectThrows[DateTimeException](MIN.minusWeeks(-104354999948L))
+      expectThrows[DateTimeException](MAX.minusWeeks(1043549999478L))
+      expectThrows[DateTimeException](MAX.minusWeeks(-1))
+      expectThrows[ArithmeticException](MIN.minusWeeks(Long.MaxValue))
+      expectThrows[ArithmeticException](MAX.minusWeeks(Long.MinValue))
+    }
+
+    it("should respond to `minusDays`") {
+      for (d <- samples)
+        testTemporal(d.minusDays(0))(d)
+      testTemporal(someDate.minusDays(365))(of(2010, 2, 28))
+      testTemporal(someDate.minusDays(1))(of(2011, 2, 27))
+      testTemporal(someDate.minusDays(-1))(of(2011, 3, 1))
+      testTemporal(someDate.minusDays(-365))(of(2012, 2, 28))
+      testTemporal(someDate.minusDays(-366))(leapDate)
+      testTemporal(leapDate.minusDays(366))(someDate)
+      testTemporal(leapDate.minusDays(365))(of(2011, 3, 1))
+      testTemporal(leapDate.minusDays(1))(of(2012, 2, 28))
+      testTemporal(leapDate.minusDays(-1))(of(2012, 3, 1))
+      testTemporal(leapDate.minusDays(-365))(of(2013, 2, 28))
+      testTemporal(leapDate.minusDays(-366))(of(2013, 3, 1))
+      testTemporal(MIN.minusDays(-730484999633L))(MAX)
+      testTemporal(MAX.minusDays(730484999633L))(MIN)
+      expectThrows[DateTimeException](MIN.minusDays(1))
+      expectThrows[DateTimeException](MIN.minusDays(-730484999634L))
+      expectThrows[DateTimeException](MAX.minusDays(730484999634L))
+      expectThrows[DateTimeException](MAX.minusDays(-1))
+      expectThrows[ArithmeticException](ofEpochDay(-2).minusDays(Long.MaxValue))
+      expectThrows[ArithmeticException](ofEpochDay(1).minusDays(Long.MinValue))
+    }
+
+    it("should respond to `adjustInto`") {
+      for {
+        d1 <- samples
+        d2 <- samples
+      } {
+        testTemporal(d1.adjustInto(d2))(d1)
+      }
+
+      val ts = Seq(LocalTime.MIN, LocalTime.MAX)
+      for {
+        d <- samples
+        t <- ts
+      } {
+        expectThrows[DateTimeException](d.adjustInto(t))
+      }
+    }
+
+    it("should respond to `until`") {
+      val samples1 = samples ++ Seq(of(2012, 1, 29), of(2012, 1, 30), of(2012, 2, 28),
+          of(2013, 2, 28), of(2013, 3, 1), of(0, 12, 31), of(1, 1, 1))
+
+      for {
+        d <- samples1
+        u <- dateBasedUnits
+      } {
+        expect(d.until(d, u) == 0).toBeTruthy
+      }
+
+      expect(MIN.until(MAX, DAYS) == 730484999633L).toBeTruthy
+      expect(MIN.until(MAX, WEEKS) == 104354999947L).toBeTruthy
+      expect(someDate.until(leapDate, MONTHS) == 12).toBeTruthy
+      expect(of(2012, 1, 29).until(leapDate, MONTHS) == 1).toBeTruthy
+      expect(of(2012, 1, 30).until(leapDate, MONTHS) == 0).toBeTruthy
+      expect(MIN.until(MAX, YEARS) == 1999999998).toBeTruthy
+      expect(someDate.until(of(2012, 2, 28), YEARS) == 1).toBeTruthy
+      expect(leapDate.until(of(2013, 2, 28), YEARS) == 0).toBeTruthy
+      expect(MIN.until(MAX, DECADES) == 199999999).toBeTruthy
+      expect(MIN.until(MAX, CENTURIES) == 19999999).toBeTruthy
+      expect(MIN.until(MAX, MILLENNIA) == 1999999).toBeTruthy
+      expect(MIN.until(MAX, ERAS) == 1).toBeTruthy
+      expect(of(0, 12, 31).until(of(1, 1, 1), ERAS) == 1).toBeTruthy
+
+      for {
+        d1 <- samples1
+        d2 <- samples1 if d2.isAfter(d1)
+        u <- dateBasedUnits
+      } {
+        expect(d2.until(d1, u) == -d1.until(d2, u)).toBeTruthy
+      }
+
+      for (d <- samples1)
+        expect(d.until(d) == Period.ZERO).toBeTruthy
+
+      for {
+        d1 <- samples1
+        d2 <- samples1
+        u <- timeBasedUnits
+      } {
+        expectThrows[UnsupportedTemporalTypeException](d1.until(d2, u))
+      }
+
+      expect(MIN.until(MAX) == Period.of(1999999998, 11, 30)).toBeTruthy
+      expect(someDate.until(leapDate) == Period.of(1, 0, 1)).toBeTruthy
+      expect(leapDate.until(of(2013, 2, 28)) == Period.of(0, 11, 30)).toBeTruthy
+      expect(leapDate.until(of(2013, 3, 1)) == Period.of(1, 0, 1)).toBeTruthy
+
+      for {
+        d1 <- samples1
+        d2 <- samples1 if d2.isAfter(d1)
+      } {
+        expect(d2.until(d1) == d1.until(d2).negated).toBeTruthy
+      }
+    }
+
+    it("should respond to `toEpochDay`") {
+      expect(MIN.toEpochDay == -365243219162L).toBeTruthy
+      expect(of(1969, 12, 31).toEpochDay == -1).toBeTruthy
+      expect(of(1970, 1, 1).toEpochDay == 0).toBeTruthy
+      expect(someDate.toEpochDay == 15033).toBeTruthy
+      expect(leapDate.toEpochDay == 15399).toBeTruthy
+      expect(MAX.toEpochDay == 365241780471L).toBeTruthy
+    }
+
+    it("should be comparable") {
+      expect(MIN.compareTo(MIN)).toEqual(0)
+      expect(MIN.compareTo(someDate)).toBeLessThan(0)
+      expect(MIN.compareTo(MAX)).toBeLessThan(0)
+      expect(someDate.compareTo(MIN)).toBeGreaterThan(0)
+      expect(someDate.compareTo(someDate)).toEqual(0)
+      expect(someDate.compareTo(MAX)).toBeLessThan(0)
+      expect(MAX.compareTo(MIN)).toBeGreaterThan(0)
+      expect(MAX.compareTo(someDate)).toBeGreaterThan(0)
+      expect(MAX.compareTo(MAX)).toEqual(0)
+    }
+
+    it("should respond to `isAfter`") {
+      expect(MIN.isAfter(MIN)).toBeFalsy
+      expect(MIN.isAfter(someDate)).toBeFalsy
+      expect(MIN.isAfter(MAX)).toBeFalsy
+      expect(someDate.isAfter(MIN)).toBeTruthy
+      expect(someDate.isAfter(someDate)).toBeFalsy
+      expect(someDate.isAfter(MAX)).toBeFalsy
+      expect(MAX.isAfter(MIN)).toBeTruthy
+      expect(MAX.isAfter(someDate)).toBeTruthy
+      expect(MAX.isAfter(MAX)).toBeFalsy
+    }
+
+    it("should respond to `isBefore`") {
+      expect(MIN.isBefore(MIN)).toBeFalsy
+      expect(MIN.isBefore(someDate)).toBeTruthy
+      expect(MIN.isBefore(MAX)).toBeTruthy
+      expect(someDate.isBefore(MIN)).toBeFalsy
+      expect(someDate.isBefore(someDate)).toBeFalsy
+      expect(someDate.isBefore(MAX)).toBeTruthy
+      expect(MAX.isBefore(MIN)).toBeFalsy
+      expect(MAX.isBefore(someDate)).toBeFalsy
+      expect(MAX.isBefore(MAX)).toBeFalsy
+    }
+
+    it("should override `toString`") {
+      expect(MIN.toString).toEqual("-999999999-01-01")
+      expect(of(-1, 12, 31).toString).toEqual("-0001-12-31")
+      expect(of(0, 1, 1).toString).toEqual("0000-01-01")
+      expect(someDate.toString).toEqual("2011-02-28")
+      expect(leapDate.toString).toEqual("2012-02-29")
+      expect(of(9999, 12, 31).toString).toEqual("9999-12-31")
+      expect(of(10000, 1, 1).toString).toEqual("+10000-01-01")
+      expect(MAX.toString).toEqual("+999999999-12-31")
+    }
+
+    it("should respond to `now`") {
+      expect(now().getEra == IsoEra.CE).toBeTruthy
+    }
+
+    it("should respond to `of`") {
+      val years = Seq(Int.MinValue, -1000000000, -999999999, 0, 999999999,
+          1000000000, Int.MaxValue)
+      val days = Seq(Int.MinValue, 0, 1, 28, 29, 30, 31, 32, Int.MaxValue)
+
+      for {
+        year <- years
+        month <- Month.values
+        day <- days
+      } {
+        testTemporal(of(year, month, day))(of(year, month.getValue, day))
+      }
+
+      expectThrows[DateTimeException](of(Int.MinValue, 1, 1))
+      expectThrows[DateTimeException](of(-1000000000, 1, 1))
+      expectThrows[DateTimeException](of(2011, Int.MinValue, 1))
+      expectThrows[DateTimeException](of(2011, 0, 1))
+      expectThrows[DateTimeException](of(2011, 13, 1))
+      expectThrows[DateTimeException](of(2011, Int.MaxValue, 1))
+
+      for (month <- Month.values) {
+        val m = month.getValue
+        expectThrows[DateTimeException](of(2011, m, Int.MinValue))
+        expectThrows[DateTimeException](of(2011, m, 0))
+        expectThrows[DateTimeException](of(2011, m, month.length(false) + 1))
+        expectThrows[DateTimeException](of(2012, m, month.length(true) + 1))
+        expectThrows[DateTimeException](of(2011, m, Int.MaxValue))
+      }
+    }
+
+    it("should respond to `ofYearDay`") {
+      testTemporal(ofYearDay(2011, 1))(of(2011, 1, 1))
+      testTemporal(ofYearDay(2011, 31))(of(2011, 1, 31))
+      testTemporal(ofYearDay(2011, 32))(of(2011, 2, 1))
+      testTemporal(ofYearDay(2011, 59))(of(2011, 2, 28))
+      testTemporal(ofYearDay(2011, 60))(of(2011, 3, 1))
+      testTemporal(ofYearDay(2011, 90))(of(2011, 3, 31))
+      testTemporal(ofYearDay(2011, 91))(of(2011, 4, 1))
+      testTemporal(ofYearDay(2011, 120))(of(2011, 4, 30))
+      testTemporal(ofYearDay(2011, 121))(of(2011, 5, 1))
+      testTemporal(ofYearDay(2011, 151))(of(2011, 5, 31))
+      testTemporal(ofYearDay(2011, 152))(of(2011, 6, 1))
+      testTemporal(ofYearDay(2011, 181))(of(2011, 6, 30))
+      testTemporal(ofYearDay(2011, 182))(of(2011, 7, 1))
+      testTemporal(ofYearDay(2011, 212))(of(2011, 7, 31))
+      testTemporal(ofYearDay(2011, 213))(of(2011, 8, 1))
+      testTemporal(ofYearDay(2011, 243))(of(2011, 8, 31))
+      testTemporal(ofYearDay(2011, 244))(of(2011, 9, 1))
+      testTemporal(ofYearDay(2011, 273))(of(2011, 9, 30))
+      testTemporal(ofYearDay(2011, 274))(of(2011, 10, 1))
+      testTemporal(ofYearDay(2011, 304))(of(2011, 10, 31))
+      testTemporal(ofYearDay(2011, 305))(of(2011, 11, 1))
+      testTemporal(ofYearDay(2011, 334))(of(2011, 11, 30))
+      testTemporal(ofYearDay(2011, 335))(of(2011, 12, 1))
+      testTemporal(ofYearDay(2011, 365))(of(2011, 12, 31))
+      testTemporal(ofYearDay(2012, 1))(of(2012, 1, 1))
+      testTemporal(ofYearDay(2012, 31))(of(2012, 1, 31))
+      testTemporal(ofYearDay(2012, 32))(of(2012, 2, 1))
+      testTemporal(ofYearDay(2012, 60))(of(2012, 2, 29))
+      testTemporal(ofYearDay(2012, 61))(of(2012, 3, 1))
+      testTemporal(ofYearDay(2012, 91))(of(2012, 3, 31))
+      testTemporal(ofYearDay(2012, 92))(of(2012, 4, 1))
+      testTemporal(ofYearDay(2012, 121))(of(2012, 4, 30))
+      testTemporal(ofYearDay(2012, 122))(of(2012, 5, 1))
+      testTemporal(ofYearDay(2012, 152))(of(2012, 5, 31))
+      testTemporal(ofYearDay(2012, 153))(of(2012, 6, 1))
+      testTemporal(ofYearDay(2012, 182))(of(2012, 6, 30))
+      testTemporal(ofYearDay(2012, 183))(of(2012, 7, 1))
+      testTemporal(ofYearDay(2012, 213))(of(2012, 7, 31))
+      testTemporal(ofYearDay(2012, 214))(of(2012, 8, 1))
+      testTemporal(ofYearDay(2012, 244))(of(2012, 8, 31))
+      testTemporal(ofYearDay(2012, 245))(of(2012, 9, 1))
+      testTemporal(ofYearDay(2012, 274))(of(2012, 9, 30))
+      testTemporal(ofYearDay(2012, 275))(of(2012, 10, 1))
+      testTemporal(ofYearDay(2012, 305))(of(2012, 10, 31))
+      testTemporal(ofYearDay(2012, 306))(of(2012, 11, 1))
+      testTemporal(ofYearDay(2012, 335))(of(2012, 11, 30))
+      testTemporal(ofYearDay(2012, 336))(of(2012, 12, 1))
+      testTemporal(ofYearDay(2012, 366))(of(2012, 12, 31))
+
+      expectThrows[DateTimeException](ofYearDay(Int.MinValue, 1))
+      expectThrows[DateTimeException](ofYearDay(-1000000000, 1))
+      expectThrows[DateTimeException](ofYearDay(1000000000, 1))
+      expectThrows[DateTimeException](ofYearDay(Int.MaxValue, 1))
+      expectThrows[DateTimeException](ofYearDay(2011, Int.MinValue))
+      expectThrows[DateTimeException](ofYearDay(2011, 0))
+      expectThrows[DateTimeException](ofYearDay(2011, 366))
+      expectThrows[DateTimeException](ofYearDay(2012, 367))
+      expectThrows[DateTimeException](ofYearDay(2011, Int.MaxValue))
+    }
+
+    it("should respond to `ofEpochDay`") {
+      testTemporal(ofEpochDay(-365243219162L))(MIN)
+      testTemporal(ofEpochDay(-1))(of(1969, 12, 31))
+      testTemporal(ofEpochDay(0))(of(1970, 1, 1))
+      testTemporal(ofEpochDay(1))(of(1970, 1, 2))
+      testTemporal(ofEpochDay(365241780471L))(MAX)
+
+      expectThrows[DateTimeException](ofEpochDay(Long.MinValue))
+      expectThrows[DateTimeException](ofEpochDay(-365243219163L))
+      expectThrows[DateTimeException](ofEpochDay(365241780472L))
+      expectThrows[DateTimeException](ofEpochDay(Long.MaxValue))
+    }
+
+    it("should respond to `from`") {
+      for (d <- samples)
+        testTemporal(from(d))(d)
+
+      for (t <- Seq(LocalTime.MIN, LocalTime.NOON, LocalTime.MAX))
+        expectThrows[DateTimeException](from(t))
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/LocalTimeTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/LocalTimeTest.scala
@@ -1,36 +1,33 @@
 package org.scalajs.testsuite.javalib.time
 
 import java.time.temporal._
-import java.time.{DateTimeException, LocalTime}
+import java.time._
 
-import temporal.TemporalAccessorTest
+import org.scalajs.testsuite.javalib.time.temporal.TemporalTest
 
-object LocalTimeTest extends TemporalAccessorTest {
+object LocalTimeTest extends TemporalTest {
   import LocalTime._
   import ChronoUnit._
   import ChronoField._
 
   describe("java.time.LocalTime") {
-    testTemporalAccessorApi(MAX, MIN, NOON)
+    val samples = Seq(MAX, NOON, MIN)
+
+    testTemporalApi(samples: _*)
 
     it("should respond to `isSupported`") {
       for {
-        t <- Seq(MAX, MIN, NOON)
-        f <- ChronoField.values()
+        t <- samples
+        f <- ChronoField.values
       } {
         expect(t.isSupported(f) == f.isTimeBased).toBeTruthy
       }
 
       for {
-        t <- Seq(MAX, MIN, NOON)
-        u <- ChronoUnit.values()
+        t <- samples
+        u <- ChronoUnit.values
       } {
         expect(t.isSupported(u) == u.isTimeBased).toBeTruthy
-      }
-
-      for (t <- Seq(MAX, MIN, NOON)) {
-        expect(t.isSupported(null: TemporalUnit)).toBeFalsy
-        expect(t.isSupported(null: TemporalField)).toBeFalsy
       }
     }
 
@@ -68,8 +65,8 @@ object LocalTimeTest extends TemporalAccessorTest {
       expect(MAX.getLong(AMPM_OF_DAY) == 1).toBeTruthy
 
       for {
-        t <- Seq(MIN, MAX)
-        field <- ChronoField.values() if !t.isSupported(field)
+        t <- samples
+        field <- ChronoField.values if !t.isSupported(field)
       } {
         expectThrows[UnsupportedTemporalTypeException](t.getLong(field))
       }
@@ -93,52 +90,51 @@ object LocalTimeTest extends TemporalAccessorTest {
       expect(MAX.getSecond).toEqual(59)
     }
 
-    it("should respond to `getNano") {
+    it("should respond to `getNano`") {
       expect(MIN.getNano).toEqual(0)
       expect(MAX.getNano).toEqual(999999999)
     }
 
     it("should respond to `with`") {
-      for (t <- Seq(MIN, MAX)) {
+      for (t <- samples) {
         for (n <- Seq(0, 999, 999999, 999999999))
-          expect(t.`with`(NANO_OF_SECOND, n) == t.withNano(n)).toBeTruthy
+          testTemporal(t.`with`(NANO_OF_SECOND, n))(t.withNano(n))
         for (n <- Seq(0L, 1000000000L, 86399999999999L))
-          expect(t.`with`(NANO_OF_DAY, n) == ofNanoOfDay(n)).toBeTruthy
+          testTemporal(t.`with`(NANO_OF_DAY, n))(ofNanoOfDay(n))
         for (n <- Seq(0, 999, 999999))
-          expect(t.`with`(MICRO_OF_SECOND, n) == t.withNano(n * 1000)).toBeTruthy
+          testTemporal(t.`with`(MICRO_OF_SECOND, n))(t.withNano(n * 1000))
         for (n <- Seq(0L, 1000000L, 86399999999L))
-          expect(t.`with`(MICRO_OF_DAY, n) == ofNanoOfDay(n * 1000)).toBeTruthy
+          testTemporal(t.`with`(MICRO_OF_DAY, n))(ofNanoOfDay(n * 1000))
         for (n <- Seq(0, 500, 999))
-          expect(t.`with`(MILLI_OF_SECOND, n) == t.withNano(n * 1000000)).toBeTruthy
+          testTemporal(t.`with`(MILLI_OF_SECOND, n))(t.withNano(n * 1000000))
         for (n <- Seq(0L, 1000L, 86399999L))
-          expect(t.`with`(MILLI_OF_DAY, n) == ofNanoOfDay(n * 1000000)).toBeTruthy
+          testTemporal(t.`with`(MILLI_OF_DAY, n))(ofNanoOfDay(n * 1000000))
         for (n <- Seq(0, 30, 59))
-          expect(t.`with`(SECOND_OF_MINUTE, n) == t.withSecond(n)).toBeTruthy
-        for (n <- Seq(0, 60, 86399)) {
-          val res = ofSecondOfDay(n).withNano(t.getNano)
-          expect(t.`with`(SECOND_OF_DAY, n) == res).toBeTruthy
-        }
+          testTemporal(t.`with`(SECOND_OF_MINUTE, n))(t.withSecond(n))
+        for (n <- Seq(0, 60, 86399))
+          testTemporal(t.`with`(SECOND_OF_DAY, n))(ofSecondOfDay(n).withNano(t.getNano))
         for (n <- Seq(0, 30, 59))
-          expect(t.`with`(MINUTE_OF_HOUR, n) == t.withMinute(n)).toBeTruthy
+          testTemporal(t.`with`(MINUTE_OF_HOUR, n))(t.withMinute(n))
         for (n <- Seq(0, 60, 1439)) {
-          val res = ofSecondOfDay(n * 60).withSecond(t.getSecond).withNano(t.getNano)
-          expect(t.`with`(MINUTE_OF_DAY, n) == res).toBeTruthy
+          testTemporal(t.`with`(MINUTE_OF_DAY, n)) {
+            ofSecondOfDay(n * 60).withSecond(t.getSecond).withNano(t.getNano)
+          }
         }
         for (n <- Seq(0, 6, 11)) {
           val h = (t.getHour / 12) * 12 + n
-          expect(t.`with`(HOUR_OF_AMPM, n) == t.withHour(h)).toBeTruthy
+          testTemporal(t.`with`(HOUR_OF_AMPM, n))(t.withHour(h))
         }
         for (n <- Seq(1, 6, 12)) {
           val h = (t.getHour / 12) * 12 + (n % 12)
-          expect(t.`with`(CLOCK_HOUR_OF_AMPM, n) == t.withHour(h)).toBeTruthy
+          testTemporal(t.`with`(CLOCK_HOUR_OF_AMPM, n))(t.withHour(h))
         }
         for (n <- Seq(0, 12, 23))
-          expect(t.`with`(HOUR_OF_DAY, n) == t.withHour(n)).toBeTruthy
+          testTemporal(t.`with`(HOUR_OF_DAY, n))(t.withHour(n))
         for (n <- Seq(1, 12, 24))
-          expect(t.`with`(CLOCK_HOUR_OF_DAY, n) == t.withHour(n % 24)).toBeTruthy
+          testTemporal(t.`with`(CLOCK_HOUR_OF_DAY, n))(t.withHour(n % 24))
         for (n <- Seq(0, 1)) {
           val h = t.getHour % 12 + n * 12
-          expect(t.`with`(AMPM_OF_DAY, n) == t.withHour(h)).toBeTruthy
+          testTemporal(t.`with`(AMPM_OF_DAY, n))(t.withHour(h))
         }
 
         for (n <- Seq(Long.MinValue, -1L, 1000000000L, Long.MaxValue))
@@ -171,23 +167,17 @@ object LocalTimeTest extends TemporalAccessorTest {
           expectThrows[DateTimeException](t.`with`(CLOCK_HOUR_OF_DAY, n))
         for (n <- Seq(Long.MinValue, -1L, 2L, Long.MaxValue))
           expectThrows[DateTimeException](t.`with`(AMPM_OF_DAY, n))
-        for {
-          field <- ChronoField.values() if !t.isSupported(field)
-          n <- Seq(Long.MinValue, 0, 1, Long.MaxValue)
-        } {
-          expectThrows[UnsupportedTemporalTypeException](t.`with`(field, n))
-        }
       }
     }
 
     it("should respond to `withHour`") {
-      expect(MIN.withHour(0) == MIN).toBeTruthy
-      expect(MIN.withHour(12) == NOON).toBeTruthy
-      expect(MIN.withHour(23) == of(23, 0)).toBeTruthy
-      expect(MAX.withHour(0) == of(0, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.withHour(23) == MAX).toBeTruthy
+      testTemporal(MIN.withHour(0))(MIN)
+      testTemporal(MIN.withHour(12))(NOON)
+      testTemporal(MIN.withHour(23))(of(23, 0))
+      testTemporal(MAX.withHour(0))(of(0, 59, 59, 999999999))
+      testTemporal(MAX.withHour(23))(MAX)
 
-      for (t <- Seq(MIN, MAX)) {
+      for (t <- samples) {
         expectThrows[DateTimeException](t.withHour(Int.MinValue))
         expectThrows[DateTimeException](t.withHour(-1))
         expectThrows[DateTimeException](t.withHour(24))
@@ -196,13 +186,13 @@ object LocalTimeTest extends TemporalAccessorTest {
     }
 
     it("should respond to `withMinute`") {
-      expect(MIN.withMinute(0) == MIN).toBeTruthy
-      expect(MIN.withMinute(30) == of(0, 30)).toBeTruthy
-      expect(MIN.withMinute(59) == of(0, 59)).toBeTruthy
-      expect(MAX.withMinute(0) == of(23, 0, 59, 999999999)).toBeTruthy
-      expect(MAX.withMinute(59) == MAX).toBeTruthy
+      testTemporal(MIN.withMinute(0))(MIN)
+      testTemporal(MIN.withMinute(30))(of(0, 30))
+      testTemporal(MIN.withMinute(59))(of(0, 59))
+      testTemporal(MAX.withMinute(0))(of(23, 0, 59, 999999999))
+      testTemporal(MAX.withMinute(59))(MAX)
 
-      for (t <- Seq(MIN, MAX)) {
+      for (t <- samples) {
         expectThrows[DateTimeException](t.withMinute(Int.MinValue))
         expectThrows[DateTimeException](t.withMinute(-1))
         expectThrows[DateTimeException](t.withMinute(60))
@@ -211,13 +201,13 @@ object LocalTimeTest extends TemporalAccessorTest {
     }
 
     it("should respond to `withSecond`") {
-      expect(MIN.withSecond(0) == MIN).toBeTruthy
-      expect(MIN.withSecond(30) == of(0, 0, 30)).toBeTruthy
-      expect(MIN.withSecond(59) == of(0, 0, 59)).toBeTruthy
-      expect(MAX.withSecond(0) == of(23, 59, 0, 999999999)).toBeTruthy
-      expect(MAX.withSecond(59) == MAX).toBeTruthy
+      testTemporal(MIN.withSecond(0))(MIN)
+      testTemporal(MIN.withSecond(30))(of(0, 0, 30))
+      testTemporal(MIN.withSecond(59))(of(0, 0, 59))
+      testTemporal(MAX.withSecond(0))(of(23, 59, 0, 999999999))
+      testTemporal(MAX.withSecond(59))(MAX)
 
-      for (t <- Seq(MIN, MAX)) {
+      for (t <- samples) {
         expectThrows[DateTimeException](t.withSecond(Int.MinValue))
         expectThrows[DateTimeException](t.withSecond(-1))
         expectThrows[DateTimeException](t.withSecond(60))
@@ -226,13 +216,13 @@ object LocalTimeTest extends TemporalAccessorTest {
     }
 
     it("should respond to `withNano`") {
-      expect(MIN.withNano(0) == MIN).toBeTruthy
-      expect(MIN.withNano(500000000) == of(0, 0, 0, 500000000)).toBeTruthy
-      expect(MIN.withNano(999999999) == of(0, 0, 0, 999999999)).toBeTruthy
-      expect(MAX.withNano(0) == of(23, 59, 59, 0)).toBeTruthy
-      expect(MAX.withNano(999999999) == MAX).toBeTruthy
+      testTemporal(MIN.withNano(0))(MIN)
+      testTemporal(MIN.withNano(500000000))(of(0, 0, 0, 500000000))
+      testTemporal(MIN.withNano(999999999))(of(0, 0, 0, 999999999))
+      testTemporal(MAX.withNano(0))(of(23, 59, 59, 0))
+      testTemporal(MAX.withNano(999999999))(MAX)
 
-      for (t <- Seq(MIN, MAX)) {
+      for (t <- samples) {
         expectThrows[DateTimeException](t.withNano(Int.MinValue))
         expectThrows[DateTimeException](t.withNano(-1))
         expectThrows[DateTimeException](t.withNano(1000000000))
@@ -241,238 +231,225 @@ object LocalTimeTest extends TemporalAccessorTest {
     }
 
     it("should respond to `truncatedTo`") {
-      expect(MIN.truncatedTo(NANOS) == MIN).toBeTruthy
-      expect(MAX.truncatedTo(NANOS) == MAX).toBeTruthy
-      expect(MIN.truncatedTo(MICROS) == MIN).toBeTruthy
-      expect(MAX.truncatedTo(MICROS) == of(23, 59, 59, 999999000)).toBeTruthy
-      expect(MIN.truncatedTo(MILLIS) == MIN).toBeTruthy
-      expect(MAX.truncatedTo(MILLIS) == of(23, 59, 59, 999000000)).toBeTruthy
-      expect(MIN.truncatedTo(SECONDS) == MIN).toBeTruthy
-      expect(MAX.truncatedTo(SECONDS) == of(23, 59, 59)).toBeTruthy
-      expect(MIN.truncatedTo(MINUTES) == MIN).toBeTruthy
-      expect(MAX.truncatedTo(MINUTES) == of(23, 59)).toBeTruthy
-      expect(MIN.truncatedTo(HOURS) == MIN).toBeTruthy
-      expect(MAX.truncatedTo(HOURS) == of(23, 0)).toBeTruthy
-      expect(MIN.truncatedTo(HALF_DAYS) == MIN).toBeTruthy
-      expect(MAX.truncatedTo(HALF_DAYS) == of(12, 0)).toBeTruthy
-      expect(MIN.truncatedTo(DAYS) == MIN).toBeTruthy
-      expect(MAX.truncatedTo(DAYS) == MIN).toBeTruthy
+      testTemporal(MIN.truncatedTo(NANOS))(MIN)
+      testTemporal(MAX.truncatedTo(NANOS))(MAX)
+      testTemporal(MIN.truncatedTo(MICROS))(MIN)
+      testTemporal(MAX.truncatedTo(MICROS))(of(23, 59, 59, 999999000))
+      testTemporal(MIN.truncatedTo(MILLIS))(MIN)
+      testTemporal(MAX.truncatedTo(MILLIS))(of(23, 59, 59, 999000000))
+      testTemporal(MIN.truncatedTo(SECONDS))(MIN)
+      testTemporal(MAX.truncatedTo(SECONDS))(of(23, 59, 59))
+      testTemporal(MIN.truncatedTo(MINUTES))(MIN)
+      testTemporal(MAX.truncatedTo(MINUTES))(of(23, 59))
+      testTemporal(MIN.truncatedTo(HOURS))(MIN)
+      testTemporal(MAX.truncatedTo(HOURS))(of(23, 0))
+      testTemporal(MIN.truncatedTo(HALF_DAYS))(MIN)
+      testTemporal(MAX.truncatedTo(HALF_DAYS))(of(12, 0))
+      testTemporal(MIN.truncatedTo(DAYS))(MIN)
+      testTemporal(MAX.truncatedTo(DAYS))(MIN)
 
+      val illegalUnits = dateBasedUnits.filter(_ != DAYS)
       for {
-        t <- Seq(MIN, MAX)
-        u <- ChronoUnit.values() if u != DAYS && u.isDateBased
+        t <- samples
+        u <- illegalUnits
       } {
         expectThrows[UnsupportedTemporalTypeException](t.truncatedTo(u))
       }
     }
 
     it("should respond to `plus`") {
-      for {
-        t <- Seq(MIN, MAX)
-        n <- Seq(Long.MinValue, -1000000000L, -86400L, -3600L, -60L, -1L, 0L,
+      val values = Seq(Long.MinValue, -1000000000L, -86400L, -3600L, -60L, -1L, 0L,
           1L, 60L, 3600L, 86400L, 1000000000L, Long.MaxValue)
-      } {
-        expect(t.plus(n, NANOS) == t.plusNanos(n)).toBeTruthy
-        expect(t.plus(n, MICROS) == t.plusNanos((n % 86400000000L) * 1000)).toBeTruthy
-        expect(t.plus(n, MILLIS) == t.plusNanos((n % 86400000) * 1000000)).toBeTruthy
-        expect(t.plus(n, SECONDS) == t.plusSeconds(n)).toBeTruthy
-        expect(t.plus(n, MINUTES) == t.plusMinutes(n)).toBeTruthy
-        expect(t.plus(n, HOURS) == t.plusHours(n)).toBeTruthy
-        expect(t.plus(n, HALF_DAYS) == t.plusHours((n % 2) * 12)).toBeTruthy
 
-        for(u <- ChronoUnit.values() if u.isDateBased)
-          expectThrows[UnsupportedTemporalTypeException](t.plus(n, u))
+      for {
+        t <- samples
+        n <- values
+      } {
+        testTemporal(t.plus(n, NANOS))(t.plusNanos(n))
+        testTemporal(t.plus(n, MICROS))(t.plusNanos((n % 86400000000L) * 1000))
+        testTemporal(t.plus(n, MILLIS))(t.plusNanos((n % 86400000) * 1000000))
+        testTemporal(t.plus(n, SECONDS))(t.plusSeconds(n))
+        testTemporal(t.plus(n, MINUTES))(t.plusMinutes(n))
+        testTemporal(t.plus(n, HOURS))(t.plusHours(n))
+        testTemporal(t.plus(n, HALF_DAYS))(t.plusHours((n % 2) * 12))
       }
     }
 
-    it("should respond to `plusHours") {
-      expect(MIN.plusHours(Long.MinValue) == of(16, 0)).toBeTruthy
-      expect(MIN.plusHours(-24) == MIN).toBeTruthy
-      expect(MIN.plusHours(-1) == of(23, 0)).toBeTruthy
-      expect(MIN.plusHours(0) == MIN).toBeTruthy
-      expect(MIN.plusHours(1) == of(1, 0)).toBeTruthy
-      expect(MIN.plusHours(24) == MIN).toBeTruthy
-      expect(MIN.plusHours(Long.MaxValue) == of(7, 0)).toBeTruthy
-      expect(MAX.plusHours(Long.MinValue) == of(15, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.plusHours(-24) == MAX).toBeTruthy
-      expect(MAX.plusHours(-1) == of(22, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.plusHours(0) == MAX).toBeTruthy
-      expect(MAX.plusHours(1) == of(0, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.plusHours(24) == MAX).toBeTruthy
-      expect(MAX.plusHours(Long.MaxValue) == of(6, 59, 59, 999999999)).toBeTruthy
+    it("should respond to `plusHours`") {
+      testTemporal(MIN.plusHours(Long.MinValue))(of(16, 0))
+      testTemporal(MIN.plusHours(-24))(MIN)
+      testTemporal(MIN.plusHours(-1))(of(23, 0))
+      testTemporal(MIN.plusHours(0))(MIN)
+      testTemporal(MIN.plusHours(1))(of(1, 0))
+      testTemporal(MIN.plusHours(24))(MIN)
+      testTemporal(MIN.plusHours(Long.MaxValue))(of(7, 0))
+      testTemporal(MAX.plusHours(Long.MinValue))(of(15, 59, 59, 999999999))
+      testTemporal(MAX.plusHours(-24))(MAX)
+      testTemporal(MAX.plusHours(-1))(of(22, 59, 59, 999999999))
+      testTemporal(MAX.plusHours(0))(MAX)
+      testTemporal(MAX.plusHours(1))(of(0, 59, 59, 999999999))
+      testTemporal(MAX.plusHours(24))(MAX)
+      testTemporal(MAX.plusHours(Long.MaxValue))(of(6, 59, 59, 999999999))
     }
 
-    it("should respond to `plusMinutes") {
-      expect(MIN.plusMinutes(Long.MinValue) == of(5, 52)).toBeTruthy
-      expect(MIN.plusMinutes(-1440) == MIN).toBeTruthy
-      expect(MIN.plusMinutes(-60) == of(23, 0)).toBeTruthy
-      expect(MIN.plusMinutes(-1) == of(23, 59)).toBeTruthy
-      expect(MIN.plusMinutes(0) == MIN).toBeTruthy
-      expect(MIN.plusMinutes(1) == of(0, 1)).toBeTruthy
-      expect(MIN.plusMinutes(60) == of(1, 0)).toBeTruthy
-      expect(MIN.plusMinutes(1440) == MIN).toBeTruthy
-      expect(MIN.plusMinutes(Long.MaxValue) == of(18, 7)).toBeTruthy
-      expect(MAX.plusMinutes(Long.MinValue) == of(5, 51, 59, 999999999)).toBeTruthy
-      expect(MAX.plusMinutes(-1440) == MAX).toBeTruthy
-      expect(MAX.plusMinutes(-60) == of(22, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.plusMinutes(-1) == of(23, 58, 59, 999999999)).toBeTruthy
-      expect(MAX.plusMinutes(0) == MAX).toBeTruthy
-      expect(MAX.plusMinutes(1) == of(0, 0, 59, 999999999)).toBeTruthy
-      expect(MAX.plusMinutes(60) == of(0, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.plusMinutes(1440) == MAX).toBeTruthy
-      expect(MAX.plusMinutes(Long.MaxValue) == of(18, 6, 59, 999999999)).toBeTruthy
+    it("should respond to `plusMinutes`") {
+      testTemporal(MIN.plusMinutes(Long.MinValue))(of(5, 52))
+      testTemporal(MIN.plusMinutes(-1440))(MIN)
+      testTemporal(MIN.plusMinutes(-60))(of(23, 0))
+      testTemporal(MIN.plusMinutes(-1))(of(23, 59))
+      testTemporal(MIN.plusMinutes(0))(MIN)
+      testTemporal(MIN.plusMinutes(1))(of(0, 1))
+      testTemporal(MIN.plusMinutes(60))(of(1, 0))
+      testTemporal(MIN.plusMinutes(1440))(MIN)
+      testTemporal(MIN.plusMinutes(Long.MaxValue))(of(18, 7))
+      testTemporal(MAX.plusMinutes(Long.MinValue))(of(5, 51, 59, 999999999))
+      testTemporal(MAX.plusMinutes(-1440))(MAX)
+      testTemporal(MAX.plusMinutes(-60))(of(22, 59, 59, 999999999))
+      testTemporal(MAX.plusMinutes(-1))(of(23, 58, 59, 999999999))
+      testTemporal(MAX.plusMinutes(0))(MAX)
+      testTemporal(MAX.plusMinutes(1))(of(0, 0, 59, 999999999))
+      testTemporal(MAX.plusMinutes(60))(of(0, 59, 59, 999999999))
+      testTemporal(MAX.plusMinutes(1440))(MAX)
+      testTemporal(MAX.plusMinutes(Long.MaxValue))(of(18, 6, 59, 999999999))
     }
 
-    it("should respond to `plusSeconds") {
-      expect(MIN.plusSeconds(Long.MinValue) == of(8, 29, 52)).toBeTruthy
-      expect(MIN.plusSeconds(-86400) == MIN).toBeTruthy
-      expect(MIN.plusSeconds(-60) == of(23, 59)).toBeTruthy
-      expect(MIN.plusSeconds(-1) == of(23, 59, 59)).toBeTruthy
-      expect(MIN.plusSeconds(0) == MIN).toBeTruthy
-      expect(MIN.plusSeconds(1) == of(0, 0, 1)).toBeTruthy
-      expect(MIN.plusSeconds(60) == of(0, 1)).toBeTruthy
-      expect(MIN.plusSeconds(86400) == MIN).toBeTruthy
-      expect(MIN.plusSeconds(Long.MaxValue) == of(15, 30, 7)).toBeTruthy
-      expect(MAX.plusSeconds(Long.MinValue) == of(8, 29, 51, 999999999)).toBeTruthy
-      expect(MAX.plusSeconds(-86400) == MAX).toBeTruthy
-      expect(MAX.plusSeconds(-60) == of(23, 58, 59, 999999999)).toBeTruthy
-      expect(MAX.plusSeconds(-1) == of(23, 59, 58, 999999999)).toBeTruthy
-      expect(MAX.plusSeconds(0) == MAX).toBeTruthy
-      expect(MAX.plusSeconds(1) == of(0, 0, 0, 999999999)).toBeTruthy
-      expect(MAX.plusSeconds(60) == of(0, 0, 59, 999999999)).toBeTruthy
-      expect(MAX.plusSeconds(86400) == MAX).toBeTruthy
-      expect(MAX.plusSeconds(Long.MaxValue) == of(15, 30, 6, 999999999)).toBeTruthy
+    it("should respond to `plusSeconds`") {
+      testTemporal(MIN.plusSeconds(Long.MinValue))(of(8, 29, 52))
+      testTemporal(MIN.plusSeconds(-86400))(MIN)
+      testTemporal(MIN.plusSeconds(-60))(of(23, 59))
+      testTemporal(MIN.plusSeconds(-1))(of(23, 59, 59))
+      testTemporal(MIN.plusSeconds(0))(MIN)
+      testTemporal(MIN.plusSeconds(1))(of(0, 0, 1))
+      testTemporal(MIN.plusSeconds(60))(of(0, 1))
+      testTemporal(MIN.plusSeconds(86400))(MIN)
+      testTemporal(MIN.plusSeconds(Long.MaxValue))(of(15, 30, 7))
+      testTemporal(MAX.plusSeconds(Long.MinValue))(of(8, 29, 51, 999999999))
+      testTemporal(MAX.plusSeconds(-86400))(MAX)
+      testTemporal(MAX.plusSeconds(-60))(of(23, 58, 59, 999999999))
+      testTemporal(MAX.plusSeconds(-1))(of(23, 59, 58, 999999999))
+      testTemporal(MAX.plusSeconds(0))(MAX)
+      testTemporal(MAX.plusSeconds(1))(of(0, 0, 0, 999999999))
+      testTemporal(MAX.plusSeconds(60))(of(0, 0, 59, 999999999))
+      testTemporal(MAX.plusSeconds(86400))(MAX)
+      testTemporal(MAX.plusSeconds(Long.MaxValue))(of(15, 30, 6, 999999999))
     }
 
-    it("should respond to `plusNanos") {
-      expect(MIN.plusNanos(Long.MinValue) == of(0, 12, 43, 145224192)).toBeTruthy
-      expect(MIN.plusNanos(-86400000000000L) == MIN).toBeTruthy
-      expect(MIN.plusNanos(-1000000000) == of(23, 59, 59)).toBeTruthy
-      expect(MIN.plusNanos(-1) == MAX).toBeTruthy
-      expect(MIN.plusNanos(0) == MIN).toBeTruthy
-      expect(MIN.plusNanos(1) == of(0, 0, 0, 1)).toBeTruthy
-      expect(MIN.plusNanos(1000000000) == of(0, 0, 1)).toBeTruthy
-      expect(MIN.plusNanos(86400000000000L) == MIN).toBeTruthy
-      expect(MIN.plusNanos(Long.MaxValue) == of(23, 47, 16, 854775807)).toBeTruthy
-      expect(MAX.plusNanos(Long.MinValue) == of(0, 12, 43, 145224191)).toBeTruthy
-      expect(MAX.plusNanos(-86400000000000L) == MAX).toBeTruthy
-      expect(MAX.plusNanos(-1000000000) == of(23, 59, 58, 999999999)).toBeTruthy
-      expect(MAX.plusNanos(-1) == of(23, 59, 59, 999999998)).toBeTruthy
-      expect(MAX.plusNanos(0) == MAX).toBeTruthy
-      expect(MAX.plusNanos(1) == MIN).toBeTruthy
-      expect(MAX.plusNanos(1000000000) == of(0, 0, 0, 999999999)).toBeTruthy
-      expect(MAX.plusNanos(86400000000000L) == MAX).toBeTruthy
-      expect(MAX.plusNanos(Long.MaxValue) == of(23, 47, 16, 854775806)).toBeTruthy
+    it("should respond to `plusNanos`") {
+      testTemporal(MIN.plusNanos(Long.MinValue))(of(0, 12, 43, 145224192))
+      testTemporal(MIN.plusNanos(-86400000000000L))(MIN)
+      testTemporal(MIN.plusNanos(-1000000000))(of(23, 59, 59))
+      testTemporal(MIN.plusNanos(-1))(MAX)
+      testTemporal(MIN.plusNanos(0))(MIN)
+      testTemporal(MIN.plusNanos(1))(of(0, 0, 0, 1))
+      testTemporal(MIN.plusNanos(1000000000))(of(0, 0, 1))
+      testTemporal(MIN.plusNanos(86400000000000L))(MIN)
+      testTemporal(MIN.plusNanos(Long.MaxValue))(of(23, 47, 16, 854775807))
+      testTemporal(MAX.plusNanos(Long.MinValue))(of(0, 12, 43, 145224191))
+      testTemporal(MAX.plusNanos(-86400000000000L))(MAX)
+      testTemporal(MAX.plusNanos(-1000000000))(of(23, 59, 58, 999999999))
+      testTemporal(MAX.plusNanos(-1))(of(23, 59, 59, 999999998))
+      testTemporal(MAX.plusNanos(0))(MAX)
+      testTemporal(MAX.plusNanos(1))(MIN)
+      testTemporal(MAX.plusNanos(1000000000))(of(0, 0, 0, 999999999))
+      testTemporal(MAX.plusNanos(86400000000000L))(MAX)
+      testTemporal(MAX.plusNanos(Long.MaxValue))(of(23, 47, 16, 854775806))
     }
 
-    it("should respond to `minus`") {
-      for {
-        t <- Seq(MIN, MAX)
-        n <- Seq(Long.MinValue, -1000000000L, -86400L, -3600L, -60L, -1L, 0L,
-          1L, 60L, 3600L, 86400L, 1000000000L, Long.MaxValue)
-      } {
-        expect(t.minus(n, NANOS) == t.minusNanos(n)).toBeTruthy
-        expect(t.minus(n, MICROS) == t.minusNanos((n % 86400000000L) * 1000)).toBeTruthy
-        expect(t.minus(n, MILLIS) == t.minusNanos((n % 86400000) * 1000000)).toBeTruthy
-        expect(t.minus(n, SECONDS) == t.minusSeconds(n)).toBeTruthy
-        expect(t.minus(n, MINUTES) == t.minusMinutes(n)).toBeTruthy
-        expect(t.minus(n, HOURS) == t.minusHours(n)).toBeTruthy
-        expect(t.minus(n, HALF_DAYS) == t.minusHours((n % 2) * 12)).toBeTruthy
-
-        for(u <- ChronoUnit.values() if u.isDateBased)
-          expectThrows[UnsupportedTemporalTypeException](t.minus(n, u))
-      }
+    it("should respond to `minusHours`") {
+      testTemporal(MIN.minusHours(Long.MinValue))(of(8, 0))
+      testTemporal(MIN.minusHours(-24))(MIN)
+      testTemporal(MIN.minusHours(-1))(of(1, 0))
+      testTemporal(MIN.minusHours(0))(MIN)
+      testTemporal(MIN.minusHours(1))(of(23, 0))
+      testTemporal(MIN.minusHours(24))(MIN)
+      testTemporal(MIN.minusHours(Long.MaxValue))(of(17, 0))
+      testTemporal(MAX.minusHours(Long.MinValue))(of(7, 59, 59, 999999999))
+      testTemporal(MAX.minusHours(-24))(MAX)
+      testTemporal(MAX.minusHours(-1))(of(0, 59, 59, 999999999))
+      testTemporal(MAX.minusHours(0))(MAX)
+      testTemporal(MAX.minusHours(1))(of(22, 59, 59, 999999999))
+      testTemporal(MAX.minusHours(24))(MAX)
+      testTemporal(MAX.minusHours(Long.MaxValue))(of(16, 59, 59, 999999999))
     }
 
-    it("should respond to `minusHours") {
-      expect(MIN.minusHours(Long.MinValue) == of(8, 0)).toBeTruthy
-      expect(MIN.minusHours(-24) == MIN).toBeTruthy
-      expect(MIN.minusHours(-1) == of(1, 0)).toBeTruthy
-      expect(MIN.minusHours(0) == MIN).toBeTruthy
-      expect(MIN.minusHours(1) == of(23, 0)).toBeTruthy
-      expect(MIN.minusHours(24) == MIN).toBeTruthy
-      expect(MIN.minusHours(Long.MaxValue) == of(17, 0)).toBeTruthy
-      expect(MAX.minusHours(Long.MinValue) == of(7, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.minusHours(-24) == MAX).toBeTruthy
-      expect(MAX.minusHours(-1) == of(0, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.minusHours(0) == MAX).toBeTruthy
-      expect(MAX.minusHours(1) == of(22, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.minusHours(24) == MAX).toBeTruthy
-      expect(MAX.minusHours(Long.MaxValue) == of(16, 59, 59, 999999999)).toBeTruthy
+    it("should respond to `minusMinutes`") {
+      testTemporal(MIN.minusMinutes(Long.MinValue))(of(18, 8))
+      testTemporal(MIN.minusMinutes(-1440))(MIN)
+      testTemporal(MIN.minusMinutes(-60))(of(1, 0))
+      testTemporal(MIN.minusMinutes(-1))(of(0, 1))
+      testTemporal(MIN.minusMinutes(0))(MIN)
+      testTemporal(MIN.minusMinutes(1))(of(23, 59))
+      testTemporal(MIN.minusMinutes(60))(of(23, 0))
+      testTemporal(MIN.minusMinutes(1440))(MIN)
+      testTemporal(MIN.minusMinutes(Long.MaxValue))(of(5, 53))
+      testTemporal(MAX.minusMinutes(Long.MinValue))(of(18, 7, 59, 999999999))
+      testTemporal(MAX.minusMinutes(-1440))(MAX)
+      testTemporal(MAX.minusMinutes(-60))(of(0, 59, 59, 999999999))
+      testTemporal(MAX.minusMinutes(-1))(of(0, 0, 59, 999999999))
+      testTemporal(MAX.minusMinutes(0))(MAX)
+      testTemporal(MAX.minusMinutes(1))(of(23, 58, 59, 999999999))
+      testTemporal(MAX.minusMinutes(60))(of(22, 59, 59, 999999999))
+      testTemporal(MAX.minusMinutes(1440))(MAX)
+      testTemporal(MAX.minusMinutes(Long.MaxValue))(of(5, 52, 59, 999999999))
     }
 
-    it("should respond to `minusMinutes") {
-      expect(MIN.minusMinutes(Long.MinValue) == of(18, 8)).toBeTruthy
-      expect(MIN.minusMinutes(-1440) == MIN).toBeTruthy
-      expect(MIN.minusMinutes(-60) == of(1, 0)).toBeTruthy
-      expect(MIN.minusMinutes(-1) == of(0, 1)).toBeTruthy
-      expect(MIN.minusMinutes(0) == MIN).toBeTruthy
-      expect(MIN.minusMinutes(1) == of(23, 59)).toBeTruthy
-      expect(MIN.minusMinutes(60) == of(23, 0)).toBeTruthy
-      expect(MIN.minusMinutes(1440) == MIN).toBeTruthy
-      expect(MIN.minusMinutes(Long.MaxValue) == of(5, 53)).toBeTruthy
-      expect(MAX.minusMinutes(Long.MinValue) == of(18, 7, 59, 999999999)).toBeTruthy
-      expect(MAX.minusMinutes(-1440) == MAX).toBeTruthy
-      expect(MAX.minusMinutes(-60) == of(0, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.minusMinutes(-1) == of(0, 0, 59, 999999999)).toBeTruthy
-      expect(MAX.minusMinutes(0) == MAX).toBeTruthy
-      expect(MAX.minusMinutes(1) == of(23, 58, 59, 999999999)).toBeTruthy
-      expect(MAX.minusMinutes(60) == of(22, 59, 59, 999999999)).toBeTruthy
-      expect(MAX.minusMinutes(1440) == MAX).toBeTruthy
-      expect(MAX.minusMinutes(Long.MaxValue) == of(5, 52, 59, 999999999)).toBeTruthy
+    it("should respond to `minusSeconds`") {
+      testTemporal(MIN.minusSeconds(Long.MinValue))(of(15, 30, 8))
+      testTemporal(MIN.minusSeconds(-86400))(MIN)
+      testTemporal(MIN.minusSeconds(-60))(of(0, 1))
+      testTemporal(MIN.minusSeconds(-1))(of(0, 0, 1))
+      testTemporal(MIN.minusSeconds(0))(MIN)
+      testTemporal(MIN.minusSeconds(1))(of(23, 59, 59))
+      testTemporal(MIN.minusSeconds(60))(of(23, 59))
+      testTemporal(MIN.minusSeconds(86400))(MIN)
+      testTemporal(MIN.minusSeconds(Long.MaxValue))(of(8, 29, 53))
+      testTemporal(MAX.minusSeconds(Long.MinValue))(of(15, 30, 7, 999999999))
+      testTemporal(MAX.minusSeconds(-86400))(MAX)
+      testTemporal(MAX.minusSeconds(-60))(of(0, 0, 59, 999999999))
+      testTemporal(MAX.minusSeconds(-1))(of(0, 0, 0, 999999999))
+      testTemporal(MAX.minusSeconds(0))(MAX)
+      testTemporal(MAX.minusSeconds(1))(of(23, 59, 58, 999999999))
+      testTemporal(MAX.minusSeconds(60))(of(23, 58, 59, 999999999))
+      testTemporal(MAX.minusSeconds(86400))(MAX)
+      testTemporal(MAX.minusSeconds(Long.MaxValue))(of(8, 29, 52, 999999999))
     }
 
-    it("should respond to `minusSeconds") {
-      expect(MIN.minusSeconds(Long.MinValue) == of(15, 30, 8)).toBeTruthy
-      expect(MIN.minusSeconds(-86400) == MIN).toBeTruthy
-      expect(MIN.minusSeconds(-60) == of(0, 1)).toBeTruthy
-      expect(MIN.minusSeconds(-1) == of(0, 0, 1)).toBeTruthy
-      expect(MIN.minusSeconds(0) == MIN).toBeTruthy
-      expect(MIN.minusSeconds(1) == of(23, 59, 59)).toBeTruthy
-      expect(MIN.minusSeconds(60) == of(23, 59)).toBeTruthy
-      expect(MIN.minusSeconds(86400) == MIN).toBeTruthy
-      expect(MIN.minusSeconds(Long.MaxValue) == of(8, 29, 53)).toBeTruthy
-      expect(MAX.minusSeconds(Long.MinValue) == of(15, 30, 7, 999999999)).toBeTruthy
-      expect(MAX.minusSeconds(-86400) == MAX).toBeTruthy
-      expect(MAX.minusSeconds(-60) == of(0, 0, 59, 999999999)).toBeTruthy
-      expect(MAX.minusSeconds(-1) == of(0, 0, 0, 999999999)).toBeTruthy
-      expect(MAX.minusSeconds(0) == MAX).toBeTruthy
-      expect(MAX.minusSeconds(1) == of(23, 59, 58, 999999999)).toBeTruthy
-      expect(MAX.minusSeconds(60) == of(23, 58, 59, 999999999)).toBeTruthy
-      expect(MAX.minusSeconds(86400) == MAX).toBeTruthy
-      expect(MAX.minusSeconds(Long.MaxValue) == of(8, 29, 52, 999999999)).toBeTruthy
-    }
-
-    it("should respond to `minusNanos") {
-      expect(MIN.minusNanos(Long.MinValue) == of(23, 47, 16, 854775808)).toBeTruthy
-      expect(MIN.minusNanos(-86400000000000L) == MIN).toBeTruthy
-      expect(MIN.minusNanos(-1000000000) == of(0, 0, 1)).toBeTruthy
-      expect(MIN.minusNanos(-1) == of(0, 0, 0, 1)).toBeTruthy
-      expect(MIN.minusNanos(0) == MIN).toBeTruthy
-      expect(MIN.minusNanos(1) == MAX).toBeTruthy
-      expect(MIN.minusNanos(1000000000) == of(23, 59, 59)).toBeTruthy
-      expect(MIN.minusNanos(86400000000000L) == MIN).toBeTruthy
-      expect(MIN.minusNanos(Long.MaxValue) == of(0, 12, 43, 145224193)).toBeTruthy
-      expect(MAX.minusNanos(Long.MinValue) == of(23, 47, 16, 854775807)).toBeTruthy
-      expect(MAX.minusNanos(-86400000000000L) == MAX).toBeTruthy
-      expect(MAX.minusNanos(-1000000000) == of(0, 0, 0, 999999999)).toBeTruthy
-      expect(MAX.minusNanos(-1) == MIN).toBeTruthy
-      expect(MAX.minusNanos(0) == MAX).toBeTruthy
-      expect(MAX.minusNanos(1) == of(23, 59, 59, 999999998)).toBeTruthy
-      expect(MAX.minusNanos(1000000000) == of(23, 59, 58, 999999999)).toBeTruthy
-      expect(MAX.minusNanos(86400000000000L) == MAX).toBeTruthy
-      expect(MAX.minusNanos(Long.MaxValue) == of(0, 12, 43, 145224192)).toBeTruthy
+    it("should respond to `minusNanos`") {
+      testTemporal(MIN.minusNanos(Long.MinValue))(of(23, 47, 16, 854775808))
+      testTemporal(MIN.minusNanos(-86400000000000L))(MIN)
+      testTemporal(MIN.minusNanos(-1000000000))(of(0, 0, 1))
+      testTemporal(MIN.minusNanos(-1))(of(0, 0, 0, 1))
+      testTemporal(MIN.minusNanos(0))(MIN)
+      testTemporal(MIN.minusNanos(1))(MAX)
+      testTemporal(MIN.minusNanos(1000000000))(of(23, 59, 59))
+      testTemporal(MIN.minusNanos(86400000000000L))(MIN)
+      testTemporal(MIN.minusNanos(Long.MaxValue))(of(0, 12, 43, 145224193))
+      testTemporal(MAX.minusNanos(Long.MinValue))(of(23, 47, 16, 854775807))
+      testTemporal(MAX.minusNanos(-86400000000000L))(MAX)
+      testTemporal(MAX.minusNanos(-1000000000))(of(0, 0, 0, 999999999))
+      testTemporal(MAX.minusNanos(-1))(MIN)
+      testTemporal(MAX.minusNanos(0))(MAX)
+      testTemporal(MAX.minusNanos(1))(of(23, 59, 59, 999999998))
+      testTemporal(MAX.minusNanos(1000000000))(of(23, 59, 58, 999999999))
+      testTemporal(MAX.minusNanos(86400000000000L))(MAX)
+      testTemporal(MAX.minusNanos(Long.MaxValue))(of(0, 12, 43, 145224192))
     }
 
     it("should respond to `adjustInto`") {
       for {
-        t1 <- Seq(MIN, MAX)
-        t2 <- Seq(MIN, MAX)
+        t1 <- samples
+        t2 <- samples
       } {
-        expect(t1.adjustInto(t2) == t1).toBeTruthy
+        testTemporal(t1.adjustInto(t2))(t1)
       }
 
-      // TODO: Add tests for other Temporals
+      val ds = Seq(LocalDate.MIN, LocalDate.MAX)
+      for {
+        t <- samples
+        d <- ds
+      } {
+        expectThrows[DateTimeException](t.adjustInto(d))
+      }
     }
 
     it("should respond to `until`") {
@@ -483,22 +460,15 @@ object LocalTimeTest extends TemporalAccessorTest {
       expect(MIN.until(MAX, MINUTES) == 1439).toBeTruthy
       expect(MIN.until(MAX, HOURS) == 23).toBeTruthy
       expect(MIN.until(MAX, HALF_DAYS) == 1).toBeTruthy
-      for (u <- ChronoUnit.values() if u.isTimeBased) {
+
+      for (u <- timeBasedUnits) {
         expect(MAX.until(MIN, u) == -MIN.until(MAX, u)).toBeTruthy
         expect(MIN.until(MIN, u) == 0).toBeTruthy
         expect(MAX.until(MAX, u) == 0).toBeTruthy
       }
-
-      for {
-        t1 <- Seq(MIN, MAX)
-        t2 <- Seq(MIN, MAX)
-        u <- ChronoUnit.values() if u.isDateBased
-      } {
-        expectThrows[UnsupportedTemporalTypeException](t1.until(t2, u))
-      }
     }
 
-    it("should respond to `toSecondOfDay") {
+    it("should respond to `toSecondOfDay`") {
       expect(MIN.toSecondOfDay).toEqual(0)
       expect(MAX.toSecondOfDay).toEqual(86399)
     }
@@ -515,14 +485,14 @@ object LocalTimeTest extends TemporalAccessorTest {
       expect(MAX.compareTo(MAX)).toEqual(0)
     }
 
-    it("should respond to `isAfter") {
+    it("should respond to `isAfter`") {
       expect(MIN.isAfter(MIN)).toBeFalsy
       expect(MIN.isAfter(MAX)).toBeFalsy
       expect(MAX.isAfter(MIN)).toBeTruthy
       expect(MAX.isAfter(MAX)).toBeFalsy
     }
 
-    it("should respond to `isBefore") {
+    it("should respond to `isBefore`") {
       expect(MIN.isBefore(MIN)).toBeFalsy
       expect(MIN.isBefore(MAX)).toBeTruthy
       expect(MAX.isBefore(MIN)).toBeFalsy
@@ -532,7 +502,7 @@ object LocalTimeTest extends TemporalAccessorTest {
     it("should override `toString`") {
       expect(MIN.toString).toEqual("00:00")
       expect(MAX.toString).toEqual("23:59:59.999999999")
-      expect(of(1 ,1).toString).toEqual("01:01")
+      expect(of(1, 1).toString).toEqual("01:01")
       expect(of(1, 1, 1).toString).toEqual("01:01:01")
       expect(of(1, 1, 1, 1).toString).toEqual("01:01:01.000000001")
       expect(of(1, 1, 1, 100000000).toString).toEqual("01:01:01.100")
@@ -541,16 +511,16 @@ object LocalTimeTest extends TemporalAccessorTest {
     }
 
     it("should respond to `now`") {
-      now()
+      expect(now() != null).toBeTruthy
     }
 
     it("should respond to `of`") {
-      expect(of(0, 0) == MIN).toBeTruthy
-      expect(of(0, 0, 0) == MIN).toBeTruthy
-      expect(of(0, 0, 0, 0) == MIN).toBeTruthy
-      expect(of(23, 59) == of(23, 59, 0, 0)).toBeTruthy
-      expect(of(23, 59, 59) == of(23, 59, 59, 0)).toBeTruthy
-      expect(of(23, 59, 59, 999999999) == MAX).toBeTruthy
+      testTemporal(of(0, 0))(MIN)
+      testTemporal(of(0, 0, 0))(MIN)
+      testTemporal(of(0, 0, 0, 0))(MIN)
+      testTemporal(of(23, 59))(of(23, 59, 0, 0))
+      testTemporal(of(23, 59, 59))(of(23, 59, 59, 0))
+      testTemporal(of(23, 59, 59, 999999999))(MAX)
 
       expectThrows[DateTimeException](of(-1, 0))
       expectThrows[DateTimeException](of(0, -1))
@@ -563,30 +533,32 @@ object LocalTimeTest extends TemporalAccessorTest {
     }
 
     it("should respond to `ofSecondOfDay`") {
-      expect(ofSecondOfDay(0) == MIN).toBeTruthy
-      expect(ofSecondOfDay(1) == of(0, 0, 1)).toBeTruthy
-      expect(ofSecondOfDay(60) == of(0, 1)).toBeTruthy
-      expect(ofSecondOfDay(86399) == of(23, 59, 59)).toBeTruthy
+      testTemporal(ofSecondOfDay(0))(MIN)
+      testTemporal(ofSecondOfDay(1))(of(0, 0, 1))
+      testTemporal(ofSecondOfDay(60))(of(0, 1))
+      testTemporal(ofSecondOfDay(86399))(of(23, 59, 59))
 
       expectThrows[DateTimeException](ofSecondOfDay(-1))
       expectThrows[DateTimeException](ofSecondOfDay(86400))
     }
 
     it("should respond to `ofNanoOfDay`") {
-      expect(ofNanoOfDay(0) == MIN).toBeTruthy
-      expect(ofNanoOfDay(1) == of(0, 0, 0, 1)).toBeTruthy
-      expect(ofNanoOfDay(1000000000) == of(0, 0, 1)).toBeTruthy
-      expect(ofNanoOfDay(86399999999999L) == MAX).toBeTruthy
+      testTemporal(ofNanoOfDay(0))(MIN)
+      testTemporal(ofNanoOfDay(1))(of(0, 0, 0, 1))
+      testTemporal(ofNanoOfDay(1000000000))(of(0, 0, 1))
+      testTemporal(ofNanoOfDay(86399999999999L))(MAX)
 
       expectThrows[DateTimeException](ofNanoOfDay(-1))
       expectThrows[DateTimeException](ofNanoOfDay(86400000000000L))
     }
 
     it("should respond to `from`") {
-      expect(from(MIN) == MIN).toBeTruthy
-      expect(from(MAX) == MAX).toBeTruthy
+      for (t <- samples)
+        testTemporal(from(t))(t)
 
-      // TODO: Add tests for other classes
+      expectThrows[DateTimeException](from(LocalDate.of(2012, 2, 29)))
+      expectThrows[DateTimeException](from(Month.JANUARY))
+      expectThrows[DateTimeException](from(DayOfWeek.MONDAY))
     }
   }
 }

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/MonthTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/MonthTest.scala
@@ -1,0 +1,214 @@
+package org.scalajs.testsuite.javalib.time
+
+import java.time._
+import java.time.temporal.ChronoField
+
+import org.scalajs.testsuite.javalib.time.temporal.TemporalAccessorTest
+
+object MonthTest extends TemporalAccessorTest {
+  import Month._
+
+  describe("java.time.Month") {
+    testTemporalAccessorApi(values():_*)
+
+    it("should respond to `getValue`") {
+      expect(JANUARY.getValue).toEqual(1)
+      expect(FEBRUARY.getValue).toEqual(2)
+      expect(MARCH.getValue).toEqual(3)
+      expect(APRIL.getValue).toEqual(4)
+      expect(MAY.getValue).toEqual(5)
+      expect(JUNE.getValue).toEqual(6)
+      expect(JULY.getValue).toEqual(7)
+      expect(AUGUST.getValue).toEqual(8)
+      expect(SEPTEMBER.getValue).toEqual(9)
+      expect(OCTOBER.getValue).toEqual(10)
+      expect(NOVEMBER.getValue).toEqual(11)
+      expect(DECEMBER.getValue).toEqual(12)
+    }
+
+    it("should respond to `isSupported`") {
+      for {
+        m <- Month.values()
+        f <- ChronoField.values()
+      } {
+        if (f == ChronoField.MONTH_OF_YEAR)
+          expect(m.isSupported(f)).toBeTruthy
+        else
+          expect(m.isSupported(f)).toBeFalsy
+      }
+    }
+
+    it("should respond to `getLong`") {
+      for (m <- Month.values())
+        expect(m.getLong(ChronoField.MONTH_OF_YEAR)).toEqual(m.getValue)
+    }
+
+    it("should respond to `plus`") {
+      expect(JANUARY.plus(Long.MinValue) == MAY).toBeTruthy
+      expect(FEBRUARY.plus(-12) == FEBRUARY).toBeTruthy
+      expect(MARCH.plus(-1) == FEBRUARY).toBeTruthy
+      expect(APRIL.plus(0) == APRIL).toBeTruthy
+      expect(MAY.plus(1) == JUNE).toBeTruthy
+      expect(JUNE.plus(12) == JUNE).toBeTruthy
+      expect(JULY.plus(Long.MaxValue) == FEBRUARY).toBeTruthy
+    }
+
+    it("should respond to `minus`") {
+      expect(JANUARY.minus(Long.MinValue) == SEPTEMBER).toBeTruthy
+      expect(FEBRUARY.minus(-12) == FEBRUARY).toBeTruthy
+      expect(MARCH.minus(-1) == APRIL).toBeTruthy
+      expect(APRIL.minus(0) == APRIL).toBeTruthy
+      expect(MAY.minus(1) == APRIL).toBeTruthy
+      expect(JUNE.minus(12) == JUNE).toBeTruthy
+      expect(JULY.minus(Long.MaxValue) == DECEMBER).toBeTruthy
+    }
+
+    it("should respond to `minLength`") {
+      expect(JANUARY.minLength).toEqual(31)
+      expect(FEBRUARY.minLength).toEqual(28)
+      expect(MARCH.minLength).toEqual(31)
+      expect(APRIL.minLength).toEqual(30)
+      expect(MAY.minLength).toEqual(31)
+      expect(JUNE.minLength).toEqual(30)
+      expect(JULY.minLength).toEqual(31)
+      expect(AUGUST.minLength).toEqual(31)
+      expect(SEPTEMBER.minLength).toEqual(30)
+      expect(OCTOBER.minLength).toEqual(31)
+      expect(NOVEMBER.minLength).toEqual(30)
+      expect(DECEMBER.minLength).toEqual(31)
+    }
+
+    it("should respond to `maxLength`") {
+      expect(JANUARY.maxLength).toEqual(31)
+      expect(FEBRUARY.maxLength).toEqual(29)
+      expect(MARCH.maxLength).toEqual(31)
+      expect(APRIL.maxLength).toEqual(30)
+      expect(MAY.maxLength).toEqual(31)
+      expect(JUNE.maxLength).toEqual(30)
+      expect(JULY.maxLength).toEqual(31)
+      expect(AUGUST.maxLength).toEqual(31)
+      expect(SEPTEMBER.maxLength).toEqual(30)
+      expect(OCTOBER.maxLength).toEqual(31)
+      expect(NOVEMBER.maxLength).toEqual(30)
+      expect(DECEMBER.maxLength).toEqual(31)
+    }
+
+    it("should respond to `length`") {
+      for (m <- Month.values()) {
+        expect(m.length(false)).toEqual(m.minLength)
+        expect(m.length(true)).toEqual(m.maxLength)
+      }
+    }
+
+    it("should respond to `firstDayOfYear`") {
+      expect(JANUARY.firstDayOfYear(false)).toEqual(1)
+      expect(JANUARY.firstDayOfYear(true)).toEqual(1)
+      expect(FEBRUARY.firstDayOfYear(false)).toEqual(32)
+      expect(FEBRUARY.firstDayOfYear(true)).toEqual(32)
+      expect(MARCH.firstDayOfYear(false)).toEqual(60)
+      expect(MARCH.firstDayOfYear(true)).toEqual(61)
+      expect(APRIL.firstDayOfYear(false)).toEqual(91)
+      expect(APRIL.firstDayOfYear(true)).toEqual(92)
+      expect(MAY.firstDayOfYear(false)).toEqual(121)
+      expect(MAY.firstDayOfYear(true)).toEqual(122)
+      expect(JUNE.firstDayOfYear(false)).toEqual(152)
+      expect(JUNE.firstDayOfYear(true)).toEqual(153)
+      expect(JULY.firstDayOfYear(false)).toEqual(182)
+      expect(JULY.firstDayOfYear(true)).toEqual(183)
+      expect(AUGUST.firstDayOfYear(false)).toEqual(213)
+      expect(AUGUST.firstDayOfYear(true)).toEqual(214)
+      expect(SEPTEMBER.firstDayOfYear(false)).toEqual(244)
+      expect(SEPTEMBER.firstDayOfYear(true)).toEqual(245)
+      expect(OCTOBER.firstDayOfYear(false)).toEqual(274)
+      expect(OCTOBER.firstDayOfYear(true)).toEqual(275)
+      expect(NOVEMBER.firstDayOfYear(false)).toEqual(305)
+      expect(NOVEMBER.firstDayOfYear(true)).toEqual(306)
+      expect(DECEMBER.firstDayOfYear(false)).toEqual(335)
+      expect(DECEMBER.firstDayOfYear(true)).toEqual(336)
+    }
+
+    it("should respond to `firstMonthOfQuarter`") {
+      expect(JANUARY.firstMonthOfQuarter == JANUARY).toBeTruthy
+      expect(FEBRUARY.firstMonthOfQuarter == JANUARY).toBeTruthy
+      expect(MARCH.firstMonthOfQuarter == JANUARY).toBeTruthy
+      expect(APRIL.firstMonthOfQuarter == APRIL).toBeTruthy
+      expect(MAY.firstMonthOfQuarter == APRIL).toBeTruthy
+      expect(JUNE.firstMonthOfQuarter == APRIL).toBeTruthy
+      expect(JULY.firstMonthOfQuarter == JULY).toBeTruthy
+      expect(AUGUST.firstMonthOfQuarter == JULY).toBeTruthy
+      expect(SEPTEMBER.firstMonthOfQuarter == JULY).toBeTruthy
+      expect(OCTOBER.firstMonthOfQuarter == OCTOBER).toBeTruthy
+      expect(NOVEMBER.firstMonthOfQuarter == OCTOBER).toBeTruthy
+      expect(DECEMBER.firstMonthOfQuarter == OCTOBER).toBeTruthy
+    }
+
+    it("should be comparable") {
+      expect(JULY.compareTo(JULY)).toEqual(0)
+      expect(JANUARY.compareTo(MARCH)).toBeLessThan(0)
+      expect(DECEMBER.compareTo(OCTOBER)).toBeGreaterThan(0)
+    }
+
+    it("should respond to `values`") {
+      val months = Month.values()
+
+      expect(months.length).toEqual(12)
+      expect(months(0) == JANUARY).toBeTruthy
+      expect(months(1) == FEBRUARY).toBeTruthy
+      expect(months(2) == MARCH).toBeTruthy
+      expect(months(3) == APRIL).toBeTruthy
+      expect(months(4) == MAY).toBeTruthy
+      expect(months(5) == JUNE).toBeTruthy
+      expect(months(6) == JULY).toBeTruthy
+      expect(months(7) == AUGUST).toBeTruthy
+      expect(months(8) == SEPTEMBER).toBeTruthy
+      expect(months(9) == OCTOBER).toBeTruthy
+      expect(months(10) == NOVEMBER).toBeTruthy
+      expect(months(11) == DECEMBER).toBeTruthy
+    }
+
+    it("should respond to `valueOf`") {
+      expect(valueOf("JANUARY") == JANUARY).toBeTruthy
+      expect(valueOf("FEBRUARY") == FEBRUARY).toBeTruthy
+      expect(valueOf("MARCH") == MARCH).toBeTruthy
+      expect(valueOf("APRIL") == APRIL).toBeTruthy
+      expect(valueOf("MAY") == MAY).toBeTruthy
+      expect(valueOf("JUNE") == JUNE).toBeTruthy
+      expect(valueOf("JULY") == JULY).toBeTruthy
+      expect(valueOf("AUGUST") == AUGUST).toBeTruthy
+      expect(valueOf("SEPTEMBER") == SEPTEMBER).toBeTruthy
+      expect(valueOf("OCTOBER") == OCTOBER).toBeTruthy
+      expect(valueOf("NOVEMBER") == NOVEMBER).toBeTruthy
+      expect(valueOf("DECEMBER") == DECEMBER).toBeTruthy
+
+      expectThrows[IllegalArgumentException](valueOf(""))
+    }
+
+    it("should respond to `of`") {
+      expect(of(1) == JANUARY).toBeTruthy
+      expect(of(2) == FEBRUARY).toBeTruthy
+      expect(of(3) == MARCH).toBeTruthy
+      expect(of(4) == APRIL).toBeTruthy
+      expect(of(5) == MAY).toBeTruthy
+      expect(of(6) == JUNE).toBeTruthy
+      expect(of(7) == JULY).toBeTruthy
+      expect(of(8) == AUGUST).toBeTruthy
+      expect(of(9) == SEPTEMBER).toBeTruthy
+      expect(of(10) == OCTOBER).toBeTruthy
+      expect(of(11) == NOVEMBER).toBeTruthy
+      expect(of(12) == DECEMBER).toBeTruthy
+
+      for (n <- Seq(Int.MinValue, 0, 13, Int.MaxValue))
+        expectThrows[DateTimeException](of(n))
+    }
+
+    it("should respond to `from`") {
+      for (m <- Month.values()) {
+        expect(from(m) == m).toBeTruthy
+        expect(from(LocalDate.of(1, m, 1)) == m).toBeTruthy
+      }
+
+      expectThrows[DateTimeException](from(DayOfWeek.MONDAY))
+      expectThrows[DateTimeException](from(LocalTime.MIN))
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/PeriodTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/PeriodTest.scala
@@ -1,0 +1,413 @@
+package org.scalajs.testsuite.javalib.time
+
+import java.time._
+import java.time.chrono.IsoChronology
+import java.time.temporal.ChronoUnit
+
+import org.scalajs.jasminetest.JasmineTest
+import org.scalajs.testsuite.utils.ExpectExceptions
+
+object PeriodTest extends JasmineTest with ExpectExceptions {
+  import Period._
+  import ChronoUnit._
+
+  final val pmin = of(Int.MinValue, Int.MinValue, Int.MinValue)
+  final val pmin1 = of(-Int.MaxValue, -Int.MaxValue, -Int.MaxValue)
+  final val pmax = of(Int.MaxValue, Int.MaxValue, Int.MaxValue)
+  final val oneYear = of(1, 0, 0)
+  final val oneMonth = of(0, 1, 0)
+  final val oneDay = of(0, 0, 1)
+  final val samples1 = Seq(ZERO, oneYear, oneYear.negated,
+      oneMonth, oneMonth.negated, oneDay, oneDay.negated)
+  final val samples = samples1 ++ Seq(pmin, pmin1, pmax)
+
+  describe("java.time.Period") {
+    it("should respond to `get`") {
+      for (p <- samples) {
+        expect(p.get(YEARS) == p.getYears).toBeTruthy
+        expect(p.get(MONTHS) == p.getMonths).toBeTruthy
+        expect(p.get(DAYS) == p.getDays).toBeTruthy
+      }
+    }
+
+    it("should respond to `getUnits`") {
+      for (p <- samples) {
+        val units = p.getUnits
+        expect(units.size).toEqual(3)
+        expect(units.get(0) == YEARS).toBeTruthy
+        expect(units.get(1) == MONTHS).toBeTruthy
+        expect(units.get(2) == DAYS).toBeTruthy
+      }
+    }
+
+    it("should respond to `getChronology`") {
+      for (p <- samples) {
+        expect(p.getChronology == IsoChronology.INSTANCE).toBeTruthy
+      }
+    }
+
+    it("should respond to `isZero`") {
+      for (p <- samples) {
+        if (p == ZERO) expect(p.isZero).toBeTruthy
+        else expect(p.isZero).toBeFalsy
+      }
+    }
+
+    it("should respond to `isNegative`") {
+      for (p <- Seq(ZERO, oneYear, oneMonth, oneDay, pmax))
+        expect(p.isNegative).toBeFalsy
+      for (p <- Seq(oneYear.negated, oneMonth.negated, oneDay.negated, pmin, pmin1))
+        expect(p.isNegative).toBeTruthy
+      for (p <- Seq(of(-1, 1, 1), of(1, -1, 1), of(1, 1, -1)))
+        expect(p.isNegative).toBeTruthy
+    }
+
+    it("should respond to `getYears`") {
+      expect(oneYear.getYears).toEqual(1)
+      expect(oneMonth.getYears).toEqual(0)
+      expect(oneDay.getYears).toEqual(0)
+      expect(pmin.getYears).toEqual(Int.MinValue)
+      expect(pmin1.getYears).toEqual(Int.MinValue + 1)
+      expect(pmax.getYears).toEqual(Int.MaxValue)
+    }
+
+    it("should respond to `getMonths`") {
+      expect(oneYear.getMonths).toEqual(0)
+      expect(oneMonth.getMonths).toEqual(1)
+      expect(oneDay.getMonths).toEqual(0)
+      expect(pmin.getMonths).toEqual(Int.MinValue)
+      expect(pmin1.getMonths).toEqual(Int.MinValue + 1)
+      expect(pmax.getMonths).toEqual(Int.MaxValue)
+    }
+
+    it("should respond to `getDays`") {
+      expect(oneYear.getDays).toEqual(0)
+      expect(oneMonth.getDays).toEqual(0)
+      expect(oneDay.getDays).toEqual(1)
+      expect(pmin.getDays).toEqual(Int.MinValue)
+      expect(pmin1.getDays).toEqual(Int.MinValue + 1)
+      expect(pmax.getDays).toEqual(Int.MaxValue)
+    }
+
+    it("should respond to `withYears`") {
+      for {
+        p <- samples
+        n <- Seq(Int.MinValue, 0, Int.MaxValue)
+      } {
+        val p1 = p.withYears(n)
+        expect(p1.getYears).toEqual(n)
+        expect(p1.getMonths).toEqual(p.getMonths)
+        expect(p1.getDays).toEqual(p.getDays)
+      }
+    }
+
+    it("should respond to `withMonths`") {
+      for {
+        p <- samples
+        n <- Seq(Int.MinValue, 0, Int.MaxValue)
+      } {
+        val p1 = p.withMonths(n)
+        expect(p1.getYears).toEqual(p.getYears)
+        expect(p1.getMonths).toEqual(n)
+        expect(p1.getDays).toEqual(p.getDays)
+      }
+    }
+
+    it("should respond to `withDays`") {
+      for {
+        p <- samples
+        n <- Seq(Int.MinValue, 0, Int.MaxValue)
+      } {
+        val p1 = p.withDays(n)
+        expect(p1.getYears).toEqual(p.getYears)
+        expect(p1.getMonths).toEqual(p.getMonths)
+        expect(p1.getDays).toEqual(n)
+      }
+    }
+
+    it("should respond to `plus`") {
+      for {
+        p1 <- samples1 :+ pmin1
+        p2 <- if (p1 != pmin1) samples1 :+ pmin1 else samples1
+      } {
+        val p = p1.plus(p2)
+        expect(p.getYears).toEqual(p1.getYears + p2.getYears)
+        expect(p.getMonths).toEqual(p1.getMonths + p2.getMonths)
+        expect(p.getDays).toEqual(p1.getDays + p2.getDays)
+      }
+
+      for (p <- Seq(oneYear, oneMonth, oneDay))
+        expectThrows[ArithmeticException](pmax.plus(p))
+      for (p <- Seq(oneYear.negated, oneMonth.negated, oneDay.negated))
+        expectThrows[ArithmeticException](pmin.plus(p))
+      for (p <- samples)
+        expectThrows[DateTimeException](p.plus(Duration.ZERO))
+    }
+
+    it("should respond to `plusYears`") {
+      for {
+        p <- samples1
+        n <- Seq(Int.MinValue + 1, -1, 0, 1, Int.MaxValue - 1)
+      } {
+        val p1 = p.plusYears(n)
+        expect(p1.getYears).toEqual(p.getYears + n)
+        expect(p1.getMonths).toEqual(p.getMonths)
+        expect(p1.getDays).toEqual(p.getDays)
+      }
+
+      expectThrows[ArithmeticException](oneYear.plusYears(Int.MaxValue))
+      expectThrows[ArithmeticException](oneYear.negated.plusYears(Int.MinValue))
+      expectThrows[ArithmeticException](pmax.plusYears(1))
+      expectThrows[ArithmeticException](pmin.plusYears(-1))
+    }
+
+    it("should respond to `plusMonths`") {
+      for {
+        p <- samples1
+        n <- Seq(Int.MinValue + 1, -1, 0, 1, Int.MaxValue - 1)
+      } {
+        val p1 = p.plusMonths(n)
+        expect(p1.getYears).toEqual(p.getYears)
+        expect(p1.getMonths).toEqual(p.getMonths + n)
+        expect(p1.getDays).toEqual(p.getDays)
+      }
+
+      expectThrows[ArithmeticException](oneMonth.plusMonths(Int.MaxValue))
+      expectThrows[ArithmeticException](oneMonth.negated.plusMonths(Int.MinValue))
+      expectThrows[ArithmeticException](pmax.plusMonths(1))
+      expectThrows[ArithmeticException](pmin.plusMonths(-1))
+    }
+
+    it("should respond to `plusDays`") {
+      for {
+        p <- samples1
+        n <- Seq(Int.MinValue + 1, -1, 0, 1, Int.MaxValue - 1)
+      } {
+        val p1 = p.plusDays(n)
+        expect(p1.getYears).toEqual(p.getYears)
+        expect(p1.getMonths).toEqual(p.getMonths)
+        expect(p1.getDays).toEqual(p.getDays + n)
+      }
+
+      expectThrows[ArithmeticException](oneDay.plusDays(Int.MaxValue))
+      expectThrows[ArithmeticException](oneDay.negated.plusDays(Int.MinValue))
+      expectThrows[ArithmeticException](pmax.plusDays(1))
+      expectThrows[ArithmeticException](pmin.plusDays(-1))
+    }
+
+    it("should respond to `minus`") {
+      for {
+        p1 <- samples1 :+ pmin1
+        p2 <- if (p1.isNegative) samples1 :+ pmin1 else samples1
+      } {
+        val p = p1.minus(p2)
+        expect(p.getYears).toEqual(p1.getYears - p2.getYears)
+        expect(p.getMonths).toEqual(p1.getMonths - p2.getMonths)
+        expect(p.getDays).toEqual(p1.getDays - p2.getDays)
+      }
+
+      for (p <- Seq(oneYear, oneMonth, oneDay))
+        expectThrows[ArithmeticException](pmin.minus(p))
+      for (p <- Seq(oneYear.negated, oneMonth.negated, oneDay.negated))
+        expectThrows[ArithmeticException](pmax.minus(p))
+      for (p <- samples)
+        expectThrows[DateTimeException](p.minus(Duration.ZERO))
+    }
+
+    it("should respond to `minusYears`") {
+      for {
+        p <- samples1
+        n <- Seq(Int.MinValue + 2, -1, 0, 1, Int.MaxValue)
+      } {
+        val p1 = p.minusYears(n)
+        expect(p1.getYears).toEqual(p.getYears - n)
+        expect(p1.getMonths).toEqual(p.getMonths)
+        expect(p1.getDays).toEqual(p.getDays)
+      }
+
+      expectThrows[ArithmeticException](oneYear.minusYears(Int.MinValue + 1))
+      expectThrows[ArithmeticException](pmin.minusYears(1))
+      expectThrows[ArithmeticException](pmax.minusYears(-1))
+    }
+
+    it("should respond to `minusMonths`") {
+      for {
+        p <- samples1
+        n <- Seq(Int.MinValue + 2, -1, 0, 1, Int.MaxValue)
+      } {
+        val p1 = p.minusMonths(n)
+        expect(p1.getYears).toEqual(p.getYears)
+        expect(p1.getMonths).toEqual(p.getMonths - n)
+        expect(p1.getDays).toEqual(p.getDays)
+      }
+
+      expectThrows[ArithmeticException](oneMonth.minusMonths(Int.MinValue + 1))
+      expectThrows[ArithmeticException](pmin.minusMonths(1))
+      expectThrows[ArithmeticException](pmax.minusMonths(-1))
+    }
+
+    it("should respond to `minusDays`") {
+      for {
+        p <- samples1
+        n <- Seq(Int.MinValue + 2, -1, 0, 1, Int.MaxValue)
+      } {
+        val p1 = p.minusDays(n)
+        expect(p1.getYears).toEqual(p.getYears)
+        expect(p1.getMonths).toEqual(p.getMonths)
+        expect(p1.getDays).toEqual(p.getDays - n)
+      }
+
+      expectThrows[ArithmeticException](oneDay.minusDays(Int.MinValue + 1))
+      expectThrows[ArithmeticException](pmin.minusDays(1))
+      expectThrows[ArithmeticException](pmax.minusDays(-1))
+    }
+
+    it("should respond to `multipliedBy`") {
+      for {
+        p <- samples1
+        min = if (p.isNegative) Int.MinValue + 1 else Int.MinValue
+        n <- Seq(min, -2, 2, Int.MaxValue)
+      } {
+        val p1 = p.multipliedBy(n)
+        expect(p1.getYears).toEqual(p.getYears * n)
+        expect(p1.getMonths).toEqual(p.getMonths * n)
+        expect(p1.getDays).toEqual(p.getDays * n)
+      }
+      for (p <- samples) {
+        expect(p.multipliedBy(1) == p).toBeTruthy
+        expect(p.multipliedBy(0) == ZERO).toBeTruthy
+      }
+      for (p <- samples if p != pmin)
+        expect(p.multipliedBy(-1) == p.negated)
+
+      expectThrows[ArithmeticException](pmin.multipliedBy(2))
+      expectThrows[ArithmeticException](pmin.multipliedBy(-1))
+      for (p <- Seq(pmin1, pmax)) {
+        expectThrows[ArithmeticException](p.multipliedBy(2))
+        expectThrows[ArithmeticException](p.multipliedBy(-2))
+      }
+      for (p <- samples1 if p != ZERO) {
+        val p2 = p.multipliedBy(2)
+        expectThrows[ArithmeticException](p2.multipliedBy(Int.MaxValue))
+        expectThrows[ArithmeticException](p2.multipliedBy(Int.MinValue))
+      }
+      for (p <- Seq(oneYear.negated, oneMonth.negated, oneDay.negated))
+        expectThrows[ArithmeticException](p.multipliedBy(Int.MinValue))
+    }
+
+    it("should respond to `negated`") {
+      for (p <- samples if p != pmin) {
+        val p1 = p.negated
+        expect(p1.getYears).toEqual(-p.getYears)
+        expect(p1.getMonths).toEqual(-p.getMonths)
+        expect(p1.getDays).toEqual(-p.getDays)
+      }
+
+      expectThrows[ArithmeticException](pmin.negated)
+    }
+
+    it("should respond to `normalized`") {
+      val ps = samples1 ++ Seq(of(1, -1, 0), of(-1, 1, 0)) ++
+          Seq(of(1, -25, 1), of(-1, 25, -1), of(1, 13, 1), of(-1, -13, -1))
+      for (p <- ps) {
+        val p1 = p.normalized
+        val years = p1.getYears
+        val months = p1.getMonths
+        expect(Math.abs(months) < 12)
+        expect(years > 0 && months < 0).toBeFalsy
+        expect(years < 0 && months > 0).toBeFalsy
+        expect(years * 12 + months == p.getYears * 12 + p.getMonths)
+      }
+
+      for (p <- Seq(pmin, pmin1, pmax))
+        expectThrows[ArithmeticException](p.normalized)
+    }
+
+    it("should respond to `toTotalMonths`") {
+      for (p <- samples)
+        expect(p.toTotalMonths == p.getYears.toLong * 12 + p.getMonths).toBeTruthy
+    }
+
+    it("should respond to `addTo`") {
+      val ds = Seq(LocalDate.MIN, LocalDate.MAX, LocalDate.of(2011, 2, 28),
+          LocalDate.of(2012, 2, 29))
+      val ts = Seq(LocalTime.MIN, LocalTime.NOON, LocalTime.MAX)
+      val p1 = Period.of(1, 3, 5)
+      val p2 = p1.negated
+
+      for (t <- ds ++ ts)
+        expect(ZERO.addTo(t) == t).toBeTruthy
+
+      expect(Period.of(1999999998, 11, 30).addTo(LocalDate.MIN) ==
+          LocalDate.MAX).toBeTruthy
+      expect(Period.of(-1999999998, -11, -30).addTo(LocalDate.MAX) ==
+          LocalDate.MIN).toBeTruthy
+      expect(Period.of(1, 0, 1).addTo(LocalDate.of(2011, 2, 28)) ==
+          LocalDate.of(2012, 2, 29)).toBeTruthy
+      expect(Period.of(-1, 0, -1).addTo(LocalDate.of(2012, 2, 29)) ==
+          LocalDate.of(2011, 2, 27)).toBeTruthy
+      expect(oneYear.addTo(LocalDate.of(2012, 2, 29)) ==
+          LocalDate.of(2013, 2, 28)).toBeTruthy
+      expect(Period.of(-1, 0, 1).addTo(LocalDate.of(2013, 2, 28)) ==
+          LocalDate.of(2012, 2, 29)).toBeTruthy
+
+      for (p <- Seq(oneYear, oneMonth, oneYear, pmin, pmax))
+        expectThrows[DateTimeException](p.addTo(LocalDate.MAX))
+      for (p <- Seq(oneYear.negated, oneMonth.negated, oneYear.negated, pmin, pmax))
+        expectThrows[DateTimeException](p.addTo(LocalDate.MIN))
+      for {
+        p <- samples if p != ZERO
+        t <- ts
+      } {
+        expectThrows[DateTimeException](p.addTo(t))
+      }
+    }
+
+    it("should respond to `subtractFrom`") {
+      val ds = Seq(LocalDate.MIN, LocalDate.MAX, LocalDate.of(2012, 2, 29))
+      val ts = Seq(LocalTime.MIN, LocalTime.NOON, LocalTime.MAX)
+
+      for (t <- ds ++ ts)
+        expect(ZERO.subtractFrom(t) == t).toBeTruthy
+
+      expect(Period.of(-1999999998, -11, -30).subtractFrom(LocalDate.MIN) ==
+          LocalDate.MAX).toBeTruthy
+      expect(Period.of(1999999998, 11, 30).subtractFrom(LocalDate.MAX) ==
+          LocalDate.MIN).toBeTruthy
+      expect(Period.of(-1, 0, -1).subtractFrom(LocalDate.of(2011, 2, 28)) ==
+          LocalDate.of(2012, 2, 29)).toBeTruthy
+      expect(Period.of(1, 0, 1).subtractFrom(LocalDate.of(2012, 2, 29)) ==
+          LocalDate.of(2011, 2, 27)).toBeTruthy
+      expect(oneYear.negated.subtractFrom(LocalDate.of(2012, 2, 29)) ==
+          LocalDate.of(2013, 2, 28)).toBeTruthy
+      expect(Period.of(1, 0, -1).subtractFrom(LocalDate.of(2013, 2, 28)) ==
+          LocalDate.of(2012, 2, 29)).toBeTruthy
+
+      for (p <- Seq(oneYear.negated, oneMonth.negated, oneYear.negated, pmin, pmax))
+        expectThrows[DateTimeException](p.subtractFrom(LocalDate.MAX))
+      for (p <- Seq(oneYear, oneMonth, oneYear, pmin, pmax))
+        expectThrows[DateTimeException](p.subtractFrom(LocalDate.MIN))
+      for {
+        p <- samples if p != ZERO
+        t <- ts
+      } {
+        expectThrows[DateTimeException](p.subtractFrom(t))
+      }
+    }
+
+    it("should override `toString`") {
+      expect(ZERO.toString).toEqual("P0D")
+      expect(pmin.toString).toEqual("P-2147483648Y-2147483648M-2147483648D")
+      expect(pmax.toString).toEqual("P2147483647Y2147483647M2147483647D")
+      expect(oneYear.toString).toEqual("P1Y")
+      expect(oneYear.negated.toString).toEqual("P-1Y")
+      expect(oneMonth.toString).toEqual("P1M")
+      expect(oneMonth.negated.toString).toEqual("P-1M")
+      expect(oneDay.toString).toEqual("P1D")
+      expect(oneDay.negated.toString).toEqual("P-1D")
+      expect(of(2, -3, 0).toString).toEqual("P2Y-3M")
+      expect(of(-5, 0, 7).toString).toEqual("P-5Y7D")
+      expect(of(0, 11, -13).toString).toEqual("P11M-13D")
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/ChronoLocalDateTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/ChronoLocalDateTest.scala
@@ -1,0 +1,32 @@
+package org.scalajs.testsuite.javalib.time.chrono
+
+import java.time.{DateTimeException, LocalTime, LocalDate}
+import java.time.chrono.ChronoLocalDate
+
+import org.scalajs.testsuite.javalib.time.temporal.TemporalTest
+
+object ChronoLocalDateTest extends TemporalTest {
+  import ChronoLocalDate._
+
+  describe("java.time.chrono.ChronoLocalDate") {
+    it("should respond to `timeLineOrder`") {
+      val ord = timeLineOrder
+      val ds = Seq(LocalDate.MIN, LocalDate.of(2011, 2, 28), LocalDate.MAX)
+
+      for {
+        d1 <- ds
+        d2 <- ds
+      } {
+        expect(ord.compare(d1, d2) == d1.compareTo(d2)).toBeTruthy
+      }
+    }
+
+    it("should respond to `from`") {
+      for (d <- Seq(LocalDate.MIN, LocalDate.of(2011, 2, 28), LocalDate.MAX))
+        testTemporal(from(d))(d)
+
+      for (t <- Seq(LocalTime.MIN, LocalTime.NOON, LocalTime.MAX))
+        expectThrows[DateTimeException](from(t))
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/ChronoPeriodTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/ChronoPeriodTest.scala
@@ -1,0 +1,21 @@
+package org.scalajs.testsuite.javalib.time.chrono
+
+import java.time.LocalDate
+
+import org.scalajs.jasminetest.JasmineTest
+import org.scalajs.testsuite.utils.ExpectExceptions
+import java.time.chrono.ChronoPeriod
+
+object ChronoPeriodTest extends JasmineTest with ExpectExceptions {
+  describe("java.time.chrono.ChronoPeriod") {
+    it("should respond to `between`") {
+      val ds = Seq(LocalDate.MIN, LocalDate.of(2011, 2, 28), LocalDate.MAX)
+      for {
+        d1 <- ds
+        d2 <- ds
+      } {
+        expect(ChronoPeriod.between(d1, d2) == d1.until(d2)).toBeTruthy
+      }
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/ChronologyTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/ChronologyTest.scala
@@ -1,0 +1,24 @@
+package org.scalajs.testsuite.javalib.time.chrono
+
+import java.time.DateTimeException
+import java.time.chrono.{IsoChronology, Chronology}
+
+import org.scalajs.jasminetest.JasmineTest
+import org.scalajs.testsuite.utils.ExpectExceptions
+
+object ChronologyTest extends JasmineTest with ExpectExceptions {
+  import Chronology._
+
+  describe("java.time.chrono.Chronology") {
+    it("should respond to `of`") {
+      expect(of("ISO") == IsoChronology.INSTANCE).toBeTruthy
+
+      expectThrows[DateTimeException](of(""))
+    }
+
+    it("should respond to `getAvailableChronologies`") {
+      val chronologies = Chronology.getAvailableChronologies
+      expect(chronologies.contains(IsoChronology.INSTANCE)).toBeTruthy
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/IsoChronologyTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/IsoChronologyTest.scala
@@ -1,0 +1,121 @@
+package org.scalajs.testsuite.javalib.time.chrono
+
+import java.time.{Period, LocalDate, DateTimeException}
+import java.time.chrono.{IsoChronology, IsoEra}
+import java.time.temporal.ChronoField
+
+import org.scalajs.testsuite.javalib.time.temporal.TemporalTest
+
+object IsoChronologyTest extends TemporalTest {
+  final val iso = IsoChronology.INSTANCE
+
+  describe("java.time.chrono.IsoChronology") {
+    it("should respond to `getId`") {
+      expect(iso.getId).toEqual("ISO")
+    }
+
+    it("should respond to `getCalendarType`") {
+      expect(iso.getCalendarType).toEqual("iso8601")
+    }
+
+    it("should respond to `date`") {
+      val years = Seq(Int.MinValue, -1000000000, -999999999, -1, 0,
+        1, 999999999, 1000000000, Int.MaxValue)
+      val months = Seq(Int.MinValue, 0, 1, 12, 13, Int.MaxValue)
+      val days = Seq(Int.MinValue, 0, 1, 28, 29, 30, 31, 32, Int.MaxValue)
+
+      for {
+        year <- years
+        month <- months
+        day <- days
+      } {
+        testTemporal(iso.date(IsoEra.CE, year, month, day))(LocalDate.of(year, month, day))
+        testTemporal(iso.date(IsoEra.BCE, 1 - year, month, day))(LocalDate.of(year, month, day))
+        testTemporal(iso.date(year, month, day))(LocalDate.of(year, month, day))
+        expectThrows[ClassCastException](iso.date(null, year, month, day))
+      }
+    }
+
+    it("should respond to `dateYearDay`") {
+      val years = Seq(Int.MinValue, -1000000000, -999999999, -1, 0,
+        1, 999999999, 1000000000, Int.MaxValue)
+      val months = Seq(Int.MinValue, 0, 1, 12, 13, Int.MaxValue)
+      val days = Seq(Int.MinValue, 0, 1, 365, 366, Int.MaxValue)
+
+      for {
+        year <- years
+        day <- days
+      } {
+        testTemporal(iso.dateYearDay(IsoEra.CE, year, day))(LocalDate.ofYearDay(year, day))
+        testTemporal(iso.dateYearDay(IsoEra.BCE, 1 - year, day))(LocalDate.ofYearDay(year, day))
+        testTemporal(iso.dateYearDay(year, day))(LocalDate.ofYearDay(year, day))
+        expectThrows[ClassCastException](iso.dateYearDay(null, year, day))
+      }
+    }
+
+    it("should respond to `dateEpochDay`") {
+      for (day <- Seq(Long.MinValue, -365243219163L, -365243219162L, -1L, 0L,
+          1L, 365241780471L, 365241780472L, Long.MaxValue)) {
+        testTemporal(iso.dateEpochDay(day))(LocalDate.ofEpochDay(day))
+      }
+    }
+
+    it("should respond to `dateNow`") {
+      expect(iso.dateNow().getEra == IsoEra.CE).toBeTruthy
+    }
+
+    it("should respond to `isLeapYear`") {
+      for (year <- Seq(Int.MinValue, -400, -104, -96, -4, 0, 4, 1896, 1904,
+          1996, 2000, 2004, 2147483644)) {
+        expect(iso.isLeapYear(year)).toBeTruthy
+      }
+      for (year <- Seq(-2147483647, -100, -99, -1, 1, 1900, 1999, 2001, 2002,
+          2003, 2005, Int.MaxValue)) {
+        expect(iso.isLeapYear(year)).toBeFalsy
+      }
+    }
+
+    it("should respond to `prolepticYear`") {
+      for (year <- Seq(-Int.MinValue, -1, 0, 1, Int.MaxValue)) {
+        expect(iso.prolepticYear(IsoEra.CE, year)).toEqual(year)
+        expect(iso.prolepticYear(IsoEra.BCE, year)).toEqual(1 - year)
+      }
+    }
+
+    it("should respond to `eraOf`") {
+      expect(iso.eraOf(0) == IsoEra.BCE).toBeTruthy
+      expect(iso.eraOf(1) == IsoEra.CE).toBeTruthy
+
+      for (n <- Seq(-Int.MinValue, -1, 2, Int.MaxValue))
+        expectThrows[DateTimeException](iso.eraOf(n))
+    }
+
+    it("should respond to `eras`") {
+      val eras = iso.eras()
+
+      expect(eras.size).toEqual(2)
+      expect(eras.get(0) == IsoEra.BCE).toBeTruthy
+      expect(eras.get(1) == IsoEra.CE).toBeTruthy
+    }
+
+    it("should respond to `range`") {
+      for (f <- ChronoField.values)
+        expect(iso.range(f) == f.range).toBeTruthy
+    }
+
+    it("should respond to `period`") {
+      val yearss = Seq(Int.MinValue, -1, 0, 1, Int.MaxValue)
+      val monthss = Seq(Int.MinValue, -1, 0, 1, Int.MaxValue)
+      val dayss = Seq(Int.MinValue, -1, 0, 1, Int.MaxValue)
+
+      for {
+        years <- yearss
+        months <- monthss
+        days <- dayss
+      } {
+        expect(iso.period(years, months, days) ==
+            Period.of(years, months, days)).toBeTruthy
+      }
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/IsoEraTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/chrono/IsoEraTest.scala
@@ -1,0 +1,67 @@
+package org.scalajs.testsuite.javalib.time.chrono
+
+import java.time.chrono.IsoEra
+import java.time.temporal.ChronoField
+import java.time.DateTimeException
+
+import org.scalajs.testsuite.javalib.time.temporal.TemporalAccessorTest
+
+object IsoEraTest extends TemporalAccessorTest {
+  import IsoEra._
+
+  describe("java.time.chrono.IsoEra") {
+    testTemporalAccessorApi(BCE, CE)
+
+    it("should respond to `getValue`") {
+      expect(BCE.getValue).toEqual(0)
+      expect(CE.getValue).toEqual(1)
+    }
+
+    it("should respond to `isSupported`") {
+      for {
+        era <- Seq(BCE, CE)
+        f <- ChronoField.values()
+      } {
+        if (f == ChronoField.ERA)
+          expect(era.isSupported(f)).toBeTruthy
+        else
+          expect(era.isSupported(f)).toBeFalsy
+      }
+    }
+
+    it("should respond to `getLong`") {
+      for (era <- Seq(BCE, CE))
+        expect(era.getLong(ChronoField.ERA)).toEqual(era.getValue)
+    }
+
+    it("should be comparable") {
+      expect(BCE.compareTo(BCE)).toEqual(0)
+      expect(BCE.compareTo(CE)).toBeLessThan(0)
+      expect(CE.compareTo(BCE)).toBeGreaterThan(0)
+      expect(CE.compareTo(CE)).toEqual(0)
+    }
+
+    it("should respond to `values`") {
+      val eras = IsoEra.values()
+
+      expect(eras.length).toEqual(2)
+      expect(eras(0) == BCE).toBeTruthy
+      expect(eras(1) == CE).toBeTruthy
+    }
+
+    it("should respond to `valueOf`") {
+      expect(valueOf("BCE") == BCE).toBeTruthy
+      expect(valueOf("CE") == CE).toBeTruthy
+
+      expectThrows[IllegalArgumentException](valueOf(""))
+    }
+
+    it("should respond to `of`") {
+      expect(of(0) == BCE).toBeTruthy
+      expect(of(1) == CE).toBeTruthy
+
+      for (n <- Seq(Int.MinValue, -1, 2, Int.MaxValue))
+        expectThrows[DateTimeException](of(n))
+    }
+  }
+}

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/temporal/TemporalAccessorTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/temporal/TemporalAccessorTest.scala
@@ -9,13 +9,18 @@ import org.scalajs.testsuite.utils.ExpectExceptions
 trait TemporalAccessorTest extends JasmineTest with ExpectExceptions {
 
   def testTemporalAccessorApi(samples: TemporalAccessor*): Unit = {
+    it("should respond with false to `isSupported(null: TemporalField)`") {
+      for (accessor <- samples)
+        expect(accessor.isSupported(null)).toBeFalsy
+    }
+
     it("should respond to `range`") {
       for {
         accessor <- samples
         field <- ChronoField.values()
       } {
         if (accessor.isSupported(field))
-          expect(accessor.range(field) == field.range).toBeTruthy()
+          expect(accessor.range(field) == field.range).toBeTruthy
         else
           expectThrows[UnsupportedTemporalTypeException](accessor.range(field))
       }
@@ -32,6 +37,15 @@ trait TemporalAccessorTest extends JasmineTest with ExpectExceptions {
           expectThrows[DateTimeException](accessor.get(field))
         else
           expectThrows[UnsupportedTemporalTypeException](accessor.get(field))
+      }
+    }
+
+    it("should throw at `getLong` for unsupported fields") {
+      for {
+        accessor <- samples
+        field <- ChronoField.values() if !accessor.isSupported(field)
+      } {
+        expectThrows[UnsupportedTemporalTypeException](accessor.getLong(field))
       }
     }
   }

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/temporal/TemporalTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/temporal/TemporalTest.scala
@@ -1,0 +1,99 @@
+package org.scalajs.testsuite.javalib.time.temporal
+
+import java.time.DateTimeException
+import java.time.temporal._
+
+trait TemporalTest extends TemporalAccessorTest {
+  val dateBasedUnits = ChronoUnit.values.filter(_.isDateBased)
+
+  val timeBasedUnits = ChronoUnit.values.filter(_.isTimeBased)
+
+  def testTemporal(actual: => Temporal)(expected: => Temporal): Unit = {
+    try {
+      val e = expected
+      expectNoException(actual)
+      expect(e == actual).toBeTruthy
+    } catch {
+      case _: UnsupportedTemporalTypeException =>
+        expectThrows[UnsupportedTemporalTypeException](actual)
+
+      case _: DateTimeException =>
+        expectThrows[DateTimeException](actual)
+
+      case _: ArithmeticException =>
+        expectThrows[ArithmeticException](actual)
+    }
+  }
+
+  def testTemporalApi(samples: Temporal*): Unit = {
+    testTemporalAccessorApi(samples:_*)
+
+    it("should respond with false to `isSupported(null: TemporalUnit)`") {
+      for (temporal <- samples)
+        expect(temporal.isSupported(null: TemporalUnit)).toBeFalsy
+    }
+
+    it("should throw at `with` for unsupported fields") {
+      val values = Seq(Long.MinValue, Int.MinValue.toLong, -1L, 0L, 1L,
+          Int.MaxValue.toLong, Long.MaxValue)
+
+      for {
+        temporal <- samples
+        field <- ChronoField.values if !temporal.isSupported(field)
+        n <- values
+      } {
+        expectThrows[UnsupportedTemporalTypeException](temporal.`with`(field, n))
+      }
+    }
+
+    it("should throw at `plus` for unsupported units") {
+      for {
+        temporal <- samples
+        unit <- ChronoUnit.values() if !temporal.isSupported(unit)
+        n <- Seq(Long.MinValue, Int.MinValue.toLong, -1L, 0L, 1L,
+            Int.MaxValue.toLong, Long.MaxValue)
+      } {
+        expectThrows[UnsupportedTemporalTypeException](temporal.plus(n, unit))
+      }
+    }
+
+    it("should respond to `minus`") {
+      for {
+        temporal <- samples
+        unit <- ChronoUnit.values() if temporal.isSupported(unit)
+        n <- Seq(
+            Long.MinValue, Int.MinValue.toLong, -1000000000L, -86400L,
+            -3600L, -366L, -365L, -60L, -24L, -7L, -1L, 0L,
+            1L, 7L, 24L, 60L, 365L, 366L, 3600L, 86400L, 1000000000L,
+            Int.MaxValue.toLong, Long.MaxValue)
+      } {
+        testTemporal(temporal.minus(n, unit)) {
+          if (n != Long.MinValue) temporal.plus(-n, unit)
+          else temporal.plus(Long.MaxValue, unit).plus(1, unit)
+        }
+      }
+    }
+
+    it("should throw at `minus` for unsupported units") {
+      for {
+        temporal <- samples
+        unit <- ChronoUnit.values() if !temporal.isSupported(unit)
+        n <- Seq(Long.MinValue, Int.MinValue.toLong, -1L, 0L, 1L,
+            Int.MaxValue.toLong, Long.MaxValue)
+      } {
+        expectThrows[UnsupportedTemporalTypeException](temporal.minus(n, unit))
+      }
+    }
+
+    it("should throw at `until` for unsupported units") {
+      for {
+        temporal1 <- samples
+        temporal2 <- samples
+        unit <- ChronoUnit.values() if !temporal1.isSupported(unit)
+      } {
+        expectThrows[UnsupportedTemporalTypeException](
+            temporal1.until(temporal2, unit))
+      }
+    }
+  }
+}


### PR DESCRIPTION
Implement `java.time.Period`, `java.time.LocalDate`,
`java.time.DayOfWeek` and `java.time.Month` as well as
most classes in `java.time.chrono`.
Also add more tests for existing `java.time` classes.