### PR TITLE
Fix #2587: Corner case in BigDecimal.multiply().

### DIFF
--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -675,7 +675,14 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     if (this.isZero || multiplicand.isZero) {
       zeroScaledBy(newScale)
     } else if (this._bitLength + multiplicand._bitLength < 64) {
-      valueOf(this._smallValue * multiplicand._smallValue, safeLongToInt(newScale))
+      val smallResult = this._smallValue * multiplicand._smallValue
+      if (smallResult == Long.MinValue &&
+          this._smallValue < 0L && multiplicand._smallValue < 0L) {
+        // Corner case #2587: the result should be -Long.MinValue
+        new BigDecimal(BigInteger.getPowerOfTwo(63), safeLongToInt(newScale))
+      } else {
+        valueOf(smallResult, safeLongToInt(newScale))
+      }
     } else {
       val unscaled = this.getUnscaledValue.multiply(multiplicand.getUnscaledValue)
       new BigDecimal(unscaled, safeLongToInt(newScale))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -1104,6 +1104,14 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), cScale)
   }
 
+  @Test def testMultiplySmallOverflow_issue2587(): Unit = {
+    val x = new BigDecimal(Int.MinValue)
+    val y = new BigDecimal(Int.MinValue.toLong * 2L)
+    val z = new BigDecimal("9223372036854775808")
+    assertEquals(z, x.multiply(y))
+    assertEquals(z, y.multiply(x))
+  }
+
   @Test def testPow(): Unit = {
     val a = "123121247898748298842980"
     val aScale = 10


### PR DESCRIPTION
When multiplying two negative numbers for which the product should be `-2^63` (which is `-Long.MinValue`), the sum of the bit lengths is 63, but the result is still not representable. This is now detected as a special case.

This PR based on #2588 with some tweaks to avoid 3 relatively costly calls to `JLong.signum`. Also, in the corner case, we precisely know the one possible result, so we return it directly instead of going through the big multiplication.

Supersedes #2588.