### PR TITLE
Fix #2338: Restore the bootstrap tests for 2.12.0-M4.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -599,12 +599,25 @@ object Build {
               yield s""""${escapeJS(f.getAbsolutePath)}""""
           }
 
+          val scalaJSEnv = if (scalaVersion.value != "2.12.0-M4") {
+            "null"
+          } else {
+            /* 2.12.0-M4 introduced this bug, this should be removed in 2.12.0-M5
+             * with all references to "scalac.hasBoxedUnitBug" in the tests
+             */
+            """
+            {"javaSystemProperties": {
+              "scalac.hasBoxedUnitBug": "true"
+            }}
+            """
+          }
+
           val code = {
             s"""
             var linker = scalajs.QuickLinker();
             var lib = linker.linkTestSuiteNode(${irPaths.mkString(", ")});
 
-            var __ScalaJSEnv = null;
+            var __ScalaJSEnv = $scalaJSEnv;
 
             eval("(function() { 'use strict'; " +
               lib + ";" +


### PR DESCRIPTION
In the bootstrap tests, the flag for the `classOf[Unit]` bug of 2.12.0-M4 was not set. This caused the 3 affected tests to fail. This commit adds the flag to fix this.