### PR TITLE
DO NOT MERGE For discussion: add the ES6 standard library

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Generator.scala
+++ b/library/src/main/scala/scala/scalajs/js/Generator.scala
@@ -1,0 +1,60 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.language.implicitConversions
+
+import scala.annotation.implicitNotFound
+import scala.annotation.unchecked.uncheckedVariance
+
+import scala.scalajs.js
+import js.annotation._
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Generator, such as the result of generator function.
+ *
+ *  @tparam V The type of elements returned by `next()`
+ *  @tparam I The type of values expected by `next()` as parameter
+ *  @tparam R The type of the result/done value.
+ */
+@ScalaJSDefined
+trait Generator[+V, -I, +R] extends js.Object {
+  def next(value: I): Generator.Entry[V, R]
+
+  def `return`[S](result: S): Generator.Entry[Nothing, S]
+
+  def `throw`(ex: scala.Any): Generator.Entry[V, R]
+}
+
+object Generator {
+  /** The type of a simple Generator that takes no input in `next()` and
+   *  returns no value.
+   */
+  type Iter[+V] = Generator[V, Unit, Unit]
+
+  implicit def asIterator[V](g: Generator[V, Unit, _]): js.Iterator[V] =
+    g.asInstanceOf[js.Iterator[V]]
+
+  implicit def toIteratorOps[V](g: Generator[V, Unit, _]): js.Iterator.IteratorOps[V] =
+    asIterator(g)
+
+  @ScalaJSDefined
+  trait Entry[+V, +R] extends js.Object {
+    def value: V @uncheckedVariance | R @uncheckedVariance
+    def done: Boolean
+  }
+
+  object Entry {
+    implicit class EntryOps[+V, +R](val self: Entry[V, R]) extends AnyVal {
+      @inline def iterValue: V = self.value.asInstanceOf[V]
+      @inline def doneValue: R = self.value.asInstanceOf[R]
+    }
+  }
+}

--- a/library/src/main/scala/scala/scalajs/js/Iterable.scala
+++ b/library/src/main/scala/scala/scalajs/js/Iterable.scala
@@ -1,0 +1,41 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import js.annotation._
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Iterable.
+ *
+ *  An Iterable must define a method `[Symbol.iterator]`.
+ */
+@ScalaJSDefined
+trait Iterable[+A] extends js.Object
+
+object Iterable {
+  @js.native
+  private trait IteratorCallAccess[+A] extends js.Object {
+    @JSBracketCall
+    def iteratorCall(sym: Symbol)(): Iterator[A]
+  }
+
+  @inline
+  implicit final class IterableOps[+A](val self: Iterable[A])
+      extends scala.collection.Iterable[A] {
+
+    @inline
+    def jsIterator(): Iterator[A] =
+      self.asInstanceOf[IteratorCallAccess[A]].iteratorCall(Symbol.iterator)()
+
+    @inline
+    def iterator: scala.collection.Iterator[A] = self.jsIterator()
+  }
+}

--- a/library/src/main/scala/scala/scalajs/js/Iterator.scala
+++ b/library/src/main/scala/scala/scalajs/js/Iterator.scala
@@ -1,0 +1,41 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import js.annotation._
+
+@ScalaJSDefined
+trait Iterator[+A] extends js.Object {
+  def next(): Iterator.Entry[A]
+}
+
+object Iterator {
+  @ScalaJSDefined
+  trait Entry[+A] extends js.Object {
+    def done: Boolean
+    def value: A
+  }
+
+  @inline
+  final implicit class IteratorOps[+A](val self: Iterator[A])
+      extends scala.collection.Iterator[A] {
+
+    private[this] var lastEntry = self.next()
+
+    def hasNext: Boolean = !lastEntry.done
+
+    def next(): A = {
+      val value = lastEntry.value
+      lastEntry = self.next()
+      value
+    }
+  }
+}

--- a/library/src/main/scala/scala/scalajs/js/Map.scala
+++ b/library/src/main/scala/scala/scalajs/js/Map.scala
@@ -1,0 +1,45 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Map.
+ *
+ *  In a JavaScript Map, keys are *not* compared according to the `==`
+ *  equality of Scala. They are compared according to reference equality, with
+ *  two notable special-cases: `NaN` is equal to `NaN`, and `+0.0` is equal to
+ *  `-0.0`.
+ *
+ *  In fact, `-0.0` is inserted in the map as `+0.0`.
+ */
+@js.native
+class Map[K, V] extends js.Object with js.Iterable[js.Tuple2[K, V]] {
+  def this(iterable: js.Iterable[js.Tuple2[K, V]]) = this()
+
+  def size: Int = js.native
+
+  def clear(): Unit = js.native
+
+  def has(key: K): Boolean = js.native
+
+  def get(key: K): js.UndefOr[V] = js.native
+
+  def set(key: K, value: V): this.type = js.native
+
+  def delete(key: K): Boolean = js.native
+
+  def entries(): js.Iterator[js.Tuple2[K, V]] = js.native
+
+  def keys(): js.Iterator[K] = js.native
+
+  def values(): js.Iterator[V] = js.native
+}

--- a/library/src/main/scala/scala/scalajs/js/Promise.scala
+++ b/library/src/main/scala/scala/scalajs/js/Promise.scala
@@ -61,9 +61,7 @@ object Promise extends js.Object {
   /** Returns a new [[Promise]] failed with the specified `reason`. */
   def reject(reason: scala.Any): Promise[Nothing] = js.native
 
-  // TODO Use js.Iterable
-  def all[A](promises: js.Array[_ <: Promise[A]]): Promise[js.Array[A]] = js.native
+  def all[A](promises: js.Iterable[Promise[A]]): Promise[js.Array[A]] = js.native
 
-  // TODO Use js.Iterable
-  def race[A](promises: js.Array[_ <: Promise[A]]): Promise[A] = js.native
+  def race[A](promises: js.Iterable[Promise[A]]): Promise[A] = js.native
 }

--- a/library/src/main/scala/scala/scalajs/js/Set.scala
+++ b/library/src/main/scala/scala/scalajs/js/Set.scala
@@ -1,0 +1,43 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Set.
+ *
+ *  In a JavaScript Set, values are *not* compared according to the `==`
+ *  equality of Scala. They are compared according to reference equality, with
+ *  two notable special-cases: `NaN` is equal to `NaN`, and `+0.0` is equal to
+ *  `-0.0`.
+ *
+ *  In fact, `-0.0` is inserted in the set as `+0.0`.
+ */
+@js.native
+class Set[A] extends js.Object with js.Iterable[A] {
+  def this(iterable: js.Iterable[A]) = this()
+
+  def size: Int = js.native
+
+  def clear(): Unit = js.native
+
+  def has(value: A): Boolean = js.native
+
+  def add(value: A): this.type = js.native
+
+  def delete(value: A): Boolean = js.native
+
+  def entries(): js.Iterator[js.Tuple2[A, A]] = js.native
+
+  def keys(): js.Iterator[A] = js.native
+
+  def values(): js.Iterator[A] = js.native
+}

--- a/library/src/main/scala/scala/scalajs/js/Symbol.scala
+++ b/library/src/main/scala/scala/scalajs/js/Symbol.scala
@@ -1,0 +1,43 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import js.annotation._
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Symbol.
+ */
+@js.native
+sealed trait Symbol extends js.Any
+
+object Symbol {
+  @JSName("Symbol")
+  @js.native
+  private object NativeSymbol extends js.Object {
+    def apply(): Symbol = js.native
+    def apply(description: String): Symbol = js.native
+
+    def `for`(key: String): Symbol = js.native
+    def keyFor(sym: Symbol): String = js.native
+
+    val iterator: Symbol = js.native
+  }
+
+  def apply(): Symbol = NativeSymbol()
+  def apply(description: String): Symbol = NativeSymbol()
+
+  def apply(sym: scala.Symbol): Symbol = forKey(sym.name)
+
+  def forKey(key: String): Symbol = NativeSymbol.`for`(key)
+  def keyFor(sym: Symbol): String = NativeSymbol.keyFor(sym)
+
+  val iterator: Symbol = NativeSymbol.iterator
+}

--- a/library/src/main/scala/scala/scalajs/js/UndefOr.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOr.scala
@@ -209,7 +209,7 @@ final class UndefOrOps[A](val self: UndefOr[A]) extends AnyVal {
   /** Returns a singleton iterator returning the $option's value
    *  if it is nonempty, or an empty iterator if the option is empty.
    */
-  def iterator: Iterator[A] =
+  def iterator: scala.collection.Iterator[A] =
     if (isEmpty) scala.collection.Iterator.empty
     else scala.collection.Iterator.single(this.forceGet)
 

--- a/library/src/main/scala/scala/scalajs/js/WeakMap.scala
+++ b/library/src/main/scala/scala/scalajs/js/WeakMap.scala
@@ -1,0 +1,30 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript WeakMap.
+ *
+ *  A WeakMap cannot contain primitive values as keys.
+ */
+@js.native
+class WeakMap[K <: AnyRef, V] extends js.Object {
+  def this(iterable: js.Iterable[js.Tuple2[K, V]]) = this()
+
+  def has(key: K): Boolean = js.native
+
+  def get(key: K): js.UndefOr[V] = js.native
+
+  def set(key: K, value: V): this.type = js.native
+
+  def delete(key: K): Boolean = js.native
+}

--- a/library/src/main/scala/scala/scalajs/js/WeakSet.scala
+++ b/library/src/main/scala/scala/scalajs/js/WeakSet.scala
@@ -1,0 +1,28 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript WeakSet.
+ *
+ *  A WeakSet cannot contain primitive values.
+ */
+@js.native
+class WeakSet[A] extends js.Object {
+  def this(iterable: js.Iterable[A]) = this()
+
+  def has(value: A): Boolean = js.native
+
+  def add(value: A): this.type = js.native
+
+  def delete(value: A): Boolean = js.native
+}

--- a/library/src/main/scala/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/WrappedDictionary.scala
@@ -57,11 +57,11 @@ class WrappedDictionary[A](val dict: Dictionary[A])
     this
   }
 
-  def iterator: Iterator[(String, A)] =
+  def iterator: scala.collection.Iterator[(String, A)] =
     new DictionaryIterator(dict)
 
   @inline
-  override def keys: Iterable[String] =
+  override def keys: scala.collection.Iterable[String] =
     Object.keys(dict.asInstanceOf[Object])
 
   override def empty: WrappedDictionary[A] =
@@ -84,7 +84,7 @@ object WrappedDictionary {
     Cache.safeHasOwnProperty(dict, key)
 
   private final class DictionaryIterator[+A](
-      dict: Dictionary[A]) extends Iterator[(String, A)] {
+      dict: Dictionary[A]) extends scala.collection.Iterator[(String, A)] {
     private[this] val keys = Object.keys(dict.asInstanceOf[Object])
     private[this] var index: Int = 0
     def hasNext(): Boolean = index < keys.length


### PR DESCRIPTION
This PR is more like a Request For Comments on the best design for the integration of the ES6 standard library to the typings in `scala.scalajs.js`.

Several things are definitely worth discussing:
- We should probably add the Scala collection API on `js.Map` and `js.Set`
- Should we put these things in a separate namespace?
- <del>Typings of `Promise` and `Thenable`.</del>
- Typings of `Generator`.
