### PR TITLE
Sbt-plugin sharedSrcDir use Seq instead of Option.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossProject.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossProject.scala
@@ -315,11 +315,9 @@ object CrossProject extends CrossProjectExtra {
   )
 
   // Inspired by sbt's Defaults.makeCrossSources
-  private def makeCrossSources(sharedSrcDir: Option[File],
+  private def makeCrossSources(sharedSrcDir: Seq[File],
       scalaBinaryVersion: String, cross: Boolean): Seq[File] = {
-    sharedSrcDir.fold[Seq[File]] {
-      Seq.empty
-    } { srcDir =>
+    sharedSrcDir.map{ srcDir =>
       if (cross)
         Seq(srcDir.getParentFile / s"${srcDir.name}-$scalaBinaryVersion", srcDir)
       else

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossType.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/cross/CrossType.scala
@@ -34,6 +34,8 @@ abstract class CrossType {
    */
   def sharedSrcDir(projectBase: File, conf: String): Option[File]
 
+  /** Retro-compatibility */
+  implicit def optToSeq(fs: Option[File]): Seq[File] = fs.toSeq
 }
 
 object CrossType {
@@ -42,23 +44,23 @@ object CrossType {
     def projectDir(crossBase: File, projectType: String): File =
       crossBase / projectType
 
-    def sharedSrcDir(projectBase: File, conf: String): Option[File] =
-      Some(projectBase.getParentFile / "shared" / "src" / conf / "scala")
+    def sharedSrcDir(projectBase: File, conf: String): Seq[File] =
+      List(projectBase.getParentFile / "shared" / "src" / conf / "scala")
   }
 
   object Pure extends CrossType {
     def projectDir(crossBase: File, projectType: String): File =
       crossBase / ("." + projectType)
 
-    def sharedSrcDir(projectBase: File, conf: String): Option[File] =
-      Some(projectBase.getParentFile / "src" / conf / "scala")
+    def sharedSrcDir(projectBase: File, conf: String): Seq[File] =
+      List(projectBase.getParentFile / "src" / conf / "scala")
   }
 
   object Dummy extends CrossType {
     def projectDir(crossBase: File, projectType: String): File =
       crossBase / projectType
 
-    def sharedSrcDir(projectBase: File, conf: String): Option[File] = None
+    def sharedSrcDir(projectBase: File, conf: String): Seq[File] = Nil
   }
 
 }


### PR DESCRIPTION
We would like to use cross-projects with possibly more source files than just one.