### PR TITLE
Fix #2027: Call genBCode.bTypes.initializeCoreBTypes().

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
@@ -58,6 +58,48 @@ trait Compat210Component {
     }
   }
 
+  /* global.genBCode.bTypes.initializeCoreBTypes()
+   *
+   * This one has a very particular history:
+   * - in 2.10.x, no genBCode in global
+   * - in 2.11.{0-1}, there is genBCode but it has no bTypes member
+   * - In 2.11.{2-5}, there is genBCode.bTypes, but it has no
+   *   initializeCoreBTypes (it was actually typo'ed as intializeCoreBTypes!)
+   * - In 2.11.6+, including 2.12, we finally have
+   *   genBCode.bTypes.initializeCoreBTypes
+   * - As of 2.12.0-M4, it is mandatory to call that method from GenJSCode.run()
+   */
+
+  object LowPrioGenBCodeCompat {
+    object genBCode { // scalastyle:ignore
+      object bTypes { // scalastyle:ignore
+        def initializeCoreBTypes(): Unit = ()
+      }
+    }
+  }
+
+  def initializeCoreBTypesCompat(): Unit = {
+    import LowPrioGenBCodeCompat._
+
+    {
+      import global._
+
+      import LowPrioGenBCodeCompat.genBCode._
+
+      {
+        import genBCode._
+
+        import LowPrioGenBCodeCompat.genBCode.bTypes._
+
+        {
+          import bTypes._
+
+          initializeCoreBTypes()
+        }
+      }
+    }
+  }
+
   // ErasedValueType has a different encoding
 
   implicit final class ErasedValueTypeCompat(self: global.ErasedValueType) {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -161,6 +161,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
     override def run(): Unit = {
       scalaPrimitives.init()
+      initializeCoreBTypesCompat()
       jsPrimitives.init()
       super.run()
     }


### PR DESCRIPTION
This requires extensive compatibility magic due to the rather peculiar history of the "path" towards that method. See the comments in the code for the details.