### PR TITLE
Prove that `js.|[X, Y]` is `js.Any` (given that `X` and `Y` are, of c…

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Union.scala
+++ b/library/src/main/scala/scala/scalajs/js/Union.scala
@@ -10,6 +10,7 @@
 package scala.scalajs.js
 
 import scala.language.implicitConversions
+import scala.reflect.ClassTag
 
 /** Value of type A or B (union type).
  *
@@ -73,4 +74,10 @@ object | { // scalastyle:ignore
     def merge[B](implicit ev: |.Evidence[A, B]): B =
       self.asInstanceOf[B]
   }
+
+  implicit def UnionEvidence[A: ClassTag, B: ClassTag](ab: A | B)(implicit eva: A => Any, evb: B => Any): Any =
+    ab match {
+      case a: A => eva(a)
+      case b: B => evb(b)
+    }
 }


### PR DESCRIPTION
There is also this thing that seem to crop up every once in a while that i would have expected to just work.
Im not sure if i need to keep those `ClassTag`s around, or if a simple cast would do the trick