### PR TITLE
Fix #2689: Do not propagate tailPosLabels inside finally block.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSDesugaring.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSDesugaring.scala
@@ -1192,7 +1192,7 @@ private[emitter] class JSDesugaring(internalOptions: InternalOptions) {
         case TryFinally(block, finalizer) =>
           extractLet { newLhs =>
             val newBlock = pushLhsInto(newLhs, block, tailPosLabels)
-            val newFinalizer = transformStat(finalizer, tailPosLabels)
+            val newFinalizer = transformStat(finalizer, Set.empty)
             js.TryFinally(newBlock, newFinalizer)
           }
 


### PR DESCRIPTION
Inside a `finally` block, we lose the property that we are in tail position of any label. This is because the code of the `finally` block is implicitly followed by some test to re-`throw` a caught exception or further `return` a returned value.