### PR TITLE
Fix #2220: Deal with 2.12 Function lambdas inside JS classes.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -410,6 +410,17 @@ object ScalaJSDefinedTest extends JasmineTest {
       expect(obj.isInstanceOf[NativeParentClass]).toBeTruthy
     }
 
+    it("lambda inside a method - #2220") {
+      @ScalaJSDefined
+      class LambdaInsideMethod extends js.Object {
+        def foo(): Int = {
+          List(1, 2, 3).map(_ * 2).sum
+        }
+      }
+
+      expect(new LambdaInsideMethod().foo()).toEqual(12)
+    }
+
     it("nested inside a Scala class") {
       class OuterScalaClass(val x: Int) {
         @ScalaJSDefined


### PR DESCRIPTION
There were two problems:

* A wrong assertion.
* Calling the method as if it were a Scala method (rather than
  a non-exposed JS method, which is in fact a static method).