### PR TITLE
Fix #2265 and #2741: Look for repeated args in all parameter lists.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/util/JSASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/util/JSASTTest.scala
@@ -97,13 +97,15 @@ abstract class JSASTTest extends DirectTest {
 
   def stringAST(code: String): JSAST = stringAST(defaultGlobal)(code)
   def stringAST(global: Global)(code: String): JSAST = {
-    compileString(global)(code)
+    if (!compileString(global)(code))
+      throw new IllegalArgumentException("snippet did not compile")
     lastAST
   }
 
   def sourceAST(source: SourceFile): JSAST = sourceAST(defaultGlobal)(source)
   def sourceAST(global: Global)(source: SourceFile): JSAST = {
-    compileSources(global)(source)
+    if (!compileSources(global)(source))
+      throw new IllegalArgumentException("snippet did not compile")
     lastAST
   }
 


### PR DESCRIPTION
Usually, in the compiler back-end, we use `methodTpe.params` to read the list of all parameters. This works because multiple parameter lists are flattened. The code that optimizes varargs as `new js.WrappedArray(js.Array(...))` was reading parameters right after `typer` in the type history. It has to use `.paramss.flatten` in that case, because `.params` represents only the first parameter list.