### PR TITLE
Allow concrete val/var/defs in JS traits with `= js.undefined`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -28,6 +28,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackage, newTermName("constructorOf"))
       lazy val JSPackage_debugger      = getMemberMethod(ScalaJSJSPackage, newTermName("debugger"))
       lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackage, newTermName("native"))
+      lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackage, newTermName("undefined"))
 
     lazy val JSNativeAnnotation = getRequiredClass("scala.scalajs.js.native")
 
@@ -69,6 +70,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val ScalaJSDefinedAnnotation  = getRequiredClass("scala.scalajs.js.annotation.ScalaJSDefined")
     lazy val SJSDefinedAnonymousClassAnnotation = getRequiredClass("scala.scalajs.js.annotation.SJSDefinedAnonymousClass")
     lazy val HasJSNativeLoadSpecAnnotation = getRequiredClass("scala.scalajs.js.annotation.internal.HasJSNativeLoadSpec")
+    lazy val JSOptionalAnnotation      = getRequiredClass("scala.scalajs.js.annotation.internal.JSOptional")
 
     lazy val JavaDefaultMethodAnnotation = getRequiredClass("scala.scalajs.js.annotation.JavaDefaultMethod")
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/InternalAnnotationsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/InternalAnnotationsTest.scala
@@ -9,7 +9,7 @@ import org.junit._
 class InternalAnnotationsTest extends DirectTest with TestHelpers {
 
   override def preamble: String =
-    "import scala.scalajs.js, js.annotation._"
+    "import scala.scalajs.js, js.annotation._, js.annotation.internal._"
 
   @Test
   def exposedJSMember: Unit = {
@@ -31,7 +31,15 @@ class InternalAnnotationsTest extends DirectTest with TestHelpers {
     test("SJSDefinedAnonymousClass")
   }
 
-  private def test(annotation: String): Unit = {
+  @Test
+  def jsOptional: Unit = {
+    test("JSOptional", "scala.scalajs.js.annotation.internal.JSOptional")
+  }
+
+  private def test(annotation: String): Unit =
+    test(annotation, s"scala.scalajs.js.annotation.$annotation")
+
+  private def test(annotation: String, annotFullName: String): Unit = {
     s"""
        @$annotation trait A
        @$annotation class B {
@@ -44,28 +52,28 @@ class InternalAnnotationsTest extends DirectTest with TestHelpers {
        }
     """ hasErrors
     s"""
-       |newSource1.scala:2: error: scala.scalajs.js.annotation.$annotation is for compiler internal use only. Do not use it yourself.
+       |newSource1.scala:2: error: $annotFullName is for compiler internal use only. Do not use it yourself.
        |       @$annotation trait A
        |        ^
-       |newSource1.scala:3: error: scala.scalajs.js.annotation.$annotation is for compiler internal use only. Do not use it yourself.
+       |newSource1.scala:3: error: $annotFullName is for compiler internal use only. Do not use it yourself.
        |       @$annotation class B {
        |        ^
-       |newSource1.scala:4: error: scala.scalajs.js.annotation.$annotation is for compiler internal use only. Do not use it yourself.
+       |newSource1.scala:4: error: $annotFullName is for compiler internal use only. Do not use it yourself.
        |         @$annotation val a = ???
        |          ^
-       |newSource1.scala:5: error: scala.scalajs.js.annotation.$annotation is for compiler internal use only. Do not use it yourself.
+       |newSource1.scala:5: error: $annotFullName is for compiler internal use only. Do not use it yourself.
        |         @$annotation var b = ???
        |          ^
-       |newSource1.scala:6: error: scala.scalajs.js.annotation.$annotation is for compiler internal use only. Do not use it yourself.
+       |newSource1.scala:6: error: $annotFullName is for compiler internal use only. Do not use it yourself.
        |         @$annotation def c = ???
        |          ^
-       |newSource1.scala:7: error: scala.scalajs.js.annotation.$annotation is for compiler internal use only. Do not use it yourself.
+       |newSource1.scala:7: error: $annotFullName is for compiler internal use only. Do not use it yourself.
        |         def d(@$annotation i: Int) = ???
        |                ^
-       |newSource1.scala:8: error: scala.scalajs.js.annotation.$annotation is for compiler internal use only. Do not use it yourself.
+       |newSource1.scala:8: error: $annotFullName is for compiler internal use only. Do not use it yourself.
        |         @$annotation class X
        |          ^
-       |newSource1.scala:9: error: scala.scalajs.js.annotation.$annotation is for compiler internal use only. Do not use it yourself.
+       |newSource1.scala:9: error: $annotFullName is for compiler internal use only. Do not use it yourself.
        |         @$annotation trait Y
        |          ^
     """

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala
@@ -1,0 +1,160 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+
+import org.junit.Test
+import org.junit.Ignore
+
+// scalastyle:off line.size.limit
+
+class JSOptionalTest extends DirectTest with TestHelpers {
+
+  override def preamble: String = {
+    """
+    import scala.scalajs.js
+    import scala.scalajs.js.annotation._
+    """
+  }
+
+  @Test
+  def optionalRequiresUndefinedRHS: Unit = {
+    s"""
+    @ScalaJSDefined
+    trait A extends js.Object {
+      val a1: js.UndefOr[Int] = 5
+      val a2: Int = 5
+
+      def b1: js.UndefOr[Int] = 5
+      def b2: Int = 5
+
+      var c1: js.UndefOr[Int] = 5
+      var c2: Int = 5
+    }
+    """ hasErrors
+    s"""
+      |newSource1.scala:7: error: Members of Scala.js-defined JS traits must either be abstract, or their right-hand-side must be `js.undefined`.
+      |      val a1: js.UndefOr[Int] = 5
+      |                                ^
+      |newSource1.scala:8: error: Members of Scala.js-defined JS traits must either be abstract, or their right-hand-side must be `js.undefined`.
+      |      val a2: Int = 5
+      |                    ^
+      |newSource1.scala:10: error: Members of Scala.js-defined JS traits must either be abstract, or their right-hand-side must be `js.undefined`.
+      |      def b1: js.UndefOr[Int] = 5
+      |                                ^
+      |newSource1.scala:11: error: Members of Scala.js-defined JS traits must either be abstract, or their right-hand-side must be `js.undefined`.
+      |      def b2: Int = 5
+      |                    ^
+      |newSource1.scala:13: error: Members of Scala.js-defined JS traits must either be abstract, or their right-hand-side must be `js.undefined`.
+      |      var c1: js.UndefOr[Int] = 5
+      |                                ^
+      |newSource1.scala:14: error: Members of Scala.js-defined JS traits must either be abstract, or their right-hand-side must be `js.undefined`.
+      |      var c2: Int = 5
+      |                    ^
+    """
+  }
+
+  @Test
+  def noOverrideConcreteNonOptionalWithOptional: Unit = {
+    s"""
+    @ScalaJSDefined
+    abstract class A extends js.Object {
+      val a1: js.UndefOr[Int] = 5
+      val a2: js.UndefOr[Int]
+
+      def b1: js.UndefOr[Int] = 5
+      def b2: js.UndefOr[Int]
+    }
+
+    @ScalaJSDefined
+    trait B extends A {
+      override val a1: js.UndefOr[Int] = js.undefined
+      override val a2: js.UndefOr[Int] = js.undefined
+
+      override def b1: js.UndefOr[Int] = js.undefined
+      override def b2: js.UndefOr[Int] = js.undefined
+    }
+    """ hasErrors
+    s"""
+      |newSource1.scala:16: error: Cannot override concrete val a1: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |      override val a1: js.UndefOr[Int] = js.undefined
+      |                   ^
+      |newSource1.scala:19: error: Cannot override concrete def b1: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |      override def b1: js.UndefOr[Int] = js.undefined
+      |                   ^
+    """
+
+    s"""
+    @js.native
+    class A extends js.Object {
+      val a: js.UndefOr[Int] = js.native
+      def b: js.UndefOr[Int] = js.native
+    }
+
+    @ScalaJSDefined
+    trait B extends A {
+      override val a: js.UndefOr[Int] = js.undefined
+      override def b: js.UndefOr[Int] = js.undefined
+    }
+    """ hasErrors
+    s"""
+      |newSource1.scala:13: error: Cannot override concrete val a: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |      override val a: js.UndefOr[Int] = js.undefined
+      |                   ^
+      |newSource1.scala:14: error: Cannot override concrete def b: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |      override def b: js.UndefOr[Int] = js.undefined
+      |                   ^
+    """
+
+    s"""
+    @js.native
+    trait A extends js.Object {
+      val a: js.UndefOr[Int] = js.native
+      def b: js.UndefOr[Int] = js.native
+    }
+
+    @js.native
+    class B extends A
+
+    @ScalaJSDefined
+    trait C extends B {
+      override val a: js.UndefOr[Int] = js.undefined
+      override def b: js.UndefOr[Int] = js.undefined
+    }
+    """ hasErrors
+    s"""
+      |newSource1.scala:16: error: Cannot override concrete val a: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |      override val a: js.UndefOr[Int] = js.undefined
+      |                   ^
+      |newSource1.scala:17: error: Cannot override concrete def b: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |      override def b: js.UndefOr[Int] = js.undefined
+      |                   ^
+    """
+  }
+
+  @Test
+  def noOptionalDefWithParens: Unit = {
+    s"""
+    @ScalaJSDefined
+    trait A extends js.Object {
+      def a(): js.UndefOr[Int] = js.undefined
+      def b(x: Int): js.UndefOr[Int] = js.undefined
+      def c_=(v: Int): js.UndefOr[Int] = js.undefined
+    }
+    """ hasErrors
+    s"""
+      |newSource1.scala:7: error: In Scala.js-defined JS traits, defs with parentheses must be abstract.
+      |      def a(): js.UndefOr[Int] = js.undefined
+      |                                    ^
+      |newSource1.scala:8: error: In Scala.js-defined JS traits, defs with parentheses must be abstract.
+      |      def b(x: Int): js.UndefOr[Int] = js.undefined
+      |                                          ^
+      |newSource1.scala:9: error: Raw JS setters must return Unit
+      |      def c_=(v: Int): js.UndefOr[Int] = js.undefined
+      |          ^
+      |newSource1.scala:9: error: In Scala.js-defined JS traits, defs with parentheses must be abstract.
+      |      def c_=(v: Int): js.UndefOr[Int] = js.undefined
+      |                                            ^
+    """
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -596,12 +596,16 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     @ScalaJSDefined
     trait A extends js.Object {
       def foo(x: Int): Int = x + 1
+      def bar[A](x: A): A = x
     }
     """ hasErrors
     """
-      |newSource1.scala:7: error: A Scala.js-defined JS trait can only contain abstract members
+      |newSource1.scala:7: error: In Scala.js-defined JS traits, defs with parentheses must be abstract.
       |      def foo(x: Int): Int = x + 1
-      |          ^
+      |                               ^
+      |newSource1.scala:8: error: In Scala.js-defined JS traits, defs with parentheses must be abstract.
+      |      def bar[A](x: A): A = x
+      |                            ^
     """
   }
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/internal/JSOptional.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/internal/JSOptional.scala
@@ -1,0 +1,22 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package scala.scalajs.js.annotation.internal
+
+import scala.annotation.meta._
+
+/** IMPLEMENTATION DETAIL: Marks concrete members of Scala.js-defined JS
+ *  traits, so that they can be identified by the back-end not to emit them.
+ *
+ *  Internally, such members are known as "optional", in reference to their
+ *  primary intended use case: optional fields in configuration objects.
+ *
+ *  Do not use this annotation yourself.
+ */
+@field @getter @setter
+class JSOptional extends scala.annotation.StaticAnnotation

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1312,9 +1312,14 @@ object Build {
       val sharedTestDir =
         testDir.getParentFile.getParentFile.getParentFile / "shared/src/test"
 
+      val scalaV = scalaVersion.value
+      val isScalaAtLeast212 =
+        !scalaV.startsWith("2.10.") && !scalaV.startsWith("2.11.")
+
       List(sharedTestDir / "scala") ++
       includeIf(sharedTestDir / "require-jdk7", javaVersion.value >= 7) ++
-      includeIf(sharedTestDir / "require-jdk8", javaVersion.value >= 8)
+      includeIf(sharedTestDir / "require-jdk8", javaVersion.value >= 8) ++
+      includeIf(testDir / "require-2.12", isJSTest && isScalaAtLeast212)
     },
 
     sources in Test ++= {

--- a/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
+++ b/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
@@ -1,0 +1,245 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.JSAssert._
+
+/** 2.12+ tests for `@JSOptional`.
+ *
+ *  This class is basically a copy-paste of `JSOptionalTest`, where
+ *  `override val/def`s do not have an explicit result type. Instead, they
+ *  are inferred from the superclasses.
+ */
+class JSOptionalTest212 {
+  import JSOptionalTest212._
+
+  @Test def classImplementsTraitWithOptional(): Unit = {
+    val obj = new ClassImplementsTraitWithOptional
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def anonClassImplementsTraitWithOptional(): Unit = {
+    val obj = new TraitWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def undefinedInClassIsNotOptional(): Unit = {
+    val obj = new UndefinedInClassIsNotOptional
+
+    assertEquals(js.undefined, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertTrue(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def overrideWithUndefinedInClassIsNotOptional(): Unit = {
+    val obj = new OverrideWithUndefinedInClassIsNotOptional
+
+    assertEquals(js.undefined, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertTrue(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def classOverrideOptionalWithConcrete(): Unit = {
+    val obj = new ClassImplementsTraitWithOptionalOverrideWithConcrete
+
+    assertEquals(42, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals("hello", obj.y)
+    assertTrue(obj.hasOwnProperty("y"))
+
+    assertEquals("world", obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(Some(5), obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def anonClassOverrideOptionalWithConcrete(): Unit = {
+    val obj = new TraitWithOptional {
+      override val x = 42
+      override val y = "hello"
+      override def y2 = "world" // scalastyle:ignore
+      z = Some(5)
+    }
+
+    assertEquals(42, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals("hello", obj.y)
+    assertTrue(obj.hasOwnProperty("y"))
+
+    assertEquals("world", obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(Some(5), obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def overrideClassAbstractWithOptional(): Unit = {
+    @ScalaJSDefined
+    abstract class ClassWithAbstracts extends js.Object {
+      val x: js.UndefOr[Int]
+      def y: js.UndefOr[String]
+      def y2: js.UndefOr[String]
+      var z: js.UndefOr[Option[Int]]
+    }
+
+    @ScalaJSDefined
+    trait OverrideClassAbstractWithOptional extends ClassWithAbstracts {
+      val x = js.undefined
+      def y = js.undefined
+      val y2 = js.undefined
+      var z: js.UndefOr[Option[Int]] = js.undefined
+    }
+
+    val obj = new OverrideClassAbstractWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def overrideTraitAbstractWithOptional(): Unit = {
+    @ScalaJSDefined
+    trait TraitWithAbstracts extends js.Object {
+      val x: js.UndefOr[Int]
+      def y: js.UndefOr[String]
+      def y2: js.UndefOr[String]
+      var z: js.UndefOr[Option[Int]]
+    }
+
+    @ScalaJSDefined
+    trait OverrideTraitAbstractWithOptional extends TraitWithAbstracts {
+      val x = js.undefined
+      def y = js.undefined
+      val y2 = js.undefined
+      var z: js.UndefOr[Option[Int]] = js.undefined
+    }
+
+    val obj = new OverrideTraitAbstractWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+}
+
+object JSOptionalTest212 {
+  @ScalaJSDefined
+  trait TraitWithOptional extends js.Object {
+    val x: js.UndefOr[Int] = js.undefined
+    def y: js.UndefOr[String] = js.undefined
+    def y2: js.UndefOr[String] = js.undefined
+    var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  class ClassImplementsTraitWithOptional extends TraitWithOptional
+
+  @ScalaJSDefined
+  class UndefinedInClassIsNotOptional extends js.Object {
+    val x: js.UndefOr[Int] = js.undefined
+    def y: js.UndefOr[String] = js.undefined
+    def y2: js.UndefOr[String] = js.undefined
+    var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  class OverrideWithUndefinedInClassIsNotOptional extends TraitWithOptional {
+    override val x = js.undefined
+    override def y = js.undefined // scalastyle:ignore
+    override def y2 = js.undefined // scalastyle:ignore
+    z = js.undefined
+  }
+
+  @ScalaJSDefined
+  class ClassImplementsTraitWithOptionalOverrideWithConcrete
+      extends TraitWithOptional {
+    override val x = 42
+    override val y = "hello"
+    override def y2 = "world" // scalastyle:ignore
+    z = Some(5)
+  }
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
@@ -1,0 +1,299 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.JSAssert._
+
+class JSOptionalTest {
+  import JSOptionalTest._
+
+  @Test def classImplementsTraitWithOptional(): Unit = {
+    val obj = new ClassImplementsTraitWithOptional
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def anonClassImplementsTraitWithOptional(): Unit = {
+    val obj = new TraitWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def undefinedInClassIsNotOptional(): Unit = {
+    val obj = new UndefinedInClassIsNotOptional
+
+    assertEquals(js.undefined, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertTrue(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def overrideWithUndefinedInClassIsNotOptional(): Unit = {
+    val obj = new OverrideWithUndefinedInClassIsNotOptional
+
+    assertEquals(js.undefined, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertTrue(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def classOverrideOptionalWithConcrete(): Unit = {
+    val obj = new ClassImplementsTraitWithOptionalOverrideWithConcrete
+
+    assertEquals(42, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals("hello", obj.y)
+    assertTrue(obj.hasOwnProperty("y"))
+
+    assertEquals("world", obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(Some(5), obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def anonClassOverrideOptionalWithConcrete(): Unit = {
+    val obj = new TraitWithOptional {
+      override val x: js.UndefOr[Int] = 42
+      override val y: js.UndefOr[String] = "hello"
+      override def y2: js.UndefOr[String] = "world"
+      z = Some(5)
+    }
+
+    assertEquals(42, obj.x)
+    assertTrue(obj.hasOwnProperty("x"))
+
+    assertEquals("hello", obj.y)
+    assertTrue(obj.hasOwnProperty("y"))
+
+    assertEquals("world", obj.y2)
+    assertTrue(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(Some(5), obj.z)
+    assertTrue(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def overrideOptionalWithOptional(): Unit = {
+    val obj = new OverrideOptionalWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+  }
+
+  @Test def overrideOptionalWithOptionalImplicitType(): Unit = {
+    val obj = new OverrideOptionalWithOptionalImplicitType {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+  }
+
+  @Test def overrideClassAbstractWithOptional(): Unit = {
+    @ScalaJSDefined
+    abstract class ClassWithAbstracts extends js.Object {
+      val x: js.UndefOr[Int]
+      def y: js.UndefOr[String]
+      def y2: js.UndefOr[String]
+      var z: js.UndefOr[Option[Int]]
+    }
+
+    @ScalaJSDefined
+    trait OverrideClassAbstractWithOptional extends ClassWithAbstracts {
+      val x: js.UndefOr[Int] = js.undefined
+      def y: js.UndefOr[String] = js.undefined
+      val y2: js.UndefOr[String] = js.undefined
+      var z: js.UndefOr[Option[Int]] = js.undefined
+    }
+
+    val obj = new OverrideClassAbstractWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  @Test def overrideTraitAbstractWithOptional(): Unit = {
+    @ScalaJSDefined
+    trait TraitWithAbstracts extends js.Object {
+      val x: js.UndefOr[Int]
+      def y: js.UndefOr[String]
+      def y2: js.UndefOr[String]
+      var z: js.UndefOr[Option[Int]]
+    }
+
+    @ScalaJSDefined
+    trait OverrideTraitAbstractWithOptional extends TraitWithAbstracts {
+      val x: js.UndefOr[Int] = js.undefined
+      def y: js.UndefOr[String] = js.undefined
+      val y2: js.UndefOr[String] = js.undefined
+      var z: js.UndefOr[Option[Int]] = js.undefined
+    }
+
+    val obj = new OverrideTraitAbstractWithOptional {}
+
+    assertEquals(js.undefined, obj.x)
+    assertFalse(obj.hasOwnProperty("x"))
+
+    assertEquals(js.undefined, obj.y)
+    assertFalse(js.Object.hasProperty(obj, "y"))
+
+    assertEquals(js.undefined, obj.y2)
+    assertFalse(js.Object.hasProperty(obj, "y2"))
+
+    assertEquals(js.undefined, obj.z)
+    assertFalse(obj.hasOwnProperty("z"))
+    obj.z = Some(3)
+    assertEquals(Some(3), obj.z)
+  }
+
+  def polyOptionalMethod(): Unit = {
+    @ScalaJSDefined
+    trait TraitWithPolyOptionalMethod extends js.Object {
+      def foo[A]: js.UndefOr[A] = js.undefined
+    }
+
+    val obj = new TraitWithPolyOptionalMethod {}
+
+    assertEquals(js.undefined, obj.foo[Int])
+    assertFalse(js.Object.hasProperty(obj, "foo"))
+  }
+}
+
+object JSOptionalTest {
+  @ScalaJSDefined
+  trait TraitWithOptional extends js.Object {
+    val x: js.UndefOr[Int] = js.undefined
+    def y: js.UndefOr[String] = js.undefined
+    def y2: js.UndefOr[String] = js.undefined
+    var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  class ClassImplementsTraitWithOptional extends TraitWithOptional
+
+  @ScalaJSDefined
+  class UndefinedInClassIsNotOptional extends js.Object {
+    val x: js.UndefOr[Int] = js.undefined
+    def y: js.UndefOr[String] = js.undefined
+    def y2: js.UndefOr[String] = js.undefined
+    var z: js.UndefOr[Option[Int]] = js.undefined
+  }
+
+  @ScalaJSDefined
+  class OverrideWithUndefinedInClassIsNotOptional extends TraitWithOptional {
+    override val x: js.UndefOr[Int] = js.undefined
+    override def y: js.UndefOr[String] = js.undefined
+    override def y2: js.UndefOr[String] = js.undefined
+    z = js.undefined
+  }
+
+  @ScalaJSDefined
+  class ClassImplementsTraitWithOptionalOverrideWithConcrete
+      extends TraitWithOptional {
+    override val x: js.UndefOr[Int] = 42
+    override val y: js.UndefOr[String] = "hello"
+    override def y2: js.UndefOr[String] = "world"
+    z = Some(5)
+  }
+
+  @ScalaJSDefined
+  trait OverrideOptionalWithOptional extends TraitWithOptional {
+    override val x: js.UndefOr[Int] = js.undefined
+    override val y: js.UndefOr[String] = js.undefined
+    override def y2: js.UndefOr[String] = js.undefined
+  }
+
+  @ScalaJSDefined
+  trait OverrideOptionalWithOptionalImplicitType extends TraitWithOptional {
+    /* Unlike cases where the rhs is an Int, String, etc., this compiles even
+     * in 2.10 and 2.11, because the inferred type is `js.UndefOr[Nothing]`
+     * (the type of `js.undefined`) which is truly a subtype of the inherited
+     * member's type `js.UndefOr[Int/String]`. Note that in this case, it
+     * would be impossible to re-override these fields with a
+     * `js.UndefOr[Int/String]` in a subclass, which means this is pretty
+     * useless in practice.
+     */
+    override val x = js.undefined
+    override val y = js.undefined
+    override def y2 = js.undefined // scalastyle:ignore
+  }
+}


### PR DESCRIPTION
Normally, term members in Scala.js-defined JS traits must be abstract. This commit relaxes the restriction to allow val, vars and defs without parentheses to be concrete, if their right-hand-side is `js.undefined`.

Such fields and methods are not actually created on Scala.js-defined JS classes and objects that extend those traits. Instead, they get a value of `undefined` by virtue of JavaScript using `undefined` for missing fields. In case of a `var`, the field can be created later by explicit assignment. For `val`s and `def`s, it can be created in subclasses with an `override val` or `override def`.

This is particularly useful to model "configuration objects" as used in many JavaScript APIs. A Scala.js-defined JS trait with concrete `js.undefined` fields can define a typed API for the configuration object. It is then easy to create a configuration object with only a few fields set by defining `override val`s. Other fields stay optional (by inheritance) and are not created on the resulting JavaScript object.

This is an alternative to #2662.