### PR TITLE
Enable JSPromise conversion for "anything Future-like"

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSConverters.scala
@@ -21,7 +21,7 @@ import scala.scalajs.runtime.genTraversableOnce2jsArray
 sealed abstract class JSConvertersLowPrioImplicits { this: JSConverters.type =>
 
   @inline
-  implicit def JSRichFutureNonThenable[A](f: Future[A]): JSRichFuture[A] =
+  implicit def JSRichFutureNonThenable[A, A1](f: A1)(implicit ev: A1 => Future[A]): JSRichFuture[A] =
     new JSRichFuture[A](f.asInstanceOf[Future[A | Thenable[A]]])
 
 }
@@ -63,7 +63,7 @@ object JSConverters extends JSConvertersLowPrioImplicits {
     new JSRichGenTraversableOnce(arr)
 
   @inline
-  implicit def JSRichFutureThenable[A](f: Future[Thenable[A]]): JSRichFuture[A] =
+  implicit def JSRichFutureThenable[A, A1](f: A1)(implicit ev: A1 => Future[Thenable[A]]): JSRichFuture[A] =
     new JSRichFuture[A](f.asInstanceOf[Future[A | Thenable[A]]])
 
   final class JSRichFuture[A](val self: Future[A | Thenable[A]]) extends AnyVal {

--- a/library/src/main/scala/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSConverters.scala
@@ -22,7 +22,7 @@ sealed abstract class JSConvertersLowPrioImplicits { this: JSConverters.type =>
 
   @inline
   implicit def JSRichFutureNonThenable[A, A1](f: A1)(implicit ev: A1 => Future[A]): JSRichFuture[A] =
-    new JSRichFuture[A](f.asInstanceOf[Future[A | Thenable[A]]])
+    new JSRichFuture[A](ev(f).asInstanceOf[Future[A | Thenable[A]]])
 
 }
 
@@ -63,7 +63,7 @@ object JSConverters extends JSConvertersLowPrioImplicits {
     new JSRichGenTraversableOnce(arr)
 
   @inline
-  implicit def JSRichFutureThenable[A, A1](f: A1)(implicit ev: A1 => Future[Thenable[A]]): JSRichFuture[A] =
+  implicit def JSRichFutureThenable[A](f: Future[Thenable[A]]): JSRichFuture[A] =
     new JSRichFuture[A](f.asInstanceOf[Future[A | Thenable[A]]])
 
   final class JSRichFuture[A](val self: Future[A | Thenable[A]]) extends AnyVal {


### PR DESCRIPTION
This allows chaining the implicit conversions such as going from a Q.Promise to a JSPromise, as in:
```scala
httpService.get[T](url)toJSPromise
```