### PR TITLE
Fix #2495: Move labeledExprLHSes of Desugar into the environment.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -12,7 +12,11 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.transformStat"),
       ProblemFilters.exclude[MissingMethodProblem](
-          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.pushLhsInto")
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.pushLhsInto"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.labeledExprLHSes"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.labeledExprLHSes_=")
   )
 
   val JSEnvs = Seq(


### PR DESCRIPTION
In the process, simplify the desugaring of `Labeled`. There was a special case for `Return` which was not necessary as of the introduction of `usedLabels` to track which labels are actually used.