### PR TITLE
Fix #2350: Add an sbt setting isScalaJSProject.

### DIFF
--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -113,13 +113,25 @@ lazy val multiTest = crossProject.
     // Make FrameworkDetector resilient to other output - #1572
     jsDependencies in Test += ProvidedJS / "consoleWriter.js",
     testOptions += Tests.Argument(
-      TestFramework("com.novocode.junit.JUnitFramework"), "-v", "-a")
+      TestFramework("com.novocode.junit.JUnitFramework"), "-v", "-a"),
+
+    // Test isScalaJSProject (as a setting, it's evaluated when loading the build)
+    isScalaJSProject ~= { value =>
+      assert(value, "isScalaJSProject should be true in multiTestJS")
+      value
+    }
   ).
   jvmSettings(versionSettings: _*).
   jvmSettings(
     name := "Multi test framework test JVM",
     libraryDependencies +=
-      "com.novocode" % "junit-interface" % "0.9" % "test"
+      "com.novocode" % "junit-interface" % "0.9" % "test",
+
+    // Test isScalaJSProject (as a setting, it's evaluated when loading the build)
+    isScalaJSProject ~= { value =>
+      assert(!value, "isScalaJSProject should be true in multiTestJVM")
+      value
+    }
   ).
   settings(
     // Scala cross-version support for shared source directory - #2005

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -136,6 +136,11 @@ object ScalaJSPlugin extends AutoPlugin {
 
     // All our public-facing keys
 
+    val isScalaJSProject = SettingKey[Boolean]("isScalaJSProject",
+        "Tests whether the current project is a Scala.js project. " +
+        "Do not set the value of this setting (only use it as read-only).",
+        BSetting)
+
     val fastOptJS = TaskKey[Attributed[File]]("fastOptJS",
         "Quickly link all compiled JavaScript into a single file", APlusTask)
 
@@ -263,6 +268,7 @@ object ScalaJSPlugin extends AutoPlugin {
 
   override def globalSettings: Seq[Setting[_]] = {
     super.globalSettings ++ Seq(
+        isScalaJSProject := false,
         scalaJSStage := Stage.FastOpt,
         scalaJSUseRhino := true,
         scalaJSClearCacheStats := globalIRCache.clearStats()

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -783,8 +783,10 @@ object ScalaJSPluginInternal {
   )
 
   val scalaJSProjectBaseSettings = Seq(
-      relativeSourceMaps   := false,
-      persistLauncher      := false,
+      isScalaJSProject := true,
+
+      relativeSourceMaps := false,
+      persistLauncher := false,
 
       emitSourceMaps := true,
 

--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/impl/DependencyBuilders.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/impl/DependencyBuilders.scala
@@ -92,7 +92,7 @@ object ScalaJSGroupID {
 
     reify {
       val cross = {
-        if (keys.splice.jsDependencies.?.value.isDefined)
+        if (keys.splice.isScalaJSProject.value)
           ScalaJSCrossVersion.binary
         else
           CrossVersion.binary


### PR DESCRIPTION
This sbt setting is true if and only if the current project is a Scala.js project. It is not meant to be written to by users (only to be read).