### PR TITLE
Fix #2755: Fix array out of bounds in BigDecimal.divide(scale).

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -497,6 +497,14 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), newScale)
   }
 
+  @Test def testDivideBigDecimalScale_issue2755(): Unit = {
+    val a = new BigDecimal(2L)
+    val b = new BigDecimal(1L)
+    val r = a.divide(b, 1, RoundingMode.UNNECESSARY)
+    assertEquals(1, r.scale())
+    assertEquals(2L, r.longValueExact())
+  }
+
   @Test def testDivideByZero(): Unit = {
     val a = "1231212478987482988429808779810457634781384756794987"
     val aScale = 15


### PR DESCRIPTION
There were computations based on `LongTenPows` that would access indices before testing whether they are valid or not. The fix is to delay those accesses after we've made sure that indices are valid.

In the process, I have rearranged the computation of `diffScale` to convert it to an `Int` earlier, avoid some useless `Long` operations.