### PR TITLE
Improve js.JavaScriptException.getMessage().

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
+++ b/library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
@@ -11,7 +11,7 @@
 package scala.scalajs.js
 
 case class JavaScriptException(exception: scala.Any) extends RuntimeException {
-  override def toString(): String = exception.toString()
+  override def getMessage(): String = exception.toString()
 
   override def fillInStackTrace(): Throwable = {
     scala.scalajs.runtime.StackTrace.captureState(this, exception)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/JavaScriptExceptionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/JavaScriptExceptionTest.scala
@@ -1,0 +1,31 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.library
+
+import scala.scalajs.js
+
+import org.junit.Assert._
+import org.junit.Test
+
+class JavaScriptExceptionTest {
+
+  @Test def getMessageTest(): Unit = {
+    val error = new js.TypeError("custom message")
+    val jsException = js.JavaScriptException(error)
+    assertEquals("TypeError: custom message", jsException.getMessage())
+  }
+
+  @Test def toStringTest(): Unit = {
+    val error = new js.TypeError("custom message")
+    val jsException = js.JavaScriptException(error)
+    assertEquals(
+        "scala.scalajs.js.JavaScriptException: TypeError: custom message",
+        jsException.toString())
+  }
+
+}


### PR DESCRIPTION
Instead of overriding `toString()` to forward to the inner exception's `toString()` message, we do this in `getMessage()`. This improves the display of `JavaScriptException`s in tools that bypass `toString()`, such as JUnit's error reporter.