### PR TITLE
java.util.NavigableMap interface

### DIFF
--- a/javalib/src/main/scala/java/util/NavigableMap.scala
+++ b/javalib/src/main/scala/java/util/NavigableMap.scala
@@ -1,0 +1,25 @@
+package java.util
+
+trait NavigableMap[K, V] extends SortedMap[K, V] {
+  def lowerEntry(key: K): Map.Entry[K, V]
+  def lowerKey(key: K): K
+  def floorEntry(key: K): Map.Entry[K, V]
+  def floorKey(key: K): K
+  def ceilingEntry(key: K): Map.Entry[K, V]
+  def ceilingKey(key: K): K
+  def higherEntry(key: K): Map.Entry[K, V]
+  def higherKey(key: K): K
+  def firstEntry(): Map.Entry[K, V]
+  def lastEntry(): Map.Entry[K, V]
+  def pollFirstEntry(): Map.Entry[K, V]
+  def pollLastEntry(): Map.Entry[K, V]
+  def descendingMap(): NavigableMap[K, V]
+  def navigableKeySet(): NavigableSet[K]
+  def descendingKeySet(): NavigableSet[K]
+  def subMap(fromKey: K, fromInclusive: Boolean, toKey: K, toInclusive: Boolean): NavigableMap[K, V]
+  def headMap(toKey: K, inclusive: Boolean): NavigableMap[K, V]
+  def tailMap(toKey: K, inclusive: Boolean): NavigableMap[K, V]
+  def subMap(fromKey: K, toKey: K): SortedMap[K, V]
+  def headMap(toKey: K): SortedMap[K, V]
+  def tailMap(fromKey: K): SortedMap[K, V]
+}


### PR DESCRIPTION
This is the definition of the java interface `java.util.NavigableMap` as defined in [NavigableMap](https://docs.oracle.com/javase/7/docs/api/java/util/NavigableMap.html)

This interface is required to implement the `ZoneRulesProvider` class on the `java.time` API, in particular methods like [getVersions](https://docs.oracle.com/javase/8/docs/api/java/time/zone/ZoneRulesProvider.html#getVersions-java.lang.String-)
