### PR TITLE
Fix #2570: Fix the test for Date.toString wrt time zones.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -91,10 +91,10 @@ class DateTest {
   @Test def toStringTest(): Unit = {
     def test(expectedRegex: String, actual: String): Unit =
       assertTrue(s"expected:<$expectedRegex> to match:<$actual>", actual.matches(expectedRegex))
-    test("Mon Nov 03 06:23:27 .+ 1997", new Date(Date.UTC(97, 10, 3, 5, 23, 27)).toString)
-    test("Sun Dec 31 01:00:00 .+ 1899", new Date(Date.UTC(0, 0, 0, 0, 0, 0)).toString)
-    test("Sun Jan 05 09:01:09 .+ 1902", new Date(Date.UTC(1, 12, 5, 8, 1, 9)).toString)
-    test("Sat Jan 09 06:03:04 .+ 2900", new Date(Date.UTC(1000, 0, 9, 5, 3, 4)).toString)
+    test("Mon Nov 03 05:23:27 .+ 1997", new Date(97, 10, 3, 5, 23, 27).toString)
+    test("Sun Dec 31 00:00:00 .+ 1899", new Date(0, 0, 0, 0, 0, 0).toString)
+    test("Sun Jan 05 08:01:09 .+ 1902", new Date(1, 12, 5, 8, 1, 9).toString)
+    test("Sat Jan 09 05:03:04 .+ 2900", new Date(1000, 0, 9, 5, 3, 4).toString)
   }
 
   @Test def toGMTString(): Unit = {


### PR DESCRIPTION
`toString()` displays dates in the local time zone, so we should also create the dates we're testing in the local time zone. That way, both offsets cancel each other out.