### PR TITLE
Fix #2738: Implement Float and Double methods from JDK8.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Byte.scala
+++ b/javalanglib/src/main/scala/java/lang/Byte.scala
@@ -35,6 +35,7 @@ final class Byte private () extends Number with Comparable[Byte] {
 object Byte {
   final val TYPE = classOf[scala.Byte]
   final val SIZE = 8
+  final val BYTES = 1
 
   /* MIN_VALUE and MAX_VALUE should be 'final val's. But it is impossible to
    * write a proper Byte literal in Scala, that would both considered a Byte

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -164,6 +164,7 @@ object Character {
   final val MIN_VALUE = '\u0000'
   final val MAX_VALUE = '\uffff'
   final val SIZE = 16
+  final val BYTES = 2
 
   def valueOf(charValue: scala.Char): Character = new Character(charValue)
 

--- a/javalanglib/src/main/scala/java/lang/Double.scala
+++ b/javalanglib/src/main/scala/java/lang/Double.scala
@@ -51,10 +51,12 @@ object Double {
   final val NEGATIVE_INFINITY = 1.0 / -0.0
   final val NaN = 0.0 / 0.0
   final val MAX_VALUE = scala.Double.MaxValue
+  final val MIN_NORMAL = 2.2250738585072014e-308
   final val MIN_VALUE = scala.Double.MinPositiveValue
   final val MAX_EXPONENT = 1023
   final val MIN_EXPONENT = -1022
   final val SIZE = 64
+  final val BYTES = 8
 
   @inline def valueOf(doubleValue: scala.Double): Double =
     new Double(doubleValue)

--- a/javalanglib/src/main/scala/java/lang/Double.scala
+++ b/javalanglib/src/main/scala/java/lang/Double.scala
@@ -29,7 +29,7 @@ final class Double private () extends Number with Comparable[Double] {
   }
 
   @inline override def hashCode(): Int =
-    scala.scalajs.runtime.Bits.numberHashCode(doubleValue)
+    Double.hashCode(doubleValue)
 
   @inline override def compareTo(that: Double): Int =
     Double.compare(doubleValue, that.doubleValue)
@@ -84,6 +84,61 @@ object Double {
   @inline def toString(d: scala.Double): String =
     "" + d
 
+  def toHexString(d: scala.Double): String = {
+    val ebits = 11 // exponent size
+    val mbits = 52 // mantissa size
+    val bias = (1 << (ebits - 1)) - 1
+
+    val bits = doubleToLongBits(d)
+    val s = bits < 0
+    val m = bits & ((1L << mbits) - 1L)
+    val e = (bits >>> mbits).toInt & ((1 << ebits) - 1) // biased
+
+    val posResult = if (e > 0) {
+      if (e == (1 << ebits) - 1) {
+        // Special
+        if (m != 0L) "NaN"
+        else "Infinity"
+      } else {
+        // Normalized
+        "0x1." + mantissaToHexString(m) + "p" + (e - bias)
+      }
+    } else {
+      if (m != 0L) {
+        // Subnormal
+        "0x0." + mantissaToHexString(m) + "p-1022"
+      } else {
+        // Zero
+        "0x0.0p0"
+      }
+    }
+
+    if (bits < 0) "-" + posResult else posResult
+  }
+
+  @inline
+  private def mantissaToHexString(m: scala.Long): String =
+    mantissaToHexStringLoHi(m.toInt, (m >>> 32).toInt)
+
+  private def mantissaToHexStringLoHi(lo: Int, hi: Int): String = {
+    @inline def padHex5(i: Int): String = {
+      val s = Integer.toHexString(i)
+      "00000".substring(s.length) + s // 5 zeros
+    }
+
+    @inline def padHex8(i: Int): String = {
+      val s = Integer.toHexString(i)
+      "00000000".substring(s.length) + s // 8 zeros
+    }
+
+    val padded = padHex5(hi) + padHex8(lo)
+
+    var len = padded.length
+    while (len > 1 && padded.charAt(len - 1) == '0')
+      len -= 1
+    padded.substring(0, len)
+  }
+
   def compare(a: scala.Double, b: scala.Double): scala.Int = {
     // NaN must equal itself, and be greater than anything else
     if (isNaN(a)) {
@@ -115,9 +170,24 @@ object Double {
   @inline def isInfinite(v: scala.Double): scala.Boolean =
     v == POSITIVE_INFINITY || v == NEGATIVE_INFINITY
 
+  @inline def isFinite(d: scala.Double): scala.Boolean =
+    !isNaN(d) && !isInfinite(d)
+
+  @inline def hashCode(value: scala.Double): Int =
+    scala.scalajs.runtime.Bits.numberHashCode(value)
+
   @inline def longBitsToDouble(bits: scala.Long): scala.Double =
     scala.scalajs.runtime.Bits.longBitsToDouble(bits)
 
   @inline def doubleToLongBits(value: scala.Double): scala.Long =
     scala.scalajs.runtime.Bits.doubleToLongBits(value)
+
+  @inline def sum(a: scala.Double, b: scala.Double): scala.Double =
+    a + b
+
+  @inline def max(a: scala.Double, b: scala.Double): scala.Double =
+    Math.max(a, b)
+
+  @inline def min(a: scala.Double, b: scala.Double): scala.Double =
+    Math.min(a, b)
 }

--- a/javalanglib/src/main/scala/java/lang/Float.scala
+++ b/javalanglib/src/main/scala/java/lang/Float.scala
@@ -26,9 +26,8 @@ final class Float private () extends Number with Comparable[Float] {
       false
   }
 
-  // Uses the hashCode of Doubles. See Bits.numberHashCode for the rationale.
   @inline override def hashCode(): Int =
-    scala.scalajs.runtime.Bits.numberHashCode(doubleValue)
+    Float.hashCode(floatValue)
 
   @inline override def compareTo(that: Float): Int =
     Float.compare(floatValue, that.floatValue)
@@ -67,11 +66,55 @@ object Float {
   @inline def toString(f: scala.Float): String =
     "" + f
 
+  def toHexString(f: scala.Float): String = {
+    val ebits = 8 // exponent size
+    val mbits = 23 // mantissa size
+    val bias = (1 << (ebits - 1)) - 1
+
+    val bits = floatToIntBits(f)
+    val s = bits < 0
+    val m = bits & ((1 << mbits) - 1)
+    val e = (bits >>> mbits).toInt & ((1 << ebits) - 1) // biased
+
+    val posResult = if (e > 0) {
+      if (e == (1 << ebits) - 1) {
+        // Special
+        if (m != 0) "NaN"
+        else "Infinity"
+      } else {
+        // Normalized
+        "0x1." + mantissaToHexString(m) + "p" + (e - bias)
+      }
+    } else {
+      if (m != 0) {
+        // Subnormal
+        "0x0." + mantissaToHexString(m) + "p-126"
+      } else {
+        // Zero
+        "0x0.0p0"
+      }
+    }
+
+    if (bits < 0) "-" + posResult else posResult
+  }
+
+  @inline
+  private def mantissaToHexString(m: Int): String = {
+    @inline def padHex6(i: Int): String = {
+      val s = Integer.toHexString(i)
+      "000000".substring(s.length) + s // 6 zeros
+    }
+
+    // The << 1 turns `m` from a 23-bit int into a 24-bit int (multiple of 4)
+    val padded = padHex6(m << 1)
+    var len = padded.length
+    while (len > 1 && padded.charAt(len - 1) == '0')
+      len -= 1
+    padded.substring(0, len)
+  }
+
   @inline def compare(a: scala.Float, b: scala.Float): scala.Int =
     Double.compare(a, b)
-
-  @inline protected def equals(a: scala.Float, b: scala.Float): scala.Boolean =
-    a == b || (isNaN(a) && isNaN(b))
 
   @inline def isNaN(v: scala.Float): scala.Boolean =
     v != v
@@ -79,9 +122,25 @@ object Float {
   @inline def isInfinite(v: scala.Float): scala.Boolean =
     v == POSITIVE_INFINITY || v == NEGATIVE_INFINITY
 
+  @inline def isFinite(f: scala.Float): scala.Boolean =
+    !isNaN(f) && !isInfinite(f)
+
+  // Uses the hashCode of Doubles. See Bits.numberHashCode for the rationale.
+  @inline def hashCode(value: scala.Float): Int =
+    scala.scalajs.runtime.Bits.numberHashCode(value)
+
   @inline def intBitsToFloat(bits: scala.Int): scala.Float =
     scala.scalajs.runtime.Bits.intBitsToFloat(bits)
 
   @inline def floatToIntBits(value: scala.Float): scala.Int =
     scala.scalajs.runtime.Bits.floatToIntBits(value)
+
+  @inline def sum(a: scala.Float, b: scala.Float): scala.Float =
+    a + b
+
+  @inline def max(a: scala.Float, b: scala.Float): scala.Float =
+    Math.max(a, b)
+
+  @inline def min(a: scala.Float, b: scala.Float): scala.Float =
+    Math.min(a, b)
 }

--- a/javalanglib/src/main/scala/java/lang/Float.scala
+++ b/javalanglib/src/main/scala/java/lang/Float.scala
@@ -50,10 +50,12 @@ object Float {
   final val NEGATIVE_INFINITY = 1.0f / -0.0f
   final val NaN = 0.0f / 0.0f
   final val MAX_VALUE = scala.Float.MaxValue
+  final val MIN_NORMAL = 1.17549435e-38f
   final val MIN_VALUE = scala.Float.MinPositiveValue
   final val MAX_EXPONENT = 127
   final val MIN_EXPONENT = -126
   final val SIZE = 32
+  final val BYTES = 4
 
   @inline def valueOf(floatValue: scala.Float): Float = new Float(floatValue)
 

--- a/javalanglib/src/main/scala/java/lang/Short.scala
+++ b/javalanglib/src/main/scala/java/lang/Short.scala
@@ -34,6 +34,7 @@ final class Short private () extends Number with Comparable[Short] {
 object Short {
   final val TYPE = classOf[scala.Short]
   final val SIZE = 16
+  final val BYTES = 2
 
   /* MIN_VALUE and MAX_VALUE should be 'final val's. But it is impossible to
    * write a proper Short literal in Scala, that would both considered a Short

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/DoubleTestJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/DoubleTestJDK8.scala
@@ -1,0 +1,72 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scalajs.testsuite.javalib.lang
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.Platform.executingInJVM
+
+import java.lang.{Double => JDouble}
+
+class DoubleTestJDK8 {
+
+  @Test def isFinite(): Unit = {
+    assertFalse(JDouble.isFinite(Double.PositiveInfinity))
+    assertFalse(JDouble.isFinite(Double.NegativeInfinity))
+    assertFalse(JDouble.isFinite(Double.NaN))
+    assertFalse(JDouble.isFinite(1d/0))
+    assertFalse(JDouble.isFinite(-1d/0))
+
+    assertTrue(JDouble.isFinite(0d))
+    assertTrue(JDouble.isFinite(1d))
+    assertTrue(JDouble.isFinite(123456d))
+    assertTrue(JDouble.isFinite(Double.MinValue))
+    assertTrue(JDouble.isFinite(Double.MaxValue))
+    assertTrue(JDouble.isFinite(Double.MinPositiveValue))
+  }
+
+  @Test def staticHashCodeTest(): Unit = {
+    assumeFalse("Hash codes for doubles are different in JS than on the JVM",
+        executingInJVM)
+
+    def test(x: Double, expected: Int): Unit =
+      assertEquals(expected, JDouble.hashCode(x))
+
+    test(0.0, 0)
+    test(-0.0, -2147483648)
+    test(1234.0, 1234)
+    test(1.5, 1073217536)
+    test(Math.PI, 340593891)
+    test(-54.0, -54)
+
+    test(Double.MinPositiveValue, 1)
+    test(Double.MinValue, 1048576)
+    test(Double.MaxValue, -2146435072)
+
+    test(Double.NaN, 2146959360)
+    test(Double.PositiveInfinity, 2146435072)
+    test(Double.NegativeInfinity, -1048576)
+  }
+
+  // The following tests are only to make sure that things link
+
+  @Test def sum(): Unit = {
+    assertEquals(12d, JDouble.sum(5d, 7d), 0d)
+  }
+
+  @Test def max(): Unit = {
+    assertEquals(7d, JDouble.max(5d, 7d), 0d)
+  }
+
+  @Test def min(): Unit = {
+    assertEquals(5d, JDouble.min(5d, 7d), 0d)
+  }
+
+}

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/FloatTestJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/FloatTestJDK8.scala
@@ -1,0 +1,71 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scalajs.testsuite.javalib.lang
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.Platform.executingInJVM
+
+import java.lang.{Float => JFloat}
+
+class FloatTestJDK8 {
+
+  @Test def isFinite(): Unit = {
+    assertFalse(JFloat.isFinite(Float.PositiveInfinity))
+    assertFalse(JFloat.isFinite(Float.NegativeInfinity))
+    assertFalse(JFloat.isFinite(Float.NaN))
+    assertFalse(JFloat.isFinite(1f/0))
+    assertFalse(JFloat.isFinite(-1f/0))
+
+    assertTrue(JFloat.isFinite(0f))
+    assertTrue(JFloat.isFinite(1f))
+    assertTrue(JFloat.isFinite(123456f))
+    assertTrue(JFloat.isFinite(Float.MinValue))
+    assertTrue(JFloat.isFinite(Float.MaxValue))
+    assertTrue(JFloat.isFinite(Float.MinPositiveValue))
+  }
+
+  @Test def staticHashCodeTest(): Unit = {
+    assumeFalse("Hash codes for doubles are different in JS than on the JVM",
+        executingInJVM)
+
+    def test(x: Float, expected: Int): Unit =
+      assertEquals(expected, JFloat.hashCode(x))
+
+    test(0.0f, 0)
+    test(-0.0f, -2147483648)
+    test(1234.0f, 1234)
+    test(1.5f, 1073217536)
+    test(-54.0f, -54)
+
+    test(Float.MinPositiveValue, 916455424)
+    test(Float.MinValue, 670040063)
+    test(Float.MaxValue, -1477443585)
+
+    test(Float.NaN, 2146959360)
+    test(Float.PositiveInfinity, 2146435072)
+    test(Float.NegativeInfinity, -1048576)
+  }
+
+  // The following tests are only to make sure that things link
+
+  @Test def sum(): Unit = {
+    assertEquals(12f, JFloat.sum(5f, 7f), 0f)
+  }
+
+  @Test def max(): Unit = {
+    assertEquals(7f, JFloat.max(5f, 7f), 0f)
+  }
+
+  @Test def min(): Unit = {
+    assertEquals(5f, JFloat.min(5f, 7f), 0f)
+  }
+
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -76,6 +76,28 @@ class DoubleTest {
     assertEquals("1.2", 1.2.toString)
   }
 
+  @Test def toHexStringTest(): Unit = {
+    import java.lang.Double.toHexString
+
+    assertEquals("0x0.0p0", toHexString(0.0))
+    assertEquals("-0x0.0p0", toHexString(-0.0))
+    assertEquals("NaN", toHexString(Double.NaN))
+    assertEquals("Infinity", toHexString(Double.PositiveInfinity))
+    assertEquals("-Infinity", toHexString(Double.NegativeInfinity))
+    assertEquals("0x1.0p0", toHexString(1.0))
+    assertEquals("-0x1.0p0", toHexString(-1.0))
+    assertEquals("0x1.0p1", toHexString(2.0))
+    assertEquals("0x1.8p1", toHexString(3.0))
+    assertEquals("0x1.0p-1", toHexString(0.5))
+    assertEquals("0x1.0p-2", toHexString(0.25))
+    assertEquals("0x1.00204p3", toHexString(8.003936767578125))
+    assertEquals("0x0.00204p-1022", toHexString(1.094949828138e-311))
+    assertEquals("0x1.fffffffffffffp1023", toHexString(Double.MaxValue))
+    assertEquals("0x1.0p-1022", toHexString(java.lang.Double.MIN_NORMAL))
+    assertEquals("0x0.fffffffffffffp-1022", toHexString(2.225073858507201E-308))
+    assertEquals("0x0.0000000000001p-1022", toHexString(Double.MinPositiveValue))
+  }
+
   @Test def should_parse_strings(): Unit = {
     assertEquals(0.0, "0.0".toDouble, 0.0)
     assertTrue("NaN".toDouble.isNaN)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -79,6 +79,28 @@ class FloatTest {
     assertEquals("1.2", 1.2f.toString.substring(0,3))
   }
 
+  @Test def toHexStringTest(): Unit = {
+    import java.lang.Float.toHexString
+
+    assertEquals("NaN", toHexString(Float.NaN))
+    assertEquals("Infinity", toHexString(Float.PositiveInfinity))
+    assertEquals("-Infinity", toHexString(Float.NegativeInfinity))
+    assertEquals("0x0.0p0", toHexString(0.0f))
+    assertEquals("-0x0.0p0", toHexString(-0.0f))
+    assertEquals("0x1.0p0", toHexString(1.0f))
+    assertEquals("-0x1.0p0", toHexString(-1.0f))
+    assertEquals("0x1.0p1", toHexString(2.0f))
+    assertEquals("0x1.8p1", toHexString(3.0f))
+    assertEquals("0x1.0p-1", toHexString(0.5f))
+    assertEquals("0x1.0p-2", toHexString(0.25f))
+    assertEquals("0x1.00204p3", toHexString(8.003937f))
+    assertEquals("0x0.00204p-126", toHexString(5.785e-42f))
+    assertEquals("0x1.fffffep127", toHexString(Float.MaxValue))
+    assertEquals("0x1.0p-126", toHexString(java.lang.Float.MIN_NORMAL))
+    assertEquals("0x0.fffffep-126", toHexString(1.1754942E-38f))
+    assertEquals("0x0.000002p-126", toHexString(Float.MinPositiveValue))
+  }
+
   @Test def should_parse_strings(): Unit = {
     assertEquals(0.0f, "0.0".toFloat, 0.0f)
     assertTrue("NaN".toFloat.isNaN)


### PR DESCRIPTION
* `hashCode`
* `isFinite`
* `max`
* `min`
* `sum`
* and `toHexString` (actually this one is from JDK5)