### PR TITLE
Fix #2687: Be compatible with Scala 2.13.

### DIFF
--- a/scalalib/overrides-2.13/scala/Console.scala
+++ b/scalalib/overrides-2.13/scala/Console.scala
@@ -1,0 +1,222 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+
+import java.io.{ BufferedReader, InputStream, InputStreamReader, OutputStream, PrintStream, Reader }
+import scala.io.{ AnsiColor, StdIn }
+import scala.util.DynamicVariable
+
+/** Implements functionality for
+ *  printing Scala values on the terminal as well as reading specific values.
+ *  Also defines constants for marking up text on ANSI terminals.
+ *
+ *  @author  Matthias Zenger
+ *  @version 1.0, 03/09/2003
+ */
+object Console extends DeprecatedConsole with AnsiColor {
+  private val outVar = new DynamicVariable[PrintStream](java.lang.System.out)
+  private val errVar = new DynamicVariable[PrintStream](java.lang.System.err)
+  private val inVar  = new DynamicVariable[BufferedReader](null)
+    //new BufferedReader(new InputStreamReader(java.lang.System.in)))
+
+  protected def setOutDirect(out: PrintStream): Unit  = outVar.value = out
+  protected def setErrDirect(err: PrintStream): Unit  = errVar.value = err
+  protected def setInDirect(in: BufferedReader): Unit = inVar.value = in
+
+  /** The default output, can be overridden by `setOut` */
+  def out = outVar.value
+  /** The default error, can be overridden by `setErr` */
+  def err = errVar.value
+  /** The default input, can be overridden by `setIn` */
+  def in = inVar.value
+
+  /** Sets the default output stream for the duration
+   *  of execution of one thunk.
+   *
+   *  @example {{{
+   *  withOut(Console.err) { println("This goes to default _error_") }
+   *  }}}
+   *
+   *  @param out the new output stream.
+   *  @param thunk the code to execute with
+   *               the new output stream active
+   *  @return the results of `thunk`
+   *  @see `withOut[T](out:OutputStream)(thunk: => T)`
+   */
+  def withOut[T](out: PrintStream)(thunk: =>T): T =
+    outVar.withValue(out)(thunk)
+
+  /** Sets the default output stream for the duration
+   *  of execution of one thunk.
+   *
+   *  @param out the new output stream.
+   *  @param thunk the code to execute with
+   *               the new output stream active
+   *  @return the results of `thunk`
+   *  @see `withOut[T](out:PrintStream)(thunk: => T)`
+   */
+  def withOut[T](out: OutputStream)(thunk: =>T): T =
+    withOut(new PrintStream(out))(thunk)
+
+  /** Set the default error stream for the duration
+   *  of execution of one thunk.
+   *  @example {{{
+   *  withErr(Console.out) { println("This goes to default _out_") }
+   *  }}}
+   *
+   *  @param err the new error stream.
+   *  @param thunk the code to execute with
+   *               the new error stream active
+   *  @return the results of `thunk`
+   *  @see `withErr[T](err:OutputStream)(thunk: =>T)`
+   */
+  def withErr[T](err: PrintStream)(thunk: =>T): T =
+    errVar.withValue(err)(thunk)
+
+  /** Sets the default error stream for the duration
+   *  of execution of one thunk.
+   *
+   *  @param err the new error stream.
+   *  @param thunk the code to execute with
+   *               the new error stream active
+   *  @return the results of `thunk`
+   *  @see `withErr[T](err:PrintStream)(thunk: =>T)`
+   */
+  def withErr[T](err: OutputStream)(thunk: =>T): T =
+    withErr(new PrintStream(err))(thunk)
+
+  /** Sets the default input stream for the duration
+   *  of execution of one thunk.
+   *
+   *  @example {{{
+   *  val someFile:Reader = openFile("file.txt")
+   *  withIn(someFile) {
+   *    // Reads a line from file.txt instead of default input
+   *    println(readLine)
+   *  }
+   *  }}}
+   *
+   *  @param thunk the code to execute with
+   *               the new input stream active
+   *
+   * @return the results of `thunk`
+   * @see `withIn[T](in:InputStream)(thunk: =>T)`
+   */
+  def withIn[T](reader: Reader)(thunk: =>T): T =
+    inVar.withValue(new BufferedReader(reader))(thunk)
+
+  /** Sets the default input stream for the duration
+   *  of execution of one thunk.
+   *
+   *  @param in the new input stream.
+   *  @param thunk the code to execute with
+   *               the new input stream active
+   * @return the results of `thunk`
+   * @see `withIn[T](reader:Reader)(thunk: =>T)`
+   */
+  def withIn[T](in: InputStream)(thunk: =>T): T =
+    withIn(new InputStreamReader(in))(thunk)
+
+  /** Prints an object to `out` using its `toString` method.
+   *
+   *  @param obj the object to print; may be null.
+   */
+  def print(obj: Any) {
+    out.print(if (null == obj) "null" else obj.toString())
+  }
+
+  /** Flushes the output stream. This function is required when partial
+   *  output (i.e. output not terminated by a newline character) has
+   *  to be made visible on the terminal.
+   */
+  def flush() { out.flush() }
+
+  /** Prints a newline character on the default output.
+   */
+  def println() { out.println() }
+
+  /** Prints out an object to the default output, followed by a newline character.
+   *
+   *  @param x the object to print.
+   */
+  def println(x: Any) { out.println(x) }
+
+  /** Prints its arguments as a formatted string to the default output,
+   *  based on a string pattern (in a fashion similar to printf in C).
+   *
+   *  The interpretation of the formatting patterns is described in
+   *  <a href="" target="contentFrame" class="java/util/Formatter">
+   *  `java.util.Formatter`</a>.
+   *
+   *  @param text the pattern for formatting the arguments.
+   *  @param args the arguments used to instantiating the pattern.
+   *  @throws java.lang.IllegalArgumentException if there was a problem with the format string or arguments
+   */
+  def printf(text: String, args: Any*) { out.print(text format (args : _*)) }
+}
+
+private[scala] abstract class DeprecatedConsole {
+  self: Console.type =>
+
+  /** Internal usage only. */
+  protected def setOutDirect(out: PrintStream): Unit
+  protected def setErrDirect(err: PrintStream): Unit
+  protected def setInDirect(in: BufferedReader): Unit
+
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readBoolean(): Boolean                     = StdIn.readBoolean()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readByte(): Byte                           = StdIn.readByte()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readChar(): Char                           = StdIn.readChar()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readDouble(): Double                       = StdIn.readDouble()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readFloat(): Float                         = StdIn.readFloat()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readInt(): Int                             = StdIn.readInt()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readLine(): String                         = StdIn.readLine()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readLine(text: String, args: Any*): String = StdIn.readLine(text, args: _*)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readLong(): Long                           = StdIn.readLong()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readShort(): Short                         = StdIn.readShort()
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readf(format: String): List[Any]           = StdIn.readf(format)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readf1(format: String): Any                = StdIn.readf1(format)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readf2(format: String): (Any, Any)         = StdIn.readf2(format)
+  @deprecated("Use the method in scala.io.StdIn", "2.11.0") def readf3(format: String): (Any, Any, Any)    = StdIn.readf3(format)
+
+  /** Sets the default output stream.
+   *
+   *  @param out the new output stream.
+   */
+  @deprecated("Use withOut", "2.11.0") def setOut(out: PrintStream): Unit = setOutDirect(out)
+
+  /** Sets the default output stream.
+   *
+   *  @param out the new output stream.
+   */
+  @deprecated("Use withOut", "2.11.0") def setOut(out: OutputStream): Unit = setOutDirect(new PrintStream(out))
+
+  /** Sets the default error stream.
+   *
+   *  @param err the new error stream.
+   */
+  @deprecated("Use withErr", "2.11.0") def setErr(err: PrintStream): Unit = setErrDirect(err)
+
+  /** Sets the default error stream.
+   *
+   *  @param err the new error stream.
+   */
+  @deprecated("Use withErr", "2.11.0") def setErr(err: OutputStream): Unit = setErrDirect(new PrintStream(err))
+
+  /** Sets the default input stream.
+   *
+   *  @param reader specifies the new input stream.
+   */
+  @deprecated("Use withIn", "2.11.0") def setIn(reader: Reader): Unit = setInDirect(new BufferedReader(reader))
+
+  /** Sets the default input stream.
+   *
+   *  @param in the new input stream.
+   */
+  @deprecated("Use withIn", "2.11.0") def setIn(in: InputStream): Unit = setInDirect(new BufferedReader(new InputStreamReader(in)))
+}

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -1,0 +1,375 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package collection
+package immutable
+
+// TODO: Now the specialization exists there is no clear reason to have
+// separate classes for Range/NumericRange.  Investigate and consolidate.
+
+/** `NumericRange` is a more generic version of the
+ *  `Range` class which works with arbitrary types.
+ *  It must be supplied with an `Integral` implementation of the
+ *  range type.
+ *
+ *  Factories for likely types include `Range.BigInt`, `Range.Long`,
+ *  and `Range.BigDecimal`.  `Range.Int` exists for completeness, but
+ *  the `Int`-based `scala.Range` should be more performant.
+ *
+ *  {{{
+ *     val r1 = new Range(0, 100, 1)
+ *     val veryBig = Int.MaxValue.toLong + 1
+ *     val r2 = Range.Long(veryBig, veryBig + 100, 1)
+ *     assert(r1 sameElements r2.map(_ - veryBig))
+ *  }}}
+ *
+ *  @author  Paul Phillips
+ *  @version 2.8
+ *  @define Coll `NumericRange`
+ *  @define coll numeric range
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ */
+abstract class NumericRange[T]
+  (val start: T, val end: T, val step: T, val isInclusive: Boolean)
+  (implicit num: Integral[T])
+extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
+  /** Note that NumericRange must be invariant so that constructs
+   *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
+   */
+  import num._
+
+  // See comment in Range for why this must be lazy.
+  private lazy val numRangeElements: Int =
+    NumericRange.count(start, end, step, isInclusive)
+
+  override def length  = numRangeElements
+  override def isEmpty = length == 0
+  override lazy val last: T =
+    if (length == 0) Nil.last
+    else locationAfterN(length - 1)
+
+  /** Create a new range with the start and end values of this range and
+   *  a new `step`.
+   */
+  def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
+
+  /** Create a copy of this range.
+   */
+  def copy(start: T, end: T, step: T): NumericRange[T]
+
+  override def foreach[U](f: T => U) {
+    var count = 0
+    var current = start
+    while (count < length) {
+      f(current)
+      current += step
+      count += 1
+    }
+  }
+
+  // TODO: these private methods are straight copies from Range, duplicated
+  // to guard against any (most likely illusory) performance drop.  They should
+  // be eliminated one way or another.
+
+  // Tests whether a number is within the endpoints, without testing
+  // whether it is a member of the sequence (i.e. when step > 1.)
+  private def isWithinBoundaries(elem: T) = !isEmpty && (
+    (step > zero && start <= elem && elem <= last ) ||
+    (step < zero &&  last <= elem && elem <= start)
+  )
+  // Methods like apply throw exceptions on invalid n, but methods like take/drop
+  // are forgiving: therefore the checks are with the methods.
+  private def locationAfterN(n: Int): T = start + (step * fromInt(n))
+
+  // When one drops everything.  Can't ever have unchecked operations
+  // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
+  // will overflow.  This creates an exclusive range where start == end
+  // based on the given value.
+  private def newEmptyRange(value: T) = NumericRange(value, value, step)
+
+  final override def take(n: Int): NumericRange[T] = (
+    if (n <= 0 || length == 0) newEmptyRange(start)
+    else if (n >= length) this
+    else new NumericRange.Inclusive(start, locationAfterN(n - 1), step)
+  )
+
+  final override def drop(n: Int): NumericRange[T] = (
+    if (n <= 0 || length == 0) this
+    else if (n >= length) newEmptyRange(end)
+    else copy(locationAfterN(n), end, step)
+  )
+
+  def apply(idx: Int): T = {
+    if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
+    else locationAfterN(idx)
+  }
+
+  import NumericRange.defaultOrdering
+
+  override def min[T1 >: T](implicit ord: Ordering[T1]): T =
+    // We can take the fast path:
+    // - If the Integral of this NumericRange is also the requested Ordering
+    //   (Integral <: Ordering). This can happen for custom Integral types.
+    // - The Ordering is the default Ordering of a well-known Integral type.
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
+      if (num.signum(step) > 0) start
+      else last
+    } else super.min(ord)
+
+  override def max[T1 >: T](implicit ord: Ordering[T1]): T =
+    // See comment for fast path in min().
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
+      if (num.signum(step) > 0) last
+      else start
+    } else super.max(ord)
+
+  // Motivated by the desire for Double ranges with BigDecimal precision,
+  // we need some way to map a Range and get another Range.  This can't be
+  // done in any fully general way because Ranges are not arbitrary
+  // sequences but step-valued, so we have a custom method only we can call
+  // which we promise to use responsibly.
+  //
+  // The point of it all is that
+  //
+  //   0.0 to 1.0 by 0.1
+  //
+  // should result in
+  //
+  //   NumericRange[Double](0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
+  //
+  // and not
+  //
+  //   NumericRange[Double](0.0, 0.1, 0.2, 0.30000000000000004, 0.4, 0.5, 0.6000000000000001, 0.7000000000000001, 0.8, 0.9)
+  //
+  // or perhaps more importantly,
+  //
+  //   (0.1 to 0.3 by 0.1 contains 0.3) == true
+  //
+  private[immutable] def mapRange[A](fm: T => A)(implicit unum: Integral[A]): NumericRange[A] = {
+    val self = this
+
+    // XXX This may be incomplete.
+    new NumericRange[A](fm(start), fm(end), fm(step), isInclusive) {
+      def copy(start: A, end: A, step: A): NumericRange[A] =
+        if (isInclusive) NumericRange.inclusive(start, end, step)
+        else NumericRange(start, end, step)
+
+      private lazy val underlyingRange: NumericRange[T] = self
+      override def foreach[U](f: A => U) { underlyingRange foreach (x => f(fm(x))) }
+      override def isEmpty = underlyingRange.isEmpty
+      override def apply(idx: Int): A = fm(underlyingRange(idx))
+      override def containsTyped(el: A) = underlyingRange exists (x => fm(x) == el)
+
+      override def toString = {
+        def simpleOf(x: Any): String = x.getClass.getName.split("\\.").last
+        val stepped = simpleOf(underlyingRange.step)
+        s"${super.toString} (using $underlyingRange of $stepped)"
+      }
+    }
+  }
+
+  // a well-typed contains method.
+  def containsTyped(x: T): Boolean =
+    isWithinBoundaries(x) && (((x - start) % step) == zero)
+
+  override def contains[A1 >: T](x: A1): Boolean =
+    try containsTyped(x.asInstanceOf[T])
+    catch { case _: ClassCastException => false }
+
+  final override def sum[B >: T](implicit num: Numeric[B]): B = {
+    if (isEmpty) num.zero
+    else if (numRangeElements == 1) head
+    else {
+      // If there is no overflow, use arithmetic series formula
+      //   a + ... (n terms total) ... + b = n*(a+b)/2
+      if ((num eq scala.math.Numeric.IntIsIntegral)||
+          (num eq scala.math.Numeric.ShortIsIntegral)||
+          (num eq scala.math.Numeric.ByteIsIntegral)||
+          (num eq scala.math.Numeric.CharIsIntegral)) {
+        // We can do math with no overflow in a Long--easy
+        val exact = (numRangeElements * ((num toLong head) + (num toInt last))) / 2
+        num fromInt exact.toInt
+      }
+      else if (num eq scala.math.Numeric.LongIsIntegral) {
+        // Uh-oh, might be overflow, so we have to divide before we overflow.
+        // Either numRangeElements or (head + last) must be even, so divide the even one before multiplying
+        val a = head.toLong
+        val b = last.toLong
+        val ans =
+          if ((numRangeElements & 1) == 0) (numRangeElements / 2) * (a + b)
+          else numRangeElements * {
+            // Sum is even, but we might overflow it, so divide in pieces and add back remainder
+            val ha = a/2
+            val hb = b/2
+            ha + hb + ((a - 2*ha) + (b - 2*hb)) / 2
+          }
+        ans.asInstanceOf[B]
+      }
+      else {
+        // User provided custom Numeric, so we cannot rely on arithmetic series formula (e.g. won't work on something like Z_6)
+        if (isEmpty) num.zero
+        else {
+          var acc = num.zero
+          var i = head
+          var idx = 0
+          while(idx < length) {
+            acc = num.plus(acc, i)
+            i = i + step
+            idx = idx + 1
+          }
+          acc
+        }
+      }
+    }
+  }
+
+  override lazy val hashCode = super.hashCode()
+  override def equals(other: Any) = other match {
+    case x: NumericRange[_] =>
+      (x canEqual this) && (length == x.length) && (
+        (length == 0) ||                      // all empty sequences are equal
+        (start == x.start && last == x.last)  // same length and same endpoints implies equality
+      )
+    case _ =>
+      super.equals(other)
+  }
+
+  override def toString = {
+    val empty = if (isEmpty) "empty " else ""
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    s"${empty}NumericRange $start $preposition $end$stepped"
+  }
+}
+
+/** A companion object for numeric ranges.
+ */
+object NumericRange {
+
+  /** Calculates the number of elements in a range given start, end, step, and
+   *  whether or not it is inclusive.  Throws an exception if step == 0 or
+   *  the number of elements exceeds the maximum Int.
+   */
+  def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
+    val zero    = num.zero
+    val upward  = num.lt(start, end)
+    val posStep = num.gt(step, zero)
+
+    if (step == zero) throw new IllegalArgumentException("step cannot be 0.")
+    else if (start == end) if (isInclusive) 1 else 0
+    else if (upward != posStep) 0
+    else {
+      /* We have to be frightfully paranoid about running out of range.
+       * We also can't assume that the numbers will fit in a Long.
+       * We will assume that if a > 0, -a can be represented, and if
+       * a < 0, -a+1 can be represented.  We also assume that if we
+       * can't fit in Int, we can represent 2*Int.MaxValue+3 (at least).
+       * And we assume that numbers wrap rather than cap when they overflow.
+       */
+      // Check whether we can short-circuit by deferring to Int range.
+      val startint = num.toInt(start)
+      if (start == num.fromInt(startint)) {
+        val endint = num.toInt(end)
+        if (end == num.fromInt(endint)) {
+          val stepint = num.toInt(step)
+          if (step == num.fromInt(stepint)) {
+            return {
+              if (isInclusive) Range.inclusive(startint, endint, stepint).length
+              else             Range          (startint, endint, stepint).length
+            }
+          }
+        }
+      }
+      // If we reach this point, deferring to Int failed.
+      // Numbers may be big.
+      val one = num.one
+      val limit = num.fromInt(Int.MaxValue)
+      def check(t: T): T = 
+        if (num.gt(t, limit)) throw new IllegalArgumentException("More than Int.MaxValue elements.")
+        else t
+      // If the range crosses zero, it might overflow when subtracted
+      val startside = num.signum(start)
+      val endside = num.signum(end)
+      num.toInt{
+        if (startside*endside >= 0) {
+          // We're sure we can subtract these numbers.
+          // Note that we do not use .rem because of different conventions for Long and BigInt
+          val diff = num.minus(end, start)
+          val quotient = check(num.quot(diff, step))
+          val remainder = num.minus(diff, num.times(quotient, step))
+          if (!isInclusive && zero == remainder) quotient else check(num.plus(quotient, one))
+        }
+        else {
+          // We might not even be able to subtract these numbers.
+          // Jump in three pieces:
+          //   * start to -1 or 1, whichever is closer (waypointA)
+          //   * one step, which will take us at least to 0 (ends at waypointB)
+          //   * there to the end
+          val negone = num.fromInt(-1)
+          val startlim  = if (posStep) negone else one
+          val startdiff = num.minus(startlim, start)
+          val startq    = check(num.quot(startdiff, step))
+          val waypointA = if (startq == zero) start else num.plus(start, num.times(startq, step))
+          val waypointB = num.plus(waypointA, step)
+          check {
+            if (num.lt(waypointB, end) != upward) {
+              // No last piece
+              if (isInclusive && waypointB == end) num.plus(startq, num.fromInt(2))
+              else num.plus(startq, one)
+            }
+            else {
+              // There is a last piece
+              val enddiff = num.minus(end,waypointB)
+              val endq    = check(num.quot(enddiff, step))
+              val last    = if (endq == zero) waypointB else num.plus(waypointB, num.times(endq, step))
+              // Now we have to tally up all the pieces
+              //   1 for the initial value
+              //   startq steps to waypointA
+              //   1 step to waypointB
+              //   endq steps to the end (one less if !isInclusive and last==end)
+              num.plus(startq, num.plus(endq, if (!isInclusive && last==end) one else num.fromInt(2)))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  class Inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
+  extends NumericRange(start, end, step, true) {
+    def copy(start: T, end: T, step: T): Inclusive[T] =
+      NumericRange.inclusive(start, end, step)
+
+    def exclusive: Exclusive[T] = NumericRange(start, end, step)
+  }
+
+  class Exclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
+  extends NumericRange(start, end, step, false) {
+    def copy(start: T, end: T, step: T): Exclusive[T] =
+      NumericRange(start, end, step)
+
+    def inclusive: Inclusive[T] = NumericRange.inclusive(start, end, step)
+  }
+
+  def apply[T](start: T, end: T, step: T)(implicit num: Integral[T]): Exclusive[T] =
+    new Exclusive(start, end, step)
+  def inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T]): Inclusive[T] =
+    new Inclusive(start, end, step)
+
+  private[collection] val defaultOrdering = Map[Numeric[_], Ordering[_]](
+    Numeric.IntIsIntegral -> Ordering.Int,
+    Numeric.ShortIsIntegral -> Ordering.Short,
+    Numeric.ByteIsIntegral -> Ordering.Byte,
+    Numeric.CharIsIntegral -> Ordering.Char,
+    Numeric.LongIsIntegral -> Ordering.Long
+  )
+
+}
+

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -1,0 +1,533 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+package scala
+package collection.immutable
+
+import scala.collection.parallel.immutable.ParRange
+
+/** The `Range` class represents integer values in range
+ *  ''[start;end)'' with non-zero step value `step`.
+ *  It's a special case of an indexed sequence.
+ *  For example:
+ *
+ *  {{{
+ *     val r1 = 0 until 10
+ *     val r2 = r1.start until r1.end by r1.step + 1
+ *     println(r2.length) // = 5
+ *  }}}
+ *
+ *  Ranges that contain more than `Int.MaxValue` elements can be created, but
+ *  these overfull ranges have only limited capabilities.  Any method that
+ *  could require a collection of over `Int.MaxValue` length to be created, or
+ *  could be asked to index beyond `Int.MaxValue` elements will throw an
+ *  exception.  Overfull ranges can safely be reduced in size by changing
+ *  the step size (e.g. `by 3`) or taking/dropping elements.  `contains`,
+ *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
+ *  `init`) are also permitted on overfull ranges.
+ *
+ *  @param start      the start of this range.
+ *  @param end        the end of the range.  For exclusive ranges, e.g. 
+ *                    `Range(0,3)` or `(0 until 3)`, this is one
+ *                    step past the last one in the range.  For inclusive
+ *                    ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
+ *                    it may be in the range if it is not skipped by the step size.
+ *                    To find the last element inside a non-empty range,
+                      use `last` instead.
+ *  @param step       the step for the range.
+ *
+ *  @author Martin Odersky
+ *  @author Paul Phillips
+ *  @version 2.8
+ *  @since   2.5
+ *  @see [[http://docs.scala-lang.org/overviews/collections/concrete-immutable-collection-classes.html#ranges "Scala's Collection Library overview"]]
+ *  section on `Ranges` for more information.
+ *
+ *  @define coll range
+ *  @define mayNotTerminateInf
+ *  @define willNotTerminateInf
+ *  @define doesNotUseBuilders
+ *    '''Note:''' this method does not use builders to construct a new range,
+ *         and its complexity is O(1).
+ */
+@SerialVersionUID(7618862778670199309L)
+@inline
+@deprecatedInheritance("The implementation details of Range makes inheriting from it unwise.", "2.11.0")
+class Range(val start: Int, val end: Int, val step: Int)
+extends scala.collection.AbstractSeq[Int]
+   with IndexedSeq[Int]
+   with scala.collection.CustomParallelizable[Int, ParRange]
+   with Serializable
+{
+  override def par = new ParRange(this)
+
+  private def gap           = end.toLong - start.toLong
+  private def isExact       = gap % step == 0
+  private def hasStub       = isInclusive || !isExact
+  private def longLength    = gap / step + ( if (hasStub) 1 else 0 )
+
+  // Check cannot be evaluated eagerly because we have a pattern where
+  // ranges are constructed like: "x to y by z" The "x to y" piece
+  // should not trigger an exception. So the calculation is delayed,
+  // which means it will not fail fast for those cases where failing was
+  // correct.
+  override final val isEmpty = (
+       (start > end && step > 0)
+    || (start < end && step < 0)
+    || (start == end && !isInclusive)
+  )
+
+  private val numRangeElements: Int = {
+    if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
+    else if (isEmpty) 0
+    else {
+      val len = longLength
+      if (len > scala.Int.MaxValue) -1
+      else len.toInt
+    }
+  }
+
+  // This field has a sensible value only for non-empty ranges
+  private val lastElement = step match {
+    case 1  => if (isInclusive) end else end-1
+    case -1 => if (isInclusive) end else end+1
+    case _  =>
+      val remainder = (gap % step).toInt
+      if (remainder != 0) end - remainder
+      else if (isInclusive) end
+      else end - step
+  }
+
+  /** The last element of this range.  This method will return the correct value
+   *  even if there are too many elements to iterate over.
+   */
+  override def last = if (isEmpty) Nil.last else lastElement
+  override def head = if (isEmpty) Nil.head else start
+
+  override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
+    if (ord eq Ordering.Int) {
+      if (step > 0) head
+      else last
+    } else super.min(ord)
+
+  override def max[A1 >: Int](implicit ord: Ordering[A1]): Int =
+    if (ord eq Ordering.Int) {
+      if (step > 0) last
+      else head
+    } else super.max(ord)
+
+  protected def copy(start: Int, end: Int, step: Int): Range = new Range(start, end, step)
+
+  /** Create a new range with the `start` and `end` values of this range and
+   *  a new `step`.
+   *
+   *  @return a new range with a different step
+   */
+  def by(step: Int): Range = copy(start, end, step)
+
+  def isInclusive = false
+
+  override def size = length
+  override def length = if (numRangeElements < 0) fail() else numRangeElements
+
+  private def fail() = Range.fail(start, end, step, isInclusive)
+  private def validateMaxLength() {
+    if (numRangeElements < 0)
+      fail()
+  }
+
+  final def apply(idx: Int): Int = {
+    validateMaxLength()
+    if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(idx.toString)
+    else start + (step * idx)
+  }
+
+  @inline final override def foreach[@specialized(Unit) U](f: Int => U) {
+    // Implementation chosen on the basis of favorable microbenchmarks
+    // Note--initialization catches step == 0 so we don't need to here
+    if (!isEmpty) {
+      var i = start
+      while (true) {
+        f(i)
+        if (i == lastElement) return
+        i += step
+      }
+    }
+  }
+
+  /** Creates a new range containing the first `n` elements of this range.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param n  the number of elements to take.
+   *  @return   a new range consisting of `n` first elements.
+   */
+  final override def take(n: Int): Range = (
+    if (n <= 0 || isEmpty) newEmptyRange(start)
+    else if (n >= numRangeElements && numRangeElements >= 0) this
+    else {
+      // May have more than Int.MaxValue elements in range (numRangeElements < 0)
+      // but the logic is the same either way: take the first n
+      new Range.Inclusive(start, locationAfterN(n - 1), step)
+    }
+  )
+
+  /** Creates a new range containing all the elements of this range except the first `n` elements.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param n  the number of elements to drop.
+   *  @return   a new range consisting of all the elements of this range except `n` first elements.
+   */
+  final override def drop(n: Int): Range = (
+    if (n <= 0 || isEmpty) this
+    else if (n >= numRangeElements && numRangeElements >= 0) newEmptyRange(end)
+    else {
+      // May have more than Int.MaxValue elements (numRangeElements < 0)
+      // but the logic is the same either way: go forwards n steps, keep the rest
+      copy(locationAfterN(n), end, step)
+    }
+  )
+  
+  /** Creates a new range containing the elements starting at `from` up to but not including `until`.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @param from  the element at which to start
+   *  @param until  the element at which to end (not included in the range)
+   *  @return   a new range consisting of a contiguous interval of values in the old range
+   */
+  override def slice(from: Int, until: Int): Range =
+    if (from <= 0) take(until)
+    else if (until >= numRangeElements && numRangeElements >= 0) drop(from)
+    else {
+      val fromValue = locationAfterN(from)
+      if (from >= until) newEmptyRange(fromValue)
+      else new Range.Inclusive(fromValue, locationAfterN(until-1), step)
+    }
+    
+  /** Creates a new range containing all the elements of this range except the last one.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @return  a new range consisting of all the elements of this range except the last one.
+   */
+  final override def init: Range = {
+    if (isEmpty)
+      Nil.init
+
+    dropRight(1)
+  }
+
+  /** Creates a new range containing all the elements of this range except the first one.
+   *
+   *  $doesNotUseBuilders
+   *
+   *  @return  a new range consisting of all the elements of this range except the first one.
+   */
+  final override def tail: Range = {
+    if (isEmpty)
+      Nil.tail
+
+    drop(1)
+  }
+
+  // Advance from the start while we meet the given test
+  private def argTakeWhile(p: Int => Boolean): Long = {
+    if (isEmpty) start
+    else {
+      var current = start
+      val stop = last
+      while (current != stop && p(current)) current += step
+      if (current != stop || !p(current)) current
+      else current.toLong + step
+    }
+  }
+  // Methods like apply throw exceptions on invalid n, but methods like take/drop
+  // are forgiving: therefore the checks are with the methods.
+  private def locationAfterN(n: Int) = start + (step * n)
+
+  // When one drops everything.  Can't ever have unchecked operations
+  // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
+  // will overflow.  This creates an exclusive range where start == end
+  // based on the given value.
+  private def newEmptyRange(value: Int) = new Range(value, value, step)
+
+  final override def takeWhile(p: Int => Boolean): Range = {
+    val stop = argTakeWhile(p)
+    if (stop==start) newEmptyRange(start)
+    else {
+      val x = (stop - step).toInt
+      if (x == last) this
+      else new Range.Inclusive(start, x, step)
+    }
+  }
+  final override def dropWhile(p: Int => Boolean): Range = {
+    val stop = argTakeWhile(p)
+    if (stop == start) this
+    else {
+      val x = (stop - step).toInt
+      if (x == last) newEmptyRange(last)
+      else new Range.Inclusive(x + step, last, step)
+    }
+  }
+  final override def span(p: Int => Boolean): (Range, Range) = {
+    val border = argTakeWhile(p)
+    if (border == start) (newEmptyRange(start), this)
+    else {
+      val x = (border - step).toInt
+      if (x == last) (this, newEmptyRange(last))
+      else (new Range.Inclusive(start, x, step), new Range.Inclusive(x+step, last, step))
+    }
+  }
+
+  /** Creates a pair of new ranges, first consisting of elements before `n`, and the second
+   *  of elements after `n`.
+   *
+   *  $doesNotUseBuilders
+   */
+  final override def splitAt(n: Int) = (take(n), drop(n))
+
+  /** Creates a new range consisting of the last `n` elements of the range.
+   *
+   *  $doesNotUseBuilders
+   */
+  final override def takeRight(n: Int): Range = {
+    if (n <= 0) newEmptyRange(start)
+    else if (numRangeElements >= 0) drop(numRangeElements - n)
+    else {
+    // Need to handle over-full range separately
+      val y = last
+      val x = y - step.toLong*(n-1)
+      if ((step > 0 && x < start) || (step < 0 && x > start)) this
+      else new Range.Inclusive(x.toInt, y, step)
+    }
+  }
+
+  /** Creates a new range consisting of the initial `length - n` elements of the range.
+   *
+   *  $doesNotUseBuilders
+   */
+  final override def dropRight(n: Int): Range = {
+    if (n <= 0) this
+    else if (numRangeElements >= 0) take(numRangeElements - n)
+    else {
+    // Need to handle over-full range separately
+      val y = last - step.toInt*n
+      if ((step > 0 && y < start) || (step < 0 && y > start)) newEmptyRange(start)
+      else new Range.Inclusive(start, y.toInt, step)
+    }
+  }
+
+  /** Returns the reverse of this range.
+   *
+   *  $doesNotUseBuilders
+   */
+  final override def reverse: Range =
+    if (isEmpty) this
+    else new Range.Inclusive(last, start, -step)
+
+  /** Make range inclusive.
+   */
+  def inclusive =
+    if (isInclusive) this
+    else new Range.Inclusive(start, end, step)
+
+  final def contains(x: Int) = {
+    if (x==end && !isInclusive) false
+    else if (step > 0) {
+      if (x < start || x > end) false
+      else (step == 1) || (((x - start) % step) == 0)
+    }
+    else {
+      if (x < end || x > start) false
+      else (step == -1) || (((x - start) % step) == 0)
+    }
+  }
+
+  final override def sum[B >: Int](implicit num: Numeric[B]): Int = {
+    if (num eq scala.math.Numeric.IntIsIntegral) {
+      // this is normal integer range with usual addition. arithmetic series formula can be used
+      if (isEmpty) 0
+      else if (numRangeElements == 1) head
+      else ((numRangeElements * (head.toLong + last)) / 2).toInt
+    } else {
+      // user provided custom Numeric, we cannot rely on arithmetic series formula
+      if (isEmpty) num.toInt(num.zero)
+      else {
+        var acc = num.zero
+        var i = head
+        while (true) {
+          acc = num.plus(acc, i)
+          if (i == lastElement) return num.toInt(acc)
+          i = i + step
+        }
+        0 // Never hit this--just to satisfy compiler since it doesn't know while(true) has type Nothing
+      }
+    }
+  }
+
+  override def toIterable = this
+
+  override def toSeq = this
+
+  override def equals(other: Any) = other match {
+    case x: Range =>
+      // Note: this must succeed for overfull ranges (length > Int.MaxValue)
+      (x canEqual this) && {
+        if (isEmpty) x.isEmpty                  // empty sequences are equal
+        else                                    // this is non-empty...
+          x.nonEmpty && start == x.start && {   // ...so other must contain something and have same start
+            val l0 = last
+            (l0 == x.last && (                    // And same end
+              start == l0 || step == x.step       // And either the same step, or not take any steps
+            ))
+          }
+      }
+    case _ =>
+      super.equals(other)
+  }
+
+  /* Note: hashCode can't be overridden without breaking Seq's equals contract. */
+
+  override def toString = {
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
+    s"${prefix}Range $start $preposition $end$stepped"
+  }
+}
+
+/** A companion object for the `Range` class.
+ */
+object Range {
+  private[immutable] val MAX_PRINT = 512  // some arbitrary value
+
+  private def description(start: Int, end: Int, step: Int, isInclusive: Boolean) =
+    start + (if (isInclusive) " to " else " until ") + end + " by " + step
+
+  private def fail(start: Int, end: Int, step: Int, isInclusive: Boolean) =
+    throw new IllegalArgumentException(description(start, end, step, isInclusive) +
+        ": seqs cannot contain more than Int.MaxValue elements.")
+
+  /** Counts the number of range elements.
+   *  @pre  step != 0
+   *  If the size of the range exceeds Int.MaxValue, the
+   *  result will be negative.
+   */
+  def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
+    if (step == 0)
+      throw new IllegalArgumentException("step cannot be 0.")
+
+    val isEmpty = (
+      if (start == end) !isInclusive
+      else if (start < end) step < 0
+      else step > 0
+    )
+    if (isEmpty) 0
+    else {
+      // Counts with Longs so we can recognize too-large ranges.
+      val gap: Long    = end.toLong - start.toLong
+      val jumps: Long  = gap / step
+      // Whether the size of this range is one larger than the
+      // number of full-sized jumps.
+      val hasStub      = isInclusive || (gap % step != 0)
+      val result: Long = jumps + ( if (hasStub) 1 else 0 )
+
+      if (result > scala.Int.MaxValue) -1
+      else result.toInt
+    }
+  }
+  def count(start: Int, end: Int, step: Int): Int =
+    count(start, end, step, isInclusive = false)
+
+  @inline
+  class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
+//    override def par = new ParRange(this)
+    override def isInclusive = true
+    override protected def copy(start: Int, end: Int, step: Int): Range = new Inclusive(start, end, step)
+  }
+
+  /** Make a range from `start` until `end` (exclusive) with given step value.
+   * @note step != 0
+   */
+  def apply(start: Int, end: Int, step: Int): Range = new Range(start, end, step)
+
+  /** Make a range from `start` until `end` (exclusive) with step value 1.
+   */
+  def apply(start: Int, end: Int): Range = new Range(start, end, 1)
+
+  /** Make an inclusive range from `start` to `end` with given step value.
+   * @note step != 0
+   */
+  def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Inclusive(start, end, step)
+
+  /** Make an inclusive range from `start` to `end` with step value 1.
+   */
+  def inclusive(start: Int, end: Int): Range.Inclusive = new Inclusive(start, end, 1)
+
+  // BigInt and Long are straightforward generic ranges.
+  object BigInt {
+    def apply(start: BigInt, end: BigInt, step: BigInt) = NumericRange(start, end, step)
+    def inclusive(start: BigInt, end: BigInt, step: BigInt) = NumericRange.inclusive(start, end, step)
+  }
+
+  object Long {
+    def apply(start: Long, end: Long, step: Long) = NumericRange(start, end, step)
+    def inclusive(start: Long, end: Long, step: Long) = NumericRange.inclusive(start, end, step)
+  }
+
+  // BigDecimal uses an alternative implementation of Numeric in which
+  // it pretends to be Integral[T] instead of Fractional[T].  See Numeric for
+  // details.  The intention is for it to throw an exception anytime
+  // imprecision or surprises might result from anything, although this may
+  // not yet be fully implemented.
+  object BigDecimal {
+    implicit val bigDecAsIntegral = scala.math.Numeric.BigDecimalAsIfIntegral
+
+    def apply(start: BigDecimal, end: BigDecimal, step: BigDecimal) =
+      NumericRange(start, end, step)
+    def inclusive(start: BigDecimal, end: BigDecimal, step: BigDecimal) =
+      NumericRange.inclusive(start, end, step)
+  }
+
+  // Double works by using a BigDecimal under the hood for precise
+  // stepping, but mapping the sequence values back to doubles with
+  // .doubleValue.  This constructs the BigDecimals by way of the
+  // String constructor (valueOf) instead of the Double one, which
+  // is necessary to keep 0.3d at 0.3 as opposed to
+  // 0.299999999999999988897769753748434595763683319091796875 or so.
+  object Double {
+    implicit val bigDecAsIntegral = scala.math.Numeric.BigDecimalAsIfIntegral
+    implicit val doubleAsIntegral = scala.math.Numeric.DoubleAsIfIntegral
+    def toBD(x: Double): BigDecimal = scala.math.BigDecimal valueOf x
+
+    def apply(start: Double, end: Double, step: Double) =
+      BigDecimal(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
+
+    def inclusive(start: Double, end: Double, step: Double) =
+      BigDecimal.inclusive(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
+  }
+
+  // As there is no appealing default step size for not-really-integral ranges,
+  // we offer a partially constructed object.
+  class Partial[T, U](private val f: T => U) extends AnyVal {
+    def by(x: T): U = f(x)
+    override def toString = "Range requires step"
+  }
+
+  // Illustrating genericity with Int Range, which should have the same behavior
+  // as the original Range class.  However we leave the original Range
+  // indefinitely, for performance and because the compiler seems to bootstrap
+  // off it and won't do so with our parameterized version without modifications.
+  object Int {
+    def apply(start: Int, end: Int, step: Int) = NumericRange(start, end, step)
+    def inclusive(start: Int, end: Int, step: Int) = NumericRange.inclusive(start, end, step)
+  }
+}

--- a/scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
@@ -1,0 +1,735 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package collection
+package mutable
+
+import scala.reflect.ClassTag
+import scala.runtime.BoxedUnit
+
+import scala.scalajs.js
+
+/** A builder class for arrays.
+ *
+ *  @since 2.8
+ *
+ *  @tparam T    the type of the elements for the builder.
+ */
+abstract class ArrayBuilder[T] extends ReusableBuilder[T, Array[T]] with Serializable
+
+/** A companion object for array builders.
+ *
+ *  @since 2.8
+ */
+object ArrayBuilder {
+
+  /** Creates a new arraybuilder of type `T`.
+   *
+   *  @tparam T     type of the elements for the array builder, with a `ClassTag` context bound.
+   *  @return       a new empty array builder.
+   */
+  @inline
+  def make[T: ClassTag](): ArrayBuilder[T] =
+    new ArrayBuilder.generic[T](implicitly[ClassTag[T]].runtimeClass)
+
+  /** A generic ArrayBuilder optimized for Scala.js.
+   *
+   *  @tparam T              type of elements for the array builder.
+   *  @param  elementClass   runtime class of the elements in the array.
+   */
+  @inline
+  private final class generic[T](elementClass: Class[_]) extends ArrayBuilder[T] {
+
+    private val isCharArrayBuilder = classOf[Char] == elementClass
+    private var elems: js.Array[Any] = js.Array()
+
+    def +=(elem: T): this.type = {
+      val unboxedElem =
+        if (isCharArrayBuilder) elem.asInstanceOf[Char].toInt
+        else if (elem == null) zeroOf(elementClass)
+        else elem
+      elems.push(unboxedElem)
+      this
+    }
+
+    def clear(): Unit =
+      elems = js.Array()
+
+    def result(): Array[T] = {
+      val elemRuntimeClass =
+        if (classOf[Unit] == elementClass) classOf[BoxedUnit]
+        else if (classOf[Null] == elementClass || classOf[Nothing] == elementClass) classOf[Object]
+        else elementClass
+      genericArrayBuilderResult(elemRuntimeClass, elems)
+    }
+
+    override def toString(): String = "ArrayBuilder.generic"
+  }
+
+  // Intrinsic
+  private def zeroOf(runtimeClass: Class[_]): Any = runtimeClass match {
+    case java.lang.Byte.TYPE      => 0.toByte
+    case java.lang.Short.TYPE     => 0.toShort
+    case java.lang.Character.TYPE => 0 // yes, as an Int
+    case java.lang.Integer.TYPE   => 0
+    case java.lang.Long.TYPE      => 0L
+    case java.lang.Float.TYPE     => 0.0f
+    case java.lang.Double.TYPE    => 0.0
+    case java.lang.Boolean.TYPE   => false
+    case java.lang.Void.TYPE      => ()
+    case _                        => null
+  }
+
+  // Intrinsic
+  private def genericArrayBuilderResult[T](runtimeClass: Class[_],
+      a: js.Array[Any]): Array[T] = {
+    val len = a.length
+
+    if (classOf[Char] == runtimeClass) {
+      val result = new Array[Char](len)
+      var i = 0
+      while (i != len) {
+        result(i) = a(i).asInstanceOf[Int].toChar
+        i += 1
+      }
+      result.asInstanceOf[Array[T]]
+    } else {
+      val result: Array[T] = java.lang.reflect.Array.newInstance(
+          runtimeClass, len).asInstanceOf[Array[T]]
+      var i = 0
+      while (i != len) {
+        result(i) = a(i).asInstanceOf[T]
+        i += 1
+      }
+      result
+    }
+  }
+
+  /** A class for array builders for arrays of reference types.
+   *
+   *  This builder can be reused.
+   *
+   *  @tparam T     type of elements for the array builder, subtype of `AnyRef` with a `ClassTag` context bound.
+   */
+  final class ofRef[T <: AnyRef : ClassTag] extends ArrayBuilder[T] {
+
+    private var elems: Array[T] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[T] = {
+      val newelems = new Array[T](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: T): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[T]): this.type = (xs.asInstanceOf[AnyRef]) match {
+      case xs: WrappedArray.ofRef[_] =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofRef[_] => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofRef"
+  }
+
+  /** A class for array builders for arrays of `byte`s. It can be reused. */
+  final class ofByte extends ArrayBuilder[Byte] {
+
+    private var elems: Array[Byte] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[Byte] = {
+      val newelems = new Array[Byte](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: Byte): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Byte]): this.type = xs match {
+      case xs: WrappedArray.ofByte =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofByte => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofByte"
+  }
+
+  /** A class for array builders for arrays of `short`s. It can be reused. */
+  final class ofShort extends ArrayBuilder[Short] {
+
+    private var elems: Array[Short] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[Short] = {
+      val newelems = new Array[Short](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: Short): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Short]): this.type = xs match {
+      case xs: WrappedArray.ofShort =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofShort => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofShort"
+  }
+
+  /** A class for array builders for arrays of `char`s. It can be reused. */
+  final class ofChar extends ArrayBuilder[Char] {
+
+    private var elems: Array[Char] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[Char] = {
+      val newelems = new Array[Char](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: Char): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Char]): this.type = xs match {
+      case xs: WrappedArray.ofChar =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofChar => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofChar"
+  }
+
+  /** A class for array builders for arrays of `int`s. It can be reused. */
+  final class ofInt extends ArrayBuilder[Int] {
+
+    private var elems: Array[Int] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[Int] = {
+      val newelems = new Array[Int](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: Int): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Int]): this.type = xs match {
+      case xs: WrappedArray.ofInt =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofInt => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofInt"
+  }
+
+  /** A class for array builders for arrays of `long`s. It can be reused. */
+  final class ofLong extends ArrayBuilder[Long] {
+
+    private var elems: Array[Long] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[Long] = {
+      val newelems = new Array[Long](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: Long): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Long]): this.type = xs match {
+      case xs: WrappedArray.ofLong =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofLong => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofLong"
+  }
+
+  /** A class for array builders for arrays of `float`s. It can be reused. */
+  final class ofFloat extends ArrayBuilder[Float] {
+
+    private var elems: Array[Float] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[Float] = {
+      val newelems = new Array[Float](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: Float): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Float]): this.type = xs match {
+      case xs: WrappedArray.ofFloat =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofFloat => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofFloat"
+  }
+
+  /** A class for array builders for arrays of `double`s. It can be reused. */
+  final class ofDouble extends ArrayBuilder[Double] {
+
+    private var elems: Array[Double] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[Double] = {
+      val newelems = new Array[Double](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: Double): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Double]): this.type = xs match {
+      case xs: WrappedArray.ofDouble =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofDouble => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofDouble"
+  }
+
+  /** A class for array builders for arrays of `boolean`s. It can be reused. */
+  class ofBoolean extends ArrayBuilder[Boolean] {
+
+    private var elems: Array[Boolean] = _
+    private var capacity: Int = 0
+    private var size: Int = 0
+
+    private def mkArray(size: Int): Array[Boolean] = {
+      val newelems = new Array[Boolean](size)
+      if (this.size > 0) Array.copy(elems, 0, newelems, 0, this.size)
+      newelems
+    }
+
+    private def resize(size: Int) {
+      elems = mkArray(size)
+      capacity = size
+    }
+
+    override def sizeHint(size: Int) {
+      if (capacity < size) resize(size)
+    }
+
+    private def ensureSize(size: Int) {
+      if (capacity < size || capacity == 0) {
+        var newsize = if (capacity == 0) 16 else capacity * 2
+        while (newsize < size) newsize *= 2
+        resize(newsize)
+      }
+    }
+
+    def +=(elem: Boolean): this.type = {
+      ensureSize(size + 1)
+      elems(size) = elem
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Boolean]): this.type = xs match {
+      case xs: WrappedArray.ofBoolean =>
+        ensureSize(this.size + xs.length)
+        Array.copy(xs.array, 0, elems, this.size, xs.length)
+        size += xs.length
+        this
+      case _ =>
+        super.++=(xs)
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      if (capacity != 0 && capacity == size) {
+        capacity = 0
+        elems
+      }
+      else mkArray(size)
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofBoolean => (size == x.size) && (elems == x.elems)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofBoolean"
+  }
+
+  /** A class for array builders for arrays of `Unit` type. It can be reused. */
+  final class ofUnit extends ArrayBuilder[Unit] {
+
+    private var size: Int = 0
+
+    def +=(elem: Unit): this.type = {
+      size += 1
+      this
+    }
+
+    override def ++=(xs: TraversableOnce[Unit]): this.type = {
+      size += xs.size
+      this
+    }
+
+    def clear() { size = 0 }
+
+    def result() = {
+      val ans = new Array[Unit](size)
+      var i = 0
+      while (i < size) { ans(i) = (); i += 1 }
+      ans
+    }
+
+    override def equals(other: Any): Boolean = other match {
+      case x: ofUnit => (size == x.size)
+      case _ => false
+    }
+
+    override def toString = "ArrayBuilder.ofUnit"
+  }
+}

--- a/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
@@ -1,0 +1,51 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+
+package scala
+package collection
+package mutable
+
+import generic._
+
+import scala.scalajs.js
+
+/** Buffers are used to create sequences of elements incrementally by
+ *  appending, prepending, or inserting new elements. It is also
+ *  possible to access and modify elements in a random access fashion
+ *  via the index of the element in the current sequence.
+ *
+ *  @author Matthias Zenger
+ *  @author Martin Odersky
+ *  @version 2.8
+ *  @since   1
+ *
+ *  @tparam A    type of the elements contained in this buffer.
+ *
+ *  @define Coll `Buffer`
+ *  @define coll buffer
+ */
+trait Buffer[A] extends Seq[A]
+                   with GenericTraversableTemplate[A, Buffer]
+                   with BufferLike[A, Buffer[A]]
+                   with scala.Cloneable {
+  override def companion: GenericCompanion[Buffer] = Buffer
+}
+
+/** $factoryInfo
+ *  @define coll buffer
+ *  @define Coll `Buffer`
+ */
+object Buffer extends SeqFactory[Buffer] {
+  implicit def canBuildFrom[A]: CanBuildFrom[Coll, A, Buffer[A]] = ReusableCBF.asInstanceOf[GenericCanBuildFrom[A]]
+  def newBuilder[A]: Builder[A, Buffer[A]] = new js.WrappedArray
+}
+
+/** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
+abstract class AbstractBuffer[A] extends AbstractSeq[A] with Buffer[A]

--- a/scalalib/overrides-2.13/scala/compat/Platform.scala
+++ b/scalalib/overrides-2.13/scala/compat/Platform.scala
@@ -1,0 +1,132 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package compat
+
+import java.lang.System
+
+object Platform {
+
+  /** Thrown when a stack overflow occurs because a method or function recurses too deeply.
+    *
+    * On the JVM, this is a type alias for `java.lang.StackOverflowError`, which itself extends `java.lang.Error`.
+    * The same rules apply to catching a `java.lang.Error` as for Java, that it indicates a serious problem that a reasonable application should not try and catch.
+    */
+  type StackOverflowError = java.lang.StackOverflowError
+
+  /** This is a type alias for `java.util.ConcurrentModificationException`,
+    * which may be thrown by methods that detect an invalid modification of an object.
+    * For example, many common collection types do not allow modifying a collection
+    * while it is being iterated over.
+    */
+  type ConcurrentModificationException = java.util.ConcurrentModificationException
+
+  /** Copies `length` elements of array `src` starting at position `srcPos` to the
+    * array `dest` starting at position `destPos`. If `src`==`dest`, the copying will
+    * behave as if the elements copied from `src` were first copied to a temporary
+    * array before being copied back into the array at the destination positions.
+    *
+    * @param src     A non-null array as source for the copy.
+    * @param srcPos  The starting index in the source array.
+    * @param dest    A non-null array as destination for the copy.
+    * @param destPos The starting index in the destination array.
+    * @param length  The number of elements to be copied.
+    * @throws java.lang.NullPointerException If either `src` or `dest` are `null`.
+    * @throws java.lang.ArrayStoreException If either `src` or `dest` are not of type
+    *                [java.lang.Array]; or if the element type of `src` is not
+    *                compatible with that of `dest`.
+    * @throws java.lang.IndexOutOfBoundsException If either srcPos` or `destPos` are
+    *                outside of the bounds of their respective arrays; or if `length`
+    *                is negative; or if there are less than `length` elements available
+    *                after `srcPos` or `destPos` in `src` and `dest` respectively.
+    */
+  @inline
+  def arraycopy(src: AnyRef, srcPos: Int, dest: AnyRef, destPos: Int, length: Int) {
+    System.arraycopy(src, srcPos, dest, destPos, length)
+  }
+
+  /** Creates a new array of the specified type and given length.
+   *
+   *  Note that if `elemClass` is a subclass of [[scala.AnyVal]] then the returned value is an Array of the corresponding java primitive type.
+   *  For example, the following code `scala.compat.Platform.createArray(classOf[Int], 4)` returns an array of the java primitive type `int`.
+   *
+   *  For a [[scala.AnyVal]] array, the values of the array are set to 0 for ''numeric value types'' ([[scala.Double]], [[scala.Float]], [[scala.Long]], [[scala.Int]], [[scala.Char]],
+   *  [[scala.Short]], and [[scala.Byte]]), and `false` for [[scala.Boolean]]. Creation of an array of type [[scala.Unit]] is not possible.
+   *
+   *  For subclasses of [[scala.AnyRef]], the values of the array are set to `null`.
+   *
+   *  The caller must cast the returned value to the correct type.
+   *
+   *  @example {{{
+   *  val a = scala.compat.Platform.createArray(classOf[Int], 4).asInstanceOf[Array[Int]] // returns Array[Int](0, 0, 0, 0)
+   *  }}}
+   *
+   *  @param elemClass the `Class` object of the component type of the array
+   *  @param length    the length of the new array.
+   *  @return          an array of the given component type as an `AnyRef`.
+   *  @throws java.lang.NullPointerException If `elemClass` is `null`.
+   *  @throws java.lang.IllegalArgumentException if componentType is [[scala.Unit]] or `java.lang.Void.TYPE`
+   *  @throws java.lang.NegativeArraySizeException if the specified length is negative
+   */
+  @inline
+  def createArray(elemClass: Class[_], length: Int): AnyRef =
+    java.lang.reflect.Array.newInstance(elemClass, length)
+
+  /** Assigns the value of 0 to each element in the array.
+    * @param arr     A non-null Array[Int].
+    * @throws java.lang.NullPointerException If `arr` is `null`.
+    */
+  @inline
+  def arrayclear(arr: Array[Int]) { java.util.Arrays.fill(arr, 0) }
+
+  /** Returns the `Class` object associated with the class or interface with the given string name using the current `ClassLoader`.
+   *  On the JVM, invoking this method is equivalent to: `java.lang.Class.forName(name)`
+   *
+   *  For more information, please see the Java documentation for [[java.lang.Class]].
+   *
+   * @param    name the fully qualified name of the desired class.
+   * @return   the `Class` object for the class with the specified name.
+   * @throws java.lang.LinkageError if the linkage fails
+   * @throws java.lang.ExceptionInInitializerError if the initialization provoked by this method fails
+   * @throws java.lang.ClassNotFoundException if the class cannot be located
+   *  @example {{{
+   *  val a = scala.compat.Platform.getClassForName("java.lang.Integer")  // returns the Class[_] for java.lang.Integer
+   *  }}}
+   */
+  @inline
+  def getClassForName(name: String): Class[_] = java.lang.Class.forName(name)
+
+  /** The default line separator.
+   *
+   *  On the JavaScript backend, this is always "\n".
+   */
+  val EOL = "\n"
+
+  /** The current time in milliseconds. The time is counted since 1 January 1970
+    * UTC.
+    *
+    * Note that the operating system timer used to obtain this value may be less
+    * precise than a millisecond.
+    */
+  @inline
+  def currentTime: Long = System.currentTimeMillis()
+
+  /** Runs the garbage collector.
+   *
+   * This is a request that the underlying JVM runs the garbage collector.
+   * The results of this call depends heavily on the JVM used.
+   * The underlying JVM is free to ignore this request.
+   */
+  @inline
+  def collectGarbage(): Unit = System.gc()
+
+  /** The name of the default character set encoding as a string */
+  @inline
+  def defaultCharsetName: String = java.nio.charset.Charset.defaultCharset.name
+}

--- a/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala
+++ b/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala
@@ -1,0 +1,183 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala.concurrent
+
+
+import java.util.concurrent.{ ExecutorService, Executor }
+import scala.annotation.implicitNotFound
+import scala.util.Try
+
+/**
+ * An `ExecutionContext` can execute program logic asynchronously,
+ * typically but not necessarily on a thread pool.
+ *
+ * A general purpose `ExecutionContext` must be asynchronous in executing
+ * any `Runnable` that is passed into its `execute`-method. A special purpose
+ * `ExecutionContext` may be synchronous but must only be passed to code that
+ * is explicitly safe to be run using a synchronously executing `ExecutionContext`.
+ *
+ * APIs such as `Future.onComplete` require you to provide a callback
+ * and an implicit `ExecutionContext`. The implicit `ExecutionContext`
+ * will be used to execute the callback.
+ *
+ * It is possible to simply import
+ * `scala.concurrent.ExecutionContext.Implicits.global` to obtain an
+ * implicit `ExecutionContext`. This global context is a reasonable
+ * default thread pool.
+ *
+ * However, application developers should carefully consider where they
+ * want to set policy; ideally, one place per application (or per
+ * logically-related section of code) will make a decision about
+ * which `ExecutionContext` to use. That is, you might want to avoid
+ * hardcoding `scala.concurrent.ExecutionContext.Implicits.global` all
+ * over the place in your code.
+ * One approach is to add `(implicit ec: ExecutionContext)`
+ * to methods which need an `ExecutionContext`. Then import a specific
+ * context in one place for the entire application or module,
+ * passing it implicitly to individual methods.
+ *
+ * A custom `ExecutionContext` may be appropriate to execute code
+ * which blocks on IO or performs long-running computations.
+ * `ExecutionContext.fromExecutorService` and `ExecutionContext.fromExecutor`
+ * are good ways to create a custom `ExecutionContext`.
+ *
+ * The intent of `ExecutionContext` is to lexically scope code execution.
+ * That is, each method, class, file, package, or application determines
+ * how to run its own code. This avoids issues such as running
+ * application callbacks on a thread pool belonging to a networking library.
+ * The size of a networking library's thread pool can be safely configured,
+ * knowing that only that library's network operations will be affected.
+ * Application callback execution can be configured separately.
+ */
+@implicitNotFound("""Cannot find an implicit ExecutionContext. You might pass
+an (implicit ec: ExecutionContext) parameter to your method
+or import scala.concurrent.ExecutionContext.Implicits.global.""")
+trait ExecutionContext {
+
+  /** Runs a block of code on this execution context.
+   *
+   *  @param runnable  the task to execute
+   */
+  def execute(runnable: Runnable): Unit
+
+  /** Reports that an asynchronous computation failed.
+   *
+   *  @param cause  the cause of the failure
+   */
+  def reportFailure(@deprecatedName('t) cause: Throwable): Unit
+
+  /** Prepares for the execution of a task. Returns the prepared
+     *  execution context. The recommended implementation of
+     *  `prepare` is to return `this`.
+     * 
+     *  This method should no longer be overridden or called. It was
+     *  originally expected that `prepare` would be called by
+     *  all libraries that consume ExecutionContexts, in order to
+     *  capture thread local context. However, this usage has proven
+     *  difficult to implement in practice and instead it is
+     *  now better to avoid using `prepare` entirely.
+     *
+     *  Instead, if an `ExecutionContext` needs to capture thread
+     *  local context, it should capture that context when it is
+     *  constructed, so that it doesn't need any additional
+     *  preparation later.
+     */
+  @deprecated("Preparation of ExecutionContexts will be removed.", "2.12")
+  def prepare(): ExecutionContext = this
+}
+
+/**
+ * An [[ExecutionContext]] that is also a
+ * Java [[http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/Executor.html Executor]].
+ */
+trait ExecutionContextExecutor extends ExecutionContext with Executor
+
+/**
+ * An [[ExecutionContext]] that is also a
+ * Java [[http://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ExecutorService.html ExecutorService]].
+ */
+trait ExecutionContextExecutorService extends ExecutionContextExecutor with ExecutorService
+
+
+/** Contains factory methods for creating execution contexts.
+ */
+object ExecutionContext {
+  /**
+   * The explicit global `ExecutionContext`. Invoke `global` when you want to provide the global
+   * `ExecutionContext` explicitly.
+   *
+   * The default `ExecutionContext` implementation is backed by a work-stealing thread pool. By default,
+   * the thread pool uses a target number of worker threads equal to the number of
+   * [[https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors-- available processors]].
+   *
+   * @return the global `ExecutionContext`
+   */
+  def global: ExecutionContextExecutor = Implicits.global.asInstanceOf[ExecutionContextExecutor]
+
+  object Implicits {
+    /**
+     * The implicit global `ExecutionContext`. Import `global` when you want to provide the global
+     * `ExecutionContext` implicitly.
+     *
+     * The default `ExecutionContext` implementation is backed by a work-stealing thread pool. By default,
+     * the thread pool uses a target number of worker threads equal to the number of
+     * [[https://docs.oracle.com/javase/8/docs/api/java/lang/Runtime.html#availableProcessors-- available processors]].
+     */
+    implicit lazy val global: ExecutionContext =
+      scala.scalajs.concurrent.JSExecutionContext.queue
+  }
+
+  /** Creates an `ExecutionContext` from the given `ExecutorService`.
+   *
+   *  @param e         the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext$@global:scala.concurrent.ExecutionContextExecutor default configuration]].
+   *  @param reporter  a function for error reporting
+   *  @return          the `ExecutionContext` using the given `ExecutorService`
+   */
+  def fromExecutorService(e: ExecutorService, reporter: Throwable => Unit): ExecutionContextExecutorService =
+    impl.ExecutionContextImpl.fromExecutorService(e, reporter)
+
+  /** Creates an `ExecutionContext` from the given `ExecutorService` with the [[scala.concurrent.ExecutionContext$.defaultReporter default reporter]].
+   *
+   *  If it is guaranteed that none of the executed tasks are blocking, a single-threaded `ExecutorService`
+   *  can be used to create an `ExecutionContext` as follows:
+   *
+   *  {{{
+   *  import java.util.concurrent.Executors
+   *  val ec = ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+   *  }}}
+   *
+   *  @param e the `ExecutorService` to use. If `null`, a new `ExecutorService` is created with [[http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext$@global:scala.concurrent.ExecutionContextExecutor default configuration]].
+   *  @return  the `ExecutionContext` using the given `ExecutorService`
+   */
+  def fromExecutorService(e: ExecutorService): ExecutionContextExecutorService = fromExecutorService(e, defaultReporter)
+
+  /** Creates an `ExecutionContext` from the given `Executor`.
+   *
+   *  @param e         the `Executor` to use. If `null`, a new `Executor` is created with [[http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext$@global:scala.concurrent.ExecutionContextExecutor default configuration]].
+   *  @param reporter  a function for error reporting
+   *  @return          the `ExecutionContext` using the given `Executor`
+   */
+  def fromExecutor(e: Executor, reporter: Throwable => Unit): ExecutionContextExecutor =
+    impl.ExecutionContextImpl.fromExecutor(e, reporter)
+
+  /** Creates an `ExecutionContext` from the given `Executor` with the [[scala.concurrent.ExecutionContext$.defaultReporter default reporter]].
+   *
+   *  @param e the `Executor` to use. If `null`, a new `Executor` is created with [[http://www.scala-lang.org/api/current/index.html#scala.concurrent.ExecutionContext$@global:scala.concurrent.ExecutionContextExecutor default configuration]].
+   *  @return  the `ExecutionContext` using the given `Executor`
+   */
+  def fromExecutor(e: Executor): ExecutionContextExecutor = fromExecutor(e, defaultReporter)
+
+  /** The default reporter simply prints the stack trace of the `Throwable` to [[http://docs.oracle.com/javase/8/docs/api/java/lang/System.html#err System.err]].
+   *
+   *  @return the function for error reporting
+   */
+  def defaultReporter: Throwable => Unit = _.printStackTrace()
+}
+
+

--- a/scalalib/overrides-2.13/scala/package.scala
+++ b/scalalib/overrides-2.13/scala/package.scala
@@ -1,0 +1,133 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+
+/**
+ * Core Scala types. They are always available without an explicit import.
+ * @contentDiagram hideNodes "scala.Serializable"
+ */
+package object scala {
+  type Throwable = java.lang.Throwable
+  type Exception = java.lang.Exception
+  type Error     = java.lang.Error
+
+  type RuntimeException                = java.lang.RuntimeException
+  type NullPointerException            = java.lang.NullPointerException
+  type ClassCastException              = java.lang.ClassCastException
+  type IndexOutOfBoundsException       = java.lang.IndexOutOfBoundsException
+  type ArrayIndexOutOfBoundsException  = java.lang.ArrayIndexOutOfBoundsException
+  type StringIndexOutOfBoundsException = java.lang.StringIndexOutOfBoundsException
+  type UnsupportedOperationException   = java.lang.UnsupportedOperationException
+  type IllegalArgumentException        = java.lang.IllegalArgumentException
+  type NoSuchElementException          = java.util.NoSuchElementException
+  type NumberFormatException           = java.lang.NumberFormatException
+  type AbstractMethodError             = java.lang.AbstractMethodError
+  type InterruptedException            = java.lang.InterruptedException
+
+  // A dummy used by the specialization annotation.
+  val AnyRef = new Specializable {
+    override def toString = "object AnyRef"
+  }
+
+  type TraversableOnce[+A] = scala.collection.TraversableOnce[A]
+
+  type Traversable[+A] = scala.collection.Traversable[A]
+  val Traversable = scala.collection.Traversable
+
+  type Iterable[+A] = scala.collection.Iterable[A]
+  val Iterable = scala.collection.Iterable
+
+  type Seq[+A] = scala.collection.Seq[A]
+  val Seq = scala.collection.Seq
+
+  type IndexedSeq[+A] = scala.collection.IndexedSeq[A]
+  val IndexedSeq = scala.collection.IndexedSeq
+
+  type Iterator[+A] = scala.collection.Iterator[A]
+  val Iterator = scala.collection.Iterator
+
+  type BufferedIterator[+A] = scala.collection.BufferedIterator[A]
+
+  type List[+A] = scala.collection.immutable.List[A]
+  val List = scala.collection.immutable.List
+
+  val Nil = scala.collection.immutable.Nil
+
+  type ::[A] = scala.collection.immutable.::[A]
+  val :: = scala.collection.immutable.::
+
+  val +: = scala.collection.+:
+  val :+ = scala.collection.:+
+
+  type Stream[+A] = scala.collection.immutable.Stream[A]
+  val Stream = scala.collection.immutable.Stream
+  val #:: = scala.collection.immutable.Stream.#::
+
+  type Vector[+A] = scala.collection.immutable.Vector[A]
+  val Vector = scala.collection.immutable.Vector
+
+  type StringBuilder = scala.collection.mutable.StringBuilder
+  val StringBuilder = scala.collection.mutable.StringBuilder
+
+  type Range = scala.collection.immutable.Range
+  val Range = scala.collection.immutable.Range
+
+  // Numeric types which were moved into scala.math.*
+
+  type BigDecimal = scala.math.BigDecimal
+  lazy val BigDecimal = scala.math.BigDecimal
+
+  type BigInt = scala.math.BigInt
+  lazy val BigInt = scala.math.BigInt
+
+  type Equiv[T] = scala.math.Equiv[T]
+  val Equiv = scala.math.Equiv
+
+  type Fractional[T] = scala.math.Fractional[T]
+  val Fractional = scala.math.Fractional
+
+  type Integral[T] = scala.math.Integral[T]
+  val Integral = scala.math.Integral
+
+  type Numeric[T] = scala.math.Numeric[T]
+  val Numeric = scala.math.Numeric
+
+  type Ordered[T] = scala.math.Ordered[T]
+  val Ordered = scala.math.Ordered
+
+  type Ordering[T] = scala.math.Ordering[T]
+  val Ordering = scala.math.Ordering
+
+  type PartialOrdering[T] = scala.math.PartialOrdering[T]
+  type PartiallyOrdered[T] = scala.math.PartiallyOrdered[T]
+
+  type Either[+A, +B] = scala.util.Either[A, B]
+  val Either = scala.util.Either
+
+  type Left[+A, +B] = scala.util.Left[A, B]
+  val Left = scala.util.Left
+
+  type Right[+A, +B] = scala.util.Right[A, B]
+  val Right = scala.util.Right
+
+  // Annotations which we might move to annotation.*
+/*
+  type SerialVersionUID = annotation.SerialVersionUID
+  type deprecated = annotation.deprecated
+  type deprecatedName = annotation.deprecatedName
+  type inline = annotation.inline
+  type native = annotation.native
+  type noinline = annotation.noinline
+  type remote = annotation.remote
+  type specialized = annotation.specialized
+  type transient = annotation.transient
+  type throws  = annotation.throws
+  type unchecked = annotation.unchecked.unchecked
+  type volatile = annotation.volatile
+  */
+}

--- a/scalalib/overrides-2.13/scala/reflect/ClassTag.scala
+++ b/scalalib/overrides-2.13/scala/reflect/ClassTag.scala
@@ -1,0 +1,159 @@
+package scala
+package reflect
+
+import java.lang.{ Class => jClass }
+
+/**
+ *
+ * A `ClassTag[T]` stores the erased class of a given type `T`, accessible via the `runtimeClass`
+ * field. This is particularly useful for instantiating `Array`s whose element types are unknown
+ * at compile time.
+ *
+ * `ClassTag`s are a weaker special case of [[scala.reflect.api.TypeTags#TypeTag]]s, in that they
+ * wrap only the runtime class of a given type, whereas a `TypeTag` contains all static type
+ * information. That is, `ClassTag`s are constructed from knowing only the top-level class of a
+ * type, without necessarily knowing all of its argument types. This runtime information is enough
+ * for runtime `Array` creation.
+ *
+ * For example:
+ * {{{
+ *   scala> def mkArray[T : ClassTag](elems: T*) = Array[T](elems: _*)
+ *   mkArray: [T](elems: T*)(implicit evidence$1: scala.reflect.ClassTag[T])Array[T]
+ *
+ *   scala> mkArray(42, 13)
+ *   res0: Array[Int] = Array(42, 13)
+ *
+ *   scala> mkArray("Japan","Brazil","Germany")
+ *   res1: Array[String] = Array(Japan, Brazil, Germany)
+ * }}}
+ *
+ * See [[scala.reflect.api.TypeTags]] for more examples, or the
+ * [[http://docs.scala-lang.org/overviews/reflection/typetags-manifests.html Reflection Guide: TypeTags]]
+ * for more details.
+ *
+ */
+@scala.annotation.implicitNotFound(msg = "No ClassTag available for ${T}")
+trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serializable {
+  // please, don't add any APIs here, like it was with `newWrappedArray` and `newArrayBuilder`
+  // class tags, and all tags in general, should be as minimalistic as possible
+
+  /** A class representing the type `U` to which `T` would be erased.
+   *  Note that there is no subtyping relationship between `T` and `U`.
+   */
+  def runtimeClass: jClass[_]
+
+  /** Produces a `ClassTag` that knows how to instantiate an `Array[Array[T]]` */
+  def wrap: ClassTag[Array[T]] = ClassTag[Array[T]](arrayClass(runtimeClass))
+
+  /** Produces a new array with element type `T` and length `len` */
+  override def newArray(len: Int): Array[T] =
+    runtimeClass match {
+      case java.lang.Byte.TYPE      => new Array[Byte](len).asInstanceOf[Array[T]]
+      case java.lang.Short.TYPE     => new Array[Short](len).asInstanceOf[Array[T]]
+      case java.lang.Character.TYPE => new Array[Char](len).asInstanceOf[Array[T]]
+      case java.lang.Integer.TYPE   => new Array[Int](len).asInstanceOf[Array[T]]
+      case java.lang.Long.TYPE      => new Array[Long](len).asInstanceOf[Array[T]]
+      case java.lang.Float.TYPE     => new Array[Float](len).asInstanceOf[Array[T]]
+      case java.lang.Double.TYPE    => new Array[Double](len).asInstanceOf[Array[T]]
+      case java.lang.Boolean.TYPE   => new Array[Boolean](len).asInstanceOf[Array[T]]
+      case java.lang.Void.TYPE      => new Array[Unit](len).asInstanceOf[Array[T]]
+      case _                        => java.lang.reflect.Array.newInstance(runtimeClass, len).asInstanceOf[Array[T]]
+    }
+
+  /** A ClassTag[T] can serve as an extractor that matches only objects of type T.
+   *
+   * The compiler tries to turn unchecked type tests in pattern matches into checked ones
+   * by wrapping a `(_: T)` type pattern as `ct(_: T)`, where `ct` is the `ClassTag[T]` instance.
+   * Type tests necessary before calling other extractors are treated similarly.
+   * `SomeExtractor(...)` is turned into `ct(SomeExtractor(...))` if `T` in `SomeExtractor.unapply(x: T)`
+   * is uncheckable, but we have an instance of `ClassTag[T]`.
+   */
+  def unapply(x: Any): Option[T] =
+    if (null != x && (
+            (runtimeClass.isInstance(x))
+         || (x.isInstanceOf[Byte]    && runtimeClass.isAssignableFrom(classOf[Byte]))
+         || (x.isInstanceOf[Short]   && runtimeClass.isAssignableFrom(classOf[Short]))
+         || (x.isInstanceOf[Char]    && runtimeClass.isAssignableFrom(classOf[Char]))
+         || (x.isInstanceOf[Int]     && runtimeClass.isAssignableFrom(classOf[Int]))
+         || (x.isInstanceOf[Long]    && runtimeClass.isAssignableFrom(classOf[Long]))
+         || (x.isInstanceOf[Float]   && runtimeClass.isAssignableFrom(classOf[Float]))
+         || (x.isInstanceOf[Double]  && runtimeClass.isAssignableFrom(classOf[Double]))
+         || (x.isInstanceOf[Boolean] && runtimeClass.isAssignableFrom(classOf[Boolean]))
+         || (x.isInstanceOf[Unit]    && runtimeClass.isAssignableFrom(classOf[Unit])))
+       ) Some(x.asInstanceOf[T])
+    else None
+
+  // TODO: deprecate overloads in 2.12.0, remove in 2.13.0
+  def unapply(x: Byte)    : Option[T] = unapplyImpl(x, classOf[Byte])
+  def unapply(x: Short)   : Option[T] = unapplyImpl(x, classOf[Short])
+  def unapply(x: Char)    : Option[T] = unapplyImpl(x, classOf[Char])
+  def unapply(x: Int)     : Option[T] = unapplyImpl(x, classOf[Int])
+  def unapply(x: Long)    : Option[T] = unapplyImpl(x, classOf[Long])
+  def unapply(x: Float)   : Option[T] = unapplyImpl(x, classOf[Float])
+  def unapply(x: Double)  : Option[T] = unapplyImpl(x, classOf[Double])
+  def unapply(x: Boolean) : Option[T] = unapplyImpl(x, classOf[Boolean])
+  def unapply(x: Unit)    : Option[T] = unapplyImpl(x, classOf[Unit])
+
+  private[this] def unapplyImpl(x: Any, primitiveCls: java.lang.Class[_]): Option[T] =
+    if (runtimeClass.isInstance(x) || runtimeClass.isAssignableFrom(primitiveCls)) Some(x.asInstanceOf[T])
+    else None
+
+  // case class accessories
+  override def canEqual(x: Any) = x.isInstanceOf[ClassTag[_]]
+  override def equals(x: Any) = x.isInstanceOf[ClassTag[_]] && this.runtimeClass == x.asInstanceOf[ClassTag[_]].runtimeClass
+  override def hashCode = runtimeClass.##
+  override def toString = {
+    def prettyprint(clazz: jClass[_]): String =
+      if (clazz.isArray) s"Array[${prettyprint(clazz.getComponentType)}]" else
+      clazz.getName
+    prettyprint(runtimeClass)
+  }
+}
+
+/**
+ * Class tags corresponding to primitive types and constructor/extractor for ClassTags.
+ */
+object ClassTag {
+  def Byte    : ClassTag[scala.Byte]       = ManifestFactory.Byte
+  def Short   : ClassTag[scala.Short]      = ManifestFactory.Short
+  def Char    : ClassTag[scala.Char]       = ManifestFactory.Char
+  def Int     : ClassTag[scala.Int]        = ManifestFactory.Int
+  def Long    : ClassTag[scala.Long]       = ManifestFactory.Long
+  def Float   : ClassTag[scala.Float]      = ManifestFactory.Float
+  def Double  : ClassTag[scala.Double]     = ManifestFactory.Double
+  def Boolean : ClassTag[scala.Boolean]    = ManifestFactory.Boolean
+  def Unit    : ClassTag[scala.Unit]       = ManifestFactory.Unit
+  def Any     : ClassTag[scala.Any]        = ManifestFactory.Any
+  def Object  : ClassTag[java.lang.Object] = ManifestFactory.Object
+  def AnyVal  : ClassTag[scala.AnyVal]     = ManifestFactory.AnyVal
+  def AnyRef  : ClassTag[scala.AnyRef]     = ManifestFactory.AnyRef
+  def Nothing : ClassTag[scala.Nothing]    = ManifestFactory.Nothing
+  def Null    : ClassTag[scala.Null]       = ManifestFactory.Null
+
+  @inline
+  private class GenericClassTag[T](val runtimeClass: jClass[_]) extends ClassTag[T]
+
+  def apply[T](runtimeClass1: jClass[_]): ClassTag[T] =
+    runtimeClass1 match {
+      case java.lang.Byte.TYPE      => ClassTag.Byte.asInstanceOf[ClassTag[T]]
+      case java.lang.Short.TYPE     => ClassTag.Short.asInstanceOf[ClassTag[T]]
+      case java.lang.Character.TYPE => ClassTag.Char.asInstanceOf[ClassTag[T]]
+      case java.lang.Integer.TYPE   => ClassTag.Int.asInstanceOf[ClassTag[T]]
+      case java.lang.Long.TYPE      => ClassTag.Long.asInstanceOf[ClassTag[T]]
+      case java.lang.Float.TYPE     => ClassTag.Float.asInstanceOf[ClassTag[T]]
+      case java.lang.Double.TYPE    => ClassTag.Double.asInstanceOf[ClassTag[T]]
+      case java.lang.Boolean.TYPE   => ClassTag.Boolean.asInstanceOf[ClassTag[T]]
+      case java.lang.Void.TYPE      => ClassTag.Unit.asInstanceOf[ClassTag[T]]
+      case _                        =>
+        if (classOf[java.lang.Object] == runtimeClass1)
+          ClassTag.Object.asInstanceOf[ClassTag[T]]
+        else if (classOf[scala.runtime.Nothing$] == runtimeClass1)
+          ClassTag.Nothing.asInstanceOf[ClassTag[T]]
+        else if (classOf[scala.runtime.Null$] == runtimeClass1)
+          ClassTag.Null.asInstanceOf[ClassTag[T]]
+        else
+          new GenericClassTag[T](runtimeClass1)
+    }
+
+  def unapply[T](ctag: ClassTag[T]): Option[Class[_]] = Some(ctag.runtimeClass)
+}

--- a/scalalib/overrides-2.13/scala/reflect/Manifest.scala
+++ b/scalalib/overrides-2.13/scala/reflect/Manifest.scala
@@ -1,0 +1,300 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2007-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package reflect
+
+import scala.collection.mutable.{ArrayBuilder, WrappedArray}
+
+/** A `Manifest[T]` is an opaque descriptor for type T.  Its supported use
+ *  is to give access to the erasure of the type as a `Class` instance, as
+ *  is necessary for the creation of native `Arrays` if the class is not
+ *  known at compile time.
+ *
+ *  The type-relation operators `<:<` and `=:=` should be considered
+ *  approximations only, as there are numerous aspects of type conformance
+ *  which are not yet adequately represented in manifests.
+ *
+ *  Example usages:
+ *  {{{
+ *    def arr[T] = new Array[T](0)                          // does not compile
+ *    def arr[T](implicit m: Manifest[T]) = new Array[T](0) // compiles
+ *    def arr[T: Manifest] = new Array[T](0)                // shorthand for the preceding
+ *
+ *    // Methods manifest, classManifest, and optManifest are in [[scala.Predef]].
+ *    def isApproxSubType[T: Manifest, U: Manifest] = manifest[T] <:< manifest[U]
+ *    isApproxSubType[List[String], List[AnyRef]] // true
+ *    isApproxSubType[List[String], List[Int]]    // false
+ *
+ *    def methods[T: ClassManifest] = classManifest[T].erasure.getMethods
+ *    def retType[T: ClassManifest](name: String) =
+ *      methods[T] find (_.getName == name) map (_.getGenericReturnType)
+ *
+ *    retType[Map[_, _]]("values")  // Some(scala.collection.Iterable<B>)
+ *  }}}
+ */
+@scala.annotation.implicitNotFound(msg = "No Manifest available for ${T}.")
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("use scala.reflect.ClassTag (to capture erasures) or scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+trait Manifest[T] extends ClassManifest[T] with Equals {
+  override def typeArguments: List[Manifest[_]] = Nil
+
+  override def arrayManifest: Manifest[Array[T]] =
+    Manifest.classType[Array[T]](arrayClass[T](runtimeClass), this)
+
+  override def canEqual(that: Any): Boolean = that match {
+    case _: Manifest[_]   => true
+    case _                => false
+  }
+  /** Note: testing for erasure here is important, as it is many times
+   *  faster than <:< and rules out most comparisons.
+   */
+  override def equals(that: Any): Boolean = that match {
+    case m: Manifest[_] => (m canEqual this) && (this.runtimeClass == m.runtimeClass) && (this <:< m) && (m <:< this)
+    case _              => false
+  }
+  override def hashCode = this.runtimeClass.##
+}
+
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("use type tags and manually check the corresponding class or type instead", "2.10.0")
+@SerialVersionUID(1L)
+abstract class AnyValManifest[T <: AnyVal](override val toString: String) extends Manifest[T] with Equals {
+  override def <:<(that: ClassManifest[_]): Boolean =
+    (that eq this) || (that eq Manifest.Any) || (that eq Manifest.AnyVal)
+  override def canEqual(other: Any) = other match {
+    case _: AnyValManifest[_] => true
+    case _                    => false
+  }
+  override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
+  override def hashCode = System.identityHashCode(this)
+}
+
+/** `ManifestFactory` defines factory methods for manifests.
+ *  It is intended for use by the compiler and should not be used in client code.
+ *
+ *  Unlike `Manifest`, this factory isn't annotated with a deprecation warning.
+ *  This is done to prevent avalanches of deprecation warnings in the code that calls methods with manifests.
+ *  Why so complicated? Read up the comments for `ClassManifestFactory`.
+ */
+object ManifestFactory {
+  def valueManifests: List[AnyValManifest[_]] =
+    List(Byte, Short, Char, Int, Long, Float, Double, Boolean, Unit)
+
+  private object ByteManifest extends AnyValManifest[scala.Byte]("Byte") {
+    def runtimeClass = java.lang.Byte.TYPE
+    override def newArray(len: Int): Array[Byte] = new Array[Byte](len)
+    override def newWrappedArray(len: Int): WrappedArray[Byte] = new WrappedArray.ofByte(new Array[Byte](len))
+    override def newArrayBuilder(): ArrayBuilder[Byte] = new ArrayBuilder.ofByte()
+    private def readResolve(): Any = Manifest.Byte
+  }
+  def Byte: AnyValManifest[Byte] = ByteManifest
+
+  private object ShortManifest extends AnyValManifest[scala.Short]("Short") {
+    def runtimeClass = java.lang.Short.TYPE
+    override def newArray(len: Int): Array[Short] = new Array[Short](len)
+    override def newWrappedArray(len: Int): WrappedArray[Short] = new WrappedArray.ofShort(new Array[Short](len))
+    override def newArrayBuilder(): ArrayBuilder[Short] = new ArrayBuilder.ofShort()
+    private def readResolve(): Any = Manifest.Short
+  }
+  def Short: AnyValManifest[Short] = ShortManifest
+
+  private object CharManifest extends AnyValManifest[scala.Char]("Char") {
+    def runtimeClass = java.lang.Character.TYPE
+    override def newArray(len: Int): Array[Char] = new Array[Char](len)
+    override def newWrappedArray(len: Int): WrappedArray[Char] = new WrappedArray.ofChar(new Array[Char](len))
+    override def newArrayBuilder(): ArrayBuilder[Char] = new ArrayBuilder.ofChar()
+    private def readResolve(): Any = Manifest.Char
+  }
+  def Char: AnyValManifest[Char] = CharManifest
+
+  private object IntManifest extends AnyValManifest[scala.Int]("Int") {
+    def runtimeClass = java.lang.Integer.TYPE
+    override def newArray(len: Int): Array[Int] = new Array[Int](len)
+    override def newWrappedArray(len: Int): WrappedArray[Int] = new WrappedArray.ofInt(new Array[Int](len))
+    override def newArrayBuilder(): ArrayBuilder[Int] = new ArrayBuilder.ofInt()
+    private def readResolve(): Any = Manifest.Int
+  }
+  def Int: AnyValManifest[Int] = IntManifest
+
+  private object LongManifest extends AnyValManifest[scala.Long]("Long") {
+    def runtimeClass = java.lang.Long.TYPE
+    override def newArray(len: Int): Array[Long] = new Array[Long](len)
+    override def newWrappedArray(len: Int): WrappedArray[Long] = new WrappedArray.ofLong(new Array[Long](len))
+    override def newArrayBuilder(): ArrayBuilder[Long] = new ArrayBuilder.ofLong()
+    private def readResolve(): Any = Manifest.Long
+  }
+  def Long: AnyValManifest[Long] = LongManifest
+
+  private object FloatManifest extends AnyValManifest[scala.Float]("Float") {
+    def runtimeClass = java.lang.Float.TYPE
+    override def newArray(len: Int): Array[Float] = new Array[Float](len)
+    override def newWrappedArray(len: Int): WrappedArray[Float] = new WrappedArray.ofFloat(new Array[Float](len))
+    override def newArrayBuilder(): ArrayBuilder[Float] = new ArrayBuilder.ofFloat()
+    private def readResolve(): Any = Manifest.Float
+  }
+  def Float: AnyValManifest[Float] = FloatManifest
+
+  private object DoubleManifest extends AnyValManifest[scala.Double]("Double") {
+    def runtimeClass = java.lang.Double.TYPE
+    override def newArray(len: Int): Array[Double] = new Array[Double](len)
+    override def newWrappedArray(len: Int): WrappedArray[Double] = new WrappedArray.ofDouble(new Array[Double](len))
+    override def newArrayBuilder(): ArrayBuilder[Double] = new ArrayBuilder.ofDouble()
+    private def readResolve(): Any = Manifest.Double
+  }
+  def Double: AnyValManifest[Double] = DoubleManifest
+
+  private object BooleanManifest extends AnyValManifest[scala.Boolean]("Boolean") {
+    def runtimeClass = java.lang.Boolean.TYPE
+    override def newArray(len: Int): Array[Boolean] = new Array[Boolean](len)
+    override def newWrappedArray(len: Int): WrappedArray[Boolean] = new WrappedArray.ofBoolean(new Array[Boolean](len))
+    override def newArrayBuilder(): ArrayBuilder[Boolean] = new ArrayBuilder.ofBoolean()
+    private def readResolve(): Any = Manifest.Boolean
+  }
+  def Boolean: AnyValManifest[Boolean] = BooleanManifest
+
+  private object UnitManifest extends AnyValManifest[scala.Unit]("Unit") {
+    def runtimeClass = java.lang.Void.TYPE
+    override def newArray(len: Int): Array[Unit] = new Array[Unit](len)
+    override def newWrappedArray(len: Int): WrappedArray[Unit] = new WrappedArray.ofUnit(new Array[Unit](len))
+    override def newArrayBuilder(): ArrayBuilder[Unit] = new ArrayBuilder.ofUnit()
+    override protected def arrayClass[T](tp: Class[_]): Class[Array[T]] =
+      if (tp eq runtimeClass) classOf[Array[scala.runtime.BoxedUnit]].asInstanceOf[Class[Array[T]]]
+      else super.arrayClass(tp)
+    private def readResolve(): Any = Manifest.Unit
+  }
+  def Unit: AnyValManifest[Unit] = UnitManifest
+
+  private object AnyManifest extends PhantomManifest[scala.Any](classOf[java.lang.Object], "Any") {
+    override def runtimeClass = classOf[java.lang.Object]
+    override def newArray(len: Int) = new Array[scala.Any](len)
+    override def <:<(that: ClassManifest[_]): Boolean = (that eq this)
+    private def readResolve(): Any = Manifest.Any
+  }
+  def Any: Manifest[scala.Any] = AnyManifest
+
+  private object ObjectManifest extends PhantomManifest[java.lang.Object](classOf[java.lang.Object], "Object") {
+    override def runtimeClass = classOf[java.lang.Object]
+    override def newArray(len: Int) = new Array[java.lang.Object](len)
+    override def <:<(that: ClassManifest[_]): Boolean = (that eq this) || (that eq Any)
+    private def readResolve(): Any = Manifest.Object
+  }
+  def Object: Manifest[java.lang.Object] = ObjectManifest
+
+  def AnyRef: Manifest[scala.AnyRef] = Object.asInstanceOf[Manifest[scala.AnyRef]]
+
+  private object AnyValManifest extends PhantomManifest[scala.AnyVal](classOf[java.lang.Object], "AnyVal") {
+    override def runtimeClass = classOf[java.lang.Object]
+    override def newArray(len: Int) = new Array[scala.AnyVal](len)
+    override def <:<(that: ClassManifest[_]): Boolean = (that eq this) || (that eq Any)
+    private def readResolve(): Any = Manifest.AnyVal
+  }
+  def AnyVal: Manifest[scala.AnyVal] = AnyValManifest
+
+  private object NullManifest extends PhantomManifest[scala.Null](classOf[scala.runtime.Null$], "Null") {
+    override def runtimeClass = classOf[scala.runtime.Null$]
+    override def newArray(len: Int) = new Array[scala.Null](len)
+    override def <:<(that: ClassManifest[_]): Boolean =
+      (that ne null) && (that ne Nothing) && !(that <:< AnyVal)
+    private def readResolve(): Any = Manifest.Null
+  }
+  def Null: Manifest[scala.Null] = NullManifest
+
+  private object NothingManifest extends PhantomManifest[scala.Nothing](classOf[scala.runtime.Nothing$], "Nothing") {
+    override def runtimeClass = classOf[scala.runtime.Nothing$]
+    override def newArray(len: Int) = new Array[scala.Nothing](len)
+    override def <:<(that: ClassManifest[_]): Boolean = (that ne null)
+    private def readResolve(): Any = Manifest.Nothing
+  }
+  def Nothing: Manifest[scala.Nothing] = NothingManifest
+
+  private class SingletonTypeManifest[T <: AnyRef](value: AnyRef) extends Manifest[T] {
+    lazy val runtimeClass = value.getClass
+    override lazy val toString = value.toString + ".type"
+  }
+
+  /** Manifest for the singleton type `value.type`. */
+  def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
+    new SingletonTypeManifest[T](value)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a top-level or static class.
+    * @note This no-prefix, no-arguments case is separate because we
+    *       it's called from ScalaRunTime.boxArray itself. If we
+    *       pass varargs as arrays into this, we get an infinitely recursive call
+    *       to boxArray. (Besides, having a separate case is more efficient)
+    */
+  def classType[T](clazz: Predef.Class[_]): Manifest[T] =
+    new ClassTypeManifest[T](None, clazz, Nil)
+
+  /** Manifest for the class type `clazz`, where `clazz` is
+    * a top-level or static class and args are its type arguments. */
+  def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
+    new ClassTypeManifest[T](None, clazz, arg1 :: args.toList)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a class with non-package prefix type `prefix` and type arguments `args`.
+    */
+  def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    new ClassTypeManifest[T](Some(prefix), clazz, args.toList)
+
+  private abstract class PhantomManifest[T](_runtimeClass: Predef.Class[_],
+                                            override val toString: String) extends ClassTypeManifest[T](None, _runtimeClass, Nil) {
+    override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
+    override def hashCode = System.identityHashCode(this)
+  }
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a top-level or static class. */
+  private class ClassTypeManifest[T](prefix: Option[Manifest[_]],
+                                     runtimeClass1: Predef.Class[_],
+                                     override val typeArguments: List[Manifest[_]]) extends Manifest[T] {
+    def runtimeClass: Predef.Class[_] = runtimeClass1
+    override def toString =
+      (if (prefix.isEmpty) "" else prefix.get.toString+"#") +
+      (if (runtimeClass.isArray) "Array" else runtimeClass.getName) +
+      argString
+   }
+
+  def arrayType[T](arg: Manifest[_]): Manifest[Array[T]] =
+    arg.asInstanceOf[Manifest[T]].arrayManifest
+
+  private class AbstractTypeManifest[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Seq[Manifest[_]]) extends Manifest[T] {
+    def runtimeClass = upperBound
+    override val typeArguments = args.toList
+    override def toString = prefix.toString+"#"+name+argString
+  }
+
+  /** Manifest for the abstract type `prefix # name`. `upperBound` is not
+    * strictly necessary as it could be obtained by reflection. It was
+    * added so that erasure can be calculated without reflection. */
+  def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    new AbstractTypeManifest[T](prefix, name, upperBound, args)
+
+  private class WildcardManifest[T](lowerBound: Manifest[_], upperBound: Manifest[_]) extends Manifest[T] {
+    def runtimeClass = upperBound.runtimeClass
+    override def toString =
+      "_" +
+        (if (lowerBound eq Nothing) "" else " >: "+lowerBound) +
+        (if (upperBound eq Nothing) "" else " <: "+upperBound)
+  }
+
+  /** Manifest for the unknown type `_ >: L <: U` in an existential.
+    */
+  def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
+    new WildcardManifest[T](lowerBound, upperBound)
+
+  private class IntersectionTypeManifest[T](parents: Seq[Manifest[_]]) extends Manifest[T] {
+    def runtimeClass = parents.head.runtimeClass
+    override def toString = parents.mkString(" with ")
+  }
+
+  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  def intersectionType[T](parents: Manifest[_]*): Manifest[T] =
+    new IntersectionTypeManifest[T](parents)
+}

--- a/scalalib/overrides-2.13/scala/reflect/NameTransformer.scala
+++ b/scalalib/overrides-2.13/scala/reflect/NameTransformer.scala
@@ -1,0 +1,161 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package reflect
+
+/** Provides functions to encode and decode Scala symbolic names.
+ *  Also provides some constants.
+ */
+object NameTransformer {
+  // XXX Short term: providing a way to alter these without having to recompile
+  // the compiler before recompiling the compiler.
+  val MODULE_SUFFIX_STRING          = "$"
+  val NAME_JOIN_STRING              = "$"
+  val MODULE_INSTANCE_NAME          = "MODULE$"
+  val LOCAL_SUFFIX_STRING           = " "
+  val SETTER_SUFFIX_STRING          = "_$eq"
+  val TRAIT_SETTER_SEPARATOR_STRING = "$_setter_$"
+
+  private val nops = 128
+  private val ncodes = 26 * 26
+
+  private class OpCodes(val op: Char, val code: String, val next: OpCodes)
+
+  private val op2code = new Array[String](nops)
+  private val code2op = new Array[OpCodes](ncodes)
+  private def enterOp(op: Char, code: String) = {
+    op2code(op.toInt) = code
+    val c = (code.charAt(1) - 'a') * 26 + code.charAt(2) - 'a'
+    code2op(c.toInt) = new OpCodes(op, code, code2op(c))
+  }
+
+  /* Note: decoding assumes opcodes are only ever lowercase. */
+  enterOp('~', "$tilde")
+  enterOp('=', "$eq")
+  enterOp('<', "$less")
+  enterOp('>', "$greater")
+  enterOp('!', "$bang")
+  enterOp('#', "$hash")
+  enterOp('%', "$percent")
+  enterOp('^', "$up")
+  enterOp('&', "$amp")
+  enterOp('|', "$bar")
+  enterOp('*', "$times")
+  enterOp('/', "$div")
+  enterOp('+', "$plus")
+  enterOp('-', "$minus")
+  enterOp(':', "$colon")
+  enterOp('\\', "$bslash")
+  enterOp('?', "$qmark")
+  enterOp('@', "$at")
+
+  /** Replace operator symbols by corresponding `\$opname`.
+   *
+   *  @param name the string to encode
+   *  @return     the string with all recognized opchars replaced with their encoding
+   */
+  def encode(name: String): String = {
+    var buf: StringBuilder = null
+    val len = name.length()
+    var i = 0
+    while (i < len) {
+      val c = name charAt i
+      if (c < nops && (op2code(c.toInt) ne null)) {
+        if (buf eq null) {
+          buf = new StringBuilder()
+          buf.append(name.substring(0, i))
+        }
+        buf.append(op2code(c.toInt))
+      /* Handle glyphs that are not valid Java/JVM identifiers */
+      }
+      else if (!Character.isJavaIdentifierPart(c)) {
+        if (buf eq null) {
+          buf = new StringBuilder()
+          buf.append(name.substring(0, i))
+        }
+        buf.append("$u%04X".format(c.toInt))
+      }
+      else if (buf ne null) {
+        buf.append(c)
+      }
+      i += 1
+    }
+    if (buf eq null) name else buf.toString()
+  }
+
+  /** Replace `\$opname` by corresponding operator symbol.
+   *
+   *  @param name0 the string to decode
+   *  @return      the string with all recognized operator symbol encodings replaced with their name
+   */
+  def decode(name0: String): String = {
+    //System.out.println("decode: " + name);//DEBUG
+    val name = if (name0.endsWith("<init>")) name0.stripSuffix("<init>") + "this"
+               else name0
+    var buf: StringBuilder = null
+    val len = name.length()
+    var i = 0
+    while (i < len) {
+      var ops: OpCodes = null
+      var unicode = false
+      val c = name charAt i
+      if (c == '$' && i + 2 < len) {
+        val ch1 = name.charAt(i+1)
+        if ('a' <= ch1 && ch1 <= 'z') {
+          val ch2 = name.charAt(i+2)
+          if ('a' <= ch2 && ch2 <= 'z') {
+            ops = code2op((ch1 - 'a') * 26 + ch2 - 'a')
+            while ((ops ne null) && !name.startsWith(ops.code, i)) ops = ops.next
+            if (ops ne null) {
+              if (buf eq null) {
+                buf = new StringBuilder()
+                buf.append(name.substring(0, i))
+              }
+              buf.append(ops.op)
+              i += ops.code.length()
+            }
+            /* Handle the decoding of Unicode glyphs that are
+             * not valid Java/JVM identifiers */
+          } else if ((len - i) >= 6 && // Check that there are enough characters left
+                     ch1 == 'u' &&
+                     ((Character.isDigit(ch2)) ||
+                     ('A' <= ch2 && ch2 <= 'F'))) {
+            /* Skip past "$u", next four should be hexadecimal */
+            val hex = name.substring(i+2, i+6)
+            try {
+              val str = Integer.parseInt(hex, 16).toChar
+              if (buf eq null) {
+                buf = new StringBuilder()
+                buf.append(name.substring(0, i))
+              }
+              buf.append(str)
+              /* 2 for "$u", 4 for hexadecimal number */
+              i += 6
+              unicode = true
+            } catch {
+              case _:NumberFormatException =>
+                /* `hex` did not decode to a hexadecimal number, so
+                 * do nothing. */
+            }
+          }
+        }
+      }
+      /* If we didn't see an opcode or encoded Unicode glyph, and the
+        buffer is non-empty, write the current character and advance
+         one */
+      if ((ops eq null) && !unicode) {
+        if (buf ne null)
+          buf.append(c)
+        i += 1
+      }
+    }
+    //System.out.println("= " + (if (buf == null) name else buf.toString()));//DEBUG
+    if (buf eq null) name else buf.toString()
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
@@ -64,32 +64,32 @@ class RangesTest {
   }
 
   @Test def Range_toString_issue_2412(): Unit = {
-    if (scalaVersion.startsWith("2.12.")) {
-      assertEquals("inexact Range 1 to 10 by 2", (1 to 10 by 2).toString)
-      assertEquals("empty Range 1 until 1 by 2", (1 until 1 by 2).toString)
-      assertEquals("Range requires step", (0.0 to 1.0).toString)
-      assertEquals("Range 0 to 1", (0 to 1).toString)
-    } else {
+    if (scalaVersion.startsWith("2.10.") || scalaVersion.startsWith("2.11.")) {
       assertEquals("Range(1, 3, 5, 7, 9)", (1 to 10 by 2).toString)
       assertEquals("Range()", (1 until 1 by 2).toString)
       assertTrue((0.0 to 1.0).toString.startsWith("scala.collection.immutable.Range$Partial"))
       assertEquals("Range(0, 1)", (0 to 1).toString)
+    } else {
+      assertEquals("inexact Range 1 to 10 by 2", (1 to 10 by 2).toString)
+      assertEquals("empty Range 1 until 1 by 2", (1 until 1 by 2).toString)
+      assertEquals("Range requires step", (0.0 to 1.0).toString)
+      assertEquals("Range 0 to 1", (0 to 1).toString)
     }
   }
 
   @Test def NumericRange_toString_issue_2412(): Unit = {
-    if (scalaVersion.startsWith("2.12.")) {
-      assertEquals(s"NumericRange 0.1 to ${1.0} by 0.1",
-          (0.1 to 1.0 by 0.1).toString())
-      assertEquals(
-          s"NumericRange 0.1 until ${1.0} by 0.1 (using NumericRange 0.1 until ${1.0} by 0.1 of BigDecimal)",
-          Range.Double(0.1, 1.0, 0.1).toString)
-    } else {
+    if (scalaVersion.startsWith("2.10.") || scalaVersion.startsWith("2.11.")) {
       assertEquals("NumericRange(0.1, 0.2, 0.30000000000000004, 0.4, 0.5, 0.6, 0.7, " +
           "0.7999999999999999, 0.8999999999999999, 0.9999999999999999)",
           (0.1 to 1.0 by 0.1).toString())
       assertEquals(
           "NumericRange(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)",
+          Range.Double(0.1, 1.0, 0.1).toString)
+    } else {
+      assertEquals(s"NumericRange 0.1 to ${1.0} by 0.1",
+          (0.1 to 1.0 by 0.1).toString())
+      assertEquals(
+          s"NumericRange 0.1 until ${1.0} by 0.1 (using NumericRange 0.1 until ${1.0} by 0.1 of BigDecimal)",
           Range.Double(0.1, 1.0, 0.1).toString)
     }
   }


### PR DESCRIPTION
Overrides in the scalalib are literally copied from the overrides for 2.12.

`RangesTest` is slightly adapted so that tests under 2.13 use the same code path as under 2.12.