### PR TITLE
Fix #1381: Add top-level exports

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -405,7 +405,9 @@ abstract class GenJSCode extends plugins.PluginComponent
           if (isStaticModule(sym)) genModuleAccessorExports(sym)
           else genConstructorExports(sym)
 
-        memberExports ++ exportedConstructorsOrAccessors
+        val topLevelExports = genTopLevelExports(sym)
+
+        memberExports ++ exportedConstructorsOrAccessors ++ topLevelExports
       }
 
       // Hashed definitions of the class

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -63,6 +63,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSExportDescendentClassesAnnotation = getRequiredClass("scala.scalajs.js.annotation.JSExportDescendentClasses")
     lazy val JSExportAllAnnotation     = getRequiredClass("scala.scalajs.js.annotation.JSExportAll")
     lazy val JSExportNamedAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSExportNamed")
+    lazy val JSExportTopLevelAnnotation = getRequiredClass("scala.scalajs.js.annotation.JSExportTopLevel")
     lazy val JSImportAnnotation        = getRequiredClass("scala.scalajs.js.annotation.JSImport")
     lazy val JSGlobalScopeAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSGlobalScope")
     lazy val ScalaJSDefinedAnnotation  = getRequiredClass("scala.scalajs.js.annotation.ScalaJSDefined")

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -51,6 +51,7 @@ trait JSGlobalAddons extends JSDefinitions
       val jsName: String
       val pos: Position
       val isNamed: Boolean
+      val isTopLevel: Boolean
     }
 
     def clearGlobalState(): Unit = {
@@ -58,19 +59,12 @@ trait JSGlobalAddons extends JSDefinitions
       jsNativeLoadSpecs.clear()
     }
 
-    private def assertValidForRegistration(sym: Symbol): Unit = {
-      assert(sym.isConstructor || sym.isClass,
-          "Can only register constructors or classes for export")
-    }
-
     def registerForExport(sym: Symbol, infos: List[ExportInfo]): Unit = {
       assert(!exportedSymbols.contains(sym), "Same symbol exported twice")
-      assertValidForRegistration(sym)
       exportedSymbols.put(sym, infos)
     }
 
     def registeredExportsOf(sym: Symbol): List[ExportInfo] = {
-      assertValidForRegistration(sym)
       exportedSymbols.getOrElse(sym, Nil)
     }
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -1095,4 +1095,160 @@ class JSExportTest extends DirectTest with TestHelpers {
     if (version.startsWith("2.10.") || version.startsWith("2.11.")) ""
     else s" (since $v)"
   }
+
+  @Test
+  def noExportTopLevelModule: Unit = {
+    """
+    @JSExportTopLevel("foo")
+    object A
+    """ hasErrors
+    """
+      |newSource1.scala:3: error: Use @JSExport on objects and constructors to export to the top level
+      |    @JSExportTopLevel("foo")
+      |     ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelTrait: Unit = {
+    """
+    @JSExportTopLevel("foo")
+    trait A
+    """ hasErrors
+    """
+      |newSource1.scala:3: error: Use @JSExport on objects and constructors to export to the top level
+      |    @JSExportTopLevel("foo")
+      |     ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelClass: Unit = {
+    """
+    @JSExportTopLevel("foo")
+    class A
+    """ hasErrors
+    """
+      |newSource1.scala:3: error: Use @JSExport on objects and constructors to export to the top level
+      |    @JSExportTopLevel("foo")
+      |     ^
+    """
+
+    """
+    class A {
+      @JSExportTopLevel("foo")
+      def this(x: Int) = this()
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: Use @JSExport on objects and constructors to export to the top level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelGetter: Unit = {
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      def a: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: You may not export a getter or a setter to the top level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelVal: Unit = {
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      val a: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: You may not export a getter or a setter to the top level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelVar: Unit = {
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      var a: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: You may not export a getter or a setter to the top level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelSetter: Unit = {
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      def a_=(x: Int): Unit = ()
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: You may not export a getter or a setter to the top level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelNonStatic: Unit = {
+    """
+    class A {
+      @JSExportTopLevel("foo")
+      def a(): Unit = ()
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: Only static objects may export their members to the top level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+
+    """
+    class A {
+      object B {
+        @JSExportTopLevel("foo")
+        def a(): Unit = ()
+      }
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: Only static objects may export their members to the top level
+      |        @JSExportTopLevel("foo")
+      |         ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelJSModule: Unit = {
+    """
+    @ScalaJSDefined
+    object A extends js.Object {
+      @JSExportTopLevel("foo")
+      def a(): Unit = ()
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: You may not export a method of a subclass of js.Any
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
 }

--- a/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
@@ -66,7 +66,16 @@ object Definitions {
   val AncestorsOfPseudoArrayClass = Set(
       ObjectClass, SerializableClass, CloneableClass)
 
-  val ExportedConstructorsName = "__exportedInits"
+  /** Name used for infos of class exports
+   *
+   *  These currently are exported constructors and top level exports)
+   *
+   *  TODO give this a better name once we can break backwards compat.
+   */
+  val ClassExportsName = "__exportedInits"
+
+  @deprecated("Use ClassExportsName instead", "0.6.14")
+  def ExportedConstructorsName: String = "__exportedInits"
 
   /** Encodes a class name. */
   def encodeClassName(fullName: String): String = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -856,6 +856,10 @@ object Printers {
           printEscapeJS(fullName, out)
           print('\"')
 
+        case TopLevelExportDef(member) =>
+          print("export top ")
+          print(member)
+
         case _ =>
           print(s"<error, elem of class ${tree.getClass()}>")
       }

--- a/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
@@ -21,7 +21,7 @@ object ScalaJSVersions {
    *  - a prior release version (i.e. "0.5.0", *not* "0.5.0-SNAPSHOT")
    *  - `current`
    */
-  val binaryEmitted: String = "0.6.13"
+  val binaryEmitted: String = current
 
   /** Versions whose binary files we can support (used by deserializer) */
   val binarySupported: Set[String] = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -457,6 +457,10 @@ object Serializers {
         case ModuleExportDef(fullName) =>
           writeByte(TagModuleExportDef)
           writeString(fullName)
+
+        case TopLevelExportDef(member) =>
+          writeByte(TagTopLevelExportDef)
+          writeTree(member)
       }
       if (UseDebugMagic)
         writeInt(DebugMagic)
@@ -870,10 +874,10 @@ object Serializers {
           } else {
             result
           }
-        case TagJSClassExportDef =>
-          JSClassExportDef(readString())
-        case TagModuleExportDef =>
-          ModuleExportDef(readString())
+
+        case TagJSClassExportDef  => JSClassExportDef(readString())
+        case TagModuleExportDef   => ModuleExportDef(readString())
+        case TagTopLevelExportDef => TopLevelExportDef(readTree())
       }
       if (UseDebugMagic) {
         val magic = readInt()

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -104,6 +104,7 @@ private[ir] object Tags {
   final val TagJSClassExportDef = TagLoadJSModule + 1
   final val TagTryCatch = TagJSClassExportDef + 1
   final val TagTryFinally = TagTryCatch + 1
+  final val TagTopLevelExportDef = TagTryFinally + 1
 
   // Tags for Types
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -231,6 +231,9 @@ object Transformers {
         case _:JSClassExportDef | _:ModuleExportDef =>
           tree
 
+        case TopLevelExportDef(member) =>
+          TopLevelExportDef(transformDef(member))
+
         case _ =>
           sys.error(s"Invalid tree in transformDef() of class ${tree.getClass}")
       }

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -204,6 +204,9 @@ object Traversers {
       case ConstructorExportDef(fullName, args, body) =>
         traverse(body)
 
+      case TopLevelExportDef(member) =>
+        traverse(member)
+
       // Trees that need not be traversed
 
       case _:Skip | _:Continue | _:Debugger | _:LoadModule |

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -810,6 +810,11 @@ object Trees {
     val tpe = NoType
   }
 
+  case class TopLevelExportDef(member: Tree)(
+      implicit val pos: Position) extends Tree {
+    val tpe = NoType
+  }
+
   final class OptimizerHints(val bits: Int) extends AnyVal {
     import OptimizerHints._
 

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -1049,4 +1049,15 @@ class PrintersTest {
         """export module "pkg.Foo"""",
         ModuleExportDef("pkg.Foo"))
   }
+
+  @Test def printTopLevelExportDef(): Unit = {
+    assertPrintEquals(
+        """
+          |export top static def "pkg.foo"(x: any): any = {
+          |  5
+          |}""",
+        TopLevelExportDef(MethodDef(static = true, StringLiteral("pkg.foo"),
+            List(ParamDef("x", AnyType, mutable = false, rest = false)),
+            AnyType, Some(i(5)))(NoOptHints, None)))
+  }
 }

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExportTopLevel.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExportTopLevel.scala
@@ -1,0 +1,20 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+
+package scala.scalajs.js.annotation
+
+import scala.annotation.meta._
+
+/** Specifies that the given member should be exported to the top level of the module.
+ *
+ *  @see [[http://www.scala-js.org/doc/export-to-javascript.html Export Scala.js APIs to JavaScript]]
+ */
+@field @getter @setter
+class JSExportTopLevel(name: String) extends scala.annotation.StaticAnnotation

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -3,6 +3,9 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val IR = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.ir.Infos#GenInfoTraverser.generateExportedConstructorsInfo")
   )
 
   val Tools = Seq(

--- a/stubs/src/main/scala/scala/scalajs/js/annotation/ExportAnnotations.scala
+++ b/stubs/src/main/scala/scala/scalajs/js/annotation/ExportAnnotations.scala
@@ -30,3 +30,5 @@ class JSExportNamed extends scala.annotation.Annotation {
 class JSExport extends scala.annotation.Annotation {
   def this(name: String) = this()
 }
+
+class JSExportTopLevel(name: String) extends scala.annotation.Annotation

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -1231,6 +1231,35 @@ class ExportsTest {
     assertThrows(classOf[Throwable], obj2.z1)
   }
 
+  // @JSExportTopLevel
+
+  @Test def basic_top_level_export(): Unit = {
+    assertEquals(1, jsPackage.toplevel.basic())
+  }
+
+  @Test def overloaded_top_level_export(): Unit = {
+    assertEquals("Hello World", jsPackage.toplevel.overload("World"))
+    assertEquals(2, jsPackage.toplevel.overload(2))
+    assertEquals(9, jsPackage.toplevel.overload(2, 7))
+    assertEquals(10, jsPackage.toplevel.overload(1, 2, 3, 4))
+  }
+
+  @Test def top_level_export_uses_unique_object(): Unit = {
+    jsPackage.toplevel.set(3)
+    assertEquals(3, TopLevelExports.myVar)
+    jsPackage.toplevel.set(7)
+    assertEquals(7, TopLevelExports.myVar)
+  }
+
+  @Test def top_level_export_from_nested_object(): Unit = {
+    jsPackage.toplevel.setNested(28)
+    assertEquals(28, TopLevelExports.Nested.myVar)
+  }
+
+  @Test def top_level_export_is_always_reachable(): Unit = {
+    assertEquals("Hello World", jsPackage.toplevel.reachability())
+  }
+
   // @JSExportDescendentObjects
 
   @Test def auto_exports_for_objects_extending_a_trait(): Unit = {
@@ -1640,4 +1669,37 @@ object ExportHolder {
   @JSExport("qualified.nested.SJSDefinedExportedClass")
   @ScalaJSDefined
   class SJSDefinedExportedClass extends js.Object
+}
+
+object TopLevelExports {
+  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.basic")
+  def basic(): Int = 1
+
+  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.overload")
+  def overload(x: String): String = "Hello " + x
+
+  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.overload")
+  def overload(x: Int, y: Int*): Int = x + y.sum
+
+  var myVar: Int = _
+
+  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.set")
+  def setMyVar(x: Int): Unit = myVar = x
+
+  object Nested {
+    var myVar: Int = _
+
+    @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.setNested")
+    def setMyVar(x: Int): Unit = myVar = x
+  }
+}
+
+/* This object is only reachable via the top level export to make sure the
+ * analyzer behaves correctly.
+ */
+object TopLevelExportsReachability {
+  private val name = "World"
+
+  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.reachability")
+  def basic(): String = "Hello " + name
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
@@ -66,6 +66,9 @@ final class LinkedClass(
     case ConstructorExportDef(name, _, _) => name
     case ModuleExportDef(name)            => name
     case JSClassExportDef(name)           => name
+
+    case TopLevelExportDef(MethodDef(_, StringLiteral(name), _, _, _)) =>
+      name
   }
 
   def fullName: String = Definitions.decodeClassName(encodedName)
@@ -182,8 +185,7 @@ object LinkedClass {
         sys.error(s"Illegal tree in ClassDef of class ${tree.getClass}")
     }
 
-    val classExportInfo =
-      memberInfoByName.get(Definitions.ExportedConstructorsName)
+    val classExportInfo = memberInfoByName.get(Definitions.ClassExportsName)
 
     new LinkedClass(
         classDef.name,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -251,6 +251,9 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
       case e: ModuleExportDef =>
         classExports += e
 
+      case e: TopLevelExportDef =>
+        classExports += e
+
       case tree =>
         sys.error(s"Illegal tree in ClassDef of class ${tree.getClass}")
     }
@@ -281,8 +284,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
       }
     }
 
-    val classExportInfo =
-      memberInfoByName.get(Definitions.ExportedConstructorsName)
+    val classExportInfo = memberInfoByName.get(Definitions.ClassExportsName)
 
     val kind =
       if (analyzerInfo.isModuleAccessed) classDef.kind


### PR DESCRIPTION
The new annotation @JSExportTopLevel allows modules to export their
methods to the top-level of the export scope, so they can be called
directly. For example:

    object MyApp {
      @JSExportTopLevel("main")
      def main(): Unit = ???
    }

Assuming that the export namespace is the `window` object, `MyApp.main`
can now be invoked as follows in JavaScript:

    window.main()

As opposed to (if one assumes `MyApp` and `main` to be exported):

    window.MyApp().main()

Overloading is supported from within the same module. Exporting to the
same name (irrespective of the export type) from different modules will
cause a link time error.

Current restrictions of top-level exports:

- Properties (or fields) cannot be exported.
- The fully qualified name of the export needs to be given.