### PR TITLE
Fix #2129: Only request source jars for scalalib

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -838,6 +838,9 @@ object Build {
           // Tell the plugin to hack-fix bad classOf trees
           scalacOptions += "-P:scalajs:fixClassOf",
 
+          libraryDependencies +=
+            "org.scala-lang" % "scala-library" % scalaVersion.value classifier "sources",
+
           artifactPath in fetchScalaSource :=
             target.value / "scalaSources" / scalaVersion.value,
 
@@ -847,11 +850,11 @@ object Build {
             val ver = scalaVersion.value
             val trgDir = (artifactPath in fetchScalaSource).value
 
-            val report = updateClassifiers.value
+            val report = update.value
             val scalaLibSourcesJar = report.select(
                 configuration = Set("compile"),
                 module = moduleFilter(name = "scala-library"),
-                artifact = artifactFilter(`type` = "src")).headOption.getOrElse {
+                artifact = artifactFilter(classifier = "sources")).headOption.getOrElse {
               sys.error(s"Could not fetch scala-library sources for version $ver")
             }
 


### PR DESCRIPTION
updateClassifiers requests source and javadoc jars for all
dependencies. This fails for the Scala.js compiler.

Instead, we explicitly specify the scala-library sources as a dependency
and read them from the normal update.