### PR TITLE
Fix #2519: Test the behavior of setting readonly properties.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -20,7 +20,8 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.JSUtils
+import org.scalajs.testsuite.utils.{JSUtils, Platform}
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ExportsTest {
 
@@ -196,6 +197,28 @@ class ExportsTest {
     assertEquals(6, bar.y)
     bar.y = 7
     assertEquals(7, bar.y)
+  }
+
+  @Test def readonly_properties(): Unit = {
+    assumeFalse(
+        "Assuming strict mode semantics, which are not honored by Rhino",
+        Platform.executingInRhino)
+
+    class Foo {
+      @JSExport
+      val foo: Int = 1
+      @JSExport
+      def bar: Int = 1
+    }
+
+    val x: js.Dynamic = (new Foo()).asInstanceOf[js.Dynamic]
+
+    assertThrows(classOf[js.JavaScriptException], {
+      x.foo = 2
+    })
+    assertThrows(classOf[js.JavaScriptException], {
+      x.bar = 2
+    })
   }
 
   @Test def properties_are_not_enumerable(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -11,9 +11,12 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
 import org.junit.Assert._
+import org.junit.Assume._
 import org.junit.Test
 
 import org.scalajs.testsuite.utils.JSAssert._
+import org.scalajs.testsuite.utils.Platform
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ScalaJSDefinedTest {
   import org.scalajs.testsuite.jsinterop.{ScalaJSDefinedTestSeparateRun => SepRun}
@@ -563,6 +566,32 @@ class ScalaJSDefinedTest {
     assertEquals(42, dyn.bar())
     assertEquals(js.typeOf(dyn.foo), "function")
     assertEquals(100, dyn.foo())
+  }
+
+  @Test def readonly_properties(): Unit = {
+    assumeFalse(
+        "Assuming strict mode semantics, which are not honored by Rhino",
+        Platform.executingInRhino)
+
+    // Named classes
+    @ScalaJSDefined
+    class Foo extends js.Object {
+      def bar: Int = 1
+    }
+
+    val x: js.Dynamic = (new Foo()).asInstanceOf[js.Dynamic]
+    assertThrows(classOf[js.JavaScriptException], {
+      x.bar = 2
+    })
+
+    // Anonymous classes
+    val y = new js.Object {
+      def bar: Int = 1
+    }.asInstanceOf[js.Dynamic]
+
+    assertThrows(classOf[js.JavaScriptException], {
+      y.bar = 2
+    })
   }
 
   @Test def properties_are_not_enumerable(): Unit = {


### PR DESCRIPTION
* Exports of `val`s and `def`s without parentheses
* `def`s without parentheses in Scala.js-defined JS classes