### PR TITLE
Fix #2494: Store the location of source map files as attributes.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -263,7 +263,8 @@
         jsDependenciesTest/packageJSDependencies \
         jsDependenciesTest/packageMinifiedJSDependencies \
         jsDependenciesTest/regressionTestForIssue2243 \
-        jsNoDependenciesTest/regressionTestForIssue2243
+        jsNoDependenciesTest/regressionTestForIssue2243 \
+        multiTestJS/test:testScalaJSSourceMapAttribute
   ]]></task>
 
   <task id="partest-noopt"><![CDATA[

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -20,6 +20,8 @@ val baseSettings = versionSettings ++ Seq(
 
 val regressionTestForIssue2243 = TaskKey[Unit]("regressionTestForIssue2243",
   "", KeyRanks.BTask)
+val testScalaJSSourceMapAttribute = TaskKey[Unit](
+  "testScalaJSSourceMapAttribute", "", KeyRanks.BTask)
 
 def withRegretionTestForIssue2243(project: Project): Project = {
   project.settings(inConfig(Compile)(Seq(
@@ -118,6 +120,19 @@ lazy val multiTest = crossProject.
     isScalaJSProject ~= { value =>
       assert(value, "isScalaJSProject should be true in multiTestJS")
       value
+    },
+
+    // Test the scalaJSSourceMap attribute of fastOptJS and fullOptJS
+    testScalaJSSourceMapAttribute in Test := {
+      val fastOptFile = (fastOptJS in Test).value
+      assert(fastOptFile.get(scalaJSSourceMap).exists {
+        _.getPath == fastOptFile.data.getPath + ".map"
+      }, "fastOptJS does not have the correct scalaJSSourceMap attribute")
+
+      val fullOptFile = (fullOptJS in Test).value
+      assert(fullOptFile.get(scalaJSSourceMap).exists {
+        _.getPath == fullOptFile.data.getPath + ".map"
+      }, "fullOptJS does not have the correct scalaJSSourceMap attribute")
     }
   ).
   jvmSettings(versionSettings: _*).

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -267,6 +267,10 @@ object ScalaJSPlugin extends AutoPlugin {
         "scalaJSJavaSystemProperties",
         "List of arguments to pass to the Scala.js Java System.properties.",
         CTask)
+
+    val scalaJSSourceMap = AttributeKey[File]("scalaJSSourceMap",
+        "Source map file attached to an Attributed .js file.",
+        BSetting)
   }
 
   import autoImport._

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -245,7 +245,8 @@ object ScalaJSPluginInternal {
             Set(output)
           } (realFiles.toSet)
 
-          Attributed.blank(output)
+          val sourceMapFile = FileVirtualJSFile(output).sourceMapFile
+          Attributed.blank(output).put(scalaJSSourceMap, sourceMapFile)
         } tag((usesScalaJSLinkerTag in key).value)
       },
 


### PR DESCRIPTION
The source maps of `fastOptJS` can now be accessed with `fastOptJS.value.get(scalaJSSourceMap).get`, and similarly for `fullOptJS`.