### PR TITLE
Fix #1997: Add support for js.Symbols in @JSName annotations.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1100,7 +1100,7 @@ abstract class GenJSCode extends plugins.PluginComponent
         else (subConstructors.head.overrideNumBounds._1, overrideNum)
 
       def get(methodName: String): Option[ConstructorTree] = {
-        if (methodName == this.method.name.name) {
+        if (methodName == this.method.name.encodedName) {
           Some(this)
         } else {
           subConstructors.iterator.map(_.get(methodName)).collectFirst {
@@ -1370,7 +1370,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
       var overrideNum = -1
       def mkConstructorTree(method: js.MethodDef): ConstructorTree = {
-        val methodName = method.name.name
+        val methodName = method.name.encodedName
         val subCtrTrees = ctorToChildren(methodName).map(mkConstructorTree)
         overrideNum += 1
         new ConstructorTree(overrideNum, method, subCtrTrees)

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -239,6 +239,11 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
   def needsModuleClassSuffix(sym: Symbol): Boolean =
     sym.isModuleClass && !foreignIsImplClass(sym)
 
+  def encodeComputedNameIdentity(sym: Symbol): String = {
+    assert(sym.owner.isModuleClass)
+    encodeClassFullName(sym.owner) + "__" + encodeMemberNameInternal(sym)
+  }
+
   private def encodeMemberNameInternal(sym: Symbol): String =
     sym.name.toString.replace("_", "$und")
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -457,9 +457,9 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:12: error: The argument to JSName must be a literal string
+      |newSource1.scala:12: error: A string argument to JSName must be a literal string
       |      @JSName(A.a)
-      |       ^
+      |                ^
     """
 
     """
@@ -477,9 +477,9 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:12: error: The argument to JSName must be a literal string
+      |newSource1.scala:12: error: A string argument to JSName must be a literal string
       |      @JSName(A.a)
-      |       ^
+      |                ^
     """
   }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -492,8 +492,18 @@ object Hashers {
     def mixOptIdent(optIdent: Option[Ident]): Unit = optIdent.foreach(mixIdent)
 
     def mixPropertyName(name: PropertyName): Unit = name match {
-      case name: Ident         => mixIdent(name)
-      case name: StringLiteral => mixTree(name)
+      case name: Ident =>
+        mixTag(TagPropertyNameIdent)
+        mixIdent(name)
+
+      case name: StringLiteral =>
+        mixTag(TagPropertyNameStringLiteral)
+        mixTree(name)
+
+      case ComputedName(tree, logicalName) =>
+        mixTag(TagPropertyNameComputedName)
+        mixTree(tree)
+        mixString(logicalName)
     }
 
     def mixPos(pos: Position): Unit = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
@@ -376,7 +376,13 @@ object Infos {
         .setEncodedName(methodDef.name.encodedName)
         .setIsStatic(methodDef.static)
         .setIsAbstract(methodDef.body.isEmpty)
-        .setIsExported(methodDef.name.isInstanceOf[StringLiteral])
+        .setIsExported(!methodDef.name.isInstanceOf[Ident])
+
+      methodDef.name match {
+        case ComputedName(tree, _) =>
+          traverse(tree)
+        case _ =>
+      }
 
       methodDef.body.foreach(traverse)
 
@@ -388,6 +394,12 @@ object Infos {
         .setEncodedName(propertyDef.name.encodedName)
         .setIsStatic(propertyDef.static)
         .setIsExported(true)
+
+      propertyDef.name match {
+        case ComputedName(tree, _) =>
+          traverse(tree)
+        case _ =>
+      }
 
       propertyDef.getterBody.foreach(traverse)
       propertyDef.setterArgAndBody foreach { case (_, body) =>

--- a/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
@@ -373,7 +373,7 @@ object Infos {
 
     def generateMethodInfo(methodDef: MethodDef): MethodInfo = {
       builder
-        .setEncodedName(methodDef.name.name)
+        .setEncodedName(methodDef.name.encodedName)
         .setIsStatic(methodDef.static)
         .setIsAbstract(methodDef.body.isEmpty)
         .setIsExported(methodDef.name.isInstanceOf[StringLiteral])
@@ -385,7 +385,7 @@ object Infos {
 
     def generatePropertyInfo(propertyDef: PropertyDef): MethodInfo = {
       builder
-        .setEncodedName(propertyDef.name.name)
+        .setEncodedName(propertyDef.name.encodedName)
         .setIsStatic(propertyDef.static)
         .setIsExported(true)
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -797,7 +797,7 @@ object Printers {
           }
           jsNativeLoadSpec.foreach { spec =>
             print(" loadfrom ")
-            print(spec.toString)
+            print(spec)
           }
           print(" ")
           printColumn(defs, "{", "", "}")
@@ -933,6 +933,33 @@ object Printers {
     private final def print(propName: PropertyName): Unit = propName match {
       case lit: StringLiteral => print(lit: Tree)
       case ident: Ident       => print(ident)
+    }
+
+    private def print(spec: JSNativeLoadSpec): Unit = {
+      def printPath(path: List[String]): Unit = {
+        for (propName <- path) {
+          if (isValidIdentifier(propName)) {
+            print('.')
+            print(propName)
+          } else {
+            print('[')
+            print(propName)
+            print(']')
+          }
+        }
+      }
+
+      spec match {
+        case JSNativeLoadSpec.Global(path) =>
+          print("<global>")
+          printPath(path)
+
+        case JSNativeLoadSpec.Import(module, path) =>
+          print("import(")
+          print(module)
+          print(')')
+          printPath(path)
+      }
     }
 
     protected def print(s: String): Unit =

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -933,6 +933,13 @@ object Printers {
     private final def print(propName: PropertyName): Unit = propName match {
       case lit: StringLiteral => print(lit: Tree)
       case ident: Ident       => print(ident)
+
+      case ComputedName(tree, index) =>
+        print("[")
+        print(tree)
+        print("](")
+        print(index)
+        print(")")
     }
 
     private def print(spec: JSNativeLoadSpec): Unit = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -870,7 +870,7 @@ object Serializers {
             result1
           }
           if (useHacks065 && result2.resultType != NoType &&
-              isConstructorName(result2.name.name)) {
+              isConstructorName(result2.name.encodedName)) {
             result2.copy(resultType = NoType, body = result2.body)(
                 result2.optimizerHints, result2.hash)(
                 result2.pos)

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -409,20 +409,11 @@ object Serializers {
           writeInt(tree.optimizerHints.bits)
 
         case FieldDef(static, name, ftpe, mutable) =>
-          /* TODO Simply use `writePropertyName` when we can break binary
-           * compatibility.
-           */
-          name match {
-            case name: Ident =>
-              writeByte(TagFieldDef)
-              writeBoolean(static)
-              writeIdent(name)
-            case name: StringLiteral =>
-              writeByte(TagStringLitFieldDef)
-              writeBoolean(static)
-              writeTree(name)
-          }
-          writeType(ftpe); writeBoolean(mutable)
+          writeByte(TagFieldDef)
+          writeBoolean(static)
+          writePropertyName(name)
+          writeType(ftpe)
+          writeBoolean(mutable)
 
         case methodDef: MethodDef =>
           val MethodDef(static, name, args, resultType, body) = methodDef
@@ -556,11 +547,19 @@ object Serializers {
     def writeReferenceType(tpe: ReferenceType): Unit =
       writeType(tpe.asInstanceOf[Type])
 
-    def writePropertyName(name: PropertyName): Unit = {
-      name match {
-        case name: Ident         => buffer.writeBoolean(true); writeIdent(name)
-        case name: StringLiteral => buffer.writeBoolean(false); writeTree(name)
-      }
+    def writePropertyName(name: PropertyName): Unit = name match {
+      case name: Ident =>
+        buffer.writeByte(TagPropertyNameIdent)
+        writeIdent(name)
+
+      case name: StringLiteral =>
+        buffer.writeByte(TagPropertyNameStringLiteral)
+        writeTree(name)
+
+      case ComputedName(tree, index) =>
+        buffer.writeByte(TagPropertyNameComputedName)
+        writeTree(tree)
+        writeString(index)
     }
 
     def writePosition(pos: Position): Unit = {
@@ -841,19 +840,14 @@ object Serializers {
               optimizerHints)
 
         case TagFieldDef =>
-          val static =
-            if (useHacks0614) false
-            else readBoolean()
-          FieldDef(static, readIdent(), readType(), readBoolean())
-        case TagStringLitFieldDef =>
-          /* TODO Merge this into TagFieldDef and use readPropertyName()
-           * when we can break binary compatibility.
-           */
-          val static =
-            if (useHacks0614) false
-            else readBoolean()
-          FieldDef(static, readTree().asInstanceOf[StringLiteral], readType(),
-              readBoolean())
+          if (useHacks0614)
+            FieldDef(static = false, readIdent(), readType(), readBoolean())
+          else
+            FieldDef(readBoolean(), readPropertyName(), readType(), readBoolean())
+
+        case TagStringLitFieldDef if useHacks0614 =>
+          FieldDef(static = false, readTree().asInstanceOf[StringLiteral],
+              readType(), readBoolean())
 
         case TagMethodDef =>
           val optHash = readOptHash()
@@ -980,8 +974,21 @@ object Serializers {
       readType().asInstanceOf[ReferenceType]
 
     def readPropertyName(): PropertyName = {
-      if (input.readBoolean()) readIdent()
-      else readTree().asInstanceOf[StringLiteral]
+      if (useHacks0614) {
+        if (input.readBoolean()) readIdent()
+        else readTree().asInstanceOf[StringLiteral]
+      } else {
+        input.readByte() match {
+          case TagPropertyNameIdent =>
+            readIdent()
+
+          case TagPropertyNameStringLiteral =>
+            readTree().asInstanceOf[StringLiteral]
+
+          case TagPropertyNameComputedName =>
+            ComputedName(readTree(), readString())
+        }
+      }
     }
 
     def readPosition(): Position = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -126,6 +126,12 @@ private[ir] object Tags {
   final val TagRecordType = TagArrayType + 1
   final val TagNoType = TagRecordType + 1
 
+  // Tags for PropertyNames
+
+  final val TagPropertyNameIdent = 1
+  final val TagPropertyNameStringLiteral = TagPropertyNameIdent + 1
+  final val TagPropertyNameComputedName = TagPropertyNameStringLiteral + 1
+
   // Tags for JS native loading specs
 
   final val TagJSNativeLoadSpecNone = 0

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -176,7 +176,14 @@ object Transformers {
 
         case JSObjectConstr(fields) =>
           JSObjectConstr(fields map {
-            case (name, value) => (name, transformExpr(value))
+            case (name, value) =>
+              val newName = name match {
+                case ComputedName(tree, logicalName) =>
+                  ComputedName(transformExpr(tree), logicalName)
+                case _ =>
+                  name
+              }
+              (newName, transformExpr(value))
           })
 
         // Atomic expressions

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -179,7 +179,14 @@ object Traversers {
         items foreach traverse
 
       case JSObjectConstr(fields) =>
-        fields foreach { f => traverse(f._2) }
+        for ((key, value) <- fields) {
+          key match {
+            case ComputedName(tree, _) =>
+              traverse(tree)
+            case _ =>
+          }
+          traverse(value)
+        }
 
       // Atomic expressions
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -31,8 +31,13 @@ object Trees {
   // Identifiers and properties
 
   sealed trait PropertyName {
-    /** Encoded name of this PropertyName within its owner's scope. */
+    /** Encoded name of this PropertyName within its owner's scope.
+     *
+     *  For [[ComputedName]]s, the value of `encodedName` cannot be relied on
+     *  beyond equality tests, and the fact that it starts with `"__computed_"`.
+     */
     def encodedName: String
+
     def pos: Position
   }
 
@@ -80,6 +85,12 @@ object Trees {
       "goto", "int", "long", "native", "short", "synchronized", "throws",
       "transient", "volatile"
   )
+
+  case class ComputedName(tree: Tree, logicalName: String) extends PropertyName {
+    requireValidIdent(logicalName)
+    def pos: Position = tree.pos
+    override def encodedName: String = "__computed_" + logicalName
+  }
 
   // Definitions
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -31,13 +31,15 @@ object Trees {
   // Identifiers and properties
 
   sealed trait PropertyName {
-    def name: String
+    /** Encoded name of this PropertyName within its owner's scope. */
+    def encodedName: String
     def pos: Position
   }
 
   case class Ident(name: String, originalName: Option[String])(
       implicit val pos: Position) extends PropertyName {
     requireValidIdent(name)
+    def encodedName: String = name
   }
 
   object Ident {
@@ -741,7 +743,7 @@ object Trees {
   case class StringLiteral(value: String)(
       implicit val pos: Position) extends Literal with PropertyName {
     val tpe = StringType
-    override def name: String = value
+    override def encodedName: String = value
   }
 
   case class ClassOf(cls: ReferenceType)(

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -880,7 +880,7 @@ class PrintersTest {
   @Test def printClassDefJSNativeLoadSpec(): Unit = {
     assertPrintEquals(
         """
-          |native js class LTest extends O loadfrom Global(List(Foo)) {
+          |native js class LTest extends O loadfrom <global>.Foo {
           |}
         """,
         ClassDef("LTest", ClassKind.NativeJSClass, Some(ObjectClass), Nil,
@@ -889,7 +889,7 @@ class PrintersTest {
 
     assertPrintEquals(
         """
-          |native js class LTest extends O loadfrom Import(foo,List(Bar)) {
+          |native js class LTest extends O loadfrom import(foo).Bar {
           |}
         """,
         ClassDef("LTest", ClassKind.NativeJSClass, Some(ObjectClass), Nil,

--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
@@ -41,7 +41,7 @@ private[rhino] class ScalaJSCoreLib(linkingUnit: LinkingUnit) {
     for (linkedClass <- linkingUnit.classDefs) {
       def hasStaticInitializer = {
         linkedClass.staticMethods.exists {
-          _.tree.name.name == ir.Definitions.StaticInitializerName
+          _.tree.name.encodedName == ir.Definitions.StaticInitializerName
         }
       }
 

--- a/library/src/main/scala/scala/scalajs/js/Symbol.scala
+++ b/library/src/main/scala/scala/scalajs/js/Symbol.scala
@@ -1,0 +1,131 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Symbol.
+ */
+@js.native
+sealed trait Symbol extends js.Any
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  Factory for [[Symbol js.Symbol]]s and well-known symbols.
+ *
+ *  @groupname factories Factories for unique symbols
+ *  @groupprio 10
+ *
+ *  @groupname registry Global symbol registry
+ *  @groupprio 20
+ *
+ *  @groupname wellknownsyms Well-known symbols
+ *  @groupprio 30
+ */
+@js.native
+object Symbol extends js.Object {
+  /** Creates a new unique symbol without description.
+   *
+   *  @group factories
+   */
+  def apply(): Symbol = js.native
+
+  /** Creates a new unique symbol with the specified description.
+   *
+   *  @group factories
+   */
+  def apply(description: String): Symbol = js.native
+
+  /** Retrieves the symbol with the specified key in the global symbol registry.
+   *
+   *  The returned symbol's description is also the key.
+   *
+   *  Asking twice `forKey` with the same key returns the same symbol,
+   *  globally.
+   *
+   *  @group registry
+   */
+  @JSName("for")
+  def forKey(key: String): Symbol = js.native
+
+  /** Retrieves the key under which the specified symbol is registered in the
+   *  global symbol registry, or `undefined` if it is not registered.
+   *
+   *  @group registry
+   */
+  def keyFor(sym: Symbol): js.UndefOr[String] = js.native
+
+  /** The well-known symbol `@@hasInstance`.
+   *
+   *  @group wellknownsyms
+   */
+  val hasInstance: Symbol = js.native
+
+  /** The well-known symbol `@@isConcatSpreadable`.
+   *
+   *  @group wellknownsyms
+   */
+  val isConcatSpreadable: Symbol = js.native
+
+  /** The well-known symbol `@@iterator`.
+   *
+   *  @group wellknownsyms
+   */
+  val iterator: Symbol = js.native
+
+  /** The well-known symbol `@@match`.
+   *
+   *  @group wellknownsyms
+   */
+  val `match`: Symbol = js.native
+
+  /** The well-known symbol `@@replace`.
+   *
+   *  @group wellknownsyms
+   */
+  val replace: Symbol = js.native
+
+  /** The well-known symbol `@@search`.
+   *
+   *  @group wellknownsyms
+   */
+  val search: Symbol = js.native
+
+  /** The well-known symbol `@@species`.
+   *
+   *  @group wellknownsyms
+   */
+  val species: Symbol = js.native
+
+  /** The well-known symbol `@@split`.
+   *
+   *  @group wellknownsyms
+   */
+  val split: Symbol = js.native
+
+  /** The well-known symbol `@@toPrimitive`.
+   *
+   *  @group wellknownsyms
+   */
+  val toPrimitive: Symbol = js.native
+
+  /** The well-known symbol `@@toStringTag`.
+   *
+   *  @group wellknownsyms
+   */
+  val toStringTag: Symbol = js.native
+
+  /** The well-known symbol `@@unscopables`.
+   *
+   *  @group wellknownsyms
+   */
+  val unscopables: Symbol = js.native
+}

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSName.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSName.scala
@@ -17,4 +17,7 @@ import scala.annotation.meta._
  *  @see [[http://www.scala-js.org/doc/calling-javascript.html Calling JavaScript from Scala.js]]
  */
 @field @getter @setter
-class JSName(name: String) extends scala.annotation.StaticAnnotation
+class JSName private () extends scala.annotation.StaticAnnotation {
+  def this(name: String) = this()
+  def this(symbol: scala.scalajs.js.Symbol) = this()
+}

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -45,6 +45,12 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // Breaking. Remove PropertyName.name
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.javascript.Trees#PropertyName.name"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.javascript.Trees#StringLiteral.name"),
+
       // private, not an issue
       ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.scalajs.core.tools.sem.Semantics.this"),
@@ -58,6 +64,10 @@ object BinaryIncompatibilities {
           "org.scalajs.core.tools.linker.analyzer.Analyzer.org$scalajs$core$tools$linker$analyzer$Analyzer$$createMissingMethodInfo$default$2"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.scalajs.core.tools.linker.analyzer.Analyzer.org$scalajs$core$tools$linker$analyzer$Analyzer$$createMissingMethodInfo$default$3"),
+
+      // private[closure], not an issue
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.core.tools.linker.backend.closure.ClosureAstTransformer.transformString"),
 
       // private[emitter], not an issue
       ProblemFilters.exclude[MissingMethodProblem](

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -37,6 +37,14 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.scalajs.core.ir.Tags.TagTopLevelExportDef"),
 
+      // Breaking: PropertyName.{name -> encodedName}
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "org.scalajs.core.ir.Trees#PropertyName.encodedName"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.ir.Trees#StringLiteral.name"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.ir.Trees#PropertyName.name"),
+
       // private, not an issue
       ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.scalajs.core.ir.Infos#MethodInfo.this"),

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -78,10 +78,14 @@ object BinaryIncompatibilities {
           "org.scalajs.core.tools.linker.backend.closure.ClosureAstTransformer.transformString"),
 
       // private[emitter], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genAddToPrototype"),
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genClass"),
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genClassDef"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genPropertyName"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genTopLevelExportDef"),
       ProblemFilters.exclude[DirectMissingMethodProblem](

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -7,6 +7,7 @@
 \*                                                                      */
 package org.scalajs.testsuite.utils
 
+import scala.scalajs.js
 import scala.scalajs.runtime
 
 object Platform {
@@ -28,6 +29,9 @@ object Platform {
 
   def areTypedArraysSupported: Boolean =
     runtime.Bits.areTypedArraysSupported
+
+  def areJSSymbolsSupported: Boolean =
+    !js.isUndefined(js.Dynamic.global.Symbol)
 
   def executingInRhino: Boolean = sysProp("rhino")
   def executingInNodeJS: Boolean = sysProp("nodejs")

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -1,0 +1,531 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{Test, BeforeClass}
+
+class JSSymbolTest {
+  import JSSymbolTest._
+  import SJSDefinedWithSyms._
+
+  @Test def native_with_defs_that_are_properties(): Unit = {
+    val obj = mkObject(sym1 -> 1)
+
+    assertEquals(1, obj.asInstanceOf[PropDefClass].internalDef)
+    assertEquals(1, obj.asInstanceOf[PropDefTrait].internalDef)
+    assertEquals(1, selectSymbol(obj, sym1))
+  }
+
+  @Test def sjsdefined_with_defs_that_are_properties(): Unit = {
+    val obj = new SJSDefinedPropDef
+    assertEquals(456, obj.internalDef)
+
+    val asTrait: PropDefTrait = obj
+    assertEquals(456, asTrait.internalDef)
+
+    assertEquals(456, selectSymbol(obj, sym1))
+  }
+
+  @Test def native_with_vals(): Unit = {
+    val obj = mkObject(sym1 -> "hi")
+
+    assertEquals("hi", obj.asInstanceOf[PropValClass].internalVal)
+    assertEquals("hi", obj.asInstanceOf[PropValTrait].internalVal)
+    assertEquals("hi", selectSymbol(obj, sym1))
+  }
+
+  @Test def sjsdefined_with_vals(): Unit = {
+    val obj = new SJSDefinedPropVal
+    assertEquals("hello", obj.internalVal)
+
+    val asTrait: PropValTrait = obj
+    assertEquals("hello", asTrait.internalVal)
+
+    assertEquals("hello", selectSymbol(obj, sym1))
+  }
+
+  @Test def native_with_vars(): Unit = {
+    val obj0 = mkObject(sym1 -> 0.1).asInstanceOf[PropVarClass]
+    assertEquals(0.1, obj0.internalVar)
+    obj0.internalVar = 0.2
+    assertEquals(0.2, obj0.internalVar)
+
+    val obj1 = mkObject(sym1 -> 8.0).asInstanceOf[PropVarTrait]
+    assertEquals(8.0, obj1.internalVar)
+    obj1.internalVar = 8.2
+    assertEquals(8.2, obj1.internalVar)
+
+    val obj2 = mkObject(sym1 -> 8.0)
+    assertEquals(8.0, selectSymbol(obj2, sym1))
+    updateSymbol(obj2, sym1, 8.2)
+    assertEquals(8.2, selectSymbol(obj2, sym1))
+  }
+
+  @Test def sjsdefined_with_vars(): Unit = {
+    val obj0 = new SJSDefinedPropVar
+    assertEquals(1511.1989, obj0.internalVar)
+    obj0.internalVar = 0.2
+    assertEquals(0.2, obj0.internalVar)
+
+    val obj1: PropVarTrait = new SJSDefinedPropVar
+    assertEquals(1511.1989, obj1.internalVar)
+    obj1.internalVar = 8.2
+    assertEquals(8.2, obj1.internalVar)
+
+    val obj2 = new SJSDefinedPropVar
+    assertEquals(1511.1989, selectSymbol(obj2, sym1))
+    updateSymbol(obj2, sym1, 8.2)
+    assertEquals(8.2, selectSymbol(obj2, sym1))
+  }
+
+  @Test def sjsdefined_with_inner_object(): Unit = {
+    val obj0 = new SJSDefinedInnerObject
+    assertEquals("object", js.typeOf(obj0.innerObject.asInstanceOf[js.Any]))
+    assertEquals("SJSDefinedInnerObject.innerObject", obj0.innerObject.toString())
+
+    val obj1: InnerObjectTrait = new SJSDefinedInnerObject
+    assertEquals("object", js.typeOf(obj1.innerObject.asInstanceOf[js.Any]))
+    assertEquals("SJSDefinedInnerObject.innerObject", obj1.innerObject.toString())
+
+    assertEquals("object",
+        js.typeOf(selectSymbol(obj1, sym1).asInstanceOf[js.Any]))
+    assertEquals("SJSDefinedInnerObject.innerObject",
+        selectSymbol(obj1, sym1).toString())
+  }
+
+  @Test def native_with_methods(): Unit = {
+    val obj = mkObject(
+        sym1 -> ((x: Int) => x + 2),
+        sym2 -> ((x: String) => "Hello " + x)
+    )
+
+    assertEquals(4, obj.asInstanceOf[MethodClass].foo(2))
+    assertEquals("Hello World", obj.asInstanceOf[MethodClass].bar("World"))
+
+    assertEquals(6, obj.asInstanceOf[MethodTrait].foo(4))
+    assertEquals("Hello Moon", obj.asInstanceOf[MethodTrait].bar("Moon"))
+
+    assertEquals(6, callSymbol(obj, sym1)(4))
+    assertEquals("Hello Moon", callSymbol(obj, sym2)("Moon"))
+  }
+
+  @Test def sjsdefined_with_methods(): Unit = {
+    val obj = new SJSDefinedMethod
+    assertEquals(4, obj.foo(2))
+    assertEquals("Hello World", obj.bar("World"))
+
+    val asTrait: MethodTrait = obj
+    assertEquals(6, asTrait.foo(4))
+    assertEquals("Hello Moon", asTrait.bar("Moon"))
+
+    assertEquals(6, callSymbol(obj, sym1)(4))
+    assertEquals("Hello Moon", callSymbol(obj, sym2)("Moon"))
+  }
+
+  @Test def native_with_overloaded_methods(): Unit = {
+    val obj = mkObject(
+        sym1 -> ((x: Int) => x + 3),
+        sym2 -> ((x: String) => "Hello " + x)
+    )
+
+    assertEquals(5, obj.asInstanceOf[OverloadedMethodClass].foo(2))
+    assertEquals("Hello World", obj.asInstanceOf[OverloadedMethodClass].foo("World"))
+
+    assertEquals(6, obj.asInstanceOf[OverloadedMethodTrait].foo(3))
+    assertEquals("Hello Moon", obj.asInstanceOf[OverloadedMethodTrait].foo("Moon"))
+
+    assertEquals(6, callSymbol(obj, sym1)(3))
+    assertEquals("Hello Moon", callSymbol(obj, sym2)("Moon"))
+  }
+
+  @Test def sjsdefined_with_overloaded_methods(): Unit = {
+    val obj = new SJSDefinedOverloadedMethod
+    assertEquals(5, obj.foo(2))
+    assertEquals("Hello World", obj.foo("World"))
+
+    val asTrait: OverloadedMethodTrait = obj
+    assertEquals(6, asTrait.foo(3))
+    assertEquals("Hello Moon", asTrait.foo("Moon"))
+
+    assertEquals(6, callSymbol(obj, sym1)(3))
+    assertEquals("Hello Moon", callSymbol(obj, sym2)("Moon"))
+  }
+
+  @Test def native_with_overloaded_runtime_dispatch_methods(): Unit = {
+    val obj = mkObject(
+        sym1 -> { (x: Any) =>
+          x match {
+            case x: Int    => x + 3
+            case x: String => "Hello " + x
+          }
+        }
+    )
+
+    assertEquals(5,
+        obj.asInstanceOf[OverloadedRuntimeDispatchMethodClass].foo(2))
+    assertEquals("Hello World",
+        obj.asInstanceOf[OverloadedRuntimeDispatchMethodClass].foo("World"))
+
+    assertEquals(6,
+        obj.asInstanceOf[OverloadedRuntimeDispatchMethodTrait].foo(3))
+    assertEquals("Hello Moon",
+        obj.asInstanceOf[OverloadedRuntimeDispatchMethodTrait].foo("Moon"))
+
+    assertEquals(6, callSymbol(obj, sym1)(3))
+    assertEquals("Hello Moon", callSymbol(obj, sym1)("Moon"))
+  }
+
+  @Test def sjsdefined_with_overloaded_runtime_dispatch_methods(): Unit = {
+    val obj = new SJSDefinedOverloadedRuntimeDispatchMethod
+    assertEquals(5, obj.foo(2))
+    assertEquals("Hello World", obj.foo("World"))
+
+    val asTrait: OverloadedRuntimeDispatchMethodTrait = obj
+    assertEquals(6, asTrait.foo(3))
+    assertEquals("Hello Moon", asTrait.foo("Moon"))
+
+    assertEquals(6, callSymbol(obj, sym1)(3))
+    assertEquals("Hello Moon", callSymbol(obj, sym1)("Moon"))
+  }
+
+  @Test def native_with_symbols_in_sjsdefined_object(): Unit = {
+    val obj = mkObject(
+        sym3 -> ((x: Int) => x + 2)
+    )
+
+    assertEquals(65,
+        obj.asInstanceOf[ClassWithSymsInSJSDefinedObject].symInSJSDefinedObject(63))
+    assertEquals(65,
+        obj.asInstanceOf[TraitWithSymsInSJSDefinedObject].symInSJSDefinedObject(63))
+
+    assertEquals(65, callSymbol(obj, sym3)(63))
+  }
+
+  @Test def sjsdefined_with_symbols_in_sjsdefined_object(): Unit = {
+    val obj = new SJSDefinedWithSymsInSJSDefinedObject
+    assertEquals(65, obj.symInSJSDefinedObject(63))
+
+    val asTrait: TraitWithSymsInSJSDefinedObject = obj
+    assertEquals(65, asTrait.symInSJSDefinedObject(63))
+
+    assertEquals(65, callSymbol(obj, sym3)(63))
+  }
+
+  @Test def native_iterable(): Unit = {
+    val obj = mkObject(
+        js.Symbol.iterator -> (() => singletonIterator(653))
+    )
+
+    assertArrayEquals(Array(653),
+        iterableToArray(obj.asInstanceOf[ClassJSIterable[Int]]).toArray)
+    assertArrayEquals(Array(653),
+        iterableToArray(obj.asInstanceOf[JSIterable[Int]]).toArray)
+
+    val content = Array.newBuilder[Int]
+    iterateIterable(obj.asInstanceOf[JSIterable[Int]])(content += _)
+    assertArrayEquals(Array(653), content.result())
+  }
+
+  @Test def sjsdefined_iterable(): Unit = {
+    val obj = new SJSDefinedIterable
+
+    assertArrayEquals(Array(532), iterableToArray(obj).toArray)
+
+    val content = Array.newBuilder[Int]
+    iterateIterable(obj)(content += _)
+    assertArrayEquals(Array(532), content.result())
+  }
+}
+
+object JSSymbolTest {
+
+  @BeforeClass
+  def beforeClass(): Unit = {
+    assumeTrue("Assuming JavaScript symbols are supported",
+        org.scalajs.testsuite.utils.Platform.areJSSymbolsSupported)
+  }
+
+  /* These need to be lazy vals, so that they do not blow up if there is no
+   * symbol support at all.
+   */
+  lazy val sym1 = js.Symbol()
+  lazy val sym2 = js.Symbol()
+
+  @ScalaJSDefined
+  object SJSDefinedWithSyms extends js.Object {
+    val sym3 = js.Symbol()
+  }
+
+  import SJSDefinedWithSyms._
+
+  def mkObject(members: (js.Symbol, js.Any)*): js.Object = {
+    val obj = (new js.Object).asInstanceOf[ObjectCreator]
+    for ((sym, member) <- members) {
+      obj(sym) = member
+    }
+    obj
+  }
+
+  private def selectSymbol(obj: js.Any, sym: js.Symbol): Any =
+    obj.asInstanceOf[SymDynamic].selectSymbol(sym)
+
+  private def updateSymbol(obj: js.Any, sym: js.Symbol, value: Any): Unit =
+    obj.asInstanceOf[SymDynamic].updateSymbol(sym, value)
+
+  private def callSymbol(obj: js.Any, sym: js.Symbol)(args: js.Any*): Any =
+    obj.asInstanceOf[SymDynamic].callSymbol(sym)(args: _*)
+
+  @js.native
+  private trait SymDynamic extends js.Any {
+    @JSBracketAccess
+    def selectSymbol(sym: js.Symbol): Any = js.native
+
+    @JSBracketAccess
+    def updateSymbol(sym: js.Symbol, value: Any): Unit = js.native
+
+    @JSBracketCall
+    def callSymbol(sym: js.Symbol)(args: js.Any*): Any = js.native
+  }
+
+  def singletonIterator(singleton: Any): js.Dynamic = {
+    var first = true
+    js.Dynamic.literal(
+        next = { () =>
+          if (first) {
+            first = false
+            js.Dynamic.literal(value = singleton.asInstanceOf[js.Any],
+                done = false)
+          } else {
+            js.Dynamic.literal(value = (), done = true)
+          }
+        }
+    )
+  }
+
+  def iterableToArray[A](iterable: JSIterable[A]): js.Array[A] =
+    js.constructorOf[js.Array[_]].from(iterable).asInstanceOf[js.Array[A]]
+
+  def iterateIterable[A](iterable: JSIterable[A])(f: A => Any): Unit = {
+    val iterator = iterable.iterator()
+    def loop(): Unit = {
+      val entry = iterator.next()
+      // 2.10 didn't like the use of DynamicImplicits on the following line
+      if (!entry.done.asInstanceOf[Boolean]) {
+        f(entry.value.asInstanceOf[A])
+        loop()
+      }
+    }
+    loop()
+  }
+
+  @js.native
+  private trait ObjectCreator extends js.Object {
+    @JSBracketAccess
+    def update(s: js.Symbol, v: js.Any): Unit = js.native
+  }
+
+  @ScalaJSDefined
+  trait PropDefTrait extends js.Any {
+    @JSName(sym1)
+    def internalDef: Int
+  }
+
+  @js.native
+  @JSName("dummy")
+  class PropDefClass extends js.Any {
+    @JSName(sym1)
+    def internalDef: Int = js.native
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedPropDef extends js.Object with PropDefTrait {
+    @JSName(sym1)
+    def internalDef: Int = 456
+  }
+
+  @ScalaJSDefined
+  trait PropValTrait extends js.Any {
+    @JSName(sym1)
+    val internalVal: String
+  }
+
+  @js.native
+  @JSName("dummy")
+  class PropValClass extends js.Any {
+    @JSName(sym1)
+    val internalVal: String = js.native
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedPropVal extends js.Object with PropValTrait {
+    @JSName(sym1)
+    val internalVal: String = "hello"
+  }
+
+  @ScalaJSDefined
+  trait PropVarTrait extends js.Any {
+    @JSName(sym1)
+    var internalVar: Double
+  }
+
+  @js.native
+  @JSName("dummy")
+  class PropVarClass extends js.Any {
+    @JSName(sym1)
+    var internalVar: Double = js.native
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedPropVar extends js.Object with PropVarTrait {
+    @JSName(sym1)
+    var internalVar: Double = 1511.1989
+  }
+
+  @ScalaJSDefined
+  trait InnerObjectTrait extends js.Any {
+    @JSName(sym1)
+    val innerObject: AnyRef
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedInnerObject extends js.Object with InnerObjectTrait {
+    @JSName(sym1)
+    object innerObject { // scalastyle:ignore
+      override def toString(): String = "SJSDefinedInnerObject.innerObject"
+    }
+  }
+
+  @ScalaJSDefined
+  trait MethodTrait extends js.Any {
+    @JSName(sym1)
+    def foo(x: Int): Int
+
+    @JSName(sym2)
+    def bar(x: String): String
+  }
+
+  @js.native
+  @JSName("dummy")
+  class MethodClass extends js.Any {
+    @JSName(sym1)
+    def foo(x: Int): Int = js.native
+
+    @JSName(sym2)
+    def bar(x: String): String = js.native
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedMethod extends js.Object with MethodTrait {
+    @JSName(sym1)
+    def foo(x: Int): Int = x + 2
+
+    @JSName(sym2)
+    def bar(x: String): String = "Hello " + x
+  }
+
+  @ScalaJSDefined
+  trait OverloadedMethodTrait extends js.Any {
+    @JSName(sym1)
+    def foo(x: Int): Int
+
+    @JSName(sym2)
+    def foo(x: String): String
+  }
+
+  @js.native
+  @JSName("dummy")
+  class OverloadedMethodClass extends js.Any {
+    @JSName(sym1)
+    def foo(x: Int): Int = js.native
+
+    @JSName(sym2)
+    def foo(x: String): String = js.native
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedOverloadedMethod extends js.Object with OverloadedMethodTrait {
+    @JSName(sym1)
+    def foo(x: Int): Int = x + 3
+
+    @JSName(sym2)
+    def foo(x: String): String = "Hello " + x
+  }
+
+  @ScalaJSDefined
+  trait OverloadedRuntimeDispatchMethodTrait extends js.Any {
+    @JSName(sym1)
+    def foo(x: Int): Int
+
+    @JSName(sym1)
+    def foo(x: String): String
+  }
+
+  @js.native
+  @JSName("dummy")
+  class OverloadedRuntimeDispatchMethodClass extends js.Any {
+    @JSName(sym1)
+    def foo(x: Int): Int = js.native
+
+    @JSName(sym1)
+    def foo(x: String): String = js.native
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedOverloadedRuntimeDispatchMethod
+      extends js.Object with OverloadedRuntimeDispatchMethodTrait {
+    @JSName(sym1)
+    def foo(x: Int): Int = x + 3
+
+    @JSName(sym1)
+    def foo(x: String): String = "Hello " + x
+  }
+
+  @ScalaJSDefined
+  trait TraitWithSymsInSJSDefinedObject extends js.Object {
+    @JSName(sym3)
+    def symInSJSDefinedObject(x: Int): Int
+  }
+
+  @js.native
+  @JSName("dummy")
+  class ClassWithSymsInSJSDefinedObject extends js.Object {
+    @JSName(sym3)
+    def symInSJSDefinedObject(x: Int): Int = js.native
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedWithSymsInSJSDefinedObject
+      extends TraitWithSymsInSJSDefinedObject {
+    @JSName(sym3)
+    def symInSJSDefinedObject(x: Int): Int = x + 2
+  }
+
+  @ScalaJSDefined
+  trait JSIterable[+A] extends js.Object {
+    @JSName(js.Symbol.iterator)
+    def iterator(): js.Dynamic
+  }
+
+  @js.native
+  @JSName("dummy")
+  class ClassJSIterable[+A] extends JSIterable[A] {
+    @JSName(js.Symbol.iterator)
+    def iterator(): js.Dynamic = js.native
+  }
+
+  @ScalaJSDefined
+  class SJSDefinedIterable extends JSIterable[Int] {
+    @JSName(js.Symbol.iterator)
+    def iterator(): js.Dynamic = singletonIterator(532)
+  }
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SymbolTest.scala
@@ -1,0 +1,61 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{BeforeClass, Test}
+
+object SymbolTest {
+  @BeforeClass def assumeSymbolsAreSupported(): Unit = {
+    assumeTrue("Assuming JavaScript symbols are supported",
+        org.scalajs.testsuite.utils.Platform.areJSSymbolsSupported)
+  }
+}
+
+class SymbolTest {
+
+  val namedSymbol = js.Symbol.forKey("namedsym")
+  val opaqueSymbolWithDesc = js.Symbol("opaqueSymbolWithDesc")
+  val opaqueSymbolWithoutDesc = js.Symbol()
+
+  @Test def typeOf(): Unit = {
+    assertEquals("symbol", js.typeOf(namedSymbol))
+    assertEquals("symbol", js.typeOf(opaqueSymbolWithDesc))
+    assertEquals("symbol", js.typeOf(opaqueSymbolWithoutDesc))
+  }
+
+  @Test def keyFor(): Unit = {
+    assertEquals("namedsym", js.Symbol.keyFor(namedSymbol))
+    assertEquals(js.undefined, js.Symbol.keyFor(opaqueSymbolWithDesc))
+    assertEquals(js.undefined, js.Symbol.keyFor(opaqueSymbolWithoutDesc))
+  }
+
+  @Test def identity(): Unit = {
+    assertSame(namedSymbol, js.Symbol.forKey("namedsym"))
+    assertNotSame(namedSymbol, js.Symbol("namedsym"))
+    assertNotSame(opaqueSymbolWithDesc, js.Symbol("opaqueSymbolWithDesc"))
+    assertNotSame(opaqueSymbolWithoutDesc, js.Symbol())
+  }
+
+  @Test def testToString(): Unit = {
+    assertEquals("Symbol(namedsym)", namedSymbol.toString())
+    assertEquals("Symbol(opaqueSymbolWithDesc)", opaqueSymbolWithDesc.toString())
+    assertEquals("Symbol()", opaqueSymbolWithoutDesc.toString())
+  }
+
+  @Test def wellKnownSymbolIterator(): Unit = {
+    val sym = js.Symbol.iterator
+    assertEquals("symbol", js.typeOf(sym))
+    assertEquals(js.undefined, js.Symbol.keyFor(sym))
+    assertEquals("Symbol(Symbol.iterator)", sym.toString())
+  }
+
+}

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
@@ -233,15 +233,20 @@ private[closure] class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
     setNodePosition(Node.newString(Token.LABEL_NAME, ident.name),
         ident.pos orElse parentPos)
 
-  def transformString(pName: PropertyName)(implicit parentPos: Position): Node =
-    setNodePosition(Node.newString(pName.name), pName.pos orElse parentPos)
+  def transformString(ident: Ident)(implicit parentPos: Position): Node =
+    setNodePosition(Node.newString(ident.name), ident.pos orElse parentPos)
 
   def transformStringKey(pName: PropertyName)(
       implicit parentPos: Position): Node = {
-    val node = Node.newString(Token.STRING_KEY, pName.name)
+    val node = pName match {
+      case Ident(name, _) =>
+        Node.newString(Token.STRING_KEY, name)
 
-    if (pName.isInstanceOf[StringLiteral])
-      node.setQuotedString()
+      case StringLiteral(name) =>
+        val node = Node.newString(Token.STRING_KEY, name)
+        node.setQuotedString()
+        node
+    }
 
     setNodePosition(node, pName.pos orElse parentPos)
   }

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
@@ -246,6 +246,12 @@ private[closure] class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
         val node = Node.newString(Token.STRING_KEY, name)
         node.setQuotedString()
         node
+
+      case ComputedName(tree) =>
+        throw new AssertionError(
+            "The Closure AST compiler received a ComputedName, which it " +
+            "cannot translate because it always emits ES 5.1 code. " +
+            "Position: " + parentPos)
     }
 
     setNodePosition(node, pName.pos orElse parentPos)

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
@@ -107,15 +107,16 @@ final class ClosureLinkerBackend(
   private def makeExternsForExports(linkingUnit: LinkingUnit): VirtualJSFile = {
     import org.scalajs.core.ir.Trees._
 
-    def exportName(tree: Tree): String = (tree: @unchecked) match {
-      case MethodDef(_, StringLiteral(name), _, _, _) => name
-      case PropertyDef(_, StringLiteral(name), _, _)  => name
+    def exportName(tree: Tree): Option[String] = (tree: @unchecked) match {
+      case MethodDef(_, StringLiteral(name), _, _, _) => Some(name)
+      case PropertyDef(_, StringLiteral(name), _, _)  => Some(name)
+      case _                                          => None
     }
 
     val exportedPropertyNames = for {
       classDef <- linkingUnit.classDefs
       member <- classDef.exportedMembers
-      name = exportName(member.tree)
+      name <- exportName(member.tree)
       if isValidIdentifier(name)
     } yield {
       name

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
@@ -561,6 +561,11 @@ object Printers {
     private final def print(propName: PropertyName): Unit = propName match {
       case lit: StringLiteral => print(lit: Tree)
       case ident: Ident       => print(ident)
+
+      case ComputedName(tree) =>
+        print("[")
+        print(tree)
+        print("]")
     }
 
     protected def print(s: String): Unit =

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
@@ -37,7 +37,6 @@ object Trees {
   // Identifiers and properties
 
   sealed trait PropertyName {
-    def name: String
     def pos: Position
   }
 
@@ -205,9 +204,7 @@ object Trees {
   case class DoubleLiteral(value: Double)(implicit val pos: Position) extends Literal
 
   case class StringLiteral(value: String)(
-      implicit val pos: Position) extends Literal with PropertyName {
-    override def name = value
-  }
+      implicit val pos: Position) extends Literal with PropertyName
 
   // Atomic expressions
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
@@ -50,6 +50,10 @@ object Trees {
       new Ident(name, Some(name))
   }
 
+  case class ComputedName(tree: Tree) extends PropertyName {
+    def pos = tree.pos
+  }
+
   // Definitions
 
   sealed trait LocalDef extends Tree {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
@@ -146,12 +146,12 @@ object LinkedClass {
     val classExports = mutable.Buffer.empty[Tree]
 
     def linkedMethod(m: MethodDef) = {
-      val info = memberInfoByName(m.name.name)
+      val info = memberInfoByName(m.name.encodedName)
       new LinkedMember(info, m, None)
     }
 
     def linkedProperty(p: PropertyDef) = {
-      val info = memberInfoByName(p.name.name)
+      val info = memberInfoByName(p.name.encodedName)
       new LinkedMember(info, p, None)
     }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSDesugaring.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSDesugaring.scala
@@ -1478,7 +1478,7 @@ private[emitter] class JSDesugaring(semantics: Semantics,
             val assignFields = fields.foldRight((Set.empty[String], List.empty[Tree])) {
               case ((prop, value), (namesSeen, statsAcc)) =>
                 implicit val pos = value.pos
-                val name = prop.name
+                val name = prop.encodedName
                 val stat = prop match {
                   case _ if namesSeen.contains(name) =>
                     /* Important: do not emit the assignment, otherwise
@@ -1574,7 +1574,7 @@ private[emitter] class JSDesugaring(semantics: Semantics,
     /** Tests whether a [[JSObjectConstr]] must be desugared. */
     private def doesObjectConstrRequireDesugaring(
         tree: JSObjectConstr): Boolean = {
-      val names = tree.fields.map(_._1.name)
+      val names = tree.fields.map(_._1.encodedName)
       names.toSet.size != names.size // i.e., there is at least one duplicate
     }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/KnowledgeGuardian.scala
@@ -55,7 +55,7 @@ private[emitter] final class KnowledgeGuardian {
 
       if (linkedClass.encodedName == LongImpl.RuntimeLongClass) {
         newHasNewRuntimeLong = linkedClass.memberMethods.exists { linkedMethod =>
-          linkedMethod.tree.name.name == LongImpl.initFromParts
+          linkedMethod.tree.name.encodedName == LongImpl.initFromParts
         }
       }
     }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ScalaJSClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ScalaJSClassEmitter.scala
@@ -340,7 +340,7 @@ private[emitter] final class ScalaJSClassEmitter(semantics: Semantics,
   def genStaticInitialization(tree: LinkedClass): js.Tree = {
     import Definitions.StaticInitializerName
     implicit val pos = tree.pos
-    if (tree.staticMethods.exists(_.tree.name.name == StaticInitializerName)) {
+    if (tree.staticMethods.exists(_.tree.name.encodedName == StaticInitializerName)) {
       val fullName = tree.encodedName + "__" + StaticInitializerName
       js.Apply(envField("s", fullName, Some("<clinit>")), Nil)
     } else {
@@ -359,7 +359,7 @@ private[emitter] final class ScalaJSClassEmitter(semantics: Semantics,
     val methodFun0 = desugarToFunction(className,
         method.args, methodBody, method.resultType == NoType)
 
-    val methodFun = if (Definitions.isConstructorName(method.name.name)) {
+    val methodFun = if (Definitions.isConstructorName(method.name.encodedName)) {
       // init methods have to return `this` so that we can chain them to `new`
       js.Function(methodFun0.args, {
         implicit val pos = methodFun0.body.pos

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -128,7 +128,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
        */
       val staticFieldDefs = classDef.fields.filter(_.static)
       for {
-        fieldsWithSameName <- staticFieldDefs.groupBy(_.name.name).values
+        fieldsWithSameName <- staticFieldDefs.groupBy(_.name.encodedName).values
         duplicate <- fieldsWithSameName.tail
       } {
         implicit val ctx = ErrorContext(duplicate)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -201,13 +201,13 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
     val classExports = mutable.Buffer.empty[Tree]
 
     def linkedMethod(m: MethodDef) = {
-      val info = memberInfoByStaticAndName((m.static, m.name.name))
+      val info = memberInfoByStaticAndName((m.static, m.name.encodedName))
       val version = m.hash.map(Hashers.hashAsVersion(_, considerPositions))
       new LinkedMember(info, m, version)
     }
 
     def linkedProperty(p: PropertyDef) = {
-      val info = memberInfoByStaticAndName((p.static, p.name.name))
+      val info = memberInfoByStaticAndName((p.static, p.name.encodedName))
       new LinkedMember(info, p, None)
     }
 
@@ -220,7 +220,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
     classDef.defs.foreach {
       // Static methods
       case m: MethodDef if m.static =>
-        if (analyzerInfo.staticMethodInfos(m.name.name).isReachable) {
+        if (analyzerInfo.staticMethodInfos(m.name.encodedName).isReachable) {
           if (m.name.isInstanceOf[StringLiteral])
             exportedMembers += linkedMethod(m)
           else
@@ -234,7 +234,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
 
       // Normal methods
       case m: MethodDef =>
-        if (analyzerInfo.methodInfos(m.name.name).isReachable) {
+        if (analyzerInfo.methodInfos(m.name.encodedName).isReachable) {
           if (m.name.isInstanceOf[StringLiteral])
             exportedMembers += linkedMethod(m)
           else if (m.body.isDefined)
@@ -445,7 +445,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
     val (classDef, _) = getTree(classInfo.encodedName)
     classDef.defs.collectFirst {
       case mDef: MethodDef
-          if !mDef.static && mDef.name.name == methodName => mDef
+          if !mDef.static && mDef.name.encodedName == methodName => mDef
     }.getOrElse {
       throw new AssertionError(
           s"Cannot find $methodName in ${classInfo.encodedName}")

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -221,10 +221,10 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
       // Static methods
       case m: MethodDef if m.static =>
         if (analyzerInfo.staticMethodInfos(m.name.encodedName).isReachable) {
-          if (m.name.isInstanceOf[StringLiteral])
-            exportedMembers += linkedMethod(m)
-          else
+          if (m.name.isInstanceOf[Ident])
             staticMethods += linkedMethod(m)
+          else
+            exportedMembers += linkedMethod(m)
         }
 
       // Fields
@@ -235,12 +235,14 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
       // Normal methods
       case m: MethodDef =>
         if (analyzerInfo.methodInfos(m.name.encodedName).isReachable) {
-          if (m.name.isInstanceOf[StringLiteral])
+          if (m.name.isInstanceOf[Ident]) {
+            if (m.body.isDefined)
+              memberMethods += linkedMethod(m)
+            else
+              abstractMethods += linkedMethod(m)
+          } else {
             exportedMembers += linkedMethod(m)
-          else if (m.body.isDefined)
-            memberMethods += linkedMethod(m)
-          else
-            abstractMethods += linkedMethod(m)
+          }
         }
 
       case m: PropertyDef =>

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -142,7 +142,7 @@ private[optimizer] abstract class OptimizerCore(
           transformIsolatedBody(Some(myself), thisType, params, resultType, body)
       }
       val newBody =
-        if (name.name == "init___") tryElimStoreModule(newBody1)
+        if (name.encodedName == "init___") tryElimStoreModule(newBody1)
         else newBody1
       val m = MethodDef(static, name, newParams, resultType,
           Some(newBody))(originalDef.optimizerHints, None)(originalDef.pos)


### PR DESCRIPTION
(Old PR description below)

The `@JSName` annotation could previously be used to specify the JavaScript *string* name of a property/method, independently of its Scala name. This can be used both in native JS classes as well as Scala.js-defined JS classes.

This commit extends the capability of `@JSName` to admit a (static, stable) reference to a `js.Symbol`. This applies to both native and Scala.js-defined JS types.

At call site, the semantics and compilation scheme are straightforward: it is a `JSBracketSelect` whose `item` part is a call to the symbol accessor. Since it is static by construction, we can call it from anywhere.

At definition site for native JS types, there is nothing to do (besides validity checks).

At definition site for Scala.js-defined JS classes, things get tricky. We can now have "exported" class members whose name is not a constant string anymore. This requires to extend the IR with `ComputedName`s (a concept that exists in ECMAScript 2015). A computed name is an arbitrary expression `Tree` that is evaluated to obtain the dynamic name of a property. This complicates the Emitter somewhat, but not that much because Scala.js-defined JS classes are created lazily, so we can execute arbitrary user-defined code at class-definition time.

For overloading resolution, `ComputedName`s have a `logicalName`, derived from the fully qualified name of the symbol accessors. All `ComputedName`'d properties/methods with the same logical name (i.e., referencing the same static stable `js.Symbol`) are considered to be overloaded. This has an unavoidable caveat: if two `ComputedName`s in the same class have a different logical name, but actually evaluate to the same symbol, things will go wrong at run-time.

`JSObjectConstr` is enhanced to support `ComputedName`s as well, for consistency. It is also consistent with Object Initializers in ECMAScript 2015. This actually complicates their treatment, mostly because of evaluation order concerns.

Exports (in Scala classes and at the top-level) cannot use symbolic names. This is not expected to change in the future.

There is one implementation restriction: `@JSName` with a symbol is not supported on native JS classes and objects that are nested within a native JS object. There is no language reason to disallow this, but the implementation is surprisingly difficult, due to the way scalac flattens such entities.

---

# Old PR description

We introduce @JSSymbol as a pendant to @JSName to define member access through ES6 symbols. On a high level, the following happens in the compiler:

## PrepJSInterop / Definition Site
Take the content of @JSSymbol annotations and put it into a special method, the "symbol forwarder". This is necessary, since otherwise the trees won't get compiled. As a nice side effect, it allows changing the symbol without breaking binary compatibility.

Further, we replace the tree inside @JSSymbol with a simple tree calling the symbol forwarder. This tree will not get compiled, but we will only use its symbol.

## PrepJSInterop / Call Site
Nothing.

## GenJSCode / Definition Site
We emit symbol forwarders as static methods on the native JS class. This does not need an IR change, since this is already supported (but was unused so far).

For traits pre 2.12.0, this is a bit more involved, since the symbol forwarder gets moved to the implementation class. We retrieve the implementation class and move the forwarder.

## GenJSCode / Call Site
Instead of generating a string literal inside the bracket select, we generate a call to the symbol forwarder. The symbol forwarder's symbol is conveniently available inside the tree of the @JSSymbol annotation.

## Caveat
Since we generate number suffixes to disambiguate symbol forwarder overloads, adding an overload to a method with @JSSymbol is a potentially binary breaking change.