### PR TITLE
Fix #2587: Fix integer multiplication truncation error.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -1405,4 +1405,11 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.toString, c)
     assertEquals(result.scale(), cScale)
   }
+
+  // https://github.com/scala-js/scala-js/issues/2587
+  @Test def testMultiplicationOverflow(): Unit = {
+    val x = new BigDecimal(Int.MinValue)
+    val y = new BigDecimal("9223372036854775808")
+    assertEquals(y, x.multiply(x.add(x)))
+  }
 }


### PR DESCRIPTION
The Int.MinValue \* Int.MinValue case was a situation where both values
fit in 32-bits, but the result of the multiplication cannot fit into
64-bits.

Fixes #2587
