### PR TITLE
Demand `@JSGlobal` for non-`@JSImport` JS native classes and objects.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -67,6 +67,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSExportStaticAnnotation  = getRequiredClass("scala.scalajs.js.annotation.JSExportStatic")
     lazy val JSExportTopLevelAnnotation = getRequiredClass("scala.scalajs.js.annotation.JSExportTopLevel")
     lazy val JSImportAnnotation        = getRequiredClass("scala.scalajs.js.annotation.JSImport")
+    lazy val JSGlobalAnnotation        = getRequiredClass("scala.scalajs.js.annotation.JSGlobal")
     lazy val JSGlobalScopeAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSGlobalScope")
     lazy val ScalaJSDefinedAnnotation  = getRequiredClass("scala.scalajs.js.annotation.ScalaJSDefined")
     lazy val SJSDefinedAnonymousClassAnnotation = getRequiredClass("scala.scalajs.js.annotation.SJSDefinedAnonymousClass")

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -191,17 +191,19 @@ trait JSGlobalAddons extends JSDefinitions
      */
     def jsNameOf(sym: Symbol): JSName = {
       sym.getAnnotation(JSNameAnnotation).fold[JSName] {
-        val base = sym.unexpandedName.decoded.stripSuffix("_=")
-        val name =
-          if (!sym.isMethod) base.stripSuffix(" ")
-          else base
-        JSName.Literal(name)
+        JSName.Literal(defaultJSNameOf(sym))
       } { annotation =>
         annotation.args.head match {
           case Literal(Constant(name: String)) => JSName.Literal(name)
           case tree                            => JSName.Computed(tree.symbol)
         }
       }
+    }
+
+    def defaultJSNameOf(sym: Symbol): String = {
+      val base = sym.unexpandedName.decoded.stripSuffix("_=")
+      if (!sym.isMethod) base.stripSuffix(" ")
+      else base
     }
 
     /** Gets the fully qualified JS name of a static module Symbol compiled

--- a/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSOptions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSOptions.scala
@@ -22,6 +22,9 @@ trait ScalaJSOptions {
   /** Should we suppress deprecations of exports coming from 0.6.15? */
   def suppressExportDeprecations: Boolean
 
+  /** Should we suppress deprecations related to missing `@JSGlobal`? */
+  def suppressMissingJSGlobalDeprecations: Boolean
+
   /** which source locations in source maps should be relativized (or where
    *  should they be mapped to)? */
   def sourceURIMaps: List[URIMap]

--- a/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
@@ -45,6 +45,7 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
     import ScalaJSOptions.URIMap
     var fixClassOf: Boolean = false
     var suppressExportDeprecations: Boolean = false
+    var suppressMissingJSGlobalDeprecations: Boolean = false
     lazy val sourceURIMaps: List[URIMap] = {
       if (_sourceURIMaps.nonEmpty)
         _sourceURIMaps.reverse
@@ -115,6 +116,8 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
         }
       } else if (option == "suppressExportDeprecations") {
         suppressExportDeprecations = true
+      } else if (option == "suppressMissingJSGlobalDeprecations") {
+        suppressMissingJSGlobalDeprecations = true
       // The following options are deprecated (how do we show this to the user?)
       } else if (option.startsWith("relSourceMap:")) {
         val uriStr = option.stripPrefix("relSourceMap:")

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
@@ -58,9 +58,9 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     """
 
     """
-    @js.native class NativeJSClass extends js.Object
+    @js.native @JSGlobal class NativeJSClass extends js.Object
     @js.native trait NativeJSTrait extends js.Object
-    @js.native object NativeJSObject extends js.Object
+    @js.native @JSGlobal object NativeJSObject extends js.Object
 
     @ScalaJSDefined class JSClass extends js.Object
     @ScalaJSDefined trait JSTrait extends js.Object
@@ -145,9 +145,9 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     """
 
     """
-    @js.native class NativeJSClass extends js.Object
+    @js.native @JSGlobal class NativeJSClass extends js.Object
     @js.native trait NativeJSTrait extends js.Object
-    @js.native object NativeJSObject extends js.Object
+    @js.native @JSGlobal object NativeJSObject extends js.Object
 
     @ScalaJSDefined class JSClass extends js.Object
     @ScalaJSDefined trait JSTrait extends js.Object
@@ -212,7 +212,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     import scala.scalajs.runtime
 
     object ScalaObject
-    @js.native object NativeJSObject extends js.Object
+    @js.native @JSGlobal object NativeJSObject extends js.Object
     @ScalaJSDefined object JSObject extends js.Object
 
     object A {
@@ -239,9 +239,9 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     class ScalaClass
     trait ScalaTrait
 
-    @js.native class NativeJSClass extends js.Object
+    @js.native @JSGlobal class NativeJSClass extends js.Object
     @js.native trait NativeJSTrait extends js.Object
-    @js.native object NativeJSObject extends js.Object
+    @js.native @JSGlobal object NativeJSObject extends js.Object
 
     @ScalaJSDefined class JSClass extends js.Object
     @ScalaJSDefined trait JSTrait extends js.Object

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -577,6 +577,7 @@ class JSExportTest extends DirectTest with TestHelpers {
 
     @JSExport
     @js.native
+    @JSGlobal("Dummy")
     object A extends js.Object
     """ hasErrors
     """
@@ -603,6 +604,7 @@ class JSExportTest extends DirectTest with TestHelpers {
 
     @JSExport
     @js.native
+    @JSGlobal("Dummy")
     class A extends js.Object {
       @JSExport
       def this(x: Int) = this()
@@ -612,7 +614,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:5: error: You may not export a native JS class or object
       |    @JSExport
       |     ^
-      |newSource1.scala:8: error: You may not export a constructor of a subclass of js.Any
+      |newSource1.scala:9: error: You may not export a constructor of a subclass of js.Any
       |      @JSExport
       |       ^
     """
@@ -626,13 +628,14 @@ class JSExportTest extends DirectTest with TestHelpers {
     import scala.scalajs.js
 
     @js.native
+    @JSGlobal("Dummy")
     class A extends js.Object {
       @JSExport
       def foo: Int = js.native
     }
     """ hasErrors
     """
-      |newSource1.scala:7: error: You may not export a method of a subclass of js.Any
+      |newSource1.scala:8: error: You may not export a method of a subclass of js.Any
       |      @JSExport
       |       ^
     """
@@ -1724,13 +1727,14 @@ class JSExportTest extends DirectTest with TestHelpers {
     class StaticContainer extends js.Object
 
     @js.native
+    @JSGlobal("Dummy")
     object StaticContainer extends js.Object {
       @JSExportStatic
       def a(): Unit = js.native
     }
     """ hasErrors
     """
-      |newSource1.scala:8: error: You may not export a method of a subclass of js.Any
+      |newSource1.scala:9: error: You may not export a method of a subclass of js.Any
       |      @JSExportStatic
       |       ^
     """
@@ -1769,6 +1773,7 @@ class JSExportTest extends DirectTest with TestHelpers {
 
     """
     @js.native
+    @JSGlobal("Dummy")
     class StaticContainer extends js.Object
 
     object StaticContainer {
@@ -1777,7 +1782,7 @@ class JSExportTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:7: error: Only a static object whose companion class is a Scala.js-defined JS class may export its members as static.
+      |newSource1.scala:8: error: Only a static object whose companion class is a Scala.js-defined JS class may export its members as static.
       |      @JSExportStatic
       |       ^
     """

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala
@@ -85,6 +85,7 @@ class JSOptionalTest extends DirectTest with TestHelpers {
 
     s"""
     @js.native
+    @JSGlobal
     class A extends js.Object {
       val a: js.UndefOr[Int] = js.native
       def b: js.UndefOr[Int] = js.native
@@ -97,10 +98,10 @@ class JSOptionalTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     s"""
-      |newSource1.scala:13: error: Cannot override concrete val a: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |newSource1.scala:14: error: Cannot override concrete val a: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
       |      override val a: js.UndefOr[Int] = js.undefined
       |                   ^
-      |newSource1.scala:14: error: Cannot override concrete def b: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |newSource1.scala:15: error: Cannot override concrete def b: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
       |      override def b: js.UndefOr[Int] = js.undefined
       |                   ^
     """
@@ -113,6 +114,7 @@ class JSOptionalTest extends DirectTest with TestHelpers {
     }
 
     @js.native
+    @JSGlobal
     class B extends A
 
     @ScalaJSDefined
@@ -122,10 +124,10 @@ class JSOptionalTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     s"""
-      |newSource1.scala:16: error: Cannot override concrete val a: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |newSource1.scala:17: error: Cannot override concrete val a: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
       |      override val a: js.UndefOr[Int] = js.undefined
       |                   ^
-      |newSource1.scala:17: error: Cannot override concrete def b: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
+      |newSource1.scala:18: error: Cannot override concrete def b: scala.scalajs.js.UndefOr[Int] from A in a Scala.js-defined JS trait.
       |      override def b: js.UndefOr[Int] = js.undefined
       |                   ^
     """

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsSuppressedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsSuppressedTest.scala
@@ -1,0 +1,88 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+/* This is a copy of MissingJSGlobalDeprecationsTest, but with all the
+ * relevant deprecations suppressed. This tests the suppression mechanism.
+ */
+class MissingJSGlobalDeprecationsSuppressedTest
+    extends DirectTest with TestHelpers {
+
+  override def extraArgs: List[String] =
+    super.extraArgs :+ "-P:scalajs:suppressMissingJSGlobalDeprecations"
+
+  override def preamble: String =
+    """import scala.scalajs.js, js.annotation._
+    """
+
+  @Test
+  def noWarnNoAnnotClass: Unit = {
+    """
+    @js.native
+    class A extends js.Object
+
+    @js.native
+    abstract class B extends js.Object
+    """.hasNoWarns
+  }
+
+  @Test
+  def noWarnNoAnnotObject: Unit = {
+    """
+    @js.native
+    object A extends js.Object
+    """.hasNoWarns
+  }
+
+  @Test
+  def noWarnJSNameClass: Unit = {
+    """
+    @js.native
+    @JSName("Foo")
+    class A extends js.Object
+
+    @js.native
+    @JSName("Foo")
+    abstract class B extends js.Object
+    """.hasNoWarns
+  }
+
+  @Test
+  def noWarnJSNameObject: Unit = {
+    """
+    @js.native
+    @JSName("Foo")
+    object A extends js.Object
+    """.hasNoWarns
+  }
+
+  @Test
+  def noWarnJSNameNestedClass: Unit = {
+    """
+    object Enclosing {
+      @js.native
+      @JSName("Foo")
+      class A extends js.Object
+
+      @js.native
+      @JSName("Foo")
+      abstract class B extends js.Object
+    }
+    """.hasNoWarns
+  }
+
+  @Test
+  def noWarnJSNameNestObject: Unit = {
+    """
+    object Enclosing {
+      @js.native
+      @JSName("Foo")
+      object A extends js.Object
+    }
+    """.hasNoWarns
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsTest.scala
@@ -1,0 +1,132 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+class MissingJSGlobalDeprecationsTest extends DirectTest with TestHelpers {
+
+  override def preamble: String =
+    """import scala.scalajs.js, js.annotation._
+    """
+
+  @Test
+  def warnNoAnnotClass: Unit = {
+    """
+    @js.native
+    class A extends js.Object
+
+    @js.native
+    abstract class B extends js.Object
+    """ hasWarns
+    """
+      |newSource1.scala:4: warning: Top-level native JS classes and objects should have an @JSGlobal or @JSImport annotation. This will be enforced in 1.0.
+      |  If migrating from 0.6.14 or earlier, the equivalent behavior is an @JSGlobal without parameter.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |    class A extends js.Object
+      |          ^
+      |newSource1.scala:7: warning: Top-level native JS classes and objects should have an @JSGlobal or @JSImport annotation. This will be enforced in 1.0.
+      |  If migrating from 0.6.14 or earlier, the equivalent behavior is an @JSGlobal without parameter.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |    abstract class B extends js.Object
+      |                   ^
+    """
+  }
+
+  @Test
+  def warnNoAnnotObject: Unit = {
+    """
+    @js.native
+    object A extends js.Object
+    """ hasWarns
+    """
+      |newSource1.scala:4: warning: Top-level native JS classes and objects should have an @JSGlobal or @JSImport annotation. This will be enforced in 1.0.
+      |  If migrating from 0.6.14 or earlier, the equivalent behavior is an @JSGlobal without parameter.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |    object A extends js.Object
+      |           ^
+    """
+  }
+
+  @Test
+  def warnJSNameClass: Unit = {
+    """
+    @js.native
+    @JSName("Foo")
+    class A extends js.Object
+
+    @js.native
+    @JSName("Foo")
+    abstract class B extends js.Object
+    """ hasWarns
+    """
+      |newSource1.scala:4: warning: @JSName on top-level native JS classes and objects (or native JS classes and objects inside Scala objects) is deprecated, and should be replaced by @JSGlobal (with the same meaning). This will be enforced in 1.0.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |    @JSName("Foo")
+      |     ^
+      |newSource1.scala:8: warning: @JSName on top-level native JS classes and objects (or native JS classes and objects inside Scala objects) is deprecated, and should be replaced by @JSGlobal (with the same meaning). This will be enforced in 1.0.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |    @JSName("Foo")
+      |     ^
+    """
+  }
+
+  @Test
+  def warnJSNameObject: Unit = {
+    """
+    @js.native
+    @JSName("Foo")
+    object A extends js.Object
+    """ hasWarns
+    """
+      |newSource1.scala:4: warning: @JSName on top-level native JS classes and objects (or native JS classes and objects inside Scala objects) is deprecated, and should be replaced by @JSGlobal (with the same meaning). This will be enforced in 1.0.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |    @JSName("Foo")
+      |     ^
+    """
+  }
+
+  @Test
+  def warnJSNameNestedClass: Unit = {
+    """
+    object Enclosing {
+      @js.native
+      @JSName("Foo")
+      class A extends js.Object
+
+      @js.native
+      @JSName("Foo")
+      abstract class B extends js.Object
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:5: warning: @JSName on top-level native JS classes and objects (or native JS classes and objects inside Scala objects) is deprecated, and should be replaced by @JSGlobal (with the same meaning). This will be enforced in 1.0.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |      @JSName("Foo")
+      |       ^
+      |newSource1.scala:9: warning: @JSName on top-level native JS classes and objects (or native JS classes and objects inside Scala objects) is deprecated, and should be replaced by @JSGlobal (with the same meaning). This will be enforced in 1.0.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |      @JSName("Foo")
+      |       ^
+    """
+  }
+
+  @Test
+  def warnJSNameNestObject: Unit = {
+    """
+    object Enclosing {
+      @js.native
+      @JSName("Foo")
+      object A extends js.Object
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:5: warning: @JSName on top-level native JS classes and objects (or native JS classes and objects inside Scala objects) is deprecated, and should be replaced by @JSGlobal (with the same meaning). This will be enforced in 1.0.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressMissingJSGlobalDeprecations` to scalac)
+      |      @JSName("Foo")
+      |       ^
+    """
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ReflectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ReflectTest.scala
@@ -29,6 +29,7 @@ class ReflectTest extends DirectTest with TestHelpers {
 
     @EnableReflectiveInstantiation
     @js.native
+    @JSGlobal
     class D extends js.Object
 
     @EnableReflectiveInstantiation
@@ -37,6 +38,7 @@ class ReflectTest extends DirectTest with TestHelpers {
 
     @EnableReflectiveInstantiation
     @js.native
+    @JSGlobal
     object F extends js.Object
     """ hasErrors
     """
@@ -52,10 +54,10 @@ class ReflectTest extends DirectTest with TestHelpers {
       |newSource1.scala:16: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
       |    @EnableReflectiveInstantiation
       |     ^
-      |newSource1.scala:20: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
+      |newSource1.scala:21: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
       |    @EnableReflectiveInstantiation
       |     ^
-      |newSource1.scala:24: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
+      |newSource1.scala:25: error: @EnableReflectiveInstantiation cannot be used on types extending js.Any.
       |    @EnableReflectiveInstantiation
       |     ^
     """

--- a/examples/helloworld/HelloWorld.scala
+++ b/examples/helloworld/HelloWorld.scala
@@ -77,7 +77,7 @@ trait DOMElement extends js.Object {
 }
 
 @js.native
-@JSName("jQuery")
+@JSGlobal("jQuery")
 object JQuery extends js.Object {
   def apply(selector: String): JQuery = js.native
 }

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -37,6 +37,7 @@ import annotation._
  *  @constructor Creates a new array of length 0.
  */
 @native
+@JSGlobal
 class Array[A] extends Object with Iterable[A] {
   /** Creates a new array with the given length.
    *  @param arrayLength Initial length of the array.
@@ -169,6 +170,7 @@ class Array[A] extends Object with Iterable[A] {
 
 /** Factory for [[js.Array]] objects. */
 @native
+@JSGlobal
 object Array extends Object {
   // Do not expose this one - use new Array(len) instead
   // def apply[A](arrayLength: Int): Array[A] = native

--- a/library/src/main/scala/scala/scalajs/js/Date.scala
+++ b/library/src/main/scala/scala/scalajs/js/Date.scala
@@ -14,6 +14,8 @@
  */
 package scala.scalajs.js
 
+import scala.scalajs.js.annotation._
+
 /**
  * Creates a JavaScript Date instance that represents a single moment in time.
  * Date objects are based on a time value that is the number of milliseconds
@@ -22,6 +24,7 @@ package scala.scalajs.js
  * MDN
  */
 @native
+@JSGlobal
 class Date extends Object {
 
   def this(value: Double) = this()
@@ -188,6 +191,7 @@ class Date extends Object {
 
 /** Factory for [[js.Date]] objects. */
 @native
+@JSGlobal
 object Date extends Object {
   def apply(): String = native
 

--- a/library/src/main/scala/scala/scalajs/js/Error.scala
+++ b/library/src/main/scala/scala/scalajs/js/Error.scala
@@ -14,7 +14,10 @@
  */
 package scala.scalajs.js
 
+import scala.scalajs.js.annotation._
+
 @native
+@JSGlobal
 class Error(message0: String = "") extends Object {
   val name: String = native
   /**
@@ -26,6 +29,7 @@ class Error(message0: String = "") extends Object {
 }
 
 @native
+@JSGlobal
 object Error extends Object {
   def apply(message: String = ""): Error = native
 }
@@ -37,9 +41,11 @@ object Error extends Object {
  * MDN
  */
 @native
+@JSGlobal
 class EvalError(message: String = "") extends Error
 
 @native
+@JSGlobal
 object EvalError extends Object {
   def apply(message: String = ""): EvalError = native
 }
@@ -57,9 +63,11 @@ object EvalError extends Object {
  * MDN
  */
 @native
+@JSGlobal
 class RangeError(message: String = "") extends Error
 
 @native
+@JSGlobal
 object RangeError extends Object {
   def apply(message: String = ""): RangeError = native
 }
@@ -73,9 +81,11 @@ object RangeError extends Object {
  * MDN
  */
 @native
+@JSGlobal
 class ReferenceError(message: String = "") extends Error
 
 @native
+@JSGlobal
 object ReferenceError extends Object {
   def apply(message: String = ""): ReferenceError = native
 }
@@ -89,9 +99,11 @@ object ReferenceError extends Object {
  * MDN
  */
 @native
+@JSGlobal
 class SyntaxError(message: String = "") extends Error
 
 @native
+@JSGlobal
 object SyntaxError extends Object {
   def apply(message: String = ""): SyntaxError = native
 }
@@ -105,9 +117,11 @@ object SyntaxError extends Object {
  * MDN
  */
 @native
+@JSGlobal
 class TypeError(message: String = "") extends Error
 
 @native
+@JSGlobal
 object TypeError extends Object {
   def apply(message: String = ""): TypeError = native
 }
@@ -120,9 +134,11 @@ object TypeError extends Object {
  * MDN
  */
 @native
+@JSGlobal
 class URIError(message: String = "") extends Error
 
 @native
+@JSGlobal
 object URIError extends Object {
   def apply(message: String = ""): URIError = native
 }

--- a/library/src/main/scala/scala/scalajs/js/Function.scala
+++ b/library/src/main/scala/scala/scalajs/js/Function.scala
@@ -14,6 +14,8 @@
  */
 package scala.scalajs.js
 
+import scala.scalajs.js.annotation._
+
 /**
  * The Function constructor creates a new Function object. In JavaScript every
  * function is actually a Function object.
@@ -40,6 +42,7 @@ package scala.scalajs.js
  * MDN
  */
 @native
+@JSGlobal
 class Function(args: String*) extends Object {
   /**
    * length is a property of a function object, and indicates how many arguments
@@ -99,6 +102,7 @@ class Function(args: String*) extends Object {
 }
 
 @native
+@JSGlobal
 object Function extends Object {
   def apply(args: String*): Function = native
 }

--- a/library/src/main/scala/scala/scalajs/js/JSON.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSON.scala
@@ -14,6 +14,8 @@
  */
 package scala.scalajs.js
 
+import scala.scalajs.js.annotation._
+
 /**
  * The JSON object contains methods for converting values to JavaScript Object
  * Notation (JSON) and for converting JSON to values.
@@ -21,6 +23,7 @@ package scala.scalajs.js
  * MDN
  */
 @native
+@JSGlobal
 object JSON extends Object {
   /**
    * Parse a string as JSON, optionally transforming the value produced by parsing.

--- a/library/src/main/scala/scala/scalajs/js/Math.scala
+++ b/library/src/main/scala/scala/scalajs/js/Math.scala
@@ -14,6 +14,8 @@
  */
 package scala.scalajs.js
 
+import scala.scalajs.js.annotation._
+
 /**
  * Math is a built-in object that has properties and methods for mathematical
  * constants and functions. Not a function object.
@@ -21,6 +23,7 @@ package scala.scalajs.js
  * MDN
  */
 @native
+@JSGlobal
 object Math extends Object {
   /**
    * Euler's constant and the base of natural logarithms, approximately 2.718.

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -14,8 +14,11 @@
  */
 package scala.scalajs.js
 
+import scala.scalajs.js.annotation._
+
 /** Base class of all JavaScript objects. */
 @native
+@JSGlobal
 class Object extends Any {
   def this(value: Any) = this()
 
@@ -46,6 +49,7 @@ class Object extends Any {
 
 /** The top-level `Object` JavaScript object. */
 @native
+@JSGlobal
 object Object extends Object {
   def apply(): Object = native
   def apply(value: Any): Object = native

--- a/library/src/main/scala/scala/scalajs/js/Promise.scala
+++ b/library/src/main/scala/scala/scalajs/js/Promise.scala
@@ -12,6 +12,7 @@ package scala.scalajs.js
 import scala.language.implicitConversions
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 import scala.concurrent.Future
 
@@ -37,6 +38,7 @@ import scala.concurrent.Future
  *  directly use the methods of `Future` on `Promise`s.
  */
 @js.native
+@JSGlobal
 class Promise[+A](
     executor: js.Function2[js.Function1[A | Thenable[A], _], js.Function1[scala.Any, _], _])
     extends js.Object with js.Thenable[A] {
@@ -54,6 +56,7 @@ class Promise[+A](
 }
 
 @js.native
+@JSGlobal
 object Promise extends js.Object {
   /** Returns a new [[Promise]] completed with the specified `value`. */
   def resolve[A](value: A | Thenable[A]): Promise[A] = js.native

--- a/library/src/main/scala/scala/scalajs/js/RegExp.scala
+++ b/library/src/main/scala/scala/scalajs/js/RegExp.scala
@@ -14,6 +14,8 @@
  */
 package scala.scalajs.js
 
+import scala.scalajs.js.annotation._
+
 /**
  * The RegExp constructor creates a regular expression object for matching
  * text with a pattern.
@@ -21,6 +23,7 @@ package scala.scalajs.js
  * MDN
  */
 @native
+@JSGlobal
 class RegExp(pattern: String, flags: String = "") extends Object {
   /** Creates a new RegExp with the same pattern and flags as the given one. */
   def this(pattern: RegExp) = this("", "")
@@ -103,6 +106,7 @@ class RegExp(pattern: String, flags: String = "") extends Object {
 }
 
 @native
+@JSGlobal
 object RegExp extends Object {
   def apply(pattern: String, flags: String = ""): RegExp = native
 

--- a/library/src/main/scala/scala/scalajs/js/Symbol.scala
+++ b/library/src/main/scala/scala/scalajs/js/Symbol.scala
@@ -31,6 +31,7 @@ sealed trait Symbol extends js.Any
  *  @groupprio 30
  */
 @js.native
+@JSGlobal
 object Symbol extends js.Object {
   /** Creates a new unique symbol without description.
    *

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSGlobal.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSGlobal.scala
@@ -1,0 +1,46 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js API               **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package scala.scalajs.js.annotation
+
+/** Marks the annotated class or object as being a member of the JavaScript
+ *  global scope.
+ *
+ *  The annotated class/object must also be annotated with `@js.native`, and
+ *  therefore extend [[scala.scalajs.js.Any js.Any]].
+ *
+ *  Given:
+ *  {{{
+ *  @js.native
+ *  @JSGlobal
+ *  class Foo extends js.Object
+ *
+ *  @js.native
+ *  @JSGlobal("Foobar")
+ *  object Bar extends js.Object
+ *
+ *  @js.native
+ *  @JSGlobal("Lib.Babar")
+ *  class Babar extends js.Object
+ *  }}}
+ *
+ *  The following mappings apply (`global` denotes the global scope):
+ *
+ *  {{{
+ *  Scala.js                | JavaScript
+ *  ------------------------+------------------
+ *  new Foo()               | new global.Foo()
+ *  Bar                     | global.Foobar
+ *  js.constructorOf[Babar] | global.Lib.Babar
+ *  }}}
+ *
+ *  @see [[http://www.scala-js.org/doc/calling-javascript.html Calling JavaScript from Scala.js]]
+ */
+class JSGlobal extends scala.annotation.StaticAnnotation {
+  def this(name: String) = this()
+}

--- a/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBuffer.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBuffer.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  An ArrayBuffer is a block of contiguous, non-resizable memory.
  */
 @js.native
+@JSGlobal
 class ArrayBuffer(length: Int) extends js.Object {
 
   /** Length of this buffer in bytes */

--- a/library/src/main/scala/scala/scalajs/js/typedarray/DataView.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/DataView.scala
@@ -1,12 +1,14 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A DataView allows for extraction of particular data types at specific
  *  offsets.
  */
 @js.native
+@JSGlobal
 class DataView(buffer: ArrayBuffer, byteOffset: Int = 0,
     byteLength: Int = ???) extends ArrayBufferView {
 

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of single precision floats
  */
 @js.native
+@JSGlobal
 class Float32Array private extends TypedArray[Float, Float32Array] {
 
   /** Constructs a Float32Array with the given length. Initialized to all 0 */
@@ -29,4 +31,5 @@ class Float32Array private extends TypedArray[Float, Float32Array] {
  *  [[Float32Array]] companion
  */
 @js.native
+@JSGlobal
 object Float32Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of double precision floats
  */
 @js.native
+@JSGlobal
 class Float64Array private extends TypedArray[Double, Float64Array] {
 
   /** Constructs a Float64Array with the given length. Initialized to all 0 */
@@ -29,4 +31,5 @@ class Float64Array private extends TypedArray[Double, Float64Array] {
  *  [[Float64Array]] companion
  */
 @js.native
+@JSGlobal
 object Float64Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of signed 16-bit integers
  */
 @js.native
+@JSGlobal
 class Int16Array private extends TypedArray[Short, Int16Array] {
 
   /** Constructs a Int16Array with the given length. Initialized to all 0 */
@@ -29,4 +31,5 @@ class Int16Array private extends TypedArray[Short, Int16Array] {
  *  [[Int16Array]] companion
  */
 @js.native
+@JSGlobal
 object Int16Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of signed 32-bit integers
  */
 @js.native
+@JSGlobal
 class Int32Array private extends TypedArray[Int, Int32Array] {
 
   /** Constructs a Int32Array with the given length. Initialized to all 0 */
@@ -29,4 +31,5 @@ class Int32Array private extends TypedArray[Int, Int32Array] {
  *  [[Int32Array]] companion
  */
 @js.native
+@JSGlobal
 object Int32Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of signed 8-bit integers
  */
 @js.native
+@JSGlobal
 class Int8Array private extends TypedArray[Byte, Int8Array] {
 
   /** Constructs a Int8Array with the given length. Initialized to all 0 */
@@ -29,4 +31,5 @@ class Int8Array private extends TypedArray[Byte, Int8Array] {
  *  [[Int8Array]] companion
  */
 @js.native
+@JSGlobal
 object Int8Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of unsigned 16-bit integers
  */
 @js.native
+@JSGlobal
 class Uint16Array private extends TypedArray[Int, Uint16Array] {
 
   /** Constructs a Uint16Array with the given length. Initialized to all 0 */
@@ -29,4 +31,5 @@ class Uint16Array private extends TypedArray[Int, Uint16Array] {
  *  [[Uint16Array]] companion
  */
 @js.native
+@JSGlobal
 object Uint16Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of unsigned 32-bit integers
  */
 @js.native
+@JSGlobal
 class Uint32Array private extends TypedArray[Double, Uint32Array] {
 
   /** Constructs a Uint32Array with the given length. Initialized to all 0 */
@@ -29,4 +31,5 @@ class Uint32Array private extends TypedArray[Double, Uint32Array] {
  *  [[Uint32Array]] companion
  */
 @js.native
+@JSGlobal
 object Uint32Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
@@ -1,11 +1,13 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of unsigned 8-bit integers
  */
 @js.native
+@JSGlobal
 class Uint8Array private extends TypedArray[Short, Uint8Array] {
 
   /** Constructs a Uint8Array with the given length. Initialized to all 0 */
@@ -29,4 +31,5 @@ class Uint8Array private extends TypedArray[Short, Uint8Array] {
  *  [[Uint8Array]] companion
  */
 @js.native
+@JSGlobal
 object Uint8Array extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
@@ -1,12 +1,14 @@
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 
 /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
  *  A [[TypedArray]] of unsigned 8-bit integers whose values are clamped to
  *  their max/min rather than wrapped around if they overflow.
  */
 @js.native
+@JSGlobal
 class Uint8ClampedArray private extends TypedArray[Int, Uint8ClampedArray] {
 
   /** Constructs a Uint8ClampedArray with the given length. Initialized to all 0 */
@@ -30,4 +32,5 @@ class Uint8ClampedArray private extends TypedArray[Int, Uint8ClampedArray] {
  *  [[Uint8ClampedArray]] companion
  */
 @js.native
+@JSGlobal
 object Uint8ClampedArray extends TypedArrayStatic

--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
@@ -3,6 +3,7 @@ package scala.scalajs.runtime
 import java.util.Comparator
 
 import scala.scalajs.js
+import scala.scalajs.js.annotation._
 import js.JSStringOps._
 
 import java.nio.ByteBuffer
@@ -399,7 +400,7 @@ private[runtime] object RuntimeString {
   }
 
   @js.native
-  @js.annotation.JSName("String")
+  @JSGlobal("String")
   private object NativeJSString extends js.Object {
     def fromCharCode(charCodes: Int*): String = js.native
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1418,10 +1418,12 @@ object Build {
       testHtmlSettings(testHtmlFullOpt, FullOptStage) ++ Seq(
         name := "Scala.js test suite",
 
-        /* We still have zillions of run test for top-level @JSExport. Don't
-         * drown the test:compile output under useless warnings.
+        /* We still have zillions of run test for top-level @JSExport and for
+         * @JSName/missing @JSGlobal. Don't drown the test:compile output under
+         * useless warnings.
          */
         scalacOptions in Test += "-P:scalajs:suppressExportDeprecations",
+        scalacOptions in Test += "-P:scalajs:suppressMissingJSGlobalDeprecations",
 
         unmanagedSourceDirectories in Test ++= {
           val testDir = (sourceDirectory in Test).value

--- a/test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
@@ -9,7 +9,7 @@ package org.scalajs.testinterface
 
 import scala.scalajs.js
 import scala.scalajs.concurrent.QueueExecutionContext
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation._
 import js.URIUtils.{decodeURIComponent, encodeURIComponent}
 
 import scala.collection.mutable
@@ -432,7 +432,7 @@ protected[testinterface] object HTMLRunner extends js.JSApp {
 
   // Mini dom facade.
   private object dom { // scalastyle:ignore
-    @JSName("document")
+    @JSGlobal("document")
     @js.native
     object document extends js.Object { // scalastyle:ignore
       def body: Element = js.native

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/Com.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/Com.scala
@@ -1,10 +1,10 @@
 package org.scalajs.testinterface.internal
 
 import scala.scalajs.js
-import js.annotation.JSName
+import scala.scalajs.js.annotation._
 
 @js.native
-@JSName("scalajsCom")
+@JSGlobal("scalajsCom")
 object Com extends js.Object {
   def init(onReceive: js.Function1[String, Unit]): Unit = js.native
   def send(msg: String): Unit = js.native

--- a/test-suite/js/src/test/resources/ScalaJSDefinedTestNatives.js
+++ b/test-suite/js/src/test/resources/ScalaJSDefinedTestNatives.js
@@ -55,6 +55,7 @@
   $g.ConstructorDefaultParam = ConstructorDefaultParam;
 
   $g.JSNativeObjectInPackageFoo = {};
+  $g.JSNativeObjectInPackageFooJSNameOmitted = $g.JSNativeObjectInPackageFoo;
   $g.JSNativeObjectInPackageBar = {};
   var JSNativeClassInPackageFoo = function() {
     $g.Object.call(this);
@@ -63,6 +64,7 @@
     return "foo";
   };
   $g.JSNativeClassInPackageFoo = JSNativeClassInPackageFoo;
+  $g.JSNativeClassInPackageFooJSNameOmitted = $g.JSNativeClassInPackageFoo;
   var JSNativeClassInPackageBar = function() {
     $g.Object.call(this);
   };

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -118,6 +118,12 @@ class InteroperabilityTest {
     assertEquals(42, obj.field)
     assertEquals("42", obj.method)
     assertEquals("Scala.js", obj.getConstructorParam)
+
+    // With @JSName (old-style)
+    val objOld = new InteroperabilityTestPatternJSName("Scala.js")
+    assertEquals(42, objOld.field)
+    assertEquals("42", objOld.method)
+    assertEquals("Scala.js", objOld.getConstructorParam)
   }
 
   @Test def should_acces_top_level_JS_objects_via_Scala_objects_inheriting_from_js_Object(): Unit = {
@@ -134,10 +140,16 @@ class InteroperabilityTest {
 
     // Use alias for convenience: see end of file for definition
     val TopLevel = InteroperabilityTestTopLevel
-
     val obj = TopLevel("7357")
     assertEquals("7357", obj.value)
     assertEquals(7357, obj.valueAsInt)
+
+    // With @JSName (old-style)
+    val TopLevelOld = InteroperabilityTestTopLevelJSName
+    assertSame(TopLevel, TopLevelOld)
+    val objOld = TopLevelOld("7357")
+    assertEquals("7357", objOld.value)
+    assertEquals(7357, objOld.valueAsInt)
   }
 
   @Test def should_access_native_JS_classes_and_objects_nested_in_JS_objects(): Unit = {
@@ -159,6 +171,8 @@ class InteroperabilityTest {
           this.x = x || 42;
         }
       };
+      var InteroperabilityTestContainerObjectJSNameOmitted =
+        InteroperabilityTestContainerObject;
     """)
 
     // Use alias for convenience: see end of file for definition
@@ -181,6 +195,28 @@ class InteroperabilityTest {
 
     val obj6 = new TopLevel.ContainedClassWithDefaultParam(10)
     assertEquals(10, obj6.x)
+
+    // With an omitted @JSName (old-style)
+    val TopLevelOld = InteroperabilityTestContainerObjectJSNameOmitted
+    assertSame(TopLevel, TopLevelOld)
+
+    val obj1Old = new TopLevelOld.ContainedClass(34)
+    assertEquals(34, obj1Old.x)
+
+    val obj2Old = TopLevelOld.ContainedObject
+    assertEquals(42, obj2Old.x)
+
+    val obj3Old = new TopLevelOld.ContainedClassWithJSName(65)
+    assertEquals(130, obj3Old.x)
+
+    val obj4Old = TopLevelOld.ContainedObjectWithJSName
+    assertEquals(4242, obj4Old.x)
+
+    val obj5Old = new TopLevelOld.ContainedClassWithDefaultParam()
+    assertEquals(42, obj5Old.x)
+
+    val obj6Old = new TopLevelOld.ContainedClassWithDefaultParam(10)
+    assertEquals(10, obj6Old.x)
   }
 
   @Test def should_access_native_JS_classes_and_objects_nested_in_atJSNamed_JS_objects(): Unit = {
@@ -202,7 +238,7 @@ class InteroperabilityTest {
     """)
 
     // Use alias for convenience: see end of file for definition
-    val TopLevel = InteroperabilityTestContainerObjectWithJSName
+    val TopLevel = InteroperabilityTestContainerObjectExplicitName
 
     val obj1 = new TopLevel.ContainedClass(34)
     assertEquals(34, obj1.x)
@@ -215,6 +251,22 @@ class InteroperabilityTest {
 
     val obj4 = TopLevel.ContainedObjectWithJSName
     assertEquals(4242, obj4.x)
+
+    // With @JSName (old-style)
+    val TopLevelOld = InteroperabilityTestContainerObjectExplicitNameJSName
+    assertSame(TopLevel, TopLevelOld)
+
+    val obj1Old = new TopLevelOld.ContainedClass(34)
+    assertEquals(34, obj1Old.x)
+
+    val obj2Old = TopLevelOld.ContainedObject
+    assertEquals(42, obj2Old.x)
+
+    val obj3Old = new TopLevelOld.ContainedClassWithJSName(65)
+    assertEquals(130, obj3Old.x)
+
+    val obj4Old = TopLevelOld.ContainedObjectWithJSName
+    assertEquals(4242, obj4Old.x)
   }
 
   @Test def should_allow_to_call_JS_methods_with_variadic_parameters(): Unit = {
@@ -651,9 +703,18 @@ object InteroperabilityTest {
  * their tests.
  */
 
-@JSName("InteroperabilityTestInherit.Pattern")
+@JSGlobal("InteroperabilityTestInherit.Pattern")
 @js.native
 class InteroperabilityTestPattern protected () extends js.Object {
+  def this(pattern: String) = this()
+  val field: Int = js.native
+  def method(): String = js.native
+  def getConstructorParam(): String = js.native
+}
+
+@JSName("InteroperabilityTestInherit.Pattern")
+@js.native
+class InteroperabilityTestPatternJSName protected () extends js.Object {
   def this(pattern: String) = this()
   val field: Int = js.native
   def method(): String = js.native
@@ -666,13 +727,20 @@ trait InteroperabilityTestTopLevel extends js.Object {
   def valueAsInt(): Int = js.native
 }
 
-@JSName("InteroperabilityTestTopLevelObject")
+@JSGlobal("InteroperabilityTestTopLevelObject")
 @js.native
 object InteroperabilityTestTopLevel extends js.Object {
   def apply(value: String): InteroperabilityTestTopLevel = js.native
 }
 
+@JSName("InteroperabilityTestTopLevelObject")
 @js.native
+object InteroperabilityTestTopLevelJSName extends js.Object {
+  def apply(value: String): InteroperabilityTestTopLevel = js.native
+}
+
+@js.native
+@JSGlobal
 object InteroperabilityTestContainerObject extends js.Object {
   @js.native
   class ContainedClass(_x: Int) extends js.Object {
@@ -702,9 +770,65 @@ object InteroperabilityTestContainerObject extends js.Object {
   }
 }
 
+@js.native
+object InteroperabilityTestContainerObjectJSNameOmitted extends js.Object {
+  @js.native
+  class ContainedClass(_x: Int) extends js.Object {
+    val x: Int = js.native
+  }
+
+  @js.native
+  object ContainedObject extends js.Object {
+    val x: Int = js.native
+  }
+
+  @JSName("ContainedClassRenamed")
+  @js.native
+  class ContainedClassWithJSName(_x: Int) extends js.Object {
+    val x: Int = js.native
+  }
+
+  @JSName("ContainedObjectRenamed")
+  @js.native
+  object ContainedObjectWithJSName extends js.Object {
+    val x: Int = js.native
+  }
+
+  @js.native
+  class ContainedClassWithDefaultParam(_x: Int = ???) extends js.Object {
+    val x: Int = js.native
+  }
+}
+
+@JSGlobal("InteroperabilityTestContainerObjectRenamed")
+@js.native
+object InteroperabilityTestContainerObjectExplicitName extends js.Object {
+  @js.native
+  class ContainedClass(_x: Int) extends js.Object {
+    val x: Int = js.native
+  }
+
+  @js.native
+  object ContainedObject extends js.Object {
+    val x: Int = js.native
+  }
+
+  @JSName("ContainedClassRenamed")
+  @js.native
+  class ContainedClassWithJSName(_x: Int) extends js.Object {
+    val x: Int = js.native
+  }
+
+  @JSName("ContainedObjectRenamed")
+  @js.native
+  object ContainedObjectWithJSName extends js.Object {
+    val x: Int = js.native
+  }
+}
+
 @JSName("InteroperabilityTestContainerObjectRenamed")
 @js.native
-object InteroperabilityTestContainerObjectWithJSName extends js.Object {
+object InteroperabilityTestContainerObjectExplicitNameJSName extends js.Object {
   @js.native
   class ContainedClass(_x: Int) extends js.Object {
     val x: Int = js.native
@@ -749,6 +873,7 @@ trait InteroperabilityTestPolyClassPolyNullaryMethod[+T] extends js.Object {
 }
 
 @js.native
+@JSGlobal
 class InteroperabilityTestVariadicCtor(inargs: Any*) extends js.Object {
   val args: js.Array[Any] = js.native
 }
@@ -775,9 +900,11 @@ class SomeValueClass(val i: Int) extends AnyVal {
 }
 
 @js.native
+@JSGlobal
 class InteroperabilityTestCtor(x: Int = 5, y: Int = ???) extends js.Object {
   def values: js.Array[Int] = js.native
 }
 
 @js.native
+@JSGlobal
 class InteroparabilityCtorInlineValue(val x: Int, var y: Int) extends js.Object

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -15,7 +15,7 @@ import java.io.Serializable
 import scala.reflect.{classTag, ClassTag}
 
 import scala.scalajs.js
-import js.annotation.JSName
+import js.annotation.JSGlobal
 
 import org.junit.Test
 import org.junit.Assert._
@@ -161,7 +161,7 @@ object ReflectionTest {
 
   class RenamedTestClass
 
-  @JSName("ReflectionTestRawJSClass")
+  @JSGlobal("ReflectionTestRawJSClass")
   @js.native
   class ReflectionTestRawJSClass extends js.Object
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -11,7 +11,7 @@ import java.lang.Cloneable
 import java.io.Serializable
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation.JSGlobal
 
 import org.junit.Test
 import org.junit.Assert._
@@ -148,7 +148,7 @@ object RuntimeTypesTest {
   @js.native
   trait SomeJSInterface extends ParentJSType
 
-  @JSName("SomeJSClass")
+  @JSGlobal("SomeJSClass")
   @js.native
   class SomeJSClass extends ParentJSType
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -1821,9 +1821,9 @@ object SJSDefinedAutoExportedIgnoreClassObject extends SJSDefinedAutoExportIgnor
 @ScalaJSDefined
 class SJSDefinedAutoExportedIgnoreClassClass(val x: Int) extends SJSDefinedAutoExportIgnoreClass
 
-@js.native
+@js.native @JSGlobal
 object NativeInvalidExportObject extends SJSDefinedAutoExportIgnoreClass
-@js.native
+@js.native @JSGlobal
 class NativeInvalidExportClass extends SJSDefinedAutoExportIgnoreClass
 @ScalaJSDefined
 class SJSDefinedInvalidExportClass private () extends SJSDefinedAutoExportIgnoreClass

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNativeInPackage.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNativeInPackage.scala
@@ -4,18 +4,32 @@ import org.junit.Test
 import org.junit.Assert._
 
 import scala.scalajs.js
-import scala.scalajs.js.annotation.JSName
+import scala.scalajs.js.annotation._
 
 package object packageobjectwithnatives {
   @js.native
+  @JSGlobal
   object JSNativeObjectInPackageFoo extends js.Object
 
   @js.native
-  @JSName("JSNativeObjectInPackageBar")
+  object JSNativeObjectInPackageFooJSNameOmitted extends js.Object
+
+  @js.native
+  @JSGlobal("JSNativeObjectInPackageBar")
   object JSNativeObjectInPackageBaz extends js.Object
 
   @js.native
+  @JSName("JSNativeObjectInPackageBar")
+  object JSNativeObjectInPackageBazJSName extends js.Object
+
+  @js.native
+  @JSGlobal
   class JSNativeClassInPackageFoo extends js.Object {
+    def foo(): String = js.native
+  }
+
+  @js.native
+  class JSNativeClassInPackageFooJSNameOmitted extends js.Object {
     def foo(): String = js.native
   }
 
@@ -24,19 +38,32 @@ package object packageobjectwithnatives {
   class JSNativeClassInPackageBaz extends js.Object {
     def baz(): String = js.native
   }
+
+  @js.native
+  @JSGlobal("JSNativeClassInPackageBar")
+  class JSNativeClassInPackageBazJSName extends js.Object {
+    def baz(): String = js.native
+  }
 }
 
 class JSNativeInPackage {
   import packageobjectwithnatives._
   import js.Dynamic.global
 
-  @Test def testOvjectDefaultJSName(): Unit = {
+  @Test def testObjectDefaultJSGlobal(): Unit = {
     val gJSNativeObjectInPackageFoo = global.JSNativeObjectInPackageFoo
     assertFalse(js.isUndefined(gJSNativeObjectInPackageFoo))
     assertSame(JSNativeObjectInPackageFoo, gJSNativeObjectInPackageFoo)
   }
 
-  @Test def testObjectJSName(): Unit = {
+  @Test def testObjectDefaultJSName(): Unit = {
+    val gJSNativeObjectInPackageFoo = global.JSNativeObjectInPackageFoo
+    assertFalse(js.isUndefined(gJSNativeObjectInPackageFoo))
+    assertSame(JSNativeObjectInPackageFooJSNameOmitted,
+        gJSNativeObjectInPackageFoo)
+  }
+
+  @Test def testObjectJSGlobal(): Unit = {
     val gJSNativeObjectInPackageBar = global.JSNativeObjectInPackageBar
     val gJSNativeObjectInPackageBaz = global.JSNativeObjectInPackageBaz
     assertFalse(js.isUndefined(gJSNativeObjectInPackageBar))
@@ -44,7 +71,15 @@ class JSNativeInPackage {
     assertSame(JSNativeObjectInPackageBaz, gJSNativeObjectInPackageBar)
   }
 
-  @Test def testClassDefaultJSName(): Unit = {
+  @Test def testObjectJSName(): Unit = {
+    val gJSNativeObjectInPackageBar = global.JSNativeObjectInPackageBar
+    val gJSNativeObjectInPackageBaz = global.JSNativeObjectInPackageBaz
+    assertFalse(js.isUndefined(gJSNativeObjectInPackageBar))
+    assertTrue(js.isUndefined(gJSNativeObjectInPackageBaz))
+    assertSame(JSNativeObjectInPackageBazJSName, gJSNativeObjectInPackageBar)
+  }
+
+  @Test def testClassDefaultJSGlobal(): Unit = {
     val gJSNativeClassInPackageFooCtr = global.JSNativeClassInPackageFoo
     assertFalse(js.isUndefined(gJSNativeClassInPackageFooCtr))
     assertEquals(js.constructorOf[JSNativeClassInPackageFoo],
@@ -56,7 +91,19 @@ class JSNativeInPackage {
     assertEquals("foo", new JSNativeClassInPackageFoo().foo())
   }
 
-  @Test def testClassJSName(): Unit = {
+  @Test def testClassDefaultJSName(): Unit = {
+    val gJSNativeClassInPackageFooCtr = global.JSNativeClassInPackageFoo
+    assertFalse(js.isUndefined(gJSNativeClassInPackageFooCtr))
+    assertEquals(js.constructorOf[JSNativeClassInPackageFooJSNameOmitted],
+        gJSNativeClassInPackageFooCtr)
+
+    val gJSNativeClassInPackageFoo =
+      js.Dynamic.newInstance(gJSNativeClassInPackageFooCtr)()
+    assertEquals("foo", gJSNativeClassInPackageFoo.foo())
+    assertEquals("foo", new JSNativeClassInPackageFooJSNameOmitted().foo())
+  }
+
+  @Test def testClassJSGlobal(): Unit = {
     val gJSNativeClassInPackageBarCtr = global.JSNativeClassInPackageBar
     val gJSNativeClassInPackageBazCtr = global.JSNativeClassInPackageBaz
     assertFalse(js.isUndefined(gJSNativeClassInPackageBarCtr))
@@ -68,5 +115,19 @@ class JSNativeInPackage {
       js.Dynamic.newInstance(gJSNativeClassInPackageBarCtr)()
     assertEquals("baz", gJSNativeClassInPackageBar.baz())
     assertEquals("baz", new JSNativeClassInPackageBaz().baz())
+  }
+
+  @Test def testClassJSName(): Unit = {
+    val gJSNativeClassInPackageBarCtr = global.JSNativeClassInPackageBar
+    val gJSNativeClassInPackageBazCtr = global.JSNativeClassInPackageBaz
+    assertFalse(js.isUndefined(gJSNativeClassInPackageBarCtr))
+    assertSame(js.constructorOf[JSNativeClassInPackageBazJSName],
+        gJSNativeClassInPackageBarCtr)
+    assertTrue(js.isUndefined(gJSNativeClassInPackageBazCtr))
+
+    val gJSNativeClassInPackageBar =
+      js.Dynamic.newInstance(gJSNativeClassInPackageBarCtr)()
+    assertEquals("baz", gJSNativeClassInPackageBar.baz())
+    assertEquals("baz", new JSNativeClassInPackageBazJSName().baz())
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -341,7 +341,7 @@ object JSSymbolTest {
   }
 
   @js.native
-  @JSName("dummy")
+  @JSGlobal("dummy")
   class PropDefClass extends js.Any {
     @JSName(sym1)
     def internalDef: Int = js.native
@@ -360,7 +360,7 @@ object JSSymbolTest {
   }
 
   @js.native
-  @JSName("dummy")
+  @JSGlobal("dummy")
   class PropValClass extends js.Any {
     @JSName(sym1)
     val internalVal: String = js.native
@@ -379,7 +379,7 @@ object JSSymbolTest {
   }
 
   @js.native
-  @JSName("dummy")
+  @JSGlobal("dummy")
   class PropVarClass extends js.Any {
     @JSName(sym1)
     var internalVar: Double = js.native
@@ -415,7 +415,7 @@ object JSSymbolTest {
   }
 
   @js.native
-  @JSName("dummy")
+  @JSGlobal("dummy")
   class MethodClass extends js.Any {
     @JSName(sym1)
     def foo(x: Int): Int = js.native
@@ -443,7 +443,7 @@ object JSSymbolTest {
   }
 
   @js.native
-  @JSName("dummy")
+  @JSGlobal("dummy")
   class OverloadedMethodClass extends js.Any {
     @JSName(sym1)
     def foo(x: Int): Int = js.native
@@ -471,7 +471,7 @@ object JSSymbolTest {
   }
 
   @js.native
-  @JSName("dummy")
+  @JSGlobal("dummy")
   class OverloadedRuntimeDispatchMethodClass extends js.Any {
     @JSName(sym1)
     def foo(x: Int): Int = js.native
@@ -497,7 +497,7 @@ object JSSymbolTest {
   }
 
   @js.native
-  @JSName("dummy")
+  @JSGlobal("dummy")
   class ClassWithSymsInSJSDefinedObject extends js.Object {
     @JSName(sym3)
     def symInSJSDefinedObject(x: Int): Int = js.native
@@ -517,7 +517,7 @@ object JSSymbolTest {
   }
 
   @js.native
-  @JSName("dummy")
+  @JSGlobal("dummy")
   class ClassJSIterable[+A] extends JSIterable[A] {
     @JSName(js.Symbol.iterator)
     def iterator(): js.Dynamic = js.native

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -215,7 +215,7 @@ object MiscInteropTest {
     def foo(x: Int): Int = js.native
   }
 
-  @JSName("DirectSubclassOfJSAny")
+  @JSGlobal("DirectSubclassOfJSAny")
   @js.native
   class DirectSubclassOfJSAny extends js.Any {
     def bar(x: Int): Int = js.native

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -1572,7 +1572,7 @@ class ScalaJSDefinedTest {
 object ScalaJSDefinedTest {
 
   // Defined in test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
-  @JSName("ScalaJSDefinedTestNativeParentClass")
+  @JSGlobal("ScalaJSDefinedTestNativeParentClass")
   @js.native
   class NativeParentClass(val x: Int) extends js.Object {
     def foo(s: String): String = js.native
@@ -1595,7 +1595,7 @@ object ScalaJSDefinedTest {
   }
 
   // Defined in test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
-  @JSName("ScalaJSDefinedTestNativeParentClassWithDeferred")
+  @JSGlobal("ScalaJSDefinedTestNativeParentClassWithDeferred")
   @js.native
   abstract class NativeParentClassWithDeferred extends NativeTraitWithDeferred {
     def foo(y: Int): Int = js.native // = bar(y + 4) + x
@@ -1604,7 +1604,7 @@ object ScalaJSDefinedTest {
   }
 
   // Defined in test-suite/src/test/resources/ScalaJSDefinedTestNatives.js
-  @JSName("ScalaJSDefinedTestNativeParentClassWithVarargs")
+  @JSGlobal("ScalaJSDefinedTestNativeParentClassWithVarargs")
   @js.native
   class NativeParentClassWithVarargs(
       _x: Int, _args: Int*) extends js.Object {
@@ -1689,25 +1689,25 @@ object ScalaJSDefinedTest {
   object ConstructorDefaultParamScalaJSNonNative extends js.Object
 
   @js.native
-  @JSName("ConstructorDefaultParam")
+  @JSGlobal("ConstructorDefaultParam")
   class ConstructorDefaultParamJSNativeNone(val foo: Int = -1) extends js.Object
 
   @js.native
-  @JSName("ConstructorDefaultParam")
+  @JSGlobal("ConstructorDefaultParam")
   class ConstructorDefaultParamJSNativeScala(val foo: Int = -1) extends js.Object
   object ConstructorDefaultParamJSNativeScala
 
   @js.native
-  @JSName("ConstructorDefaultParam")
+  @JSGlobal("ConstructorDefaultParam")
   class ConstructorDefaultParamJSNativeJSNonNative(val foo: Int = -1) extends js.Object
   @ScalaJSDefined
   object ConstructorDefaultParamJSNativeJSNonNative extends js.Object
 
   @js.native
-  @JSName("ConstructorDefaultParam")
+  @JSGlobal("ConstructorDefaultParam")
   class ConstructorDefaultParamJSNativeJSNative(val foo: Int = -1) extends js.Object
   @js.native
-  @JSName("ConstructorDefaultParam")
+  @JSGlobal("ConstructorDefaultParam")
   object ConstructorDefaultParamJSNativeJSNative extends js.Object
 
   // sanity check


### PR DESCRIPTION
Previously, a top-level `@js.native` class/object was loaded from the global scope by default, either with an explicit name through `@JSName` or with an implicit name derived from its Scala name.

With this commit, such a native class/object should be declared with an `@JSGlobal` annotation instead (either with or without an explicit name).

For example,
```scala
  @js.native class Foo extends js.Object
  @js.native @JSName("Foobaz") object Bar extends js.Object
```
would now be written as
```scala
  @js.native @JSGlobal class Foo extends js.Object
  @js.native @JSGlobal("Foobaz") object Bar extends js.Object
```

There are two main reasons for such a change.

First, it brings loading from the global scope syntactically on par with importing from a module. As the JS eco-system moves towards modules, the syntactic bias towards globally scoped things is not relevant anymore.

Second, it removes the overloaded meaning of `@JSName`. Indeed, this annotation has significantly different meanings whether it is attached to a top-level native class/object versus a member of a JS type. For example, a `.` has a special meaning for top-level native class/object, but not for a member of a JS type. The changes in this commit close #2615 by leaving only the meaning where `.` is not special, and therefore need not be forbidden.

Since this is a fairly disruptive change, the deprecation warnings can be suppressed with the option `-P:scalajs:suppressMissingJSGlobalDeprecations` during the 0.6.x cycle, to ease migration.