### PR TITLE
Fix #2579: Deprecate RhinoJSEnv, use NodeJSEnv by default instead

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -15,11 +15,9 @@
 
   <task id="main"><![CDATA[
     setJavaVersion $java
+    sbtretry ++$scala 'set scalaJSUseRhino in Global := true' helloworld/run &&
     sbtretry ++$scala helloworld/run &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
-        ++$scala helloworld/run &&
     sbtretry 'set scalaJSStage in Global := FullOptStage' \
-        'set scalaJSUseRhino in Global := false' \
         ++$scala helloworld/run \
         helloworld/clean &&
     sbtretry 'set inScope(ThisScope in helloworld)(jsEnv := JSDOMNodeJSEnv().value)' \
@@ -29,9 +27,9 @@
         ++$scala helloworld/run \
         helloworld/clean &&
     sbtretry 'set scalaJSOptimizerOptions in helloworld ~= (_.withDisableOptimizer(true))' \
+        'set scalaJSUseRhino in Global := true' \
         ++$scala helloworld/run &&
     sbtretry 'set scalaJSOptimizerOptions in helloworld ~= (_.withDisableOptimizer(true))' \
-        'set scalaJSUseRhino in Global := false' \
         ++$scala helloworld/run \
         helloworld/clean &&
     sbtretry 'set scalaJSSemantics in helloworld ~= (_.withAsInstanceOfs(org.scalajs.core.tools.sem.CheckedBehavior.Unchecked))' \
@@ -42,11 +40,10 @@
     sbtretry 'set inScope(ThisScope in helloworld)(jsEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala helloworld/run &&
-    sbtretry ++$scala testingExample/test:run testingExample/test &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
+    sbtretry 'set scalaJSUseRhino in Global := true' \
         ++$scala testingExample/test:run testingExample/test &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
-        'set scalaJSStage in Global := FullOptStage' \
+    sbtretry ++$scala testingExample/test:run testingExample/test &&
+    sbtretry 'set scalaJSStage in Global := FullOptStage' \
         ++$scala testingExample/test:run testingExample/test \
         testingExample/clean &&
     sbtretry 'set inScope(ThisScope in testingExample)(jsEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
@@ -62,10 +59,8 @@
         ++$scala testingExample/test:run testingExample/test &&
     sbtretry ++$scala testSuiteJVM/test testSuiteJVM/clean &&
     sbtretry ++$scala 'testSuite/test:runMain org.scalajs.testsuite.junit.JUnitBootstrapTest' testSuite/clean &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
-        ++$scala javalibExTestSuite/test &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
-        'set scalaJSStage in Global := FullOptStage' \
+    sbtretry ++$scala javalibExTestSuite/test &&
+    sbtretry 'set scalaJSStage in Global := FullOptStage' \
         ++$scala javalibExTestSuite/test &&
     sbtretry ++$scala testSuite/test:doc compiler/test reversi/fastOptJS reversi/fullOptJS &&
     sbtretry ++$scala compiler/compile:doc library/compile:doc javalibEx/compile:doc \
@@ -79,13 +74,11 @@
   <task id="test-suite-ecma-script5"><![CDATA[
     setJavaVersion $java
     sbtretry ++$scala jUnitTestOutputsJVM/test jUnitTestOutputsJS/test \
-        'set scalaJSUseRhino in Global := false' jUnitTestOutputsJS/test \
         'set scalaJSStage in Global := FullOptStage' jUnitTestOutputsJS/test &&
+    sbtretry ++$scala 'set scalaJSUseRhino in Global := true' jUnitTestOutputsJS/test &&
+    sbtretry ++$scala 'set scalaJSUseRhino in Global := true' $testSuite/test &&
     sbtretry ++$scala $testSuite/test &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
-        ++$scala $testSuite/test &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
-        'set scalaJSStage in Global := FullOptStage' \
+    sbtretry 'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set inScope(ThisScope in $testSuite)(jsEnv := JSDOMNodeJSEnv().value)' \
@@ -94,35 +87,32 @@
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
+    sbtretry ++$scala 'set scalaJSUseRhino in Global := true' noIrCheckTest/test &&
     sbtretry ++$scala noIrCheckTest/test &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
-        ++$scala noIrCheckTest/test &&
-    sbtretry 'set scalaJSUseRhino in Global := false' \
-        'set scalaJSStage in Global := FullOptStage' \
+    sbtretry 'set scalaJSStage in Global := FullOptStage' \
         ++$scala noIrCheckTest/test \
         noIrCheckTest/clean &&
     sbtretry 'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
+        'set scalaJSUseRhino in Global := true' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
-        'set scalaJSUseRhino in Global := false' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSSemantics in $testSuite ~= makeCompliant' \
+        'set scalaJSUseRhino in Global := true' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSSemantics in $testSuite ~= makeCompliant' \
-        'set scalaJSUseRhino in Global := false' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSSemantics in $testSuite ~= makeCompliant' \
-        'set scalaJSUseRhino in Global := false' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
+        'set scalaJSUseRhino in Global := true' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
-        'set scalaJSUseRhino in Global := false' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set inScope(ThisScope in $testSuite)(jsEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
@@ -134,21 +124,17 @@
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalacOptions in $testSuite += "-Xexperimental"' \
+        'set scalaJSUseRhino in Global := true' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalacOptions in $testSuite += "-Xexperimental"' \
-        'set scalaJSUseRhino in Global := false' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalacOptions in $testSuite += "-Xexperimental"' \
-        'set scalaJSUseRhino in Global := false' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test
   ]]></task>
 
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
-    sbtretry ++$scala jUnitTestOutputsJVM/test jUnitTestOutputsJS/test \
-        'set scalaJSUseRhino in Global := false' jUnitTestOutputsJS/test \
-        'set scalaJSStage in Global := FullOptStage' jUnitTestOutputsJS/test &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
         ++$scala $testSuite/test \
@@ -188,11 +174,9 @@
 
   <task id="bootstrap"><![CDATA[
     setJavaVersion $java
-    sbt 'set scalaJSUseRhino in Global := false' \
-        'set jsEnv in toolsJS := NodeJSEnv(args = Seq("--max_old_space_size=2048")).value.withSourceMap(false)' \
+    sbt 'set jsEnv in toolsJS := NodeJSEnv(args = Seq("--max_old_space_size=2048")).value.withSourceMap(false)' \
         ++$scala irJS/test toolsJS/test &&
-    sbt 'set scalaJSUseRhino in Global := false' \
-        'set jsEnv in toolsJS := NodeJSEnv(args = Seq("--max_old_space_size=2048")).value.withSourceMap(false)' \
+    sbt 'set jsEnv in toolsJS := NodeJSEnv(args = Seq("--max_old_space_size=2048")).value.withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala irJS/test toolsJS/test
   ]]></task>
@@ -257,14 +241,13 @@
     sbt noDOM/run noDOM/testHtmlFastOpt noDOM/testHtmlFullOpt \
         withDOM/run withDOM/testHtmlFastOpt withDOM/testHtmlFullOpt \
         multiTestJS/test:run multiTestJS/testHtmlFastOpt multiTestJS/testHtmlFullOpt \
-        test \
-        'set scalaJSUseRhino in Global := false' \
         jetty9/run test \
         jsDependenciesTest/packageJSDependencies \
         jsDependenciesTest/packageMinifiedJSDependencies \
         jsDependenciesTest/regressionTestForIssue2243 \
         jsNoDependenciesTest/regressionTestForIssue2243 \
-        multiTestJS/test:testScalaJSSourceMapAttribute
+        multiTestJS/test:testScalaJSSourceMapAttribute \
+        'set scalaJSUseRhino in Global := true' test
   ]]></task>
 
   <task id="partest-noopt"><![CDATA[

--- a/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
+++ b/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
@@ -3,7 +3,7 @@ package org.scalajs.jsenv.test
 import org.scalajs.core.tools.io.VirtualJSFile
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.logging._
-import org.scalajs.jsenv.rhino.RhinoJSEnv
+import org.scalajs.jsenv.nodejs.NodeJSEnv
 import org.scalajs.jsenv.{ComJSRunner, JSConsole, _}
 
 import scala.concurrent.Future
@@ -19,7 +19,7 @@ class RetryingComJSEnvTest extends JSEnvTest with ComTests {
   }
 
   protected def newJSEnv: RetryingComJSEnv =
-    new RetryingComJSEnv(new FailingEnv(new RhinoJSEnv), maxFails)
+    new RetryingComJSEnv(new FailingEnv(new NodeJSEnv), maxFails)
 
   private final class FailingEnv(baseEnv: ComJSEnv) extends ComJSEnv {
     def name: String = s"FailingJSEnv of ${baseEnv.name}"

--- a/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RhinoJSEnvTest.scala
+++ b/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RhinoJSEnvTest.scala
@@ -1,7 +1,10 @@
 package org.scalajs.jsenv.test
 
+import org.scalajs.core.tools.sem.Semantics
+
 import org.scalajs.jsenv.rhino._
 
 class RhinoJSEnvTest extends TimeoutComTests {
-  protected def newJSEnv: RhinoJSEnv = new RhinoJSEnv
+  protected def newJSEnv: RhinoJSEnv =
+    new RhinoJSEnv(Semantics.Defaults, withDOM = false, internal = ())
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
@@ -35,6 +35,11 @@ import scala.reflect.ClassTag
 
 import org.mozilla.javascript._
 
+/** A JS environment using a modified Rhino interpreter (deprecated).
+ *
+ *  As of Scala.js 0.6.13, `RhinoJSEnv` is deprecated. It will be removed in
+ *  Scala.js 1.0.0.
+ */
 final class RhinoJSEnv private (
     semantics: Semantics,
     withDOM: Boolean,
@@ -43,8 +48,18 @@ final class RhinoJSEnv private (
 
   import RhinoJSEnv._
 
+  @deprecated(
+      "The Rhino JS environment is being phased out. " +
+      "It will be removed in Scala.js 1.0.0. ",
+      "0.6.13")
   def this(semantics: Semantics = Semantics.Defaults, withDOM: Boolean = false) =
     this(semantics, withDOM, sourceMap = true)
+
+  /** A non-deprecated constructor for internal use. */
+  private[scalajs] def this(semantics: Semantics, withDOM: Boolean,
+      internal: Unit) = {
+    this(semantics, withDOM, sourceMap = true)
+  }
 
   def withSourceMap(sourceMap: Boolean): RhinoJSEnv =
     new RhinoJSEnv(semantics, withDOM, sourceMap)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -62,6 +62,18 @@ object ScalaJSPlugin extends AutoPlugin {
 
     // Factory methods for JSEnvs
 
+    /** A non-deprecated version of `RhinoJSEnv` for internal use. */
+    private[sbtplugin]
+    def RhinoJSEnvInternal(): Def.Initialize[Task[RhinoJSEnv]] = Def.task {
+      /* We take the semantics from the linker, since they depend on the stage.
+       * This way we are sure we agree on the semantics with the linker.
+       */
+      import ScalaJSPluginInternal.{scalaJSLinker, scalaJSRequestsDOM}
+      val semantics = scalaJSLinker.value.semantics
+      val withDOM = scalaJSRequestsDOM.value
+      new RhinoJSEnv(semantics, withDOM, internal = ())
+    }
+
     /** Creates a [[sbt.Def.Initialize Def.Initialize]] for a [[RhinoJSEnv]].
      *
      *  Use this to explicitly specify in your build that you would like to run
@@ -80,15 +92,11 @@ object ScalaJSPlugin extends AutoPlugin {
      *  case) or scope it manually, using
      *  [[sbt.ProjectExtra.inScope[* Project.inScope]].
      */
-    def RhinoJSEnv(): Def.Initialize[Task[RhinoJSEnv]] = Def.task {
-      /* We take the semantics from the linker, since they depend on the stage.
-       * This way we are sure we agree on the semantics with the linker.
-       */
-      import ScalaJSPluginInternal.{scalaJSLinker, scalaJSRequestsDOM}
-      val semantics = scalaJSLinker.value.semantics
-      val withDOM = scalaJSRequestsDOM.value
-      new RhinoJSEnv(semantics, withDOM)
-    }
+    @deprecated(
+        "The Rhino JS environment is being phased out. " +
+        "It will be removed in Scala.js 1.0.0. ",
+        "0.6.13")
+    def RhinoJSEnv(): Def.Initialize[Task[RhinoJSEnv]] = RhinoJSEnvInternal()
 
     /**
      *  Creates a [[sbt.Def.Initialize Def.Initialize]] for a NodeJSEnv. Use

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -562,7 +562,7 @@ object ScalaJSPluginInternal {
 
       resolvedJSEnv := jsEnv.?.value.getOrElse {
         if (scalaJSUseRhinoInternal.value) {
-          RhinoJSEnv().value
+          RhinoJSEnvInternal().value
         } else if (scalaJSRequestsDOM.value) {
           PhantomJSEnv().value
         } else {

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -21,9 +21,7 @@ import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.backend.{LinkerBackend, OutputMode}
 
 import org.scalajs.jsenv._
-import org.scalajs.jsenv.rhino.RhinoJSEnv
-import org.scalajs.jsenv.nodejs.NodeJSEnv
-import org.scalajs.jsenv.phantomjs.{PhantomJSEnv, PhantomJettyClassLoader}
+import org.scalajs.jsenv.phantomjs.PhantomJettyClassLoader
 
 import org.scalajs.core.ir
 import org.scalajs.core.ir.Utils.escapeJS
@@ -563,17 +561,12 @@ object ScalaJSPluginInternal {
       },
 
       resolvedJSEnv := jsEnv.?.value.getOrElse {
-        if (scalaJSUseRhino.value) {
-          /* We take the semantics from the linker, since they depend on the
-           * stage. This way we are sure we agree on the semantics with the
-           * linker.
-           */
-          val semantics = scalaJSLinker.value.semantics
-          new RhinoJSEnv(semantics, withDOM = scalaJSRequestsDOM.value)
+        if (scalaJSUseRhinoInternal.value) {
+          RhinoJSEnv().value
         } else if (scalaJSRequestsDOM.value) {
-          new PhantomJSEnv(jettyClassLoader = scalaJSPhantomJSClassLoader.value)
+          PhantomJSEnv().value
         } else {
-          new NodeJSEnv
+          NodeJSEnv().value
         }
       },
 


### PR DESCRIPTION
~~Second commit to come to actually deprecate `RhinoJSEnv`. CI for now.~~ Done