### PR TITLE
Fix #2625: Fix clash of outer pointers in 2.12.0-RC2 onwards.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -86,6 +86,12 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
         refClass.values ++ volatileRefClass.values)
   }
 
+  /** See comment in `encodeFieldSym()`. */
+  private lazy val shouldMangleOuterPointerName = {
+    val v = scala.util.Properties.versionNumberString
+    !(v.startsWith("2.10.") || v.startsWith("2.11.") || v == "2.12.0-RC1")
+  }
+
   def encodeFieldSym(sym: Symbol)(implicit pos: Position): js.Ident = {
     require(sym.owner.isClass && sym.isTerm && !sym.isMethod && !sym.isModule,
         "encodeFieldSym called with non-field symbol: " + sym)
@@ -99,12 +105,29 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
      * because they are emitted as private by our .scala source files, but
      * they are considered public at use site since their symbols come from
      * Java-emitted .class files.
+     *
+     * Starting with 2.12.0-RC2, we also special case outer fields. This
+     * essentially fixes #2382, which is caused by a class having various $outer
+     * pointers in its hierarchy that points to different outer instances.
+     * Without this fix, they all collapse to the same field in the IR. We
+     * cannot fix this for all Scala versions at the moment, because that would
+     * break backwards binary compatibility. We *do* fix it for 2.12.0-RC2
+     * onwards because that also fixes #2625, which surfaced in 2.12 and is
+     * therefore a regression. We can do this because the 2.12 ecosystem is
+     * not binary compatible anyway (because of Scala) so we can break it on
+     * our side at the same time.
      */
-    val idSuffix =
-      if (sym.isPrivate || allRefClasses.contains(sym.owner))
+    val idSuffix: String = {
+      val usePerClassSuffix = {
+        sym.isPrivate ||
+        allRefClasses.contains(sym.owner) ||
+        (shouldMangleOuterPointerName && sym.isOuterField)
+      }
+      if (usePerClassSuffix)
         sym.owner.ancestors.count(!_.isTraitOrInterface).toString
       else
         "f"
+    }
 
     val encodedName = name + "$" + idSuffix
     js.Ident(mangleJSName(encodedName), Some(sym.unexpandedName.decoded))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1409,6 +1409,31 @@ object Build {
           IO.write(outFile,
               replaced.replace("@Test def workTest(): Unit = sys.error(\"stubs\")", unitTests))
           Seq(outFile)
+        },
+
+        // Exclude tests based on version-dependent bugs
+        sources in Test := {
+          val sourceFiles = (sources in Test).value
+          val v = scalaVersion.value
+
+          val hasBug2625 = v == "2.12.0-RC1"
+          val sourceFiles1 = {
+            if (hasBug2625)
+              sourceFiles.filterNot(_.getName == "PatMatOuterPointerCheckTest.scala")
+            else
+              sourceFiles
+          }
+
+          val hasBug2382 =
+            v.startsWith("2.10.") || v.startsWith("2.11.") || v == "2.12.0-RC1"
+          val sourceFiles2 = {
+            if (hasBug2382)
+              sourceFiles1.filterNot(_.getName == "OuterClassTest.scala")
+            else
+              sourceFiles1
+          }
+
+          sourceFiles2
         }
       )
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/OuterClassTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/OuterClassTest.scala
@@ -1,0 +1,146 @@
+package org.scalajs.testsuite.compiler
+
+import org.junit.Test
+import org.junit.Assert._
+
+/* This test only works with 2.12.0-RC2 onwards. With previous versions of
+ * Scala, it suffers from #2382.
+ */
+class OuterClassTest {
+
+  @Test def `Test code variant 1 from #2382`(): Unit = {
+    val b1 = new B1 {}
+    val y1 = new b1.Y1
+    val z1 = new y1.Z1
+
+    assertEquals(1, b1.a)
+    assertEquals(1, z1.z1)
+    assertEquals(1, z1.z2)
+    assertEquals(2, y1.y)
+  }
+
+  @Test def `Test code variant 2 from #2382`(): Unit = {
+    val b2 = new B2 {}
+    val y2 = new b2.Y2
+    val z2 = new y2.Z2
+
+    assertEquals(1, b2.a)
+    assertEquals(1, z2.z1)
+    assertEquals(2, y2.y)
+    assertEquals(2, z2.z2)
+  }
+
+  @Test def `Test code variant 3 from #2382`(): Unit = {
+    val a3 = new A3 {}
+    val y3 = new a3.Y3
+    val z3 = new y3.Z3
+
+    assertEquals(1, a3.a)
+    assertEquals(1, z3.b)
+  }
+
+  @Test def `Test code variant 4 from #2382`(): Unit = {
+    val a4 = new A4 {}
+    val y4 = new a4.Y4
+    val z4 = new y4.Z4
+
+    assertEquals(1, a4.a)
+    assertEquals(1, z4.b)
+  }
+
+  @Test def `Test code variant 5 from #2382`(): Unit = {
+    val a5 = new A5 {}
+    val y5 = new a5.Y5
+    val z5 = new y5.Z5
+
+    assertEquals(1, a5.a)
+    assertEquals(1, z5.b)
+    assertEquals(2, z5.c)
+    assertEquals(2, z5.d)
+    assertEquals(3, z5.e)
+    assertEquals(3, z5.f)
+  }
+}
+
+// Code from issue #2382 variant 1
+
+trait A1 {
+  val a: Int = 1
+  class X1 {
+    def x: Int = a
+  }
+}
+
+trait B1 extends A1 {
+  class Y1 {
+    def y: Int = 2
+    class Z1 extends X1 {
+      def z1: Int = a
+      def z2: Int = x
+    }
+  }
+}
+
+// Code from issue #2382 variant 2
+
+trait A2 {
+  val a: Int = 1
+  class X2
+}
+
+trait B2 extends A2 {
+  class Y2 {
+    def y: Int = 2
+    class Z2 extends X2 {
+      def z1: Int = a
+      def z2: Int = y
+    }
+  }
+}
+
+// Code from issue #2382 variant 2
+
+trait A3 {
+  val a: Int = 1
+  class X3
+  class Y3 {
+    class Z3 extends X3 {
+      def b: Int = a
+    }
+  }
+}
+
+// Code from issue #2382 variant 4
+
+class A4 {
+  val a: Int = 1
+  class X4
+  class Y4 {
+    class Z4 extends X4 {
+      def b: Int = a
+    }
+  }
+}
+
+// Code from issue #2382 variant 5
+
+class A5 {
+  val a: Int = 1
+  trait B5 {
+    def c: Int = 2
+  }
+  trait C5 extends B5
+  trait D5 extends C5
+  class X5 {
+    def e: Int = 3
+  }
+  trait U5 extends X5
+  trait S5 extends U5
+  class Y5 extends S5 {
+    class Z5 extends X5 with D5 {
+      def b: Int = a
+      def d: Int = c
+      def f: Int = e
+    }
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/PatMatOuterPointerCheckTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/PatMatOuterPointerCheckTest.scala
@@ -1,0 +1,28 @@
+package org.scalajs.testsuite.compiler
+
+import org.junit.Test
+import org.junit.Assert._
+
+class PatMatOuterPointerCheckTest {
+  import PatMatOuterPointerCheckTest._
+
+  @Test def testPatMatOuterPointerCheck(): Unit = {
+    assertEquals(1, (new A).call())
+  }
+}
+
+object PatMatOuterPointerCheckTest {
+  class A {
+    def call(): Int = f(Foo.B(1))
+
+    private def f(x: Foo): Int = x match {
+      case Foo.B(x) => x
+    }
+
+    sealed abstract class Foo
+
+    object Foo {
+      case class B(x: Int) extends Foo
+    }
+  }
+}


### PR DESCRIPTION
The root cause of the bug #2625 which surfaces in 2.12.0 is actually #2382. We cannot fix #2382 without breaking backwards binary compatibility in general. However, we can fix it only for 2.12.0-RC2 onwards, as RCs of Scala (and the upcoming final) have separate binary ecosystems anyway.

So this commit fixes #2382 but only for 2.12.0-RC2 onwards. The fix is trivial: name mangle all outer pointers in the same way as if they were private, i.e., with the number of class ancestors of its owner.