### PR TITLE
Micro-improvements to {highest,lowest}OneBit.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -157,9 +157,23 @@ object Integer {
     asInt(dividend.toUint % divisor.toUint)
   }
 
-  @inline def highestOneBit(i: Int): Int =
-    if (i == 0) 0
-    else (1 << 31) >>> numberOfLeadingZeros(i)
+  @inline def highestOneBit(i: Int): Int = {
+    /* The natural way of implementing this is:
+     *   if (i == 0) 0
+     *   else (1 << 31) >>> numberOfLeadingZeros(i)
+     *
+     * We can deal with the 0 case in a branchless fashion by adding `& i` to
+     * the else branch:
+     *   ((1 << 31) >>> numberOfLeadingZeros(i)) & i
+     * Indeed, when i == 0, the `& i` collapses everything to 0. And otherwise,
+     * we know that ((1 << 31) >>> numberOfLeadingZeros(i)) is the highest 1
+     * bit of i, so &'ing with i is a no-op.
+     *
+     * Finally, since we're &'ing with i anyway, we can replace the >>> by a
+     * >>, which is shorter in JS and does not require the additional `| 0`.
+     */
+    ((1 << 31) >> numberOfLeadingZeros(i)) & i
+  }
 
   @inline def lowestOneBit(i: Int): Int =
     i & -i

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -360,16 +360,20 @@ object Long {
 
   @inline
   def highestOneBit(i: scala.Long): scala.Long = {
+    val lo = i.toInt
     val hi = (i >>> 32).toInt
-    if (hi != 0) Integer.highestOneBit(hi).toLong << 32
-    else Integer.highestOneBit(i.toInt).toLong & 0xffffffffL
+    makeLongFromLoHi(
+        if (hi != 0) 0 else Integer.highestOneBit(lo),
+        Integer.highestOneBit(hi))
   }
 
   @inline
   def lowestOneBit(i: scala.Long): scala.Long = {
     val lo = i.toInt
-    if (lo != 0) Integer.lowestOneBit(lo).toLong & 0xffffffffL
-    else Integer.lowestOneBit((i >>> 32).toInt).toLong << 32
+    val hi = (i >> 32).toInt
+    makeLongFromLoHi(
+        Integer.lowestOneBit(lo),
+        if (lo != 0) 0 else Integer.lowestOneBit(hi))
   }
 
   @inline
@@ -381,10 +385,17 @@ object Long {
 
   @inline
   def reverseBytes(i: scala.Long): scala.Long = {
-    val hiReversed = Integer.reverseBytes((i >>> 32).toInt)
-    val loReversed = Integer.reverseBytes(i.toInt)
-    (loReversed.toLong << 32) | (hiReversed.toLong & 0xffffffffL)
+    makeLongFromLoHi(
+        Integer.reverseBytes((i >>> 32).toInt),
+        Integer.reverseBytes(i.toInt))
   }
+
+  /** Make a `Long` value from its lo and hi 32-bit parts.
+   *  When the optimizer is enabled, this operation is free.
+   */
+  @inline
+  private def makeLongFromLoHi(lo: Int, hi: Int): scala.Long =
+    (lo.toLong & 0xffffffffL) | (hi.toLong << 32)
 
   @inline
   def rotateLeft(i: scala.Long, distance: scala.Int): scala.Long =


### PR DESCRIPTION
`Integer.highestOneBit` is now branchless.

`Long.highestOneBit` (resp. `lowestOneBit`) now uses a branch only in the `lo` part (resp. `hi` part), the other being branchless, which generates less JavaScript code.