### PR TITLE
Add implicit class to convert scala Future to js.Promise

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Promise.scala
+++ b/library/src/main/scala/scala/scalajs/js/Promise.scala
@@ -66,4 +66,15 @@ object Promise extends js.Object {
 
   // TODO Use js.Iterable
   def race[A](promises: js.Array[_ <: Promise[A]]): Promise[A] = js.native
+  
+  implicit class FutureToJS[T](f: Future[T]) {
+    def toJSPromise = {
+      new js.Promise[T](js.Any.fromFunction2 { (resolve, reject) =>
+        f.onComplete {
+          case Success(r) => resolve(r)
+          case Failure(ex) => reject(ex)
+        }
+      })
+    }
+  }
 }


### PR DESCRIPTION
Adds the posibility to do

Future { ... }.toJSPromise

for cases where you need to call JavaScript code that expects a promise (Such as RxJS observable flatMaps)