### PR TITLE
Fix #2118: InputStreamReader.read() after EOF

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -239,4 +239,18 @@ class InputStreamReaderTest {
     expectRead("日本語を読めますか。")
     assertEquals(-1, r.read())
   }
+
+  @Test def should_comply_with_read_after_eof_behaviour(): Unit = {
+    val data = "Lorem ipsum".getBytes()
+    val streamReader = new InputStreamReader(new ByteArrayInputStream(data))
+    val bytes = new Array[Char](11)
+
+    assertEquals(11, streamReader.read(bytes))
+    // Do it twice to check for a regression where this used to throw
+    assertEquals(-1, streamReader.read(bytes))
+    assertEquals(-1, streamReader.read(bytes))
+    expectThrows(classOf[IndexOutOfBoundsException], streamReader.read(bytes, 10, 3))
+    assertEquals(0, streamReader.read(new Array[Char](0)))
+  }
+
 }


### PR DESCRIPTION
Under certain circumstances, a call to InputStreamReader.read() may trigger an IllegalStateException when a previous call to read() returned -1.

see #2118 

This patch makes sure no processing happens at all in `read` when the end of the stream has been reached.