### PR TITLE
Fix #2285: Adapt to 2.12 trait encoding (removal of impl classes).

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
@@ -27,6 +27,10 @@ trait Compat210Component {
     def originalName: Name = sys.error("infinite loop in Compat")
 
     def isLocalToBlock: Boolean = self.isLocal
+
+    def implClass: Symbol = NoSymbol
+
+    def isTraitOrInterface: Boolean = self.isTrait || self.isInterface
   }
 
   // enteringPhase/exitingPhase replace beforePhase/afterPhase
@@ -56,6 +60,24 @@ trait Compat210Component {
       def freeVarsOf(function: Function): mutable.LinkedHashSet[Symbol] =
         sys.error("FreeVarTraverser should not be called on 2.10")
     }
+  }
+
+  // Impl classes disappeared in 2.12.0-M4
+
+  lazy val scalaUsesImplClasses: Boolean =
+    definitions.SeqClass.implClass != NoSymbol // a trait we know has an impl class
+
+  implicit final class StdTermNamesCompat(self: global.nme.type) {
+    def IMPL_CLASS_SUFFIX: String = sys.error("No impl classes in this version")
+
+    def isImplClassName(name: Name): Boolean = false
+  }
+
+  implicit final class StdTypeNamesCompat(self: global.tpnme.type) {
+    def IMPL_CLASS_SUFFIX: String = sys.error("No impl classes in this version")
+
+    def interfaceName(implname: Name): TypeName =
+      sys.error("No impl classes in this version")
   }
 
   /* global.genBCode.bTypes.initializeCoreBTypes()

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -727,7 +727,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
 
   private def isOverridingExport(sym: Symbol): Boolean = {
     lazy val osym = sym.nextOverriddenSymbol
-    sym.isOverridingSymbol && !osym.owner.isInterface
+    sym.isOverridingSymbol && !osym.owner.isTraitOrInterface
   }
 
   private sealed abstract class RTTypeTest

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -102,7 +102,7 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
      */
     val idSuffix =
       if (sym.isPrivate || allRefClasses.contains(sym.owner))
-        sym.owner.ancestors.count(!_.isInterface).toString
+        sym.owner.ancestors.count(!_.isTraitOrInterface).toString
       else
         "f"
 
@@ -148,12 +148,15 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
 
     def name = encodeMemberNameInternal(sym)
 
+    def privateSuffix(owner: Symbol): String =
+      if (owner.isTraitOrInterface && !owner.isImplClass) encodeClassFullName(owner)
+      else owner.ancestors.count(!_.isTraitOrInterface).toString
+
     val encodedName = {
       if (sym.isClassConstructor)
         "init" + InnerSep
       else if (sym.isPrivate)
-        mangleJSName(name) + OuterSep + "p" +
-          sym.owner.ancestors.count(!_.isInterface).toString
+        mangleJSName(name) + OuterSep + "p" + privateSuffix(sym.owner)
       else
         mangleJSName(name)
     }

--- a/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
@@ -175,7 +175,7 @@ object StackTrace {
    */
   private def extractClassMethod(functionName: String): (String, String) = {
     val PatC = """^(?:Object\.|\[object Object\]\.)?(?:ScalaJS\.c\.|\$c_)([^\.]+)(?:\.prototype)?\.([^\.]+)$""".re
-    val PatS = """^(?:Object\.|\[object Object\]\.)?(?:ScalaJS\.s\.|\$s_)((?:_[^_]|[^_])+)__([^\.]+)$""".re
+    val PatS = """^(?:Object\.|\[object Object\]\.)?(?:ScalaJS\.(?:s|f)\.|\$(?:s|f)_)((?:_[^_]|[^_])+)__([^\.]+)$""".re
     val PatM = """^(?:Object\.|\[object Object\]\.)?(?:ScalaJS\.m\.|\$m_)([^\.]+)$""".re
 
     var isModule = false

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
@@ -30,7 +30,8 @@ class StackTraceTest {
           assertTrue(trace exists { elem =>
             /* We use startsWith for class name because some VMs will add
              * additional information at the end of the class name, for some
-             * reason.
+             * reason + there can be a '$class' suffix for methods in impl
+             * classes (when default methods are not used by scalac).
              */
             val prefix = "org.scalajs.testsuite.library.StackTraceTest$"
             (elem.getClassName.startsWith(prefix + className) &&
@@ -57,11 +58,11 @@ class StackTraceTest {
         new Bar().g(7)
       }
 
-      verifyClassMethodNames("Foo" -> "f", "FooTrait$class" -> "h") {
+      verifyClassMethodNames("Foo" -> "f", "FooTrait" -> "h") {
         new Foo().h(78)
       }
 
-      verifyClassMethodNames("Foo" -> "f", "FooTrait$class" -> "h",
+      verifyClassMethodNames("Foo" -> "f", "FooTrait" -> "h",
           "Baz" -> "<init>") {
         new Baz()
       }


### PR DESCRIPTION
The main changes are actually related to keeping source compatibility with older versions, through more compat hacks.

Also:
* Use `isTraitOrInterface` instead of `isInterface` to identify something that should be an interface at the IR level.
* A method is abstract iff its body is `EmptyTree`.