### PR TITLE
Fix #2708: Remove a years-old workaround for a Closure bug.

### DIFF
--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -709,12 +709,6 @@ ScalaJS.typedArray2DoubleArray = function(value) {
   return new arrayClassData.constr(new ScalaJS.g["Float64Array"](value));
 };
 
-/* We have to force a non-elidable *read* of ScalaJS.e, otherwise Closure will
- * eliminate it altogether, along with all the exports, which is ... er ...
- * plain wrong.
- */
-this["__ScalaJSExportsNamespace"] = ScalaJS.e;
-
 // TypeData class
 
 //!if outputMode != ECMAScript6


### PR DESCRIPTION
In the original implementation of a custom exports namespace, 6680f72e8167af954d58797d26e943cf3326c4af, we introduced a workaround for an apparent bug of Closure: we forced some unelidable read of `ScalaJS.e` so that Closure would not get rid of it, and all our exports alongside it.

The workaround was refined later in 8793d47c9f88def176e927a2296fb82db893859a to fix #518.

It appears this workaround is not needed anymore. It might be because of the update of Closure, or because we have another read of `ScalaJS.e` at the beginning of the file, or anything else really. In any case, I cannot reproduce the bug anymore without the workaround.

Since that line was causing #2708, removing it fixes that issue.