### PR TITLE
Widen Settings[_] to SettingsDefinition in CrossProject.[js, jvm]Settings()

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
@@ -225,11 +225,11 @@ final class CrossProject private (
     copy(js = transformer(js))
 
   /** Add settings specific to the underlying JVM project */
-  def jvmSettings(ss: Def.Setting[_]*): CrossProject =
+  def jvmSettings(ss: Def.SettingsDefinition*): CrossProject =
     jvmConfigure(_.settings(ss: _*))
 
   /** Add settings specific to the underlying JS project */
-  def jsSettings(ss: Def.Setting[_]*): CrossProject =
+  def jsSettings(ss: Def.SettingsDefinition*): CrossProject =
     jsConfigure(_.settings(ss: _*))
 
   // Concrete alteration members
@@ -278,7 +278,7 @@ final class CrossProject private (
   def settingSets(select: AddSettings*): CrossProject =
     copy(jvm.settingSets(select: _*), js.settingSets(select: _*))
 
-  def settings(ss: Def.Setting[_]*): CrossProject =
+  def settings(ss: Def.SettingsDefinition*): CrossProject =
     copy(jvm.settings(ss: _*), js.settings(ss: _*))
 
   override def toString(): String = s"CrossProject(jvm = $jvm, js = $js)"


### PR DESCRIPTION
reference: https://github.com/sbt/sbt/blob/1.0.x/main/src/main/scala/sbt/Project.scala#L194

this allows to write

```scala
val defaultSettings = Seq(scalaVersion := "2.11.8")

lazy val app = crossProject.settings(defaultSettings)

// or
lazy val app = crossProject.jsSettings(defaultSettings)

// or
lazy val app = crossProject.jvmSettings(defaultSettings)
```

it's backward compatible with

```scala
lazy val app = crossProject.settings(defaultSettings: _*)

// or
lazy val app = crossProject.jsSettings(defaultSettings: _*)

// or
lazy val app = crossProject.jvmSettings(defaultSettings: _*)
```