### PR TITLE
Implement System.lineSeparator().

### DIFF
--- a/javalanglib/src/main/scala/java/lang/System.scala
+++ b/javalanglib/src/main/scala/java/lang/System.scala
@@ -245,6 +245,8 @@ object System {
   def getProperties(): ju.Properties =
     SystemProperties.value
 
+  def lineSeparator(): String = "\n"
+
   def setProperties(properties: ju.Properties): Unit = {
     SystemProperties.value =
       if (properties != null) properties

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/SystemTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/SystemTestOnJDK7.scala
@@ -1,0 +1,24 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.javalib.lang
+
+import org.scalajs.testsuite.utils.Platform._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class SystemTestOnJDK7 {
+  @Test def lineSeparator(): Unit = {
+    val lineSep = System.lineSeparator()
+
+    if (!executingInJVM)
+      assertEquals("\n", lineSep)
+    else
+      assertTrue(Set("\n", "\r", "\r\n").contains(lineSep))
+  }
+}


### PR DESCRIPTION
This is a JDK7 API. In Scala.js, it trivially returns `"\n"`.

scala/scala is deprecating `scala.compat.Platform.lineSeparator`, and encourages people to use `System.lineSeparator()` instead. So we need to support it :p See https://github.com/scala/scala/pull/5677