### PR TITLE
Fix #2184: Reach j.l.Integer.compareTo(j.l.{Byte,Short}).

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -50,7 +50,9 @@ abstract class GenIncOptimizer private[optimizer] (semantics: Semantics,
     import factory._
 
     callMethods(LongImpl.RuntimeLongClass, LongImpl.AllIntrinsicMethods) ++
-    optional(callMethods(LongImpl.RuntimeLongClass, LongImpl.OptionalIntrinsicMethods))
+    optional(callMethods(LongImpl.RuntimeLongClass, LongImpl.OptionalIntrinsicMethods)) ++
+    callMethods(Definitions.BoxedIntegerClass,
+        Seq("compareTo__jl_Byte__I", "compareTo__jl_Short__I")) // #2184
   }
 
   private[optimizer] val CollOps: AbsCollOps


### PR DESCRIPTION
After optimizations, and in particular type refinement of `j.l.Byte` into a primitive `byte`, which is actually an `int`, it can happen that a `j.l.Byte.compareTo(j.l.Byte)` is transformed into a `j.l.Integer.compareTo(j.l.Byte)`. It is therefore necessary to keep this method until the optimizer. The same happens with `j.l.Short`.