### PR TITLE
Fix #1889: Override the dependency of partest on scala-library.jar.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1384,6 +1384,9 @@ object Build extends sbt.Build {
           fork in Test := true,
           javaOptions in Test += "-Xmx1G",
 
+          // Override the dependency of partest - see #1889
+          dependencyOverrides += "org.scala-lang" % "scala-library" % scalaVersion.value % "test",
+
           testFrameworks ++= {
             if (shouldPartest.value)
               Seq(new TestFramework("scala.tools.partest.scalajs.Framework"))


### PR DESCRIPTION
For some reason, the transitive dependency of scala-partest on
scala-library.jar leaks into the classpath used to compile the
partests. Since scala-partest 1.0.9 depends on scala-library
2.11.6, that version overrides the scala-library for the current
Scala version when testing on 2.11.5 and earlier. This causes
wrong warnings to be reported, and the check files are not happy.

This commit fixes this problem by overriding transitive
dependencies and forcing scala-library with the version we're
testing.