### PR TITLE
DO NOT MERGE Upgrade to GCC v20160517.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -571,7 +571,7 @@ object Build {
       base = file("tools/jvm"),
       settings = commonToolsSettings ++ Seq(
           libraryDependencies ++= Seq(
-              "com.google.javascript" % "closure-compiler" % "v20130603",
+              "com.google.javascript" % "closure-compiler" % "v20160517",
               "com.googlecode.json-simple" % "json-simple" % "1.1.1" exclude("junit", "junit"),
               "com.novocode" % "junit-interface" % "0.9" % "test"
           )
@@ -1529,7 +1529,7 @@ object Build {
               Seq(
                 "org.scala-sbt" % "sbt" % sbtVersion.value,
                 "org.scala-lang.modules" %% "scala-partest" % "1.0.13",
-                "com.google.javascript" % "closure-compiler" % "v20130603",
+                "com.google.javascript" % "closure-compiler" % "v20160517",
                 "io.apigee" % "rhino" % "1.7R5pre4",
                 "com.googlecode.json-simple" % "json-simple" % "1.1.1" exclude("junit", "junit")
               )

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -11,7 +11,7 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.8")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
 
-libraryDependencies += "com.google.javascript" % "closure-compiler" % "v20130603"
+libraryDependencies += "com.google.javascript" % "closure-compiler" % "v20160517"
 
 libraryDependencies += "io.apigee" % "rhino" % "1.7R5pre4"
 

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstBuilder.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstBuilder.scala
@@ -7,7 +7,6 @@ import org.scalajs.core.tools.javascript.Trees.Tree
 import org.scalajs.core.tools.javascript.JSTreeBuilder
 
 import com.google.javascript.rhino._
-import com.google.javascript.rhino.jstype.{StaticSourceFile, SimpleSourceFile}
 import com.google.javascript.jscomp._
 
 import scala.collection.mutable

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
@@ -264,7 +264,7 @@ private[closure] class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
     @inline def ctorDoc(node: Node) = {
       val b = new JSDocInfoBuilder(false)
       b.recordConstructor()
-      b.build(node)
+      b.build()
     }
 
     val block = new Node(Token.BLOCK)


### PR DESCRIPTION
In theory, this version of GCC does not support JDK6 anymore, but maybe it works in practice because our use of it does not use any file I/O nor charset-based encoding/decoding.

CI only for now. I just want to see what breaks.