### PR TITLE
Export fields at the top-level with `@JSExportTopLevel`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -149,11 +149,16 @@ trait JSGlobalAddons extends JSDefinitions
       registeredExportsOf(sym).nonEmpty
     }
 
-    /** The only export info of a static field.
+    /** The export info of a static field.
+     *
      *  Requires `isFieldStatic(sym)`.
+     *
+     *  The result is non-empty. If it contains an `ExportInfo` with
+     *  `isStatic = true`, then it is the only element in the list. Otherwise,
+     *  all elements have `isTopLevel = true`.
      */
-    def staticFieldInfoOf(sym: Symbol): ExportInfo =
-      registeredExportsOf(sym).head
+    def staticFieldInfoOf(sym: Symbol): List[ExportInfo] =
+      registeredExportsOf(sym)
 
     /** has this symbol to be translated into a JS bracket access (JS to Scala) */
     def isJSBracketAccess(sym: Symbol): Boolean =

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -1163,36 +1163,6 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelVal: Unit = {
-    """
-    object A {
-      @JSExportTopLevel("foo")
-      val a: Int = 1
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:4: error: You may not export a getter or a setter to the top level
-      |      @JSExportTopLevel("foo")
-      |       ^
-    """
-  }
-
-  @Test
-  def noExportTopLevelVar: Unit = {
-    """
-    object A {
-      @JSExportTopLevel("foo")
-      var a: Int = 1
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:4: error: You may not export a getter or a setter to the top level
-      |      @JSExportTopLevel("foo")
-      |       ^
-    """
-  }
-
-  @Test
   def noExportTopLevelSetter: Unit = {
     """
     object A {
@@ -1202,6 +1172,57 @@ class JSExportTest extends DirectTest with TestHelpers {
     """ hasErrors
     """
       |newSource1.scala:4: error: You may not export a getter or a setter to the top level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelFieldsWithSameName: Unit = {
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      val a: Int = 1
+
+      @JSExportTopLevel("foo")
+      var b: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: Duplicate top-level export with name 'foo': a field may not share its exported name with another field or method
+      |      val a: Int = 1
+      |          ^
+    """
+  }
+
+  @Test
+  def noExportTopLevelFieldsAndMethodsWithSameName: Unit = {
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      val a: Int = 1
+
+      @JSExportTopLevel("foo")
+      def b(x: Int): Int = x + 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: Duplicate top-level export with name 'foo': a field may not share its exported name with another field or method
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      def a(x: Int): Int = x + 1
+
+      @JSExportTopLevel("foo")
+      val b: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: Duplicate top-level export with name 'foo': a field may not share its exported name with another field or method
       |      @JSExportTopLevel("foo")
       |       ^
     """
@@ -1357,6 +1378,44 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
       |newSource1.scala:8: error: Fields (val or var) cannot be exported as static more than once
       |      @JSExportStatic("b")
+      |       ^
+    """
+  }
+
+  @Test
+  def noExportValAsStaticAndTopLevel: Unit = {
+    """
+    @ScalaJSDefined
+    class StaticContainer extends js.Object
+
+    object StaticContainer {
+      @JSExportStatic
+      @JSExportTopLevel("foo")
+      val a: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: Fields (val or var) cannot be exported both as static and at the top-level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
+
+  @Test
+  def noExportVarAsStaticAndTopLevel: Unit = {
+    """
+    @ScalaJSDefined
+    class StaticContainer extends js.Object
+
+    object StaticContainer {
+      @JSExportStatic
+      @JSExportTopLevel("foo")
+      var a: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: Fields (val or var) cannot be exported both as static and at the top-level
+      |      @JSExportTopLevel("foo")
       |       ^
     """
   }

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -206,6 +206,12 @@ object Hashers {
           mixIdent(item)
           mixType(tree.tpe)
 
+        case SelectStatic(cls, item) =>
+          mixTag(TagSelectStatic)
+          mixType(cls)
+          mixIdent(item)
+          mixType(tree.tpe)
+
         case Apply(receiver, method, args) =>
           mixTag(TagApply)
           mixTree(receiver)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -299,6 +299,11 @@ object Printers {
           print('.')
           print(item)
 
+        case SelectStatic(cls, item) =>
+          print(cls)
+          print('.')
+          print(item)
+
         case Apply(receiver, method, args) =>
           print(receiver)
           print(".")
@@ -861,6 +866,13 @@ object Printers {
         case TopLevelExportDef(member) =>
           print("export top ")
           print(member)
+
+        case TopLevelFieldExportDef(fullName, field) =>
+          print("export top static field ")
+          print(field)
+          print(" as \"")
+          printEscapeJS(fullName, out)
+          print('\"')
 
         case _ =>
           print(s"<error, elem of class ${tree.getClass()}>")

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -198,6 +198,11 @@ object Serializers {
           writeTree(qualifier); writeIdent(item)
           writeType(tree.tpe)
 
+        case SelectStatic(cls, item) =>
+          writeByte(TagSelectStatic)
+          writeClassType(cls); writeIdent(item)
+          writeType(tree.tpe)
+
         case Apply(receiver, method, args) =>
           writeByte(TagApply)
           writeTree(receiver); writeIdent(method); writeTrees(args)
@@ -463,6 +468,10 @@ object Serializers {
         case TopLevelExportDef(member) =>
           writeByte(TagTopLevelExportDef)
           writeTree(member)
+
+        case TopLevelFieldExportDef(fullName, field) =>
+          writeByte(TagTopLevelFieldExportDef)
+          writeString(fullName); writeIdent(field)
       }
       if (UseDebugMagic)
         writeInt(DebugMagic)
@@ -723,6 +732,7 @@ object Serializers {
         case TagLoadModule      => LoadModule(readClassType())
         case TagStoreModule     => StoreModule(readClassType(), readTree())
         case TagSelect          => Select(readTree(), readIdent())(readType())
+        case TagSelectStatic    => SelectStatic(readClassType(), readIdent())(readType())
         case TagApply           => Apply(readTree(), readIdent(), readTrees())(readType())
         case TagApplyStatically =>
           val result1 =
@@ -886,9 +896,10 @@ object Serializers {
             result
           }
 
-        case TagJSClassExportDef  => JSClassExportDef(readString())
-        case TagModuleExportDef   => ModuleExportDef(readString())
-        case TagTopLevelExportDef => TopLevelExportDef(readTree())
+        case TagJSClassExportDef       => JSClassExportDef(readString())
+        case TagModuleExportDef        => ModuleExportDef(readString())
+        case TagTopLevelExportDef      => TopLevelExportDef(readTree())
+        case TagTopLevelFieldExportDef => TopLevelFieldExportDef(readString(), readIdent())
       }
       if (UseDebugMagic) {
         val magic = readInt()

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -105,6 +105,8 @@ private[ir] object Tags {
   final val TagTryCatch = TagJSClassExportDef + 1
   final val TagTryFinally = TagTryCatch + 1
   final val TagTopLevelExportDef = TagTryFinally + 1
+  final val TagSelectStatic = TagTopLevelExportDef + 1
+  final val TagTopLevelFieldExportDef = TagSelectStatic + 1
 
   // Tags for Types
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -187,7 +187,7 @@ object Transformers {
 
         // Trees that need not be transformed
 
-        case _:Skip | _:Continue | _:Debugger | _:LoadModule |
+        case _:Skip | _:Continue | _:Debugger | _:LoadModule | _:SelectStatic |
             _:LoadJSConstructor | _:LoadJSModule  | _:JSLinkingInfo |
             _:Literal | _:UndefinedParam | _:VarRef | _:This  =>
           tree
@@ -228,7 +228,7 @@ object Transformers {
         case ConstructorExportDef(fullName, args, body) =>
           ConstructorExportDef(fullName, args, transformStat(body))
 
-        case _:JSClassExportDef | _:ModuleExportDef =>
+        case _:JSClassExportDef | _:ModuleExportDef | _:TopLevelFieldExportDef =>
           tree
 
         case TopLevelExportDef(member) =>

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -209,10 +209,10 @@ object Traversers {
 
       // Trees that need not be traversed
 
-      case _:Skip | _:Continue | _:Debugger | _:LoadModule |
+      case _:Skip | _:Continue | _:Debugger | _:LoadModule | _:SelectStatic |
           _:LoadJSConstructor | _:LoadJSModule | _:JSLinkingInfo | _:Literal |
           _:UndefinedParam | _:VarRef | _:This | _:FieldDef |
-          _:JSClassExportDef | _:ModuleExportDef =>
+          _:JSClassExportDef | _:ModuleExportDef | _:TopLevelFieldExportDef =>
 
       case _ =>
         sys.error(s"Invalid tree in traverse() of class ${tree.getClass}")

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -135,7 +135,7 @@ object Trees {
   case class Assign(lhs: Tree, rhs: Tree)(
       implicit val pos: Position) extends Tree {
     require(lhs match {
-      case _:VarRef | _:Select | _:ArraySelect |
+      case _:VarRef | _:Select | _:SelectStatic | _:ArraySelect |
            _:JSDotSelect | _:JSBracketSelect | _:JSSuperBracketSelect => true
       case _ => false
     }, s"Invalid lhs for Assign: $lhs")
@@ -214,6 +214,9 @@ object Trees {
   }
 
   case class Select(qualifier: Tree, item: Ident)(val tpe: Type)(
+      implicit val pos: Position) extends Tree
+
+  case class SelectStatic(cls: ClassType, item: Ident)(val tpe: Type)(
       implicit val pos: Position) extends Tree
 
   /** Apply an instance method with dynamic dispatch (the default). */
@@ -812,6 +815,11 @@ object Trees {
   }
 
   case class TopLevelExportDef(member: Tree)(
+      implicit val pos: Position) extends Tree {
+    val tpe = NoType
+  }
+
+  case class TopLevelFieldExportDef(fullName: String, field: Ident)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType
   }

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -296,6 +296,11 @@ class PrintersTest {
     assertPrintEquals("x.f$1", Select(ref("x", "Ltest_Test"), "f$1")(IntType))
   }
 
+  @Test def printSelectStatic(): Unit = {
+    assertPrintEquals("Ltest_Test.f$1",
+        SelectStatic("Ltest_Test", "f$1")(IntType))
+  }
+
   @Test def printApply(): Unit = {
     assertPrintEquals("x.m__V()",
         Apply(ref("x", "Ltest_Test"), "m__V", Nil)(NoType))
@@ -1071,5 +1076,13 @@ class PrintersTest {
         TopLevelExportDef(MethodDef(static = true, StringLiteral("pkg.foo"),
             List(ParamDef("x", AnyType, mutable = false, rest = false)),
             AnyType, Some(i(5)))(NoOptHints, None)))
+  }
+
+  @Test def printTopLevelFieldExportDef(): Unit = {
+    assertPrintEquals(
+        """
+          |export top static field x$1 as "x"
+        """,
+        TopLevelFieldExportDef("x", "x$1"))
   }
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
@@ -138,6 +138,7 @@ private[rhino] class ScalaJSCoreLib(linkingUnit: LinkingUnit) {
       Info("c"),
       Info("h"),
       Info("s", isStatics = true),
+      Info("t", isStatics = true),
       Info("f", isStatics = true),
       Info("n"),
       Info("m"),

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -15,10 +15,26 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
           "org.scalajs.core.ir.Trees#FieldDef.copy$default$2"),
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
-          "org.scalajs.core.ir.Trees#FieldDef.copy$default$3")
+          "org.scalajs.core.ir.Trees#FieldDef.copy$default$3"),
+
+      // private, not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.ir.Infos#MethodInfo.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.ir.Infos#GenInfoTraverser.generateClassExportsInfo")
   )
 
   val Tools = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.checker.IRChecker#CheckedField.this"),
+
+      // private, not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.analyzer.Analyzer.org$scalajs$core$tools$linker$analyzer$Analyzer$$createMissingMethodInfo$default$2"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.analyzer.Analyzer.org$scalajs$core$tools$linker$analyzer$Analyzer$$createMissingMethodInfo$default$3"),
+
       // private[emitter], not an issue
       ProblemFilters.exclude[MissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.ScalaJSClassEmitter.genClass"),

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -130,6 +130,7 @@ ScalaJS.b = {};         // Scala.js-defined JS class value fields
 ScalaJS.c = {};         // Scala.js constructors
 ScalaJS.h = {};         // Inheritable constructors (without initialization code)
 ScalaJS.s = {};         // Static methods
+ScalaJS.t = {};         // Static fields
 ScalaJS.f = {};         // Default methods
 ScalaJS.n = {};         // Module instances
 ScalaJS.m = {};         // Module accessors

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
@@ -69,6 +69,8 @@ final class LinkedClass(
 
     case TopLevelExportDef(MethodDef(_, StringLiteral(name), _, _, _)) =>
       name
+
+    case TopLevelFieldExportDef(name, _) => name
   }
 
   def fullName: String = Definitions.decodeClassName(encodedName)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -259,6 +259,9 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
       case e: TopLevelExportDef =>
         classExports += e
 
+      case e: TopLevelFieldExportDef =>
+        classExports += e
+
       case tree =>
         sys.error(s"Illegal tree in ClassDef of class ${tree.getClass}")
     }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -173,8 +173,9 @@ private[optimizer] abstract class OptimizerCore(
         } else {
           val after = from.tail
           val afterIsTrivial = after.forall {
-            case Assign(Select(This(), Ident(_, _)),
-                _:Literal | _:VarRef) =>
+            case Assign(Select(This(), _), _:Literal | _:VarRef) =>
+              true
+            case Assign(SelectStatic(_, _), _:Literal | _:VarRef) =>
               true
             case _ =>
               false
@@ -670,8 +671,8 @@ private[optimizer] abstract class OptimizerCore(
 
       // Trees that need not be transformed
 
-      case _:Skip | _:Debugger | _:LoadModule | _:LoadJSConstructor |
-          _:LoadJSModule | _:JSLinkingInfo | _:Literal =>
+      case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic |
+          _:LoadJSConstructor | _:LoadJSModule | _:JSLinkingInfo | _:Literal =>
         tree
 
       case _ =>
@@ -1313,7 +1314,7 @@ private[optimizer] abstract class OptimizerCore(
 
   /** Keeps only the side effects of a Tree (overapproximation). */
   private def keepOnlySideEffects(stat: Tree): Tree = stat match {
-    case _:VarRef | _:This | _:Literal =>
+    case _:VarRef | _:This | _:Literal | _:SelectStatic =>
       Skip()(stat.pos)
     case VarDef(_, _, _, rhs) =>
       keepOnlySideEffects(rhs)


### PR DESCRIPTION
This commit implements the third part of the proposal #2702, i.e., exporting fields at the top-level.

The `@JSExportTopLevel` annotation can now be used on `val`s and `var`s in addition to methods. This causes the specified field to be stored as a static field in the IR (which becomes a top-level var in JS) and exported at the top-level. Field exports are read-only views, as is the case in ECMAScript 2015 modules, so JS code cannot modify exported vars, but can observe changes to it done by Scala code.