### PR TITLE
Fix #2445: Look inside PolyType for NullaryMethodType.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -109,7 +109,11 @@ trait JSGlobalAddons extends JSDefinitions
     /** has this symbol to be translated into a JS getter (both directions)? */
     def isJSGetter(sym: Symbol): Boolean = {
       sym.tpe.params.isEmpty && enteringUncurryIfAtPhaseAfter {
-        sym.tpe.isInstanceOf[NullaryMethodType]
+        sym.tpe match {
+          case _: NullaryMethodType              => true
+          case PolyType(_, _: NullaryMethodType) => true
+          case _                                 => false
+        }
       }
     }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -244,6 +244,34 @@ class InteroperabilityTest {
     assertArrayEquals(Array("plop", 42, 51), stat.foo(elems: _*))
   }
 
+  @Test def call_polytype_nullary_method_issue_2445(): Unit = {
+    val obj = js.eval("""
+      var obj = {
+        emptyArray: []
+      };
+      obj;
+    """)
+
+    val objNative =
+      obj.asInstanceOf[InteroperabilityTestPolyTypeNullaryMethodNative]
+    val a = objNative.emptyArray[Int]
+    assertTrue((a: Any).isInstanceOf[js.Array[_]])
+    assertEquals(0, a.length)
+
+    val objNonNative =
+      obj.asInstanceOf[InteroperabilityTestPolyTypeNullaryMethodNonNative]
+    val b = objNonNative.emptyArray[Int]
+    assertTrue((b: Any).isInstanceOf[js.Array[_]])
+    assertEquals(0, b.length)
+
+    // From the bug report
+    val objPoly =
+      obj.asInstanceOf[InteroperabilityTestPolyClassPolyNullaryMethod[Int]]
+    val c = objPoly.emptyArray[Any]
+    assertTrue((c: Any).isInstanceOf[js.Array[_]])
+    assertEquals(0, c.length)
+  }
+
   @Test def should_allow_to_call_JS_constructors_with_variadic_parameters(): Unit = {
     import js.Dynamic.{newInstance => jsnew}
 
@@ -679,6 +707,21 @@ object InteroperabilityTestContainerObjectWithJSName extends js.Object {
 @js.native
 trait InteroperabilityTestVariadicMethod extends js.Object {
   def foo(args: Any*): js.Array[Any] = js.native
+}
+
+@js.native
+trait InteroperabilityTestPolyTypeNullaryMethodNative extends js.Object {
+  def emptyArray[T]: js.Array[T] = js.native
+}
+
+@ScalaJSDefined
+trait InteroperabilityTestPolyTypeNullaryMethodNonNative extends js.Object {
+  def emptyArray[T]: js.Array[T]
+}
+
+@js.native
+trait InteroperabilityTestPolyClassPolyNullaryMethod[+T] extends js.Object {
+  def emptyArray[T2 >: T]: js.Array[T2] = js.native
 }
 
 @js.native

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -369,6 +369,17 @@ class ExportsTest {
     assertEquals(js.Dynamic.literal(arg = "hello").toMap, a.foo("hello").toMap)
   }
 
+  @Test def exports_for_polytype_nullary_method_issue_2445(): Unit = {
+    class ExportPolyTypeNullaryMethod {
+      @JSExport def emptyArray[T]: js.Array[T] = js.Array()
+    }
+
+    val obj = (new ExportPolyTypeNullaryMethod).asInstanceOf[js.Dynamic]
+    val a = obj.emptyArray
+    assertTrue((a: Any).isInstanceOf[js.Array[_]])
+    assertEquals(0, a.length)
+  }
+
   @Test def exports_for_variable_argument_methods_issue_393(): Unit = {
     class A {
       @JSExport

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -767,6 +767,23 @@ class ScalaJSDefinedTest {
     assertEquals(7, baz10.bar)
   }
 
+  @Test def polytype_nullary_method_issue_2445(): Unit = {
+    @ScalaJSDefined
+    class PolyTypeNullaryMethod extends js.Object {
+      def emptyArray[T]: js.Array[T] = js.Array()
+    }
+
+    val obj = new PolyTypeNullaryMethod
+    val a = obj.emptyArray[Int]
+    assertTrue((a: Any).isInstanceOf[js.Array[_]])
+    assertEquals(0, a.length)
+
+    val dyn = obj.asInstanceOf[js.Dynamic]
+    val b = dyn.emptyArray
+    assertTrue((b: Any).isInstanceOf[js.Array[_]])
+    assertEquals(0, b.length)
+  }
+
   @Test def default_parameters(): Unit = {
     @ScalaJSDefined
     class DefaultParameters extends js.Object {


### PR DESCRIPTION
Methods with type parameters but without parentheses have a type of the shape `PolyType(_, _: NullaryMethodType)` instead of `_: NullaryMethodType` for monomorphic methods. This commit fixes `isJSGetter` to correctly identify those as getters.