### PR TITLE
Fix #2532: Emit "private" field access for Java-defined fields.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
@@ -67,4 +67,41 @@ class ByteArrayOutputStreamTest {
     assertArrayEquals(Array[Byte](0, 1, 2, 3, 4, 5, 6, 7, 8, 9), out.toByteArray)
   }
 
+  @Test def buf_field(): Unit = {
+    class ByteArrayOutputStreamWithBufAccess extends ByteArrayOutputStream {
+      def getBuf(): Array[Byte] = buf
+      def setBuf(b: Array[Byte]): Unit = buf = b
+    }
+
+    val os = new ByteArrayOutputStreamWithBufAccess
+    os.write(5.toInt)
+    os.flush()
+    assertEquals(5.toByte, os.getBuf()(0))
+
+    val newBuf = Array(10.toByte)
+    os.setBuf(newBuf)
+    assertSame(newBuf, os.getBuf())
+    val output = os.toByteArray()
+    assertArrayEquals(newBuf, output)
+    assertNotSame(newBuf, output)
+  }
+
+  @Test def count_field(): Unit = {
+    class ByteArrayOutputStreamWithCountAccess extends ByteArrayOutputStream {
+      def getCount(): Int = count
+      def setCount(c: Int): Unit = count = c
+    }
+
+    val os = new ByteArrayOutputStreamWithCountAccess
+    os.write(Array[Byte](5, 7, 10, 15, 25, -4))
+    os.flush()
+    assertEquals(6, os.getCount())
+    assertArrayEquals(Array[Byte](5, 7, 10, 15, 25, -4), os.toByteArray())
+
+    os.setCount(3)
+    assertEquals(3, os.getCount())
+    assertEquals(3, os.size())
+    assertArrayEquals(Array[Byte](5, 7, 10), os.toByteArray())
+  }
+
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/EventObjectTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/EventObjectTest.scala
@@ -19,7 +19,6 @@ class EventObjectTest {
     assertSame(src, e.getSource)
   }
 
-  /* #2532 This does not link, because we cannot declare a Java field
   @Test def sourceField(): Unit = {
     class E(s: AnyRef) extends EventObject(s) {
       def setSource(s: AnyRef): Unit = source = s
@@ -35,7 +34,6 @@ class EventObjectTest {
     assertSame(src2, e.otherGetSource)
     assertSame(src2, e.getSource)
   }
-  */
 
   @Test def testToString(): Unit = {
     /* There is not much we can test about toString, but it should not be the


### PR DESCRIPTION
Java-defined fields are now always accessed as if they were private. This is necessary because they are defined as private by our .scala source files, but they are considered `!isPrivate` at use site, since their symbols come from Java-emitted .class files. Fortunately, we can easily detect those as `isJavaDefined`.

This includes fields of Ref types (IntRef, ObjectRef, etc.) which were previously special-cased at use-site. This commit generalizes the idea to all fields that are Java-defined (as per the .class files).

This also fixes #2737, which was directly caused by #2532.