### PR TITLE
Properly incrementalize the Emitter using knowledge queries.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
@@ -64,9 +64,8 @@ final class RhinoJSEnv private (
   def withSourceMap(sourceMap: Boolean): RhinoJSEnv =
     new RhinoJSEnv(semantics, withDOM, sourceMap)
 
-  /* Although RhinoJSEnv does not use the Emitter directly, it uses
-   * ScalaJSCoreLib which uses the same underlying components
-   * (ScalaJSClassEmitter, JSDesugaring and CoreJSLibs).
+  /* Ask the Emitter, which we'll use in ScalaJSCoreLib to generate JS code,
+   * what are its requirements.
    */
   val symbolRequirements = Emitter.symbolRequirements(semantics, ESLevel.ES5)
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,51 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private[emitter], not an issue
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.this"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring.genRawJSClassConstructor"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring.desugarTree"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring.desugarToFunction"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring.desugarToFunction"),
+
+      // private[emitter], not an issue
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.this"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genDefaultMethods"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.isInterface"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genConstructor"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genDefaultMethod"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genClass"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genConstructorExportDef"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genTypeData"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genProperty"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genES6Class"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.linkedClassByName"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genMethod"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genClassDef"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genClassExports"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genExportedMembers"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genStaticMembers")
   )
 
   val JSEnvs = Seq(

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala
@@ -183,6 +183,7 @@ trait VirtualJarFile extends VirtualBinaryFile {
     findEntries(_.endsWith(".sjsir")) { (entry, stream) =>
       val file = new JarEntryIRFile(path, entry.getName)
       file.content = IO.readInputStreamToByteArray(stream)
+      file.version = version
       file
     }
   }
@@ -191,6 +192,7 @@ trait VirtualJarFile extends VirtualBinaryFile {
     findEntries(_.endsWith(".js")) { (entry, stream) =>
       val file = new JarEntryJSFile(path, entry.getName)
       file.content = IO.readInputStreamToString(stream)
+      file.version = version
       file
     }
   }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/CoreJSLibs.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/CoreJSLibs.scala
@@ -20,8 +20,10 @@ import org.scalajs.core.tools.linker.backend.OutputMode
 import scala.collection.immutable.Seq
 import scala.collection.mutable
 
-// The only reason this is not private[backend] is that Rhino needs it
-private[scalajs] object CoreJSLibs {
+/* The only reason this is not private[emitter] is that Closure needs it.
+ * TODO We should try and get rid of this coupling.
+ */
+private[backend] object CoreJSLibs {
 
   private type Config = (Semantics, OutputMode)
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -33,7 +33,11 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
   def this(semantics: Semantics, outputMode: OutputMode) =
     this(semantics, outputMode, InternalOptions())
 
-  private var classEmitter: ScalaJSClassEmitter = _
+  private val knowledgeGuardian = new KnowledgeGuardian
+
+  private val classEmitter =
+    new ScalaJSClassEmitter(semantics, outputMode, internalOptions)
+
   private val classCaches = mutable.Map.empty[List[String], ClassCache]
 
   private[this] var statsClassesReused: Int = 0
@@ -73,15 +77,13 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
   }
 
   def emit(unit: LinkingUnit, builder: JSTreeBuilder, logger: Logger): Unit = {
-    classEmitter = new ScalaJSClassEmitter(outputMode, internalOptions, unit)
-    startRun()
+    startRun(unit)
     try {
       val orderedClasses = unit.classDefs.sortWith(compareClasses)
       for (classInfo <- orderedClasses)
         emitLinkedClass(classInfo, builder)
     } finally {
       endRun(logger)
-      classEmitter = null
     }
   }
 
@@ -103,11 +105,16 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
     else lhs.encodedName.compareTo(rhs.encodedName) < 0
   }
 
-  private def startRun(): Unit = {
+  private def startRun(unit: LinkingUnit): Unit = {
     statsClassesReused = 0
     statsClassesInvalidated = 0
     statsMethodsReused = 0
     statsMethodsInvalidated = 0
+
+    val invalidateAll = knowledgeGuardian.update(unit)
+    if (invalidateAll)
+      classCaches.clear()
+
     classCaches.valuesIterator.foreach(_.startRun())
   }
 
@@ -136,24 +143,24 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
       val methodCache = classCache.getStaticCache(m.info.encodedName)
 
       addTree(methodCache.getOrElseUpdate(m.version,
-        classEmitter.genMethod(className, m.tree)))
+          classEmitter.genMethod(className, m.tree)(methodCache)))
     }
 
     if (linkedClass.hasInstances && kind.isAnyScalaJSDefinedClass) {
       val ctor = classTreeCache.constructor.getOrElseUpdate(
-          classEmitter.genConstructor(linkedClass))
+          classEmitter.genConstructor(linkedClass)(classCache))
 
       // Normal methods
       val memberMethods = for (m <- linkedClass.memberMethods) yield {
         val methodCache = classCache.getMethodCache(m.info.encodedName)
 
         methodCache.getOrElseUpdate(m.version,
-            classEmitter.genMethod(className, m.tree))
+            classEmitter.genMethod(className, m.tree)(methodCache))
       }
 
       // Exported Members
       val exportedMembers = classTreeCache.exportedMembers.getOrElseUpdate(
-          classEmitter.genExportedMembers(linkedClass))
+          classEmitter.genExportedMembers(linkedClass)(classCache))
 
       outputMode match {
         case OutputMode.ECMAScript51Global | OutputMode.ECMAScript51Isolated =>
@@ -169,14 +176,14 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
             case js.Skip()         => Nil
             case oneMember         => List(oneMember)
           }
-          addTree(classEmitter.genES6Class(linkedClass, allMembers))
+          addTree(classEmitter.genES6Class(linkedClass, allMembers)(classCache))
       }
     } else if (kind == ClassKind.Interface) {
       // Default methods
       for (m <- linkedClass.memberMethods) yield {
         val methodCache = classCache.getMethodCache(m.info.encodedName)
         addTree(methodCache.getOrElseUpdate(m.version,
-            classEmitter.genDefaultMethod(className, m.tree)))
+            classEmitter.genDefaultMethod(className, m.tree)(methodCache)))
       }
     }
 
@@ -189,7 +196,7 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
 
     if (linkedClass.hasRuntimeTypeInfo) {
       addTree(classTreeCache.typeData.getOrElseUpdate(
-          classEmitter.genTypeData(linkedClass)))
+          classEmitter.genTypeData(linkedClass)(classCache)))
     }
 
     if (linkedClass.hasInstances && kind.isClass && linkedClass.hasRuntimeTypeInfo)
@@ -201,7 +208,7 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
           classEmitter.genModuleAccessor(linkedClass)))
 
     addTree(classTreeCache.classExports.getOrElseUpdate(
-        classEmitter.genClassExports(linkedClass)))
+        classEmitter.genClassExports(linkedClass)(classCache)))
   }
 
   // Helpers
@@ -226,15 +233,44 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
       emitNextLine(0)
   }
 
+  // Private API for Rhino
+
+  private[scalajs] object rhinoAPI { // scalastyle:ignore
+    /** A GlobalKnowledge that never tracks dependencies. This can be used in
+     *  cases where we do not use any cache, which is what `genClassDef()` in
+     *  this class does.
+     */
+    private val globalKnowledge: GlobalKnowledge =
+      new knowledgeGuardian.KnowledgeAccessor {}
+
+    def initialize(linkingUnit: LinkingUnit): Unit =
+      startRun(linkingUnit)
+
+    def getHeaderFile(): org.scalajs.core.tools.io.VirtualJSFile =
+      CoreJSLibs.lib(semantics, outputMode)
+
+    def genClassDef(linkedClass: LinkedClass): js.Tree =
+      classEmitter.genClassDef(linkedClass)(globalKnowledge)
+  }
+
   // Caching
 
-  private final class ClassCache {
+  private final class ClassCache extends knowledgeGuardian.KnowledgeAccessor {
     private[this] var _cache: DesugaredClassCache = null
     private[this] var _lastVersion: Option[String] = None
     private[this] var _cacheUsed = false
 
     private[this] val _staticCaches = mutable.Map.empty[String, MethodCache]
     private[this] val _methodCaches = mutable.Map.empty[String, MethodCache]
+
+    override def invalidate(): Unit = {
+      /* Do not invalidate contained methods, as they have their own
+       * invalidation logic.
+       */
+      super.invalidate()
+      _cache = null
+      _lastVersion = None
+    }
 
     def startRun(): Unit = {
       _cacheUsed = false
@@ -244,6 +280,7 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
 
     def getCache(version: Option[String]): DesugaredClassCache = {
       if (_cache == null || _lastVersion.isEmpty || _lastVersion != version) {
+        invalidate()
         statsClassesInvalidated += 1
         _lastVersion = version
         _cache = new DesugaredClassCache
@@ -265,21 +302,28 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
       _methodCaches.retain((_, c) => c.cleanAfterRun())
 
       if (!_cacheUsed)
-        _cache = null
+        invalidate()
 
       _staticCaches.nonEmpty || _methodCaches.nonEmpty || _cacheUsed
     }
   }
 
-  private final class MethodCache {
+  private final class MethodCache extends knowledgeGuardian.KnowledgeAccessor {
     private[this] var _tree: js.Tree = null
     private[this] var _lastVersion: Option[String] = None
     private[this] var _cacheUsed = false
+
+    override def invalidate(): Unit = {
+      super.invalidate()
+      _tree = null
+      _lastVersion = None
+    }
 
     def startRun(): Unit = _cacheUsed = false
 
     def getOrElseUpdate(version: Option[String], v: => js.Tree): js.Tree = {
       if (_tree == null || _lastVersion.isEmpty || _lastVersion != version) {
+        invalidate()
         statsMethodsInvalidated += 1
         _tree = v
         _lastVersion = version
@@ -290,7 +334,12 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
       _tree
     }
 
-    def cleanAfterRun(): Boolean = _cacheUsed
+    def cleanAfterRun(): Boolean = {
+      if (!_cacheUsed)
+        invalidate()
+
+      _cacheUsed
+    }
   }
 }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/GlobalKnowledge.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/GlobalKnowledge.scala
@@ -1,0 +1,47 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package org.scalajs.core.tools.linker.backend.emitter
+
+import org.scalajs.core.ir.Trees.FieldDef
+
+private[emitter] trait GlobalKnowledge {
+  /** Tests whether the parent class data is accessed in the linking unit. */
+  def isParentDataAccessed: Boolean
+
+  // TODO Get rid of this when we break backward binary compatibility
+  /** Whether the standard library we're using has the new `RuntimeLong`
+   *  implementation, with `lo` and `hi`.
+   */
+  def hasNewRuntimeLong: Boolean
+
+  /** Tests whether the specified class name refers to an `Interface`. */
+  def isInterface(className: String): Boolean
+
+  /** `None` for non-native JS classes; `Some(jsName)` for native JS classes.
+   *
+   *  It is invalid to call this method with a class that is not a JS class
+   *  (native or not).
+   */
+  def getJSClassJSName(className: String): Option[String]
+
+  /** The `encodedName` of the superclass of a (non-native) JS class.
+   *
+   *  It is invalid to call this method with a class that is not a non-native
+   *  JS class.
+   */
+  def getSuperClassOfJSClass(className: String): String
+
+  /** The `FieldDef`s of a non-native JS class.
+   *
+   *  It is invalid to call this method with a class that is not a non-native
+   *  JS class.
+   */
+  def getJSClassFieldDefs(className: String): List[FieldDef]
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/KnowledgeGuardian.scala
@@ -1,0 +1,250 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package org.scalajs.core.tools.linker.backend.emitter
+
+import scala.collection.mutable
+
+import org.scalajs.core.ir.ClassKind
+import org.scalajs.core.ir.Trees.FieldDef
+
+import org.scalajs.core.tools.linker._
+
+private[emitter] final class KnowledgeGuardian {
+  import KnowledgeGuardian._
+
+  private var firstRun: Boolean = true
+
+  private var hasNewRuntimeLong: Boolean = _
+  private var isParentDataAccessed: Boolean = _
+
+  private val classes = mutable.Map.empty[String, Class]
+
+  private def askHasNewRuntimeLong(invalidatable: Invalidatable): Boolean =
+    hasNewRuntimeLong
+
+  private def askIsParentDataAccessed(invalidatable: Invalidatable): Boolean =
+    isParentDataAccessed
+
+  /** Returns `true` if *all* caches should be invalidated.
+   *
+   *  For global properties that are rarely changed and heavily used (such as
+   *  isParentDataAccessed), we do not want to pay the price of the
+   *  dependency graph, in terms of memory consumption and time spent
+   *  maintaining it. It is a better trade-off to invalidate everything in
+   *  the rare events where they do change.
+   */
+  def update(linkingUnit: LinkingUnit): Boolean = {
+    val newIsParentDataAccessed = linkingUnit.globalInfo.isParentDataAccessed
+    var newHasNewRuntimeLong: Boolean = false
+
+    // Update classes
+    for (linkedClass <- linkingUnit.classDefs) {
+      classes.get(linkedClass.encodedName).fold[Unit] {
+        // new class
+        classes.put(linkedClass.encodedName, new Class(linkedClass))
+      } { existingCls =>
+        existingCls.update(linkedClass)
+      }
+
+      if (linkedClass.encodedName == LongImpl.RuntimeLongClass) {
+        newHasNewRuntimeLong = linkedClass.memberMethods.exists { linkedMethod =>
+          linkedMethod.tree.name.name == LongImpl.initFromParts
+        }
+      }
+    }
+
+    // Garbage collection
+    classes.retain((_, cls) => cls.testAndResetIsAlive())
+
+    val invalidateAll = !firstRun && {
+      newIsParentDataAccessed != isParentDataAccessed ||
+      newHasNewRuntimeLong != hasNewRuntimeLong
+    }
+    firstRun = false
+
+    isParentDataAccessed = newIsParentDataAccessed
+    hasNewRuntimeLong = newHasNewRuntimeLong
+
+    if (invalidateAll)
+      classes.valuesIterator.foreach(_.unregisterAll())
+    invalidateAll
+  }
+
+  abstract class KnowledgeAccessor extends GlobalKnowledge with Invalidatable {
+    /* In theory, a KnowledgeAccessor should *contain* a GlobalKnowledge, not
+     * *be* a GlobalKnowledge. We organize it that way to reduce memory
+     * footprint and pointer indirections.
+     */
+
+    def hasNewRuntimeLong: Boolean =
+      askHasNewRuntimeLong(this)
+
+    def isParentDataAccessed: Boolean =
+      askIsParentDataAccessed(this)
+
+    def isInterface(className: String): Boolean =
+      classes(className).askIsInterface(this)
+
+    def getJSClassJSName(className: String): Option[String] =
+      classes(className).askJSClassJSName(this)
+
+    def getSuperClassOfJSClass(className: String): String =
+      classes(className).askJSSuperClass(this)
+
+    def getJSClassFieldDefs(className: String): List[FieldDef] =
+      classes(className).askJSClassFieldDefs(this)
+  }
+}
+
+private[emitter] object KnowledgeGuardian {
+  private[KnowledgeGuardian] trait Unregisterable {
+    def unregister(invalidatable: Invalidatable): Unit
+  }
+
+  trait Invalidatable {
+    private val _registeredTo = mutable.Set.empty[Unregisterable]
+
+    private[KnowledgeGuardian] def registeredTo(
+        unregisterable: Unregisterable): Unit = {
+      _registeredTo += unregisterable
+    }
+
+    /** To be overridden to perform subclass-specific invalidation.
+     *
+     *  All overrides should call the default implementation with `super` so
+     *  that this `Invalidatable` is unregistered from the dependency graph.
+     */
+    def invalidate(): Unit = {
+      _registeredTo.foreach(_.unregister(this))
+      _registeredTo.clear()
+    }
+  }
+
+  private class Class(initClass: LinkedClass) extends Unregisterable {
+    private var isAlive: Boolean = true
+
+    private var isInterface = computeIsInterface(initClass)
+    private var jsName = computeJSName(initClass)
+    private var jsSuperClass = computeJSSuperClass(initClass)
+    private var jsClassFieldDefs = computeJSClassFieldDefs(initClass)
+
+    private val isInterfaceAskers = mutable.Set.empty[Invalidatable]
+    private val jsNameAskers = mutable.Set.empty[Invalidatable]
+    private val jsSuperClassAskers = mutable.Set.empty[Invalidatable]
+    private val jsClassFieldDefsAskers = mutable.Set.empty[Invalidatable]
+
+    def update(linkedClass: LinkedClass): Unit = {
+      isAlive = true
+
+      val newIsInterface = computeIsInterface(linkedClass)
+      if (newIsInterface != isInterface) {
+        isInterface = newIsInterface
+        invalidateAskers(isInterfaceAskers)
+      }
+
+      val newJSName = computeJSName(linkedClass)
+      if (newJSName != jsName) {
+        jsName = newJSName
+        invalidateAskers(jsNameAskers)
+      }
+
+      val newJSSuperClass = computeJSSuperClass(linkedClass)
+      if (newJSSuperClass != jsSuperClass) {
+        jsSuperClass = newJSSuperClass
+        invalidateAskers(jsSuperClassAskers)
+      }
+
+      val newJSClassFieldDefs = computeJSClassFieldDefs(linkedClass)
+      if (newJSClassFieldDefs != jsClassFieldDefs) {
+        jsClassFieldDefs = newJSClassFieldDefs
+        invalidateAskers(jsClassFieldDefsAskers)
+      }
+    }
+
+    private def computeIsInterface(linkedClass: LinkedClass): Boolean =
+      linkedClass.kind == ClassKind.Interface
+
+    private def computeJSName(linkedClass: LinkedClass): Option[String] =
+      linkedClass.jsName
+
+    private def computeJSSuperClass(linkedClass: LinkedClass): String = {
+      linkedClass.kind match {
+        case ClassKind.JSClass | ClassKind.JSModuleClass =>
+          linkedClass.superClass.get.name
+        case _ =>
+          null
+      }
+    }
+
+    private def computeJSClassFieldDefs(
+        linkedClass: LinkedClass): List[FieldDef] = {
+      if (linkedClass.kind == ClassKind.JSClass)
+        linkedClass.fields
+      else
+        Nil
+    }
+
+    private def invalidateAskers(askers: mutable.Set[Invalidatable]): Unit = {
+      /* Calling `invalidateAndUnregisterFromAll()` will cause the
+       * `Invalidatable` to call `unregister()` in this class, which will
+       * mutate the `askers` set. Therefore, we cannot directly iterate over
+       * `askers`, and need to take a snapshot instead.
+       */
+      val snapshot = askers.toSeq
+      askers.clear()
+      snapshot.foreach(_.invalidate())
+    }
+
+    def testAndResetIsAlive(): Boolean = {
+      val result = isAlive
+      isAlive = false
+      result
+    }
+
+    def askIsInterface(invalidatable: Invalidatable): Boolean = {
+      invalidatable.registeredTo(this)
+      isInterfaceAskers += invalidatable
+      isInterface
+    }
+
+    def askJSClassJSName(invalidatable: Invalidatable): Option[String] = {
+      invalidatable.registeredTo(this)
+      jsNameAskers += invalidatable
+      jsName
+    }
+
+    def askJSSuperClass(invalidatable: Invalidatable): String = {
+      invalidatable.registeredTo(this)
+      jsSuperClassAskers += invalidatable
+      jsSuperClass
+    }
+
+    def askJSClassFieldDefs(invalidatable: Invalidatable): List[FieldDef] = {
+      invalidatable.registeredTo(this)
+      jsClassFieldDefsAskers += invalidatable
+      jsClassFieldDefs
+    }
+
+    def unregister(invalidatable: Invalidatable): Unit = {
+      isInterfaceAskers -= invalidatable
+      jsNameAskers -= invalidatable
+      jsSuperClassAskers -= invalidatable
+      jsClassFieldDefsAskers -= invalidatable
+    }
+
+    /** Call this when we invalidate all caches. */
+    def unregisterAll(): Unit = {
+      isInterfaceAskers.clear()
+      jsNameAskers.clear()
+      jsSuperClassAskers.clear()
+      jsClassFieldDefsAskers.clear()
+    }
+  }
+}


### PR DESCRIPTION
When a paper's terminology makes its way into a production codebase ...

The `ScalaJSClassEmitter` and `JSDesugaring` do not have access to the `linkingUnit` anymore. All their requests for global knowledge go through a `GlobalKnowledge` interface, which contains the knowledge queries. The `Emitter` contains a subsystem `KnowledgeGuardian`, which, as its name implies, is responsible for guarding global knowledge. It tracks the dependencies between arbitrary `Invalidatable`s and the knowledge queries they perform. The `Invalidatable`s are `ClassCache` and `MethodCache`, which also implement `GlobalKnowledge` by delegating queries to the `KnowledgeGuardian`.

This fixes some corner case bugs in the incremental behavior of the `Emitter`, the most significant one being changes in the `@JSName` of a native JS class or object. Previously, users of `LoadJSConstructor` (resp. `LoadJSModule`) would not be properly re-desugared when the `@JSName` of a target class (resp. module) was changed.

The new architecture can now easily be extended with new kinds of global knowledge without fear of breaking incrementality.