### PR TITLE
Fix #2498: IR-check the scope of local identifiers.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,6 +8,10 @@ object BinaryIncompatibilities {
   val Tools = Seq(
       // private, not an issue
       ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.checker.IRChecker#Env.withLocals"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.checker.IRChecker#Env.withLocal"),
+      ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#Env.this"),
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.transformStat"),

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -677,7 +677,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
             typecheckExpect(rhs, env, IntType)
           case Float_+ | Float_- | Float_* | Float_/ | Float_% =>
             typecheckExpect(lhs, env, FloatType)
-            typecheckExpect(lhs, env, FloatType)
+            typecheckExpect(rhs, env, FloatType)
           case Long_+ | Long_- | Long_* | Long_/ | Long_% |
               Long_| | Long_& | Long_^ |
               Long_== | Long_!= | Long_< | Long_<= | Long_> | Long_>= =>
@@ -689,7 +689,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
           case Double_+ | Double_- | Double_* | Double_/ | Double_% |
               Num_== | Num_!= | Num_< | Num_<= | Num_> | Num_>= =>
             typecheckExpect(lhs, env, DoubleType)
-            typecheckExpect(lhs, env, DoubleType)
+            typecheckExpect(rhs, env, DoubleType)
           case Boolean_== | Boolean_!= | Boolean_| | Boolean_& =>
             typecheckExpect(lhs, env, BooleanType)
             typecheckExpect(rhs, env, BooleanType)


### PR DESCRIPTION
* Identifiers for labels must be unique per method.
* Identifiers for local variables must have non-overlapping scopes.