### PR TITLE
Add a helper `js.defined(x)` to drive type inference in some cases.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Thenable.scala
+++ b/library/src/main/scala/scala/scalajs/js/Thenable.scala
@@ -47,16 +47,13 @@ object Thenable {
      *  operations on it will be well-typed in turn.
      */
     def toFuture: Future[A] = {
-      // Help for inference
-      def defined[A](x: A): js.UndefOr[A] = x
-
       val p2 = scala.concurrent.Promise[A]()
       p.`then`[Unit](
           { (v: A) =>
             p2.success(v)
             (): Unit | Thenable[Unit]
           },
-          defined { (e: scala.Any) =>
+          js.defined { (e: scala.Any) =>
             p2.failure(e match {
               case th: Throwable => th
               case _             => JavaScriptException(e)

--- a/library/src/main/scala/scala/scalajs/js/defined.scala
+++ b/library/src/main/scala/scala/scalajs/js/defined.scala
@@ -1,0 +1,31 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+
+object defined { // scalastyle:ignore
+  /** Explicitly upcasts an `A` to a `js.UndefOr[A]`.
+   *
+   *  This method is useful in some cases to drive Scala's type inference.
+   *  For example, when calling a method expecting a `js.UndefOr[js.FunctionN]`
+   *  as shown below:
+   *
+   *  {{{
+   *  def foo(f: js.UndefOr[js.Function1[Int, Int]] = js.undefined): Int = ???
+   *
+   *  foo((x: Int) => x + 1) // compile error (requires 2 chained implicits)
+   *  foo(js.defined((x: Int) => x + 1)) // compiles
+   *
+   *  // 2.12+ only:
+   *  foo(js.defined(x => x + 1)) // compiles as well
+   *  }}}
+   */
+  def apply[A](a: A): js.UndefOr[A] = a
+}

--- a/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
+++ b/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
@@ -204,6 +204,15 @@ class JSOptionalTest212 {
     obj.z = Some(3)
     assertEquals(Some(3), obj.z)
   }
+
+  @Test def traitWithOptionalFunction(): Unit = {
+    val obj = new TraitWithOptionalFunction {
+      override val f = js.defined(x => x + 1)
+    }
+
+    assertEquals("function", js.typeOf(obj.f))
+    assertEquals(6, obj.f.get(5))
+  }
 }
 
 object JSOptionalTest212 {
@@ -241,5 +250,10 @@ object JSOptionalTest212 {
     override val y = "hello"
     override def y2 = "world" // scalastyle:ignore
     z = Some(5)
+  }
+
+  @ScalaJSDefined
+  trait TraitWithOptionalFunction extends js.Object {
+    val f: js.UndefOr[js.Function1[Int, Int]] = js.undefined
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
@@ -236,6 +236,16 @@ class JSOptionalTest {
     assertEquals(js.undefined, obj.foo[Int])
     assertFalse(js.Object.hasProperty(obj, "foo"))
   }
+
+  @Test def traitWithOptionalFunction(): Unit = {
+    val obj = new TraitWithOptionalFunction {
+      override val f: js.UndefOr[js.Function1[Int, Int]] =
+        js.defined((x: Int) => x + 1)
+    }
+
+    assertEquals("function", js.typeOf(obj.f))
+    assertEquals(6, obj.f.get(5))
+  }
 }
 
 object JSOptionalTest {
@@ -295,5 +305,10 @@ object JSOptionalTest {
     override val x = js.undefined
     override val y = js.undefined
     override def y2 = js.undefined // scalastyle:ignore
+  }
+
+  @ScalaJSDefined
+  trait TraitWithOptionalFunction extends js.Object {
+    val f: js.UndefOr[js.Function1[Int, Int]] = js.undefined
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
@@ -225,7 +225,7 @@ class JSOptionalTest {
     assertEquals(Some(3), obj.z)
   }
 
-  def polyOptionalMethod(): Unit = {
+  @Test def polyOptionalMethod(): Unit = {
     @ScalaJSDefined
     trait TraitWithPolyOptionalMethod extends js.Object {
       def foo[A]: js.UndefOr[A] = js.undefined

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
@@ -38,6 +38,16 @@ class UndefOrTest {
     assertThrows(classOf[NoSuchElementException], x.get)
   }
 
+  @Test def explicitly_convert_A_to_js_UndefOr_A(): Unit = {
+    val x: js.UndefOr[Int] = js.defined(42)
+    assertFalse(x.isEmpty)
+    assertEquals(42, x.get)
+
+    val f: js.UndefOr[js.Function1[Int, Int]] = js.defined((x: Int) => x + 1)
+    assertFalse(f.isEmpty)
+    assertEquals(6, f.get(5))
+  }
+
   @Test def `convert_to_js_Any_when_A_<%_js_Any`(): Unit = {
     val x: js.UndefOr[Int] = 42
     assertEquals(42, x)


### PR DESCRIPTION
When the expected type of an expression `x` is of the form `js.UndefOr[A]`, but an implicit conversion or a SAM conversion is required to type `x` as an `A`, the normal implicit conversion to `js.UndefOr[A]` does not work.

We can use the helper `js.defined(x)` to drive Scala's type inference to apply the implicit conversion or the SAM conversion. This is particularly relevant for SAM conversion, for which a short-cut implicit conversion with an evidence would not be enough to allow parameter type inference anyway.

This is particularly important for configuration objects with function fields.