### PR TITLE
Increasing VMTermTimeout from 5 seconds to 1 minute

### DIFF
--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/package.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/package.scala
@@ -12,5 +12,5 @@ package org.scalajs
 import scala.concurrent.duration._
 
 package object testadapter {
-  private[testadapter] final val VMTermTimeout = 5.seconds
+  private[testadapter] final val VMTermTimeout = 1.minute
 }


### PR DESCRIPTION
Related to issue #2640 , increasing the VMTermTimeout to 1 minute to allow slaves to stop for (now longer) running Phantomjs.