### PR TITLE
Fix #2067: Add implicits for combinations of js.UndefOr and js.|

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/UndefOr.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOr.scala
@@ -10,6 +10,7 @@
 package scala.scalajs.js
 
 import scala.language.implicitConversions
+import scala.scalajs.js.|.Evidence
 
 /** Value of type A or the JS undefined value.
  *
@@ -26,6 +27,17 @@ sealed trait UndefOr[+A]
 object UndefOr {
   implicit def any2undefOrA[A](value: A): UndefOr[A] =
     value.asInstanceOf[UndefOr[A]]
+
+  /** Upcast `A` to `UndefOr[B1 | B2]`.
+    *
+    * This variant of `any2undefOrA` exists because scala doesn't
+    *  nest implicit conversions, which would otherwise be needed
+    *  to lift an `A` to for example `js.UndefOr[A | T]`
+    *
+    * This needs evidence that `A <: B1 | B2`.
+    */
+  implicit def any2undefOrUnion[A, B1, B2](a: A)(implicit ev: Evidence[A, B1 | B2]): UndefOr[B1 | B2] =
+    a.asInstanceOf[UndefOr[B1 | B2]]
 
   implicit def undefOr2ops[A](value: UndefOr[A]): UndefOrOps[A] =
     new UndefOrOps(value)

--- a/library/src/main/scala/scala/scalajs/js/Union.scala
+++ b/library/src/main/scala/scala/scalajs/js/Union.scala
@@ -43,6 +43,10 @@ object | { // scalastyle:ignore
     /** If `A <: B1`, then `A <: B1 | B2`. */
     implicit def left[A, B1, B2](implicit ev: Evidence[A, B1]): Evidence[A, B1 | B2] =
       ReusableEvidence.asInstanceOf[Evidence[A, B1 | B2]]
+
+    /** `A <: js.UndefOr[A]`. */
+    implicit def undefOr[A]: Evidence[A, UndefOr[A]] =
+      ReusableEvidence.asInstanceOf[Evidence[A, UndefOr[A]]]
   }
 
   object Evidence extends EvidenceLowPrioImplicits {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
@@ -134,6 +134,50 @@ object UnionTypeTest extends JasmineTest {
       expect(y4.toJSArray).toEqual(js.Array(3, 5))
     }
 
+    it("js.UndefOr[A | B] inference") {
+      val a: String = "hello"
+
+      /** typeError checks below are more documentation of how
+        * type inference currently works now than a requirement
+        */
+      expect(a: Int | String).toBe(a)
+      expect(a: js.UndefOr[Int] | String).toBe(a)
+      expect(a: Int | js.UndefOr[String]).toBe(a)
+      expect(a: js.UndefOr[Int] | js.UndefOr[String]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[Int]] | js.UndefOr[String]).toBe(a)
+      typeError("a: js.UndefOr[Int] | js.UndefOr[js.UndefOr[String]]")
+
+      expect(a: js.UndefOr[Int | String]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[Int] | String]).toBe(a)
+      expect(a: js.UndefOr[Int | js.UndefOr[String]]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[Int] | js.UndefOr[String]]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[js.UndefOr[Int]] | js.UndefOr[String]]).toBe(a)
+      typeError("a: js.UndefOr[js.UndefOr[Int] | js.UndefOr[js.UndefOr[String]]]")
+
+      expect(a: js.UndefOr[String | Int]).toBe(a)
+      expect(a: js.UndefOr[String | Int]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[String] | Int]).toBe(a)
+      expect(a: js.UndefOr[String | js.UndefOr[Int]]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[String] | js.UndefOr[Int]]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[String] | js.UndefOr[js.UndefOr[Int]]]).toBe(a)
+      typeError("a: js.UndefOr[js.UndefOr[js.UndefOr[String]] | js.UndefOr[Int]]")
+
+      //Confirm that we're working with triple unions too
+
+      expect(a: js.UndefOr[String | Object | Int]).toBe(a)
+      expect(a: js.UndefOr[String | Int | Object]).toBe(a)
+      expect(a: js.UndefOr[Int | String | Object]).toBe(a)
+      expect(a: js.UndefOr[Int | Object | String]).toBe(a)
+      expect(a: js.UndefOr[Object | String | Int]).toBe(a)
+      expect(a: js.UndefOr[Object | Object | String]).toBe(a)
+
+      expect(a: js.UndefOr[js.UndefOr[String] | Object | Int]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[String] | Int | Object]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[Int] | String | Object]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[Int] | Object | String]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[Object] | String | Int]).toBe(a)
+      expect(a: js.UndefOr[js.UndefOr[Object] | Object | String]).toBe(a)
+    }
   }
 
   describe("js.| (negative)") {


### PR DESCRIPTION
i saw there were several proposed options. i came up with this that seemed to solve my problem, at least these:

```scala
  val a = ""

  val a1: UndefOr[String] = a
  val a2: |[Int, String] = a
  val a3: |[String, Int] = a
  val a4: UndefOr[|[String, Int]] = a
  val a5: UndefOr[|[Int, String]] = a
  val a6: UndefOr[|[UndefOr[Int], String]] = a
```