### PR TITLE
Fix #2513: Annotate `@JSExport` with `@field @getter @setter`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -179,8 +179,12 @@ trait PrepJSExports { this: PrepJSInterop =>
     val trgSym = {
       def isOwnerScalaClass = !sym.owner.isModuleClass && !isJSAny(sym.owner)
 
-      // For accessors, look on the val/var def
-      if (sym.isAccessor) sym.accessed
+      /* For accessors, look on the val/var def, if there is one.
+       * TODO Get rid of this when we can break binary compatibility, as
+       * @JSExport and @JSExportNamed are now annotated with
+       * @field @getter @setter
+       */
+      if (sym.isAccessor && sym.accessed != NoSymbol) sym.accessed
       // For primary Scala class constructors, look on the class itself
       else if (sym.isPrimaryConstructor && isOwnerScalaClass) sym.owner
       else sym

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -410,16 +410,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
             exp <- exportsOf(sym)
             if !exp.ignoreInvalid
           } {
-            val msg = {
-              val base = "You may not export a local definition"
-              if (sym.owner.isPrimaryConstructor)
-                base + ". To export a (case) class field, use the " +
-                "meta-annotation scala.annotation.meta.field like this: " +
-                "@(JSExport @field)."
-              else
-                base
-            }
-            reporter.error(exp.pos, msg)
+            reporter.error(exp.pos, "You may not export a local definition")
           }
         }
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -291,20 +291,6 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def infoExportLocal: Unit = {
-
-    """
-    class A(@JSExport val x: Int)
-    """ hasErrors
-    """
-      |newSource1.scala:3: error: You may not export a local definition. To export a (case) class field, use the meta-annotation scala.annotation.meta.field like this: @(JSExport @field).
-      |    class A(@JSExport val x: Int)
-      |             ^
-    """
-
-  }
-
-  @Test
   def noMiddleVarArg: Unit = {
 
     """

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExport.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExport.scala
@@ -10,10 +10,13 @@
 
 package scala.scalajs.js.annotation
 
+import scala.annotation.meta._
+
 /** Specifies that the given entity should be exported for use in raw JS.
  *
  *  @see [[http://www.scala-js.org/doc/export-to-javascript.html Export Scala.js APIs to JavaScript]]
  */
+@field @getter @setter
 class JSExport extends scala.annotation.StaticAnnotation {
   def this(name: String) = this()
 }

--- a/library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala
+++ b/library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala
@@ -327,7 +327,9 @@ private[scalajs] object UseAsMacros {
      *  Looks on accessed field if this is an accessor
      */
     private def memberAnnotations(sym: MethodSymbol): List[Annotation] = {
-      val trgSym = if (sym.isAccessor) sym.accessed else sym
+      val trgSym =
+        if (sym.isAccessor && sym.accessed != NoSymbol) sym.accessed
+        else sym
 
       // Force typeSignature to calculate annotations
       trgSym.typeSignature

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -153,6 +153,46 @@ class ExportsTest {
     assertEquals(43, foo.y)
   }
 
+  @Test def exports_for_abstract_properties_in_class_issue_2513(): Unit = {
+    abstract class Foo {
+      @JSExport
+      val x: Int
+      @JSExport
+      var y: Int
+    }
+
+    class Bar extends Foo {
+      val x: Int = 5
+      var y: Int = 6
+    }
+
+    val bar = (new Bar).asInstanceOf[js.Dynamic]
+    assertEquals(5, bar.x)
+    assertEquals(6, bar.y)
+    bar.y = 7
+    assertEquals(7, bar.y)
+  }
+
+  @Test def exports_for_abstract_properties_in_trait_issue_2513(): Unit = {
+    trait Foo {
+      @JSExport
+      val x: Int
+      @JSExport
+      var y: Int
+    }
+
+    class Bar extends Foo {
+      val x: Int = 5
+      var y: Int = 6
+    }
+
+    val bar = (new Bar).asInstanceOf[js.Dynamic]
+    assertEquals(5, bar.x)
+    assertEquals(6, bar.y)
+    bar.y = 7
+    assertEquals(7, bar.y)
+  }
+
   @Test def overloaded_exports_for_methods(): Unit = {
     class Foo {
       @JSExport("foobar")
@@ -773,12 +813,32 @@ class ExportsTest {
   }
 
   @Test def exporting_constructor_parameter_fields_issue_970(): Unit = {
+    class Foo(@JSExport val x: Int, @JSExport var y: Int)
+
+    val foo = new Foo(5, 6).asInstanceOf[js.Dynamic]
+    assertEquals(5, foo.x)
+    assertEquals(6, foo.y)
+    foo.y = 7
+    assertEquals(7, foo.y)
+  }
+
+  @Test def exporting_case_class_fields_issue_970(): Unit = {
+    case class Bar(@JSExport x: Int, @JSExport var y: Int)
+
+    val bar = Bar(5, 6).asInstanceOf[js.Dynamic]
+    assertEquals(5, bar.x)
+    assertEquals(6, bar.y)
+    bar.y = 7
+    assertEquals(7, bar.y)
+  }
+
+  @Test def exporting_constructor_parameter_fields_issue_970_old(): Unit = {
     class Foo(@(JSExport @meta.field) val x: Int)
     val foo = (new Foo(1)).asInstanceOf[js.Dynamic]
     assertEquals(1, foo.x)
   }
 
-  @Test def exporting_case_class_fields_issue_970(): Unit = {
+  @Test def exporting_case_class_fields_issue_970_old(): Unit = {
     case class Foo(@(JSExport @meta.field) x: Int)
     val foo = (new Foo(1)).asInstanceOf[js.Dynamic]
     assertEquals(1, foo.x)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala
@@ -225,6 +225,40 @@ class UseAsScalaTypesTest {
     js.use(new A).as[JSVars]
   }
 
+  @Test def should_support_abstract_members_class(): Unit = {
+    abstract class AbstractFieldsClass {
+      @JSExport
+      def a: Int
+      @JSExport
+      def a_=(x: Int): Unit
+
+      @JSExport("b")
+      var fooB: String
+
+      @JSExport
+      var c: js.Object
+    }
+
+    js.use(null: AbstractFieldsClass).as[JSVars]
+  }
+
+  @Test def should_support_abstract_members_trait(): Unit = {
+    trait AbstractFieldsTrait {
+      @JSExport
+      def a: Int
+      @JSExport
+      def a_=(x: Int): Unit
+
+      @JSExport("b")
+      var fooB: String
+
+      @JSExport
+      var c: js.Object
+    }
+
+    js.use(null: AbstractFieldsTrait).as[JSVars]
+  }
+
   @Test def should_support_basic_default_arguments(): Unit = {
     @JSExportAll
     class A {


### PR DESCRIPTION
In addition, the compiler and the `js.use(x).as[T]` macro need to look for `@JSExport` on the getter/setter itself, if there is no accessed field. In theory, it should do so unconditionally, but backward binary compatibility demand that we still recognize exports built with a previous version of the library.

Incidentally, this provides a better fix to the old issue #970. It is not necessary to use `@(JSExport @meta.field)` for constructor parameter fields anymore.