### PR TITLE
Fix #2752: Survive in `test` if there is no testing framework.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -57,6 +57,7 @@
     sbtretry 'set inScope(ThisScope in testingExample)(jsEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
         'set scalaJSOptimizerOptions in testingExample ~= (_.withDisableOptimizer(true))' \
         ++$scala testingExample/test:run testingExample/test &&
+    sbtretry ++$scala library/test &&
     sbtretry ++$scala testSuiteJVM/test testSuiteJVM/clean &&
     sbtretry ++$scala 'testSuite/test:runMain org.scalajs.testsuite.junit.JUnitBootstrapTest' &&
     sbtretry ++$scala testSuite/test &&

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
@@ -39,9 +39,25 @@ private[sbtplugin] final class FrameworkDetector(jsEnv: JSEnv,
       (function(exportsNamespace) {
         "use strict";
 
+        /* #2752: if there is no testing framework at all on the classpath,
+         * the testing interface will not be there, and therefore the
+         * `detectFrameworks` function will not exist. We must therefore be
+         * careful when selecting it.
+         */
+        var namespace = exportsNamespace;
+        namespace = namespace.org || {};
+        namespace = namespace.scalajs || {};
+        namespace = namespace.testinterface || {};
+        namespace = namespace.internal || {};
+        var detectFrameworksFun = namespace.detectFrameworks || (function(data) {
+          var results = [];
+          for (var i = 0; i < data.length; ++i)
+            results.push(void 0);
+          return results;
+        });
+
         var data = ${jsonToString(data)};
-        var results =
-          exportsNamespace.org.scalajs.testinterface.internal.detectFrameworks(data);
+        var results = detectFrameworksFun(data);
         for (var i = 0; i < results.length; ++i) {
           console.log("$ConsoleFrameworkPrefix" + (results[i] || ""));
         }


### PR DESCRIPTION
The `test` task should trivially succeed if there is no testing framework on the classpath. However, f46050f245bed6c318e2f2855a811ea6afb5d0cd broke this scenario, by requiring an export from the testing interface to be present.

This commit fixes the scenario to tolerate the absence of that export. In that case, no candidate testing framework is reported to be available.

We add `library/test` to the CI matrix as a test for this scenario, as the `library` project does not and will not contain any tests.