### PR TITLE
Fix #2864: Optimizer performance regression.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,19 +6,6 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
-      // private[optimizer], not an issue
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.scalajs.core.tools.linker.frontend.optimizer.ConcurrencyUtils#AtomicAcc.apply"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-          "org.scalajs.core.tools.linker.frontend.optimizer.ConcurrencyUtils#AtomicAccOps.removeAll$extension"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-          "org.scalajs.core.tools.linker.frontend.optimizer.ConcurrencyUtils#AtomicAccOps.removeAll"),
-      ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.scalajs.core.tools.linker.frontend.optimizer.ParIncOptimizer#CollOps.prepAdd"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-          "org.scalajs.core.tools.linker.frontend.optimizer.ParIncOptimizer#CollOps.finishAdd"),
-      ProblemFilters.exclude[IncompatibleResultTypeProblem](
-          "org.scalajs.core.tools.linker.frontend.optimizer.ParIncOptimizer#CollOps.emptyParIterable")
   )
 
   val JSEnvs = Seq(

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/ParIncOptimizer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/ParIncOptimizer.scala
@@ -11,8 +11,8 @@ package org.scalajs.core.tools.linker.frontend.optimizer
 
 import scala.collection.{GenTraversableOnce, GenIterable}
 import scala.collection.concurrent.TrieMap
-import scala.collection.parallel.mutable.ParTrieMap
-import scala.collection.parallel.immutable.ParVector
+import scala.collection.parallel.mutable.{ParTrieMap, ParArray}
+import scala.collection.parallel._
 
 import java.util.concurrent.atomic._
 
@@ -29,13 +29,13 @@ final class ParIncOptimizer(semantics: Semantics, esLevel: ESLevel,
     type Map[K, V] = TrieMap[K, V]
     type ParMap[K, V] = ParTrieMap[K, V]
     type AccMap[K, V] = TrieMap[K, AtomicAcc[V]]
-    type ParIterable[V] = ParVector[V]
+    type ParIterable[V] = ParArray[V]
     type Addable[V] = AtomicAcc[V]
 
     def emptyAccMap[K, V]: AccMap[K, V] = TrieMap.empty
     def emptyMap[K, V]: Map[K, V] = TrieMap.empty
     def emptyParMap[K, V]: ParMap[K, V] =  ParTrieMap.empty
-    def emptyParIterable[V]: ParIterable[V] = ParVector.empty
+    def emptyParIterable[V]: ParIterable[V] = ParArray.empty
 
     // Operations on ParMap
     def put[K, V](map: ParMap[K, V], k: K, v: V): Unit = map.put(k, v)
@@ -53,21 +53,21 @@ final class ParIncOptimizer(semantics: Semantics, esLevel: ESLevel,
       map.getOrPut(k, AtomicAcc.empty) += v
 
     def getAcc[K, V](map: AccMap[K, V], k: K): GenIterable[V] =
-      map.get(k).fold[ParVector[V]](ParVector.empty)(_.removeAll())
+      map.get(k).fold[Iterable[V]](Nil)(_.removeAll()).toParArray
 
     def parFlatMapKeys[A, B](map: AccMap[A, _])(
         f: A => GenTraversableOnce[B]): GenIterable[B] =
-      new ParVector(map.keys.flatMap(f).toVector)
+      map.keys.flatMap(f).toParArray
 
     // Operations on ParIterable
     def prepAdd[V](it: ParIterable[V]): Addable[V] =
-      AtomicAcc(it)
+      AtomicAcc(it.toList)
 
     def add[V](addable: Addable[V], v: V): Unit =
       addable += v
 
     def finishAdd[V](addable: Addable[V]): ParIterable[V] =
-      addable.removeAll()
+      addable.removeAll().toParArray
   }
 
   private val _interfaces = TrieMap.empty[String, InterfaceType]
@@ -82,7 +82,7 @@ final class ParIncOptimizer(semantics: Semantics, esLevel: ESLevel,
       encodedName: String): MethodImpl = new ParMethodImpl(owner, encodedName)
 
   private[optimizer] def processAllTaggedMethods(): Unit = {
-    val methods = methodsToProcess.removeAll()
+    val methods = methodsToProcess.removeAll().toParArray
     logProcessingMethods(methods.count(!_.deleted))
     for (method <- methods)
       method.process()


### PR DESCRIPTION
This essentially reverts commit ec3c3bd685ff32f9fbbe4e19db085cb651babf8c modulo:

- The build file changes to include the par-collections.
- An additional import to get `.toParArray` back.

Performance on testSuite/test:fastOptJS on
MacBook Air, 2.2 GHz Intel Core i7, 8 GB 1600 MHz DDR3

tl;dr: optimizer is 10x faster after the revert.

Before:

Linker: Check Infos: 5253899 us
Linker: Compute reachability: 2527607 us
Linker: Assemble LinkedClasses: 429050 us
Linker: Check IR: 2320856 us
Basic Linking: 10591499 us
Inc. optimizer: Batch mode: true
Inc. optimizer: Incremental part: 39471999 us
Inc. optimizer: Optimizing 35061 methods.
Inc. optimizer: Optimizer part: 348688137 us
Inc. optimizer: 388289830 us
Refiner: Compute reachability: 382626 us
Refiner: Assemble LinkedClasses: 82460 us
Refiner: 476345 us
Emitter: Class tree cache stats: reused: 2785 -- invalidated: 2975
Emitter: Method tree cache stats: resued: 0 -- invalidated: 24570
Emitter (write output): 6734101 us
Global IR cache stats: reused: 159 -- invalidated: 2187 -- trees read: 5747

After:

Linker: Check Infos: 5480910 us
Linker: Compute reachability: 3199914 us
Linker: Assemble LinkedClasses: 529704 us
Linker: Check IR: 2257044 us
Basic Linking: 11544069 us
Inc. optimizer: Batch mode: true
Inc. optimizer: Incremental part: 746521 us
Inc. optimizer: Optimizing 35061 methods.
Inc. optimizer: Optimizer part: 37023884 us
Inc. optimizer: 37889433 us
Refiner: Compute reachability: 380839 us
Refiner: Assemble LinkedClasses: 68282 us
Refiner: 463019 us
Emitter: Class tree cache stats: reused: 2785 -- invalidated: 2975
Emitter: Method tree cache stats: resued: 0 -- invalidated: 24570
Emitter (write output): 11078321 us
Global IR cache stats: reused: 0 -- invalidated: 2346 -- trees read: 5747