### PR TITLE
Fix #1899: Fix public members of anonymous js.Any classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PreTyperComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PreTyperComponent.scala
@@ -1,0 +1,132 @@
+/* Scala.js compiler
+ * Copyright 2013 LAMP/EPFL
+ * @author Nicolas Stucki
+ */
+
+package org.scalajs.core.compiler
+
+import scala.tools.nsc
+import nsc._
+
+/** This `jspretyper` phase prepares a fix for issue SI-9487 in the case of
+ *  anonymous classes that extend js.Any.
+ *
+ *  During `typer`, due to a bug (SI-9487), Scalac transfroms some public method
+ *  definitions of a quite specific syntactic form of anonymous classes into
+ *  private methods. This affects both methods and field accessors. This phase
+ *  identifies any anonymous class and adds a `@WasPublicBeforeTyper` annotation
+ *  on its public methods and fields. After the `typer` in `jsinterop` the
+ *  anonymous classes are fixed if they extend js.Any using the annotations as
+ *  reference.
+ *
+ *  As an example:
+ *  {{{
+ *  class $anon extends ... {
+ *    val foo = ???
+ *    var bar = ???
+ *    def baz = ???
+ *    private val foo2 = ???
+ *    private var bar2 = ???
+ *    private def baz2 = ???
+ *  }
+ *  }}}
+ *
+ *  Would become:
+ *  {{{
+ *  class $anon extends ... {
+ *    @WasPublicBeforeTyper val foo = ???
+ *    @WasPublicBeforeTyper var bar = ???
+ *    @WasPublicBeforeTyper def baz = ???
+ *    private val foo2 = ???
+ *    private var bar2 = ???
+ *    private def baz2 = ???
+ *  }
+ *  }}}
+ *
+ *  And after `typer` (if has SI-9487) will be:
+ *  {{{
+ *  class $anon extends ... {
+ *    @WasPublicBeforeTyper private[this] var foo = ???
+ *    private <stable> <accessor> def foo = ??? // Needs fix
+ *
+ *    @WasPublicBeforeTyper private[this] var bar = ???
+ *    private <accessor> def bar = ??? // Needs fix
+ *    private <accessor> def bar_=(...) = ??? // Needs fix
+ *
+ *    @WasPublicBeforeTyper private def baz = ??? // Needs fix
+ *    ...
+ *  }
+ *  }}}
+ *
+ *  @author Nicolas Stucki
+ */
+abstract class PreTyperComponent
+    extends plugins.PluginComponent with transform.Transform with Compat210Component {
+
+  import global._
+
+  val phaseName = "jspretyper"
+
+  override protected def newTransformer(unit: CompilationUnit): Transformer =
+    new PreTyperTransformer(unit)
+
+  class PreTyperTransformer(unit: CompilationUnit) extends Transformer {
+    override def transform(tree: Tree): Tree = tree match {
+      case tree: ClassDef if needsAnnotations(tree) =>
+        val newBody = tree.impl.body.map {
+          case vdef: ValDef if needsAnnotations(vdef) =>
+            treeCopy.ValDef(vdef, withWasPublic(vdef.mods), vdef.name,
+                vdef.tpt, transform(vdef.rhs))
+
+          case ddef: DefDef if needsAnnotations(ddef) =>
+            treeCopy.DefDef(ddef, withWasPublic(ddef.mods), ddef.name,
+                ddef.tparams, ddef.vparamss, ddef.tpt, transform(ddef.rhs))
+
+          case member => transform(member)
+        }
+        val newImpl =
+          treeCopy.Template(tree.impl, tree.impl.parents, tree.impl.self, newBody)
+        treeCopy.ClassDef(tree, tree.mods, tree.name, tree.tparams, newImpl)
+
+      case tree: Template =>
+        /* Avoid filtering out members that are EmptyTree during this transform.
+         *
+         * run/macro-term-declared-in-trait is an example of code where they
+         * should not be cleaned.
+         */
+        val newBody = tree.body.map(transform)
+        treeCopy.Template(tree, tree.parents, tree.self, newBody)
+
+      case _ => super.transform(tree)
+    }
+  }
+
+  private def needsAnnotations(classDef: ClassDef): Boolean = {
+    classDef.name == nme.ANON_CLASS_NAME.toTypeName &&
+    classDef.impl.body.exists {
+      case vdef: ValDef => needsAnnotations(vdef)
+      case ddef: DefDef => needsAnnotations(ddef)
+      case _ => false
+    }
+  }
+
+  private def needsAnnotations(vdef: ValDef): Boolean =
+    vdef.mods.isPublic
+
+  private def needsAnnotations(ddef: DefDef): Boolean =
+    ddef.mods.isPublic && ddef.name != nme.CONSTRUCTOR
+
+  private def withWasPublic(mods: Modifiers): Modifiers =
+    mods.withAnnotations(List(anonymousClassMethodWasPublicAnnotation))
+
+  private val scalajs = newTermName("scalajs")
+  private val js = newTermName("js")
+  private val wasPublicBeforeTyper = newTypeName("WasPublicBeforeTyper")
+
+  private def anonymousClassMethodWasPublicAnnotation: Tree = {
+    val runtimePackage = Select(Select(Select(Select(Ident(nme.ROOTPKG),
+        nme.scala_), scalajs), js), nme.annotation)
+    val cls = Select(runtimePackage, wasPublicBeforeTyper)
+    Apply(Select(New(cls), nme.CONSTRUCTOR), Nil)
+  }
+}

--- a/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
@@ -25,10 +25,12 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
   val name = "scalajs"
   val description = "Compile to JavaScript"
   val components = {
-    if (global.forScaladoc)
+    if (global.forScaladoc) {
       List[NscPluginComponent](PrepInteropComponent)
-    else
-      List[NscPluginComponent](PrepInteropComponent, GenCodeComponent)
+    } else {
+      List[NscPluginComponent](PreTyperComponentComponent, PrepInteropComponent,
+          GenCodeComponent)
+    }
   }
 
   /** Called when the JS ASTs are generated. Override for testing */
@@ -61,6 +63,12 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
    */
   def registerModuleExports(sym: Symbol): Unit =
     PrepInteropComponent.registerModuleExports(sym)
+
+  object PreTyperComponentComponent extends {
+    val global: ScalaJSPlugin.this.global.type = ScalaJSPlugin.this.global
+    val runsAfter = List("parser")
+    override val runsBefore = List("namer")
+  } with PreTyperComponent
 
   object PrepInteropComponent extends {
     val global: ScalaJSPlugin.this.global.type = ScalaJSPlugin.this.global

--- a/library/src/main/scala/scala/scalajs/js/annotation/WasPublicBeforeTyper.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/WasPublicBeforeTyper.scala
@@ -1,0 +1,10 @@
+package scala.scalajs.js.annotation
+
+/** IMPLEMENTATION DETAIL: Marks public members of anonymous classes before typer.
+ *
+ *  This annotation is added automatically by the compiler to all public
+ *  members of anonymous classes.
+ *
+ *  Do not use this annotation yourself.
+ */
+class WasPublicBeforeTyper extends scala.annotation.Annotation

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/t6446-additional.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/t6446-additional.check
@@ -1,41 +1,31 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/t6446-missing.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/t6446-missing.check
@@ -2,39 +2,30 @@ Error: unable to load class: t6446.Ploogin
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/t6446-show-phases.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/t6446-show-phases.check
@@ -1,39 +1,30 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/t7494-no-options.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/t7494-no-options.check
@@ -2,41 +2,31 @@ error: Error: ploogin takes no options
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/run/t6102.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/run/t6102.check
@@ -1,4 +1,5 @@
 [running phase parser on t6102.scala]
+[running phase jspretyper on t6102.scala]
 [running phase namer on t6102.scala]
 [running phase packageobjects on t6102.scala]
 [running phase typer on t6102.scala]

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/t6446-additional.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/t6446-additional.check
@@ -1,41 +1,31 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/t6446-missing.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/t6446-missing.check
@@ -2,39 +2,30 @@ Error: unable to load class: t6446.Ploogin
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/t6446-show-phases.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/t6446-show-phases.check
@@ -1,39 +1,30 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/t7494-no-options.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/t7494-no-options.check
@@ -2,41 +2,31 @@ error: Error: ploogin takes no options
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/run/t6102.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/run/t6102.check
@@ -1,4 +1,5 @@
 [running phase parser on t6102.scala]
+[running phase jspretyper on t6102.scala]
 [running phase namer on t6102.scala]
 [running phase packageobjects on t6102.scala]
 [running phase typer on t6102.scala]

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/t6446-additional.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/t6446-additional.check
@@ -1,41 +1,31 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/t6446-missing.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/t6446-missing.check
@@ -2,39 +2,30 @@ Error: unable to load class: t6446.Ploogin
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/t6446-show-phases.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/t6446-show-phases.check
@@ -1,39 +1,30 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/t7494-no-options.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/t7494-no-options.check
@@ -2,41 +2,31 @@ error: Error: ploogin takes no options
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/run/t6102.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/run/t6102.check
@@ -1,4 +1,5 @@
 [running phase parser on t6102.scala]
+[running phase jspretyper on t6102.scala]
 [running phase namer on t6102.scala]
 [running phase packageobjects on t6102.scala]
 [running phase typer on t6102.scala]

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/t6446-additional.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/t6446-additional.check
@@ -1,41 +1,31 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/t6446-missing.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/t6446-missing.check
@@ -2,39 +2,30 @@ Error: unable to load class: t6446.Ploogin
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/t6446-show-phases.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/t6446-show-phases.check
@@ -1,39 +1,30 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/t7494-no-options.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/t7494-no-options.check
@@ -2,41 +2,31 @@ error: Error: ploogin takes no options
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/run/t6102.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/run/t6102.check
@@ -1,4 +1,5 @@
 [running phase parser on t6102.scala]
+[running phase jspretyper on t6102.scala]
 [running phase namer on t6102.scala]
 [running phase packageobjects on t6102.scala]
 [running phase typer on t6102.scala]

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/t6446-additional.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/t6446-additional.check
@@ -1,41 +1,31 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/t6446-missing.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/t6446-missing.check
@@ -2,39 +2,30 @@ Error: unable to load class: t6446.Ploogin
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/t6446-show-phases.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/t6446-show-phases.check
@@ -1,39 +1,30 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/t7494-no-options.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/t7494-no-options.check
@@ -2,41 +2,31 @@ error: Error: ploogin takes no options
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/run/t6102.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/run/t6102.check
@@ -1,4 +1,5 @@
 [running phase parser on t6102.scala]
+[running phase jspretyper on t6102.scala]
 [running phase namer on t6102.scala]
 [running phase packageobjects on t6102.scala]
 [running phase typer on t6102.scala]

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/t6446-additional.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/t6446-additional.check
@@ -1,41 +1,31 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/t6446-missing.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/t6446-missing.check
@@ -2,39 +2,30 @@ Error: unable to load class: t6446.Ploogin
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/t6446-show-phases.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/t6446-show-phases.check
@@ -1,39 +1,30 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/t7494-no-options.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/t7494-no-options.check
@@ -2,41 +2,31 @@ error: Error: ploogin takes no options
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/run/t6102.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/run/t6102.check
@@ -1,4 +1,5 @@
 [running phase parser on t6102.scala]
+[running phase jspretyper on t6102.scala]
 [running phase namer on t6102.scala]
 [running phase packageobjects on t6102.scala]
 [running phase typer on t6102.scala]

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M3/neg/t6446-additional.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M3/neg/t6446-additional.check
@@ -1,41 +1,31 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M3/neg/t6446-missing.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M3/neg/t6446-missing.check
@@ -2,39 +2,30 @@ Error: unable to load class: t6446.Ploogin
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M3/neg/t6446-show-phases.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M3/neg/t6446-show-phases.check
@@ -1,39 +1,30 @@
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-      terminal  27  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-      terminal  32  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+      terminal  28  the last phase during a compilation run

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M3/neg/t7494-no-options.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M3/neg/t7494-no-options.check
@@ -2,41 +2,31 @@ error: Error: ploogin takes no options
     phase name  id  description
     ----------  --  -----------
         parser   1  parse source into ASTs, perform simple desugaring
-         namer   2  resolve names, attach symbols to named trees
-packageobjects   3  load package objects
-         typer   4  the meat and potatoes: type the trees
-     jsinterop   5  
-        patmat   6  translate match expressions
-superaccessors   7  add super accessors in traits and nested classes
-    extmethods   8  add extension methods for inline classes
-       pickler   9  serialize symbol tables
-     refchecks  10  reference/override checking, translate nested objects
-       uncurry  11  uncurry, translate function values to anonymous classes
-     tailcalls  12  replace tail calls by jumps
-    specialize  13  @specialized-driven class and method specialization
- explicitouter  14  this refs to outer pointers
-       erasure  15  erase types, add interfaces for traits
-   posterasure  16  clean up erased inline classes
-      lazyvals  17  allocate bitmaps, translate lazy vals into lazified defs
-    lambdalift  18  move nested functions to top level
-  constructors  19  move field definitions into constructors
-       flatten  20  eliminate inner classes
-         mixin  21  mixin composition
-        jscode  22  
-       cleanup  23  platform-specific cleanups, generate reflective calls
-    delambdafy  24  remove lambdas
-         icode  25  generate portable intermediate code
-#partest !-optimise
-           jvm  26  generate JVM bytecode
-       ploogin  27  A sample phase that does so many things it's kind of hard...
-      terminal  28  the last phase during a compilation run
-#partest -optimise
-       inliner  26  optimization: do inlining
-inlinehandlers  27  optimization: inline exception handlers
-      closelim  28  optimization: eliminate uncalled closures
-      constopt  29  optimization: optimize null and other constants
-           dce  30  optimization: eliminate dead code
-           jvm  31  generate JVM bytecode
-       ploogin  32  A sample phase that does so many things it's kind of hard...
-      terminal  33  the last phase during a compilation run
-#partest
+    jspretyper   2  
+         namer   3  resolve names, attach symbols to named trees
+packageobjects   4  load package objects
+         typer   5  the meat and potatoes: type the trees
+     jsinterop   6  
+        patmat   7  translate match expressions
+superaccessors   8  add super accessors in traits and nested classes
+    extmethods   9  add extension methods for inline classes
+       pickler  10  serialize symbol tables
+     refchecks  11  reference/override checking, translate nested objects
+       uncurry  12  uncurry, translate function values to anonymous classes
+     tailcalls  13  replace tail calls by jumps
+    specialize  14  @specialized-driven class and method specialization
+ explicitouter  15  this refs to outer pointers
+       erasure  16  erase types, add interfaces for traits
+   posterasure  17  clean up erased inline classes
+      lazyvals  18  allocate bitmaps, translate lazy vals into lazified defs
+    lambdalift  19  move nested functions to top level
+  constructors  20  move field definitions into constructors
+       flatten  21  eliminate inner classes
+         mixin  22  mixin composition
+        jscode  23  
+       cleanup  24  platform-specific cleanups, generate reflective calls
+    delambdafy  25  remove lambdas
+         icode  26  generate portable intermediate code
+           jvm  27  generate JVM bytecode
+       ploogin  28  A sample phase that does so many things it's kind of hard...
+      terminal  29  the last phase during a compilation run


### PR DESCRIPTION
The fix requires an additional phase (<del>`prepwaspublicbeforetyper`</del> `jspretyper`)
between `parser` and `namer` that adds @WasPublicBeforeTyper annotations
on every public `ValDef` or `DefDef` of anonymous classes.
The `jsinterop` will additionally fix the methods that should be public
in the js.Any anonymous classes.