### PR TITLE
DO NOT MERGE Create Scala.js-defined JS class values lazily.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
@@ -133,6 +133,8 @@ private[rhino] class ScalaJSCoreLib(linkingUnit: LinkingUnit) {
 
   private val scalaJSLazyFields = Seq(
       Info("d"),
+      Info("a"),
+      Info("b"),
       Info("c"),
       Info("h"),
       Info("s", isStatics = true),

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,11 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private[emitter], not an issue
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genClass"),
+      ProblemFilters.exclude[MissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genClassDef")
   )
 
   val JSEnvs = Seq(

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
@@ -204,6 +204,8 @@ private[closure] class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
 
       case Function(args, body) =>
         genFunction("", args, body)
+      case FunctionDef(name, args, body) =>
+        genFunction(name.name, args, body)
 
       case _ =>
         throw new TransformException(s"Unknown tree of class ${tree.getClass()}")

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -125,6 +125,8 @@ ScalaJS.clz32 = ScalaJS.g["Math"]["clz32"] || (function(i) {
 // Other fields
 //!if outputMode == ECMAScript51Global
 ScalaJS.d = {};         // Data for types
+ScalaJS.a = {};         // Scala.js-defined JS class value accessors
+ScalaJS.b = {};         // Scala.js-defined JS class value fields
 ScalaJS.c = {};         // Scala.js constructors
 ScalaJS.h = {};         // Inheritable constructors (without initialization code)
 ScalaJS.s = {};         // Static methods

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
@@ -491,10 +491,14 @@ object Printers {
         // Named function definition
 
         case FunctionDef(name, args, body) =>
+          if (!isStat)
+            print('(')
           print("function ")
           print(name)
           printSig(args)
           printBlock(body)
+          if (!isStat)
+            print(')')
 
         // ECMAScript 6 classes
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ScalaJSClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ScalaJSClassEmitter.scala
@@ -38,13 +38,11 @@ private[emitter] final class ScalaJSClassEmitter(
 
   private implicit def implicitOutputMode: OutputMode = outputMode
 
-  /** Desugar a Scala.js class into ECMAScript 5 constructs
+  /** Desugars a Scala.js class specifically for use by the Rhino interpreter.
    *
    *  @param tree The IR tree to emit to raw JavaScript
-   *  @param ancestors Encoded names of the ancestors of the class (not only
-   *                   parents), including the class itself.
    */
-  def genClassDef(tree: LinkedClass)(
+  def genClassDefForRhino(tree: LinkedClass)(
       implicit globalKnowledge: GlobalKnowledge): js.Tree = {
 
     implicit val pos = tree.pos
@@ -56,7 +54,7 @@ private[emitter] final class ScalaJSClassEmitter(
     if (kind == ClassKind.Interface)
       reverseParts ::= genDefaultMethods(tree)
     if (kind.isAnyScalaJSDefinedClass && tree.hasInstances)
-      reverseParts ::= genClass(tree)
+      reverseParts ::= genClassForRhino(tree)
     if (needInstanceTests(tree)) {
       reverseParts ::= genInstanceTests(tree)
       reverseParts ::= genArrayInstanceTests(tree)
@@ -88,20 +86,26 @@ private[emitter] final class ScalaJSClassEmitter(
     js.Block(defaultMethodDefs)(tree.pos)
   }
 
-  def genClass(tree: LinkedClass)(
+  private def genClassForRhino(tree: LinkedClass)(
       implicit globalKnowledge: GlobalKnowledge): js.Tree = {
 
     val className = tree.name.name
-    val typeFunctionDef = genConstructor(tree)
+    val ctor = genConstructor(tree)
     val memberDefs =
       tree.memberMethods.map(m => genMethod(className, m.tree))
-
     val exportedDefs = genExportedMembers(tree)
 
-    val allDefsBlock =
-      js.Block(typeFunctionDef +: memberDefs :+ exportedDefs)(tree.pos)
+    buildClass(tree, ctor, memberDefs, exportedDefs)
+  }
 
-    outputMode match {
+  def buildClass(tree: LinkedClass, ctor: js.Tree, memberDefs: List[js.Tree],
+      exportedDefs: js.Tree)(
+      implicit globalKnowledge: GlobalKnowledge): js.Tree = {
+    val className = tree.name.name
+    val allDefsBlock =
+      js.Block(ctor +: memberDefs :+ exportedDefs)(tree.pos)
+
+    val entireClassDef = outputMode match {
       case OutputMode.ECMAScript51Global | OutputMode.ECMAScript51Isolated =>
         allDefsBlock
 
@@ -112,6 +116,37 @@ private[emitter] final class ScalaJSClassEmitter(
           case oneDef            => List(oneDef)
         }
         genES6Class(tree, allDefs)
+    }
+
+    if (!tree.kind.isJSClass) {
+      entireClassDef
+    } else {
+      // Wrap the entire class def in an accessor function
+      import TreeDSL._
+      implicit val pos = tree.pos
+
+      val createClassValueVar =
+        envFieldDef("b", className, js.Undefined(), mutable = true)
+
+      val createAccessor = {
+        val classValueVar = envField("b", className)
+
+        val body = js.Block(
+            js.If(!classValueVar, {
+              js.Block(
+                  entireClassDef,
+                  classValueVar := envField("c", className)
+              )
+            }, {
+              js.Skip()
+            }),
+            js.Return(classValueVar)
+        )
+
+        envFieldDef("a", className, js.Function(Nil, body))
+      }
+
+      js.Block(createClassValueVar, createAccessor)
     }
   }
 
@@ -164,7 +199,8 @@ private[emitter] final class ScalaJSClassEmitter(
     def makeInheritableCtorDef(ctorToMimic: js.Tree) = {
       js.Block(
         js.DocComment("@constructor"),
-        envFieldDef("h", className, js.Function(Nil, js.Skip())),
+        envFieldDef("h", className, None, js.Function(Nil, js.Skip()),
+            mutable = false, keepFunctionExpression = isJSClass),
         js.Assign(envField("h", className).prototype, ctorToMimic.prototype)
       )
     }
@@ -185,7 +221,8 @@ private[emitter] final class ScalaJSClassEmitter(
 
     val typeVar = encodeClassVar(className)
     val docComment = js.DocComment("@constructor")
-    val ctorDef = envFieldDef("c", className, ctorFun)
+    val ctorDef = envFieldDef("c", className, None, ctorFun, mutable = false,
+        keepFunctionExpression = isJSClass)
 
     val chainProto = tree.superClass.fold[js.Tree] {
       js.Skip()
@@ -740,11 +777,17 @@ private[emitter] final class ScalaJSClassEmitter(
       val moduleInstanceVar = envField("n", className)
 
       val assignModule = {
-        val jsNew = js.New(encodeClassVar(className), Nil)
-        val instantiateModule =
-          if (tree.kind == ClassKind.JSModuleClass) jsNew
-          else js.Apply(jsNew DOT js.Ident("init___"), Nil)
-        moduleInstanceVar := instantiateModule
+        moduleInstanceVar := {
+          if (tree.kind == ClassKind.JSModuleClass) {
+            js.New(
+                genRawJSClassConstructor(className, None),
+                Nil)
+          } else {
+            js.Apply(
+                js.New(encodeClassVar(className), Nil) DOT js.Ident("init___"),
+                Nil)
+          }
+        }
       }
 
       val initBlock = semantics.moduleInit match {
@@ -860,7 +903,7 @@ private[emitter] final class ScalaJSClassEmitter(
 
     implicit val pos = tree.pos
 
-    val classVar = envField("c", cd.name.name)
+    val classVar = genRawJSClassConstructor(cd.name.name, None)
     genClassOrModuleExportDef(cd, tree.fullName, classVar)
   }
 


### PR DESCRIPTION
This will be necessary to implement features which require user-defined code to be executed at class-definition-time. Since such code can have arbitrary cyclic dependencies on anything else, it is absolutely necessary that everything else is defined or lazily loaded.

The two features that will need that are:

* `@JSSymbol` (#1997)
* Static fields, with their static initializers (#1902)