### PR TITLE
Fix #2631: Gracefully fail if UndefinedParam slips

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSFiles.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSFiles.scala
@@ -29,6 +29,20 @@ trait GenJSFiles extends SubComponent { self: GenJSCode =>
     try {
       ir.InfoSerializers.serialize(output, Infos.generateClassInfo(tree))
       ir.Serializers.serialize(output, tree)
+    } catch {
+      case e: ir.InvalidIRException =>
+        e.tree match {
+          case ir.Trees.UndefinedParam() =>
+            reporter.error(sym.pos, "Found a dangling UndefinedParam at " +
+                s"${e.tree.pos}. This is likely due to a bad interaction " +
+                "between a macro or a compiler plugin and the Scala.js " +
+                "compiler plugin. If you hit this, please let us know.")
+
+          case _ =>
+            reporter.error(sym.pos, "The Scala.js compiler generated " +
+                "invalid IR for this class. Please report this as a bug. IR: " +
+                e.tree)
+        }
     } finally {
       output.close()
     }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSUndefinedParamTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSUndefinedParamTest.scala
@@ -1,0 +1,89 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+/** This tests the UndefinedParam tracker in the compiler backend.
+ *
+ *  In order to properly implement removal of trailing default parameters, the
+ *  compiler backend may generate a UndefinedParam tree and catch it later.
+ *  However, some macros and compiler plugins may generate trees the backend
+ *  doesn't expect. As a result the backend used to generate invalid IR.
+ *  Instead, we now track these helper trees and emit a more helpful error
+ *  message if one of them sticks around.
+ *
+ *  This test contains a macro that generates a tree we cannot handle and
+ *  verifies that the compiler bails out.
+ */
+class JSUndefinedParamTest extends DirectTest with TestHelpers {
+
+  /* We need a macro in the test. Therefore, we add scala-reflect and the
+   * compiler's output path itself to the classpath.
+   */
+  override def classpath: List[String] =
+    super.classpath ++ List(scalaReflectPath, testOutputPath)
+
+  @Test def noDanglingUndefinedParam: Unit = {
+
+    // Define macro that extracts method parameter.
+    """
+    import language.experimental.macros
+
+    /** Dummy object to get the right shadowing for cross compilation */
+    private object Compat210 {
+      object blackbox { // scalastyle:ignore
+        type Context = scala.reflect.macros.Context
+      }
+    }
+
+    import Compat210._
+
+    object JSUndefinedParamTest {
+      import scala.reflect.macros._ // shadows blackbox from above
+      import blackbox.Context
+
+      def extractArg(call: Any): Any = macro extractArg_impl
+
+      def extractArg_impl(c: Context)(call: c.Expr[Any]): c.Expr[Any] = {
+        import c.universe._
+
+        call.tree match {
+          case Apply(fun, List(arg)) => c.Expr[Any](arg)
+
+          case tree =>
+            c.abort(tree.pos, "Bad tree. Need function call with single argument.")
+        }
+      }
+    }
+    """.succeeds()
+
+    // Use the macro to trigger UndefinedParam catcher.
+    """
+    import scala.scalajs.js
+    import scala.scalajs.js.annotation._
+
+    @js.native
+    trait MyTrait extends js.Any {
+      def foo(x: Int = js.native): Int = js.native
+    }
+
+    object A {
+      val myTrait: MyTrait = ???
+
+      /* We assign the default parameter value for foo to b.
+       * This should fail.
+       */
+      val b = JSUndefinedParamTest.extractArg(myTrait.foo())
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:10: error: Found a dangling UndefinedParam at Position(virtualfile:newSource1.scala,15,54). This is likely due to a bad interaction between a macro or a compiler plugin and the Scala.js compiler plugin. If you hit this, please let us know.
+      |    object A {
+      |           ^
+    """
+
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
@@ -8,6 +8,8 @@ import org.scalajs.core.compiler.ScalaJSPlugin
 
 import scala.collection.mutable
 
+import java.io.File
+
 /** This is heavily inspired by scala's partest suite's DirectTest */
 abstract class DirectTest {
 
@@ -26,7 +28,7 @@ abstract class DirectTest {
         List(
             "-d", testOutputPath,
             "-bootclasspath", scalaLibPath,
-            "-classpath", scalaJSLibPath) ++
+            "-classpath", classpath.mkString(File.pathSeparator)) ++
         extraArgs ++ args.toList)
 
     lazy val global: Global = new Global(settings, newReporter(settings)) {
@@ -68,8 +70,16 @@ abstract class DirectTest {
   // Filed as #1443
   def defaultGlobal: Global = newScalaJSCompiler()
 
-  def testOutputPath: String = sys.props("scala.scalajs.compiler.test.output")
+  def testOutputPath: String = {
+    val baseDir = sys.props("scala.scalajs.compiler.test.output")
+    val outDir = new File(baseDir, getClass.getName)
+    outDir.mkdirs()
+    outDir.getAbsolutePath
+  }
+
   def scalaJSLibPath: String = sys.props("scala.scalajs.compiler.test.scalajslib")
   def scalaLibPath: String   = sys.props("scala.scalajs.compiler.test.scalalib")
+  def scalaReflectPath: String = sys.props("scala.scalajs.compiler.test.scalareflect")
 
+  def classpath: List[String] = List(scalaJSLibPath)
 }

--- a/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
@@ -382,6 +382,14 @@ object Infos {
         case LoadJSModule(ClassType(cls)) =>
           builder.addAccessedModule(cls)
 
+        /* We explicitly catch UndefinedParam here to make sure, we do not
+         * emit it in the compiler. This does not entirely belong here, as it
+         * supports GenJSCode, but it is not wrong to throw an exception.
+         */
+        case UndefinedParam() =>
+          throw new InvalidIRException(tree,
+              "Found UndefinedParam while building infos")
+
         case _ =>
       }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/InvalidIRException.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/InvalidIRException.scala
@@ -1,0 +1,4 @@
+package org.scalajs.core.ir
+
+class InvalidIRException(val tree: Trees.Tree, message: String)
+    extends Exception(message)


### PR DESCRIPTION
In Scala, default parameters are resolved at call site. Therefore, it is valid for a macro or a compiler plugin to move them around or even completely decouple from the function call they originated from.

However, for Scala.js' facade types, this is not the case, mainly because in JavaScript, default parameters are resolved at definition site. Macros and compiler plugins must (to some extent) be aware of this restriction when running together with the Scala.js compiler plugin.

With this commit, we gracefully report if we cannot compile a tree we received due to this restriction. Before this fix, the compiler emitted invalid IR.