### PR TITLE
Fix #2780: Reach all methods of j.l.Integer before the optimizer.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -52,8 +52,25 @@ abstract class GenIncOptimizer private[optimizer] (semantics: Semantics,
 
     callMethods(LongImpl.RuntimeLongClass, LongImpl.AllIntrinsicMethods) ++
     optional(callMethods(LongImpl.RuntimeLongClass, LongImpl.OptionalIntrinsicMethods)) ++
-    callMethods(Definitions.BoxedIntegerClass,
-        Seq("compareTo__jl_Byte__I", "compareTo__jl_Short__I")) ++ // #2184
+    /* #2184 + #2780: we need to keep all methods of j.l.Integer, in case
+     * the corresponding methods are called on j.l.Byte or j.l.Short, and
+     * through optimizations become calls on j.l.Integer.
+     */
+    callMethods(Definitions.BoxedIntegerClass, Seq(
+        "byteValue__B",
+        "shortValue__S",
+        "intValue__I",
+        "longValue__J",
+        "floatValue__F",
+        "doubleValue__D",
+        "equals__O__Z",
+        "hashCode__I",
+        "compareTo__jl_Integer__I",
+        "toString__T",
+        "compareTo__jl_Byte__I",
+        "compareTo__jl_Short__I",
+        "compareTo__O__I"
+    )) ++
     instantiateClass("jl_NullPointerException", "init___")
   }
 


### PR DESCRIPTION
This was already partially fixed in 10997e9b04eb1a82225f85975073a64c09982448, which was a fix for `compareTo(Short)` were affected. #2780 shows that all methods of `java.lang.Integer` are affected, in fact, so this commit extends the existing fix to all methods.

Note that the methods still disappear after the refiner if they are not needed, and anyway they are all hijacked as helpers, so the quality of DCE is not affected by this fix.

There is no additional test, because the warnings could already be observed before, but as warnings, they did not fail the build.