### PR TITLE
Fix #2457: Remove useless breaks and labels in JSDesugaring.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,13 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#Env.this"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.transformStat"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.pushLhsInto")
   )
 
   val JSEnvs = Seq(


### PR DESCRIPTION
The desugaring phase maintains two sets of label names:

First, a set of labels for which we are in "tail position", i.e., breaking to that label is equivalent to no-op. `Break`s to labels in that set can be replaced by `Skip()`, allowing the removal of the label altogether. For example, in
```javascript
var y;
lbl: {
  var x = 5;
  if (b) {
    y = x + 3;
    break lbl;
  } else {
    y = x + 5;
  }
}
```
the `break lbl` is in tail position for the label `lbl`, and can therefore be removed. After removal of the labeled block itself, the snippet rewrites as:
```javascript
var y;
var x = 5;
if (b) {
  y = x + 3;
} else {
  y = x + 5;
}
```

Second, a set of "default" labels, for which `break` is equivalent to `break lbl`. This is the set of tail-position labels of the closest enclosing `while/do..while/switch` "loop". Breaks to labels in that set can be replaced by `break` without label, also allowing the removal of the labeled block. For example, in
```javascript
var y;
lbl: {
  var i = 0;
  while (true) {
    if (x == 5) {
      y = 3;
      break lbl;
    }
    i = i - 1;
  }
}
```
the `break lbl` is in "default" position of the label `lbl`, since the closest enclosing `while/do..while/switch` is in tail position of `lbl`. The snippet can therefore be rewritten as:
```javascript
var y;
var i = 0;
while (true) {
  if (x == 5) {
    y = 3;
    break;
  }
  i = i - 1;
}
```
This is particularly interesting for `Range.foreach`, because, when inlined, its `return` statement becomes a `break` to an `inlinereturn` label, which is a default label at the point of the `return`. We can therefore avoid the useless labeled block for this common case.