### PR TITLE
Deprecate top-level @JSExport, and @JSExportDescendent{Classes,Objects}.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -353,6 +353,9 @@ abstract class PrepJSInterop extends plugins.PluginComponent
         case _ => super.transform(tree)
       }
 
+      if (tree.isInstanceOf[ImplDef])
+        checkDeprecationOfJSExportDescendentClassesObjects(tree.symbol)
+
       postTransform(preTransformedTree)
     }
 

--- a/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSOptions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSOptions.scala
@@ -19,6 +19,9 @@ trait ScalaJSOptions {
    *  If false, bad calls to classOf will cause an error. */
   def fixClassOf: Boolean
 
+  /** Should we suppress deprecations of exports coming from 0.6.15? */
+  def suppressExportDeprecations: Boolean
+
   /** which source locations in source maps should be relativized (or where
    *  should they be mapped to)? */
   def sourceURIMaps: List[URIMap]

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala
@@ -1,0 +1,105 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+class JSExportDeprecationsTest extends DirectTest with TestHelpers {
+
+  override def extraArgs: List[String] =
+    super.extraArgs :+ "-deprecation"
+
+  override def preamble: String =
+    """import scala.scalajs.js, js.annotation._
+    """
+
+  @Test
+  def warnJSExportClass: Unit = {
+    """
+    @JSExport
+    class A
+
+    @JSExport("Foo")
+    class B
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: @JSExport on classes is deprecated and will be removed in 1.0.0. Use @JSExportTopLevel instead (which does exactly the same thing on classes).
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |    @JSExport
+      |     ^
+      |newSource1.scala:6: warning: @JSExport on classes is deprecated and will be removed in 1.0.0. Use @JSExportTopLevel instead (which does exactly the same thing on classes).
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |    @JSExport("Foo")
+      |     ^
+    """
+  }
+
+  @Test
+  def warnJSExportObject: Unit = {
+    """
+    @JSExport
+    object A
+
+    @JSExport("Foo")
+    object B
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: @JSExport on objects is deprecated and will be removed in 1.0.0. Use @JSExportTopLevel instead. Note that it exports the object itself (rather than a 0-arg function returning the object), so the calling JavaScript code must be adapted.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |    @JSExport
+      |     ^
+      |newSource1.scala:6: warning: @JSExport on objects is deprecated and will be removed in 1.0.0. Use @JSExportTopLevel instead. Note that it exports the object itself (rather than a 0-arg function returning the object), so the calling JavaScript code must be adapted.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |    @JSExport("Foo")
+      |     ^
+    """
+  }
+
+  @Test
+  def warnJSExportDescendentClasses: Unit = {
+    for (kind <- Seq("class", "trait", "object")) {
+      s"""
+      @JSExportDescendentClasses
+      $kind A
+
+      @JSExportDescendentClasses(ignoreInvalidDescendants = true)
+      $kind B
+      """ hasWarns
+      """
+        |newSource1.scala:3: warning: @JSExportDescendentClasses is deprecated and will be removed in 1.0.0. For use cases where you want to simulate "reflective" instantiation, use @EnableReflectiveInstantion and scala.scalajs.reflect.Reflect.lookupInstantiatableClass instead.
+        |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+        |      @JSExportDescendentClasses
+        |       ^
+        |newSource1.scala:6: warning: @JSExportDescendentClasses is deprecated and will be removed in 1.0.0. For use cases where you want to simulate "reflective" instantiation, use @EnableReflectiveInstantion and scala.scalajs.reflect.Reflect.lookupInstantiatableClass instead.
+        |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+        |      @JSExportDescendentClasses(ignoreInvalidDescendants = true)
+        |       ^
+      """
+    }
+  }
+
+  @Test
+  def warnJSExportDescendentObjects: Unit = {
+    for (kind <- Seq("class", "trait", "object")) {
+      s"""
+      @JSExportDescendentObjects
+      $kind A
+
+      @JSExportDescendentObjects(ignoreInvalidDescendants = true)
+      $kind B
+      """ hasWarns
+      """
+        |newSource1.scala:3: warning: @JSExportDescendentObjects is deprecated and will be removed in 1.0.0. For use cases where you want to simulate "reflective" loading, use @EnableReflectiveInstantion and scala.scalajs.reflect.Reflect.lookupLoadableModuleClass instead.
+        |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+        |      @JSExportDescendentObjects
+        |       ^
+        |newSource1.scala:6: warning: @JSExportDescendentObjects is deprecated and will be removed in 1.0.0. For use cases where you want to simulate "reflective" loading, use @EnableReflectiveInstantion and scala.scalajs.reflect.Reflect.lookupLoadableModuleClass instead.
+        |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+        |      @JSExportDescendentObjects(ignoreInvalidDescendants = true)
+        |       ^
+      """
+    }
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -8,7 +8,7 @@ import org.junit.Test
 class JSExportTest extends DirectTest with TestHelpers {
 
   override def extraArgs: List[String] =
-    super.extraArgs :+ "-deprecation"
+    super.extraArgs ::: List("-deprecation", "-P:scalajs:suppressExportDeprecations")
 
   override def preamble: String =
     """import scala.scalajs.js, js.annotation._

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -9,6 +9,9 @@ import org.junit.Ignore
 
 class ScalaJSDefinedTest extends DirectTest with TestHelpers {
 
+  override def extraArgs: List[String] =
+    super.extraArgs :+ "-P:scalajs:suppressExportDeprecations"
+
   override def preamble: String =
     """
     import scala.scalajs.js

--- a/examples/reversi/Reversi.scala
+++ b/examples/reversi/Reversi.scala
@@ -7,7 +7,7 @@ package reversi
 
 import scala.annotation.tailrec
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation._
 
 sealed abstract class OptPlayer
 
@@ -25,7 +25,7 @@ case object Black extends Player {
   val opponent = White
 }
 
-@JSExport("Reversi")
+@JSExportTopLevel("Reversi")
 class Reversi(jQuery: JQueryStatic, playground: JQuery) {
 
   // The Model -----------------------------------------------------------------

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/InfoSender.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/InfoSender.scala
@@ -3,9 +3,9 @@ package org.scalajs.testinterface.internal
 import scala.scalajs.js
 import js.Dynamic.{literal => lit}
 import js.JSConverters._
-import js.annotation.JSExport
+import js.annotation._
 
-@JSExport
+@JSExportTopLevel("org.scalajs.testinterface.internal.InfoSender")
 final class InfoSender(frameworkName: String) {
 
   @JSExport

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/Master.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/Master.scala
@@ -2,7 +2,7 @@ package org.scalajs.testinterface.internal
 
 import scala.scalajs.js
 import js.Dynamic.{literal => lit}
-import js.annotation.JSExport
+import js.annotation._
 
 import sbt.testing._
 
@@ -10,7 +10,7 @@ import scala.util.Try
 
 import org.scalajs.testinterface.ScalaJSClassLoader
 
-@JSExport
+@JSExportTopLevel("org.scalajs.testinterface.internal.Master")
 final class Master(frameworkName: String) extends BridgeBase(frameworkName) {
 
   private[this] var runner: Runner = _

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/Slave.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/Slave.scala
@@ -1,7 +1,7 @@
 package org.scalajs.testinterface.internal
 
 import scala.scalajs.js
-import js.annotation.JSExport
+import js.annotation._
 
 import sbt.testing._
 
@@ -12,7 +12,7 @@ import scala.util.{Try, Success, Failure}
 
 import org.scalajs.testinterface.ScalaJSClassLoader
 
-@JSExport
+@JSExportTopLevel("org.scalajs.testinterface.internal.Slave")
 final class Slave(frameworkName: String, args: js.Array[String],
     remoteArgs: js.Array[String]) extends BridgeBase(frameworkName) {
 

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -7,9 +7,9 @@ import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.logging._
 import org.scalajs.core.tools.linker.Linker
 
-import scala.scalajs.js.annotation.JSExport
+import scala.scalajs.js.annotation._
 
-@JSExport("scalajs.QuickLinker")
+@JSExportTopLevel("scalajs.QuickLinker")
 object QuickLinker {
 
   /** Link a Scala.js application on Node.js */

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
@@ -1,13 +1,13 @@
 package org.scalajs.core.tools.test.js
 
 import scala.scalajs.js
-import js.annotation.JSExport
+import scala.scalajs.js.annotation._
 
 import org.scalajs.testinterface.{ScalaJSClassLoader, TestDetector}
 
 import sbt.testing._
 
-@JSExport("scalajs.TestRunner")
+@JSExportTopLevel("scalajs.TestRunner")
 object TestRunner {
 
   @JSExport


### PR DESCRIPTION
Top-level `@JSExport`s (on classes and objects) should be replaced by `@JSExportTopLevel`. For objects, this is a change of semantics, as the object itself is exported, rather than a 0-arg function returning the object. It is still possible to achieve the same behavior as before by explicitly exporting a 0-arg method returning the object with `@JSExportTopLevel`, so we do not lose any expressiveness.

`@JSExportDescendentClasses` and `@JSExportDescendentObjects` should not have any use cases left, now that reflective instantiation and module loading is properly supported through `@EnableReflectiveInstantiation` and `scala.scalajs.reflect.Reflect`.