### PR TITLE
Further tools refactoring.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -124,36 +124,36 @@
 
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in noIrCheckTest := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
         ++$scala noIrCheckTest/test \
         noIrCheckTest/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
         'set scalaJSSemantics in testSuite ~= makeCompliant' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
         'set scalaJSSemantics in testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
         'set scalaJSSemantics in testSuite ~= { _.optimized }' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
         'set scalaJSSemantics in testSuite ~= { _.optimized }' \
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
@@ -163,36 +163,36 @@
 
   <task id="test-suite-ecma-script6-strong-mode"><![CDATA[
     setJavaVersion $java
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6StrongMode' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6StrongModeNodeArgs).value.withSourceMap(false)' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
+    sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6StrongMode' \
         'set jsEnv in noIrCheckTest := NodeJSEnv(args = ES6StrongModeNodeArgs).value.withSourceMap(false)' \
         ++$scala noIrCheckTest/test \
         noIrCheckTest/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6StrongMode' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6StrongModeNodeArgs).value.withSourceMap(false)' \
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6StrongMode' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6StrongModeNodeArgs).value.withSourceMap(false)' \
         'set scalaJSSemantics in testSuite ~= makeCompliant' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6StrongMode' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6StrongModeNodeArgs).value.withSourceMap(false)' \
         'set scalaJSSemantics in testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6StrongMode' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6StrongModeNodeArgs).value.withSourceMap(false)' \
         'set scalaJSSemantics in testSuite ~= { _.optimized }' \
         ++$scala testSuite/test \
         testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode' \
+    sbtretry 'set scalaJSOutputMode in testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6StrongMode' \
         'set jsEnv in testSuite := NodeJSEnv(args = ES6StrongModeNodeArgs).value.withSourceMap(false)' \
         'set scalaJSSemantics in testSuite ~= { _.optimized }' \
         'set scalaJSOptimizerOptions in testSuite ~= (_.withDisableOptimizer(true))' \

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -12,7 +12,6 @@ package org.scalajs.cli
 import org.scalajs.core.ir.ScalaJSVersions
 
 import org.scalajs.core.tools.sem._
-import org.scalajs.core.tools.javascript.OutputMode
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.logging._
 
@@ -20,7 +19,7 @@ import CheckedBehavior.Compliant
 
 import org.scalajs.core.tools.linker.Linker
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
-import org.scalajs.core.tools.linker.backend.LinkerBackend
+import org.scalajs.core.tools.linker.backend.{LinkerBackend, OutputMode}
 
 import scala.collection.immutable.Seq
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
@@ -16,9 +16,11 @@ import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.logging._
+
 import org.scalajs.core.tools.linker.LinkingUnit
-import org.scalajs.core.tools.linker.backend.Emitter
-import org.scalajs.core.tools.javascript.{OutputMode, ESLevel}
+import org.scalajs.core.tools.linker.backend.OutputMode
+import org.scalajs.core.tools.linker.backend.emitter.Emitter
+import org.scalajs.core.tools.javascript.ESLevel
 
 import scala.annotation.tailrec
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
@@ -21,7 +21,8 @@ import org.scalajs.core.tools.javascript._
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.corelib._
 
-import OutputMode.ECMAScript51Global
+import org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript51Global
+import org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter
 
 private[rhino] class ScalaJSCoreLib(linkingUnit: LinkingUnit) {
   import ScalaJSCoreLib._

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -106,7 +106,15 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "org.scalajs.cli.Scalajsld#Options.apply"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
-          "org.scalajs.cli.Scalajsld#Options.<init>$default$3")
+          "org.scalajs.cli.Scalajsld#Options.<init>$default$3"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsld#Options.copy$default$5"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsld#Options.outputMode"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsld#Options.apply$default$5"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.cli.Scalajsld#Options.<init>$default$5")
   )
 
   val Library = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -34,6 +34,7 @@ import Implicits._
 import org.scalajs.core.tools.io.MemVirtualJSFile
 import org.scalajs.core.tools.sem._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
+import org.scalajs.core.tools.linker.backend.OutputMode
 
 import sbtassembly.AssemblyPlugin.autoImport._
 
@@ -1134,7 +1135,7 @@ object Build extends sbt.Build {
         })
 
         val modeTags = (scalaJSOutputMode in Test).value match {
-          case org.scalajs.core.tools.javascript.OutputMode.ECMAScript6StrongMode =>
+          case OutputMode.ECMAScript6StrongMode =>
             Seq(Tests.Argument("-tstrong-mode"))
           case _ =>
             Seq()

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -12,9 +12,9 @@ package org.scalajs.sbtplugin
 import sbt._
 
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.javascript.OutputMode
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.linker.LinkingUnit
+import org.scalajs.core.tools.linker.backend.OutputMode
 import org.scalajs.core.tools.jsdep.{JSDependencyManifest, ResolvedJSDependency}
 import org.scalajs.core.tools.jsdep.ManifestFilters.ManifestFilter
 import org.scalajs.core.tools.jsdep.DependencyResolver.DependencyFilter

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -11,14 +11,13 @@ import complete.DefaultParsers._
 import Implicits._
 
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.javascript.OutputMode
 import org.scalajs.core.tools.io.{IO => toolsIO, _}
 import org.scalajs.core.tools.jsdep._
 import org.scalajs.core.tools.json._
 import org.scalajs.core.tools.corelib.CoreJSLibs
 import org.scalajs.core.tools.linker.{ClearableLinker, Linker}
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
-import org.scalajs.core.tools.linker.backend.LinkerBackend
+import org.scalajs.core.tools.linker.backend.{LinkerBackend, OutputMode}
 
 import org.scalajs.jsenv._
 import org.scalajs.jsenv.rhino.RhinoJSEnv

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -10,11 +10,10 @@
 package org.scalajs.core.tools.linker
 
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.javascript.OutputMode
 
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.frontend.optimizer.IncOptimizer
-import org.scalajs.core.tools.linker.backend.{LinkerBackend, BasicLinkerBackend}
+import org.scalajs.core.tools.linker.backend._
 
 trait LinkerPlatformExtensions { this: Linker.type =>
   def apply(

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -10,11 +10,10 @@
 package org.scalajs.core.tools.linker
 
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.javascript.OutputMode
 
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.frontend.optimizer.{ParIncOptimizer, IncOptimizer}
-import org.scalajs.core.tools.linker.backend.{LinkerBackend, BasicLinkerBackend}
+import org.scalajs.core.tools.linker.backend._
 import org.scalajs.core.tools.linker.backend.closure.ClosureLinkerBackend
 
 trait LinkerPlatformExtensions { this: Linker.type =>
@@ -39,7 +38,9 @@ trait LinkerPlatformExtensions { this: Linker.type =>
 
     val backend = {
       if (useClosureCompiler) {
-        new ClosureLinkerBackend(semantics, outputMode,
+        require(outputMode == OutputMode.ECMAScript51Isolated,
+            s"Cannot use output mode $outputMode with the Closure Compiler")
+        new ClosureLinkerBackend(semantics,
             withSourceMap, backendConfig)
       } else {
         new BasicLinkerBackend(semantics, outputMode,

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstBuilder.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstBuilder.scala
@@ -4,7 +4,7 @@ import org.scalajs.core.ir
 import ir.Position.NoPosition
 
 import org.scalajs.core.tools.javascript.Trees.Tree
-import org.scalajs.core.tools.linker.backend.JSTreeBuilder
+import org.scalajs.core.tools.javascript.JSTreeBuilder
 
 import com.google.javascript.rhino._
 import com.google.javascript.rhino.jstype.{StaticSourceFile, SimpleSourceFile}

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
@@ -20,13 +20,14 @@ import com.google.javascript.jscomp.{
 
 import org.scalajs.core.tools.corelib.CoreJSLibs
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.javascript.OutputMode
+import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.sem.Semantics
 
 import org.scalajs.core.tools.linker.LinkingUnit
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
-import org.scalajs.core.tools.linker.backend.{LinkerBackend, Emitter}
+import org.scalajs.core.tools.linker.backend.{OutputMode, LinkerBackend}
+import org.scalajs.core.tools.linker.backend.emitter.Emitter
 
 /** The Closure backend of the Scala.js linker.
  *
@@ -35,12 +36,12 @@ import org.scalajs.core.tools.linker.backend.{LinkerBackend, Emitter}
  */
 final class ClosureLinkerBackend(
     semantics: Semantics,
-    outputMode: OutputMode,
     withSourceMap: Boolean,
     config: LinkerBackend.Config
-) extends LinkerBackend(semantics, outputMode, withSourceMap, config) {
+) extends LinkerBackend(semantics, ESLevel.ES5, withSourceMap, config) {
 
-  private[this] val emitter = new Emitter(semantics, outputMode)
+  private[this] val emitter =
+    new Emitter(semantics, OutputMode.ECMAScript51Isolated)
 
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements
 
@@ -66,8 +67,8 @@ final class ClosureLinkerBackend(
     // Build a Closure JSModule which includes the core libs
     val module = new JSModule("Scala.js")
 
-    module.add(new CompilerInput(
-        toClosureSource(CoreJSLibs.lib(semantics, outputMode))))
+    module.add(new CompilerInput(toClosureSource(
+        CoreJSLibs.lib(semantics, OutputMode.ECMAScript51Isolated))))
 
     val ast = builder.closureAST
     module.add(new CompilerInput(ast, ast.getInputId(), false))

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/corelib/CoreJSLibs.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/corelib/CoreJSLibs.scala
@@ -15,7 +15,7 @@ import org.scalajs.core.ir.ScalaJSVersions
 import org.scalajs.core.tools.io._
 
 import org.scalajs.core.tools.sem._
-import org.scalajs.core.tools.javascript.OutputMode
+import org.scalajs.core.tools.linker.backend.OutputMode
 
 import scala.collection.immutable.Seq
 import scala.collection.mutable

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/JSBuilders.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/JSBuilders.scala
@@ -7,7 +7,7 @@
 \*                                                                      */
 
 
-package org.scalajs.core.tools.linker.backend
+package org.scalajs.core.tools.javascript
 
 import scala.annotation.tailrec
 
@@ -18,7 +18,6 @@ import java.util.regex.Pattern
 import java.net.{ URI, URISyntaxException }
 
 import org.scalajs.core.ir.Position
-import org.scalajs.core.tools.{javascript => js}
 import org.scalajs.core.tools.io._
 
 /** An abstract builder taking IR or JSTrees */
@@ -27,7 +26,7 @@ trait JSTreeBuilder {
    *  The tree must be a valid JavaScript tree (typically obtained by
    *  desugaring a full-fledged IR tree).
    */
-  def addJSTree(tree: js.Trees.Tree): Unit
+  def addJSTree(tree: Trees.Tree): Unit
 
   /** Completes the builder. */
   def complete(): Unit = ()
@@ -55,8 +54,8 @@ class JSFileBuilder(val name: String,
    *  The tree must be a valid JavaScript tree (typically obtained by
    *  desugaring a full-fledged IR tree).
    */
-  def addJSTree(tree: js.Trees.Tree): Unit = {
-    val printer = new js.Printers.JSTreePrinter(outputWriter)
+  def addJSTree(tree: Trees.Tree): Unit = {
+    val printer = new Printers.JSTreePrinter(outputWriter)
     printer.printTopLevelTree(tree)
     // Do not close the printer: we do not have ownership of the writers
   }
@@ -69,7 +68,7 @@ class JSFileBuilder(val name: String,
 }
 
 class JSFileBuilderWithSourceMapWriter(n: String, ow: Writer,
-    protected val sourceMapWriter: js.SourceMapWriter)
+    protected val sourceMapWriter: SourceMapWriter)
     extends JSFileBuilder(n, ow) {
 
   override def addLine(line: String): Unit = {
@@ -121,8 +120,8 @@ class JSFileBuilderWithSourceMapWriter(n: String, ow: Writer,
     }
   }
 
-  override def addJSTree(tree: js.Trees.Tree): Unit = {
-    val printer = new js.Printers.JSTreePrinterWithSourceMap(
+  override def addJSTree(tree: Trees.Tree): Unit = {
+    val printer = new Printers.JSTreePrinterWithSourceMap(
         outputWriter, sourceMapWriter)
     printer.printTopLevelTree(tree)
     // Do not close the printer: we do not have ownership of the writers
@@ -140,7 +139,7 @@ class JSFileBuilderWithSourceMap(n: String, ow: Writer,
     relativizeSourceMapBasePath: Option[URI] = None)
     extends JSFileBuilderWithSourceMapWriter(
         n, ow,
-        new js.SourceMapWriter(sourceMapOutputWriter, n,
+        new SourceMapWriter(sourceMapOutputWriter, n,
             relativizeSourceMapBasePath)) {
 
   override def complete(): Unit = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/package.scala
@@ -1,0 +1,12 @@
+package org.scalajs.core.tools
+
+package object javascript {
+  // Backward source compatibility for build files
+
+  @deprecated("Use org.scalajs.core.tools.linker.backend.OutputMode instead.", "0.6.6")
+  type OutputMode = org.scalajs.core.tools.linker.backend.OutputMode
+
+  @deprecated("Use org.scalajs.core.tools.linker.backend.OutputMode instead.", "0.6.6")
+  lazy val OutputMode = org.scalajs.core.tools.linker.backend.OutputMode
+
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
@@ -13,7 +13,7 @@ import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.javascript.OutputMode
+import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 
 /** A box around a [[GenLinker]] to support clearing.
@@ -28,7 +28,7 @@ final class ClearableLinker(newLinker: () => GenLinker, batchMode: Boolean)
     extends GenLinker {
 
   private[this] var _semantics: Semantics = _
-  private[this] var _outputMode: OutputMode = _
+  private[this] var _esLevel: ESLevel = _
   private[this] var _linker: GenLinker = _
 
   def semantics: Semantics = {
@@ -36,9 +36,9 @@ final class ClearableLinker(newLinker: () => GenLinker, batchMode: Boolean)
     _semantics
   }
 
-  def outputMode: OutputMode = {
+  def esLevel: ESLevel = {
     ensureLinker()
-    _outputMode
+    _esLevel
   }
 
   def linkUnit(irFiles: Seq[VirtualScalaJSIRFile],
@@ -82,10 +82,10 @@ final class ClearableLinker(newLinker: () => GenLinker, batchMode: Boolean)
       else
         require(_semantics == candidate.semantics, "Linker changed Semantics")
 
-      if (_outputMode == null)
-        _outputMode = candidate.outputMode
+      if (_esLevel == null)
+        _esLevel = candidate.esLevel
       else
-        require(_outputMode == candidate.outputMode, "Linker changed OutputMode")
+        require(_esLevel == candidate.esLevel, "Linker changed ESLevel")
 
       _linker = candidate
     }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
@@ -13,7 +13,7 @@ import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.javascript.OutputMode
+import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 
 /** Common supertrait of [[Linker]] and [[ClearableLinker]].
@@ -22,7 +22,7 @@ import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
  */
 trait GenLinker {
   def semantics: Semantics
-  def outputMode: OutputMode
+  def esLevel: ESLevel
 
   def linkUnit(irFiles: Seq[VirtualScalaJSIRFile],
       symbolRequirements: SymbolRequirement, logger: Logger): LinkingUnit

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
@@ -13,7 +13,7 @@ import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.javascript.OutputMode
+import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.frontend.optimizer.IncOptimizer
@@ -27,11 +27,11 @@ final class Linker(frontend: LinkerFrontend, backend: LinkerBackend)
       "Frontend must have source maps enabled if backend has them enabled")
   require(frontend.semantics == backend.semantics,
       "Frontend and backend must agree on semantics")
-  require(frontend.esLevel == backend.outputMode.esLevel,
+  require(frontend.esLevel == backend.esLevel,
       "Frontend and backend must agree on ESLevel")
 
   val semantics: Semantics = frontend.semantics
-  val outputMode: OutputMode = backend.outputMode
+  val esLevel: ESLevel = backend.esLevel
 
   private[this] var _valid = true
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala
@@ -12,12 +12,13 @@ package org.scalajs.core.tools.linker.backend
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io.WritableVirtualJSFile
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.javascript.OutputMode
 import org.scalajs.core.tools.linker.LinkingUnit
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
+import org.scalajs.core.tools.linker.backend.emitter.Emitter
+import org.scalajs.core.tools.javascript.{JSFileBuilder, JSFileBuilderWithSourceMap}
 
 /** The basic backend for the Scala.js linker.
- *  
+ *
  *  Simply emits the JavaScript without applying any further optimizations.
  */
 final class BasicLinkerBackend(
@@ -25,14 +26,14 @@ final class BasicLinkerBackend(
     outputMode: OutputMode,
     withSourceMap: Boolean,
     config: LinkerBackend.Config
-) extends LinkerBackend(semantics, outputMode, withSourceMap, config) {
+) extends LinkerBackend(semantics, outputMode.esLevel, withSourceMap, config) {
 
   private[this] val emitter = new Emitter(semantics, outputMode)
 
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements
 
   /** Emit the given [[LinkingUnit]] to the target output
-   * 
+   *
    *  @param unit [[LinkingUnit]] to emit
    *  @param output File to write to
    */

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala
@@ -12,7 +12,7 @@ package org.scalajs.core.tools.linker.backend
 import java.net.URI
 
 import org.scalajs.core.tools.io.WritableVirtualJSFile
-import org.scalajs.core.tools.javascript.OutputMode
+import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.sem.Semantics
 
@@ -27,7 +27,7 @@ import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
  */
 abstract class LinkerBackend(
     val semantics: Semantics,
-    val outputMode: OutputMode,
+    val esLevel: ESLevel,
     val withSourceMap: Boolean,
     protected val config: LinkerBackend.Config) {
 
@@ -35,7 +35,7 @@ abstract class LinkerBackend(
   val symbolRequirements: SymbolRequirement
 
   /** Emit the given [[LinkingUnit]] to the target output
-   * 
+   *
    *  @param unit [[LinkingUnit]] to emit
    *  @param output File to write to
    *  @param logger Logger to use
@@ -52,7 +52,7 @@ abstract class LinkerBackend(
   protected def verifyUnit(unit: LinkingUnit): Unit = {
     require(unit.semantics == semantics,
         "LinkingUnit and LinkerBackend must agree on semantics")
-    require(unit.esLevel == outputMode.esLevel,
+    require(unit.esLevel == esLevel,
         "LinkingUnit and LinkerBackend must agree on esLevel")
   }
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/OutputMode.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/OutputMode.scala
@@ -7,7 +7,9 @@
 \*                                                                      */
 
 
-package org.scalajs.core.tools.javascript
+package org.scalajs.core.tools.linker.backend
+
+import org.scalajs.core.tools.javascript.ESLevel
 
 /** JavaScript output mode. */
 sealed abstract class OutputMode {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -7,30 +7,29 @@
 \*                                                                      */
 
 
-package org.scalajs.core.tools.linker.backend
+package org.scalajs.core.tools.linker.backend.emitter
 
 import scala.annotation.tailrec
 
 import scala.collection.mutable
 
+import org.scalajs.core.ir.{ClassKind, Position}
+
 import org.scalajs.core.tools.sem._
 import org.scalajs.core.tools.logging._
 
 import org.scalajs.core.tools.corelib.CoreJSLibs
-import org.scalajs.core.tools.javascript
-import javascript.{Trees => js, OutputMode, ESLevel, LongImpl}
-
-import org.scalajs.core.ir.{ClassKind, Definitions, Position}
-import org.scalajs.core.ir.{Trees => ir}
+import org.scalajs.core.tools.javascript.{Trees => js, _}
 
 import org.scalajs.core.tools.linker._
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
+import org.scalajs.core.tools.linker.backend.OutputMode
 
 /** Emits a desugared JS tree to a builder */
 final class Emitter(semantics: Semantics, outputMode: OutputMode) {
   import Emitter._
 
-  private var classEmitter: javascript.ScalaJSClassEmitter = _
+  private var classEmitter: ScalaJSClassEmitter = _
   private val classCaches = mutable.Map.empty[List[String], ClassCache]
 
   private[this] var statsClassesReused: Int = 0
@@ -71,7 +70,7 @@ final class Emitter(semantics: Semantics, outputMode: OutputMode) {
   }
 
   def emit(unit: LinkingUnit, builder: JSTreeBuilder, logger: Logger): Unit = {
-    classEmitter = new javascript.ScalaJSClassEmitter(outputMode, unit)
+    classEmitter = new ScalaJSClassEmitter(outputMode, unit)
     startRun()
     try {
       val orderedClasses = unit.classDefs.sortWith(compareClasses)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/LongImpl.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/LongImpl.scala
@@ -7,9 +7,9 @@
 \*                                                                      */
 
 
-package org.scalajs.core.tools.javascript
+package org.scalajs.core.tools.linker.backend.emitter
 
-private[tools] object LongImpl {
+private[linker] object LongImpl {
   final val RuntimeLongClass = "sjsr_RuntimeLong"
   final val RuntimeLongModuleClass = "sjsr_RuntimeLong$"
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ScalaJSClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ScalaJSClassEmitter.scala
@@ -7,7 +7,7 @@
 \*                                                                      */
 
 
-package org.scalajs.core.tools.javascript
+package org.scalajs.core.tools.linker.backend.emitter
 
 import org.scalajs.core.ir._
 import Position._
@@ -19,23 +19,26 @@ import org.scalajs.core.tools.sem._
 import CheckedBehavior.Unchecked
 
 import org.scalajs.core.tools.javascript.{Trees => js}
-
+import org.scalajs.core.tools.linker.backend.OutputMode
 import org.scalajs.core.tools.linker.{LinkedClass, LinkingUnit}
 
 /** Defines methods to emit Scala.js classes to JavaScript code.
  *  The results are completely desugared.
+ *
+ *  The only reason this is not `private[emitter]` is because `RhinoJSEnv`
+ *  needs it.
  */
-final class ScalaJSClassEmitter(
-    private[javascript] val outputMode: OutputMode,
+private[scalajs] final class ScalaJSClassEmitter(
+    private[emitter] val outputMode: OutputMode,
     linkingUnit: LinkingUnit) {
 
   import ScalaJSClassEmitter._
   import JSDesugaring._
 
-  private[javascript] lazy val linkedClassByName: Map[String, LinkedClass] =
+  private[emitter] lazy val linkedClassByName: Map[String, LinkedClass] =
     linkingUnit.classDefs.map(c => c.encodedName -> c).toMap
 
-  private[javascript] def isInterface(className: String): Boolean = {
+  private[emitter] def isInterface(className: String): Boolean = {
     /* TODO In theory, there is a flaw in the incremental behavior about this.
      *
      * This method is used to desugar ApplyStatically nodes. Depending on
@@ -61,7 +64,7 @@ final class ScalaJSClassEmitter(
     linkedClassByName(className).kind == ClassKind.Interface
   }
 
-  private[javascript] def semantics: Semantics = linkingUnit.semantics
+  private[emitter] def semantics: Semantics = linkingUnit.semantics
 
   private implicit def implicitOutputMode: OutputMode = outputMode
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/TreeDSL.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/TreeDSL.scala
@@ -7,16 +7,16 @@
 \*                                                                      */
 
 
-package org.scalajs.core.tools.javascript
+package org.scalajs.core.tools.linker.backend.emitter
 
 import scala.language.implicitConversions
 
 import org.scalajs.core.ir
 import org.scalajs.core.ir.Position
 
-import Trees._
+import org.scalajs.core.tools.javascript.Trees._
 
-private[javascript] object TreeDSL {
+private[emitter] object TreeDSL {
   implicit class TreeOps(val self: Tree) extends AnyVal {
     /** Select a member */
     def DOT(field: Ident)(implicit pos: Position): DotSelect =

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -22,11 +22,12 @@ import Trees._
 import Types._
 
 import org.scalajs.core.tools.sem._
-import org.scalajs.core.tools.javascript.{ESLevel, LongImpl}
+import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.logging._
 
 import org.scalajs.core.tools.linker._
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
+import org.scalajs.core.tools.linker.backend.emitter.LongImpl
 
 /** Incremental optimizer.
  *  An incremental optimizer optimizes a [[LinkingUnit]] in an incremental way.

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -24,9 +24,10 @@ import Trees._
 import Types._
 
 import org.scalajs.core.tools.sem.{CheckedBehavior, Semantics}
-import org.scalajs.core.tools.javascript.{LongImpl, ESLevel}
+import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.logging._
 import org.scalajs.core.tools.linker._
+import org.scalajs.core.tools.linker.backend.emitter.LongImpl
 
 /** Optimizer core.
  *  Designed to be "mixed in" [[IncOptimizer#MethodImpl#Optimizer]].


### PR DESCRIPTION
This commit mostly shuffles classes around in packages for a better
organization and stricter encapsulation of concerns:

* Everything related to Emitting JavaScript code from the IR is
  moved to backend.emitter.
* The OutputMode is not visible at the generic LinkerBackend level
  nor at the GenLinker level. It is a specificity of the two
  existing backends, but one could create a separate backend having
  nothing to do with those.