### PR TITLE
Synthesize reflective proxies at link time.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
@@ -130,7 +130,7 @@ object InfoSerializers {
       }
 
       val methods0 = readList(readMethod())
-      val methods = if (true) { // useHacks065
+      val methods = if (useHacks065) {
         methods0.filter(m => !Definitions.isReflProxyName(m.encodedName))
       } else {
         methods0

--- a/ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
@@ -101,6 +101,9 @@ object InfoSerializers {
 
       import input._
 
+      val useHacks065 =
+        Set("0.6.0", "0.6.3", "0.6.4", "0.6.5").contains(version)
+
       val encodedName = readUTF()
       val isExported = readBoolean()
       val kind = ClassKind.fromByte(readByte())
@@ -126,7 +129,12 @@ object InfoSerializers {
             accessedClassData)
       }
 
-      val methods = readList(readMethod())
+      val methods0 = readList(readMethod())
+      val methods = if (true) { // useHacks065
+        methods0.filter(m => !Definitions.isReflProxyName(m.encodedName))
+      } else {
+        methods0
+      }
 
       val info = ClassInfo(encodedName, isExported, kind,
           superClass, interfaces, methods)

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -712,7 +712,17 @@ object Serializers {
           val superClass = readOptIdent()
           val parents = readIdents()
           val jsName = Some(readString()).filter(_ != "")
-          val defs = readTrees()
+          val defs0 = readTrees()
+          val defs = if (true) { // useHacks065
+            defs0.filter {
+              case MethodDef(_, Ident(name, _), _, _, _) =>
+                !Definitions.isReflProxyName(name)
+              case _ =>
+                true
+            }
+          } else {
+            defs0
+          }
           val optimizerHints = new OptimizerHints(readInt())
           ClassDef(name, kind, superClass, parents, jsName, defs)(optimizerHints)
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -713,7 +713,7 @@ object Serializers {
           val parents = readIdents()
           val jsName = Some(readString()).filter(_ != "")
           val defs0 = readTrees()
-          val defs = if (true) { // useHacks065
+          val defs = if (useHacks065) {
             defs0.filter {
               case MethodDef(_, Ident(name, _), _, _, _) =>
                 !Definitions.isReflProxyName(name)

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -12,12 +12,44 @@ object BinaryIncompatibilities {
   )
 
   val SbtPlugin = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.sbtplugin.ScalaJSPluginInternal.org$scalajs$sbtplugin$ScalaJSPluginInternal$$filterOutReflProxies")
   )
 
   val TestAdapter = Seq(
   )
 
   val CLI = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[MissingTypesProblem](
+          "org.scalajs.cli.Scalajsp$Options$"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.cli.Scalajsp#Options.this"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsp#Options.<init>$default$2"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsp#Options.<init>$default$3"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.cli.Scalajsp#Options.<init>$default$4"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.cli.Scalajsp#Options.apply"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsp#Options.apply$default$2"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsp#Options.apply$default$3"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.cli.Scalajsp#Options.apply$default$4"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.cli.Scalajsp#Options.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsp#Options.copy$default$2"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsp#Options.copy$default$3"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.cli.Scalajsp#Options.copy$default$4"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.cli.Scalajsp#Options.showReflProxy")
   )
 
   val Library = Seq(

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
@@ -221,6 +221,24 @@ object ReflectiveCallTest extends JasmineTest {
       expect(call(new C)).toEqual(1)
     }
 
+    it("should be bug-compatible with Scala/JVM for inherited overloads") {
+      class Base {
+        def foo(x: Option[Int]): String = "a"
+      }
+
+      class Sub extends Base {
+        def foo(x: Option[String]): Int = 1
+      }
+
+      val sub = new Sub
+
+      val x: { def foo(x: Option[Int]): Any } = sub
+      expect(x.foo(Some(1)).asInstanceOf[js.Any]).toEqual(1) // here is the "bug"
+
+      val y: { def foo(x: Option[String]): Any } = sub
+      expect(y.foo(Some("hello")).asInstanceOf[js.Any]).toEqual(1)
+    }
+
     it("should work on java.lang.Object.{ notify, notifyAll } - #303") {
       type ObjNotifyLike = Any {
         def notify(): Unit

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Analysis.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Analysis.scala
@@ -75,6 +75,7 @@ object Analysis {
     final case object None extends MethodSyntheticKind
     // TODO Get rid of InheritedConstructor when we can break binary compat
     final case object InheritedConstructor extends MethodSyntheticKind
+    final case class ReflectiveProxy(target: String) extends MethodSyntheticKind
   }
 
   sealed trait Error {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Refiner.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/Refiner.scala
@@ -16,7 +16,7 @@ final class Refiner(semantics: Semantics, outputMode: OutputMode) {
   def refine(unit: LinkingUnit, logger: Logger): LinkingUnit = {
     val analysis = logTime(logger, "Refiner: Compute reachability") {
       val analyzer = new Analyzer(semantics, outputMode,
-          reachOptimizerSymbols = false, initialLink = false)
+          reachOptimizerSymbols = false, allowAddingSyntheticMethods = false)
       analyzer.computeReachability(unit.infos.values.toList)
     }
 


### PR DESCRIPTION
~~PR in progress to tests one commit at a time. All commits are in [no-refl-proxy-in-sjsir-2](https://github.com/scala-js/scala-js/compare/master...sjrd:no-refl-proxy-in-sjsir-2)~~

Instead of relying on reflective proxies stored in sjsir files by the compiler, we synthesize them at link time, on demand. During deserialization of sjsir files, we throw away all the reflective proxies. The Analyzer identifies the reflective proxies needed to satisfy calls of reflective methods, and the Linker synthesizes the bridges.

The compiler does not need to generate reflective proxies anymore, which simplifies it a bit.

More importantly, this reduces the amount of virtually useless stuff stored in sjsir files. This improves their size, but also the time it takes to deserialize them, and the memory footprint for the deserialized reflective proxies that are never used.