### PR TITLE
Fix #2762: Remove obsolete Node.js flags for rest and spread.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -143,46 +143,46 @@
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in noIrCheckTest := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in noIrCheckTest := NodeJSEnv().value.withSourceMap(false)' \
         ++$scala noIrCheckTest/test \
         noIrCheckTest/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv(args = ES6NodeArgs).value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -42,7 +42,6 @@ import sbtassembly.AssemblyPlugin.autoImport._
 object ExposedValues extends AutoPlugin {
   object autoImport {
     val makeCompliant = Build.makeCompliant
-    val ES6NodeArgs = Build.ES6NodeArgs
   }
 }
 
@@ -81,9 +80,6 @@ object Build {
       .withModuleInit(CheckedBehavior.Compliant)
       .withStrictFloats(true)
   }
-
-  // set postLinkJSEnv in someProject := NodeJSEnv(args = ES6NodeArgs).value
-  val ES6NodeArgs = Seq("--harmony-rest-parameters", "--harmony-spreadcalls")
 
   private def includeIf(testDir: File, condition: Boolean): List[File] =
     if (condition) List(testDir)


### PR DESCRIPTION
Node.js 6.x, which is now installed in the CI servers, does not support the `--harmony-rest-parameters` and `--harmony-spreadcalls` flags anymore. Instead, it supports those features by default.

This commit removes those flags when running with Node.js. This fixes the issue if a recent Node.js is used.

Caveat: this fix will *break* runs in ES6 mode with an older Node.js. I do not see an easy way to correctly run on both old and new versions. Since this is an internal issue anyway, I don't think it's worth complicating the build with logic to detect the version of Node.js or whatnot.