### PR TITLE
Consider module accessor a JSGetter

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -108,13 +108,17 @@ trait JSGlobalAddons extends JSDefinitions
 
     /** has this symbol to be translated into a JS getter (both directions)? */
     def isJSGetter(sym: Symbol): Boolean = {
-      sym.tpe.params.isEmpty && enteringUncurryIfAtPhaseAfter {
+      /* We only get here when `sym.isMethod`, thus `sym.isModule` implies that
+       * `sym` is the module's accessor. In 2.12, module accessors are synthesized
+       * after uncurry, thus their first info is a MethodType at phase fields.
+       */
+      sym.isModule || (sym.tpe.params.isEmpty && enteringUncurryIfAtPhaseAfter {
         sym.tpe match {
           case _: NullaryMethodType              => true
           case PolyType(_, _: NullaryMethodType) => true
           case _                                 => false
         }
-      }
+      })
     }
 
     /** has this symbol to be translated into a JS setter (both directions)? */


### PR DESCRIPTION
Redundant on 2.11, but required for the upcoming 2.12.0-RC1,
where the field refactoring synthesizes module accessors
after uncurry, so that their type history does not even
go back as far as uncurry, where a NullaryMethodType might
have been observed otherwise.

I tried splicing NMTs in the info history of modules,
but they already are pretty hacking (a module's term symbol
is converted into a method pretty late in the game, and it
would be risky to have them start with NMTs from namers).

With this, scala-js's test suite passes on scala/scala#5141 
(well, I'm about to rewind that branch to a stable point where this holds)

# TODO
  - [x] add comment