### PR TITLE
Add PreTransUnaryOp and PreTransBinaryOp in the optimizer.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -231,14 +231,8 @@ object Trees {
   /** Unary operation (always preserves pureness). */
   case class UnaryOp(op: UnaryOp.Code, lhs: Tree)(
       implicit val pos: Position) extends Tree {
-    import UnaryOp._
-    val tpe = (op: @switch) match {
-      case LongToInt | DoubleToInt  => IntType
-      case IntToLong | DoubleToLong => LongType
-      case DoubleToFloat            => FloatType
-      case LongToDouble             => DoubleType
-      case Boolean_!                => BooleanType
-    }
+
+    val tpe = UnaryOp.resultTypeOf(op)
   }
 
   object UnaryOp {
@@ -253,31 +247,21 @@ object Trees {
     final val DoubleToInt   = 5
     final val DoubleToFloat = 6
     final val DoubleToLong  = 7
+
+    def resultTypeOf(op: Code): Type = (op: @switch) match {
+      case LongToInt | DoubleToInt  => IntType
+      case IntToLong | DoubleToLong => LongType
+      case DoubleToFloat            => FloatType
+      case LongToDouble             => DoubleType
+      case Boolean_!                => BooleanType
+    }
   }
 
   /** Binary operation (always preserves pureness). */
   case class BinaryOp(op: BinaryOp.Code, lhs: Tree, rhs: Tree)(
       implicit val pos: Position) extends Tree {
-    import BinaryOp._
-    val tpe = (op: @switch) match {
-      case === | !== |
-          Num_== | Num_!= | Num_< | Num_<= | Num_> | Num_>= |
-          Long_== | Long_!= | Long_< | Long_<= | Long_> | Long_>= |
-          Boolean_== | Boolean_!= | Boolean_| | Boolean_& =>
-        BooleanType
-      case String_+ =>
-        StringType
-      case Int_+ | Int_- | Int_* | Int_/ | Int_% |
-          Int_| | Int_& | Int_^ | Int_<< | Int_>>> | Int_>> =>
-        IntType
-      case Float_+ | Float_- | Float_* | Float_/ | Float_% =>
-        FloatType
-      case Double_+ | Double_- | Double_* | Double_/ | Double_% =>
-        DoubleType
-      case Long_+ | Long_- | Long_* | Long_/ | Long_% |
-          Long_| | Long_& | Long_^ | Long_<< | Long_>>> | Long_>> =>
-        LongType
-    }
+
+    val tpe = BinaryOp.resultTypeOf(op)
   }
 
   object BinaryOp {
@@ -345,6 +329,26 @@ object Trees {
     final val Boolean_!= = 49
     final val Boolean_|  = 50
     final val Boolean_&  = 51
+
+    def resultTypeOf(op: Code): Type = (op: @switch) match {
+      case === | !== |
+          Num_== | Num_!= | Num_< | Num_<= | Num_> | Num_>= |
+          Long_== | Long_!= | Long_< | Long_<= | Long_> | Long_>= |
+          Boolean_== | Boolean_!= | Boolean_| | Boolean_& =>
+        BooleanType
+      case String_+ =>
+        StringType
+      case Int_+ | Int_- | Int_* | Int_/ | Int_% |
+          Int_| | Int_& | Int_^ | Int_<< | Int_>>> | Int_>> =>
+        IntType
+      case Float_+ | Float_- | Float_* | Float_/ | Float_% =>
+        FloatType
+      case Double_+ | Double_- | Double_* | Double_/ | Double_% =>
+        DoubleType
+      case Long_+ | Long_- | Long_* | Long_/ | Long_% |
+          Long_| | Long_& | Long_^ | Long_<< | Long_>>> | Long_>> =>
+        LongType
+    }
   }
 
   case class NewArray(tpe: ArrayType, lengths: List[Tree])(

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,9 +8,25 @@ object BinaryIncompatibilities {
   val Tools = Seq(
       // private, not an issue
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#PreTransBlock.this"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#PreTransBlock.apply"),
       ProblemFilters.exclude[MissingMethodProblem](
-          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#PreTransBlock.stats")
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#PreTransBlock.stats"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#PreTransBlock.result"),
+      ProblemFilters.exclude[MissingTypesProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore$PreTransTree"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#PreTransTree.apply"),
+      ProblemFilters.exclude[MissingTypesProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore$PreTransRecordTree"),
+      ProblemFilters.exclude[MissingClassProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore$PreTransNoBlock"),
+      ProblemFilters.exclude[MissingTypesProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore$PreTransGenTree"),
+      ProblemFilters.exclude[MissingTypesProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore$PreTransLocalDef")
   )
 
   val JSEnvs = Seq(


### PR DESCRIPTION
Previously, the optimizer would be stupid on the following code:
```scala
val x: int = foo()
val y: int = x +[int] 4
val z: int = y *[int] 2
// don't use any of x, y, z
```
When performing the `withNewLocalDef` for `y`, it would have to reify `x` to put it in a `BinaryOp(Int_+, x, 4)`. Then, for the `withNewLocalDef` of `z`, it would repeat the process with `y`. Only `z` would remain virtual as a `PreTransLocalDef`.

Later on, when we discover that `z` is not used in the body of the val, it is eliminated, and the optimizer keeps only the side effects of its right-hand side, which collapses to `Skip()`.

However, `y` has already been marked as *used* a long time ago, when the right hand size of `z` was first translated. It is therefore kept, although it is clearly dead code. The same story happens to `x`, obviously.

This commit fixes this shortcoming of the optimizer by creating new `PreTransform`s for unary and binary ops. The rhs of `y` is therefore kept as a virtual `PreTransBinaryOp(Int_+, PreTransLocalDef(x), PreTransTree(4))` which does not need to reify `x`. The same happens to `z` with a virtual reference to `y`. After the body is translated, all local variables can now be removed!

This only came up recently because of the sheer ability to keep `PreTransBinding`s, which was added in 9bfc69c2a39ec3d9cab219a57c9e230cd5daa278. Now, it becomes clear that we need `PreTransform`s for all the kinds of `Tree`s that can be side-effect-free. This commit is a first (or second) step towards that goal.