### PR TITLE
DO NOT MERGE Towards 0.6.13.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
@@ -10,7 +10,7 @@ object ScalaJSVersions {
    */
 
   /** Scala.js version. */
-  val current: String = "0.6.12"
+  val current: String = "0.6.13-SNAPSHOT"
 
   /** true iff the Scala.js version is a snapshot version. */
   val currentIsSnapshot: Boolean = current endsWith "-SNAPSHOT"

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,7 +57,7 @@ object Build {
   val shouldPartest = settingKey[Boolean](
     "Whether we should partest the current scala version (and fail if we can't)")
 
-  val previousVersion = "0.6.11"
+  val previousVersion = "0.6.12"
   val previousSJSBinaryVersion =
     ScalaJSCrossVersion.binaryScalaJSVersion(previousVersion)
   val previousBinaryCrossVersion =


### PR DESCRIPTION
Note that there was no excluded binary incompatibility in 0.6.12 at all, hence there is no change to make in `project/BinaryIncompatibilities.scala`.