### PR TITLE
Optimize BigInteger by making smarter use of Longs.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/MathJDK8Bridge.scala
+++ b/javalanglib/src/main/scala/java/lang/MathJDK8Bridge.scala
@@ -58,4 +58,24 @@ private[java] object MathJDK8Bridge {
   def floorMod(a: scala.Int, b: scala.Int): scala.Int = Math.floorMod(a, b)
 
   def floorMod(a: scala.Long, b: scala.Long): scala.Long = Math.floorMod(a, b)
+
+  // A few other Math-related methods that are not really in Math
+
+  def toUnsignedString(i: scala.Int): String =
+    Integer.toUnsignedString(i)
+
+  def toUnsignedString(i: scala.Long): String =
+    Long.toUnsignedString(i)
+
+  def divideUnsigned(a: scala.Int, b: scala.Int): scala.Int =
+    Integer.divideUnsigned(a, b)
+
+  def divideUnsigned(a: scala.Long, b: scala.Long): scala.Long =
+    Long.divideUnsigned(a, b)
+
+  def remainderUnsigned(a: scala.Int, b: scala.Int): scala.Int =
+    Integer.remainderUnsigned(a, b)
+
+  def remainderUnsigned(a: scala.Long, b: scala.Long): scala.Long =
+    Long.remainderUnsigned(a, b)
 }

--- a/javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
+++ b/javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
@@ -56,4 +56,19 @@ private[java] object MathJDK8Bridge {
   def floorMod(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
 
   def floorMod(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+
+  // A few other Math-related methods that are not really in Math
+
+  def toUnsignedString(i: scala.Int): String = sys.error("stub")
+
+  def toUnsignedString(i: scala.Long): String = sys.error("stub")
+
+  def divideUnsigned(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+
+  def divideUnsigned(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+
+  def remainderUnsigned(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+
+  def remainderUnsigned(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+
 }

--- a/javalib/src/main/scala/java/math/Multiplication.scala
+++ b/javalib/src/main/scala/java/math/Multiplication.scala
@@ -153,7 +153,7 @@ private[math] object Multiplication {
    *  @param d parameter 4
    *  @return value of expression
    */
-  def unsignedMultAddAdd(a: Int, b: Int, c: Int, d: Int): Long =
+  @inline def unsignedMultAddAdd(a: Int, b: Int, c: Int, d: Int): Long =
     (a & 0xFFFFFFFFL) * (b & 0xFFFFFFFFL) + (c & 0xFFFFFFFFL) + (d & 0xFFFFFFFFL)
 
   /** Performs the multiplication with the Karatsuba's algorithm.
@@ -328,6 +328,7 @@ private[math] object Multiplication {
     }
   }
 
+  @noinline
   def pow(base: BigInteger, exponent: Int): BigInteger = {
     @inline
     @tailrec
@@ -436,7 +437,7 @@ private[math] object Multiplication {
         var carry = 0
         val aI = a(i)
         for (j <- 0 until bLen) {
-          val added = unsignedMultAddAdd(aI, b(j), t(i + j), carry.toInt)
+          val added = unsignedMultAddAdd(aI, b(j), t(i + j), carry)
           t(i + j) = added.toInt
           carry = (added >>> 32).toInt
         }


### PR DESCRIPTION
Here are a couple general ideas that have been used in several places:

* Using appropriately the unsigned division and remainder operations provided by `{Integer,Long}.{divide,remainder}Unsigned`.
* Carry variables in loops can be Ints, and reinterpreted as Longs inside the loop, which avoids having mutable records.
* When performing both unsigned division and remainder on Longs, it is much more efficient to compute the remainder from the quotient: subtraction + multiplication are way faster than one remainder.