### PR TITLE
Fix #2249: Fix the output of scalajsp -i.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -972,8 +972,7 @@ object Printers {
         while (iter.hasNext) {
           val (cls, callers) = iter.next()
           printEscapeJS(cls, out)
-          print(": [")
-          printRow(callers, ": [", ", ", "}")
+          printRow(callers, ": [", ", ", "]")
           if (iter.hasNext)
             println()
         }
@@ -986,7 +985,7 @@ object Printers {
         while (iter.hasNext) {
           val (cls, callers) = iter.next
           printEscapeJS(cls, out)
-          printRow(callers, ": [", ", ", "}")
+          printRow(callers, ": [", ", ", "]")
           if (iter.hasNext)
             println()
         }
@@ -995,11 +994,11 @@ object Printers {
       if (staticMethodsCalled.nonEmpty) {
         print("staticMethodsCalled:")
         indent(); println()
-        val iter = methodsCalledStatically.iterator
+        val iter = staticMethodsCalled.iterator
         while (iter.hasNext) {
           val (cls, callers) = iter.next()
           printEscapeJS(cls, out)
-          printRow(callers, ": [", ", ", "}")
+          printRow(callers, ": [", ", ", "]")
           if (iter.hasNext)
             println()
         }


### PR DESCRIPTION
New output:
```
encodedName: Lhelloworld_HelloWorld$
isExported: true
kind: ModuleClass
superClass: Some(O)
interfaces: [sjs_js_JSApp]
methods:
  $$js$exported$meth$main__O:
    staticMethodsCalled:
      sjs_js_JSApp$class: [$$js$exported$meth$main__sjs_js_JSApp__O]
    
  main__V:
    methodsCalled:
      Lhelloworld_HelloWorld$: [sayHelloFromDOM__V, sayHelloFromTypedDOM__V, sayHelloFromTypedJQuery__V, sayHelloFromJQuery__V]
      sjs_js_Dynamic$: [global__sjs_js_Dynamic]
      s_Predef$: [println__O__V]
      sjs_js_DynamicImplicits$: [truthValue__sjs_js_Dynamic__Z]
      sjs_js_Any$: [fromString__T__sjs_js_Any]
    accessedModules: [s_Predef$, sjs_js_Dynamic$, sjs_js_Any$, sjs_js_DynamicImplicits$]
  sayHelloFromDOM__V:
    methodsCalled:
      sjs_js_Any$: [fromString__T__sjs_js_Any]
      sjs_js_Dynamic$: [global__sjs_js_Dynamic]
    accessedModules: [sjs_js_Dynamic$, sjs_js_Any$]
  sayHelloFromTypedDOM__V:
    
  sayHelloFromJQuery__V:
    methodsCalled:
      sjs_js_Any$: [fromString__T__sjs_js_Any]
      sjs_js_Dynamic$: [global__sjs_js_Dynamic]
    accessedModules: [sjs_js_Dynamic$, sjs_js_Any$]
  sayHelloFromTypedJQuery__V:
    
  init___:
    methodsCalledStatically:
      O: [init___]
    staticMethodsCalled:
      sjs_js_JSApp$class: [$$init$__sjs_js_JSApp__V]
    
  main:
    isExported: true
    methodsCalled:
      Lhelloworld_HelloWorld$: [$$js$exported$meth$main__O]
```