### PR TITLE
Type ES6 Promises

### DIFF
--- a/library/src/main/scala/scala/scalajs/concurrent/QueueExecutionContext.scala
+++ b/library/src/main/scala/scala/scalajs/concurrent/QueueExecutionContext.scala
@@ -3,7 +3,6 @@ package scala.scalajs.concurrent
 import scala.concurrent.ExecutionContextExecutor
 
 import scala.scalajs.js
-import scala.scalajs.js.|
 
 object QueueExecutionContext {
   def timeouts(): ExecutionContextExecutor =
@@ -32,7 +31,7 @@ object QueueExecutionContext {
   }
 
   private final class PromisesExecutionContext extends ExecutionContextExecutor {
-    private val resolvedUnitPromise = js.Promise.resolve[Unit](())
+    private val resolvedUnitPromise = js.Promise.resolve(())
 
     def execute(runnable: Runnable): Unit = {
       resolvedUnitPromise.`then` { (_: Unit) =>
@@ -41,7 +40,7 @@ object QueueExecutionContext {
         } catch {
           case t: Throwable => reportFailure(t)
         }
-        (): Unit | js.Thenable[Unit]
+        ()
       }
     }
 


### PR DESCRIPTION
This is an attempt in typing ES6 Promises so that we don’t get static types that are inconsistent with the actual runtime types.

The PR is still missing some documentation, I’d like to first get your feedback on this work. As you can see in the diff it simplifies or removes some type ascriptions, but, on the other hand, the type signatures of `Promise`’s methods are harder to understand (due to the `CanBuildFrom`-like pattern).

The changes make `scala_concurrent_FutureToJSPromise_basic_case` and `scala_concurrent_FutureToJSPromise_thenable_case` tests fail with the following error:

~~~
failed: An undefined behavior was detected: undefined is not an instance of scala.scalajs.js.Thenable$Returning
~~~

I don’t understand why we get such an `undefined` value. Any idea?