### PR TITLE
Disallow exports of lazy vals to the top-level or as static.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -426,7 +426,12 @@ trait PrepJSExports { this: PrepJSInterop =>
                 "Scala.js-defined JS class may export its members as static.")
           }
 
-          if (!isMember) {
+          if (isMember) {
+            if (sym.isLazy) {
+              reporter.error(annot.pos,
+                  "You may not export a lazy val as static")
+            }
+          } else {
             if (sym.isTrait) {
               reporter.error(annot.pos,
                   "You may not export a trait as static.")

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -390,7 +390,10 @@ trait PrepJSExports { this: PrepJSInterop =>
           }
 
         case ExportDestination.TopLevel =>
-          if (!sym.isAccessor && jsInterop.isJSProperty(sym)) {
+          if (sym.isLazy) {
+            reporter.error(annot.pos,
+                "You may not export a lazy val to the top level")
+          } else if (!sym.isAccessor && jsInterop.isJSProperty(sym)) {
             reporter.error(annot.pos,
                 "You may not export a getter or a setter to the top level")
           }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -1439,6 +1439,24 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
+  def noExportStaticLazyVal: Unit = {
+    """
+    @ScalaJSDefined
+    class StaticContainer extends js.Object
+
+    object StaticContainer {
+      @JSExportStatic
+      lazy val a: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: You may not export a lazy val as static
+      |      @JSExportStatic
+      |       ^
+    """
+  }
+
+  @Test
   def noExportValAsStaticAndTopLevel: Unit = {
     """
     @ScalaJSDefined

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -1139,6 +1139,21 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
+  def noExportTopLevelLazyVal: Unit = {
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      lazy val a: Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: You may not export a lazy val to the top level
+      |      @JSExportTopLevel("foo")
+      |       ^
+    """
+  }
+
+  @Test
   def noExportTopLevelGetter: Unit = {
     """
     object A {


### PR DESCRIPTION
Exporting a lazy val to the top level does not make sense, because they must be evaluated at module loading time. In fact, the generated code was buggy.

Exporting a lazy val as static probably makes sense, but as SIP-25 on `@static` considers static lazy vals as an open question, it is safer to disallow them for now. This can be reconsidered in the future.