### PR TITLE
Fix #2649: Fall back to `updateClassifiers` on 2.10.5.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -844,13 +844,26 @@ object Build {
           artifactPath in fetchScalaSource :=
             target.value / "scalaSources" / scalaVersion.value,
 
+          /* Work around for #2649. We would like to always use `update`, but
+           * that fails if the scalaVersion we're looking for happens to be the
+           * version of Scala used by sbt itself. This is clearly a bug in sbt,
+           * which we work around here by using `updateClassifiers` instead in
+           * that case.
+           */
+          update in fetchScalaSource := Def.taskDyn {
+            if (scalaVersion.value == scala.util.Properties.versionNumberString)
+              updateClassifiers
+            else
+              update
+          }.value,
+
           fetchScalaSource := {
             val s = streams.value
             val cacheDir = s.cacheDirectory
             val ver = scalaVersion.value
             val trgDir = (artifactPath in fetchScalaSource).value
 
-            val report = update.value
+            val report = (update in fetchScalaSource).value
             val scalaLibSourcesJar = report.select(
                 configuration = Set("compile"),
                 module = moduleFilter(name = "scala-library"),


### PR DESCRIPTION
Due to what appears to be a bug in sbt, `update` will not correctly fetch the `sources` artifact of the Scala library if `scalaVersion` happens to be the version of Scala used for sbt itself. We work around this bug by falling back to `updateClassifiers` in this specific case.