### PR TITLE
Fix #2309: Support LMF-capable Function nodes of 2.12.0-M4.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSFiles.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSFiles.scala
@@ -22,9 +22,9 @@ trait GenJSFiles extends SubComponent { self: GenJSCode =>
   import global._
   import jsAddons._
 
-  def genIRFile(cunit: CompilationUnit, sym: Symbol,
+  def genIRFile(cunit: CompilationUnit, sym: Symbol, suffix: Option[String],
       tree: ir.Trees.ClassDef): Unit = {
-    val outfile = getFileFor(cunit, sym, ".sjsir")
+    val outfile = getFileFor(cunit, sym, suffix.getOrElse("") + ".sjsir")
     val output = outfile.bufferedOutput
     try {
       ir.InfoSerializers.serialize(output, Infos.generateClassInfo(tree))

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M4/BuglistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M4/BuglistedTests.txt
@@ -3,11 +3,6 @@
 # which are neither in BuglistedTests.txt, WhitelistedTests.txt or
 # BlacklistedTests.txt
 
-# Bug #2309
-run/sammy_after_implicit_view.scala
-run/sammy_restrictions_LMF.scala
-run/sammy_vararg_cbn.scala
-
 # Bug with BoxedUnit/void
 run/t5568.scala
 run/t6318_primitives.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M4/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0-M4/WhitelistedTests.txt
@@ -3126,6 +3126,9 @@ run/t9178a.scala
 run/t9110.scala
 run/sammy_cbn.scala
 run/sammy_erasure_cce.scala
+run/sammy_after_implicit_view.scala
+run/sammy_restrictions_LMF.scala
+run/sammy_vararg_cbn.scala
 run/t7807.scala
 run/sammy_return.scala
 run/t9546.scala

--- a/test-suite/shared/src/test/require-sam/org/scalajs/testsuite/compiler/SAMTest.scala
+++ b/test-suite/shared/src/test/require-sam/org/scalajs/testsuite/compiler/SAMTest.scala
@@ -1,0 +1,119 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.compiler
+
+import java.util.Comparator
+import java.util.concurrent.Callable
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+class SAMTest {
+
+  import SAMTest._
+
+  @Test def javaCallable(): Unit = {
+    val c1: Callable[Int] = () => 4
+    assertEquals(4, c1.call())
+
+    val c2: Callable[Char] = () => 'A'
+    assertEquals('A', c2.call())
+
+    val c3: Callable[String] = () => "hello"
+    assertEquals("hello", c3.call())
+
+    val c4: Callable[VC] = () => new VC(5)
+    assertEquals(new VC(5), c4.call())
+  }
+
+  @Test def specialResultTypes(): Unit = {
+    val f1: SAMReturningChar = () => 'A'
+    assertEquals('A', f1.call())
+
+    val f2: SAMReturningVC = () => new VC(5)
+    assertEquals(new VC(5), f2.call())
+  }
+
+  @Test def javaComparator(): Unit = {
+    val c1: Comparator[Int] = (a, b) => b.compareTo(a)
+    assertTrue(c1.compare(5, 7) > 0)
+
+    val c2: Comparator[Char] = (a, b) => b.compareTo(a)
+    assertTrue(c2.compare('C', 'E') > 0)
+
+    val c3: Comparator[String] = (a, b) => b.compareTo(a)
+    assertTrue(c3.compare("hello", "world") > 0)
+
+    val c4: Comparator[VC] = (a, b) => b.x.compareTo(a.x)
+    assertTrue(c4.compare(new VC(5), new VC(7)) > 0)
+  }
+
+  @Test def samHasDefaultMethod(): Unit = {
+    val c1: Comparator[Int] = (a, b) => b.compareTo(a)
+    assertTrue(c1.reversed().compare(5, 7) < 0)
+
+    val c2: Comparator[Char] = (a, b) => b.compareTo(a)
+    assertTrue(c2.reversed().compare('C', 'E') < 0)
+
+    val c3: Comparator[String] = (a, b) => b.compareTo(a)
+    assertTrue(c3.reversed().compare("hello", "world") < 0)
+
+    val c4: Comparator[VC] = (a, b) => b.x.compareTo(a.x)
+    assertTrue(c4.reversed().compare(new VC(5), new VC(7)) < 0)
+  }
+
+  @Test def specialParamTypes(): Unit = {
+    val f1: SAMTakingChar = c => c.toInt + 3
+    assertEquals(68, f1.call('A'))
+
+    val f2: SAMTakingVC = vc => vc.x + 3
+    assertEquals(8, f2.call(new VC(5)))
+  }
+
+  @Test def nonLFMCapableSAM(): Unit = {
+    val fNonLMF: NonLMFCapableSAM = x => "a"
+    assertEquals("a", fNonLMF(1))
+    assertTrue(fNonLMF.isInstanceOf[C])
+  }
+
+}
+
+object SAMTest {
+  class VC(val x: Int) extends AnyVal
+
+  trait SAMReturningChar {
+    def call(): Char
+  }
+
+  trait SAMReturningVC {
+    def call(): VC
+  }
+
+  trait SAMTakingChar {
+    def call(c: Char): Int
+  }
+
+  trait SAMTakingVC {
+    def call(vc: VC): Int
+  }
+
+  class C
+  trait A extends C
+  trait B extends A
+  trait NonLMFCapableSAM extends B {
+    def apply(x: Int): String
+  }
+
+  implicit class ComparatorCompat[A](val c: Comparator[A]) extends AnyVal {
+    def reversed(): Comparator[A] = {
+      assumeTrue("Comparator.reversed() is not available on this JDK", false)
+      ???
+    }
+  }
+}


### PR DESCRIPTION
Starting from Scala 2.12.0-M4, Function nodes typed as any `LambdaMetaFactory`-capable SAM type can reach the back-end. This commit takes care of them by synthesizing an anonymous class in the back-end.

This should not be merged until #2325 is addressed, so that we have CI tests for this, although I tested locally.

There is one subtle suboptimal aspect in the current solution: in the presence of incremental compilation, when *removing* an LMF-enabled lambda, the corresponding synthetic `.sjsir` file will *not* be removed. In general, removal of obsolete .sjsir files is done by the specialized `incOptions` defined here:
https://github.com/scala-js/scala-js/blob/v0.6.8/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala#L117
So far it always worked because an .sjsir file always has an associated .class file. With this commit, however, this is not the case anymore. It is not possible, in general, to fix `incOptions` in this case.
This is not too much of a problem because the obsolete .sjsir files will not be referenced by other code on the classpath, and they are never exported (by construction), so the linking step will ignore them. But it is not super nice.

The only way to properly fix this would be to defer the generation of synthetic SAM classes to linking. We could introduce a new node `LambdaMetaFactory(intfType, methodIdent, bodyJSFunction)` or something like that. This could bring performance and code size improvements, too, as the linker could generated a unique wrapper class for all lambdas of a given `intfType`.