### PR TITLE
Fix #2734: Allow @JSExportTopLevel on classes and objects.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -106,17 +106,33 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
       } yield {
         implicit val pos = exp.pos
         assert(!exp.isNamed, "Class cannot be exported named")
-        js.JSClassExportDef(exp.jsName)
+
+        exp.destination match {
+          case ExportDestination.Normal | ExportDestination.TopLevel =>
+            js.JSClassExportDef(exp.jsName)
+          case ExportDestination.Static =>
+            throw new AssertionError(
+                "Found a class export static for " + classSym.fullName)
+        }
       }
     }
 
-    def genModuleAccessorExports(classSym: Symbol): List[js.ModuleExportDef] = {
+    def genModuleAccessorExports(classSym: Symbol): List[js.Tree] = {
       for {
         exp <- jsInterop.registeredExportsOf(classSym)
       } yield {
         implicit val pos = exp.pos
         assert(!exp.isNamed, "Module cannot be exported named")
-        js.ModuleExportDef(exp.jsName)
+
+        exp.destination match {
+          case ExportDestination.Normal =>
+            js.ModuleExportDef(exp.jsName)
+          case ExportDestination.TopLevel =>
+            js.TopLevelModuleExportDef(exp.jsName)
+          case ExportDestination.Static =>
+            throw new AssertionError(
+                "Found a module export static for " + classSym.fullName)
+        }
       }
     }
 

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -340,10 +340,10 @@ trait PrepJSExports { this: PrepJSInterop =>
                 "You may not export a getter or a setter to the top level")
           }
 
-          if (!isMember) {
-            reporter.error(annot.pos, "Use @JSExport on objects and " +
-                "constructors to export to the top level")
-          } else if (!sym.owner.isStatic || !sym.owner.isModuleClass) {
+          val symOwner =
+            if (sym.isConstructor) sym.owner.owner
+            else sym.owner
+          if (!symOwner.isStatic || !symOwner.isModuleClass) {
             reporter.error(annot.pos,
                 "Only static objects may export their members to the top level")
           }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -1097,52 +1097,40 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelModule: Unit = {
-    """
-    @JSExportTopLevel("foo")
-    object A
-    """ hasErrors
-    """
-      |newSource1.scala:3: error: Use @JSExport on objects and constructors to export to the top level
-      |    @JSExportTopLevel("foo")
-      |     ^
-    """
-  }
-
-  @Test
   def noExportTopLevelTrait: Unit = {
     """
     @JSExportTopLevel("foo")
     trait A
+
+    @JSExportTopLevel("bar")
+    @ScalaJSDefined
+    trait B extends js.Object
     """ hasErrors
     """
-      |newSource1.scala:3: error: Use @JSExport on objects and constructors to export to the top level
+      |newSource1.scala:3: error: You may not export a trait
       |    @JSExportTopLevel("foo")
       |     ^
-    """
-  }
-
-  @Test
-  def noExportTopLevelClass: Unit = {
-    """
-    @JSExportTopLevel("foo")
-    class A
-    """ hasErrors
-    """
-      |newSource1.scala:3: error: Use @JSExport on objects and constructors to export to the top level
-      |    @JSExportTopLevel("foo")
+      |newSource1.scala:6: error: You may not export a trait
+      |    @JSExportTopLevel("bar")
       |     ^
     """
 
     """
-    class A {
+    object Container {
       @JSExportTopLevel("foo")
-      def this(x: Int) = this()
+      trait A
+
+      @JSExportTopLevel("bar")
+      @ScalaJSDefined
+      trait B extends js.Object
     }
     """ hasErrors
     """
-      |newSource1.scala:4: error: Use @JSExport on objects and constructors to export to the top level
+      |newSource1.scala:4: error: You may not export a trait
       |      @JSExportTopLevel("foo")
+      |       ^
+      |newSource1.scala:7: error: You may not export a trait
+      |      @JSExportTopLevel("bar")
       |       ^
     """
   }
@@ -1254,6 +1242,56 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:5: error: Only static objects may export their members to the top level
       |        @JSExportTopLevel("foo")
       |         ^
+    """
+
+    """
+    class A {
+      @JSExportTopLevel("Foo")
+      object B
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: Only static objects may export their members to the top level
+      |      @JSExportTopLevel("Foo")
+      |       ^
+    """
+
+    """
+    class A {
+      @JSExportTopLevel("Foo")
+      @ScalaJSDefined
+      object B extends js.Object
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: Only static objects may export their members to the top level
+      |      @JSExportTopLevel("Foo")
+      |       ^
+    """
+
+    """
+    class A {
+      @JSExportTopLevel("Foo")
+      @ScalaJSDefined
+      class B extends js.Object
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: Only static objects may export their members to the top level
+      |      @JSExportTopLevel("Foo")
+      |       ^
+    """
+
+    """
+    class A {
+      @JSExportTopLevel("Foo")
+      class B
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: Only static objects may export their members to the top level
+      |      @JSExportTopLevel("Foo")
+      |       ^
     """
   }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Infos.scala
@@ -314,7 +314,7 @@ object Infos {
       case constructorDef: ConstructorExportDef =>
         builder.setIsExported(true)
         exportedConstructors ::= constructorDef
-      case _:JSClassExportDef | _:ModuleExportDef =>
+      case _:JSClassExportDef | _:ModuleExportDef | _:TopLevelModuleExportDef =>
         builder.setIsExported(true)
       case topLevelMethodExport: TopLevelMethodExportDef =>
         builder.setIsExported(true)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -867,6 +867,11 @@ object Printers {
           printEscapeJS(fullName, out)
           print('\"')
 
+        case TopLevelModuleExportDef(fullName) =>
+          print("export top module \"")
+          printEscapeJS(fullName, out)
+          print('\"')
+
         case TopLevelMethodExportDef(methodDef) =>
           print("export top ")
           print(methodDef)

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -466,6 +466,10 @@ object Serializers {
           writeByte(TagModuleExportDef)
           writeString(fullName)
 
+        case TopLevelModuleExportDef(fullName) =>
+          writeByte(TagTopLevelModuleExportDef)
+          writeString(fullName)
+
         case TopLevelMethodExportDef(methodDef) =>
           writeByte(TagTopLevelMethodExportDef)
           writeTree(methodDef)
@@ -902,6 +906,7 @@ object Serializers {
 
         case TagJSClassExportDef        => JSClassExportDef(readString())
         case TagModuleExportDef         => ModuleExportDef(readString())
+        case TagTopLevelModuleExportDef => TopLevelModuleExportDef(readString())
         case TagTopLevelMethodExportDef => TopLevelMethodExportDef(readTree().asInstanceOf[MethodDef])
         case TagTopLevelFieldExportDef  => TopLevelFieldExportDef(readString(), readIdent())
       }

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -107,6 +107,7 @@ private[ir] object Tags {
   final val TagTopLevelMethodExportDef = TagTryFinally + 1
   final val TagSelectStatic = TagTopLevelMethodExportDef + 1
   final val TagTopLevelFieldExportDef = TagSelectStatic + 1
+  final val TagTopLevelModuleExportDef = TagTopLevelFieldExportDef + 1
 
   // Tags for Types
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -229,7 +229,8 @@ object Transformers {
         case ConstructorExportDef(fullName, args, body) =>
           ConstructorExportDef(fullName, args, transformStat(body))
 
-        case _:JSClassExportDef | _:ModuleExportDef | _:TopLevelFieldExportDef =>
+        case _:JSClassExportDef | _:ModuleExportDef |
+            _:TopLevelModuleExportDef | _:TopLevelFieldExportDef =>
           tree
 
         case TopLevelMethodExportDef(methodDef) =>

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -212,7 +212,8 @@ object Traversers {
       case _:Skip | _:Continue | _:Debugger | _:LoadModule | _:SelectStatic |
           _:LoadJSConstructor | _:LoadJSModule | _:JSLinkingInfo | _:Literal |
           _:UndefinedParam | _:VarRef | _:This | _:FieldDef |
-          _:JSClassExportDef | _:ModuleExportDef | _:TopLevelFieldExportDef =>
+          _:JSClassExportDef | _:ModuleExportDef | _:TopLevelModuleExportDef |
+          _:TopLevelFieldExportDef =>
 
       case _ =>
         sys.error(s"Invalid tree in traverse() of class ${tree.getClass}")

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -809,7 +809,25 @@ object Trees {
     val tpe = NoType
   }
 
+  /** Traditional `@JSExport` for top-level objects, as a 0-arg function.
+   *
+   *  This exports a module as a 0-arg function that returns the module
+   *  instance. It is initialized lazily in that case.
+   *
+   *  This alternative should eventually disappear.
+   */
   case class ModuleExportDef(fullName: String)(
+      implicit val pos: Position) extends Tree {
+    val tpe = NoType
+  }
+
+  /** New-style `@JSExportTopLevel` for top-level objects, directly as the
+   *  object.
+   *
+   *  This exports a module directly as a variable holding the module instance.
+   *  The instance is initialized during ES module instantiation.
+   */
+  case class TopLevelModuleExportDef(fullName: String)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType
   }

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -1073,6 +1073,12 @@ class PrintersTest {
         ModuleExportDef("pkg.Foo"))
   }
 
+  @Test def printTopLevelModuleExportDef(): Unit = {
+    assertPrintEquals(
+        """export top module "pkg.Foo"""",
+        TopLevelModuleExportDef("pkg.Foo"))
+  }
+
   @Test def printTopLevelMethodExportDef(): Unit = {
     assertPrintEquals(
         """

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -651,6 +651,13 @@ class ExportsTest {
     assertEquals("witness", obj.witness)
   }
 
+  @Test def toplevel_exports_for_objects(): Unit = {
+    val obj = exportsNamespace.TopLevelExportedObject
+    assertJSNotUndefined(obj)
+    assertEquals("object", js.typeOf(obj))
+    assertEquals("witness", obj.witness)
+  }
+
   @Test def exports_for_Scala_js_defined_JS_objects_with_explicit_name(): Unit = {
     val accessor = exportsNamespace.TheSJSDefinedExportedObject
     assertJSNotUndefined(accessor)
@@ -661,11 +668,28 @@ class ExportsTest {
     assertEquals("witness", obj.witness)
   }
 
+  @Test def toplevel_exports_for_Scala_js_defined_JS_objects(): Unit = {
+    val obj1 = exportsNamespace.SJSDefinedTopLevelExportedObject
+    assertJSNotUndefined(obj1)
+    assertEquals("object", js.typeOf(obj1))
+    assertEquals("witness", obj1.witness)
+
+    val obj2 = exportsNamespace.TheSJSDefinedTopLevelExportedObject
+    assertSame(obj1, obj2)
+  }
+
   @Test def exports_for_objects_with_qualified_name(): Unit = {
     val accessor = exportsNamespace.qualified.testobject.ExportedObject
     assertJSNotUndefined(accessor)
     assertEquals("function", js.typeOf(accessor))
     val obj = accessor()
+    assertJSNotUndefined(obj)
+    assertEquals("object", js.typeOf(obj))
+    assertEquals("witness", obj.witness)
+  }
+
+  @Test def toplevel_exports_for_objects_with_qualified_name(): Unit = {
+    val obj = exportsNamespace.qualified.testobject.TopLevelExportedObject
     assertJSNotUndefined(obj)
     assertEquals("object", js.typeOf(obj))
     assertEquals("witness", obj.witness)
@@ -679,6 +703,13 @@ class ExportsTest {
     assertJSNotUndefined(obj)
     assertEquals("object", js.typeOf(obj))
     assertSame(obj, ExportHolder.ExportedObject)
+  }
+
+  @Test def toplevel_exports_for_nested_objects(): Unit = {
+    val obj = exportsNamespace.qualified.nested.TopLevelExportedObject
+    assertJSNotUndefined(obj)
+    assertEquals("object", js.typeOf(obj))
+    assertSame(obj, ExportHolder.TopLevelExportedObject)
   }
 
   @Test def exports_for_objects_with_constant_folded_name(): Unit = {
@@ -726,6 +757,14 @@ class ExportsTest {
     assertEquals(5, obj.x)
   }
 
+  @Test def toplevel_exports_for_classes(): Unit = {
+    val constr = exportsNamespace.TopLevelExportedClass
+    assertJSNotUndefined(constr)
+    assertEquals("function", js.typeOf(constr))
+    val obj = js.Dynamic.newInstance(constr)(5)
+    assertEquals(5, obj.x)
+  }
+
   @Test def exports_for_Scala_js_defined_JS_classes_with_explicit_name(): Unit = {
     val constr = exportsNamespace.TheSJSDefinedExportedClass
     assertJSNotUndefined(constr)
@@ -735,8 +774,28 @@ class ExportsTest {
     assertEquals(5, obj.x)
   }
 
+  @Test def toplevel_exports_for_Scala_js_defined_JS_classes(): Unit = {
+    val constr = exportsNamespace.SJSDefinedTopLevelExportedClass
+    assertJSNotUndefined(constr)
+    assertEquals("function", js.typeOf(constr))
+    val obj = js.Dynamic.newInstance(constr)(5)
+    assertTrue((obj: Any).isInstanceOf[SJSDefinedTopLevelExportedClass])
+    assertEquals(5, obj.x)
+
+    val constr2 = exportsNamespace.TheSJSDefinedTopLevelExportedClass
+    assertSame(constr, constr2)
+  }
+
   @Test def exports_for_classes_with_qualified_name_ExportedClass(): Unit = {
     val constr = exportsNamespace.qualified.testclass.ExportedClass
+    assertJSNotUndefined(constr)
+    assertEquals("function", js.typeOf(constr))
+    val obj = js.Dynamic.newInstance(constr)(5)
+    assertEquals(5, obj.x)
+  }
+
+  @Test def toplevel_exports_for_classes_with_qualified_name(): Unit = {
+    val constr = exportsNamespace.qualified.testclass.TopLevelExportedClass
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)(5)
@@ -749,6 +808,14 @@ class ExportsTest {
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)()
     assertTrue((obj: Any).isInstanceOf[ExportHolder.ExportedClass])
+  }
+
+  @Test def toplevel_exports_for_nested_classes(): Unit = {
+    val constr = exportsNamespace.qualified.nested.TopLevelExportedClass
+    assertJSNotUndefined(constr)
+    assertEquals("function", js.typeOf(constr))
+    val obj = js.Dynamic.newInstance(constr)()
+    assertTrue((obj: Any).isInstanceOf[ExportHolder.TopLevelExportedClass])
   }
 
   @Test def exports_for_classes_with_qualified_name_SJSDefinedExportedClass(): Unit = {
@@ -1597,11 +1664,25 @@ object ExportedObject {
   def witness: String = "witness"
 }
 
+@JSExportTopLevel("TopLevelExportedObject")
+@JSExportTopLevel("qualified.testobject.TopLevelExportedObject")
+object TopLevelExportedObject {
+  @JSExport
+  val witness: String = "witness"
+}
+
 @JSExport
 @JSExport("TheSJSDefinedExportedObject")
 @ScalaJSDefined
 object SJSDefinedExportedObject extends js.Object {
   def witness: String = "witness"
+}
+
+@JSExportTopLevel("SJSDefinedTopLevelExportedObject")
+@JSExportTopLevel("TheSJSDefinedTopLevelExportedObject")
+@ScalaJSDefined
+object SJSDefinedTopLevelExportedObject extends js.Object {
+  val witness: String = "witness"
 }
 
 @JSExport
@@ -1619,11 +1700,23 @@ class ExportedClass(_x: Int) {
   val x = _x
 }
 
+@JSExportTopLevel("TopLevelExportedClass")
+@JSExportTopLevel("qualified.testclass.TopLevelExportedClass")
+class TopLevelExportedClass(_x: Int) {
+  @JSExport
+  val x = _x
+}
+
 @JSExport
 @JSExport("TheSJSDefinedExportedClass")
 @JSExport("qualified.testclass.SJSDefinedExportedClass")
 @ScalaJSDefined
 class SJSDefinedExportedClass(val x: Int) extends js.Object
+
+@JSExportTopLevel("SJSDefinedTopLevelExportedClass")
+@JSExportTopLevel("TheSJSDefinedTopLevelExportedClass")
+@ScalaJSDefined
+class SJSDefinedTopLevelExportedClass(val x: Int) extends js.Object
 
 @JSExport
 protected class ProtectedExportedClass(_x: Int) {
@@ -1759,8 +1852,14 @@ object ExportHolder {
   @JSExport("qualified.nested.ExportedClass")
   class ExportedClass
 
+  @JSExportTopLevel("qualified.nested.TopLevelExportedClass")
+  class TopLevelExportedClass
+
   @JSExport("qualified.nested.ExportedObject")
   object ExportedObject
+
+  @JSExportTopLevel("qualified.nested.TopLevelExportedObject")
+  object TopLevelExportedObject
 
   @JSExport("qualified.nested.SJSDefinedExportedClass")
   @ScalaJSDefined

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -160,14 +160,17 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
         implicit val ctx = ErrorContext(tree)
 
         tree match {
-          case member @ ConstructorExportDef(_, _, _) =>
-            checkConstructorExportDef(member, classDef)
+          case tree: ConstructorExportDef =>
+            checkConstructorExportDef(tree, classDef)
 
-          case member @ JSClassExportDef(_) =>
-            checkJSClassExportDef(member, classDef)
+          case tree: JSClassExportDef =>
+            checkJSClassExportDef(tree, classDef)
 
-          case member @ ModuleExportDef(_) =>
-            checkModuleExportDef(member, classDef)
+          case tree: ModuleExportDef =>
+            checkModuleExportDef(tree, classDef)
+
+          case tree: TopLevelModuleExportDef =>
+            checkTopLevelModuleExportDef(tree, classDef)
 
           case TopLevelMethodExportDef(methodDef) =>
             checkExportedMethodDef(methodDef, classDef, isTopLevel = true)
@@ -461,6 +464,17 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
 
     if (!classDef.kind.hasModuleAccessor)
       reportError(s"Exported module def can only appear in a module class")
+  }
+
+  private def checkTopLevelModuleExportDef(
+      topLevelModuleDef: TopLevelModuleExportDef,
+      classDef: LinkedClass): Unit = {
+    implicit val ctx = ErrorContext(topLevelModuleDef)
+
+    if (!classDef.kind.hasModuleAccessor) {
+      reportError(
+          "Top-level module export def can only appear in a module class")
+    }
   }
 
   private def typecheckStat(tree: Tree, env: Env): Env = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -256,6 +256,9 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel, considerPositions
       case e: ModuleExportDef =>
         classExports += e
 
+      case e: TopLevelModuleExportDef =>
+        classExports += e
+
       case e: TopLevelMethodExportDef =>
         classExports += e
 


### PR DESCRIPTION
This commit implements the Proposal #2734. The annotation `@JSExportTopLevel` can now be used on static classes and objects (both Scala classes/objects and Scala.js-defined JS classes/objects) to export them at the top-level.

For objects, the difference wrt. `@JSExport` is that the module instance itself is exported, rather than the module accessor.

For classes, this is equivalent to exporting them via `@JSExport`. We include the possibility to be consistent with objects, and with the prospect of deprecating and removing `@JSExport` on classes and objects altogether.