### PR TITLE
Fix #2758: Add `UndefOr.contains` to mimic `Option.contains`.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/UndefOr.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOr.scala
@@ -158,6 +158,18 @@ final class UndefOrOps[A](val self: UndefOr[A]) extends AnyVal {
   @inline final def withFilter(p: A => Boolean): WithFilter[A] =
     new WithFilter(self, p)
 
+  /** Tests whether the $option contains a given value as an element.
+   *
+   *  `x.contains(y)` differs from `x == y` only in the fact that it will
+   *  return `false` when `x` and `y` are both `undefined`.
+   *
+   *  @param elem the element to test.
+   *  @return `true` if the $option has an element that is equal (as
+   *  determined by `==`) to `elem`, `false` otherwise.
+   */
+  @inline final def contains[A1 >: A](elem: A1): Boolean =
+    !isEmpty && elem == this.forceGet
+
   /** Returns true if this option is nonempty '''and''' the predicate
    *  `p` returns true when applied to this $option's value.
    *  Otherwise, returns false.

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
@@ -111,6 +111,14 @@ class UndefOrTest {
     assertFalse(none[Int].filterNot(_ > 0).isDefined)
   }
 
+  @Test def contains(): Unit = {
+    assertTrue(some(7).contains(7))
+    assertFalse(some(7).contains(8))
+    assertFalse(none[Int].contains(7))
+
+    assertFalse(some(()).contains(()))
+  }
+
   @Test def exists(): Unit = {
     assertTrue(some(7).exists(_ > 0))
     assertFalse(some(7).exists(_ < 0))


### PR DESCRIPTION
`Option.contains` was added in Scala 2.11.0. This commit adds an equivalent method to `UndefOr`.