### PR TITLE
Fix #2880: Use our own definition of Sys_error.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -138,6 +138,10 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val BoxesRunTime_boxToCharacter = getMemberMethod(BoxesRunTimeModule, newTermName("boxToCharacter"))
     lazy val BoxesRunTime_unboxToChar    = getMemberMethod(BoxesRunTimeModule, newTermName("unboxToChar"))
 
+    // Copy-pasted from `Definitions.scala`, because it was removed in 2.13.
+    lazy val SysPackage = getPackageObject("scala.sys")
+      def Sys_error: Symbol = getMemberMethod(SysPackage, nme.error)
+
     lazy val ReflectModule = getRequiredModule("scala.scalajs.reflect.Reflect")
       lazy val Reflect_registerLoadableModuleClass = getMemberMethod(ReflectModule, newTermName("registerLoadableModuleClass"))
       lazy val Reflect_registerInstantiatableClass = getMemberMethod(ReflectModule, newTermName("registerInstantiatableClass"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -1078,7 +1078,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
         if (sym != JSPackage_native) {
           tree.rhs match {
             case Apply(trg, Literal(Constant("stub")) :: Nil)
-                if trg.symbol == definitions.Sys_error =>
+                if trg.symbol == jsDefinitions.Sys_error =>
             case _ =>
               reporter.error(tree.pos,
                   "The body of a primitive must be `sys.error(\"stub\")`.")


### PR DESCRIPTION
In https://github.com/scala/scala/pull/5830, the definition of `Sys_error` was removed from `Definitions.scala`. This commit reintroduces it in our own codebase, as a quickfix to #2880.

This will need to be revisited as part of #2876 not use `sys.error` at all, but that is less urgent.