### PR TITLE
Fix #2655: NumericRange.{min|max} for Doubles

### DIFF
--- a/scalalib/overrides-2.10/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.10/scala/collection/immutable/NumericRange.scala
@@ -128,13 +128,18 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
   import NumericRange.defaultOrdering
   
   override def min[T1 >: T](implicit ord: Ordering[T1]): T =
-    if (ord eq defaultOrdering(num)) {
+    // We can take the fast path:
+    // - If the Integral of this NumericRange is also the requested Ordering
+    //   (Integral <: Ordering). This can happen for custom Integral types.
+    // - The Ordering is the default Ordering of a well-known Integral type.
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
       if (num.signum(step) > 0) start
       else last
     } else super.min(ord)
   
   override def max[T1 >: T](implicit ord: Ordering[T1]): T = 
-    if (ord eq defaultOrdering(num)) {
+    // See comment for fast path in min().
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
       if (num.signum(step) > 0) last
       else start
     } else super.max(ord)

--- a/scalalib/overrides-2.11/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.11/scala/collection/immutable/NumericRange.scala
@@ -114,13 +114,18 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
   import NumericRange.defaultOrdering
 
   override def min[T1 >: T](implicit ord: Ordering[T1]): T =
-    if (ord eq defaultOrdering(num)) {
+    // We can take the fast path:
+    // - If the Integral of this NumericRange is also the requested Ordering
+    //   (Integral <: Ordering). This can happen for custom Integral types.
+    // - The Ordering is the default Ordering of a well-known Integral type.
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
       if (num.signum(step) > 0) start
       else last
     } else super.min(ord)
 
   override def max[T1 >: T](implicit ord: Ordering[T1]): T =
-    if (ord eq defaultOrdering(num)) {
+    // See comment for fast path in min().
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
       if (num.signum(step) > 0) last
       else start
     } else super.max(ord)

--- a/scalalib/overrides-2.12/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/NumericRange.scala
@@ -114,13 +114,18 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
   import NumericRange.defaultOrdering
 
   override def min[T1 >: T](implicit ord: Ordering[T1]): T =
-    if (ord eq defaultOrdering(num)) {
+    // We can take the fast path:
+    // - If the Integral of this NumericRange is also the requested Ordering
+    //   (Integral <: Ordering). This can happen for custom Integral types.
+    // - The Ordering is the default Ordering of a well-known Integral type.
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
       if (num.signum(step) > 0) start
       else last
     } else super.min(ord)
 
   override def max[T1 >: T](implicit ord: Ordering[T1]): T =
-    if (ord eq defaultOrdering(num)) {
+    // See comment for fast path in min().
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
       if (num.signum(step) > 0) last
       else start
     } else super.max(ord)


### PR DESCRIPTION
As a side-effect, this fixes min/max for arbitrary integral types (which is currently broken in Scala JVM).

This copies the upstream fix for SI-10086 (scala/scala@738ac6d7d3902767cc4cd5820fe83632e558f049).