### PR TITLE
Fix #2733: Implement on-demand reflective instantiation.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -137,6 +137,12 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val BoxesRunTime_boxToCharacter = getMemberMethod(BoxesRunTimeModule, newTermName("boxToCharacter"))
     lazy val BoxesRunTime_unboxToChar    = getMemberMethod(BoxesRunTimeModule, newTermName("unboxToChar"))
 
+    lazy val ReflectModule = getRequiredModule("scala.scalajs.reflect.Reflect")
+      lazy val Reflect_registerLoadableModuleClass = getMemberMethod(ReflectModule, newTermName("registerLoadableModuleClass"))
+      lazy val Reflect_registerInstantiatableClass = getMemberMethod(ReflectModule, newTermName("registerInstantiatableClass"))
+
+    lazy val EnableReflectiveInstantiationAnnotation = getRequiredClass("scala.scalajs.reflect.annotation.EnableReflectiveInstantiation")
+
   }
 
   // scalastyle:on line.size.limit

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -476,6 +476,14 @@ abstract class PrepJSInterop extends plugins.PluginComponent
 
       val isJSNative = !sym.hasAnnotation(ScalaJSDefinedAnnotation)
 
+      // Forbid @EnableReflectiveInstantiation on JS types
+      sym.getAnnotation(EnableReflectiveInstantiationAnnotation).foreach {
+        annot =>
+          reporter.error(annot.pos,
+              "@EnableReflectiveInstantiation cannot be used on types " +
+              "extending js.Any.")
+      }
+
       if (sym.isPackageObjectClass) {
         reporter.warning(implDef.pos,
             "Package objects inheriting from js.Any are deprecated. " +

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ReflectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ReflectTest.scala
@@ -1,0 +1,64 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+class ReflectTest extends DirectTest with TestHelpers {
+
+  override def preamble: String =
+    """import scala.scalajs.js, js.annotation._
+       import scala.scalajs.reflect.annotation._
+    """
+
+  @Test
+  def noEnableReflectiveInstantiationOnJSType: Unit = {
+    """
+    @EnableReflectiveInstantiation
+    @ScalaJSDefined
+    class A extends js.Object
+
+    @EnableReflectiveInstantiation
+    @ScalaJSDefined
+    trait B extends js.Object
+
+    @EnableReflectiveInstantiation
+    @ScalaJSDefined
+    object C extends js.Object
+
+    @EnableReflectiveInstantiation
+    @js.native
+    class D extends js.Object
+
+    @EnableReflectiveInstantiation
+    @js.native
+    trait E extends js.Object
+
+    @EnableReflectiveInstantiation
+    @js.native
+    object F extends js.Object
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
+      |    @EnableReflectiveInstantiation
+      |     ^
+      |newSource1.scala:8: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
+      |    @EnableReflectiveInstantiation
+      |     ^
+      |newSource1.scala:12: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
+      |    @EnableReflectiveInstantiation
+      |     ^
+      |newSource1.scala:16: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
+      |    @EnableReflectiveInstantiation
+      |     ^
+      |newSource1.scala:20: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
+      |    @EnableReflectiveInstantiation
+      |     ^
+      |newSource1.scala:24: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
+      |    @EnableReflectiveInstantiation
+      |     ^
+    """
+  }
+
+}

--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
@@ -39,8 +39,14 @@ private[rhino] class ScalaJSCoreLib(linkingUnit: LinkingUnit) {
     val exportedSymbols = mutable.ListBuffer.empty[String]
 
     for (linkedClass <- linkingUnit.classDefs) {
+      def hasStaticInitializer = {
+        linkedClass.staticMethods.exists {
+          _.tree.name.name == ir.Definitions.StaticInitializerName
+        }
+      }
+
       providers += linkedClass.encodedName -> linkedClass
-      if (linkedClass.isExported)
+      if (linkedClass.isExported || hasStaticInitializer)
         exportedSymbols += linkedClass.encodedName
     }
 

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTestBootstrapper.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTestBootstrapper.scala
@@ -4,9 +4,9 @@ import java.lang.annotation.Annotation
 
 import org.junit.FixMethodOrder
 
-import scala.scalajs.js.annotation.JSExportDescendentObjects
+import scala.scalajs.reflect.annotation._
 
-@JSExportDescendentObjects
+@EnableReflectiveInstantiation
 trait JUnitTestBootstrapper {
   def metadata(): JUnitClassMetadata
   def newInstance(): AnyRef

--- a/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
+++ b/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
@@ -1,0 +1,102 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.reflect
+
+import scala.collection.mutable
+
+import scala.scalajs.js
+
+final class LoadableModuleClass private[reflect] (
+    val runtimeClass: Class[_],
+    loadModuleFun: js.Function0[Any]
+) {
+  /** Loads the module instance and returns it. */
+  def loadModule(): Any = loadModuleFun()
+}
+
+final class InstantiatableClass private[reflect] (
+    val runtimeClass: Class[_],
+    val declaredConstructors: List[InvokableConstructor]
+) {
+  /** Instantiates a new instance of this class using the zero-argument
+   *  constructor.
+   *
+   *  @throws java.lang.InstantiationException (caused by a
+   *    `NoSuchMethodException`)
+   *    If this class does not have a public zero-argument constructor.
+   */
+  def newInstance(): Any = {
+    getConstructor().fold[Any] {
+      throw new InstantiationException(runtimeClass.getName).initCause(
+          new NoSuchMethodException(runtimeClass.getName + ".<init>()"))
+    } { ctor =>
+      ctor.newInstance()
+    }
+  }
+
+  /** Looks up a public constructor identified by the types of its formal
+   *  parameters.
+   *
+   *  If no such public constructor exists, returns `None`.
+   */
+  def getConstructor(parameterTypes: Class[_]*): Option[InvokableConstructor] =
+    declaredConstructors.find(_.parameterTypes.sameElements(parameterTypes))
+}
+
+final class InvokableConstructor private[reflect]  (
+    val parameterTypes: List[Class[_]],
+    newInstanceFun: js.Function
+) {
+  def newInstance(args: Any*): Any = {
+    /* Check the number of actual arguments. We let the casts and unbox
+     * operations inside `newInstanceFun` take care of the rest.
+     */
+    require(args.size == parameterTypes.size)
+    newInstanceFun.asInstanceOf[js.Dynamic].apply(
+        args.asInstanceOf[Seq[js.Any]]: _*)
+  }
+}
+
+object Reflect {
+  /* I would like those val's to be `js.Dictionary`'es instead of full-blown
+   * Scala Maps. But if I do that, GCC "dead-code"-eliminates away statements
+   * that fill `loadableModuleClasses`! We fool it into not making a fool of
+   * itself by using more complicated data structures that it does not
+   * understand -_-'.
+   */
+
+  private val loadableModuleClasses =
+    mutable.Map.empty[String, LoadableModuleClass]
+
+  private val instantiatableClasses =
+    mutable.Map.empty[String, InstantiatableClass]
+
+  // `protected[reflect]` makes it public in the IR
+  protected[reflect] def registerLoadableModuleClass[T](
+      fqcn: String, runtimeClass: Class[T],
+      loadModuleFun: js.Function0[T]): Unit = {
+    loadableModuleClasses(fqcn) =
+      new LoadableModuleClass(runtimeClass, loadModuleFun)
+  }
+
+  protected[reflect] def registerInstantiatableClass[T](
+      fqcn: String, runtimeClass: Class[T],
+      constructors: js.Array[js.Tuple2[js.Array[Class[_]], js.Function]]): Unit = {
+    val invokableConstructors = constructors.map { c =>
+      new InvokableConstructor(c._1.toList, c._2)
+    }
+    instantiatableClasses(fqcn) =
+      new InstantiatableClass(runtimeClass, invokableConstructors.toList)
+  }
+
+  def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
+    loadableModuleClasses.get(fqcn)
+
+  def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
+    instantiatableClasses.get(fqcn)
+}

--- a/library/src/main/scala/scala/scalajs/reflect/annotation/EnableReflectiveInstantiation.scala
+++ b/library/src/main/scala/scala/scalajs/reflect/annotation/EnableReflectiveInstantiation.scala
@@ -1,0 +1,16 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.reflect.annotation
+
+/** Enables reflective instantiation for the annotated class, trait or object,
+ *  and all its descendants.
+ *
+ *  Affected classes can be identified at run-time through methods of
+ *  [[scala.scalajs.reflect.Reflect]].
+ */
+class EnableReflectiveInstantiation extends scala.annotation.StaticAnnotation

--- a/sbt-plugin-test/multiTest/js/src/test/scala/sbttest/multitest/JUnitUtil.scala
+++ b/sbt-plugin-test/multiTest/js/src/test/scala/sbttest/multitest/JUnitUtil.scala
@@ -3,7 +3,7 @@ package sbttest.multitest
 import org.scalajs.junit.JUnitTestBootstrapper
 import org.junit.Assert.fail
 
-import scalajs.js
+import scala.scalajs.reflect.Reflect
 
 object JUnitUtil {
   private final val bootstrapperSuffix = "$scalajs$junit$bootstrapper"
@@ -11,9 +11,8 @@ object JUnitUtil {
   def loadBootstrapper(classFullName: String): JUnitTestBootstrapper = {
     val fullName = s"$classFullName$bootstrapperSuffix"
     try {
-      fullName.split('.').foldLeft(js.Dynamic.global) { (obj, n) =>
-        obj.selectDynamic(n)
-      }.apply().asInstanceOf[JUnitTestBootstrapper]
+      val modClass = Reflect.lookupLoadableModuleClass(fullName + "$").get
+      modClass.loadModule().asInstanceOf[JUnitTestBootstrapper]
     } catch {
       case ex: Throwable =>
         throw new AssertionError(s"could not load $fullName: ${ex.getMessage}")

--- a/sbt-plugin-test/testFramework/src/main/scala/sbttest/framework/DummyTask.scala
+++ b/sbt-plugin-test/testFramework/src/main/scala/sbttest/framework/DummyTask.scala
@@ -15,7 +15,7 @@ final class DummyTask(
     try {
       // Just create a new instance.
       val inst = TestUtils.newInstance(taskDef.fullyQualifiedName,
-        runner.testClassLoader)(Seq())
+          runner.testClassLoader, Seq())(Seq())
 
       eventHandler.handle(new DummyEvent(taskDef, None))
       loggers.foreach(_.info(s"Success: ${taskDef.fullyQualifiedName}"))

--- a/sbt-plugin-test/testFramework/src/main/scala/sbttest/framework/Test.scala
+++ b/sbt-plugin-test/testFramework/src/main/scala/sbttest/framework/Test.scala
@@ -1,6 +1,6 @@
 package sbttest.framework
 
-import scala.scalajs.js.annotation.JSExportDescendentClasses
+import scala.scalajs.reflect.annotation.EnableReflectiveInstantiation
 
-@JSExportDescendentClasses
+@EnableReflectiveInstantiation
 class Test

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
@@ -40,31 +40,10 @@ private[sbtplugin] final class FrameworkDetector(jsEnv: JSEnv,
         "use strict";
 
         var data = ${jsonToString(data)};
-
-        function frameworkExists(name) {
-          var parts = name.split(".");
-          var obj = exportsNamespace;
-          for (var i = 0; i < parts.length; ++i) {
-            obj = obj[parts[i]];
-            if (obj === void 0)
-              return false;
-          }
-          return true;
-        }
-
-        for (var i = 0; i < data.length; ++i) {
-          var gotOne = false;
-          for (var j = 0; j < data[i].length; ++j) {
-            if (frameworkExists(data[i][j])) {
-              console.log("$ConsoleFrameworkPrefix" + data[i][j]);
-              gotOne = true;
-              break;
-            }
-          }
-          if (!gotOne) {
-            // print an empty line with prefix to zip afterwards
-            console.log("$ConsoleFrameworkPrefix");
-          }
+        var results =
+          exportsNamespace.org.scalajs.testinterface.internal.detectFrameworks(data);
+        for (var i = 0; i < results.length; ++i) {
+          console.log("$ConsoleFrameworkPrefix" + (results[i] || ""));
         }
       })($exportsNamespaceExpr);
     """

--- a/stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala
+++ b/stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala
@@ -15,8 +15,15 @@ object TestUtils {
   import scala.reflect.macros._ // shadows blackbox from above
   import blackbox.Context
 
+  @deprecated(
+      "Use the overload with explicit formal constructor parameter types.",
+      "0.6.15")
   def newInstance(name: String, loader: ClassLoader)(args: Seq[AnyRef]): AnyRef =
     macro newInstance_impl
+
+  def newInstance(name: String, loader: ClassLoader, paramTypes: Seq[Class[_]])(
+      args: Seq[AnyRef]): AnyRef =
+    macro newInstance_impl2
 
   def newInstance_impl(c: Context)(name: c.Expr[String],
       loader: c.Expr[ClassLoader])(
@@ -31,6 +38,15 @@ object TestUtils {
     }
 
     val ctor = ctors.head
+    ctor.newInstance(args.splice: _*).asInstanceOf[AnyRef]
+  }
+
+  def newInstance_impl2(c: Context)(name: c.Expr[String],
+      loader: c.Expr[ClassLoader], paramTypes: c.Expr[Seq[Class[_]]])(
+      args: c.Expr[Seq[AnyRef]]): c.Expr[AnyRef] = c.universe.reify {
+
+    val clazz = loader.splice.loadClass(name.splice)
+    val ctor = clazz.getConstructor(paramTypes.splice.toArray[Class[_]]: _*)
     ctor.newInstance(args.splice: _*).asInstanceOf[AnyRef]
   }
 

--- a/stubs/src/main/scala/scala/scalajs/reflect/annotation/ReflectAnnotations.scala
+++ b/stubs/src/main/scala/scala/scalajs/reflect/annotation/ReflectAnnotations.scala
@@ -1,0 +1,10 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package scala.scalajs.reflect.annotation
+
+class EnableReflectiveInstantiation extends scala.annotation.Annotation

--- a/test-interface/src/main/scala/org/scalajs/testinterface/TestUtils.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/TestUtils.scala
@@ -1,24 +1,94 @@
 package org.scalajs.testinterface
 
 import scala.scalajs.js
+import scala.scalajs.reflect._
 
 object TestUtils {
 
-  def newInstance(name: String, loader: ClassLoader)(args: Seq[AnyRef]): AnyRef = {
-    val ctor = deepSelect(namespace(loader), name)
-    js.Dynamic.newInstance(ctor)(args.asInstanceOf[Seq[js.Any]]: _*)
+  /** Instantiates the class given by its fully qualified name.
+   *
+   *  The target class must be exported under its fully qualified name.
+   *
+   *  This overload of `newInstance` cannot instantiate classes with an
+   *  ancestor annotated with
+   *  [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation]].
+   *
+   *  Prefer using the other overload of `newInstance` for new code, which
+   *  supports reflective instantiation in addition to exports-based
+   *  instantiation.
+   */
+  @deprecated(
+      "Use the overload with explicit formal constructor parameter types.",
+      "0.6.15")
+  def newInstance(name: String, loader: ClassLoader)(
+      args: Seq[AnyRef]): AnyRef = {
+    Reflect.lookupInstantiatableClass(name).fold[AnyRef] {
+      val ctor = deepSelect(namespace(loader), name)
+      js.Dynamic.newInstance(ctor)(args.asInstanceOf[Seq[js.Any]]: _*)
+    } { clazz =>
+      throw new InstantiationException(
+          s"The class '$name' should be loaded through reflective " +
+          "instantiation, but the overload of TestUtils.newIntance() that " +
+          "was used does not support it. You can fix it by calling the other " +
+          "overload of TestUtils.newInstance().")
+    }
   }
 
+  /** Instantiates the class given by its fully qualified name.
+   *
+   *  The target class must either
+   *
+   *  - extend a class or trait annotated with
+   *    [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation]], or
+   *  - be exported under its fully qualified name.
+   *
+   *  In the former case, the overload is selected based on `paramTypes`. In
+   *  the latter case, the overload is selected by the usual export overload
+   *  resolution mechanism.
+   */
+  def newInstance(name: String, loader: ClassLoader, paramTypes: Seq[Class[_]])(
+      args: Seq[Any]): AnyRef = {
+    require(args.size == paramTypes.size, "argument count mismatch")
+
+    Reflect.lookupInstantiatableClass(name).fold[AnyRef] {
+      val ctor = deepSelect(namespace(loader), name)
+      js.Dynamic.newInstance(ctor)(args.asInstanceOf[Seq[js.Any]]: _*)
+    } { clazz =>
+      val ctor = clazz.declaredConstructors.find {
+        _.parameterTypes == paramTypes
+      }.getOrElse {
+        throw new InstantiationError(name)
+      }
+      ctor.newInstance(args: _*).asInstanceOf[AnyRef]
+    }
+  }
+
+  /** Loads the module given by its fully qualified name.
+   *
+   *  The target object must either
+   *
+   *  - extend a class or trait annotated with
+   *    [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation]], or
+   *  - be exported under its fully qualified name.
+   *
+   *  The name *must not* include the trailing `$` that is part of the module
+   *  name, as added by the Scala compiler.
+   */
   def loadModule(name: String, loader: ClassLoader): AnyRef = {
-    val accessor = deepSelect(namespace(loader), name)
-    accessor()
+    Reflect.lookupLoadableModuleClass(name + "$").fold[AnyRef] {
+      val accessor = deepSelect(namespace(loader), name)
+      accessor()
+    } { loadableModule =>
+      loadableModule.loadModule().asInstanceOf[AnyRef]
+    }
   }
 
   private def namespace(loader: ClassLoader): js.Dynamic = {
     loader match {
-      case loader: ScalaJSClassLoader => loader.namespace
-      case _ => throw new IllegalArgumentException(
-          "Need a ScalaJSClassLoader.")
+      case loader: ScalaJSClassLoader =>
+        loader.namespace
+      case _ =>
+        throw new IllegalArgumentException("Need a ScalaJSClassLoader.")
     }
   }
 

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkDetector.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkDetector.scala
@@ -1,0 +1,39 @@
+package org.scalajs.testinterface.internal
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+import scala.scalajs.js.JSConverters._
+import scala.scalajs.reflect.Reflect
+
+private[internal] object FrameworkDetector {
+  @JSExportTopLevel("org.scalajs.testinterface.internal.detectFrameworks")
+  def detectFrameworks(
+      frameworksData: js.Array[js.Array[String]]): js.Array[js.UndefOr[String]] = {
+
+    def frameworkExistsInReflect(name: String): Boolean = {
+      Reflect.lookupInstantiatableClass(name).exists { clazz =>
+        classOf[sbt.testing.Framework].isAssignableFrom(clazz.runtimeClass)
+      }
+    }
+
+    def frameworkExistsInExportsNamespace(name: String): Boolean = {
+      /* This happens for testing frameworks developed before 0.6.15 that have
+       * not yet updated to using reflective instantiation, and are still
+       * using exports.
+       * Note that here, we have to assume that whatever we find is indeed a
+       * proper class export for a class extending sbt.testing.Framework.
+       */
+      val exportsNamespace =
+        scala.scalajs.runtime.environmentInfo.exportsNamespace
+      name.split('.').foldLeft[js.UndefOr[js.Dynamic]](exportsNamespace) {
+        (prev, part) => prev.map(_.selectDynamic(part))
+      }.isDefined
+    }
+
+    def frameworkExists(name: String): Boolean =
+      frameworkExistsInReflect(name) || frameworkExistsInExportsNamespace(name)
+
+    for (frameworkNames <- frameworksData)
+      yield frameworkNames.find(frameworkExists(_)).orUndefined
+  }
+}

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkLoader.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkLoader.scala
@@ -1,17 +1,22 @@
 package org.scalajs.testinterface.internal
 
 import scala.scalajs.js
+import scala.scalajs.reflect.Reflect
 
 import sbt.testing.Framework
 
 private[internal] object FrameworkLoader {
 
   def loadFramework(frameworkName: String): Framework = {
-    val exportsNamespace =
-      scala.scalajs.runtime.environmentInfo.exportsNamespace
-    val parts = frameworkName.split('.')
-    val ctor = parts.foldLeft(exportsNamespace)(_.selectDynamic(_))
-    js.Dynamic.newInstance(ctor)().asInstanceOf[Framework]
+    Reflect.lookupInstantiatableClass(frameworkName).fold[Framework] {
+      val exportsNamespace =
+        scala.scalajs.runtime.environmentInfo.exportsNamespace
+      val parts = frameworkName.split('.')
+      val ctor = parts.foldLeft(exportsNamespace)(_.selectDynamic(_))
+      js.Dynamic.newInstance(ctor)().asInstanceOf[Framework]
+    } { clazz =>
+      clazz.newInstance().asInstanceOf[Framework]
+    }
   }
 
 }

--- a/test-interface/src/main/scala/sbt/testing/Framework.scala
+++ b/test-interface/src/main/scala/sbt/testing/Framework.scala
@@ -1,9 +1,9 @@
 package sbt.testing
 
-import scala.scalajs.js.annotation._
+import scala.scalajs.reflect.annotation._
 
 /** Interface implemented by test frameworks. */
-@JSExportDescendentClasses
+@EnableReflectiveInstantiation
 trait Framework {
 
   /** A human-friendly name of the test framework that this object represents.

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
@@ -3,17 +3,17 @@ package org.scalajs.testsuite.junit
 import org.scalajs.junit.JUnitTestBootstrapper
 import org.junit.Assert.fail
 
+import org.scalajs.testinterface._
+
 object JUnitUtil {
   private final val BootstrapperSuffix = "$scalajs$junit$bootstrapper"
 
   def loadBootstrapper(classFullName: String): JUnitTestBootstrapper = {
     val fullName = s"$classFullName$BootstrapperSuffix"
     try {
-      val exportsNamespace =
-        scala.scalajs.runtime.environmentInfo.exportsNamespace
-      fullName.split('.').foldLeft(exportsNamespace) { (obj, n) =>
-        obj.selectDynamic(n)
-      }.apply().asInstanceOf[JUnitTestBootstrapper]
+      val loader = new ScalaJSClassLoader(
+          scala.scalajs.runtime.environmentInfo.exportsNamespace)
+      TestUtils.loadModule(fullName, loader).asInstanceOf[JUnitTestBootstrapper]
     } catch {
       case ex: Throwable =>
         throw new AssertionError(s"could not load $fullName: ${ex.getMessage}")

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
@@ -1,0 +1,310 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.library
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform._
+
+import scala.scalajs.reflect._
+import scala.scalajs.reflect.annotation._
+
+class ReflectTest {
+  import ReflectTest.{Accessors, VC}
+
+  private final val Prefix = "org.scalajs.testsuite.library.ReflectTest$"
+
+  private final val NameClassEnableDirect =
+    Prefix + "ClassEnableDirect"
+  private final val NameClassEnableDirectNoZeroArgCtor =
+    Prefix + "ClassEnableDirectNoZeroArgCtor"
+  private final val NameObjectEnableDirect =
+    Prefix + "ObjectEnableDirect$"
+  private final val NameTraitEnableDirect =
+    Prefix + "TraitEnableDirect"
+  private final val NameAbstractClassEnableDirect =
+    Prefix + "AbstractClassEnableDirect"
+  private final val NameClassNoPublicConstructorEnableDirect =
+    Prefix + "ClassNoPublicConstructorEnableDirect"
+
+  private final val NameClassEnableIndirect =
+    Prefix + "ClassEnableIndirect"
+  private final val NameClassEnableIndirectNoZeroArgCtor =
+    Prefix + "ClassEnableIndirectNoZeroArgCtor"
+  private final val NameObjectEnableIndirect =
+    Prefix + "ObjectEnableIndirect$"
+  private final val NameTraitEnableIndirect =
+    Prefix + "TraitEnableIndirect"
+  private final val NameAbstractClassEnableIndirect =
+    Prefix + "AbstractClassEnableIndirect"
+  private final val NameClassNoPublicConstructorEnableIndirect =
+    Prefix + "ClassNoPublicConstructorEnableIndirect"
+
+  private final val NameClassDisable =
+    Prefix + "ClassDisable"
+  private final val NameObjectDisable =
+    Prefix + "ObjectDisable$"
+  private final val NameTraitDisable =
+    Prefix + "TraitDisable"
+
+  @Test def testClassRuntimeClass(): Unit = {
+    for {
+      name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+          NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)
+    } {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val runtimeClass = optClassData.get.runtimeClass
+      assertEquals(name, runtimeClass.getName)
+    }
+  }
+
+  @Test def testObjectRuntimeClass(): Unit = {
+    for {
+      name <- Seq(NameObjectEnableDirect, NameObjectEnableIndirect)
+    } {
+      val optClassData = Reflect.lookupLoadableModuleClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val runtimeClass = optClassData.get.runtimeClass
+      assertEquals(name, runtimeClass.getName)
+    }
+  }
+
+  @Test def testClassCannotBeFound(): Unit = {
+    for {
+      name <- Seq(NameObjectEnableDirect, NameTraitEnableDirect,
+          NameAbstractClassEnableDirect,
+          NameClassNoPublicConstructorEnableDirect, NameObjectEnableIndirect,
+          NameTraitEnableIndirect, NameAbstractClassEnableIndirect,
+          NameClassNoPublicConstructorEnableIndirect, NameClassDisable,
+          NameObjectDisable, NameTraitDisable)
+    } {
+      assertFalse(s"$name should not be found",
+          Reflect.lookupInstantiatableClass(name).isDefined)
+    }
+  }
+
+  @Test def testObjectCannotBeFound(): Unit = {
+    for {
+      name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+          NameTraitEnableDirect, NameAbstractClassEnableDirect,
+          NameClassNoPublicConstructorEnableDirect, NameClassEnableIndirect,
+          NameTraitEnableIndirect, NameAbstractClassEnableIndirect,
+          NameClassNoPublicConstructorEnableIndirect, NameClassDisable,
+          NameObjectDisable, NameTraitDisable)
+    } {
+      assertFalse(s"$name should not be found",
+          Reflect.lookupLoadableModuleClass(name).isDefined)
+    }
+  }
+
+  @Test def testClassNoArgCtor(): Unit = {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableIndirect)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val instance = classData.newInstance().asInstanceOf[Accessors]
+      assertEquals(-1, instance.x)
+      assertEquals(name.stripPrefix(Prefix), instance.y)
+    }
+  }
+
+  @Test def testClassNoArgCtorErrorCase(): Unit = {
+    for (name <- Seq(NameClassEnableDirectNoZeroArgCtor,
+        NameClassEnableIndirectNoZeroArgCtor)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      assertThrows(classOf[InstantiationException], {
+        classData.newInstance()
+      })
+    }
+  }
+
+  @Test def testClassCtorWithArgs(): Unit = {
+    for (name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
+        NameClassEnableIndirect, NameClassEnableIndirectNoZeroArgCtor)) {
+      val optClassData = Reflect.lookupInstantiatableClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val optCtorIntString =
+        classData.getConstructor(classOf[Int], classOf[String])
+      assertTrue(optCtorIntString.isDefined)
+      val instanceIntString =
+        optCtorIntString.get.newInstance(543, "foobar").asInstanceOf[Accessors]
+      assertEquals(543, instanceIntString.x)
+      assertEquals("foobar", instanceIntString.y)
+
+      val optCtorInt = classData.getConstructor(classOf[Int])
+      assertTrue(optCtorInt.isDefined)
+      val instanceInt =
+        optCtorInt.get.newInstance(123).asInstanceOf[Accessors]
+      assertEquals(123, instanceInt.x)
+      assertEquals(name.stripPrefix(Prefix), instanceInt.y)
+
+      // Value class is seen as its underlying
+      val optCtorShort = classData.getConstructor(classOf[Short])
+      assertTrue(optCtorShort.isDefined)
+      val instanceShort =
+        optCtorShort.get.newInstance(21).asInstanceOf[Accessors]
+      assertEquals(42, instanceShort.x)
+      assertEquals(name.stripPrefix(Prefix), instanceShort.y)
+
+      // Non-existent
+      assertFalse(classData.getConstructor(classOf[Boolean]).isDefined)
+      assertFalse(classData.getConstructor(classOf[VC]).isDefined)
+
+      // Non-public
+      assertFalse(classData.getConstructor(classOf[String]).isDefined)
+      assertFalse(classData.getConstructor(classOf[Double]).isDefined)
+    }
+  }
+
+  @Test def testObjectLoad(): Unit = {
+    for (name <- Seq(NameObjectEnableDirect, NameObjectEnableIndirect)) {
+      val optClassData = Reflect.lookupLoadableModuleClass(name)
+      assertTrue(optClassData.isDefined)
+      val classData = optClassData.get
+
+      val instance = classData.loadModule().asInstanceOf[Accessors]
+      assertEquals(101, instance.x)
+      assertEquals(name.stripPrefix(Prefix), instance.y)
+    }
+  }
+
+}
+
+object ReflectTest {
+  trait Accessors {
+    val x: Int
+    val y: String
+  }
+
+  final class VC(val self: Short) extends AnyVal
+
+  // Entities with directly enabled reflection
+
+  @EnableReflectiveInstantiation
+  class ClassEnableDirect(val x: Int, val y: String) extends Accessors {
+    def this(x: Int) = this(x, "ClassEnableDirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassEnableDirectNoZeroArgCtor(val x: Int, val y: String)
+      extends Accessors {
+    def this(x: Int) = this(x, "ClassEnableDirectNoZeroArgCtor")
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  object ObjectEnableDirect extends Accessors {
+    val x = 101
+    val y = "ObjectEnableDirect$"
+  }
+
+  @EnableReflectiveInstantiation
+  trait TraitEnableDirect extends Accessors
+
+  @EnableReflectiveInstantiation
+  abstract class AbstractClassEnableDirect(val x: Int, val y: String)
+      extends Accessors {
+
+    def this(x: Int) = this(x, "AbstractClassEnableDirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  @EnableReflectiveInstantiation
+  class ClassNoPublicConstructorEnableDirect private (val x: Int, val y: String)
+      extends Accessors {
+
+    protected def this(y: String) = this(-5, y)
+  }
+
+  // Entities with reflection enabled by inheritance
+
+  @EnableReflectiveInstantiation
+  trait EnablingTrait
+
+  class ClassEnableIndirect(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    def this(x: Int) = this(x, "ClassEnableIndirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  class ClassEnableIndirectNoZeroArgCtor(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+    def this(x: Int) = this(x, "ClassEnableIndirectNoZeroArgCtor")
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  object ObjectEnableIndirect extends EnablingTrait with Accessors {
+    val x = 101
+    val y = "ObjectEnableIndirect$"
+  }
+
+  trait TraitEnableIndirect extends EnablingTrait with Accessors
+
+  abstract class AbstractClassEnableIndirect(val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    def this(x: Int) = this(x, "AbstractClassEnableIndirect")
+    def this() = this(-1)
+    def this(vc: VC) = this(vc.self.toInt * 2)
+
+    protected def this(y: String) = this(-5, y)
+    private def this(d: Double) = this(d.toInt)
+  }
+
+  class ClassNoPublicConstructorEnableIndirect private (
+      val x: Int, val y: String)
+      extends EnablingTrait with Accessors {
+
+    protected def this(y: String) = this(-5, y)
+  }
+
+  // Entities with reflection disabled
+
+  class ClassDisable(val x: Int, val y: String) extends Accessors
+
+  object ObjectDisable extends Accessors {
+    val x = 101
+    val y = "ObjectDisable$"
+  }
+
+  trait TraitDisable extends Accessors
+}


### PR DESCRIPTION
This commit implements the variant of Proposal #2733 that supports all public constructors.

We introduce a new API in `scala.scalajs.reflect` which allows to do some amount of run-time reflection, namely, instantiate classes and load module instances given their fully qualified names.

Not all classes are eligible. Only objects and classes that have an ancestor annotated with `@EnableReflectiveInstantiation` can be found and instantiated that way. Moreover, traits, abstract classes, and classes without any public constructors cannot be found either.