### PR TITLE
Fix #2466: Override checkfiles for neg/choices.scala < 2.11.8.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/choices.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/neg/choices.check
@@ -1,0 +1,6 @@
+error: Usage: -Yresolve-term-conflict:<strategy>
+  where <strategy> choices are package, object, error (default: error)
+error: bad option: '-Yresolve-term-conflict'
+error: bad options: -Yresolve-term-conflict
+error: flags file may only contain compiler options, found: -Yresolve-term-conflict
+four errors found

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/choices.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/neg/choices.check
@@ -1,0 +1,6 @@
+error: Usage: -Yresolve-term-conflict:<strategy>
+  where <strategy> choices are package, object, error (default: error)
+error: bad option: '-Yresolve-term-conflict'
+error: bad options: -Yresolve-term-conflict
+error: flags file may only contain compiler options, found: -Yresolve-term-conflict
+four errors found

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/choices.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/neg/choices.check
@@ -1,0 +1,6 @@
+error: Usage: -Yresolve-term-conflict:<strategy>
+ where <strategy> choices are package, object, error (default: error)
+error: bad option: '-Yresolve-term-conflict'
+error: bad options: -Yresolve-term-conflict
+error: flags file may only contain compiler options, found: -Yresolve-term-conflict
+four errors found

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/choices.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/neg/choices.check
@@ -1,0 +1,6 @@
+error: Usage: -Yresolve-term-conflict:<strategy>
+ where <strategy> choices are package, object, error (default: error)
+error: bad option: '-Yresolve-term-conflict'
+error: bad options: -Yresolve-term-conflict
+error: flags file may only contain compiler options, found: -Yresolve-term-conflict
+four errors found

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/choices.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/neg/choices.check
@@ -1,0 +1,6 @@
+error: Usage: -Yresolve-term-conflict:<strategy>
+ where <strategy> choices are package, object, error (default: error)
+error: bad option: '-Yresolve-term-conflict'
+error: bad options: -Yresolve-term-conflict
+error: flags file may only contain compiler options, found: -Yresolve-term-conflict
+four errors found

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/choices.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/neg/choices.check
@@ -1,0 +1,6 @@
+error: Usage: -Yresolve-term-conflict:<strategy>
+ where <strategy> choices are package, object, error (default: error)
+error: bad option: '-Yresolve-term-conflict'
+error: bad options: -Yresolve-term-conflict
+error: flags file may only contain compiler options, found: -Yresolve-term-conflict
+four errors found


### PR DESCRIPTION
In scala/scala, these checkfiles have been updated in 2.11.8 and 2.12.x in the commits https://github.com/scala/scala/commit/e606e3054a2d872135b6409f43291d5746a48cf1 and https://github.com/scala/scala/commit/3d7ff96bd9f637d37e9ce2922cb5140feedc8ae3 respectively. These commits update the version of partest, so this is clearly the source of the changes. Since we use the more recent version of partest for all Scala versions, it makes sense that we have to backport the changes to the checkfiles.