### PR TITLE
Remove wrong overrides of check files for partest 2.11.8.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/neg/choices.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/neg/choices.check
@@ -1,2 +1,0 @@
-error: bad options: -Yresolve-term-conflict
-one error found

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/neg/partestInvalidFlag.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/neg/partestInvalidFlag.check
@@ -1,2 +1,0 @@
-error: bad options: -badCompilerFlag notAFlag -Yopt:badChoice
-one error found


### PR DESCRIPTION
Running those partests actually produce exactly the output expected by the JVM check files, so these overrides should not be there.