### PR TITLE
Do not make ReferenceType extend Type anymore.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -265,12 +265,12 @@ object Hashers {
         case IsInstanceOf(expr, cls) =>
           mixTag(TagIsInstanceOf)
           mixTree(expr)
-          mixType(cls)
+          mixRefType(cls)
 
         case AsInstanceOf(expr, cls) =>
           mixTag(TagAsInstanceOf)
           mixTree(expr)
-          mixType(cls)
+          mixRefType(cls)
 
         case Unbox(expr, charCode) =>
           mixTag(TagUnbox)
@@ -416,7 +416,7 @@ object Hashers {
 
         case ClassOf(cls) =>
           mixTag(TagClassOf)
-          mixType(cls)
+          mixRefType(cls)
 
         case VarRef(ident) =>
           mixTag(TagVarRef)
@@ -442,6 +442,9 @@ object Hashers {
 
     def mixTrees(trees: List[Tree]): Unit =
       trees.foreach(mixTree)
+
+    def mixRefType(tpe: ReferenceType): Unit =
+      mixType(tpe.asInstanceOf[Type])
 
     def mixType(tpe: Type): Unit = tpe match {
       case AnyType     => mixTag(TagAnyType)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -473,13 +473,13 @@ object Printers {
         case IsInstanceOf(expr, cls) =>
           print(expr)
           print(".isInstanceOf[")
-          print(cls)
+          printRefType(cls)
           print(']')
 
         case AsInstanceOf(expr, cls) =>
           print(expr)
           print(".asInstanceOf[")
-          print(cls)
+          printRefType(cls)
           print(']')
 
         case Unbox(expr, charCode) =>
@@ -727,7 +727,7 @@ object Printers {
 
         case ClassOf(cls) =>
           print("classOf[")
-          print(cls)
+          printRefType(cls)
           print(']')
 
         // Specials
@@ -843,6 +843,9 @@ object Printers {
           print(s"<error, elem of class ${tree.getClass()}>")
       }
     }
+
+    def printRefType(tpe: ReferenceType): Unit =
+      print(tpe.asInstanceOf[Type])
 
     def print(tpe: Type): Unit = tpe match {
       case AnyType              => print("any")

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -521,7 +521,7 @@ object Serializers {
     }
 
     def writeReferenceType(tpe: ReferenceType): Unit =
-      writeType(tpe)
+      writeType(tpe.asInstanceOf[Type])
 
     def writePropertyName(name: PropertyName): Unit = {
       name match {

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -375,7 +375,7 @@ object Trees {
     val tpe = cls match {
       case ClassType(Definitions.RuntimeNullClass)    => NullType
       case ClassType(Definitions.RuntimeNothingClass) => NothingType
-      case _                                          => cls
+      case _                                          => cls.asInstanceOf[Type]
     }
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/IRChecker.scala
@@ -881,7 +881,7 @@ class IRChecker(unit: LinkingUnit, logger: Logger) {
 
   def refTypeToType(refType: ReferenceType)(implicit ctx: ErrorContext): Type = {
     refType match {
-      case _: ArrayType           => refType
+      case arrayType: ArrayType   => arrayType
       case ClassType(encodedName) => classNameToType(encodedName)
     }
   }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/OptimizerCore.scala
@@ -482,7 +482,8 @@ private[optimizer] abstract class OptimizerCore(
         trampoline {
           pretransformExpr(expr) { texpr =>
             val result = {
-              if (isSubtype(texpr.tpe.base, tpe)) {
+              // TODO This cast is suspicious
+              if (isSubtype(texpr.tpe.base, tpe.asInstanceOf[Type])) {
                 if (texpr.tpe.isNullable)
                   BinaryOp(BinaryOp.!==, finishTransformExpr(texpr), Null())
                 else
@@ -824,7 +825,8 @@ private[optimizer] abstract class OptimizerCore(
             case ClassType(ObjectClass) =>
               cont(texpr)
             case _ =>
-              if (isSubtype(texpr.tpe.base, tpe)) {
+              // TODO This cast is suspicious
+              if (isSubtype(texpr.tpe.base, tpe.asInstanceOf[Type])) {
                 cont(texpr)
               } else {
                 cont(PreTransTree(


### PR DESCRIPTION
A ReferenceType is fundamentally *not* a Type. It so happens that
all concrete implementations of ReferenceType also implement Type,
but those two concepts must not be confused.

There are a few cases were it is OK-ish to treat a ReferenceType
as a Type (such as serializing/hashing), for which we introduced
casts.

This refactoring highlights a suspicious usage of ReferenceType as
Type in the OptimizerCore core. This commit leaves them as is,
with casts.