### PR TITLE
Enable local dce of vals across their scope boundaries.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,11 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#PreTransBlock.apply"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#PreTransBlock.stats")
   )
 
   val JSEnvs = Seq(


### PR DESCRIPTION
Consider this snippet:
```scala
@inline class Foo(a: Int, b: Int) {
  val x = a + b
  val y = a - b
}

val foo = new Foo(5, someNonConstant)
println(foo.y)
```
Previously, even though the optimizer could completely virtualize `foo` and replace `foo.y` by a local `val y`, it would also declare a local `val x`, although it is not used. In other words, it was not able to dce `x` away.

That is because, when pre-transforming `new Foo()`, the local vals `x` and `y` that are created are confined to a scope like this:
```scala
val foo = {
  val x = 5 + someNonConstant
  val y = 5 - someNonConstant
  <virtual>(x, y)
}
```
When escaping the scoped block, the optimizer had to assume that both `x` and `y` are used, because they are "contained" in the virtual object that escapes the scope. This prevents from dce'ing them away.

This commit fixes this limitation by enhancing `PreTransBlock`. A `PreTransBlock` can now keep virtual bindings in addition to completely transformed statements. Only when we force the `PreTransBlock` (or keep only its side-effects) do we test what bindings have actually been used. Those that are not can be dce'ed away.

The rhs of `foo` therefore becomes a virtual block (a `PreTransBlock`) which keeps the bindings of `x` and `y` virtual. When we later discover that this `PreTransBlock` need not be forced (because `foo` itself is not used), the optimizer tests whether `x` and `y` are used. `y` is used at this point, because it was used to replace `foo.y`. `x`, on the other hand, is not used, and can be removed (along with the side-effect-free parts of its rhs).

Lifting this restriction significantly improves the optimized version of `Range.foreach`. This is because, since 0e64158871d3ba57a426dcc6c859fd93b0d825e8, `numRangeElements` is not needed anymore for `foreach`. And `numRangeElements` is the one field of the initialization of `Range` that requires non-trivial operations on `Long`s: they are completely dce'ed away with the new optimizations.

Implementing these new opportunities for optimizations made it harder to support the optimizations of `Long.toInt` and `Long +/- Long` across `val`s (the thing that was stored in `ReplaceWithVarRef.longOpTree`). The current commit does not support filling in that field with `Some(_)` when appropriate. It is a small regression, in theory. But in practice, this had been added mostly to supported optimizing the `Long` operations involved in computing `numRangeElements` as `Int` operations, in the first place. Since now, `numRangeElements` is completely removed anyway, it does not really matter. This commit keeps the ability of the rest of the optimizer to *use* the `longOpTree` information if it is present, even though it is never set anymore. That is because I have ideas about how to recover the ability to optimize expressions across `val`s, in a more generic way than `longOpTree`, and I want to keep a compiling reference of what optimizations we used to be able to perform before.