### PR TITLE
Export module getters and setters as static in their companion class.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -377,10 +377,6 @@ trait PrepJSExports { this: PrepJSInterop =>
                   "Implementation restriction: cannot export a class or " +
                   "object as static")
             }
-          } else if (!sym.isAccessor && jsInterop.isJSProperty(sym)) {
-            reporter.error(annot.pos,
-                "Implementation restriction: cannot export a getter or a " +
-                "setter as static")
           }
       }
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportASTTest.scala
@@ -24,7 +24,7 @@ class JSExportASTTest extends JSASTTest {
       override def foo = 2
     }
     """.hasExactly(1, "definitions of property `foo`") {
-      case js.PropertyDef(js.StringLiteral("foo"), _, _) =>
+      case js.PropertyDef(_, js.StringLiteral("foo"), _, _) =>
     }
   }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
@@ -386,6 +386,7 @@ object Infos {
     def generatePropertyInfo(propertyDef: PropertyDef): MethodInfo = {
       builder
         .setEncodedName(propertyDef.name.name)
+        .setIsStatic(propertyDef.static)
         .setIsExported(true)
 
       propertyDef.getterBody.foreach(traverse)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -827,8 +827,10 @@ object Printers {
             printBlock(body)
           }
 
-        case PropertyDef(name, getterBody, setterArgAndBody) =>
+        case PropertyDef(static, name, getterBody, setterArgAndBody) =>
           getterBody foreach { body =>
+            if (static)
+              print("static ")
             print("get ")
             print(name)
             printSig(Nil, AnyType)
@@ -840,6 +842,8 @@ object Printers {
           }
 
           setterArgAndBody foreach { case (arg, body) =>
+            if (static)
+              print("static ")
             print("set ")
             print(name)
             printSig(arg :: Nil, NoType)

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -444,8 +444,9 @@ object Serializers {
           writeInt(length)
           bufferUnderlying.continue()
 
-        case PropertyDef(name, getter, setterArgAndBody) =>
+        case PropertyDef(static, name, getter, setterArgAndBody) =>
           writeByte(TagPropertyDef)
+          writeBoolean(static)
           writePropertyName(name)
           writeOptTree(getter)
           writeBoolean(setterArgAndBody.isDefined)
@@ -872,7 +873,11 @@ object Serializers {
           } else {
             result2
           }
+
         case TagPropertyDef =>
+          val static =
+            if (useHacks0614) false
+            else readBoolean()
           val name = readPropertyName()
           val getterBody = readOptTree()
           val setterArgAndBody = if (useHacks068) {
@@ -884,8 +889,7 @@ object Serializers {
             else
               None
           }
-
-          PropertyDef(name, getterBody, setterArgAndBody)
+          PropertyDef(static, name, getterBody, setterArgAndBody)
 
         case TagConstructorExportDef =>
           val result = ConstructorExportDef(readString(), readParamDefs(), readTree())

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -217,8 +217,9 @@ object Transformers {
           MethodDef(static, name, args, resultType, body.map(transformStat))(
               tree.optimizerHints, None)
 
-        case PropertyDef(name, getterBody, setterArgAndBody) =>
+        case PropertyDef(static, name, getterBody, setterArgAndBody) =>
           PropertyDef(
+              static,
               name,
               getterBody.map(transformStat),
               setterArgAndBody map { case (arg, body) =>

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -195,7 +195,7 @@ object Traversers {
       case MethodDef(static, name, args, resultType, body) =>
         body.foreach(traverse)
 
-      case PropertyDef(name, getterBody, setterArgAndBody) =>
+      case PropertyDef(static, name, getterBody, setterArgAndBody) =>
         getterBody.foreach(traverse)
         setterArgAndBody foreach { case (_, body) =>
           traverse(body)

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -793,8 +793,8 @@ object Trees {
     val tpe = NoType
   }
 
-  case class PropertyDef(name: PropertyName, getterBody: Option[Tree],
-      setterArgAndBody: Option[(ParamDef, Tree)])(
+  case class PropertyDef(static: Boolean, name: PropertyName,
+      getterBody: Option[Tree], setterArgAndBody: Option[(ParamDef, Tree)])(
       implicit val pos: Position) extends Tree {
     val tpe = NoType
   }

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -1010,37 +1010,43 @@ class PrintersTest {
   }
 
   @Test def printPropertyDef(): Unit = {
-    assertPrintEquals(
-        """
-          |get "prop"(): any = {
-          |  5
-          |}
-        """,
-        PropertyDef(StringLiteral("prop"), Some(i(5)), None))
+    for (static <- Seq(false, true)) {
+      val staticStr =
+        if (static) "static "
+        else ""
 
-    assertPrintEquals(
-        """
-          |set "prop"(x: any) {
-          |  7
-          |}
-        """,
-        PropertyDef(StringLiteral("prop"),
-            None,
-            Some((ParamDef("x", AnyType, mutable = false, rest = false), i(7)))))
+      assertPrintEquals(
+          s"""
+            |${staticStr}get "prop"(): any = {
+            |  5
+            |}
+          """,
+          PropertyDef(static, StringLiteral("prop"), Some(i(5)), None))
 
-    assertPrintEquals(
-        """
-          |get "prop"(): any = {
-          |  5
-          |}
-          |set "prop"(x: any) {
-          |  7
-          |}
-        """,
-        PropertyDef(StringLiteral("prop"),
-            Some(i(5)),
-            Some((ParamDef("x", AnyType, mutable = false, rest = false),
-                i(7)))))
+      assertPrintEquals(
+          s"""
+            |${staticStr}set "prop"(x: any) {
+            |  7
+            |}
+          """,
+          PropertyDef(static, StringLiteral("prop"),
+              None,
+              Some((ParamDef("x", AnyType, mutable = false, rest = false), i(7)))))
+
+      assertPrintEquals(
+          s"""
+            |${staticStr}get "prop"(): any = {
+            |  5
+            |}
+            |${staticStr}set "prop"(x: any) {
+            |  7
+            |}
+          """,
+          PropertyDef(static, StringLiteral("prop"),
+              Some(i(5)),
+              Some((ParamDef("x", AnyType, mutable = false, rest = false),
+                  i(7)))))
+    }
   }
 
   @Test def printConstructorExportDef(): Unit = {

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -17,6 +17,18 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[IncompatibleResultTypeProblem](
           "org.scalajs.core.ir.Trees#FieldDef.copy$default$3"),
 
+      // Breaking: PropertyDef has new field `static`
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.ir.Trees#PropertyDef.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.ir.Trees#PropertyDef.apply"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.ir.Trees#PropertyDef.copy"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.core.ir.Trees#PropertyDef.copy$default$1"),
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.core.ir.Trees#PropertyDef.copy$default$2"),
+
       // Breaking: TopLevelExportDef has been renamed to TopLevelMethodExportDef
       ProblemFilters.exclude[MissingClassProblem](
           "org.scalajs.core.ir.Trees$TopLevelExportDef"),

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
@@ -126,6 +126,66 @@ class JSExportStaticTest {
     assertEquals(6, obj.alsoExistsAsMember(3))
   }
 
+  // Properties
+
+  @Test def basic_static_prop_readonly(): Unit = {
+    val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
+
+    assertEquals(1, statics.basicReadOnly)
+  }
+
+  @Test def basic_static_prop_readwrite(): Unit = {
+    val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
+
+    assertEquals(5, statics.basicReadWrite)
+    statics.basicReadWrite = 10
+    assertEquals(15, statics.basicReadWrite)
+  }
+
+  @Test def static_prop_set_wrong_type_throws_classcastexception(): Unit = {
+    assumeTrue("assuming compliant asInstanceOfs", hasCompliantAsInstanceOfs)
+
+    val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
+
+    assertThrows(classOf[ClassCastException], {
+      statics.basicReadWrite = "wrong type"
+    })
+  }
+
+  @Test def overloaded_static_prop_setter(): Unit = {
+    val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
+
+    assertEquals("got: ", statics.overloadedSetter)
+    statics.overloadedSetter = "foo"
+    assertEquals("got: foo", statics.overloadedSetter)
+    statics.overloadedSetter = 5
+    assertEquals("got: foo10", statics.overloadedSetter)
+  }
+
+  @Test def overloaded_static_prop_renamed(): Unit = {
+    val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
+
+    assertEquals(5, statics.renamed)
+    statics.renamed = 10
+    assertEquals(15, statics.renamed)
+    statics.renamed = "foobar"
+    assertEquals(21, statics.renamed)
+  }
+
+  @Test def static_prop_constructor(): Unit = {
+    val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
+
+    assertEquals(102, statics.constructor)
+  }
+
+  @Test def static_prop_also_exists_in_member(): Unit = {
+    val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
+    assertEquals("also a member", statics.alsoExistsAsMember)
+
+    val obj = new JSExportStaticTest.StaticExportProperties
+    assertEquals(54, obj.alsoExistsAsMember)
+  }
+
   // Fields
 
   @Test def basic_field(): Unit = {
@@ -284,6 +344,52 @@ object JSExportStaticTest {
 
     @JSExportStatic
     def alsoExistsAsMember(x: Int): Int = x * 5
+  }
+
+  @ScalaJSDefined
+  class StaticExportProperties extends js.Object {
+    def alsoExistsAsMember: Int = 54
+  }
+
+  object StaticExportProperties {
+    @JSExportStatic
+    def basicReadOnly: Int = 1
+
+    private var basicVar: Int = 5
+
+    @JSExportStatic
+    def basicReadWrite: Int = basicVar
+
+    @JSExportStatic
+    def basicReadWrite_=(v: Int): Unit = basicVar += v
+
+    private var overloadedSetterVar: String = ""
+
+    @JSExportStatic
+    def overloadedSetter: String = "got: " + overloadedSetterVar
+
+    @JSExportStatic
+    def overloadedSetter_=(x: String): Unit = overloadedSetterVar += x
+
+    @JSExportStatic
+    def overloadedSetter_=(x: Int): Unit = overloadedSetterVar += 2 * x
+
+    private var renamedPropVar: Int = 5
+
+    @JSExportStatic("renamed")
+    def renamedProp: Int = renamedPropVar
+
+    @JSExportStatic("renamed")
+    def renamedProp_=(v: Int): Unit = renamedPropVar += v
+
+    @JSExportStatic("renamed")
+    def renamedOverload_=(x: String): Unit = renamedPropVar += x.length
+
+    @JSExportStatic
+    def constructor: Int = 102
+
+    @JSExportStatic
+    def alsoExistsAsMember: String = "also a member"
   }
 
   @ScalaJSDefined

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
@@ -109,7 +109,7 @@ final class ClosureLinkerBackend(
 
     def exportName(tree: Tree): String = (tree: @unchecked) match {
       case MethodDef(_, StringLiteral(name), _, _, _) => name
-      case PropertyDef(StringLiteral(name), _, _)     => name
+      case PropertyDef(_, StringLiteral(name), _, _)  => name
     }
 
     val exportedPropertyNames = for {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -387,7 +387,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
 
   private def checkExportedPropertyDef(propDef: PropertyDef,
       classDef: LinkedClass): Unit = withPerMethodState {
-    val PropertyDef(_, getterBody, setterArgAndBody) = propDef
+    val PropertyDef(static, _, getterBody, setterArgAndBody) = propDef
     implicit val ctx = ErrorContext(propDef)
 
     if (!classDef.kind.isAnyScalaJSDefinedClass) {
@@ -396,7 +396,8 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
     }
 
     val thisType =
-      if (classDef.kind.isJSClass) AnyType
+      if (static) NoType
+      else if (classDef.kind.isJSClass) AnyType
       else ClassType(classDef.name.name)
 
     getterBody.foreach { getterBody =>

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -207,7 +207,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
     }
 
     def linkedProperty(p: PropertyDef) = {
-      val info = memberInfoByStaticAndName((false, p.name.name))
+      val info = memberInfoByStaticAndName((p.static, p.name.name))
       new LinkedMember(info, p, None)
     }
 


### PR DESCRIPTION
This commit implements `@JSExportStatic` support for getters and setters, from the proposal #2702.

The annotation `@JSExportStatic` can now be used on getters and setters, i.e., `def`s without parentheses and `def`s whose name ends with `_=`. The annotation causes the export of a static property in the companion class.

This concludes #2702.