### PR TITLE
Fix #2345: Bring hash implem in Statics up to date wrt BoxesRunTime.

### DIFF
--- a/library-aux/src/main/scala/scala/runtime/Statics.scala
+++ b/library-aux/src/main/scala/scala/runtime/Statics.scala
@@ -34,56 +34,46 @@ object Statics {
   }
 
   def longHash(lv: Long): Int = {
-    lv.toInt
-    /*
-    val iv = lv.toInt | 0
-    if (iv == lv) iv
-    else (lv ^ (lv >>> 32)).toInt | 0
-    */
+    val lo = lv.toInt
+    val hi = (lv >>> 32).toInt
+    if (hi == (lo >> 31)) lo // it is in the Int range
+    else lo ^ hi
   }
 
   def doubleHash(dv: Double): Int = {
-    dv.toInt
-    /*
-    val iv = dv.toInt | 0
-    if (iv == dv)
-      return iv
-
-    val fv = dv.toFloat
-    if (fv == dv)
-      return java.lang.Float.floatToIntBits(fv)
-
-    val lv = dv.toLong
-    if (lv == dv)
-      return lv.toInt | 0
-
-    val lv2 == java.lang.Double.doubleToLongBits(dv)
-    return (lv2 ^ (lv2 >>> 32)).toInt | 0
-    */
+    /* This implementation is based on what 2.12.0-M5+ does on the JVM.
+     * The 2.10/2.11 implementation on the JVM was not consistent with that of
+     * BoxesRunTime, and most importantly was not consistent with the hash of
+     * Long values.
+     *
+     * In Scala.js, we always use the version consistent with BoxesRunTime.
+     * Note that, for values that happen to be valid floats but not valid
+     * longs, this implementation is *not* consistent with the JVM (just like
+     * that of BoxesRunTime).
+     */
+    val iv = dv.toInt
+    if (iv == dv) {
+      iv
+    } else {
+      // don't test the case dv.toFloat == dv
+      val lv = dv.toLong
+      if (lv == dv)
+        lv.hashCode()
+      else
+        dv.hashCode()
+    }
   }
 
   def floatHash(fv: Float): Int = {
-    fv.toInt
-    /*
-    val iv = fv.toInt
-    if (iv == fv)
-      return iv
-
-    val lv = fv.toLong
-    if (lv == fv)
-      return (lv ^ (lv >>> 32)).toInt | 0
-
-    return java.lang.Float.floatToIntBits(fv)
-    */
+    doubleHash(fv.toDouble)
   }
 
   def anyHash(x: Any): Int = {
     x match {
-      case null => 0
-      case x: Long => longHash(x)
+      case null      => 0
       case x: Double => doubleHash(x)
-      case x: Float => floatHash(x)
-      case _ => x.hashCode()
+      case x: Long   => longHash(x)
+      case _         => x.hashCode()
     }
   }
 }

--- a/scalalib/overrides/scala/runtime/BoxesRunTime.scala
+++ b/scalalib/overrides/scala/runtime/BoxesRunTime.scala
@@ -81,45 +81,28 @@ object BoxesRunTime {
     }
   }
 
-  def hashFromLong(n: java.lang.Long): Int = {
-    val iv = n.intValue()
-    if (iv == n.longValue()) iv
-    else n.hashCode()
-  }
+  @inline
+  def hashFromLong(n: java.lang.Long): Int =
+    Statics.longHash(n.asInstanceOf[Long])
 
-  def hashFromDouble(n: java.lang.Double): Int = {
-    val iv = n.intValue()
-    val dv = n.doubleValue()
-    if (iv == dv) {
-      iv
-    } else {
-      val lv = n.longValue()
-      if (lv == dv) {
-        java.lang.Long.valueOf(lv).hashCode()
-      } else {
-        // don't test the case floatValue() == dv
-        n.hashCode()
-      }
-    }
-  }
+  @inline
+  def hashFromDouble(n: java.lang.Double): Int =
+    Statics.doubleHash(n.asInstanceOf[Double])
 
-  def hashFromFloat(n: java.lang.Float): Int = {
-    hashFromDouble(java.lang.Double.valueOf(n.doubleValue()))
-  }
+  @inline
+  def hashFromFloat(n: java.lang.Float): Int =
+    Statics.floatHash(n.asInstanceOf[Float])
 
+  @inline // called only by ScalaRunTime.hash()
   def hashFromNumber(n: java.lang.Number): Int = {
     (n: Any) match {
-      case n: Int              => n
-      case n: java.lang.Long   => hashFromLong(n)
-      case n: java.lang.Double => hashFromDouble(n)
-      case n                   => n.hashCode()
+      case n: Double => Statics.doubleHash(n)
+      case n: Long   => Statics.longHash(n)
+      case n         => n.hashCode()
     }
   }
 
-  def hashFromObject(a: Object): Int = {
-    a match {
-      case a: java.lang.Number => hashFromNumber(a)
-      case a                   => a.hashCode()
-    }
-  }
+  @inline
+  def hashFromObject(a: Object): Int =
+    Statics.anyHash(a)
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -16,6 +16,8 @@ import org.junit.Assert._
  *  for a test of the implementation itself
  */
 class LongTest {
+  import LongTest._
+
   @Test def `should_correctly_handle_literals`(): Unit = {
     assertEquals(105L, 5L + 100L)
     assertEquals(2147483651L, 2147483649L + 2L)
@@ -104,6 +106,20 @@ class LongTest {
     //assertEquals(-1689438124, 7632147899696541255L.##) // xx25 on 2.10
   }
 
+  @Test def `should_have_correct_hash_in_case_classes`(): Unit = {
+    assertEquals(-1669410282, HashTestBox(0L).##)
+    assertEquals(-1561146018, HashTestBox(55L).##)
+    assertEquals(-1266055417, HashTestBox(-12L).##)
+    assertEquals(-1383472436, HashTestBox(10006548L).##)
+    assertEquals(1748124846, HashTestBox(-1098748L).##)
+
+    assertEquals(1291324266, HashTestBox(9863155567412L).##)
+    assertEquals(-450677189, HashTestBox(3632147899696541255L).##)
+
+    assertEquals(259268522, HashTestBox(1461126709984L).##)
+    assertEquals(818387364, HashTestBox(1L).##)
+  }
+
   @Test def `should_correctly_concat_to_string`(): Unit = {
     val x = 20L
     assertEquals("asdf520hello", "asdf" + 5L + x + "hello")
@@ -137,4 +153,10 @@ class LongTest {
     assertTrue(4 != 5L)
     assertTrue('A' == 65L)
   }
+}
+
+object LongTest {
+
+  case class HashTestBox(long: Long)
+
 }


### PR DESCRIPTION
The methods in `Statics` are used by the code generator for the `hashCode()` of case classes. They must be in sync with the implementations in `BoxesRunTime`.

The code duplication should be treated at the source in scala/scala.