### PR TITLE
Fix #2821: Adapt column pos in source maps for printEscapeJS

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -203,9 +203,9 @@
 
   <task id="bootstrap"><![CDATA[
     setJavaVersion $java
-    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=2048")).withSourceMap(false)' \
+    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false)' \
         ++$scala irJS/test toolsJS/test &&
-    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=2048")).withSourceMap(false)' \
+    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala irJS/test toolsJS/test
   ]]></task>

--- a/ir/src/main/scala/org/scalajs/core/ir/Utils.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Utils.scala
@@ -75,12 +75,13 @@ object Utils {
     sb.toString
   }
 
-  def printEscapeJS(str: String, out: java.lang.Appendable): Unit = {
+  def printEscapeJS(str: String, out: java.lang.Appendable): Int = {
     /* Note that Java and JavaScript happen to use the same encoding for
      * Unicode, namely UTF-16, which means that 1 char from Java always equals
      * 1 char in JavaScript. */
     val end = str.length()
     var i = 0
+    var writtenChars = 0
     /* Loop prints all consecutive ASCII printable characters starting
      * from current i and one non ASCII printable character (if it exists).
      * The new i is set at the end of the appended characters.
@@ -95,8 +96,10 @@ object Utils {
           c = str.charAt(i)
       }
       // Print ASCII printable characters from `start`
-      if (start != i)
+      if (start != i) {
         out.append(str, start, i)
+        writtenChars += i
+      }
 
       // Print next non ASCII printable character
       if (i != end) {
@@ -104,18 +107,23 @@ object Utils {
           if (6 < c && c < 14) {
             val i = 2 * (c - 7)
             out.append(EscapeJSChars, i, i + 2)
+            writtenChars += 2
           } else if (c == 34) {
             out.append(EscapeJSChars, 14, 16)
+            writtenChars += 2
           } else if (c == 92) {
             out.append(EscapeJSChars, 16, 18)
+            writtenChars += 2
           } else {
             out.append(f"\\u$c%04x")
+            writtenChars += 6
           }
         }
         escapeJSEncoded(c)
         i += 1
       }
     }
+    writtenChars
   }
 
   /** A ByteArrayOutput stream that allows to jump back to a given

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -3,6 +3,9 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val IR = Seq(
+      // Breaking: Utils.printEscapeJS now returns Int
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.core.ir.Utils.printEscapeJS")
   )
 
   val Tools = Seq(

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
@@ -22,7 +22,6 @@ import org.scalajs.core.ir
 import ir.Position
 import ir.Position.NoPosition
 import ir.Printers.IndentationManager
-import ir.Utils.printEscapeJS
 
 import Trees._
 
@@ -471,7 +470,7 @@ object Printers {
 
         case StringLiteral(value) =>
           print('\"')
-          printEscapeJS(value, out)
+          printEscapeJS(value)
           print('\"')
 
         // Atomic expressions
@@ -555,8 +554,11 @@ object Printers {
       }
     }
 
+    protected def printEscapeJS(s: String): Unit =
+      ir.Utils.printEscapeJS(s, out)
+
     protected def print(ident: Ident): Unit =
-      printEscapeJS(ident.name, out)
+      printEscapeJS(ident.name)
 
     private final def print(propName: PropertyName): Unit = propName match {
       case lit: StringLiteral => print(lit: Tree)
@@ -595,6 +597,9 @@ object Printers {
       if (pos.isDefined)
         sourceMap.endNode(column)
     }
+
+    override protected def printEscapeJS(s: String): Unit =
+      column += ir.Utils.printEscapeJS(s, out)
 
     override protected def print(ident: Ident): Unit = {
       if (ident.pos.isDefined)


### PR DESCRIPTION
When investigating issue #2795, we found that there are situations when javascript code was written, but column field used by the source map writer to point where in javascript you are was not updated.