### PR TITLE
Optimize the extraction of `lo` and `hi` parts of a Long.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -119,11 +119,13 @@ object Long {
 
   // Must be called only with valid radix
   private def toStringImpl(i: scala.Long, radix: Int): String = {
-    if (i >= Int.MinValue.toLong && i <= Int.MaxValue.toLong) {
+    val lo = i.toInt
+    val hi = (i >>> 32).toInt
+    if (lo >> 31 == hi) {
       // It's a signed int32
       import js.JSNumberOps.enableJSNumberOps
-      i.toInt.toString(radix)
-    } else if (i < 0) {
+      lo.toString(radix)
+    } else if (hi < 0) {
       "-" + toUnsignedStringInternalLarge(-i, radix)
     } else {
       toUnsignedStringInternalLarge(i, radix)
@@ -132,7 +134,7 @@ object Long {
 
   // Must be called only with valid radix
   private def toUnsignedStringImpl(i: scala.Long, radix: Int): String = {
-    if (i >>> 32 == 0L) {
+    if ((i >>> 32).toInt == 0) {
       // It's an unsigned int32
       import js.JSNumberOps._
       i.toInt.toUint.toString(radix)
@@ -386,8 +388,12 @@ object Long {
   def rotateRight(i: scala.Long, distance: scala.Int): scala.Long =
     (i >>> distance) | (i << -distance)
 
-  def signum(i: scala.Long): Int =
-    if (i < 0L) -1 else if (i == 0L) 0 else 1
+  def signum(i: scala.Long): Int = {
+    val hi = (i >>> 32).toInt
+    if (hi < 0) -1
+    else if (hi == 0 && i.toInt == 0) 0
+    else 1
+  }
 
   def numberOfLeadingZeros(l: scala.Long): Int = {
     val hi = (l >>> 32).toInt

--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
@@ -576,8 +576,9 @@ final class RuntimeLong(val lo: Int, val hi: Int)
     else js.Tuple4(quotLo, quotHi, remLo, remHi)
   }
 
-  // Support for intrinsics
+  // TODO Remove these. They were support for intrinsics before 0.6.6.
 
+  @deprecated("Use java.lang.Long.toBinaryString instead.", "0.6.6")
   def toBinaryString: String = {
     val zeros = "00000000000000000000000000000000" // 32 zeros
     @inline def padBinary32(i: Int) = {
@@ -592,6 +593,7 @@ final class RuntimeLong(val lo: Int, val hi: Int)
     else Integer.toBinaryString(lo)
   }
 
+  @deprecated("Use java.lang.Long.toHexString instead.", "0.6.6")
   def toHexString: String = {
     val zeros = "00000000" // 8 zeros
     @inline def padHex8(i: Int) = {
@@ -606,6 +608,7 @@ final class RuntimeLong(val lo: Int, val hi: Int)
     else Integer.toHexString(lo)
   }
 
+  @deprecated("Use java.lang.Long.toOctalString instead.", "0.6.6")
   def toOctalString: String = {
     val zeros = "0000000000" // 10 zeros
     @inline def padOctal10(i: Int) = {
@@ -625,9 +628,11 @@ final class RuntimeLong(val lo: Int, val hi: Int)
     else Integer.toOctalString(lp)
   }
 
+  @deprecated("Use java.lang.Long.bitCount instead.", "0.6.6")
   def bitCount: Int =
     Integer.bitCount(lo) + Integer.bitCount(hi)
 
+  @deprecated("Use java.lang.Long.signum instead.", "0.6.6")
   def signum: RuntimeLong = {
     val hi = this.hi
     if (hi < 0) MinusOne
@@ -635,12 +640,14 @@ final class RuntimeLong(val lo: Int, val hi: Int)
     else One
   }
 
+  @deprecated("Use java.lang.Long.numberOfLeadingZeros instead.", "0.6.6")
   def numberOfLeadingZeros: Int = {
     val hi = this.hi
     if (hi != 0) Integer.numberOfLeadingZeros(hi)
     else Integer.numberOfLeadingZeros(lo) + 32
   }
 
+  @deprecated("Use java.lang.Long.numberOfTrailingZeros instead.", "0.6.6")
   def numberOfTrailingZeros: Int = {
     val lo = this.lo
     if (lo != 0) Integer.numberOfTrailingZeros(lo)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/LongImpl.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/LongImpl.scala
@@ -13,6 +13,9 @@ object LongImpl {
   final val RuntimeLongClass = "sjsr_RuntimeLong"
   final val RuntimeLongModuleClass = "sjsr_RuntimeLong$"
 
+  final val lo = "lo__I"
+  final val hi = "hi__I"
+
   private final val SigUnary   = "__sjsr_RuntimeLong"
   private final val SigBinary  = "__sjsr_RuntimeLong__sjsr_RuntimeLong"
   private final val SigShift   = "__I__sjsr_RuntimeLong"

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/LongImpl.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/LongImpl.scala
@@ -72,20 +72,12 @@ object LongImpl {
 
   // Methods used for intrinsics
 
-  final val divideUnsigned        = "divideUnsigned__sjsr_RuntimeLong__sjsr_RuntimeLong"
-  final val remainderUnsigned     = "remainderUnsigned__sjsr_RuntimeLong__sjsr_RuntimeLong"
-  final val bitCount              = "bitCount__I"
-  final val signum                = "signum__sjsr_RuntimeLong"
-  final val numberOfLeadingZeros  = "numberOfLeadingZeros__I"
-  final val numberOfTrailingZeros = "numberOfTrailingZeros__I"
-  final val toBinaryString        = "toBinaryString__T"
-  final val toHexString           = "toHexString__T"
-  final val toOctalString         = "toOctalString__T"
+  final val divideUnsigned    = "divideUnsigned__sjsr_RuntimeLong__sjsr_RuntimeLong"
+  final val remainderUnsigned = "remainderUnsigned__sjsr_RuntimeLong__sjsr_RuntimeLong"
 
-  val AllIntrinsicMethods = Set(
-      bitCount, signum, numberOfLeadingZeros, numberOfTrailingZeros,
-      toBinaryString, toHexString, toOctalString)
+  val AllIntrinsicMethods = Set.empty[String]
 
+  // TODO Move these to AllIntrinsicMethods when we can break binary compatibility
   val OptionalIntrinsicMethods = Set(
       divideUnsigned, remainderUnsigned)
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/optimizer/OptimizerCore.scala
@@ -1620,20 +1620,6 @@ private[optimizer] abstract class OptimizerCore(
       case LongRemainderUnsigned =>
         contTree(Apply(firstArgAsRTLong, LongImpl.remainderUnsigned,
             List(asRTLong(newArgs(1))))(LongType))
-      case LongBitCount =>
-        contTree(Apply(firstArgAsRTLong, LongImpl.bitCount, Nil)(IntType))
-      case LongSignum =>
-        contTree(Apply(firstArgAsRTLong, LongImpl.signum, Nil)(LongType))
-      case LongLeading0s =>
-        contTree(Apply(firstArgAsRTLong, LongImpl.numberOfLeadingZeros, Nil)(IntType))
-      case LongTrailing0s =>
-        contTree(Apply(firstArgAsRTLong, LongImpl.numberOfTrailingZeros, Nil)(IntType))
-      case LongToBinStr =>
-        contTree(Apply(firstArgAsRTLong, LongImpl.toBinaryString, Nil)(StringClassType))
-      case LongToHexStr =>
-        contTree(Apply(firstArgAsRTLong, LongImpl.toHexString, Nil)(StringClassType))
-      case LongToOctalStr =>
-        contTree(Apply(firstArgAsRTLong, LongImpl.toOctalString, Nil)(StringClassType))
 
       // scala.collection.mutable.ArrayBuilder
 
@@ -3725,15 +3711,8 @@ private[optimizer] object OptimizerCore {
     final val LongCompare = LongToString + 1
     final val LongDivideUnsigned = LongCompare + 1
     final val LongRemainderUnsigned = LongDivideUnsigned + 1
-    final val LongBitCount = LongRemainderUnsigned + 1
-    final val LongSignum = LongBitCount + 1
-    final val LongLeading0s = LongSignum + 1
-    final val LongTrailing0s = LongLeading0s + 1
-    final val LongToBinStr = LongTrailing0s + 1
-    final val LongToHexStr = LongToBinStr + 1
-    final val LongToOctalStr = LongToHexStr + 1
 
-    final val ArrayBuilderZeroOf = LongToOctalStr + 1
+    final val ArrayBuilderZeroOf = LongRemainderUnsigned + 1
     final val GenericArrayBuilderResult = ArrayBuilderZeroOf + 1
 
     final val ClassGetComponentType = GenericArrayBuilderResult + 1
@@ -3770,13 +3749,6 @@ private[optimizer] object OptimizerCore {
       "jl_Long$.compare__J__J__I"            -> LongCompare,
       "jl_Long$.divideUnsigned__J__J__J"     -> LongDivideUnsigned,
       "jl_Long$.remainderUnsigned__J__J__J"  -> LongRemainderUnsigned,
-      "jl_Long$.bitCount__J__I"              -> LongBitCount,
-      "jl_Long$.signum__J__J"                -> LongSignum,
-      "jl_Long$.numberOfLeadingZeros__J__I"  -> LongLeading0s,
-      "jl_Long$.numberOfTrailingZeros__J__I" -> LongTrailing0s,
-      "jl_long$.toBinaryString__J__T"        -> LongToBinStr,
-      "jl_Long$.toHexString__J__T"           -> LongToHexStr,
-      "jl_Long$.toOctalString__J__T"         -> LongToOctalStr,
 
       "scm_ArrayBuilder$.scala$collection$mutable$ArrayBuilder$$zeroOf__jl_Class__O" -> ArrayBuilderZeroOf,
       "scm_ArrayBuilder$.scala$collection$mutable$ArrayBuilder$$genericArrayBuilderResult__jl_Class__sjs_js_Array__O" -> GenericArrayBuilderResult,


### PR DESCRIPTION
This optimization introduces two new rewritings:
* `(x >>> 32).toInt` or `(x >> 32).toInt` -> `x.hi()`
* `x.toInt` -> `x.lo()`

The calls to `hi()` and `lo()` are also inlined, giving, at the moment, `x.hi$2` and `x.lo$2`, respectively.

This allows user code extracting the 32 high and low bits of a Long to do so efficiently.

With that optimization, we can then remove several intrinsics from `java.lang.Long`.