### PR TITLE
Fix #1887: Fix HTML runners of the test suite in fullOpt.

### DIFF
--- a/test-suite/js/run-jasmine-tests.js
+++ b/test-suite/js/run-jasmine-tests.js
@@ -1,6 +1,6 @@
 window.onload = function() {
   var context = org.scalajs.jasminetest.TestSuiteContext();
-  context.setTags("typedarray");
+  context.setTags("typedarray", isFullOpt ? "fullopt-stage" : "fastopt-stage");
 
   // Load tests
   scalajs.TestDetector().loadDetectedTests();
@@ -13,6 +13,4 @@ window.onload = function() {
     return htmlReporter.specFilter(spec);
   };
   jasmineEnv.execute();
-
-  context.setTags();
 };

--- a/test-suite/js/scalajs-test-suite-2.10-fastopt.html
+++ b/test-suite/js/scalajs-test-suite-2.10-fastopt.html
@@ -10,6 +10,7 @@
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine-html.js"></script>
 <script type="text/javascript" src="./src/test/resources/ScalaJSDefinedTestNatives.js"></script>
 <script type="text/javascript" src="./target/scala-2.10/scalajs-test-suite-test-fastopt.js"></script>
+<script type="text/javascript">var isFullOpt = false;</script>
 <script type="text/javascript" src="run-jasmine-tests.js"></script>
 
 </body>

--- a/test-suite/js/scalajs-test-suite-2.10.html
+++ b/test-suite/js/scalajs-test-suite-2.10.html
@@ -10,6 +10,7 @@
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine-html.js"></script>
 <script type="text/javascript" src="./src/test/resources/ScalaJSDefinedTestNatives.js"></script>
 <script type="text/javascript" src="./target/scala-2.10/scalajs-test-suite-test-opt.js"></script>
+<script type="text/javascript">var isFullOpt = true;</script>
 <script type="text/javascript" src="run-jasmine-tests.js"></script>
 
 </body>

--- a/test-suite/js/scalajs-test-suite-2.11-fastopt.html
+++ b/test-suite/js/scalajs-test-suite-2.11-fastopt.html
@@ -10,6 +10,7 @@
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine-html.js"></script>
 <script type="text/javascript" src="./src/test/resources/ScalaJSDefinedTestNatives.js"></script>
 <script type="text/javascript" src="./target/scala-2.11/scalajs-test-suite-test-fastopt.js"></script>
+<script type="text/javascript">var isFullOpt = false;</script>
 <script type="text/javascript" src="run-jasmine-tests.js"></script>
 
 </body>

--- a/test-suite/js/scalajs-test-suite-2.11.html
+++ b/test-suite/js/scalajs-test-suite-2.11.html
@@ -10,6 +10,7 @@
 <script type="text/javascript" src="http://cdn.jsdelivr.net/jasmine/1.3.1/jasmine-html.js"></script>
 <script type="text/javascript" src="./src/test/resources/ScalaJSDefinedTestNatives.js"></script>
 <script type="text/javascript" src="./target/scala-2.11/scalajs-test-suite-test-opt.js"></script>
+<script type="text/javascript">var isFullOpt = true;</script>
 <script type="text/javascript" src="run-jasmine-tests.js"></script>
 
 </body>


### PR DESCRIPTION
Some tests must be disabled in fullOpt mode. From sbt, they are disabled by Jasmine tags, but in the HTML runners, the appropriate tags were not set. This commit fixes this.