### PR TITLE
Add test cases for BigDecimal.setScale w/rounding

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
@@ -262,6 +262,16 @@ class  BigDecimalScaleOperationsTest {
     assertEquals(a, bNumber.unscaledValue().toString)
   }
 
+  @Test def testMovePointRightIncreasePrecision(): Unit = {
+    val a = "1231212478987482988429808779810457634781384756794987"
+    val b = "12312124789874829884298087798104576347813847567949870"
+    val shift = 1
+    val aNumber = (new BigDecimal(new BigInteger(a), 0)).movePointRight(shift)
+    val bNumber = new BigDecimal(new BigInteger(b), 0)
+    assertEquals(aNumber.precision, bNumber.precision)
+    assertEquals(bNumber.compareTo(aNumber), 0)
+  }
+  
   @Test def testMovePointRightException(): Unit = {
     val a = "12312124789874829887348723648726347429808779810457634781384756794987"
     val aScale = Int.MaxValue

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
@@ -119,6 +119,7 @@ class  BigDecimalScaleOperationsTest {
     val bNumber = aNumber.setScale(newScale, BigDecimal.ROUND_UP)
     assertEquals(newScale, bNumber.scale())
     assertEquals(b, bNumber.unscaledValue().toString)
+    assertEquals("ROUND_UP", BigDecimal.ONE.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_UP)), 0)
   }
 
   @Test def testSetScaleRoundDown(): Unit = {
@@ -130,6 +131,7 @@ class  BigDecimalScaleOperationsTest {
     val bNumber = aNumber.setScale(newScale, BigDecimal.ROUND_DOWN)
     assertTrue(bNumber.scale() == newScale)
     assertTrue(bNumber.unscaledValue().toString == b)
+    assertEquals("ROUND_DOWN", BigDecimal.ZERO.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_DOWN)), 0)
   }
 
   @Test def testSetScaleRoundCeiling(): Unit = {
@@ -141,6 +143,7 @@ class  BigDecimalScaleOperationsTest {
     val bNumber = aNumber.setScale(newScale, BigDecimal.ROUND_CEILING)
     assertTrue(bNumber.scale() == newScale)
     assertTrue(bNumber.unscaledValue().toString == b)
+    assertEquals("ROUND_CEILING", BigDecimal.ONE.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_CEILING)), 0)
   }
 
   @Test def testSetScaleRoundFloor(): Unit = {
@@ -152,6 +155,7 @@ class  BigDecimalScaleOperationsTest {
     val bNumber = aNumber.setScale(newScale, BigDecimal.ROUND_FLOOR)
     assertTrue(bNumber.scale() == newScale)
     assertTrue(bNumber.unscaledValue().toString == b)
+    assertEquals("ROUND_FLOOR", BigDecimal.ZERO.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_FLOOR)), 0)
   }
 
   @Test def testSetScaleRoundHalfUp(): Unit = {
@@ -163,6 +167,7 @@ class  BigDecimalScaleOperationsTest {
     val bNumber = aNumber.setScale(newScale, BigDecimal.ROUND_HALF_UP)
     assertTrue(bNumber.scale() == newScale)
     assertTrue(bNumber.unscaledValue().toString == b)
+    assertEquals("ROUND_HALF_UP", BigDecimal.ONE.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_HALF_UP)), 0)
   }
 
   @Test def testSetScaleRoundHalfDown(): Unit = {
@@ -174,6 +179,7 @@ class  BigDecimalScaleOperationsTest {
     val bNumber = aNumber.setScale(newScale, BigDecimal.ROUND_HALF_DOWN)
     assertTrue(bNumber.scale() == newScale)
     assertTrue(bNumber.unscaledValue().toString == b)
+    assertEquals("ROUND_HALF_DOWN", BigDecimal.ZERO.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_HALF_DOWN)), 0)
   }
 
   @Test def testSetScaleRoundHalfEven(): Unit = {
@@ -185,6 +191,7 @@ class  BigDecimalScaleOperationsTest {
     val bNumber = aNumber.setScale(newScale, BigDecimal.ROUND_HALF_EVEN)
     assertTrue(bNumber.scale() == newScale)
     assertTrue(bNumber.unscaledValue().toString == b)
+    assertEquals("ROUND_HALF_EVEN", BigDecimal.ZERO.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_HALF_EVEN)), 0)
   }
 
   @Test def testSetScaleIntRoundingMode(): Unit = {


### PR DESCRIPTION
I haven't found the fix yet, but there appears to be a bug in the java.math.BigDecimal implementation... when `0 < n > 1`, adding a few test cases to reproduce it.

These all compare fine on the JVM:

```
@ BigDecimal.ONE.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_UP))
res464: Int = 0
@ BigDecimal.ZERO.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_DOWN))
res465: Int = 0
@ BigDecimal.ONE.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_CEILING))
res466: Int = 0
@ BigDecimal.ZERO.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_FLOOR))
res467: Int = 0
@ BigDecimal.ONE.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_HALF_UP))
res468: Int = 0
@ BigDecimal.ZERO.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_HALF_DOWN))
res469: Int = 0
@ BigDecimal.ZERO.compareTo(BigDecimal.valueOf(0.5).setScale(0, BigDecimal.ROUND_HALF_EVEN))
res470: Int = 0
```