### PR TITLE
Fix #2471: java.io.BufferedReader should close its underlying Reader

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -18,6 +18,7 @@ class BufferedReader(in: Reader, sz: Int) extends Reader {
 
   override def close(): Unit = {
     closed = true
+    in.close()
   }
 
   override def mark(readAheadLimit: Int): Unit = {


### PR DESCRIPTION
Fix for issue #2471. See the JavaDoc for [BufferedReader.close](https://docs.oracle.com/javase/7/docs/api/java/io/BufferedReader.html#close()). The contract is this:

- it is idempotent (check)
- it should release any associated resources

The current implementation of `BufferedReader` doesn't release the underlying `Reader` on `close()`.