### PR TITLE
Fix #2715: Emit object literals for new anonymous JS class.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -646,10 +646,16 @@ abstract class GenJSCode extends plugins.PluginComponent
           case js.JSSuperConstructorCall(args) =>
             implicit val pos = tree.pos
 
-            val ident =
-              origJsClass.superClass.getOrElse(sys.error("No superclass"))
-            val superTpe = jstpe.ClassType(ident.name)
-            val newTree = js.JSNew(js.LoadJSConstructor(superTpe), args)
+            val newTree = {
+              val ident =
+                origJsClass.superClass.getOrElse(sys.error("No superclass"))
+              if (args.isEmpty && ident.name == "sjs_js_Object") {
+                js.JSObjectConstr(Nil)
+              } else {
+                val superTpe = jstpe.ClassType(ident.name)
+                js.JSNew(js.LoadJSConstructor(superTpe), args)
+              }
+            }
 
             js.Block(
                 js.VarDef(selfName, jstpe.AnyType, mutable = false, newTree) ::

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/OptimizationTest.scala
@@ -172,4 +172,55 @@ class OptimizationTest extends JSASTTest {
     }
   }
 
+  @Test
+  def newSJSDefinedTraitProducesObjectConstr: Unit = {
+    """
+    import scala.scalajs.js
+    import scala.scalajs.js.annotation._
+
+    @ScalaJSDefined
+    trait Point extends js.Object {
+      val x: Double
+      val y: Double
+    }
+
+    class Test {
+      def newSJSDefinedTraitProducesObjectConstr(): Any = {
+        new Point {
+          val x = 5.0
+          val y = 6.5
+        }
+      }
+    }
+    """.hasNot("`new Object`") {
+      case js.JSNew(_, _) =>
+    }.has("object literal") {
+      case js.JSObjectConstr(Nil) =>
+    }
+
+    """
+    import scala.scalajs.js
+    import scala.scalajs.js.annotation._
+
+    @ScalaJSDefined
+    trait Point extends js.Object {
+      var x: js.UndefOr[Double] = js.undefined
+      var y: js.UndefOr[Double] = js.undefined
+    }
+
+    class Test {
+      def newSJSDefinedTraitProducesObjectConstr(): Any = {
+        new Point {
+          x = 5.0
+          y = 6.5
+        }
+      }
+    }
+    """.hasNot("`new Object`") {
+      case js.JSNew(_, _) =>
+    }.has("object literal") {
+      case js.JSObjectConstr(Nil) =>
+    }
+  }
+
 }


### PR DESCRIPTION
When instantiating an anonymous JS class, we actually instantiate the parent class. If that parent class happens to be `js.Object`, and there is no formal argument to the constructor, we can use an empty object literal `{}` instead.

This makes the compiler behavior consistent with a direct `new js.Object()`, for which we already applied this optimization. This allows Closure to fuse it with subsequent field assignments, eventually producing a direct object literal with fields.