### PR TITLE
Remove the dependency on ResolvedJSDependency in the JSEnv API

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala
@@ -10,19 +10,18 @@
 package org.scalajs.jsenv
 
 import org.scalajs.core.tools.io.VirtualJSFile
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 
 trait AsyncJSEnv extends JSEnv {
-  def asyncRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile): AsyncJSRunner
+  def asyncRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): AsyncJSRunner
 
   final def asyncRunner(code: VirtualJSFile): AsyncJSRunner =
     asyncRunner(Nil, code)
 
-  override def loadLibs(libs: Seq[ResolvedJSDependency]): AsyncJSEnv =
+  override def loadLibs(libs: Seq[VirtualJSFile]): AsyncJSEnv =
     new AsyncLoadedLibs { val loadedLibs = libs }
 
   private[jsenv] trait AsyncLoadedLibs extends LoadedLibs with AsyncJSEnv {
-    def asyncRunner(libs: Seq[ResolvedJSDependency],
+    def asyncRunner(libs: Seq[VirtualJSFile],
         code: VirtualJSFile): AsyncJSRunner = {
       AsyncJSEnv.this.asyncRunner(loadedLibs ++ libs, code)
     }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala
@@ -10,7 +10,6 @@
 package org.scalajs.jsenv
 
 import org.scalajs.core.tools.io.VirtualJSFile
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 
 /** An [[AsyncJSEnv]] that provides communication to and from the JS VM.
  *
@@ -28,15 +27,15 @@ import org.scalajs.core.tools.jsdep.ResolvedJSDependency
  *  }}}
  */
 trait ComJSEnv extends AsyncJSEnv {
-  def comRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile): ComJSRunner
+  def comRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): ComJSRunner
 
   final def comRunner(code: VirtualJSFile): ComJSRunner = comRunner(Nil, code)
 
-  override def loadLibs(libs: Seq[ResolvedJSDependency]): ComJSEnv =
+  override def loadLibs(libs: Seq[VirtualJSFile]): ComJSEnv =
     new ComLoadedLibs { val loadedLibs = libs }
 
   private[jsenv] trait ComLoadedLibs extends AsyncLoadedLibs with ComJSEnv {
-    def comRunner(libs: Seq[ResolvedJSDependency],
+    def comRunner(libs: Seq[VirtualJSFile],
         code: VirtualJSFile): ComJSRunner = {
       ComJSEnv.this.comRunner(loadedLibs ++ libs, code)
     }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -2,7 +2,6 @@ package org.scalajs.jsenv
 
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.logging.Logger
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 
 import java.io.{ Console => _, _ }
 import scala.io.Source
@@ -28,7 +27,7 @@ abstract class ExternalJSEnv(
   protected def customInitFiles(): Seq[VirtualJSFile] = Nil
 
   protected class AbstractExtRunner(
-      protected val libs: Seq[ResolvedJSDependency],
+      protected val libs: Seq[VirtualJSFile],
       protected val code: VirtualJSFile) extends JSInitFiles {
 
     private[this] var _logger: Logger = _
@@ -64,7 +63,7 @@ abstract class ExternalJSEnv(
 
     /** Get files that are a library (i.e. that do not run anything) */
     protected def getLibJSFiles(): Seq[VirtualJSFile] =
-      initFiles() ++ customInitFiles() ++ libs.map(_.lib)
+      initFiles() ++ customInitFiles() ++ libs
 
     /** Get all files that are passed to VM (libraries and code) */
     protected def getJSFiles(): Seq[VirtualJSFile] =
@@ -144,7 +143,7 @@ abstract class ExternalJSEnv(
 
   }
 
-  protected class ExtRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile)
+  protected class ExtRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
       extends AbstractExtRunner(libs, code) with JSRunner {
 
     def run(logger: Logger, console: JSConsole): Unit = {
@@ -157,7 +156,7 @@ abstract class ExternalJSEnv(
     }
   }
 
-  protected class AsyncExtRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile)
+  protected class AsyncExtRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
       extends AbstractExtRunner(libs, code) with AsyncJSRunner {
 
     private[this] var vmInst: Process = null

--- a/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
@@ -10,14 +10,13 @@
 package org.scalajs.jsenv
 
 import org.scalajs.core.tools.io.VirtualJSFile
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 
 trait JSEnv {
   /** Human-readable name for this [[JSEnv]] */
   def name: String
 
   /** Prepare a runner for the code in the virtual file. */
-  def jsRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile): JSRunner
+  def jsRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): JSRunner
 
   /** Prepare a runner without any libraries.
    *
@@ -36,15 +35,15 @@ trait JSEnv {
    *  jsEnv.jsRunner(a ++ b, c)
    *  }}}
    */
-  def loadLibs(libs: Seq[ResolvedJSDependency]): JSEnv =
+  def loadLibs(libs: Seq[VirtualJSFile]): JSEnv =
     new LoadedLibs { val loadedLibs = libs }
 
   private[jsenv] trait LoadedLibs extends JSEnv {
-    val loadedLibs: Seq[ResolvedJSDependency]
+    val loadedLibs: Seq[VirtualJSFile]
 
     def name: String = JSEnv.this.name
 
-    def jsRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile): JSRunner =
+    def jsRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): JSRunner =
       JSEnv.this.jsRunner(loadedLibs ++ libs, code)
   }
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
@@ -12,7 +12,6 @@ package org.scalajs.jsenv.nodejs
 import java.io.{Console => _, _}
 
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.jsenv._
 
 import org.scalajs.core.ir.Utils.escapeJS
@@ -25,28 +24,28 @@ class JSDOMNodeJSEnv(
 
   protected def vmName: String = "Node.js with JSDOM"
 
-  override def jsRunner(libs: Seq[ResolvedJSDependency],
+  override def jsRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): JSRunner = {
     new DOMNodeRunner(libs, code)
   }
 
-  override def asyncRunner(libs: Seq[ResolvedJSDependency],
+  override def asyncRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): AsyncJSRunner = {
     new AsyncDOMNodeRunner(libs, code)
   }
 
-  override def comRunner(libs: Seq[ResolvedJSDependency],
+  override def comRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): ComJSRunner = {
     new ComDOMNodeRunner(libs, code)
   }
 
-  protected class DOMNodeRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile)
+  protected class DOMNodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
       extends ExtRunner(libs, code) with AbstractDOMNodeRunner
 
-  protected class AsyncDOMNodeRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile)
+  protected class AsyncDOMNodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
       extends AsyncExtRunner(libs, code) with AbstractDOMNodeRunner
 
-  protected class ComDOMNodeRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile)
+  protected class ComDOMNodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
       extends AsyncDOMNodeRunner(libs, code) with NodeComJSRunner
 
   protected trait AbstractDOMNodeRunner extends AbstractNodeRunner {
@@ -95,9 +94,9 @@ class JSDOMNodeJSEnv(
     override protected def getJSFiles(): Seq[VirtualJSFile] =
       initFiles() ++ customInitFiles() ++ codeWithJSDOMContext()
 
-    /** Libraries are loaded via scripts in Node.js */
+    /** Libraries are loaded via scripts in the jsdom environment. */
     override protected def getLibJSFiles(): Seq[VirtualJSFile] =
-      libs.map(_.lib)
+      libs
 
     // Send code to Stdin
     override protected def sendVMStdin(out: OutputStream): Unit = {

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -11,8 +11,6 @@ package org.scalajs.jsenv.nodejs
 
 import org.scalajs.jsenv._
 
-import org.scalajs.core.ir.Utils.escapeJS
-
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.logging._
@@ -65,24 +63,6 @@ class NodeJSEnv private (
       extends AsyncNodeRunner(libs, code) with NodeComJSRunner
 
   protected trait AbstractBasicNodeRunner extends AbstractNodeRunner {
-
-    /** Libraries are loaded via require in Node.js */
-    override protected def getLibJSFiles(): Seq[VirtualJSFile] = {
-      initFiles() ++
-      customInitFiles() ++
-      libs.map(requireLibrary)
-    }
-
-    /** Rewrites a library virtual file to a require statement if possible */
-    protected def requireLibrary(dep: ResolvedJSDependency): VirtualJSFile = {
-      dep.info.commonJSName.fold(dep.lib) { varname =>
-        val fname = dep.lib.name
-        libCache.materialize(dep.lib)
-        new MemVirtualJSFile(s"require-$fname").withContent(
-          s"""$varname = require("${escapeJS(fname)}");"""
-        )
-      }
-    }
 
     // Send code to Stdin
     override protected def sendVMStdin(out: OutputStream): Unit = {

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -12,7 +12,6 @@ package org.scalajs.jsenv.nodejs
 import org.scalajs.jsenv._
 
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.logging._
 
 import java.io.{ Console => _, _ }
@@ -38,28 +37,28 @@ class NodeJSEnv private (
   // For binary compatibility, now `executable` is defined in AbstractNodeJSEnv
   override protected def executable: String = super.executable
 
-  override def jsRunner(libs: Seq[ResolvedJSDependency],
+  override def jsRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): JSRunner = {
     new NodeRunner(libs, code)
   }
 
-  override def asyncRunner(libs: Seq[ResolvedJSDependency],
+  override def asyncRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): AsyncJSRunner = {
     new AsyncNodeRunner(libs, code)
   }
 
-  override def comRunner(libs: Seq[ResolvedJSDependency],
+  override def comRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): ComJSRunner = {
     new ComNodeRunner(libs, code)
   }
 
-  protected class NodeRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile)
+  protected class NodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
       extends ExtRunner(libs, code) with AbstractBasicNodeRunner
 
-  protected class AsyncNodeRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile)
+  protected class AsyncNodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
       extends AsyncExtRunner(libs, code) with AbstractBasicNodeRunner
 
-  protected class ComNodeRunner(libs: Seq[ResolvedJSDependency], code: VirtualJSFile)
+  protected class ComNodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
       extends AsyncNodeRunner(libs, code) with NodeComJSRunner
 
   protected trait AbstractBasicNodeRunner extends AbstractNodeRunner {

--- a/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
+++ b/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
@@ -14,7 +14,6 @@ import org.scalajs.jsenv.Utils.OptDeadline
 import org.scalajs.core.ir.Utils.{escapeJS, fixFileURI}
 
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.logging._
 
 import java.io.{ Console => _, _ }
@@ -40,30 +39,30 @@ class PhantomJSEnv(
   protected def vmName: String = "PhantomJS"
   protected def executable: String = phantomjsPath
 
-  override def jsRunner(libs: Seq[ResolvedJSDependency],
+  override def jsRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): JSRunner = {
     new PhantomRunner(libs, code)
   }
 
-  override def asyncRunner(libs: Seq[ResolvedJSDependency],
+  override def asyncRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): AsyncJSRunner = {
     new AsyncPhantomRunner(libs, code)
   }
 
-  override def comRunner(libs: Seq[ResolvedJSDependency],
+  override def comRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): ComJSRunner = {
     new ComPhantomRunner(libs, code)
   }
 
-  protected class PhantomRunner(libs: Seq[ResolvedJSDependency],
+  protected class PhantomRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile) extends ExtRunner(libs, code)
       with AbstractPhantomRunner
 
-  protected class AsyncPhantomRunner(libs: Seq[ResolvedJSDependency],
+  protected class AsyncPhantomRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile) extends AsyncExtRunner(libs, code)
       with AbstractPhantomRunner
 
-  protected class ComPhantomRunner(libs: Seq[ResolvedJSDependency],
+  protected class ComPhantomRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile) extends AsyncPhantomRunner(libs, code)
       with ComJSRunner {
 

--- a/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/RetryingComJSEnv.scala
+++ b/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/RetryingComJSEnv.scala
@@ -10,7 +10,6 @@ package org.scalajs.jsenv.phantomjs
 
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.logging.Logger
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 
 import org.scalajs.jsenv._
 
@@ -43,27 +42,21 @@ final class RetryingComJSEnv(val baseEnv: ComJSEnv,
 
   def name: String = s"Retrying ${baseEnv.name}"
 
-  def jsRunner(libs: Seq[ResolvedJSDependency],
-      code: VirtualJSFile): JSRunner = {
+  def jsRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): JSRunner =
     baseEnv.jsRunner(libs, code)
-  }
 
-  def asyncRunner(libs: Seq[ResolvedJSDependency],
-      code: VirtualJSFile): AsyncJSRunner = {
+  def asyncRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): AsyncJSRunner =
     baseEnv.asyncRunner(libs, code)
-  }
 
-  def comRunner(libs: Seq[ResolvedJSDependency],
-      code: VirtualJSFile): ComJSRunner = {
+  def comRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): ComJSRunner =
     new RetryingComJSRunner(libs, code)
-  }
 
   /** Hack to work around abstract override in ComJSRunner */
   private trait DummyJSRunner {
     def stop(): Unit = ()
   }
 
-  private class RetryingComJSRunner(libs: Seq[ResolvedJSDependency],
+  private class RetryingComJSRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile) extends DummyJSRunner with ComJSRunner {
 
     private[this] val promise = Promise[Unit]

--- a/phantomjs-env/src/test/scala/org/scalajs/jsenv/phantomjs/RetryingComJSEnvTest.scala
+++ b/phantomjs-env/src/test/scala/org/scalajs/jsenv/phantomjs/RetryingComJSEnvTest.scala
@@ -1,7 +1,6 @@
 package org.scalajs.jsenv.phantomjs
 
 import org.scalajs.core.tools.io.VirtualJSFile
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.logging._
 
 import org.scalajs.jsenv.nodejs.NodeJSEnv
@@ -29,17 +28,17 @@ class RetryingComJSEnvTest extends JSEnvTest with ComTests {
     private[this] var fails = 0
     private[this] var failedReceive = false
 
-    def jsRunner(libs: Seq[ResolvedJSDependency],
+    def jsRunner(libs: Seq[VirtualJSFile],
         code: VirtualJSFile): JSRunner = {
       baseEnv.jsRunner(libs, code)
     }
 
-    def asyncRunner(libs: Seq[ResolvedJSDependency],
+    def asyncRunner(libs: Seq[VirtualJSFile],
         code: VirtualJSFile): AsyncJSRunner = {
       baseEnv.asyncRunner(libs, code)
     }
 
-    def comRunner(libs: Seq[ResolvedJSDependency],
+    def comRunner(libs: Seq[VirtualJSFile],
         code: VirtualJSFile): ComJSRunner = {
       new FailingComJSRunner(baseEnv.comRunner(libs, code))
     }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -628,8 +628,7 @@ object Build {
       ) ++ inConfig(Test) {
         // Redefine test to run Node.js and link HelloWorld
         test := {
-          val jsEnv = resolvedJSEnv.value
-          if (!jsEnv.isInstanceOf[NodeJSEnv])
+          if (!resolvedJSEnv.value.isInstanceOf[NodeJSEnv])
             sys.error("toolsJS/test must be run with Node.js")
 
           /* Collect IR relevant files from the classpath
@@ -689,10 +688,7 @@ object Build {
           val launcher = new MemVirtualJSFile("Generated launcher file")
             .withContent(code)
 
-          val linked = scalaJSLinkedFile.value
-          val libs = resolvedJSDependencies.value.data :+
-              ResolvedJSDependency.minimal(linked)
-          val runner = jsEnv.jsRunner(libs, launcher)
+          val runner = loadedJSEnv.value.jsRunner(launcher)
 
           runner.run(sbtLogger2ToolsLogger(streams.value.log), scalaJSConsole.value)
         }

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -667,7 +667,7 @@ object ScalaJSPluginInternal {
 
         val file = scalaJSLinkedFile.value
         log.debug(s"Loading JSEnv with linked file ${file.path}")
-        env.loadLibs((libs :+ file).map(ResolvedJSDependency.minimal(_)))
+        env.loadLibs(libs :+ file)
       },
 
       scalaJSModuleIdentifier := Def.taskDyn[Option[String]] {

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -638,11 +638,36 @@ object ScalaJSPluginInternal {
       loadedJSEnv := {
         val log = streams.value.log
         val env = resolvedJSEnv.value
-        val libs =
+        val deps =
           resolvedJSDependencies.value.data ++ scalaJSConfigurationLibs.value
+
+        /* Implement the behavior of commonJSName without having to burn it
+         * inside NodeJSEnv, and hence in the JSEnv API.
+         * Since this matches against NodeJSEnv specifically, it obviously
+         * breaks the OO approach, but oh well ...
+         */
+        val libs = env match {
+          case _: org.scalajs.jsenv.nodejs.NodeJSEnv =>
+            val libCache = new VirtualFileMaterializer(false)
+
+            for (dep <- deps) yield {
+              dep.info.commonJSName.fold {
+                dep.lib
+              } { commonJSName =>
+                val fname = libCache.materialize(dep.lib).getAbsolutePath
+                new MemVirtualJSFile(s"require-$fname").withContent(
+                  s"""$commonJSName = require("${escapeJS(fname)}");"""
+                )
+              }
+            }
+
+          case _ =>
+            deps.map(_.lib)
+        }
+
         val file = scalaJSLinkedFile.value
         log.debug(s"Loading JSEnv with linked file ${file.path}")
-        env.loadLibs(libs :+ ResolvedJSDependency.minimal(file))
+        env.loadLibs((libs :+ file).map(ResolvedJSDependency.minimal(_)))
       },
 
       scalaJSModuleIdentifier := Def.taskDyn[Option[String]] {


### PR DESCRIPTION
This removes the annoying dependency (sic!) of the `JSEnv` API on `ResolvedJSDependency`. This was the only part of `tools.jsdep` that was used in the `JSEnv` API, so it decouples those.

This will be very important as we separate `jsDependencies` in a separate plugin, as the `tools.jsdep` package should go with that, out of the core.