### PR TITLE
Fix #1998: Add a semantics flag for development v production mode.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/System.scala
+++ b/javalanglib/src/main/scala/java/lang/System.scala
@@ -4,7 +4,7 @@ import java.io._
 
 import scala.scalajs.js
 import js.Dynamic.global
-import scala.scalajs.runtime.assumingES6
+import scala.scalajs.LinkingInfo.assumingES6
 
 object System {
   var out: PrintStream = new JSConsoleBasedPrintStream(isErr = false)

--- a/library/src/main/scala/scala/scalajs/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/LinkingInfo.scala
@@ -1,0 +1,111 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs
+
+object LinkingInfo {
+
+  import scala.scalajs.runtime.linkingInfo
+
+  /** Returns true if we are linking for production, false otherwise.
+   *
+   *  `productionMode` is always equal to `!developmentMode`.
+   *
+   *  This ends up being constant-folded to a constant at link-time. So
+   *  constant-folding, inlining, and other local optimizations can be
+   *  leveraged with this "constant" to write code that should only be
+   *  executed in production mode or development mode.
+   *
+   *  A typical usage of this method is:
+   *  {{{
+   *  val warningsLogger =
+   *    if (productionMode) new NullLogger
+   *    else new ConsoleLogger
+   *  }}}
+   *
+   *  At link-time, `productionMode` will either be a constant true, in which
+   *  case the above snippet folds into
+   *  {{{
+   *  val warningsLogger = new NullLogger
+   *  }}}
+   *  or a constant false, in which case it folds into
+   *  {{{
+   *  val warningsLogger = new ConsoleLogger.
+   *  }}}
+   *
+   *  @see [[developmentMode]]
+   */
+  @inline
+  def productionMode: Boolean =
+    linkingInfo.semantics.productionMode
+
+  /** Returns true if we are linking for development, false otherwise.
+   *
+   *  `developmentMode` is always equal to `!productionMode`.
+   *
+   *  This ends up being constant-folded to a constant at link-time. So
+   *  constant-folding, inlining, and other local optimizations can be
+   *  leveraged with this "constant" to write code that should only be
+   *  executed in production mode or development mode.
+   *
+   *  A typical usage of this method is:
+   *  {{{
+   *  if (developmentMode) {
+   *    performExpensiveSanityChecks()
+   *  }
+   *  }}}
+   *
+   *  At link-time, `developmentMode` will either be a constant true, in which
+   *  case the above snippet folds into
+   *  {{{
+   *  performExpensiveSanityChecks()
+   *  }}}
+   *  or a constant false, in which case it is dead-code-eliminated away,
+   *  yielding maximum performance in production.
+   *
+   *  @see [[productionMode]]
+   */
+  @inline
+  def developmentMode: Boolean =
+    !productionMode
+
+  /** Returns true if we are assuming that the target platform supports
+   *  ECMAScript 6, false otherwise.
+   *
+   *  This ends up being constant-folded to a constant at link-time. So
+   *  constant-folding, inlining, and other local optimizations can be
+   *  leveraged with this "constant" to write polyfills that can be
+   *  dead-code-eliminated.
+   *
+   *  A typical usage of this method is:
+   *  {{{
+   *  if (assumingES6 || featureTest())
+   *    useES6Feature()
+   *  else
+   *    usePolyfill()
+   *  }}}
+   *
+   *  At link-time, `assumingES6` will either be a constant false, in which
+   *  case the above snippet folds into
+   *  {{{
+   *  if (featureTest())
+   *    useES6Feature()
+   *  else
+   *    usePolyfill()
+   *  }}}
+   *  or a constant true, in which case it folds into
+   *  {{{
+   *  useES6Feature()
+   *  }}}
+   */
+  @inline
+  def assumingES6: Boolean =
+    linkingInfo.assumingES6
+
+}

--- a/library/src/main/scala/scala/scalajs/runtime/Bits.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/Bits.scala
@@ -16,6 +16,8 @@ import js.typedarray
 /** Low-level stuff. */
 object Bits {
 
+  import scala.scalajs.LinkingInfo.assumingES6
+
   private[this] val _areTypedArraysSupported = {
     // Here we use `assumingES6` to dce the 4 subsequent tests
     assumingES6 || js.DynamicImplicits.truthValue(

--- a/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
@@ -24,6 +24,9 @@ object LinkingInfo {
 
     /** Whether floats have strict semantics. */
     val strictFloats: Boolean = js.native
+
+    /** Whether we are linking in production mode. */
+    val productionMode: Boolean = js.native
   }
 
   object Semantics {

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -6,38 +6,10 @@ import scala.collection.GenTraversableOnce
 
 package object runtime {
 
-  /** Returns true if we are assuming that the target platform supports
-   *  ECMAScript 6, false otherwise.
-   *
-   *  This ends up being constant-folded to a constant at link-time. So
-   *  constant-folding, inlining, and other local optimizations can be
-   *  leveraged with this "constant" to write polyfills that can be
-   *  dead-code-eliminated.
-   *
-   *  A typical usage of this method is:
-   *  {{{
-   *  if (assumingES6 || featureTest())
-   *    useES6Feature()
-   *  else
-   *    usePolyfill()
-   *  }}}
-   *
-   *  At link-time, `assumingES6` will either be a constant false, in which
-   *  case the above snippet folds into
-   *  {{{
-   *  if (featureTest())
-   *    useES6Feature()
-   *  else
-   *    usePolyfill()
-   *  }}}
-   *  or a constant true, in which case it folds into
-   *  {{{
-   *  useES6Feature()
-   *  }}}
-   */
+  @deprecated("Use scala.scalajs.LinkingInfo.assumingES6 instead.", "0.6.6")
   @inline
   def assumingES6: Boolean =
-    linkingInfo.assumingES6
+    scala.scalajs.LinkingInfo.assumingES6
 
   def wrapJavaScriptException(e: Any): Throwable = e match {
     case e: Throwable => e

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -110,6 +110,12 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+      // In theory, breaking, but this is an interface in runtime that no one should extend
+      ProblemFilters.exclude[MissingMethodProblem](
+          "scala.scalajs.runtime.LinkingInfo#Semantics.productionMode"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "scala.scalajs.runtime.LinkingInfo#Semantics.scala$scalajs$runtime$LinkingInfo$Semantics$_setter_$productionMode_="),
+
       // private[runtime], not an issue
       ProblemFilters.exclude[MissingMethodProblem](
           "scala.scalajs.runtime.RuntimeLong.TWO_PWR_16_DBL"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1112,7 +1112,11 @@ object Build extends sbt.Build {
 
         val envTags = envTagsFor((resolvedJSEnv in Test).value)
 
-        val sems = (scalaJSSemantics in Test).value
+        val sems = (scalaJSStage in Test).value match {
+          case FastOptStage => (scalaJSSemantics in (Test, fastOptJS)).value
+          case FullOptStage => (scalaJSSemantics in (Test, fullOptJS)).value
+        }
+
         val semTags = (
             if (sems.asInstanceOfs == CheckedBehavior.Compliant)
               Seq(Tests.Argument("-tcompliant-asinstanceofs"))
@@ -1126,6 +1130,10 @@ object Build extends sbt.Build {
         ) ++ (
             if (sems.strictFloats) Seq(Tests.Argument("-tstrict-floats"))
             else Seq()
+        ) ++ (
+            Seq(Tests.Argument(
+                if (sems.productionMode) "-tproduction-mode"
+                else "-tdevelopment-mode"))
         )
 
         val stageTag = Tests.Argument((scalaJSStage in Test).value match {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
@@ -1,0 +1,41 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.library
+
+import scala.scalajs.js
+import org.scalajs.jasminetest.JasmineTest
+
+object LinkingInfoTest extends JasmineTest {
+
+  import scala.scalajs.LinkingInfo
+
+  describe("scala.scalajs.LinkingInfo") {
+
+    when("production-mode").
+    it("productionMode when in production mode") {
+      expect(LinkingInfo.productionMode).toBeTruthy
+    }
+
+    when("development-mode").
+    it("productionMode when in development mode") {
+      expect(LinkingInfo.productionMode).toBeFalsy
+    }
+
+    when("production-mode").
+    it("developmentMode when in production mode") {
+      expect(LinkingInfo.developmentMode).toBeFalsy
+    }
+
+    when("development-mode").
+    it("developmentMode when in development mode") {
+      expect(LinkingInfo.developmentMode).toBeTruthy
+    }
+
+  }
+
+}

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -52,9 +52,14 @@ ScalaJS.linkingInfo = {
 //!endif
 //!endif
 //!if floats == Strict
-    "strictFloats": true
+    "strictFloats": true,
 //!else
-    "strictFloats": false
+    "strictFloats": false,
+//!endif
+//!if productionMode == true
+    "productionMode": true
+//!else
+    "productionMode": false
 //!endif
   },
 //!if outputMode == ECMAScript6

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/corelib/CoreJSLibs.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/corelib/CoreJSLibs.scala
@@ -65,6 +65,8 @@ object CoreJSLibs {
       case "floats" =>
         if (semantics.strictFloats) "Strict"
         else "Loose"
+      case "productionMode" =>
+        semantics.productionMode.toString()
       case "outputMode" =>
         outputMode.toString()
     }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -2954,6 +2954,8 @@ private[frontend] abstract class OptimizerCore(
             behavior2IntLiteral(semantics.moduleInit)
           case "strictFloats" =>
             BooleanLiteral(semantics.strictFloats)
+          case "productionMode" =>
+            BooleanLiteral(semantics.productionMode)
           case _ =>
             default
         }

--- a/tools/strongmodeenv.js
+++ b/tools/strongmodeenv.js
@@ -39,9 +39,14 @@ const $linkingInfo = {
 //!endif
 //!endif
 //!if floats == Strict
-    "strictFloats": true
+    "strictFloats": true,
 //!else
-    "strictFloats": false
+    "strictFloats": false,
+//!endif
+//!if productionMode == true
+    "productionMode": true
+//!else
+    "productionMode": false
 //!endif
   },
   "assumingES6": true


### PR DESCRIPTION
Semantics receive an additional flag `productionMode`, which is,
by default, false in fastOpt stage in true in fullOpt stage. It
can be queried with
`scala.scalajs.runtime.{production,development}Mode`
to write user-level code that optimizes itself for production,
for example by discarding expensive run-time sanity checks.