### PR TITLE
Fix #2358: Normalize the dir separator to '/' in relative paths.

### DIFF
--- a/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/scala/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -342,8 +342,9 @@ object ScalaJSPluginInternal {
         results ++= collectJar(vf)
       } else if (cpEntry.isDirectory) {
         for {
-          (file, relPath) <- Path.selectSubpaths(cpEntry, filter)
+          (file, relPath0) <- Path.selectSubpaths(cpEntry, filter)
         } {
+          val relPath = relPath0.replace(java.io.File.separatorChar, '/')
           realFiles += file
           results += collectFile(file, relPath)
         }


### PR DESCRIPTION
When reading from a directory on the classpath, we need to normalize the relative paths so that they always use '/' as directory separator.

This commit contains no test. We already have the tests that highlight the bug, but they only do it on Windows, and our CI does not run on Windows.