### PR TITLE
Fix #2643: Do not replace `this` by `thisIdent` inside `Closure`s.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -12,6 +12,12 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genDeclareTypeData"),
 
+      // private, not an issue
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#Env.this"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSDesugaring#JSDesugar.this"),
+
       // Breaking (remove js.EmptyTree)
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "org.scalajs.core.tools.javascript.Trees#Let.apply"),

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
@@ -71,4 +71,31 @@ class ThisFunctionTest {
     assertEquals("foo:42", f(obj, 42))
   }
 
+  @Test def thisFunction_in_trait_issue2643(): Unit = {
+    trait TraitWithThisFunction {
+      def create = {
+        val f = { (passedThis: js.Dynamic) =>
+          passedThis
+        }
+        js.Dynamic.literal(
+          "foo" -> ({ (passedThis: js.Dynamic) => {
+            passedThis
+          } }: js.ThisFunction0[js.Dynamic, js.Dynamic]),
+          "bar" -> js.ThisFunction.fromFunction1(f),
+          "foobar" -> (f: js.ThisFunction)
+        )
+      }
+    }
+
+    class TraitWithThisFunctionImpl extends TraitWithThisFunction
+
+    val objFactory = new TraitWithThisFunctionImpl()
+    val obj = new TraitWithThisFunctionImpl().create
+    val thisValue = new js.Object
+
+    assertSame(thisValue, obj.foo.call(thisValue))
+    assertSame(thisValue, obj.bar.call(thisValue))
+    assertSame(thisValue, obj.foobar.call(thisValue))
+  }
+
 }


### PR DESCRIPTION
`Closure`s reintroduce a new binding for `this`, which must not be replaced by `thisIdent`.