### PR TITLE
Fix #2222: Restore statesInUse when we do a rollback.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,9 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.this")
   )
 
   val JSEnvs = Seq(

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -202,11 +202,12 @@ private[optimizer] abstract class OptimizerCore(
       val trampolineId = curTrampolineId
       val savedUsedLocalNames = usedLocalNames.toMap
       val savedUsedLabelNames = usedLabelNames.toSet
+      val savedStatesInUse = statesInUse
       val stateBackups = statesInUse.map(_.makeBackup())
 
       body { () =>
         throw new RollbackException(trampolineId, savedUsedLocalNames,
-            savedUsedLabelNames, stateBackups, fallbackFun)
+            savedUsedLabelNames, savedStatesInUse, stateBackups, fallbackFun)
       }
     }
   }
@@ -3364,6 +3365,7 @@ private[optimizer] abstract class OptimizerCore(
             usedLocalNames ++= e.savedUsedLocalNames
             usedLabelNames.clear()
             usedLabelNames ++= e.savedUsedLabelNames
+            statesInUse = e.savedStatesInUse
             e.stateBackups.foreach(_.restore())
 
             rec = e.cont
@@ -3967,6 +3969,7 @@ private[optimizer] object OptimizerCore {
   private class RollbackException(val trampolineId: Int,
       val savedUsedLocalNames: Map[String, Boolean],
       val savedUsedLabelNames: Set[String],
+      val savedStatesInUse: List[State],
       val stateBackups: List[StateBackup],
       val cont: () => TailRec[Tree]) extends ControlThrowable
 


### PR DESCRIPTION
This contains the growth of the `statesInUse` list for methods performing a lot of rollbacks.