### PR TITLE
Fix #2592: Do shrink the result of Pattern.split() to an empty array.

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -42,46 +42,48 @@ final class Pattern private (jsRegExp: js.RegExp, _pattern: String, _flags: Int)
     split(input, 0)
 
   def split(input: CharSequence, limit: Int): Array[String] = {
-    val lim = if (limit > 0) limit else Int.MaxValue
-
     val inputStr = input.toString
-    val matcher = this.matcher(inputStr)
 
-    // Actually split original string
-    val builder = Array.newBuilder[String]
-    var prevEnd = 0
-    var size = 0
-    while ((size < lim-1) && matcher.find()) {
-      if (matcher.end == 0) {
-        /* If there is a zero-width match at the beginning of the string,
-         * ignore it, i.e., omit the resulting empty string at the beginning of
-         * the array.
-         */
-      } else {
-        builder += inputStr.substring(prevEnd, matcher.start)
-        size += 1
-      }
-      prevEnd = matcher.end
-    }
-    builder += inputStr.substring(prevEnd)
-    val result = builder.result()
-
-    /* With `limit == 0`, remove trailing empty strings (but do not reduce
-     * the array to be zero length).
-     */
-    if (limit != 0) {
-      result
+    // If the input string is empty, always return Array("") - #987, #2592
+    if (inputStr == "") {
+      Array("")
     } else {
-      var actualLength = result.length
-      while (actualLength > 1 && result(actualLength - 1) == "")
-        actualLength -= 1
+      // Actually split original string
+      val lim = if (limit > 0) limit else Int.MaxValue
+      val matcher = this.matcher(inputStr)
+      val builder = Array.newBuilder[String]
+      var prevEnd = 0
+      var size = 0
+      while ((size < lim-1) && matcher.find()) {
+        if (matcher.end == 0) {
+          /* If there is a zero-width match at the beginning of the string,
+           * ignore it, i.e., omit the resulting empty string at the beginning
+           * of the array.
+           */
+        } else {
+          builder += inputStr.substring(prevEnd, matcher.start)
+          size += 1
+        }
+        prevEnd = matcher.end
+      }
+      builder += inputStr.substring(prevEnd)
+      val result = builder.result()
 
-      if (actualLength == result.length) {
+      // With `limit == 0`, remove trailing empty strings.
+      if (limit != 0) {
         result
       } else {
-        val actualResult = new Array[String](actualLength)
-        System.arraycopy(result, 0, actualResult, 0, actualLength)
-        actualResult
+        var actualLength = result.length
+        while (actualLength != 0 && result(actualLength - 1) == "")
+          actualLength -= 1
+
+        if (actualLength == result.length) {
+          result
+        } else {
+          val actualResult = new Array[String](actualLength)
+          System.arraycopy(result, 0, actualResult, 0, actualLength)
+          actualResult
+        }
       }
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
@@ -52,9 +52,16 @@ class RegexPatternTest {
 
     // Splitting the empty string must return 1 element - #987
     split("", "a", Array(""))
+    split("", "a?", Array(""))
     split("", "\\*", Array(""))
     split("", "\n", Array(""))
     split("", "", Array(""))
+
+    /* Unless splitting the empty string, all trailing empty strings are
+     * removed, which can reduce it to an empty array. #2592
+     */
+    split("a", "a", Array())
+    split("a", "a?", Array())
 
     /* Should remove leading empty match under some conditions - #1171, #2573
      * The behavior changed in JDK 8 (at which point it became properly
@@ -98,9 +105,18 @@ class RegexPatternTest {
 
     // Splitting the empty string must return 1 element - #987
     splitWithLimit("", "a", 0, Array(""))
+    splitWithLimit("", "a?", 0, Array(""))
     splitWithLimit("", "\\*", 5, Array(""))
     splitWithLimit("", "\n", -2, Array(""))
     splitWithLimit("", "", 1, Array(""))
+
+    /* Unless splitting the empty string, if `limit` is 0, all trailing empty
+     * strings are removed, which can reduce it to an empty array. #2592
+     */
+    splitWithLimit("a", "a", 0, Array())
+    splitWithLimit("a", "a?", 0, Array())
+    splitWithLimit("a", "a", -1, Array("", ""))
+    splitWithLimit("a", "a?", -1, Array("", "", ""))
 
     /* Should remove leading empty match under some conditions - #1171, #2573
      * The behavior changed in JDK 8 (at which point it became properly


### PR DESCRIPTION
But not if the input string is the empty string itself.