### PR TITLE
Fix #2799: Don't use `equals` for comparing java.lang.Double/Float.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
@@ -1,0 +1,76 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.compiler
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import org.junit.Test
+import org.junit.Assert._
+
+class RegressionJSTest {
+
+  @Test def should_not_swallow_Unit_expressions_when_converting_to_js_Any_issue_83(): Unit = {
+    var effectHappened = false
+    def doEffect(): Unit = effectHappened = true
+    def f(): js.Any = doEffect()
+    f()
+    assertTrue(effectHappened)
+  }
+
+  @Test def should_resolve_overloads_on_scala_Function_apply_when_converting_to_js_Function_issue_125(): Unit = {
+    class Fct extends Function1[Int, Any] {
+      def apply(n: Int): Int = n
+    }
+
+    val scalaFunction = new Fct
+    val jsFunction: js.Any = scalaFunction
+    val thisFunction: js.ThisFunction = scalaFunction
+  }
+
+  @Test def should_not_put_bad_flags_on_caseaccessor_export_forwarders_issue_1191(): Unit = {
+    // This test used to choke patmat
+
+    @JSExportAll
+    case class T(one: Int, two: Int)
+
+    val T(a, b) = T(1, 2)
+
+    assertEquals(1, a)
+    assertEquals(2, b)
+  }
+
+  @Test def should_support_debugger_statements_through_the_whole_pipeline_issue_1402(): Unit = {
+    /* A function that hopefully persuades the optimizer not to optimize
+     * we need a debugger statement that is unreachable, but not eliminated.
+     */
+    @noinline
+    class A(var z: Int = 4) {
+      var x: Int = _
+      var y: Int = _
+
+      @noinline
+      def plus(x0: Int, y0: Int): Int = {
+        x = x0
+        y = y0
+        var res = 0
+        while (x > 0 || y > 0 || z > 0) {
+          if (x > 0) x -= 1
+          else if (y > 0) y -= 1
+          else z -= 1
+          res += 1
+        }
+        res
+      }
+    }
+
+    if (new A().plus(5, 10) < 3)
+      js.debugger()
+  }
+
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -435,6 +435,106 @@ class RegressionTest {
     assertEquals((Nil, 10), result)
   }
 
+  private val hasEqEqJLFloatDoubleBug: Boolean = {
+    val v = Platform.scalaVersion
+
+    {
+      v.startsWith("2.10.") ||
+      v.startsWith("2.11.") ||
+      v == "2.12.0" ||
+      v == "2.12.1"
+    }
+  }
+
+  def assertTrueUnlessEqEqJLFloatDoubleBug(actual: Boolean): Unit = {
+    if (hasEqEqJLFloatDoubleBug)
+      assertFalse(actual)
+    else
+      assertTrue(actual)
+  }
+
+  @Test def eqEqJLDouble(): Unit = {
+    // Taken from run/sd329.scala in scala/scala
+
+    def d1: Double = 0.0
+    def d2: Double = -0.0
+    def d3: Double = Double.NaN
+    def d4: Double = Double.NaN
+    assertTrue(d1 == d2)
+    assertTrue(d3 != d4)
+
+    def d1B: java.lang.Double = d1
+    def d2B: java.lang.Double = d2
+    def d3B: java.lang.Double = d3
+    def d4B: java.lang.Double = d4
+    assertTrueUnlessEqEqJLFloatDoubleBug(d1B == d2B)
+    assertTrue(d1 == d1B)
+    assertTrue(d1B == d1)
+    assertTrueUnlessEqEqJLFloatDoubleBug(d3B != d4B)
+    assertTrue(d3 != d4B)
+    assertTrue(d3B != d4)
+
+    assertFalse(d1B.equals(d2B)) // ! see javadoc
+    assertTrue(d3B.equals(d4B)) // ! see javadoc
+
+    def d1A: Any = d1
+    def d2A: Any = d2
+    def d3A: Any = d3
+    def d4A: Any = d4
+    assertTrue(d1A == d2A)
+    assertTrue(d1 == d1A)
+    assertTrue(d1A == d1)
+    assertTrue(d1B == d1A)
+    assertTrue(d1A == d1B)
+
+    assertTrue(d3A != d4A)
+    assertTrue(d3 != d4A)
+    assertTrue(d3A != d4)
+    assertTrue(d3B != d4A)
+    assertTrue(d3A != d4B)
+  }
+
+  @Test def eqEqJLFloat(): Unit = {
+    // Taken from run/sd329.scala in scala/scala
+
+    def f1: Float = 0.0f
+    def f2: Float = -0.0f
+    def f3: Float = Float.NaN
+    def f4: Float = Float.NaN
+    assertTrue(f1 == f2)
+    assertTrue(f3 != f4)
+
+    def f1B: java.lang.Float = f1
+    def f2B: java.lang.Float = f2
+    def f3B: java.lang.Float = f3
+    def f4B: java.lang.Float = f4
+    assertTrueUnlessEqEqJLFloatDoubleBug(f1B == f2B)
+    assertTrue(f1 == f1B)
+    assertTrue(f1B == f1)
+    assertTrueUnlessEqEqJLFloatDoubleBug(f3B != f4B)
+    assertTrue(f3 != f4B)
+    assertTrue(f3B != f4)
+
+    assertFalse(f1B.equals(f2B)) // ! see javadoc
+    assertTrue(f3B.equals(f4B)) // ! see javadoc
+
+    def f1A: Any = f1
+    def f2A: Any = f2
+    def f3A: Any = f3
+    def f4A: Any = f4
+    assertTrue(f1A == f2A)
+    assertTrue(f1 == f1A)
+    assertTrue(f1A == f1)
+    assertTrue(f1B == f1A)
+    assertTrue(f1A == f1B)
+
+    assertTrue(f3A != f4A)
+    assertTrue(f3 != f4A)
+    assertTrue(f3A != f4)
+    assertTrue(f3B != f4A)
+    assertTrue(f3A != f4B)
+  }
+
 }
 
 object RegressionTest {


### PR DESCRIPTION
This is essentially a port of the fix for scala-dev#329, which was implemented in scala/scala#5761.

To remain bug-compatible with the JVM, we explicitly look at the version of the Scala compiler that we run on to determine whether or not the fix should be applied.