### PR TITLE
Fix #2164: Support default args constructors in js.Any classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -621,8 +621,18 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
         val verifiedOrDefault = if (param.hasFlag(Flags.DEFAULTPARAM)) {
           js.If(js.BinaryOp(js.BinaryOp.===, jsArg, js.Undefined()), {
             val trgSym = {
-              if (sym.isClassConstructor) sym.owner.companionModule.moduleClass
-              else sym.owner
+              if (sym.isClassConstructor) {
+                /* Get the companion module class.
+                 * For inner classes the sym.owner.companionModule can be broken,
+                 * therefore companionModule is fetched at uncurryPhase.
+                 */
+                val companionModule = enteringPhase(currentRun.namerPhase) {
+                  sym.owner.companionModule
+                }
+                companionModule.moduleClass
+              } else {
+                sym.owner
+              }
             }
             val defaultGetter = trgSym.tpe.member(
                 nme.defaultGetterName(sym.name, i+1))

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
@@ -1125,4 +1125,29 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
+  @Test
+  def noDefaultConstructorArgsIfModuleIsJSNative: Unit = {
+    """
+    @ScalaJSDefined
+    class A(x: Int = 1) extends js.Object
+    @js.native
+    object A extends js.Object
+    """ hasErrors
+    """
+      |newSource1.scala:6: error: Implementation restriction: constructors of Scala.js-defined JS classes cannot have default parameters if their companion module is JS native.
+      |    class A(x: Int = 1) extends js.Object
+      |          ^
+    """
+
+    """
+    class A(x: Int = 1)
+    @js.native
+    object A extends js.Object
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: Implementation restriction: constructors of Scala classes cannot have default parameters if their companion module is JS native.
+      |    class A(x: Int = 1)
+      |          ^
+    """
+  }
 }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -401,19 +401,6 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noDefault: Unit = {
-    """
-    @ScalaJSDefined
-    class A(x: Int, y: Int = 4) extends js.Object
-    """ hasErrors
-    """
-      |newSource1.scala:6: error: Implementation restriction: the constructor of a Scala.js-defined JS classes cannot have default parameters.
-      |    class A(x: Int, y: Int = 4) extends js.Object
-      |          ^
-    """
-  }
-
-  @Test
   def noUseJsNative: Unit = {
     """
     @ScalaJSDefined

--- a/test-suite/js/src/test/resources/ScalaJSDefinedTestNatives.js
+++ b/test-suite/js/src/test/resources/ScalaJSDefinedTestNatives.js
@@ -40,4 +40,14 @@
   };
   $g.ScalaJSDefinedTestNativeParentClassWithVarargs =
     ScalaJSDefinedTestNativeParentClassWithVarargs;
+
+  var ConstructorDefaultParam = function(foo) {
+    $g.Object.call(this);
+    if (foo == undefined) {
+      this.foo = -1;
+    } else {
+      this.foo = foo;
+    }
+  };
+  $g.ConstructorDefaultParam = ConstructorDefaultParam;
 }).call(this);

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -116,6 +116,51 @@ object ScalaJSDefinedTest extends JasmineTest {
   }
 
   @ScalaJSDefined
+  class ConstructorDefaultParamJSNonNativeNone(val foo: Int = -1) extends js.Object
+
+  @ScalaJSDefined
+  class ConstructorDefaultParamJSNonNativeJSNonNative(val foo: Int = -1) extends js.Object
+  @ScalaJSDefined
+  object ConstructorDefaultParamJSNonNativeJSNonNative extends js.Object
+
+  @ScalaJSDefined
+  class ConstructorDefaultParamJSNonNativeScala(val foo: Int = -1) extends js.Object
+  object ConstructorDefaultParamJSNonNativeScala
+
+  class ConstructorDefaultParamScalaJSNonNative(val foo: Int = -1)
+  @ScalaJSDefined
+  object ConstructorDefaultParamScalaJSNonNative extends js.Object
+
+  @js.native
+  @JSName("ConstructorDefaultParam")
+  class ConstructorDefaultParamJSNativeNone(val foo: Int = -1) extends js.Object
+
+  @js.native
+  @JSName("ConstructorDefaultParam")
+  class ConstructorDefaultParamJSNativeScala(val foo: Int = -1) extends js.Object
+  object ConstructorDefaultParamJSNativeScala
+
+  @js.native
+  @JSName("ConstructorDefaultParam")
+  class ConstructorDefaultParamJSNativeJSNonNative(val foo: Int = -1) extends js.Object
+  @ScalaJSDefined
+  object ConstructorDefaultParamJSNativeJSNonNative extends js.Object
+
+  @js.native
+  @JSName("ConstructorDefaultParam")
+  class ConstructorDefaultParamJSNativeJSNative(val foo: Int = -1) extends js.Object
+  @js.native
+  @JSName("ConstructorDefaultParam")
+  object ConstructorDefaultParamJSNativeJSNative extends js.Object
+
+  // sanity check
+  object ConstructorDefaultParamScalaScala
+  class ConstructorDefaultParamScalaScala(val foo: Int = -1)
+
+  // sanity check
+  class ConstructorDefaultParamScalaNone(val foo: Int = -1)
+
+  @ScalaJSDefined
   class OverloadedConstructorParamNumber(val foo: Int) extends js.Object {
     def this(x: Int, y: Int) = this(x + y)
     def this(x: Int, y: Int, z: Int) = this(x + y, z)
@@ -142,6 +187,8 @@ object ScalaJSDefinedTest extends JasmineTest {
       this(w + x, y, z)
       bar = y
     }
+    def this(a: String, x: String, b: String = "", y: String = "") =
+      this((a + b).length, (x + y).length)
   }
 
   @ScalaJSDefined
@@ -786,11 +833,31 @@ object ScalaJSDefinedTest extends JasmineTest {
       val baz7 = new OverloadedConstructorComplex(1, 2, 4, 8)
       expect(baz7.foo).toEqual(3)
       expect(baz7.bar).toEqual(4)
+
+      val baz8 = new OverloadedConstructorComplex("abc", "abcd")
+      expect(baz8.foo).toEqual(3)
+      expect(baz8.bar).toEqual(4)
+
+      val baz9 = new OverloadedConstructorComplex("abc", "abcd", "zx")
+      expect(baz9.foo).toEqual(5)
+      expect(baz9.bar).toEqual(4)
+
+      val baz10 = new OverloadedConstructorComplex("abc", "abcd", "zx", "tfd")
+      expect(baz10.foo).toEqual(5)
+      expect(baz10.bar).toEqual(7)
     }
 
     it("default parameters") {
       @ScalaJSDefined
       class DefaultParameters extends js.Object {
+        def bar(x: Int, y: Int = 1): Int = x + y
+        def dependent(x: Int)(y: Int = x + 1): Int = x + y
+
+        def foobar(x: Int): Int = bar(x)
+      }
+
+      @ScalaJSDefined
+      object DefaultParametersMod extends js.Object {
         def bar(x: Int, y: Int = 1): Int = x + y
         def dependent(x: Int)(y: Int = x + 1): Int = x + y
 
@@ -804,12 +871,21 @@ object ScalaJSDefinedTest extends JasmineTest {
       expect(foo.dependent(4)(5)).toEqual(9)
       expect(foo.dependent(8)()).toEqual(17)
 
-      val dyn = foo.asInstanceOf[js.Dynamic]
-      expect(dyn.bar(4, 5)).toEqual(9)
-      expect(dyn.bar(4)).toEqual(5)
-      expect(dyn.foobar(3)).toEqual(4)
-      expect(dyn.dependent(4, 5)).toEqual(9)
-      expect(dyn.dependent(8)).toEqual(17)
+      expect(DefaultParametersMod.bar(4, 5)).toEqual(9)
+      expect(DefaultParametersMod.bar(4)).toEqual(5)
+      expect(DefaultParametersMod.foobar(3)).toEqual(4)
+      expect(DefaultParametersMod.dependent(4)(5)).toEqual(9)
+      expect(DefaultParametersMod.dependent(8)()).toEqual(17)
+
+      def testDyn(dyn: js.Dynamic): Unit = {
+        expect(dyn.bar(4, 5)).toEqual(9)
+        expect(dyn.bar(4)).toEqual(5)
+        expect(dyn.foobar(3)).toEqual(4)
+        expect(dyn.dependent(4, 5)).toEqual(9)
+        expect(dyn.dependent(8)).toEqual(17)
+      }
+      testDyn(foo.asInstanceOf[js.Dynamic])
+      testDyn(DefaultParametersMod.asInstanceOf[js.Dynamic])
     }
 
     it("override default parameters") {
@@ -886,6 +962,66 @@ object ScalaJSDefinedTest extends JasmineTest {
       expect(dyn.foobar(3)).toEqual(2)
       expect(dyn.dependent(4, 8)).toEqual(-4)
       expect(dyn.dependent(8)).toEqual(-1)
+    }
+
+    it("constructors with default parameters (ScalaJSDefined/-)") {
+      expect(new ConstructorDefaultParamJSNonNativeNone().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamJSNonNativeNone(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamJSNonNativeNone(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (ScalaJSDefined/ScalaJSDefined)") {
+      expect(new ConstructorDefaultParamJSNonNativeJSNonNative().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamJSNonNativeJSNonNative(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamJSNonNativeJSNonNative(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (ScalaJSDefined/Scala)") {
+      expect(new ConstructorDefaultParamJSNonNativeScala().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamJSNonNativeScala(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamJSNonNativeScala(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (Scala/ScalaJSDefined)") {
+      expect(new ConstructorDefaultParamScalaJSNonNative().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamScalaJSNonNative(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamScalaJSNonNative(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (Native/-)") {
+      expect(new ConstructorDefaultParamJSNativeNone().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamJSNativeNone(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamJSNativeNone(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (Native/Scala)") {
+      expect(new ConstructorDefaultParamJSNativeScala().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamJSNativeScala(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamJSNativeScala(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (Native/ScalaJSDefined)") {
+      expect(new ConstructorDefaultParamJSNativeJSNonNative().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamJSNativeJSNonNative(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamJSNativeJSNonNative(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (Native/Native)") {
+      expect(new ConstructorDefaultParamJSNativeJSNative().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamJSNativeJSNative(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamJSNativeJSNative(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (Scala/Scala)") {
+      expect(new ConstructorDefaultParamScalaScala().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamScalaScala(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamScalaScala(5).foo).toEqual(5)
+    }
+
+    it("constructors with default parameters (Scala/-)") {
+      expect(new ConstructorDefaultParamScalaNone().foo).toEqual(-1)
+      expect(new ConstructorDefaultParamScalaNone(1).foo).toEqual(1)
+      expect(new ConstructorDefaultParamScalaNone(5).foo).toEqual(5)
     }
 
     it("call super constructor with : _*") {


### PR DESCRIPTION
Add explicit restriction: ScalaJSDefined and Scala classes that
have a js.Native module cannot use constructors with default arguments.