### PR TITLE
Add an annotation `@JSOptional` for optional members in JS types.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -281,12 +281,7 @@ abstract class GenJSCode extends plugins.PluginComponent
           val isPrimitive =
             isPrimitiveValueClass(sym) || (sym == ArrayClass)
 
-          /* Similarly, do not emit code for impl classes of raw JS traits. */
-          val isRawJSImplClass =
-            sym.isImplClass && isRawJSType(
-                sym.owner.info.decl(sym.name.dropRight(nme.IMPL_CLASS_SUFFIX.length)).tpe)
-
-          if (!isPrimitive && !isRawJSImplClass) {
+          if (!isPrimitive && !isRawJSImplClass(sym)) {
             withScopedVars(
                 currentClassSym          := sym,
                 unexpectedMutatedFields  := mutable.Set.empty,
@@ -468,6 +463,8 @@ abstract class GenJSCode extends plugins.PluginComponent
               /* Exposed accessors must not be emitted, since the field they
                * access is enough.
                */
+            } else if (sym.hasAnnotation(JSOptionalAnnotation)) {
+              // Optional methods must not be emitted
             } else {
               generatedMethods ++= genMethod(dd)
 
@@ -811,6 +808,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       (for {
         f <- classSym.info.decls
         if !f.isMethod && f.isTerm && !f.isModule
+        if !f.hasAnnotation(JSOptionalAnnotation)
       } yield {
         implicit val pos = f.pos
 
@@ -1722,38 +1720,43 @@ abstract class GenJSCode extends plugins.PluginComponent
           val sym = lhs.symbol
           if (sym.isStaticMember)
             abort(s"Assignment to static member ${sym.fullName} not supported")
-          val genRhs = genExpr(rhs)
-          lhs match {
-            case Select(qualifier, _) =>
-              val ctorAssignment = (
-                  currentMethodSym.isClassConstructor &&
-                  currentMethodSym.owner == qualifier.symbol &&
-                  qualifier.isInstanceOf[This]
-              )
-              if (!ctorAssignment && !suspectFieldMutable(sym))
-                unexpectedMutatedFields += sym
+          if (rhs.symbol == Runtime_optionalUndefined) {
+            // Discard initialization assignment to @JSOptional field
+            js.Skip()
+          } else {
+            val genRhs = genExpr(rhs)
+            lhs match {
+              case Select(qualifier, _) =>
+                val ctorAssignment = (
+                    currentMethodSym.isClassConstructor &&
+                    currentMethodSym.owner == qualifier.symbol &&
+                    qualifier.isInstanceOf[This]
+                )
+                if (!ctorAssignment && !suspectFieldMutable(sym))
+                  unexpectedMutatedFields += sym
 
-              val genQual = genExpr(qualifier)
+                val genQual = genExpr(qualifier)
 
-              if (isScalaJSDefinedJSClass(sym.owner)) {
-                val genLhs = if (isExposed(sym))
-                  js.JSBracketSelect(genQual, js.StringLiteral(jsNameOf(sym)))
-                else
-                  js.JSDotSelect(genQual, encodeFieldSym(sym))
-                val boxedRhs =
-                  ensureBoxed(genRhs,
-                      enteringPhase(currentRun.posterasurePhase)(rhs.tpe))
-                js.Assign(genLhs, boxedRhs)
-              } else {
+                if (isScalaJSDefinedJSClass(sym.owner)) {
+                  val genLhs = if (isExposed(sym))
+                    js.JSBracketSelect(genQual, js.StringLiteral(jsNameOf(sym)))
+                  else
+                    js.JSDotSelect(genQual, encodeFieldSym(sym))
+                  val boxedRhs =
+                    ensureBoxed(genRhs,
+                        enteringPhase(currentRun.posterasurePhase)(rhs.tpe))
+                  js.Assign(genLhs, boxedRhs)
+                } else {
+                  js.Assign(
+                      js.Select(genQual, encodeFieldSym(sym))(toIRType(sym.tpe)),
+                      genRhs)
+                }
+              case _ =>
+                mutatedLocalVars += sym
                 js.Assign(
-                    js.Select(genQual, encodeFieldSym(sym))(toIRType(sym.tpe)),
+                    js.VarRef(encodeLocalSym(sym))(toIRType(sym.tpe)),
                     genRhs)
-              }
-            case _ =>
-              mutatedLocalVars += sym
-              js.Assign(
-                  js.VarRef(encodeLocalSym(sym))(toIRType(sym.tpe)),
-                  genRhs)
+            }
           }
 
         /** Array constructor */
@@ -2133,7 +2136,15 @@ abstract class GenJSCode extends plugins.PluginComponent
       val sym = fun.symbol
 
       if (isScalaJSDefinedJSClass(currentClassSym)) {
-        genJSSuperCall(tree, isStat)
+        if (sym.isMixinConstructor) {
+          /* Do not emit a call to the $init$ method of JS traits.
+           * This exception is necessary because @JSOptional fields cause the
+           * creation of a $init$ method, which we must not call.
+           */
+          js.Skip()
+        } else {
+          genJSSuperCall(tree, isStat)
+        }
       } else {
         val superCall = genApplyMethodStatically(
             genThis()(sup.pos), sym, genActualArgs(sym, args))
@@ -2346,7 +2357,15 @@ abstract class GenJSCode extends plugins.PluginComponent
 
     def genTraitImplApply(method: Symbol, arguments: List[js.Tree])(
         implicit pos: Position): js.Tree = {
-      genApplyStatic(method, arguments)
+      if (method.isMixinConstructor && isRawJSImplClass(method.owner)) {
+        /* Do not emit a call to the $init$ method of JS traits.
+         * This exception is necessary because @JSOptional fields cause the
+         * creation of a $init$ method, which we must not call.
+         */
+        js.Skip()
+      } else {
+        genApplyStatic(method, arguments)
+      }
     }
 
     def genApplyJSClassMethod(receiver: js.Tree, method: Symbol,
@@ -5011,6 +5030,12 @@ abstract class GenJSCode extends plugins.PluginComponent
   /** Tests whether the given class is a JS native class. */
   private def isJSNativeClass(sym: Symbol): Boolean =
     isRawJSType(sym.tpe) && !isScalaJSDefinedJSClass(sym)
+
+  /** Tests whether the given class is the impl class of a raw JS trait. */
+  private def isRawJSImplClass(sym: Symbol): Boolean = {
+    sym.isImplClass && isRawJSType(
+        sym.owner.info.decl(sym.name.dropRight(nme.IMPL_CLASS_SUFFIX.length)).tpe)
+  }
 
   /** Tests whether the given member is exposed, i.e., whether it was
    *  originally a public or protected member of a Scala.js-defined JS class.

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -28,6 +28,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackage, newTermName("constructorOf"))
       lazy val JSPackage_debugger      = getMemberMethod(ScalaJSJSPackage, newTermName("debugger"))
       lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackage, newTermName("native"))
+      lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackage, newTermName("undefined"))
 
     lazy val JSNativeAnnotation = getRequiredClass("scala.scalajs.js.native")
 
@@ -66,6 +67,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSExportTopLevelAnnotation = getRequiredClass("scala.scalajs.js.annotation.JSExportTopLevel")
     lazy val JSImportAnnotation        = getRequiredClass("scala.scalajs.js.annotation.JSImport")
     lazy val JSGlobalScopeAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSGlobalScope")
+    lazy val JSOptionalAnnotation      = getRequiredClass("scala.scalajs.js.annotation.JSOptional")
     lazy val ScalaJSDefinedAnnotation  = getRequiredClass("scala.scalajs.js.annotation.ScalaJSDefined")
     lazy val SJSDefinedAnonymousClassAnnotation = getRequiredClass("scala.scalajs.js.annotation.SJSDefinedAnonymousClass")
     lazy val HasJSNativeLoadSpecAnnotation = getRequiredClass("scala.scalajs.js.annotation.internal.HasJSNativeLoadSpec")
@@ -121,6 +123,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val Runtime_jsTupleArray2jsObject      = getMemberMethod(RuntimePackageModule, newTermName("jsTupleArray2jsObject"))
       lazy val Runtime_constructorOf              = getMemberMethod(RuntimePackageModule, newTermName("constructorOf"))
       lazy val Runtime_newConstructorTag          = getMemberMethod(RuntimePackageModule, newTermName("newConstructorTag"))
+      lazy val Runtime_optionalUndefined          = getMemberMethod(RuntimePackageModule, newTermName("optionalUndefined"))
       lazy val Runtime_propertiesOf               = getMemberMethod(RuntimePackageModule, newTermName("propertiesOf"))
       lazy val Runtime_linkingInfo                = getMemberMethod(RuntimePackageModule, newTermName("linkingInfo"))
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala
@@ -1,0 +1,186 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+
+import org.junit.Test
+import org.junit.Ignore
+
+// scalastyle:off line.size.limit
+
+class JSOptionalTest extends DirectTest with TestHelpers {
+
+  override def preamble: String = {
+    """
+    import scala.scalajs.js
+    import scala.scalajs.js.annotation._
+    """
+  }
+
+  @Test
+  def optionalRequiresUndefinedRHS: Unit = {
+    for (kind <- Seq("class", "trait", "object")) {
+      s"""
+      @ScalaJSDefined
+      $kind A extends js.Object {
+        @JSOptional val a1: js.UndefOr[Int] = 5
+        @JSOptional val a2: Int = 5
+
+        @JSOptional def b1: js.UndefOr[Int] = 5
+        @JSOptional def b2: Int = 5
+
+        @JSOptional var c1: js.UndefOr[Int] = 5
+        @JSOptional var c2: Int = 5
+      }
+      """ hasErrors
+      s"""
+        |newSource1.scala:7: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional val a1: js.UndefOr[Int] = 5
+        |                                              ^
+        |newSource1.scala:8: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional val a2: Int = 5
+        |                                  ^
+        |newSource1.scala:10: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional def b1: js.UndefOr[Int] = 5
+        |                                              ^
+        |newSource1.scala:11: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional def b2: Int = 5
+        |                                  ^
+        |newSource1.scala:13: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional var c1: js.UndefOr[Int] = 5
+        |                                              ^
+        |newSource1.scala:14: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional var c2: Int = 5
+        |                                  ^
+      """
+    }
+  }
+
+  @Test
+  def optionalCannotBeAbstract: Unit = {
+    for (kind <- Seq("abstract class", "trait")) {
+      s"""
+      @ScalaJSDefined
+      $kind A extends js.Object {
+        @JSOptional val a1: js.UndefOr[Int]
+        @JSOptional val a2: Int
+
+        @JSOptional def b1: js.UndefOr[Int]
+        @JSOptional def b2: Int
+
+        @JSOptional var c1: js.UndefOr[Int]
+        @JSOptional var c2: Int
+      }
+      """ hasErrors
+      s"""
+        |newSource1.scala:7: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional val a1: js.UndefOr[Int]
+        |                        ^
+        |newSource1.scala:8: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional val a2: Int
+        |                        ^
+        |newSource1.scala:10: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional def b1: js.UndefOr[Int]
+        |                        ^
+        |newSource1.scala:11: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional def b2: Int
+        |                        ^
+        |newSource1.scala:13: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional var c1: js.UndefOr[Int]
+        |                        ^
+        |newSource1.scala:14: error: The right-hand-side of an @JSOptional member must be `js.undefined`.
+        |        @JSOptional var c2: Int
+        |                        ^
+      """
+    }
+  }
+
+  @Test
+  def noOverrideNonOptionalWithOptional: Unit = {
+    for (childKind <- Seq("class", "trait", "object")) {
+      s"""
+      @ScalaJSDefined
+      abstract class A extends js.Object {
+        val a1: js.UndefOr[Int] = 5
+        val a2: js.UndefOr[Int]
+
+        def b1: js.UndefOr[Int] = 5
+        def b2: js.UndefOr[Int]
+      }
+
+      @ScalaJSDefined
+      $childKind B extends A {
+        @JSOptional override val a1: js.UndefOr[Int] = js.undefined
+        @JSOptional override val a2: js.UndefOr[Int] = js.undefined
+
+        @JSOptional override def b1: js.UndefOr[Int] = js.undefined
+        @JSOptional override def b2: js.UndefOr[Int] = js.undefined
+      }
+      """ hasErrors
+      s"""
+        |newSource1.scala:16: error: Overriding non-optional val a1: scala.scalajs.js.UndefOr[Int] with @JSOptional override val a1: scala.scalajs.js.UndefOr[Int] is not allowed
+        |        @JSOptional override val a1: js.UndefOr[Int] = js.undefined
+        |                                 ^
+        |newSource1.scala:17: error: Overriding non-optional val a2: scala.scalajs.js.UndefOr[Int] with @JSOptional override val a2: scala.scalajs.js.UndefOr[Int] is not allowed
+        |        @JSOptional override val a2: js.UndefOr[Int] = js.undefined
+        |                                 ^
+        |newSource1.scala:19: error: Overriding non-optional def b1: scala.scalajs.js.UndefOr[Int] with @JSOptional override def b1: scala.scalajs.js.UndefOr[Int] is not allowed
+        |        @JSOptional override def b1: js.UndefOr[Int] = js.undefined
+        |                                 ^
+        |newSource1.scala:20: error: Overriding non-optional def b2: scala.scalajs.js.UndefOr[Int] with @JSOptional override def b2: scala.scalajs.js.UndefOr[Int] is not allowed
+        |        @JSOptional override def b2: js.UndefOr[Int] = js.undefined
+        |                                 ^
+      """
+    }
+
+    for (childKind <- Seq("class", "trait", "object")) {
+      s"""
+      @ScalaJSDefined
+      trait A extends js.Object {
+        val a: js.UndefOr[Int]
+        def b: js.UndefOr[Int]
+      }
+
+      @ScalaJSDefined
+      $childKind B extends A {
+        @JSOptional override val a: js.UndefOr[Int] = js.undefined
+        @JSOptional override def b: js.UndefOr[Int] = js.undefined
+      }
+      """ hasErrors
+      s"""
+        |newSource1.scala:13: error: Overriding non-optional val a: scala.scalajs.js.UndefOr[Int] with @JSOptional override val a: scala.scalajs.js.UndefOr[Int] is not allowed
+        |        @JSOptional override val a: js.UndefOr[Int] = js.undefined
+        |                                 ^
+        |newSource1.scala:14: error: Overriding non-optional def b: scala.scalajs.js.UndefOr[Int] with @JSOptional override def b: scala.scalajs.js.UndefOr[Int] is not allowed
+        |        @JSOptional override def b: js.UndefOr[Int] = js.undefined
+        |                                 ^
+      """
+    }
+  }
+
+  @Test
+  def noOptionalDefWithParens: Unit = {
+    s"""
+    @ScalaJSDefined
+    trait A extends js.Object {
+      @JSOptional def a(): js.UndefOr[Int] = js.undefined
+      @JSOptional def b(x: Int): js.UndefOr[Int] = js.undefined
+      @JSOptional def c_=(v: Int): js.UndefOr[Int] = js.undefined
+    }
+    """ hasErrors
+    s"""
+      |newSource1.scala:7: error: @JSOptional cannot be used on methods with parentheses
+      |      @JSOptional def a(): js.UndefOr[Int] = js.undefined
+      |       ^
+      |newSource1.scala:8: error: @JSOptional cannot be used on methods with parentheses
+      |      @JSOptional def b(x: Int): js.UndefOr[Int] = js.undefined
+      |       ^
+      |newSource1.scala:9: error: Raw JS setters must return Unit
+      |      @JSOptional def c_=(v: Int): js.UndefOr[Int] = js.undefined
+      |                      ^
+      |newSource1.scala:9: error: @JSOptional cannot be used on methods with parentheses
+      |      @JSOptional def c_=(v: Int): js.UndefOr[Int] = js.undefined
+      |       ^
+    """
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -599,7 +599,7 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:7: error: A Scala.js-defined JS trait can only contain abstract members
+      |newSource1.scala:7: error: A Scala.js-defined JS trait can only contain abstract members and/or @JSOptional members
       |      def foo(x: Int): Int = x + 1
       |          ^
     """

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSOptional.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSOptional.scala
@@ -1,0 +1,29 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package scala.scalajs.js.annotation
+
+import scala.annotation.meta._
+
+/** Marks a member of a JavaScript class/trait/object as an optional field.
+ *
+ *  `@JSOptional` can annotate a concrete `val`, `var` or `def` without
+ *  parentheses in a non-native JavaScript trait, class or object.
+ *  The right-hand-side of that member must be `= js.undefined`, and its type
+ *  must therefore be a supertype of `js.UndefOr[Nothing]`.
+ *
+ *  A field annotated with `@JSOptional` is not actually created on a JavaScript
+ *  class or object. Instead, accessing it will return `undefined` because the
+ *  field is not present.
+ *
+ *  `@JSOptional` members are the only concrete members that can appear in a
+ *  non-native JS trait. This is particularly useful for "option bags": JS
+ *  traits that describe objects where fields are options with default values.
+ */
+@field @getter @setter
+class JSOptional extends scala.annotation.StaticAnnotation

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -81,6 +81,16 @@ package object runtime {
   def newConstructorTag[T <: js.Any](constructor: js.Dynamic): js.ConstructorTag[T] =
     new js.ConstructorTag[T](constructor)
 
+  /** Dummy method to identify "assignments" of `js.undefined` to `@JSOptional`
+   *  members.
+   *
+   *  An early phase of the compiler reroutes calls to `js.undefined` in the
+   *  rhs of `@JSOptional` members into `runtime.optionalUndefined()`. The
+   *  back-end then ignores assignments of `runtime.optionalUndefined()` to
+   *  fields.
+   */
+  def optionalUndefined(): js.UndefOr[Nothing] = sys.error("stub")
+
   /** Returns an array of the enumerable properties in an object's prototype
    *  chain.
    *

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1291,9 +1291,14 @@ object Build {
       val sharedTestDir =
         testDir.getParentFile.getParentFile.getParentFile / "shared/src/test"
 
+      val scalaV = scalaVersion.value
+      val isScalaAtLeast212 =
+        !scalaV.startsWith("2.10.") && ! scalaV.startsWith("2.11.")
+
       List(sharedTestDir / "scala") ++
       includeIf(sharedTestDir / "require-jdk7", javaVersion.value >= 7) ++
-      includeIf(sharedTestDir / "require-jdk8", javaVersion.value >= 8)
+      includeIf(sharedTestDir / "require-jdk8", javaVersion.value >= 8) ++
+      includeIf(testDir / "require-2.12", isJSTest && isScalaAtLeast212)
     },
 
     sources in Test ++= {

--- a/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
+++ b/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
@@ -1,0 +1,185 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.JSAssert._
+
+/** 2.12+ tests for `@JSOptional`.
+ *
+ *  This class is basically a copy-paste of `JSOptionalTest`, where
+ *  `override val/def`s do not have an explicit result type. Instead, they
+ *  are inferred from the superclasses.
+ */
+class JSOptionalTest212 {
+  import JSOptionalTest212._
+
+  @Test def classWithOptional(): Unit = {
+    val obj = new ClassWithOptional
+
+    assertEquals(js.undefined, obj.actualUndefined)
+    assertTrue(obj.hasOwnProperty("actualUndefined"))
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def objectWithOptional(): Unit = {
+    val obj = ObjectWithOptional
+
+    assertEquals(js.undefined, obj.actualUndefined)
+    assertTrue(obj.hasOwnProperty("actualUndefined"))
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def classImplementsTraitWithOptional(): Unit = {
+    val obj = new ClassImplementsTraitWithOptional
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def anonClassImplementsTraitWithOptional(): Unit = {
+    val obj = new TraitWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def classOverrideOptionalWithConcrete(): Unit = {
+    val obj = new ClassImplementsTraitWithOptionalOverrideWithConcrete
+
+    assertEquals(42, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals("hello", obj.y)
+    assertTrue(obj.hasOwnProperty("y"))
+
+    assertEquals("world", obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(Some(5), obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def anonClassOverrideOptionalWithConcrete(): Unit = {
+    val obj = new TraitWithOptional {
+      override val x = 42
+      override val y = "hello"
+      override def y2 = "world"
+      z = Some(5)
+    }
+
+    assertEquals(42, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals("hello", obj.y)
+    assertTrue(obj.hasOwnProperty("y"))
+
+    assertEquals("world", obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(Some(5), obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+}
+
+object JSOptionalTest212 {
+  @ScalaJSDefined
+  class ClassWithOptional extends js.Object {
+    val actualUndefined: js.UndefOr[Int] = js.undefined
+    @JSOptional val x: js.UndefOr[Int] = js.undefined
+    @JSOptional def y: js.UndefOr[String] = js.undefined
+    @JSOptional def y2: js.UndefOr[String] = js.undefined
+    @JSOptional var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  object ObjectWithOptional extends js.Object {
+    val actualUndefined: js.UndefOr[Int] = js.undefined
+    @JSOptional val x: js.UndefOr[Int] = js.undefined
+    @JSOptional def y: js.UndefOr[String] = js.undefined
+    @JSOptional def y2: js.UndefOr[String] = js.undefined
+    @JSOptional var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  trait TraitWithOptional extends js.Object {
+    @JSOptional val x: js.UndefOr[Int] = js.undefined
+    @JSOptional def y: js.UndefOr[String] = js.undefined
+    @JSOptional def y2: js.UndefOr[String] = js.undefined
+    @JSOptional var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  class ClassImplementsTraitWithOptional extends TraitWithOptional
+
+  @ScalaJSDefined
+  class ClassImplementsTraitWithOptionalOverrideWithConcrete
+      extends TraitWithOptional {
+    override val x = 42
+    override val y = "hello"
+    override def y2 = "world"
+    z = Some(5)
+  }
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
@@ -1,0 +1,247 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.JSAssert._
+
+class JSOptionalTest {
+  import JSOptionalTest._
+
+  @Test def classWithOptional(): Unit = {
+    val obj = new ClassWithOptional
+
+    assertEquals(js.undefined, obj.actualUndefined)
+    assertTrue(obj.hasOwnProperty("actualUndefined"))
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def objectWithOptional(): Unit = {
+    val obj = ObjectWithOptional
+
+    assertEquals(js.undefined, obj.actualUndefined)
+    assertTrue(obj.hasOwnProperty("actualUndefined"))
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def classImplementsTraitWithOptional(): Unit = {
+    val obj = new ClassImplementsTraitWithOptional
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def anonClassImplementsTraitWithOptional(): Unit = {
+    val obj = new TraitWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def classOverrideOptionalWithConcrete(): Unit = {
+    val obj = new ClassImplementsTraitWithOptionalOverrideWithConcrete
+
+    assertEquals(42, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals("hello", obj.y)
+    assertTrue(obj.hasOwnProperty("y"))
+
+    assertEquals("world", obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(Some(5), obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def anonClassOverrideOptionalWithConcrete(): Unit = {
+    val obj = new TraitWithOptional {
+      override val x: js.UndefOr[Int] = 42
+      override val y: js.UndefOr[String] = "hello"
+      override def y2: js.UndefOr[String] = "world"
+      z = Some(5)
+    }
+
+    assertEquals(42, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals("hello", obj.y)
+    assertTrue(obj.hasOwnProperty("y"))
+
+    assertEquals("world", obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(Some(5), obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def overrideOptionalWithOptional(): Unit = {
+    val obj = new TraitWithOptional {
+      @JSOptional override val x: js.UndefOr[Int] = js.undefined
+      @JSOptional override val y: js.UndefOr[String] = js.undefined
+      @JSOptional override def y2: js.UndefOr[String] = js.undefined
+    }
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+  }
+
+  @Test def overrideOptionalWithOptionalImplicitType(): Unit = {
+    val obj = new TraitWithOptional {
+      @JSOptional override val x = js.undefined
+      @JSOptional override val y = js.undefined
+      @JSOptional override def y2 = js.undefined
+    }
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+  }
+
+  @Test def overrideClassOptionalWithOptional(): Unit = {
+    val obj = new ClassWithOptional {
+      @JSOptional override val x: js.UndefOr[Int] = js.undefined
+      @JSOptional override val y: js.UndefOr[String] = js.undefined
+      @JSOptional override def y2: js.UndefOr[String] = js.undefined
+    }
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse("'x' must not be a property", obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse("'y' must not be a property", js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse("'y2' must not be a property", js.Object.hasProperty(obj, "y2"))
+  }
+
+  @Test def overrideClassOptionalWithOptionalImplicitType(): Unit = {
+    val obj = new ClassWithOptional {
+      @JSOptional override val x = js.undefined
+      @JSOptional override val y = js.undefined
+      @JSOptional override def y2 = js.undefined
+    }
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse("'x' must not be a property", obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse("'y' must not be a property", js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse("'y2' must not be a property", js.Object.hasProperty(obj, "y2"))
+  }
+}
+
+object JSOptionalTest {
+  @ScalaJSDefined
+  class ClassWithOptional extends js.Object {
+    val actualUndefined: js.UndefOr[Int] = js.undefined
+    @JSOptional val x: js.UndefOr[Int] = js.undefined
+    @JSOptional def y: js.UndefOr[String] = js.undefined
+    @JSOptional def y2: js.UndefOr[String] = js.undefined
+    @JSOptional var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  object ObjectWithOptional extends js.Object {
+    val actualUndefined: js.UndefOr[Int] = js.undefined
+    @JSOptional val x: js.UndefOr[Int] = js.undefined
+    @JSOptional def y: js.UndefOr[String] = js.undefined
+    @JSOptional def y2: js.UndefOr[String] = js.undefined
+    @JSOptional var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  trait TraitWithOptional extends js.Object {
+    @JSOptional val x: js.UndefOr[Int] = js.undefined
+    @JSOptional def y: js.UndefOr[String] = js.undefined
+    @JSOptional def y2: js.UndefOr[String] = js.undefined
+    @JSOptional var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  class ClassImplementsTraitWithOptional extends TraitWithOptional
+
+  @ScalaJSDefined
+  class ClassImplementsTraitWithOptionalOverrideWithConcrete
+      extends TraitWithOptional {
+    override val x: js.UndefOr[Int] = 42
+    override val y: js.UndefOr[String] = "hello"
+    override def y2: js.UndefOr[String] = "world"
+    z = Some(5)
+  }
+}


### PR DESCRIPTION
In a JS type, and particularly in a Scala.js-defined JS type, vals,
vars and defs without parentheses can be annotated with
`@JSOptional`. In that case, they must be concrete, and their rhs
must be `js.undefined`. This is also valid in a Scala.js-defined JS
trait, and is the only way to define a concrete member in such a
trait.

An `@JSOptional` member does not create a field nor getter in the
object or class. Instead, it gets a value of `undefined` by virtue
of JavaScript using `undefined` for missing fields. In case of a
`var`, the field can be created later by explicit assignment. For
`val`s and `def`s, it can be created in subclasses with an
`override val` or `override def`.

This is particularly useful to model "configuration objects" as
used in many JavaScript APIs. A Scala.js-defined JS trait with
`JSOptional` fields can define a typed API for the configuration
object. It is then easy to create a configuration object with only
a few fields set by defining `override val`s. Other fields stay
optional (by inheritance) and are not created on the resulting
JavaScript object.