### PR TITLE
Fix #2073: `Duration.ZERO.addTo(t)` throws for some Temporals

### DIFF
--- a/javalib/src/main/scala/java/time/Duration.scala
+++ b/javalib/src/main/scala/java/time/Duration.scala
@@ -152,11 +152,21 @@ final class Duration private (seconds: Long, nanos: Int)
 
   def abs(): Duration = if (isNegative()) negated() else this
 
-  def addTo(temporal: Temporal): Temporal =
-    temporal.plus(normalizedSeconds, SECONDS).plus(normalizedNanos, NANOS)
+  def addTo(temporal: Temporal): Temporal = {
+    val t1 =
+      if (seconds == 0) temporal
+      else temporal.plus(seconds, SECONDS)
+    if (nanos == 0) t1
+    else t1.plus(nanos, NANOS)
+  }
 
-  def subtractFrom(temporal: Temporal): Temporal =
-    temporal.minus(normalizedSeconds, SECONDS).minus(normalizedNanos, NANOS)
+  def subtractFrom(temporal: Temporal): Temporal = {
+    val t1 =
+      if (seconds == 0) temporal
+      else temporal.minus(seconds, SECONDS)
+    if (nanos == 0) t1
+    else t1.minus(nanos, NANOS)
+  }
 
   def toDays(): Long = seconds / SECONDS_IN_DAY
 

--- a/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/DurationTest.scala
+++ b/test-suite/js/src/test/require-jdk8/org/scalajs/testsuite/javalib/time/DurationTest.scala
@@ -622,22 +622,28 @@ object DurationTest extends JasmineTest with ExpectExceptions {
 
     it("should respond to `addTo`") {
       val t = LocalTime.NOON
+      val d = LocalDate.MIN
 
       expect(ZERO.addTo(t) == t).toBeTruthy
       expect(dmin.addTo(t) == LocalTime.of(20, 29, 52)).toBeTruthy
       expect(dmax.addTo(t) == LocalTime.of(3, 30, 7, 999999999)).toBeTruthy
+      expect(ZERO.addTo(d) == d).toBeTruthy
 
-      // TODO: Add tests for other Temporals
+      expectThrows[UnsupportedTemporalTypeException](ofNanos(1).addTo(d))
+      expectThrows[UnsupportedTemporalTypeException](ofSeconds(1).addTo(d))
     }
 
     it("should respond to `subtractFrom`") {
       val t = LocalTime.NOON
+      val d = LocalDate.MIN
 
       expect(ZERO.subtractFrom(t) == t).toBeTruthy
       expect(dmin.subtractFrom(t) == LocalTime.of(3, 30, 8)).toBeTruthy
       expect(dmax.subtractFrom(t) == LocalTime.of(20, 29, 52, 1)).toBeTruthy
+      expect(ZERO.subtractFrom(d) == d).toBeTruthy
 
-      // TODO: Add tests for other Temporals
+      expectThrows[UnsupportedTemporalTypeException](ofNanos(1).subtractFrom(d))
+      expectThrows[UnsupportedTemporalTypeException](ofSeconds(1).subtractFrom(d))
     }
 
     it("should respond to `toDays`") {


### PR DESCRIPTION
Also fixes `subtractFrom`.