### PR TITLE
Do not rely on `import` being relative to the `scala` package.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitBootstrapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitBootstrapTest.scala
@@ -1,6 +1,6 @@
 package org.scalajs.testsuite.junit
 
-import scalajs.js
+import scala.scalajs.js
 
 import org.junit.Test
 import org.junit.Assert.assertTrue

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
@@ -3,8 +3,6 @@ package org.scalajs.testsuite.junit
 import org.scalajs.junit.JUnitTestBootstrapper
 import org.junit.Assert.fail
 
-import scalajs.js
-
 object JUnitUtil {
   private final val BootstrapperSuffix = "$scalajs$junit$bootstrapper"
 


### PR DESCRIPTION
Because Eclipse sometimes does not like it, and it's ugly anyway.