### PR TITLE
Fix #2573: Fix `String.split()` yet again (leading 0-width match).

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -15,7 +15,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalajs.testsuite.utils.AssertThrows._
-import org.scalajs.testsuite.utils.Platform.executingInJVM
+import org.scalajs.testsuite.utils.Platform._
 
 class StringTest {
 
@@ -183,9 +183,9 @@ class StringTest {
 
   @Test def split(): Unit = {
     assertArrayEquals(Array[AnyRef]("Sc", "l", ".js"), erased("Scala.js".split("a")))
-    if (!executingInJVM) {
-      assertArrayEquals(Array[AnyRef]("", "a", "s", "d", "f"), erased("asdf".split("")))
-      assertArrayEquals(Array[AnyRef]("", "a", "s", "d", "f", ""), erased("asdf".split("", -1)))
+    if (!executingInJVMOnJDK7OrLower) {
+      assertArrayEquals(Array[AnyRef]("a", "s", "d", "f"), erased("asdf".split("")))
+      assertArrayEquals(Array[AnyRef]("a", "s", "d", "f", ""), erased("asdf".split("", -1)))
     }
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
@@ -56,26 +56,28 @@ class RegexPatternTest {
     split("", "\n", Array(""))
     split("", "", Array(""))
 
-    // Should remove leading empty match under some conditions - #1171
-    // These tests are "measured" on the JVM since the spec is unclear
+    /* Should remove leading empty match under some conditions - #1171, #2573
+     * The behavior changed in JDK 8 (at which point it became properly
+     * documented).
+     */
     split("abc", "(?=a)", Array("abc"))
     split("abc", "(?=b)", Array("a", "bc"))
-    if (!executingInJVM) {
-      split("abc", "(?=a)|b", Array("", "a", "c"))
-      split("abc", "", Array("", "a", "b", "c"))
-      split("abc", "(?=a)|(?=b)", Array("", "a", "bc"))
+    if (!executingInJVMOnJDK7OrLower) {
+      split("abc", "(?=a)|b", Array("a", "c"))
+      split("abc", "", Array("a", "b", "c"))
+      split("abc", "(?=a)|(?=b)", Array("a", "bc"))
       split("abc", "(?=a)|(?=a)", Array("abc"))
-      split("abc", "(?=a|b)", Array("", "a", "bc"))
+      split("abc", "(?=a|b)", Array("a", "bc"))
     }
     split("abc", "(?=a|d)", Array("abc"))
     split("abc", "^d*", Array("abc"))
-    if (!executingInJVM) {
-      split("abc", "d*", Array("", "a", "b", "c"))
-      split("a", "", Array("", "a"))
+    if (!executingInJVMOnJDK7OrLower) {
+      split("abc", "d*", Array("a", "b", "c"))
+      split("a", "", Array("a"))
     }
     split("a", "^d*", Array("a"))
-    if (!executingInJVM)
-      split("a", "d*", Array("", "a"))
+    if (!executingInJVMOnJDK7OrLower)
+      split("a", "d*", Array("a"))
     split("a", "(?=a)", Array("a"))
     split("ab", "a", Array("", "b"))
 
@@ -100,13 +102,19 @@ class RegexPatternTest {
     splitWithLimit("", "\n", -2, Array(""))
     splitWithLimit("", "", 1, Array(""))
 
-    // Should remove leading empty match under some conditions - #1171
-    if (!executingInJVM)
-      splitWithLimit("abc", "", 2, Array("", "abc"))
+    /* Should remove leading empty match under some conditions - #1171, #2573
+     * The behavior changed in JDK 8 (at which point it became properly
+     * documented).
+     */
+    if (!executingInJVMOnJDK7OrLower) {
+      splitWithLimit("abc", "", 2, Array("a", "bc"))
+      splitWithLimit("abc", "", -1, Array("a", "b", "c", ""))
+    }
     splitWithLimit("abc", "(?=a)", 2, Array("abc"))
     splitWithLimit("ab", "a", 1, Array("ab"))
 
-    def splitWithLimit(input: String, regex: String, limit: Int, expected: Array[String]): Unit = {
+    def splitWithLimit(input: String, regex: String, limit: Int,
+        expected: Array[String]): Unit = {
       val result = Pattern.compile(regex).split(input, limit)
       assertArrayEquals(expected, result)
     }


### PR DESCRIPTION
This brings `String.split()` up to date with the behavior of JDK 8. If there is a zero-width match of the separator at the beginning of the string, it is ignored, i.e., the empty string that precedes it is not included in the result array.