### PR TITLE
Fix #2434: Support reflective calls to default methods.

### DIFF
--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/compiler/DefaultMethodsTest.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/compiler/DefaultMethodsTest.scala
@@ -35,4 +35,19 @@ class DefaultMethodsTest {
     assertEquals(1, counter)
     assertTrue(reversed.compare(5, 7) > 0)
   }
+
+  @Test def reflectiveCallDefaultMethod(): Unit = {
+    import scala.language.reflectiveCalls
+
+    class ReflectiveCallIntComparator extends ju.Comparator[Int] {
+      def compare(o1: Int, o2: Int): Int =
+        o1.compareTo(o2)
+    }
+
+    val c = new ReflectiveCallIntComparator
+    val c2: { def reversed(): ju.Comparator[Int] } = c
+    val reversed = c2.reversed()
+
+    assertTrue(reversed.compare(5, 7) > 0)
+  }
 }


### PR DESCRIPTION
There were two problems.

First, the Analyzer did not make any effort regarding default methods when looking for targets of reflective calls. Depending on the order of lookups, the algorithm could find existing default bridges, or fail. Now, default bridges are ignored when looking for potential targets, but implemented interfaces are searched for default methods as potential targets. If a default method is found, the creation of the reflective proxy will (automatically) subsequently trigger a lookup for the target method, which will synthesize a default bridge too.

Second, the BaseLinker crashed if the lookup resolved (by chance) to a default bridge, as it tried to find an actual `MethodDef` for the bridge in the class' `Tree`. Now, if the target of a reflective proxy is a default bridge, the bridge is "dereferenced" to its original default method to find a `MethodDef`.