### PR TITLE
Add facades for ES6 Iterator and Iterable

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala/scala/scalajs/js/Any.scala
@@ -176,9 +176,14 @@ object Any extends LowPrioAnyImplicits {
     value.asInstanceOf[Any]
 }
 
-trait LowPrioAnyImplicits {
+trait LowPrioAnyImplicits extends LowestPrioAnyImplicits {
   implicit def wrapArray[A](array: Array[A]): WrappedArray[A] =
     new WrappedArray(array)
   implicit def wrapDictionary[A](dict: Dictionary[A]): WrappedDictionary[A] =
     new WrappedDictionary(dict)
+}
+
+sealed trait LowestPrioAnyImplicits {
+  implicit def iterableOps[A](iterable: Iterable[A]): IterableOps[A] =
+    new IterableOps(iterable)
 }

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -37,7 +37,7 @@ import annotation._
  *  @constructor Creates a new array of length 0.
  */
 @native
-class Array[A] extends Object {
+class Array[A] extends Object with Iterable[A] {
   /** Creates a new array with the given length.
    *  @param arrayLength Initial length of the array.
    */
@@ -72,6 +72,12 @@ class Array[A] extends Object {
    * MDN
    */
   def concat[B >: A](items: Array[_ <: B]*): Array[B] = native
+
+  /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+   *  JavaScript Iterator for this Array.
+   */
+  @JSName(Symbol.iterator)
+  def jsIterator(): Iterator[A] = native
 
   /**
    * The join() method joins all elements of an array into a string.

--- a/library/src/main/scala/scala/scalajs/js/Iterable.scala
+++ b/library/src/main/scala/scala/scalajs/js/Iterable.scala
@@ -1,0 +1,23 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import js.annotation._
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Iterable.
+ */
+@ScalaJSDefined
+trait Iterable[+A] extends js.Object {
+  /** JavaScript Iterator for this Iterable. */
+  @JSName(Symbol.iterator)
+  def jsIterator(): Iterator[A]
+}

--- a/library/src/main/scala/scala/scalajs/js/IterableOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/IterableOps.scala
@@ -1,0 +1,17 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package scala.scalajs.js
+
+/** Adapts a JavaScript Iterable to a Scala Iterable */
+@inline
+final class IterableOps[+A](self: Iterable[A])
+    extends scala.collection.Iterable[A] {
+  @inline
+  def iterator: scala.collection.Iterator[A] = self.jsIterator().toIterator
+}

--- a/library/src/main/scala/scala/scalajs/js/Iterator.scala
+++ b/library/src/main/scala/scala/scalajs/js/Iterator.scala
@@ -1,0 +1,54 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import js.annotation._
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Iterator.
+ */
+@ScalaJSDefined
+trait Iterator[+A] extends js.Object {
+  def next(): Iterator.Entry[A]
+}
+
+object Iterator {
+  /** Return value of [[Iterator.next]]. */
+  @ScalaJSDefined
+  trait Entry[+A] extends js.Object {
+    /** Whether the iterator has completed. */
+    def done: Boolean
+
+    /** The current value. Reading this value is only valid if done is false. */
+    def value: A
+  }
+
+  @inline
+  private final class WrappedIterator[+A](self: Iterator[A])
+      extends scala.collection.Iterator[A] {
+    private[this] var lastEntry = self.next()
+
+    @inline
+    def hasNext: Boolean = !lastEntry.done
+
+    @inline
+    def next(): A = {
+      val value = lastEntry.value
+      lastEntry = self.next()
+      value
+    }
+  }
+
+  final implicit class IteratorOps[A](val __self: Iterator[A]) extends AnyVal {
+    @inline
+    def toIterator: scala.collection.Iterator[A] = new WrappedIterator(__self)
+  }
+}

--- a/library/src/main/scala/scala/scalajs/js/Promise.scala
+++ b/library/src/main/scala/scala/scalajs/js/Promise.scala
@@ -61,9 +61,7 @@ object Promise extends js.Object {
   /** Returns a new [[Promise]] failed with the specified `reason`. */
   def reject(reason: scala.Any): Promise[Nothing] = js.native
 
-  // TODO Use js.Iterable
-  def all[A](promises: js.Array[_ <: Promise[A]]): Promise[js.Array[A]] = js.native
+  def all[A](promises: js.Iterable[Promise[A]]): Promise[js.Array[A]] = js.native
 
-  // TODO Use js.Iterable
-  def race[A](promises: js.Array[_ <: Promise[A]]): Promise[A] = js.native
+  def race[A](promises: js.Iterable[Promise[A]]): Promise[A] = js.native
 }

--- a/library/src/main/scala/scala/scalajs/js/UndefOr.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOr.scala
@@ -220,7 +220,7 @@ final class UndefOrOps[A](val self: UndefOr[A]) extends AnyVal {
   /** Returns a singleton iterator returning the $option's value
    *  if it is nonempty, or an empty iterator if the option is empty.
    */
-  def iterator: Iterator[A] =
+  def iterator: scala.collection.Iterator[A] =
     if (isEmpty) scala.collection.Iterator.empty
     else scala.collection.Iterator.single(this.forceGet)
 

--- a/library/src/main/scala/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/WrappedDictionary.scala
@@ -57,11 +57,11 @@ class WrappedDictionary[A](val dict: Dictionary[A])
     this
   }
 
-  def iterator: Iterator[(String, A)] =
+  def iterator: scala.collection.Iterator[(String, A)] =
     new DictionaryIterator(dict)
 
   @inline
-  override def keys: Iterable[String] =
+  override def keys: scala.collection.Iterable[String] =
     Object.keys(dict.asInstanceOf[Object])
 
   override def empty: WrappedDictionary[A] =
@@ -84,7 +84,7 @@ object WrappedDictionary {
     Cache.safeHasOwnProperty(dict, key)
 
   private final class DictionaryIterator[+A](
-      dict: Dictionary[A]) extends Iterator[(String, A)] {
+      dict: Dictionary[A]) extends scala.collection.Iterator[(String, A)] {
     private[this] val keys = Object.keys(dict.asInstanceOf[Object])
     private[this] var index: Int = 0
     def hasNext(): Boolean = index < keys.length

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -142,6 +142,18 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+      // Relaxed typing (js.Iterable instead of js.Array) in js.Promise.
+      // Not a compatibility issue (due to JS land).
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "scala.scalajs.js.Promise.race"),
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "scala.scalajs.js.Promise.all"),
+
+      // New member in non-sealed trait (for low prio implicits).
+      // Theoretically breaking.
+      ProblemFilters.exclude[InheritedNewAbstractMethodProblem](
+          "scala.scalajs.js.LowestPrioAnyImplicits.iterableOps"),
+
       // New members of an @js.native trait in `runtime`, not an issue
       ProblemFilters.exclude[ReversedMissingMethodProblem](
           "scala.scalajs.runtime.LinkingInfo#Semantics.arrayIndexOutOfBounds"),

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/IterableTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/IterableTest.scala
@@ -1,0 +1,114 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{JSName, ScalaJSDefined}
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{BeforeClass, Test}
+
+object IterableTest {
+  @BeforeClass def assumeSymbolsAreSupported(): Unit = {
+    assumeTrue("Assuming JavaScript symbols are supported",
+        org.scalajs.testsuite.utils.Platform.areJSSymbolsSupported)
+  }
+
+  @ScalaJSDefined
+  private class CounterIterable(val max: Int) extends js.Iterable[Int] {
+    @JSName(js.Symbol.iterator)
+    def jsIterator(): js.Iterator[Int] = new CounterIterator(max)
+  }
+
+  @ScalaJSDefined
+  private class CounterIterator(val max: Int) extends js.Iterator[Int] {
+    private[this] var nextNum = 0
+
+    def next(): js.Iterator.Entry[Int] = {
+      if (nextNum < max) {
+        val res = new js.Iterator.Entry[Int] {
+          val done: Boolean = false
+          val value: Int = nextNum
+        }
+
+        nextNum +=1
+
+        res
+      } else {
+        new js.Iterator.Entry[Int] {
+          val done: Boolean = true
+          val value: Int = 0
+        }
+      }
+    }
+  }
+}
+
+class IterableTest {
+  import IterableTest._
+
+  def assertValue[T](expected: T, entry: js.Iterator.Entry[T]): Unit = {
+    assertFalse(entry.done)
+    assertEquals(expected, entry.value)
+  }
+
+  @Test def jsArrayIsIterable(): Unit = {
+    val iterable: js.Iterable[Int] = js.Array(1, 2, 3)
+    val it = iterable.jsIterator()
+
+    assertValue(1, it.next())
+    assertValue(2, it.next())
+    assertValue(3, it.next())
+    assertTrue(it.next().done)
+    assertTrue(it.next().done)
+  }
+
+  @Test def iterableToScala(): Unit = {
+    val jsIterable: js.Iterable[Int] = new CounterIterable(5)
+    val iterable: Iterable[Int] = jsIterable
+    assertEquals(List(0, 1, 2, 3, 4), iterable.toList)
+  }
+
+  @Test def iteratorToScala(): Unit = {
+    val jsIterator: js.Iterator[Int] = new CounterIterator(5)
+    val iterator: Iterator[Int] = jsIterator.toIterator
+    assertEquals(List(0, 1, 2, 3, 4), iterator.toList)
+  }
+
+  @Test def jsArrayToScalaViaIterable(): Unit = {
+    val jsIterable: js.Iterable[Int] = js.Array(1, 2, 3)
+    assertEquals(List(1, 2, 3), jsIterable.toList)
+  }
+
+  @Test def scalaToIterable(): Unit = {
+    import js.JSConverters._
+
+    val jsIterable: js.Iterable[String] = Iterable("a", "b", "c").toJSIterable
+    val it = jsIterable.jsIterator()
+
+    assertValue("a", it.next())
+    assertValue("b", it.next())
+    assertValue("c", it.next())
+    assertTrue(it.next().done)
+    assertTrue(it.next().done)
+  }
+
+  @Test def scalaToIterator(): Unit = {
+    import js.JSConverters._
+
+    val it = Iterator("a", "b", "c").toJSIterator
+
+    assertValue("a", it.next())
+    assertValue("b", it.next())
+    assertValue("c", it.next())
+    assertTrue(it.next().done)
+    assertTrue(it.next().done)
+  }
+
+}


### PR DESCRIPTION
Also add conversions to and from relevant Scala types. Note that these facades do not take return values into account (which are needed for full generator typing).