### PR TITLE
Consistent condition checking in nextInt and nextLong

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -78,7 +78,7 @@ class ThreadLocalRandom extends Random {
       throw new IllegalArgumentException()
 
     val difference = bound - least
-    if (difference >= 0) {
+    if (difference > 0) {
       nextLong(difference) + least
     } else {
       /* The interval size here is greater than Long.MaxValue,


### PR DESCRIPTION
On calling `nextInt(0, IntMax)` there is an unnecessary switch to the recursive approach. This change tries to fix that corner case