### PR TITLE
Deprecate private members of native JS classes/traits/objects.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
@@ -7,6 +7,7 @@ package org.scalajs.core.compiler
 
 import scala.collection.mutable
 
+import scala.reflect.internal.Flags.{LOCAL, PRIVATE}
 import scala.tools.nsc._
 
 /** Hacks to have our source code compatible with 2.10 and 2.11.
@@ -26,6 +27,7 @@ trait Compat210Component {
     def unexpandedName: Name = self.originalName
     def originalName: Name = sys.error("infinite loop in Compat")
 
+    def isPrivateThis: Boolean = self.hasAllFlags(PRIVATE | LOCAL)
     def isLocalToBlock: Boolean = self.isLocal
 
     def implClass: Symbol = NoSymbol

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
@@ -1002,6 +1002,89 @@ class JSInteropTest extends DirectTest with TestHelpers {
   }
 
   @Test
+  def warnPrivateMemberInNative: Unit = {
+
+    """
+    @js.native
+    @JSGlobal
+    class A extends js.Object {
+      private[this] val a: Int = js.native
+      private val b: Int = js.native
+      private[A] val c: Int = js.native
+
+      private[this] var d: Int = js.native
+      private var e: Int = js.native
+      private[A] var f: Int = js.native
+
+      private[this] def g(): Int = js.native
+      private def h(): Int = js.native
+      private[A] def i(): Int = js.native
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:8: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private[this] val a: Int = js.native
+      |                        ^
+      |newSource1.scala:9: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private val b: Int = js.native
+      |                  ^
+      |newSource1.scala:10: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private[A] val c: Int = js.native
+      |                     ^
+      |newSource1.scala:12: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private[this] var d: Int = js.native
+      |                        ^
+      |newSource1.scala:13: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private var e: Int = js.native
+      |                  ^
+      |newSource1.scala:14: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private[A] var f: Int = js.native
+      |                     ^
+      |newSource1.scala:16: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private[this] def g(): Int = js.native
+      |                        ^
+      |newSource1.scala:17: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private def h(): Int = js.native
+      |                  ^
+      |newSource1.scala:18: warning: Declaring private members in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use a public member in a private facade instead. This will become an error in 1.0.0.
+      |      private[A] def i(): Int = js.native
+      |                     ^
+    """
+
+  }
+
+  @Test
+  def warnPrivateConstructorInNative: Unit = {
+
+    """
+    @js.native
+    @JSGlobal
+    class A private () extends js.Object
+    """ containsWarns
+    """
+      |newSource1.scala:7: warning: Declaring private constructors in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use `private[this]` instead. This will become an error in 1.0.0.
+      |    class A private () extends js.Object
+    """
+
+    """
+    @js.native
+    @JSGlobal
+    class A private[A] () extends js.Object
+    """ containsWarns
+    """
+      |newSource1.scala:7: warning: Declaring private constructors in native JS classes is deprecated, because they do not behave the same way as in Scala.js-defined JS classes. Use `private[this]` instead. This will become an error in 1.0.0.
+      |    class A private[A] () extends js.Object
+    """
+
+    """
+    @js.native
+    @JSGlobal
+    class A private[this] () extends js.Object
+    """.hasNoWarns
+
+  }
+
+  @Test
   def noUseJsNative: Unit = {
 
     """

--- a/library/src/main/scala/scala/scalajs/js/Dictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dictionary.scala
@@ -50,13 +50,6 @@ import annotation.JSBracketAccess
  */
 @native
 sealed trait Dictionary[A] extends Any {
-  /** Reads a field of this object by its name.
-   *
-   *  This must not be called if the dictionary does not contain the key.
-   */
-  @JSBracketAccess
-  private[js] def rawApply(key: String): A = native
-
   /** Writes a field of this object by its name. */
   @JSBracketAccess
   def update(key: String, value: A): Unit = native

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Float32Array private extends TypedArray[Float, Float32Array] {
+class Float32Array private[this] () extends TypedArray[Float, Float32Array] {
 
   /** Constructs a Float32Array with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Float64Array private extends TypedArray[Double, Float64Array] {
+class Float64Array private[this] () extends TypedArray[Double, Float64Array] {
 
   /** Constructs a Float64Array with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Int16Array private extends TypedArray[Short, Int16Array] {
+class Int16Array private[this] () extends TypedArray[Short, Int16Array] {
 
   /** Constructs a Int16Array with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Int32Array private extends TypedArray[Int, Int32Array] {
+class Int32Array private[this] () extends TypedArray[Int, Int32Array] {
 
   /** Constructs a Int32Array with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Int8Array private extends TypedArray[Byte, Int8Array] {
+class Int8Array private[this] () extends TypedArray[Byte, Int8Array] {
 
   /** Constructs a Int8Array with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Uint16Array private extends TypedArray[Int, Uint16Array] {
+class Uint16Array private[this] () extends TypedArray[Int, Uint16Array] {
 
   /** Constructs a Uint16Array with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Uint32Array private extends TypedArray[Double, Uint32Array] {
+class Uint32Array private[this] () extends TypedArray[Double, Uint32Array] {
 
   /** Constructs a Uint32Array with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
@@ -8,7 +8,7 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Uint8Array private extends TypedArray[Short, Uint8Array] {
+class Uint8Array private[this] () extends TypedArray[Short, Uint8Array] {
 
   /** Constructs a Uint8Array with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
@@ -9,7 +9,8 @@ import scala.scalajs.js.annotation._
  */
 @js.native
 @JSGlobal
-class Uint8ClampedArray private extends TypedArray[Int, Uint8ClampedArray] {
+class Uint8ClampedArray private[this] ()
+    extends TypedArray[Int, Uint8ClampedArray] {
 
   /** Constructs a Uint8ClampedArray with the given length. Initialized to all 0 */
   def this(length: Int) = this()

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -199,6 +199,10 @@ object BinaryIncompatibilities {
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "scala.scalajs.js.typedarray.Uint32Array.this"),
 
+      // private[js], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scala.scalajs.js.Dictionary.rawApply"),
+
       // New member in non-sealed trait (for low prio implicits).
       // Theoretically breaking.
       ProblemFilters.exclude[InheritedNewAbstractMethodProblem](


### PR DESCRIPTION
Historically, our compiler has tolerated `private`, `private[this]` and `private[Scope]` members in native JS classes, traits, and objects. Once compiled, it would consider that they are in fact public, with non-mangled names.

This is at odds with how private members of Scala.js-defined JS types are handled at use site, which means there are different semantics at use site between native versus Scala.js-defined types, which is bad.

This commit deprecates definitions of private members in native JS types. We still accept `private[this]` constructors, because they are sometimes necessary to have a primary constructor that other constructors delegate to. `private[this]` constructors are fine, because they cannot be called from anywhere but the secondary constructors. Note that even a `private` constructor can be called from the companion object, which can be non-native, so this is not allowed.