### PR TITLE
Add junit bootstrapper classes to the currentRun.symSource map

### DIFF
--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -241,6 +241,8 @@ class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
         scalaJSPlugin.registerModuleExports(bootSym)
         bootClazz.setSymbol(bootSym)
 
+        currentRun.symSource(bootSym) = clazz.symbol.sourceFile
+
         bootClazz
       }
 


### PR DESCRIPTION
Classes being compiled in the current compilation run are expected to
be found in this map. In this particualr case, the backend would not
build the InlineInfo for these classes and later crash when the
optimizer is enabled.