### PR TITLE
Shorter and faster `Long` multiplication.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -2923,6 +2923,14 @@ private[optimizer] abstract class OptimizerCore(
             else
               PreTransBinaryOp(Int_>>>, x, PreTransLit(IntLiteral(dist)))
 
+          case (PreTransBinaryOp(op @ (Int_| | Int_& | Int_^),
+              PreTransLit(IntLiteral(x)), y),
+              z @ PreTransLit(IntLiteral(zValue))) =>
+            foldBinaryOp(
+                op,
+                PreTransLit(IntLiteral(x >>> zValue)),
+                foldBinaryOp(Int_>>>, y, z))
+
           case (_, PreTransLit(IntLiteral(y))) =>
             val dist = y & 31
             if (dist == 0)


### PR DESCRIPTION
The key insight was that we do not need to compute the `hi` products by 16-bit components. The `hi` part is basically

    a.lo*b.hi + a.hi*b.hi + carry_from_lo_*

so only the carry from multiplying `a.lo*b.lo` needs to be computed by 16-bit components. The resulting algorithm is significantly shorter, and we can afford to completely inline it.

Subsequently, we can use the 16-bit products computed for the hi part to also compute the lo part, removing one multiplication.

The fact that we can now inline the whole algorithm allows it to benefit from call-site optimizations on the underlying `Int` arithmetics. This mostly happens when one side is constant and/or the `hi` part of operands is 0. The whole thing collapses particularly well when `a` is a constant in the range `0 <= a <= 0xffff`, which happens for mundane things like `10 * x`.

This improved implementation is significantly faster. A benchmark based on `BigInteger.multiply` exhibits > 2x improvement.

The benchmark code is the following:
```scala
  def benchmarkBigInteger(): Unit = {

    println("Bench BigInteger")
    import java.math.BigInteger

    // generate a prime number each time is too long, so here's one:
    val modHexa = "8600638d58155caded48cb45a1258593d775a03fe82679f62c62ec6c75e62e76fcb4e565f74675abe6cf6602939f6b4a159f56843f02f3f825e0f176a8df9f04f41eaa1cf60e598ca892670e30ea5b2d7002fb500b84e331d238708f600a14ec791dec30afc0fad2e5a0338847b0505f6d0a839516c892c06f4015362fbce145"

    val rand = new java.util.Random()
    val aHexa =  new BigInteger(1024, rand).toString(16)
    val bHexa =  new BigInteger(1024, rand).toString(16)

    println("Hexa String version")
    println("mod = " + modHexa)
    println("a = " + aHexa)
    println("b = " + bHexa)

    val mod =  new BigInteger(modHexa, 16)
    val a =  new BigInteger(aHexa, 16)
    val b =  new BigInteger(bHexa, 16)

    println("BigInteger version")
    println("mod = " + mod.toString(16))
    println("a = " + a.toString(16))
    println("b = " + b.toString(16))

    println("--------------------------")
    println("Do multiplication")

    var t0, t1:Long = 0
    val nbLoop = 100000
    var mutRes:BigInteger = null
    t0 = System.currentTimeMillis()
    for(i <- 0 until nbLoop) {
      mutRes = a multiply b
    }
    t1 = System.currentTimeMillis()
    val tBigInteger = (t1 - t0) * 1.0 / nbLoop
    println("--------------------------")
    println("BigInteger result = " + mutRes.toString(16))
    println("" + tBigInteger + " ms")
    println("--------------------------")
  }
```