### PR TITLE
Update the compiler back-end for specialized `synchronized`.

### DIFF
--- a/junit-runtime/src/main/scala/com/novocode/junit/RichLogger.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/RichLogger.scala
@@ -8,20 +8,20 @@ import Ansi._
 
 final class RichLogger private (loggers: Array[Logger], settings: RunSettings) {
 
-  private[this] val currentTestClassName = new mutable.Stack[String]()
+  private[this] var currentTestClassName: List[String] = Nil
 
   def this(loggers: Array[Logger], settings: RunSettings,
       testClassName: String) = {
     this(loggers, settings)
-    currentTestClassName.push(testClassName)
+    currentTestClassName ::= testClassName
   }
 
   def pushCurrentTestClassName(s: String): Unit =
-    currentTestClassName.push(s)
+    currentTestClassName ::= s
 
   def popCurrentTestClassName(): Unit = {
-    if (currentTestClassName.size > 1)
-      currentTestClassName.pop()
+    if (!currentTestClassName.isEmpty && !currentTestClassName.tail.isEmpty)
+      currentTestClassName = currentTestClassName.tail
   }
 
   def debug(s: String): Unit = {


### PR DESCRIPTION
Starting from 2.12.0-RC1, `AnyRef.synchronized` is specialized by erasure in the same way as `isInstanceOf` and `asInstanceOf`, so that it retains its type parameter until `cleanup` (and hence, until our back-end).

This commit updates the back-end to accommodate both the old generic `synchronized` (from `genPrimitiveOp`) and the new specialized one (from `genApplyTypeApply`).