### PR TITLE
Deprecate NodeJSEnv().value and JSDOMNodeJSEnv().value.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -156,46 +156,46 @@
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in noIrCheckTest := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in noIrCheckTest := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         ++$scala noIrCheckTest/test \
         noIrCheckTest/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test
@@ -203,9 +203,9 @@
 
   <task id="bootstrap"><![CDATA[
     setJavaVersion $java
-    sbt 'set jsEnv in toolsJS := NodeJSEnv(args = Seq("--max_old_space_size=2048")).value.withSourceMap(false)' \
+    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=2048")).withSourceMap(false)' \
         ++$scala irJS/test toolsJS/test &&
-    sbt 'set jsEnv in toolsJS := NodeJSEnv(args = Seq("--max_old_space_size=2048")).value.withSourceMap(false)' \
+    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=2048")).withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala irJS/test toolsJS/test
   ]]></task>

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -11,8 +11,11 @@ import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
 abstract class ExternalJSEnv(
-  final protected val additionalArgs: Seq[String],
-  final protected val additionalEnv:  Map[String, String]) extends AsyncJSEnv {
+    @deprecatedName('additionalArgs)
+    final protected val args: Seq[String],
+    @deprecatedName('additionalEnv)
+    final protected val env: Map[String, String])
+    extends AsyncJSEnv {
 
   import ExternalJSEnv._
 
@@ -23,6 +26,12 @@ abstract class ExternalJSEnv(
 
   /** Command to execute (on shell) for this VM */
   protected def executable: String
+
+  @deprecated("Use `args` instead.", "0.6.16")
+  final protected def additionalArgs: Seq[String] = args
+
+  @deprecated("Use `env` instead.", "0.6.16")
+  final protected def additionalEnv: Map[String, String] = env
 
   /** Custom initialization scripts. */
   protected def customInitFiles(): Seq[VirtualJSFile] = Nil
@@ -51,16 +60,17 @@ abstract class ExternalJSEnv(
     protected def sendVMStdin(out: OutputStream): Unit = {}
 
     /** VM arguments excluding executable. Override to adapt.
-     *  Overrider is responsible to add additionalArgs.
+     *
+     *  The default value in `ExternalJSEnv` is `args`.
      */
-    protected def getVMArgs(): Seq[String] = additionalArgs
+    protected def getVMArgs(): Seq[String] = args
 
     /** VM environment. Override to adapt.
      *
-     *  Default is `sys.env` and [[additionalEnv]]
+     *  The default value in `ExternalJSEnv` is `sys.env ++ env`.
      */
     protected def getVMEnv(): Map[String, String] =
-      sys.env ++ additionalEnv
+      sys.env ++ env
 
     /** Get files that are a library (i.e. that do not run anything) */
     protected def getLibJSFiles(): Seq[VirtualJSFile] =

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
@@ -22,9 +22,15 @@ import org.scalajs.jsenv.Utils.OptDeadline
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
-abstract class AbstractNodeJSEnv(nodejsPath: String, addArgs: Seq[String],
-    addEnv: Map[String, String], val sourceMap: Boolean)
-    extends ExternalJSEnv(addArgs, addEnv) with ComJSEnv {
+abstract class AbstractNodeJSEnv(
+    @deprecatedName('nodejsPath)
+    protected val executable: String,
+    @deprecatedName('addArgs)
+    args: Seq[String],
+    @deprecatedName('addEnv)
+    env: Map[String, String],
+    val sourceMap: Boolean)
+    extends ExternalJSEnv(args, env) with ComJSEnv {
 
   /** True, if the installed node executable supports source mapping.
    *
@@ -42,8 +48,6 @@ abstract class AbstractNodeJSEnv(nodejsPath: String, addArgs: Seq[String],
         false
     }
   }
-
-  protected def executable: String = nodejsPath
 
   /** Retry-timeout to wait for the JS VM to connect */
   protected val acceptTimeout = 5000

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
@@ -18,10 +18,13 @@ import org.scalajs.jsenv._
 import org.scalajs.core.ir.Utils.escapeJS
 
 class JSDOMNodeJSEnv(
-  nodejsPath: String = "node",
-  addArgs: Seq[String] = Seq.empty,
-  addEnv: Map[String, String] = Map.empty
-) extends AbstractNodeJSEnv(nodejsPath, addArgs, addEnv, sourceMap = false) {
+    @deprecatedName('nodejsPath)
+    executable: String = "node",
+    @deprecatedName('addArgs)
+    args: Seq[String] = Seq.empty,
+    @deprecatedName('addEnv)
+    env: Map[String, String] = Map.empty)
+    extends AbstractNodeJSEnv(executable, args, env, sourceMap = false) {
 
   protected def vmName: String = "Node.js with JSDOM"
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -19,26 +19,30 @@ import org.scalajs.core.tools.logging._
 
 import java.io.{ Console => _, _ }
 
-
 class NodeJSEnv private (
-  nodejsPath: String,
-  addArgs: Seq[String],
-  addEnv: Map[String, String],
-  sourceMap: Boolean
-) extends AbstractNodeJSEnv(nodejsPath, addArgs, addEnv, sourceMap) {
+    @deprecatedName('nodejsPath)
+    override protected val executable: String, // override val for bin compat
+    @deprecatedName('addArgs)
+    args: Seq[String],
+    @deprecatedName('addEnv)
+    env: Map[String, String],
+    sourceMap: Boolean)
+    extends AbstractNodeJSEnv(executable, args, env, sourceMap) {
 
-  def this(nodejsPath: String = "node", addArgs: Seq[String] = Seq.empty,
-      addEnv: Map[String, String] = Map.empty) = {
-    this(nodejsPath, addArgs, addEnv, sourceMap = true)
+  def this(
+      @deprecatedName('nodejsPath)
+      executable: String = "node",
+      @deprecatedName('addArgs)
+      args: Seq[String] = Seq.empty,
+      @deprecatedName('addEnv)
+      env: Map[String, String] = Map.empty) = {
+    this(executable, args, env, sourceMap = true)
   }
 
   def withSourceMap(sourceMap: Boolean): NodeJSEnv =
-    new NodeJSEnv(nodejsPath, addArgs, addEnv, sourceMap)
+    new NodeJSEnv(executable, args, env, sourceMap)
 
   protected def vmName: String = "Node.js"
-
-  // For binary compatibility, now `executable` is defined in AbstractNodeJSEnv
-  override protected def executable: String = super.executable
 
   override def jsRunner(libs: Seq[ResolvedJSDependency],
       code: VirtualJSFile): JSRunner = {

--- a/js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
@@ -29,17 +29,19 @@ import scala.concurrent.{ExecutionContext, TimeoutException, Future}
 import scala.concurrent.duration.Duration
 
 class PhantomJSEnv(
-    phantomjsPath: String = "phantomjs",
-    addArgs: Seq[String] = Seq.empty,
-    addEnv: Map[String, String] = Map.empty,
+    @deprecatedName('phantomjsPath)
+    protected val executable: String = "phantomjs",
+    @deprecatedName('addArgs)
+    args: Seq[String] = Seq.empty,
+    @deprecatedName('addEnv)
+    env: Map[String, String] = Map.empty,
     val autoExit: Boolean = true,
     jettyClassLoader: ClassLoader = null
-) extends ExternalJSEnv(addArgs, addEnv) with ComJSEnv {
+) extends ExternalJSEnv(args, env) with ComJSEnv {
 
   import PhantomJSEnv._
 
   protected def vmName: String = "PhantomJS"
-  protected def executable: String = phantomjsPath
 
   override def jsRunner(libs: Seq[ResolvedJSDependency],
       code: VirtualJSFile): JSRunner = {

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -113,6 +113,9 @@ object ScalaJSPlugin extends AutoPlugin {
      *  case) or scope it manually, using
      *  [[sbt.ProjectExtra.inScope[* Project.inScope]].
      */
+    @deprecated(
+        "Use `jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(...)` instead.",
+        "0.6.16")
     def NodeJSEnv(
         executable: String = "node",
         args: Seq[String] = Seq.empty,
@@ -137,6 +140,10 @@ object ScalaJSPlugin extends AutoPlugin {
      *  case) or scope it manually, using
      *  [[sbt.ProjectExtra.inScope[* Project.inScope]].
      */
+    @deprecated(
+        "Use `jsEnv := new org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv(...)` " +
+        "instead.",
+        "0.6.16")
     def JSDOMNodeJSEnv(
         executable: String = "node",
         args: Seq[String] = Seq.empty,

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -605,9 +605,9 @@ object ScalaJSPluginInternal {
         if (scalaJSUseRhinoInternal.value) {
           RhinoJSEnvInternal().value
         } else if (scalaJSRequestsDOM.value) {
-          JSDOMNodeJSEnv().value
+          new org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv()
         } else {
-          NodeJSEnv().value
+          new org.scalajs.jsenv.nodejs.NodeJSEnv()
         }
       },
 


### PR DESCRIPTION
The constructors `new NodeJSEnv()` and `new JSDOMNodeJSEnv()` should be used instead.

Those `Initialize` constructors were added to be consistent with `RhinoJSEnv().value` (which needs `scalaJSLinker.value` and `scalaJSRequestsDOM.value`) and `PhantomJSEnv().value` (which needs `scalaJSPhantomJSClassLoader.value`). However, as Rhino is deprecated, and PhantomJS will move in its own repo, it doesn't make any sense to keep being consistent. Moreover, `JSDOMNodeJSEnv` will also move to its own repo, and won't even provide a companion sbt plugin (because there is no need to), so `JSDOMNodeJSEnv().value` would have nowhere to go, breaking the consistency anyway.