### PR TITLE
Fix #2694: Blacklist partest pos/t9181.scala.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
@@ -10,6 +10,9 @@ pos/t533.scala
 pos/functions.scala
 pos/MailBox.scala
 
+# Kills our IR serializer, it's an artificially super-deep if/else if
+pos/t9181.scala
+
 #
 # NEG
 #

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
@@ -943,7 +943,6 @@ pos/t9356
 pos/virtpatmat_exhaust_big.scala
 pos/t9239
 pos/t9111-inliner-workaround
-pos/t9181.scala
 
 neg/volatile_no_override.scala
 neg/t800.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/BlacklistedTests.txt
@@ -10,6 +10,9 @@ pos/t533.scala
 pos/functions.scala
 pos/MailBox.scala
 
+# Kills our IR serializer, it's an artificially super-deep if/else if
+pos/t9181.scala
+
 #
 # NEG
 #

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/WhitelistedTests.txt
@@ -943,7 +943,6 @@ pos/t9356
 pos/virtpatmat_exhaust_big.scala
 pos/t9239
 pos/t9111-inliner-workaround
-pos/t9181.scala
 
 neg/volatile_no_override.scala
 neg/t800.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/BlacklistedTests.txt
@@ -5,6 +5,9 @@
 # Using Jsoup, what's that?
 pos/cycle-jsoup.scala
 
+# Kills our IR serializer, it's an artificially super-deep if/else if
+pos/t9181.scala
+
 #
 # NEG
 #

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/WhitelistedTests.txt
@@ -931,7 +931,6 @@ pos/t9356
 pos/virtpatmat_exhaust_big.scala
 pos/t9239
 pos/t9111-inliner-workaround
-pos/t9181.scala
 
 neg/volatile_no_override.scala
 neg/t800.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/BlacklistedTests.txt
@@ -5,6 +5,9 @@
 # Using Jsoup, what's that?
 pos/cycle-jsoup.scala
 
+# Kills our IR serializer, it's an artificially super-deep if/else if
+pos/t9181.scala
+
 #
 # NEG
 #

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/WhitelistedTests.txt
@@ -929,7 +929,6 @@ pos/t9356
 pos/virtpatmat_exhaust_big.scala
 pos/t9239
 pos/t9111-inliner-workaround
-pos/t9181.scala
 
 neg/volatile_no_override.scala
 neg/t800.scala


### PR DESCRIPTION
It's an artificially giant `if/else if/.../else` chain, which causes nesting of `If` nodes in our IR. This kills our IR serializer with a `StackOverflowException`.

Blacklisting as won't fix, until and unless a Scala.js user hits that limitation in real life.