### PR TITLE
Fix #1655: Allow export of classes inside objects

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -471,7 +471,10 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
     class A {
       @JSExport
-      class Nested
+      class Nested {
+        @JSExport
+        def this(x: Int) = this()
+      }
 
       @JSExport
       @ScalaJSDefined class Nested2 extends js.Object
@@ -481,25 +484,39 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:4: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
       |      @JSExport
       |       ^
-      |newSource1.scala:7: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
+      |newSource1.scala:6: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
+      |        @JSExport
+      |         ^
+      |newSource1.scala:10: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
       |      @JSExport
       |       ^
     """
+
+  }
+
+  @Test
+  def noImplicitNameNestedExportClass: Unit = {
 
     """
     object A {
       @JSExport
-      class Nested
+      class Nested {
+        @JSExport
+        def this(x: Int) = this
+      }
 
       @JSExport
       @ScalaJSDefined class Nested2 extends js.Object
     }
     """ hasErrors
     """
-      |newSource1.scala:4: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
+      |newSource1.scala:4: error: You must set an explicit name for exports of nested classes.
       |      @JSExport
       |       ^
-      |newSource1.scala:7: error: You may not export a nested class. Create an exported factory method in the outer class to work around this limitation.
+      |newSource1.scala:6: error: You must set an explicit name for exports of nested classes.
+      |        @JSExport
+      |         ^
+      |newSource1.scala:10: error: You must set an explicit name for exports of nested classes.
       |      @JSExport
       |       ^
     """
@@ -527,6 +544,11 @@ class JSExportTest extends DirectTest with TestHelpers {
       |       ^
     """
 
+  }
+
+  @Test
+  def noImplicitNameNestedExportObject: Unit = {
+
     """
     object A {
       @JSExport
@@ -537,10 +559,10 @@ class JSExportTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:4: error: You may not export a nested object
+      |newSource1.scala:4: error: You must set an explicit name for exports of nested classes.
       |      @JSExport
       |       ^
-      |newSource1.scala:7: error: You may not export a nested object
+      |newSource1.scala:7: error: You must set an explicit name for exports of nested classes.
       |      @JSExport
       |       ^
     """

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -638,6 +638,16 @@ class ExportsTest {
     assertEquals("witness", obj.witness)
   }
 
+  @Test def exports_for_nested_objects(): Unit = {
+    val accessor = exportsNamespace.qualified.nested.ExportedObject
+    assertJSNotUndefined(accessor)
+    assertEquals("function", js.typeOf(accessor))
+    val obj = accessor()
+    assertJSNotUndefined(obj)
+    assertEquals("object", js.typeOf(obj))
+    assertSame(obj, ExportHolder.ExportedObject)
+  }
+
   @Test def exports_for_objects_with_constant_folded_name(): Unit = {
     val accessor = exportsNamespace.ConstantFoldedObjectExport
     assertJSNotUndefined(accessor)
@@ -700,6 +710,14 @@ class ExportsTest {
     assertEquals(5, obj.x)
   }
 
+  @Test def exports_for_nested_classes(): Unit = {
+    val constr = exportsNamespace.qualified.nested.ExportedClass
+    assertJSNotUndefined(constr)
+    assertEquals("function", js.typeOf(constr))
+    val obj = js.Dynamic.newInstance(constr)()
+    assertTrue((obj: Any).isInstanceOf[ExportHolder.ExportedClass])
+  }
+
   @Test def exports_for_classes_with_qualified_name_SJSDefinedExportedClass(): Unit = {
     val constr = exportsNamespace.qualified.testclass.SJSDefinedExportedClass
     assertJSNotUndefined(constr)
@@ -707,6 +725,14 @@ class ExportsTest {
     val obj = js.Dynamic.newInstance(constr)(5)
     assertTrue((obj: Any).isInstanceOf[SJSDefinedExportedClass])
     assertEquals(5, obj.x)
+  }
+
+  @Test def exports_for_nested_sjs_defined_classes(): Unit = {
+    val constr = exportsNamespace.qualified.nested.SJSDefinedExportedClass
+    assertJSNotUndefined(constr)
+    assertEquals("function", js.typeOf(constr))
+    val obj = js.Dynamic.newInstance(constr)()
+    assertTrue((obj: Any).isInstanceOf[ExportHolder.SJSDefinedExportedClass])
   }
 
   @Test def exports_for_classes_with_constant_folded_name(): Unit = {
@@ -1602,4 +1628,16 @@ class ExportClassSetterNamed_= { // scalastyle:ignore
 object ExportObjSetterNamed_= { // scalastyle:ignore
   @JSExport
   val x = 1
+}
+
+object ExportHolder {
+  @JSExport("qualified.nested.ExportedClass")
+  class ExportedClass
+
+  @JSExport("qualified.nested.ExportedObject")
+  object ExportedObject
+
+  @JSExport("qualified.nested.SJSDefinedExportedClass")
+  @ScalaJSDefined
+  class SJSDefinedExportedClass extends js.Object
 }


### PR DESCRIPTION
This is a trivial extension to allow exports of static classes / modules. The only non-trivial issues is name choice, which we effectively circumvent by forcing the user to choose a name.