### PR TITLE
Fix #2808: Handle long strings in DataInputStream.

### DIFF
--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -144,7 +144,7 @@ class DataInputStream(in: InputStream) extends FilterInputStream(in)
   }
 
   def readUTF(): String = {
-    val length = readShort()
+    val length = readUnsignedShort()
     var res = ""
     var i = 0
 

--- a/javalib/src/main/scala/java/io/DataOutputStream.scala
+++ b/javalib/src/main/scala/java/io/DataOutputStream.scala
@@ -84,6 +84,10 @@ class DataOutputStream(out: OutputStream)
     }
 
     val len = idx - 2
+
+    if (len >= 0x10000)
+      throw new UTFDataFormatException(s"encoded string too long: $len bytes")
+
     buffer(0) = (len >> 8).toByte
     buffer(1) = len.toByte
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
@@ -284,6 +284,21 @@ trait DataInputStreamTest {
     assertThrows(classOf[UTFDataFormatException], badStream.readUTF)
   }
 
+  @Test def readUTF_with_very_long_string(): Unit = {
+    val length = 40000
+    val inputBytes = new Array[Byte](2 + length)
+    inputBytes(0) = (length >> 8).toByte
+    inputBytes(1) = length.toByte
+    for (i <- 2 until (2 + length))
+      inputBytes(i) = 'a'.toByte
+
+    val stream = new DataInputStream(new ByteArrayInputStream(inputBytes))
+    val result = stream.readUTF()
+    assertEquals(length, result.length)
+    assertTrue(result.forall(_ == 'a'))
+    assertEquals(-1, stream.read())
+  }
+
   @Test def should_provide_readLine(): Unit = {
     val stream = newStream(
         "Hello World\nUNIX\nWindows\r\nMac (old)\rStuff".map(_.toInt): _*)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
@@ -5,6 +5,8 @@ import java.io._
 import org.junit._
 import org.junit.Assert._
 
+import org.scalajs.testsuite.utils.AssertThrows._
+
 object DataOutputStreamTest {
   class DataOutputStreamWrittenAccess(out: OutputStream)
       extends DataOutputStream(out) {
@@ -273,5 +275,17 @@ class DataOutputStreamTest {
         0x2d, 0x3e, 0x20, 0xed, 0xa0, 0xbd, 0xed, 0xb2,
         0xa9, 0x00, 0x03, 0xe6, 0x84, 0x9b
     )
+  }
+
+  @Test def writeUTFTooLong(): Unit = {
+    val (stream, checker) = newStream()
+
+    var longString = "aaa"
+    while (longString.length < 0x10000)
+      longString = longString + longString
+
+    assertThrows(classOf[UTFDataFormatException], {
+      stream.writeUTF(longString)
+    })
   }
 }


### PR DESCRIPTION
By "long" strings we mean strings whose encoded byte length is greater than `Short.MaxValue`, for which the length must be read as an unsigned short.

Also, make sure that DataOutputStream throws for strings whose encoded byte length is `>= 0x10000`.