### PR TITLE
Fix #2197: Annotate `@JSName` with `@field @getter @setter`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -672,8 +672,12 @@ abstract class PrepJSInterop extends plugins.PluginComponent
       /* If this is an accessor, copy a potential @JSName annotation from
        * the field since otherwise it will get lost for traits (since they
        * have no fields).
+       *
+       * Do this only if the accessor does not already have an @JSName itself
+       * (this happens almost all the time now that @JSName is annotated with
+       * @field @getter @setter).
        */
-      if (sym.isAccessor)
+      if (sym.isAccessor && !sym.hasAnnotation(JSNameAnnotation))
         sym.accessed.getAnnotation(JSNameAnnotation).foreach(sym.addAnnotation)
 
       if (sym.name == nme.apply && !sym.hasAnnotation(JSNameAnnotation)) {

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSName.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSName.scala
@@ -10,8 +10,11 @@
 
 package scala.scalajs.js.annotation
 
+import scala.annotation.meta._
+
 /** Specifies the JavaScript name of an entity.
  *
  *  @see [[http://www.scala-js.org/doc/calling-javascript.html Calling JavaScript from Scala.js]]
  */
+@field @getter @setter
 class JSName(name: String) extends scala.annotation.StaticAnnotation

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
@@ -8,7 +8,7 @@
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation._
 
 import org.scalajs.jasminetest.JasmineTest
 
@@ -28,6 +28,23 @@ object JSNameTest extends JasmineTest {
 
     it("should work with vars") {
       val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarFacade]
+      expect(obj.internalVar).toEqual(0.1)
+      obj.internalVar = 0.2
+      expect(obj.internalVar).toEqual(0.2)
+    }
+
+    it("should work with defs that are properties in Scala.js-defined trait - #2197") {
+      val obj = js.Dynamic.literal(jsDef = 1).asInstanceOf[PropDefSJSDefined]
+      expect(obj.internalDef).toEqual(1)
+    }
+
+    it("should work with vals in Scala.js-defined trait - #2197") {
+      val obj = js.Dynamic.literal(jsVal = "hi").asInstanceOf[PropValSJSDefined]
+      expect(obj.internalVal).toEqual("hi")
+    }
+
+    it("should work with vars in Scala.js-defined trait - #2197") {
+      val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarSJSDefined]
       expect(obj.internalVar).toEqual(0.1)
       obj.internalVar = 0.2
       expect(obj.internalVar).toEqual(0.2)
@@ -61,6 +78,24 @@ object JSNameTest extends JasmineTest {
   trait PropVarFacade extends js.Any {
     @JSName("jsVar")
     var internalVar: Double = js.native
+  }
+
+  @ScalaJSDefined
+  trait PropDefSJSDefined extends js.Any {
+    @JSName("jsDef")
+    def internalDef: Int
+  }
+
+  @ScalaJSDefined
+  trait PropValSJSDefined extends js.Any {
+    @JSName("jsVal")
+    val internalVal: String
+  }
+
+  @ScalaJSDefined
+  trait PropVarSJSDefined extends js.Any {
+    @JSName("jsVar")
+    var internalVar: Double
   }
 
   @js.native


### PR DESCRIPTION
This causes it to be automatically replicated to the getter and/or
setter of fields. This is especially important for abstract vals
and vars in Scala.js-defined JS traits, which do not have any
field on which the Scala compiler could put the annotation.