### PR TITLE
FF-ONLY Merge 0.6.x into master

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -130,46 +130,46 @@
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in noIrCheckTest := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in noIrCheckTest := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         ++$scala noIrCheckTest/test \
         noIrCheckTest/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := NodeJSEnv().value.withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test
@@ -177,9 +177,9 @@
 
   <task id="bootstrap"><![CDATA[
     setJavaVersion $java
-    sbt 'set jsEnv in toolsJS := NodeJSEnv(args = Seq("--max_old_space_size=2048")).value.withSourceMap(false)' \
+    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=2048")).withSourceMap(false)' \
         ++$scala irJS/test toolsJS/test &&
-    sbt 'set jsEnv in toolsJS := NodeJSEnv(args = Seq("--max_old_space_size=2048")).value.withSourceMap(false)' \
+    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=2048")).withSourceMap(false)' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala irJS/test toolsJS/test
   ]]></task>

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -133,6 +133,10 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val BoxesRunTime_boxToCharacter = getMemberMethod(BoxesRunTimeModule, newTermName("boxToCharacter"))
     lazy val BoxesRunTime_unboxToChar    = getMemberMethod(BoxesRunTimeModule, newTermName("unboxToChar"))
 
+    // Copy-pasted from `Definitions.scala`, because it was removed in 2.13.
+    lazy val SysPackage = getPackageObject("scala.sys")
+      def Sys_error: Symbol = getMemberMethod(SysPackage, nme.error)
+
     lazy val ReflectModule = getRequiredModule("scala.scalajs.reflect.Reflect")
       lazy val Reflect_registerLoadableModuleClass = getMemberMethod(ReflectModule, newTermName("registerLoadableModuleClass"))
       lazy val Reflect_registerInstantiatableClass = getMemberMethod(ReflectModule, newTermName("registerInstantiatableClass"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -984,7 +984,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
         if (sym != JSPackage_native) {
           tree.rhs match {
             case Apply(trg, Literal(Constant("stub")) :: Nil)
-                if trg.symbol == definitions.Sys_error =>
+                if trg.symbol == jsDefinitions.Sys_error =>
             case _ =>
               reporter.error(tree.pos,
                   "The body of a primitive must be `sys.error(\"stub\")`.")

--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -144,7 +144,7 @@ class DataInputStream(in: InputStream) extends FilterInputStream(in)
   }
 
   def readUTF(): String = {
-    val length = readShort()
+    val length = readUnsignedShort()
     var res = ""
     var i = 0
 

--- a/javalib/src/main/scala/java/io/DataOutputStream.scala
+++ b/javalib/src/main/scala/java/io/DataOutputStream.scala
@@ -84,6 +84,10 @@ class DataOutputStream(out: OutputStream)
     }
 
     val len = idx - 2
+
+    if (len >= 0x10000)
+      throw new UTFDataFormatException(s"encoded string too long: $len bytes")
+
     buffer(0) = (len >> 8).toByte
     buffer(1) = len.toByte
 

--- a/javalib/src/main/scala/java/util/Base64.scala
+++ b/javalib/src/main/scala/java/util/Base64.scala
@@ -1,0 +1,587 @@
+package java.util
+
+import scala.annotation.tailrec
+
+import java.io._
+import java.nio.charset.StandardCharsets
+import java.nio.ByteBuffer
+
+object Base64 {
+
+  private val chars = ('A' to 'Z') ++ ('a' to 'z') ++ ('0' to '9')
+
+  private val basicEncodeTable: Array[Byte] =
+    (chars ++ Seq('+', '/')).map(_.toByte).toArray
+
+  private val urlSafeEncodeTable: Array[Byte] =
+    (chars ++ Seq('-', '_')).map(_.toByte).toArray
+
+  private def decodeTable(encode: Array[Byte]): Array[Int] = {
+    val decode = Array.fill[Int](256)(-1)
+    for ((b, i) <- encode.zipWithIndex)
+      decode(b) = i
+    decode('=') = -2
+    decode
+  }
+
+  private val basicDecodeTable = decodeTable(basicEncodeTable)
+  private val urlSafeDecodeTable = decodeTable(urlSafeEncodeTable)
+
+  private val mimeLineSeparators = Array[Byte]('\r', '\n')
+  private final val mimeLineLength = 76
+
+  private val basicEncoder =
+    new Encoder(basicEncodeTable)
+
+  private val basicDecoder =
+    new Decoder(basicDecodeTable, ignoreInvalid = false)
+
+  private val mimeEncoder =
+    new Encoder(basicEncodeTable, mimeLineLength, mimeLineSeparators)
+
+  private val mimeDecoder =
+    new Decoder(basicDecodeTable, ignoreInvalid = true)
+
+  private val urlSafeEncoder =
+    new Encoder(urlSafeEncodeTable)
+
+  private val urlSafeDecoder =
+    new Decoder(urlSafeDecodeTable, ignoreInvalid = false)
+
+  // --------------------------------------------------------------------------
+
+  def getEncoder(): Encoder = basicEncoder
+
+  def getUrlEncoder(): Encoder = urlSafeEncoder
+
+  def getMimeEncoder(): Encoder = mimeEncoder
+
+  def getMimeEncoder(lineLength: Int, lineSeparator: Array[Byte]): Encoder = {
+    for (b <- lineSeparator) {
+      if (basicDecodeTable(b & 0xff) != -1) {
+        throw new IllegalArgumentException(
+            "Illegal base64 line separator character 0x" + (b & 0xff).toHexString)
+      }
+    }
+    new Encoder(basicEncodeTable, lineLength / 4 * 4, lineSeparator)
+  }
+
+  def getDecoder(): Decoder = basicDecoder
+
+  def getUrlDecoder(): Decoder = urlSafeDecoder
+
+  def getMimeDecoder(): Decoder = mimeDecoder
+
+  // --------------------------------------------------------------------------
+
+  class Decoder private[Base64] (table: Array[Int], ignoreInvalid: Boolean) {
+
+    def decode(src: Array[Byte]): Array[Byte] = {
+      val dst = new Array[Byte](dstRequiredLength(src))
+      doDecode(new Wrapper(src), new Wrapper(dst))
+      dst
+    }
+
+    def decode(src: String): Array[Byte] =
+      decode(src.getBytes(StandardCharsets.ISO_8859_1))
+
+    def decode(src: Array[Byte], dst: Array[Byte]): Int = {
+      if (dst.length < dstMaxLength(src.length) && // dst is possibly too small
+          dst.length < dstRequiredLength(src)) {   // dst is actually too small
+        throw new IllegalArgumentException(
+            "Output byte array is too small for decoding all input bytes")
+      }
+
+      doDecode(new Wrapper(src), new Wrapper(dst))
+    }
+
+    def decode(buffer: ByteBuffer): ByteBuffer = {
+      val start = buffer.position()
+      try {
+        val src = new Array[Byte](buffer.remaining())
+        buffer.get(src)
+        val dst = new Array[Byte](dstRequiredLength(src))
+        val written = doDecode(new Wrapper(src), new Wrapper(dst))
+        ByteBuffer.wrap(dst, 0, written)
+      } catch {
+        case e: IllegalArgumentException =>
+          buffer.position(start)
+          throw e
+      }
+    }
+
+    def wrap(is: InputStream): InputStream =
+      new DecodingInputStream(is, table, ignoreInvalid)
+
+    // ------------------------------------------------------------------------
+    // PRIVATE
+    // ------------------------------------------------------------------------
+
+    private def doDecode(src: Wrapper, dst: Wrapper): Int = {
+      val srcBuffer = new Wrapper(new Array[Byte](4))
+
+      @inline
+      def inputData(): Unit = {
+        srcBuffer.position = 0
+        var shift = 18
+        var i = 0
+        while (srcBuffer.hasRemaining) {
+          i |= ((srcBuffer.get() & 0xff) << shift)
+          shift -= 6
+        }
+
+        if (shift == 12) {
+          throw new IllegalArgumentException(
+              "Last unit does not have enough valid bits")
+        }
+
+        if (shift <= 6)
+          dst.put((i >> 16).toByte)
+        if (shift <= 0)
+          dst.put((i >> 8).toByte)
+        if (shift <= -6)
+          dst.put(i.toByte)
+        srcBuffer.clear()
+      }
+
+      @tailrec
+      def iterate(): Unit = {
+        if (src.hasRemaining) {
+          if (srcBuffer.hasRemaining) {
+            val int = src.get() & 0xff
+            table(int) match {
+              case -2 =>
+
+              case -1 =>
+                if (!ignoreInvalid) {
+                  throw new IllegalArgumentException(
+                      "Illegal base64 character " + int.toHexString)
+                }
+                iterate()
+
+              case i =>
+                srcBuffer.put(i.toByte)
+                iterate()
+            }
+          } else {
+            inputData()
+            iterate()
+          }
+        }
+      }
+
+      iterate()
+
+      // end or padding
+      srcBuffer.flip()
+      inputData()
+      while (src.hasRemaining) {
+        val int = src.get() & 0xff
+        val value = table(int)
+        if (value != -2 && (!ignoreInvalid || value > 0)) {
+          throw new IllegalArgumentException(
+              s"Input byte array has incorrect ending byte at $int")
+        }
+      }
+
+      dst.position
+    }
+
+    private def dstRequiredLength(src: Array[Byte]): Int = {
+      var validBytes = 0
+
+      if (ignoreInvalid) {
+        for (i <- src.indices) {
+          if (table(src(i) & 0xff) >= 0)
+            validBytes += 1
+        }
+      } else {
+        /* We check the end for padding and compute the length from there.
+         * This is ok, if the rest contains garbage we'll have written
+         * something before throwing but the spec says "If the input byte array
+         * is not in valid Base64 encoding scheme then some bytes may have been
+         * written to the output byte array before IllegalArgumentException is
+         * thrown."
+         */
+        validBytes = src.length
+        if (src.length >= 1 && src.last == '=') {
+          validBytes -= 1
+          if (src.length >= 2 && src(src.length - 2) == '=')
+            validBytes -= 1
+        }
+
+        if (src.length >= 1 && validBytes == 0) {
+          throw new IllegalArgumentException(
+              "Input byte array has wrong 4-byte ending unit")
+        }
+      }
+
+      dstMaxLength(validBytes)
+    }
+
+    /** Computes the destination length solely based on the source length,
+     *  without knowing about padding.
+     */
+    private def dstMaxLength(srcLength: Int): Int =
+      (srcLength + 3) / 4 * 3 - (if (srcLength % 4 == 0) 0 else 4 - (srcLength % 4))
+
+  }
+
+  private object DecodingInputStream {
+    private final val DecodeState18 = 0
+    private final val DecodeState12 = 1
+    private final val DecodeState14 = 2
+    private final val DecodeState16 = 3
+  }
+
+  private class DecodingInputStream(in: InputStream, table: Array[Int],
+      ignoreInvalid: Boolean)
+      extends FilterInputStream(in) {
+
+    import DecodingInputStream._
+
+    private val oneBuf = new Array[Byte](1)
+
+    private var closed = false
+    private var eof = false
+    private var out = 0
+    private var shift = DecodeState18
+
+    override def read(): Int =
+      if (read(oneBuf, 0, 1) == -1) -1
+      else oneBuf(0) & 0xff
+
+    override def read(b: Array[Byte], off: Int, len: Int): Int = {
+      var written = 0
+
+      @inline
+      def writeValue(i: Int): Int = {
+        /* Max value means we're writing remaining bytes after EOF, no table
+         * lookup.
+         */
+        if (i == Int.MaxValue) {
+          0
+        } else {
+          table(i) match {
+            case -1 =>
+              if (!ignoreInvalid) {
+                throw new IOException(
+                    "Illegal base64 character " + i.toHexString)
+              }
+              0
+
+            case v =>
+              shift match {
+                case DecodeState18 =>
+                  out |= v << 18
+                  shift = DecodeState12
+                  0
+
+                case DecodeState12 =>
+                  out |= v << 12
+                  b(off + written) = (out >> 16).toByte
+                  out <<= 8
+                  shift = DecodeState14
+                  1
+
+                case DecodeState14 =>
+                  out |= v << 14
+                  b(off + written) = (out >> 16).toByte
+                  out <<= 8
+                  shift = DecodeState16
+                  1
+
+                case DecodeState16 =>
+                  out |= v << 16
+                  b(off + written) = (out >> 16).toByte
+                  out = 0
+                  shift = DecodeState18
+                  1
+              }
+          }
+        }
+      }
+
+      @inline
+      def endOfFile(): Int = {
+        eof = true
+        shift match {
+          case DecodeState18 =>
+            0 // nothing
+          case DecodeState12 =>
+            throw new IOException(
+                "Base64 stream has one un-decoded dangling byte.")
+          case _ =>
+            writeValue(Int.MaxValue)
+        }
+      }
+
+      @inline
+      def padding(): Int = {
+        eof = true
+        val s = shift
+        if (s == DecodeState18 || s == DecodeState12 ||
+            (s == DecodeState14 && in.read() != '=' && !ignoreInvalid)) {
+          throw new IOException ("Illegal base64 ending sequence")
+        }
+        writeValue(Int.MaxValue)
+      }
+
+      @tailrec
+      def iterate(): Unit = {
+        if (written < len) {
+          in.read() match {
+            case -1 =>
+              written += endOfFile()
+
+            case '=' =>
+              written += padding()
+              iterate()
+
+            case int =>
+              written += writeValue(int)
+              iterate()
+          }
+        }
+      }
+
+      if (closed)
+        throw new IOException("Stream is closed")
+
+      if (off < 0 || len < 0 || len > b.length - off)
+        throw new IndexOutOfBoundsException()
+
+      if (eof) {
+        -1
+      } else {
+        iterate()
+        written
+      }
+    }
+
+    override def close(): Unit = if (!closed) {
+      closed = true
+      in.close()
+    }
+  }
+
+  // --------------------------------------------------------------------------
+
+  class Encoder private[Base64] (table: Array[Byte], lineLength: Int = 0,
+      lineSeparator: Array[Byte] = Array.empty, withPadding: Boolean = true) {
+
+    def encode(src: Array[Byte]): Array[Byte] = {
+      val dst = new Array[Byte](dstLength(src.length))
+      doEncode(src, dst, dst.length)
+      dst
+    }
+
+    def encode(src: Array[Byte], dst: Array[Byte]): Int = {
+      val dstLen = dstLength(src.length)
+      if (dst.length < dstLen) {
+        throw new IllegalArgumentException(
+            "Output byte array is too small for encoding all input bytes")
+      }
+      doEncode(src, dst, dstLen)
+    }
+
+    def encodeToString(src: Array[Byte]): String =
+      new String(encode(src), StandardCharsets.ISO_8859_1)
+
+    def encode(buffer: ByteBuffer): ByteBuffer = {
+      val result = new Array[Byte](dstLength(buffer.remaining()))
+      val src = new Array[Byte](buffer.remaining())
+      buffer.get(src)
+      val written = doEncode(new Wrapper(src), new Wrapper(result))
+      ByteBuffer.wrap(result, 0, written)
+    }
+
+    def wrap(os: OutputStream): OutputStream =
+      new EncodingOutputStream(os, table, lineLength, lineSeparator, withPadding)
+
+    def withoutPadding(): Encoder =
+      if (withPadding) new Encoder(table, lineLength, lineSeparator, false)
+      else this
+
+    // ------------------------------------------------------------------------
+    // PRIVATE
+    // ------------------------------------------------------------------------
+
+    private def doEncode(src: Array[Byte], dst: Array[Byte],
+        dstLength: Int): Int = {
+      doEncode(new Wrapper(src), new Wrapper(dst, 0, dstLength))
+    }
+
+    // dst position must always be 0 here
+    private def doEncode(src: Wrapper, dst: Wrapper): Int = {
+      val length = src.remaining
+      var currentLine = 0
+
+      @inline
+      def encode(a: Byte, b: Byte, c: Byte): Unit = {
+        val bits = (a & 0xff) << 16 | (b & 0xff) << 8 | (c & 0xff)
+        dst.put(table((bits >>> 18) & 0x3f))
+        dst.put(table((bits >>> 12) & 0x3f))
+        if (dst.hasRemaining)
+          dst.put(table((bits >>> 6) & 0x3f))
+        if (dst.hasRemaining)
+          dst.put(table(bits & 0x3f))
+
+        currentLine += 4
+        if (lineSeparator.length > 0 && lineLength > 0 &&
+            currentLine == lineLength && dst.hasRemaining) {
+          lineSeparator.foreach(dst.put(_))
+          currentLine = 0
+        }
+      }
+
+      while (src.remaining >= 3)
+        encode(src.get(), src.get(), src.get())
+
+      (length % 3) match {
+        case 0 =>
+        case 1 =>
+          encode(src.get(), 0, 0)
+          if (withPadding) {
+            dst.position = dst.position - 2
+            dst.put('='.toByte)
+            dst.put('='.toByte)
+          }
+        case 2 =>
+          encode(src.get(), src.get(), 0)
+          if (withPadding) {
+            dst.position = dst.position - 1
+            dst.put('='.toByte)
+          }
+      }
+
+      dst.position
+    }
+
+    private def dstLength(srcLength: Int): Int = {
+      val withPad = ((srcLength + 2) / 3) * 4
+      val toRemove = if (withPadding) 0 else (3 - (srcLength % 3)) % 3
+      val withoutEndLines = withPad - toRemove
+      val endLines =
+        if (lineLength <= 0) 0
+        else ((withoutEndLines - 1) / lineLength) * lineSeparator.length
+      withoutEndLines + endLines
+    }
+  }
+
+  // --------------------------------------------------------------------------
+
+  private class EncodingOutputStream(out: OutputStream, table: Array[Byte],
+      lineLength: Int, lineSeparator: Array[Byte], withPadding: Boolean)
+      extends FilterOutputStream(out) {
+
+    private val inputBuf = new Wrapper(new Array[Byte](3))
+    private var currentLineLength = 0
+    private var closed = false
+
+    override def write(b: Int): Unit =
+      write(Array(b.toByte), 0, 1)
+
+    @inline
+    private def addLineSeparators(): Unit = {
+      if (lineSeparator.length > 0 && lineLength > 0 &&
+          currentLineLength == lineLength) {
+        out.write(lineSeparator)
+        currentLineLength = 0
+      }
+    }
+
+    @inline
+    private def writeBuffer(count: Int): Unit = {
+      inputBuf.clear()
+      val bits = {
+        ((inputBuf.get() & 0xff) << 16) |
+        ((inputBuf.get() & 0xff) << 8) |
+        (inputBuf.get() & 0xff)
+      }
+      var shift = 18
+      for (_ <- 0 until count) {
+        out.write(table((bits >>> shift) & 0x3f))
+        shift -= 6
+        currentLineLength += 1
+      }
+      inputBuf.clear()
+    }
+
+    override def write(bytes: Array[Byte], off: Int, len: Int): Unit = {
+      if (closed)
+        throw new IOException("Stream is closed")
+      if (off < 0 || len < 0 || len > bytes.length - off)
+        throw new IndexOutOfBoundsException()
+
+      if (len != 0) {
+        addLineSeparators()
+        for (i <- off until (off + len)) {
+          inputBuf.put(bytes(i))
+          if (!inputBuf.hasRemaining) {
+            writeBuffer(4)
+            if (i < (off + len - 1))
+              addLineSeparators()
+          }
+        }
+      }
+    }
+
+    override def close(): Unit = {
+      @inline
+      def fillAndWrite(count: Int): Unit = {
+        addLineSeparators()
+        while (inputBuf.hasRemaining)
+          inputBuf.put(0.toByte)
+        writeBuffer(count)
+        if (withPadding) {
+          for (_ <- count until 4)
+            out.write('=')
+        }
+      }
+
+      if (!closed) {
+        inputBuf.position match {
+          case 0 =>
+          case 1 => fillAndWrite(2)
+          case 2 => fillAndWrite(3)
+        }
+        out.close()
+        closed = true
+      }
+    }
+  }
+
+  /** An Array augmented with a position and a limit.
+   *
+   *  This is modeled after `java.nio.ByteBuffer`, but is more lightweight.
+   */
+  private class Wrapper(array: Array[Byte], var position: Int, var limit: Int) {
+
+    def this(array: Array[Byte]) = this(array, 0, array.length)
+
+    def hasRemaining: Boolean = position < limit
+
+    def remaining: Int = limit - position
+
+    def put(b: Byte): Unit = {
+      array(position) = b
+      position += 1
+    }
+
+    def get(): Byte = {
+      position += 1
+      array(position-1)
+    }
+
+    def clear(): Unit = {
+      position = 0
+      limit = array.length
+    }
+
+    def flip(): Unit = {
+      limit = position
+      position = 0
+    }
+  }
+}

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -10,8 +10,11 @@ import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
 abstract class ExternalJSEnv(
-  final protected val additionalArgs: Seq[String],
-  final protected val additionalEnv:  Map[String, String]) extends AsyncJSEnv {
+    @deprecatedName('additionalArgs)
+    final protected val args: Seq[String],
+    @deprecatedName('additionalEnv)
+    final protected val env: Map[String, String])
+    extends AsyncJSEnv {
 
   import ExternalJSEnv._
 
@@ -22,6 +25,12 @@ abstract class ExternalJSEnv(
 
   /** Command to execute (on shell) for this VM */
   protected def executable: String
+
+  @deprecated("Use `args` instead.", "0.6.16")
+  final protected def additionalArgs: Seq[String] = args
+
+  @deprecated("Use `env` instead.", "0.6.16")
+  final protected def additionalEnv: Map[String, String] = env
 
   /** Custom initialization scripts. */
   protected def customInitFiles(): Seq[VirtualJSFile] = Nil
@@ -50,16 +59,17 @@ abstract class ExternalJSEnv(
     protected def sendVMStdin(out: OutputStream): Unit = {}
 
     /** VM arguments excluding executable. Override to adapt.
-     *  Overrider is responsible to add additionalArgs.
+     *
+     *  The default value in `ExternalJSEnv` is `args`.
      */
-    protected def getVMArgs(): Seq[String] = additionalArgs
+    protected def getVMArgs(): Seq[String] = args
 
     /** VM environment. Override to adapt.
      *
-     *  Default is `sys.env` and [[additionalEnv]]
+     *  The default value in `ExternalJSEnv` is `sys.env ++ env`.
      */
     protected def getVMEnv(): Map[String, String] =
-      sys.env ++ additionalEnv
+      sys.env ++ env
 
     /** Get files that are a library (i.e. that do not run anything) */
     protected def getLibJSFiles(): Seq[VirtualJSFile] =

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
@@ -22,9 +22,15 @@ import org.scalajs.jsenv.Utils.OptDeadline
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
-abstract class AbstractNodeJSEnv(nodejsPath: String, addArgs: Seq[String],
-    addEnv: Map[String, String], val sourceMap: Boolean)
-    extends ExternalJSEnv(addArgs, addEnv) with ComJSEnv {
+abstract class AbstractNodeJSEnv(
+    @deprecatedName('nodejsPath)
+    protected val executable: String,
+    @deprecatedName('addArgs)
+    args: Seq[String],
+    @deprecatedName('addEnv)
+    env: Map[String, String],
+    val sourceMap: Boolean)
+    extends ExternalJSEnv(args, env) with ComJSEnv {
 
   /** True, if the installed node executable supports source mapping.
    *
@@ -42,8 +48,6 @@ abstract class AbstractNodeJSEnv(nodejsPath: String, addArgs: Seq[String],
         false
     }
   }
-
-  protected def executable: String = nodejsPath
 
   /** Retry-timeout to wait for the JS VM to connect */
   protected val acceptTimeout = 5000

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
@@ -17,10 +17,13 @@ import org.scalajs.jsenv._
 import org.scalajs.core.ir.Utils.escapeJS
 
 class JSDOMNodeJSEnv(
-  nodejsPath: String = "node",
-  addArgs: Seq[String] = Seq.empty,
-  addEnv: Map[String, String] = Map.empty
-) extends AbstractNodeJSEnv(nodejsPath, addArgs, addEnv, sourceMap = false) {
+    @deprecatedName('nodejsPath)
+    executable: String = "node",
+    @deprecatedName('addArgs)
+    args: Seq[String] = Seq.empty,
+    @deprecatedName('addEnv)
+    env: Map[String, String] = Map.empty)
+    extends AbstractNodeJSEnv(executable, args, env, sourceMap = false) {
 
   protected def vmName: String = "Node.js with JSDOM"
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -16,26 +16,30 @@ import org.scalajs.core.tools.logging._
 
 import java.io.{ Console => _, _ }
 
-
 class NodeJSEnv private (
-  nodejsPath: String,
-  addArgs: Seq[String],
-  addEnv: Map[String, String],
-  sourceMap: Boolean
-) extends AbstractNodeJSEnv(nodejsPath, addArgs, addEnv, sourceMap) {
+    @deprecatedName('nodejsPath)
+    override protected val executable: String, // override val for bin compat
+    @deprecatedName('addArgs)
+    args: Seq[String],
+    @deprecatedName('addEnv)
+    env: Map[String, String],
+    sourceMap: Boolean)
+    extends AbstractNodeJSEnv(executable, args, env, sourceMap) {
 
-  def this(nodejsPath: String = "node", addArgs: Seq[String] = Seq.empty,
-      addEnv: Map[String, String] = Map.empty) = {
-    this(nodejsPath, addArgs, addEnv, sourceMap = true)
+  def this(
+      @deprecatedName('nodejsPath)
+      executable: String = "node",
+      @deprecatedName('addArgs)
+      args: Seq[String] = Seq.empty,
+      @deprecatedName('addEnv)
+      env: Map[String, String] = Map.empty) = {
+    this(executable, args, env, sourceMap = true)
   }
 
   def withSourceMap(sourceMap: Boolean): NodeJSEnv =
-    new NodeJSEnv(nodejsPath, addArgs, addEnv, sourceMap)
+    new NodeJSEnv(executable, args, env, sourceMap)
 
   protected def vmName: String = "Node.js"
-
-  // For binary compatibility, now `executable` is defined in AbstractNodeJSEnv
-  override protected def executable: String = super.executable
 
   override def jsRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): JSRunner = {

--- a/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
+++ b/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
@@ -27,17 +27,19 @@ import scala.concurrent.{ExecutionContext, TimeoutException, Future}
 import scala.concurrent.duration.Duration
 
 class PhantomJSEnv(
-    phantomjsPath: String = "phantomjs",
-    addArgs: Seq[String] = Seq.empty,
-    addEnv: Map[String, String] = Map.empty,
+    @deprecatedName('phantomjsPath)
+    protected val executable: String = "phantomjs",
+    @deprecatedName('addArgs)
+    args: Seq[String] = Seq.empty,
+    @deprecatedName('addEnv)
+    env: Map[String, String] = Map.empty,
     val autoExit: Boolean = true,
     jettyClassLoader: ClassLoader = null
-) extends ExternalJSEnv(addArgs, addEnv) with ComJSEnv {
+) extends ExternalJSEnv(args, env) with ComJSEnv {
 
   import PhantomJSEnv._
 
   protected def vmName: String = "PhantomJS"
-  protected def executable: String = phantomjsPath
 
   override def jsRunner(libs: Seq[VirtualJSFile],
       code: VirtualJSFile): JSRunner = {

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -75,6 +75,9 @@ object ScalaJSPlugin extends AutoPlugin {
      *  case) or scope it manually, using
      *  [[sbt.ProjectExtra.inScope[* Project.inScope]].
      */
+    @deprecated(
+        "Use `jsEnv := new org.scalajs.jsenv.nodejs.NodeJSEnv(...)` instead.",
+        "0.6.16")
     def NodeJSEnv(
         executable: String = "node",
         args: Seq[String] = Seq.empty,
@@ -99,6 +102,10 @@ object ScalaJSPlugin extends AutoPlugin {
      *  case) or scope it manually, using
      *  [[sbt.ProjectExtra.inScope[* Project.inScope]].
      */
+    @deprecated(
+        "Use `jsEnv := new org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv(...)` " +
+        "instead.",
+        "0.6.16")
     def JSDOMNodeJSEnv(
         executable: String = "node",
         args: Seq[String] = Seq.empty,

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
@@ -275,6 +275,11 @@ final class CrossProject private (
    *
    *  Note: If you disable AutoPlugins here, Scala.js will not work
    */
+  @deprecated(
+      "Project#settingSets will be removed from sbt 1.0, hence " +
+      "CrossProject#settingSets will be removed from Scala.js 1.0. " +
+      "As a temporary measure, use `.configureAll(_.settingSets(select))`.",
+      "0.6.16")
   def settingSets(select: AddSettings*): CrossProject =
     copy(jvm.settingSets(select: _*), js.settingSets(select: _*))
 

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/Base64Test.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/Base64Test.scala
@@ -1,0 +1,645 @@
+package org.scalajs.testsuite.javalib.util
+
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException}
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.ISO_8859_1
+import java.util.Base64
+import java.util.Base64.Decoder
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform
+
+class Base64Test {
+  import Base64Test._
+
+  // --------------------------------------------------------------------------
+  // ENCODERS
+  // --------------------------------------------------------------------------
+
+  @Test def encodeToString(): Unit = {
+    val results =
+      for ((name, in, enc) <- encoders) yield (name -> enc.encodeToString(in))
+    assertEquals("calculated count doesn't match computed count",
+        encodedResults.length, results.size)
+    for (((name, enc), exp) <- results.zip(encodedResults))
+      assertEquals(s"encodeToString doesn't match for: $name", exp, enc)
+  }
+
+  @Test def encodeOneArray(): Unit = {
+    val results =
+      for ((name, in, enc) <- encoders) yield (name -> enc.encode(in))
+    assertEquals("calculated count doesn't match computed count",
+        encodedResults.length, results.size)
+    for (((name, enc), exp) <- results.zip(encodedResults)) {
+      assertEquals(s"encode array doesn't match for: $name",
+          exp, new String(enc, ISO_8859_1))
+    }
+  }
+
+  @Test def encodeTwoArrays(): Unit = {
+    for (((name, in, enc), exp) <- encoders.zip(encodedResults)) {
+      val dst = new Array[Byte](exp.length + 10) // array too big on purpose
+      val written = enc.encode(in, dst)
+      assertEquals(s"number of written bytes doesn't match for: $name",
+          exp.length, written)
+      val content = dst.slice(0, written)
+      val rlt = new String(content, ISO_8859_1)
+      assertEquals(s"encode array into array doesn't match for: $name",
+          exp, rlt)
+    }
+  }
+
+  @Test def encodeTwoArraysThrowsWithTooSmallDestination(): Unit = {
+    val in = "Man"
+    val dst = new Array[Byte](3) // too small
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getEncoder.encode(in.getBytes, dst)
+    })
+  }
+
+  @Test def encodeByteBuffer(): Unit = {
+    for (((name, in, enc), exp) <- encoders.zip(encodedResults)) {
+      val result1 = enc.encode(ByteBuffer.wrap(in))
+      assertEquals(s"byte buffers don't match for: $name",
+          exp, new String(result1.array(), ISO_8859_1))
+
+      val bb = ByteBuffer.allocate(in.length + 2)
+      bb.position(2)
+      bb.mark()
+      bb.put(in)
+      bb.reset()
+      val result2 = enc.encode(bb)
+      assertEquals(s"byte buffers don't match for: $name",
+          exp, new String(result2.array(), ISO_8859_1))
+    }
+  }
+
+  @Test def encodeOutputStream(): Unit = {
+    for (((name, in, enc), exp) <- encoders.zip(encodedResults)) {
+      val baos = new ByteArrayOutputStream()
+      val out = enc.wrap(baos)
+      out.write(in(0))
+      out.write(in, 1, in.length - 1)
+      out.close()
+      val result = new String(baos.toByteArray, ISO_8859_1)
+      assertEquals(s"output stream result doesn't match for: $name",
+          exp, result)
+    }
+  }
+
+  @Test def encodeOutputStreamFailsOnJVM(): Unit = {
+    assumeFalse("JDK bug JDK-8176379", Platform.executingInJVM)
+
+    // The `1` below will create a buggy encoder on the JVM
+    val encoder = Base64.getMimeEncoder(1, Array('@'))
+    val input = "Man"
+    val expected = "TWFu"
+    val ba = new ByteArrayOutputStream()
+    val out = encoder.wrap(ba)
+    out.write(input.getBytes)
+    out.close()
+    val result = new String(ba.toByteArray)
+    assertEquals("outputstream should be initialized correctly",
+        expected, result)
+  }
+
+  @Test def encodeOutputStreamTooMuch(): Unit = {
+    val enc = Base64.getEncoder
+    val out = enc.wrap(new ByteArrayOutputStream())
+    assertThrows(classOf[IndexOutOfBoundsException], {
+      out.write(Array.empty[Byte], 0, 5)
+    })
+  }
+
+  @Test def testIllegalLineSeparator(): Unit = {
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getMimeEncoder(8, Array[Byte]('A'))
+    })
+  }
+
+  // --------------------------------------------------------------------------
+  // DECODERS
+  // --------------------------------------------------------------------------
+
+  @Test def decodeFromString(): Unit = {
+    assertEquals("encoded data count doesn't match input count",
+        encoders.length, decodersAndInputs.length)
+    for ((encoded, (decoder, in)) <- encodedResults.zip(decodersAndInputs)) {
+      assertArrayEquals(s"decoded doesn't match expected $encoded",
+          in.getBytes(ISO_8859_1), decoder.decode(encoded))
+    }
+  }
+
+  @Test def decodeFromArray(): Unit = {
+    for ((encoded, (decoder, in)) <- encodedResults.zip(decodersAndInputs)) {
+      val encodedBytes = encoded.getBytes(ISO_8859_1)
+      val result = decoder.decode(encodedBytes)
+      assertEquals(s"decoded doesn't match expected for encoded $encoded",
+          in, new String(result, ISO_8859_1))
+    }
+  }
+
+  @Test def decodeFromArrayToDest(): Unit = {
+    for ((encoded, (decoder, in)) <- encodedResults.zip(decodersAndInputs)) {
+      val dst = new Array[Byte](in.length)
+      val encInBytes = encoded.getBytes(ISO_8859_1)
+      val dec = decoder.decode(encInBytes, dst)
+      assertEquals("decoded count doesn't match expected", in.length, dec)
+      assertArrayEquals("decoded array doesn't match expected",
+          in.getBytes(ISO_8859_1), dst)
+    }
+  }
+
+  @Test def decodeFromByteBuffer(): Unit = {
+    for ((encoded, (decoder, in)) <- encodedResults.zip(decodersAndInputs)) {
+      val bb = ByteBuffer.wrap(encoded.getBytes(ISO_8859_1))
+      val decoded = decoder.decode(bb)
+      val array = new Array[Byte](decoded.limit)
+      decoded.get(array)
+      assertArrayEquals("decoded byte buffer doesn't match expected",
+          in.getBytes(ISO_8859_1), array)
+    }
+  }
+
+  @Test def decodeToArrayTooSmall(): Unit = {
+    val encoded = "TWFu"
+    val dst = new Array[Byte](2) // too small
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getDecoder.decode(encoded.getBytes, dst)
+    })
+  }
+
+  @Test def decodeIllegalCharacter(): Unit = {
+    val encoded = "TWE*"
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getDecoder.decode(encoded)
+    })
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getUrlDecoder.decode(encoded)
+    })
+
+    assertEquals("MIME encoder should allow illegals",
+        "Ma", new String(Base64.getMimeDecoder.decode(encoded), ISO_8859_1))
+  }
+
+  @Test def decodeIllegalLength(): Unit = {
+    val encoded = "TWFuu"
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getDecoder.decode(encoded)
+    })
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getUrlDecoder.decode(encoded)
+    })
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getMimeDecoder.decode(encoded)
+    })
+  }
+
+  @Test def decodeIllegalPadding(): Unit = {
+    assumeFalse("JDK bug JDK-8176043", Platform.executingInJVM)
+
+    val encoded = "TQ=*"
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getDecoder.decode(encoded)
+    })
+    assertThrows(classOf[IllegalArgumentException], {
+      Base64.getUrlDecoder.decode(encoded)
+    })
+
+    assertEquals("MIME encoder should allow illegal paddings",
+        "M", new String(Base64.getMimeDecoder.decode(encoded), ISO_8859_1))
+  }
+
+  @Test def decodeInputStream(): Unit = {
+    for ((encoded, (decoder, expected)) <- encodedResults.zip(decodersAndInputs)) {
+      val byteInstream = new ByteArrayInputStream(encoded.getBytes(ISO_8859_1))
+      val instream = decoder.wrap(byteInstream)
+      val read = new Array[Byte](expected.length)
+      instream.read(read)
+      while (instream.read() != -1) {} // read padding
+      instream.close()
+      assertEquals("inputstream read value not as expected",
+          expected, new String(read, ISO_8859_1))
+    }
+  }
+
+  @Test def decodeIllegalsInputStream(): Unit = {
+    val encoded = "TQ=*"
+    assertThrows(classOf[IOException], {
+      decodeInputStream(basic, encoded)
+    })
+    assertThrows(classOf[IOException], {
+      decodeInputStream(url, encoded)
+    })
+    assertThrows(classOf[IOException], {
+      decodeInputStream(mime, "TWFu", Array('a'))
+    })
+    assertThrows(classOf[IOException], {
+      decodeInputStream(basic, "TWFu", Array(0.toByte))
+    })
+  }
+
+  @Test def decodeIllegalsInputStreamIllegalPadding(): Unit = {
+    assumeFalse("JDK bug JDK-8176043", Platform.executingInJVM)
+
+    val encoded = "TQ=*"
+    assertEquals("mime encoder should allow illegal paddings",
+        "M", decodeInputStream(mime, encoded))
+  }
+
+  @Test def decodeBufferWithJustPaddingNonMime(): Unit = {
+    for (decoder <- Seq(Base64.getDecoder, Base64.getUrlDecoder)) {
+      // Should pass for empty and throw IllegalArgumentException for = and ==
+      val bb = decoder.decode(ByteBuffer.allocate(0))
+      assertEquals(0, bb.limit())
+      for (input <- Seq("=", "==")) {
+        assertThrows(classOf[IllegalArgumentException], {
+          decoder.decode(ByteBuffer.wrap(input.getBytes))
+        })
+      }
+    }
+  }
+
+  @Test def decodeBufferWithJustPaddingMime(): Unit = {
+    assumeFalse("JDK bug JDK-8176043", Platform.executingInJVM)
+
+    for (input <- Seq("", "=", "==")) {
+      val bb = Base64.getMimeDecoder.decode(ByteBuffer.wrap(input.getBytes))
+      assertEquals(0, bb.limit())
+    }
+  }
+
+  private def decodeInputStream(decoder: Decoder, input: String,
+      dangling: Array[Byte] = Array.empty): String = {
+    val bytes = input.getBytes ++ dangling
+    val stream = decoder.wrap(new ByteArrayInputStream(bytes))
+    val tmp = new Array[Byte](bytes.length)
+    val read = stream.read(tmp)
+    new String(tmp, 0, read)
+  }
+
+}
+
+object Base64Test {
+
+  private val input: Array[Byte] = {
+    val text = {
+      "Base64 is a group of similar binary-to-text encoding schemes that " +
+      "represent binary data in an ASCII string format by translating it " +
+      "into a radix-64 representation"
+    }
+    text.getBytes(ISO_8859_1)
+  }
+
+  private val inputLengths = Seq(1, 2, 3, 4, 10, input.length)
+  private val lineDelimChars = "@$*"
+  private val lineLengths = Seq(-1, 0, 4, 5, 9)
+
+  private val stdEncPadding = Seq(
+      "basic, padding" -> Base64.getEncoder,
+      "url, padding" -> Base64.getUrlEncoder,
+      "mime, padding" -> Base64.getMimeEncoder
+  )
+
+  private val stdEncNoPadding = {
+    for ((name, enc) <- stdEncPadding)
+      yield name.replace("padding", "no padding") -> enc.withoutPadding()
+  }
+
+  private val lineDelimitersWithLineLengths: Seq[(String, Int)] = {
+    for {
+      i <- 0 to lineDelimChars.length
+      l <- lineLengths
+    } yield {
+      lineDelimChars.take(i) -> l
+    }
+  }
+
+  private val customEncPadding = {
+    for ((delim, ll) <- lineDelimitersWithLineLengths) yield {
+      (s"mime, padding, line length: $ll delimiters: $delim" ->
+          Base64.getMimeEncoder(ll, delim.getBytes))
+    }
+  }
+
+  private val customEncNoPadding = {
+    for ((name, enc) <- customEncPadding)
+      yield name.replace("padding", "no padding") -> enc.withoutPadding()
+  }
+
+  private val allEncoders =
+    stdEncPadding ++ stdEncNoPadding ++ customEncPadding ++ customEncNoPadding
+
+  private val encoders = {
+    for {
+      (name, enc) <- allEncoders
+      length <- inputLengths
+    } yield {
+      (s"$name", input.take(length), enc)
+    }
+  }
+
+  private lazy val decodersAndInputs = data.map(t => getDecoderAndInput(t._1))
+  private lazy val encodedResults = data.map(_._2)
+
+  private val basic = Base64.getDecoder
+  private val url = Base64.getUrlDecoder
+
+  private val mime = Base64.getMimeDecoder
+
+  def getDecoderAndInput(text: String): (Decoder, String) = {
+    val decoder = {
+      if (text.contains("basic")) basic
+      else if (text.contains("url")) url
+      else if (text.contains("mime")) mime
+      else throw new IllegalArgumentException(s"no decoder found in string $text")
+    }
+    val input = text.replaceAll(".*%(.*)%", "$1")
+    decoder -> input
+  }
+
+  // scalastyle:off line.size.limit
+  lazy val data = Array(
+      "basic, padding %B%" -> "Qg==",
+      "basic, padding %Ba%" -> "QmE=",
+      "basic, padding %Bas%" -> "QmFz",
+      "basic, padding %Base%" -> "QmFzZQ==",
+      "basic, padding %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "basic, padding %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "url, padding %B%" -> "Qg==",
+      "url, padding %Ba%" -> "QmE=",
+      "url, padding %Bas%" -> "QmFz",
+      "url, padding %Base%" -> "QmFzZQ==",
+      "url, padding %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "url, padding %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding %B%" -> "Qg==",
+      "mime, padding %Ba%" -> "QmE=",
+      "mime, padding %Bas%" -> "QmFz",
+      "mime, padding %Base%" -> "QmFzZQ==",
+      "mime, padding %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hl\r\nbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQg\r\nYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "basic, no padding %B%" -> "Qg",
+      "basic, no padding %Ba%" -> "QmE",
+      "basic, no padding %Bas%" -> "QmFz",
+      "basic, no padding %Base%" -> "QmFzZQ",
+      "basic, no padding %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "basic, no padding %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "url, no padding %B%" -> "Qg",
+      "url, no padding %Ba%" -> "QmE",
+      "url, no padding %Bas%" -> "QmFz",
+      "url, no padding %Base%" -> "QmFzZQ",
+      "url, no padding %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "url, no padding %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding %B%" -> "Qg",
+      "mime, no padding %Ba%" -> "QmE",
+      "mime, no padding %Bas%" -> "QmFz",
+      "mime, no padding %Base%" -> "QmFzZQ",
+      "mime, no padding %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hl\r\nbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQg\r\nYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: -1 delimiters:  %B%" -> "Qg==",
+      "mime, padding, line length: -1 delimiters:  %Ba%" -> "QmE=",
+      "mime, padding, line length: -1 delimiters:  %Bas%" -> "QmFz",
+      "mime, padding, line length: -1 delimiters:  %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: -1 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: -1 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 0 delimiters:  %B%" -> "Qg==",
+      "mime, padding, line length: 0 delimiters:  %Ba%" -> "QmE=",
+      "mime, padding, line length: 0 delimiters:  %Bas%" -> "QmFz",
+      "mime, padding, line length: 0 delimiters:  %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 0 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: 0 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 4 delimiters:  %B%" -> "Qg==",
+      "mime, padding, line length: 4 delimiters:  %Ba%" -> "QmE=",
+      "mime, padding, line length: 4 delimiters:  %Bas%" -> "QmFz",
+      "mime, padding, line length: 4 delimiters:  %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 4 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: 4 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 5 delimiters:  %B%" -> "Qg==",
+      "mime, padding, line length: 5 delimiters:  %Ba%" -> "QmE=",
+      "mime, padding, line length: 5 delimiters:  %Bas%" -> "QmFz",
+      "mime, padding, line length: 5 delimiters:  %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 5 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: 5 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 9 delimiters:  %B%" -> "Qg==",
+      "mime, padding, line length: 9 delimiters:  %Ba%" -> "QmE=",
+      "mime, padding, line length: 9 delimiters:  %Bas%" -> "QmFz",
+      "mime, padding, line length: 9 delimiters:  %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 9 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: 9 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: -1 delimiters: @ %B%" -> "Qg==",
+      "mime, padding, line length: -1 delimiters: @ %Ba%" -> "QmE=",
+      "mime, padding, line length: -1 delimiters: @ %Bas%" -> "QmFz",
+      "mime, padding, line length: -1 delimiters: @ %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: -1 delimiters: @ %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: -1 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 0 delimiters: @ %B%" -> "Qg==",
+      "mime, padding, line length: 0 delimiters: @ %Ba%" -> "QmE=",
+      "mime, padding, line length: 0 delimiters: @ %Bas%" -> "QmFz",
+      "mime, padding, line length: 0 delimiters: @ %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 0 delimiters: @ %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: 0 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 4 delimiters: @ %B%" -> "Qg==",
+      "mime, padding, line length: 4 delimiters: @ %Ba%" -> "QmE=",
+      "mime, padding, line length: 4 delimiters: @ %Bas%" -> "QmFz",
+      "mime, padding, line length: 4 delimiters: @ %Base%" -> "QmFz@ZQ==",
+      "mime, padding, line length: 4 delimiters: @ %Base64 is %" -> "QmFz@ZTY0@IGlz@IA==",
+      "mime, padding, line length: 4 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@ZTY0@IGlz@IGEg@Z3Jv@dXAg@b2Yg@c2lt@aWxh@ciBi@aW5h@cnkt@dG8t@dGV4@dCBl@bmNv@ZGlu@ZyBz@Y2hl@bWVz@IHRo@YXQg@cmVw@cmVz@ZW50@IGJp@bmFy@eSBk@YXRh@IGlu@IGFu@IEFT@Q0lJ@IHN0@cmlu@ZyBm@b3Jt@YXQg@Ynkg@dHJh@bnNs@YXRp@bmcg@aXQg@aW50@byBh@IHJh@ZGl4@LTY0@IHJl@cHJl@c2Vu@dGF0@aW9u",
+      "mime, padding, line length: 5 delimiters: @ %B%" -> "Qg==",
+      "mime, padding, line length: 5 delimiters: @ %Ba%" -> "QmE=",
+      "mime, padding, line length: 5 delimiters: @ %Bas%" -> "QmFz",
+      "mime, padding, line length: 5 delimiters: @ %Base%" -> "QmFz@ZQ==",
+      "mime, padding, line length: 5 delimiters: @ %Base64 is %" -> "QmFz@ZTY0@IGlz@IA==",
+      "mime, padding, line length: 5 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@ZTY0@IGlz@IGEg@Z3Jv@dXAg@b2Yg@c2lt@aWxh@ciBi@aW5h@cnkt@dG8t@dGV4@dCBl@bmNv@ZGlu@ZyBz@Y2hl@bWVz@IHRo@YXQg@cmVw@cmVz@ZW50@IGJp@bmFy@eSBk@YXRh@IGlu@IGFu@IEFT@Q0lJ@IHN0@cmlu@ZyBm@b3Jt@YXQg@Ynkg@dHJh@bnNs@YXRp@bmcg@aXQg@aW50@byBh@IHJh@ZGl4@LTY0@IHJl@cHJl@c2Vu@dGF0@aW9u",
+      "mime, padding, line length: 9 delimiters: @ %B%" -> "Qg==",
+      "mime, padding, line length: 9 delimiters: @ %Ba%" -> "QmE=",
+      "mime, padding, line length: 9 delimiters: @ %Bas%" -> "QmFz",
+      "mime, padding, line length: 9 delimiters: @ %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 9 delimiters: @ %Base64 is %" -> "QmFzZTY0@IGlzIA==",
+      "mime, padding, line length: 9 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0@IGlzIGEg@Z3JvdXAg@b2Ygc2lt@aWxhciBi@aW5hcnkt@dG8tdGV4@dCBlbmNv@ZGluZyBz@Y2hlbWVz@IHRoYXQg@cmVwcmVz@ZW50IGJp@bmFyeSBk@YXRhIGlu@IGFuIEFT@Q0lJIHN0@cmluZyBm@b3JtYXQg@YnkgdHJh@bnNsYXRp@bmcgaXQg@aW50byBh@IHJhZGl4@LTY0IHJl@cHJlc2Vu@dGF0aW9u",
+      "mime, padding, line length: -1 delimiters: @$ %B%" -> "Qg==",
+      "mime, padding, line length: -1 delimiters: @$ %Ba%" -> "QmE=",
+      "mime, padding, line length: -1 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, padding, line length: -1 delimiters: @$ %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: -1 delimiters: @$ %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: -1 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 0 delimiters: @$ %B%" -> "Qg==",
+      "mime, padding, line length: 0 delimiters: @$ %Ba%" -> "QmE=",
+      "mime, padding, line length: 0 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, padding, line length: 0 delimiters: @$ %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 0 delimiters: @$ %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: 0 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 4 delimiters: @$ %B%" -> "Qg==",
+      "mime, padding, line length: 4 delimiters: @$ %Ba%" -> "QmE=",
+      "mime, padding, line length: 4 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, padding, line length: 4 delimiters: @$ %Base%" -> "QmFz@$ZQ==",
+      "mime, padding, line length: 4 delimiters: @$ %Base64 is %" -> "QmFz@$ZTY0@$IGlz@$IA==",
+      "mime, padding, line length: 4 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@$ZTY0@$IGlz@$IGEg@$Z3Jv@$dXAg@$b2Yg@$c2lt@$aWxh@$ciBi@$aW5h@$cnkt@$dG8t@$dGV4@$dCBl@$bmNv@$ZGlu@$ZyBz@$Y2hl@$bWVz@$IHRo@$YXQg@$cmVw@$cmVz@$ZW50@$IGJp@$bmFy@$eSBk@$YXRh@$IGlu@$IGFu@$IEFT@$Q0lJ@$IHN0@$cmlu@$ZyBm@$b3Jt@$YXQg@$Ynkg@$dHJh@$bnNs@$YXRp@$bmcg@$aXQg@$aW50@$byBh@$IHJh@$ZGl4@$LTY0@$IHJl@$cHJl@$c2Vu@$dGF0@$aW9u",
+      "mime, padding, line length: 5 delimiters: @$ %B%" -> "Qg==",
+      "mime, padding, line length: 5 delimiters: @$ %Ba%" -> "QmE=",
+      "mime, padding, line length: 5 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, padding, line length: 5 delimiters: @$ %Base%" -> "QmFz@$ZQ==",
+      "mime, padding, line length: 5 delimiters: @$ %Base64 is %" -> "QmFz@$ZTY0@$IGlz@$IA==",
+      "mime, padding, line length: 5 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@$ZTY0@$IGlz@$IGEg@$Z3Jv@$dXAg@$b2Yg@$c2lt@$aWxh@$ciBi@$aW5h@$cnkt@$dG8t@$dGV4@$dCBl@$bmNv@$ZGlu@$ZyBz@$Y2hl@$bWVz@$IHRo@$YXQg@$cmVw@$cmVz@$ZW50@$IGJp@$bmFy@$eSBk@$YXRh@$IGlu@$IGFu@$IEFT@$Q0lJ@$IHN0@$cmlu@$ZyBm@$b3Jt@$YXQg@$Ynkg@$dHJh@$bnNs@$YXRp@$bmcg@$aXQg@$aW50@$byBh@$IHJh@$ZGl4@$LTY0@$IHJl@$cHJl@$c2Vu@$dGF0@$aW9u",
+      "mime, padding, line length: 9 delimiters: @$ %B%" -> "Qg==",
+      "mime, padding, line length: 9 delimiters: @$ %Ba%" -> "QmE=",
+      "mime, padding, line length: 9 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, padding, line length: 9 delimiters: @$ %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 9 delimiters: @$ %Base64 is %" -> "QmFzZTY0@$IGlzIA==",
+      "mime, padding, line length: 9 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0@$IGlzIGEg@$Z3JvdXAg@$b2Ygc2lt@$aWxhciBi@$aW5hcnkt@$dG8tdGV4@$dCBlbmNv@$ZGluZyBz@$Y2hlbWVz@$IHRoYXQg@$cmVwcmVz@$ZW50IGJp@$bmFyeSBk@$YXRhIGlu@$IGFuIEFT@$Q0lJIHN0@$cmluZyBm@$b3JtYXQg@$YnkgdHJh@$bnNsYXRp@$bmcgaXQg@$aW50byBh@$IHJhZGl4@$LTY0IHJl@$cHJlc2Vu@$dGF0aW9u",
+      "mime, padding, line length: -1 delimiters: @$* %B%" -> "Qg==",
+      "mime, padding, line length: -1 delimiters: @$* %Ba%" -> "QmE=",
+      "mime, padding, line length: -1 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, padding, line length: -1 delimiters: @$* %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: -1 delimiters: @$* %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: -1 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 0 delimiters: @$* %B%" -> "Qg==",
+      "mime, padding, line length: 0 delimiters: @$* %Ba%" -> "QmE=",
+      "mime, padding, line length: 0 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, padding, line length: 0 delimiters: @$* %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 0 delimiters: @$* %Base64 is %" -> "QmFzZTY0IGlzIA==",
+      "mime, padding, line length: 0 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, padding, line length: 4 delimiters: @$* %B%" -> "Qg==",
+      "mime, padding, line length: 4 delimiters: @$* %Ba%" -> "QmE=",
+      "mime, padding, line length: 4 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, padding, line length: 4 delimiters: @$* %Base%" -> "QmFz@$*ZQ==",
+      "mime, padding, line length: 4 delimiters: @$* %Base64 is %" -> "QmFz@$*ZTY0@$*IGlz@$*IA==",
+      "mime, padding, line length: 4 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@$*ZTY0@$*IGlz@$*IGEg@$*Z3Jv@$*dXAg@$*b2Yg@$*c2lt@$*aWxh@$*ciBi@$*aW5h@$*cnkt@$*dG8t@$*dGV4@$*dCBl@$*bmNv@$*ZGlu@$*ZyBz@$*Y2hl@$*bWVz@$*IHRo@$*YXQg@$*cmVw@$*cmVz@$*ZW50@$*IGJp@$*bmFy@$*eSBk@$*YXRh@$*IGlu@$*IGFu@$*IEFT@$*Q0lJ@$*IHN0@$*cmlu@$*ZyBm@$*b3Jt@$*YXQg@$*Ynkg@$*dHJh@$*bnNs@$*YXRp@$*bmcg@$*aXQg@$*aW50@$*byBh@$*IHJh@$*ZGl4@$*LTY0@$*IHJl@$*cHJl@$*c2Vu@$*dGF0@$*aW9u",
+      "mime, padding, line length: 5 delimiters: @$* %B%" -> "Qg==",
+      "mime, padding, line length: 5 delimiters: @$* %Ba%" -> "QmE=",
+      "mime, padding, line length: 5 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, padding, line length: 5 delimiters: @$* %Base%" -> "QmFz@$*ZQ==",
+      "mime, padding, line length: 5 delimiters: @$* %Base64 is %" -> "QmFz@$*ZTY0@$*IGlz@$*IA==",
+      "mime, padding, line length: 5 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@$*ZTY0@$*IGlz@$*IGEg@$*Z3Jv@$*dXAg@$*b2Yg@$*c2lt@$*aWxh@$*ciBi@$*aW5h@$*cnkt@$*dG8t@$*dGV4@$*dCBl@$*bmNv@$*ZGlu@$*ZyBz@$*Y2hl@$*bWVz@$*IHRo@$*YXQg@$*cmVw@$*cmVz@$*ZW50@$*IGJp@$*bmFy@$*eSBk@$*YXRh@$*IGlu@$*IGFu@$*IEFT@$*Q0lJ@$*IHN0@$*cmlu@$*ZyBm@$*b3Jt@$*YXQg@$*Ynkg@$*dHJh@$*bnNs@$*YXRp@$*bmcg@$*aXQg@$*aW50@$*byBh@$*IHJh@$*ZGl4@$*LTY0@$*IHJl@$*cHJl@$*c2Vu@$*dGF0@$*aW9u",
+      "mime, padding, line length: 9 delimiters: @$* %B%" -> "Qg==",
+      "mime, padding, line length: 9 delimiters: @$* %Ba%" -> "QmE=",
+      "mime, padding, line length: 9 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, padding, line length: 9 delimiters: @$* %Base%" -> "QmFzZQ==",
+      "mime, padding, line length: 9 delimiters: @$* %Base64 is %" -> "QmFzZTY0@$*IGlzIA==",
+      "mime, padding, line length: 9 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0@$*IGlzIGEg@$*Z3JvdXAg@$*b2Ygc2lt@$*aWxhciBi@$*aW5hcnkt@$*dG8tdGV4@$*dCBlbmNv@$*ZGluZyBz@$*Y2hlbWVz@$*IHRoYXQg@$*cmVwcmVz@$*ZW50IGJp@$*bmFyeSBk@$*YXRhIGlu@$*IGFuIEFT@$*Q0lJIHN0@$*cmluZyBm@$*b3JtYXQg@$*YnkgdHJh@$*bnNsYXRp@$*bmcgaXQg@$*aW50byBh@$*IHJhZGl4@$*LTY0IHJl@$*cHJlc2Vu@$*dGF0aW9u",
+      "mime, no padding, line length: -1 delimiters:  %B%" -> "Qg",
+      "mime, no padding, line length: -1 delimiters:  %Ba%" -> "QmE",
+      "mime, no padding, line length: -1 delimiters:  %Bas%" -> "QmFz",
+      "mime, no padding, line length: -1 delimiters:  %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: -1 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: -1 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 0 delimiters:  %B%" -> "Qg",
+      "mime, no padding, line length: 0 delimiters:  %Ba%" -> "QmE",
+      "mime, no padding, line length: 0 delimiters:  %Bas%" -> "QmFz",
+      "mime, no padding, line length: 0 delimiters:  %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 0 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: 0 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 4 delimiters:  %B%" -> "Qg",
+      "mime, no padding, line length: 4 delimiters:  %Ba%" -> "QmE",
+      "mime, no padding, line length: 4 delimiters:  %Bas%" -> "QmFz",
+      "mime, no padding, line length: 4 delimiters:  %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 4 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: 4 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 5 delimiters:  %B%" -> "Qg",
+      "mime, no padding, line length: 5 delimiters:  %Ba%" -> "QmE",
+      "mime, no padding, line length: 5 delimiters:  %Bas%" -> "QmFz",
+      "mime, no padding, line length: 5 delimiters:  %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 5 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: 5 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 9 delimiters:  %B%" -> "Qg",
+      "mime, no padding, line length: 9 delimiters:  %Ba%" -> "QmE",
+      "mime, no padding, line length: 9 delimiters:  %Bas%" -> "QmFz",
+      "mime, no padding, line length: 9 delimiters:  %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 9 delimiters:  %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: 9 delimiters:  %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: -1 delimiters: @ %B%" -> "Qg",
+      "mime, no padding, line length: -1 delimiters: @ %Ba%" -> "QmE",
+      "mime, no padding, line length: -1 delimiters: @ %Bas%" -> "QmFz",
+      "mime, no padding, line length: -1 delimiters: @ %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: -1 delimiters: @ %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: -1 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 0 delimiters: @ %B%" -> "Qg",
+      "mime, no padding, line length: 0 delimiters: @ %Ba%" -> "QmE",
+      "mime, no padding, line length: 0 delimiters: @ %Bas%" -> "QmFz",
+      "mime, no padding, line length: 0 delimiters: @ %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 0 delimiters: @ %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: 0 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 4 delimiters: @ %B%" -> "Qg",
+      "mime, no padding, line length: 4 delimiters: @ %Ba%" -> "QmE",
+      "mime, no padding, line length: 4 delimiters: @ %Bas%" -> "QmFz",
+      "mime, no padding, line length: 4 delimiters: @ %Base%" -> "QmFz@ZQ",
+      "mime, no padding, line length: 4 delimiters: @ %Base64 is %" -> "QmFz@ZTY0@IGlz@IA",
+      "mime, no padding, line length: 4 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@ZTY0@IGlz@IGEg@Z3Jv@dXAg@b2Yg@c2lt@aWxh@ciBi@aW5h@cnkt@dG8t@dGV4@dCBl@bmNv@ZGlu@ZyBz@Y2hl@bWVz@IHRo@YXQg@cmVw@cmVz@ZW50@IGJp@bmFy@eSBk@YXRh@IGlu@IGFu@IEFT@Q0lJ@IHN0@cmlu@ZyBm@b3Jt@YXQg@Ynkg@dHJh@bnNs@YXRp@bmcg@aXQg@aW50@byBh@IHJh@ZGl4@LTY0@IHJl@cHJl@c2Vu@dGF0@aW9u",
+      "mime, no padding, line length: 5 delimiters: @ %B%" -> "Qg",
+      "mime, no padding, line length: 5 delimiters: @ %Ba%" -> "QmE",
+      "mime, no padding, line length: 5 delimiters: @ %Bas%" -> "QmFz",
+      "mime, no padding, line length: 5 delimiters: @ %Base%" -> "QmFz@ZQ",
+      "mime, no padding, line length: 5 delimiters: @ %Base64 is %" -> "QmFz@ZTY0@IGlz@IA",
+      "mime, no padding, line length: 5 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@ZTY0@IGlz@IGEg@Z3Jv@dXAg@b2Yg@c2lt@aWxh@ciBi@aW5h@cnkt@dG8t@dGV4@dCBl@bmNv@ZGlu@ZyBz@Y2hl@bWVz@IHRo@YXQg@cmVw@cmVz@ZW50@IGJp@bmFy@eSBk@YXRh@IGlu@IGFu@IEFT@Q0lJ@IHN0@cmlu@ZyBm@b3Jt@YXQg@Ynkg@dHJh@bnNs@YXRp@bmcg@aXQg@aW50@byBh@IHJh@ZGl4@LTY0@IHJl@cHJl@c2Vu@dGF0@aW9u",
+      "mime, no padding, line length: 9 delimiters: @ %B%" -> "Qg",
+      "mime, no padding, line length: 9 delimiters: @ %Ba%" -> "QmE",
+      "mime, no padding, line length: 9 delimiters: @ %Bas%" -> "QmFz",
+      "mime, no padding, line length: 9 delimiters: @ %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 9 delimiters: @ %Base64 is %" -> "QmFzZTY0@IGlzIA",
+      "mime, no padding, line length: 9 delimiters: @ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0@IGlzIGEg@Z3JvdXAg@b2Ygc2lt@aWxhciBi@aW5hcnkt@dG8tdGV4@dCBlbmNv@ZGluZyBz@Y2hlbWVz@IHRoYXQg@cmVwcmVz@ZW50IGJp@bmFyeSBk@YXRhIGlu@IGFuIEFT@Q0lJIHN0@cmluZyBm@b3JtYXQg@YnkgdHJh@bnNsYXRp@bmcgaXQg@aW50byBh@IHJhZGl4@LTY0IHJl@cHJlc2Vu@dGF0aW9u",
+      "mime, no padding, line length: -1 delimiters: @$ %B%" -> "Qg",
+      "mime, no padding, line length: -1 delimiters: @$ %Ba%" -> "QmE",
+      "mime, no padding, line length: -1 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, no padding, line length: -1 delimiters: @$ %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: -1 delimiters: @$ %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: -1 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 0 delimiters: @$ %B%" -> "Qg",
+      "mime, no padding, line length: 0 delimiters: @$ %Ba%" -> "QmE",
+      "mime, no padding, line length: 0 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, no padding, line length: 0 delimiters: @$ %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 0 delimiters: @$ %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: 0 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 4 delimiters: @$ %B%" -> "Qg",
+      "mime, no padding, line length: 4 delimiters: @$ %Ba%" -> "QmE",
+      "mime, no padding, line length: 4 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, no padding, line length: 4 delimiters: @$ %Base%" -> "QmFz@$ZQ",
+      "mime, no padding, line length: 4 delimiters: @$ %Base64 is %" -> "QmFz@$ZTY0@$IGlz@$IA",
+      "mime, no padding, line length: 4 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@$ZTY0@$IGlz@$IGEg@$Z3Jv@$dXAg@$b2Yg@$c2lt@$aWxh@$ciBi@$aW5h@$cnkt@$dG8t@$dGV4@$dCBl@$bmNv@$ZGlu@$ZyBz@$Y2hl@$bWVz@$IHRo@$YXQg@$cmVw@$cmVz@$ZW50@$IGJp@$bmFy@$eSBk@$YXRh@$IGlu@$IGFu@$IEFT@$Q0lJ@$IHN0@$cmlu@$ZyBm@$b3Jt@$YXQg@$Ynkg@$dHJh@$bnNs@$YXRp@$bmcg@$aXQg@$aW50@$byBh@$IHJh@$ZGl4@$LTY0@$IHJl@$cHJl@$c2Vu@$dGF0@$aW9u",
+      "mime, no padding, line length: 5 delimiters: @$ %B%" -> "Qg",
+      "mime, no padding, line length: 5 delimiters: @$ %Ba%" -> "QmE",
+      "mime, no padding, line length: 5 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, no padding, line length: 5 delimiters: @$ %Base%" -> "QmFz@$ZQ",
+      "mime, no padding, line length: 5 delimiters: @$ %Base64 is %" -> "QmFz@$ZTY0@$IGlz@$IA",
+      "mime, no padding, line length: 5 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@$ZTY0@$IGlz@$IGEg@$Z3Jv@$dXAg@$b2Yg@$c2lt@$aWxh@$ciBi@$aW5h@$cnkt@$dG8t@$dGV4@$dCBl@$bmNv@$ZGlu@$ZyBz@$Y2hl@$bWVz@$IHRo@$YXQg@$cmVw@$cmVz@$ZW50@$IGJp@$bmFy@$eSBk@$YXRh@$IGlu@$IGFu@$IEFT@$Q0lJ@$IHN0@$cmlu@$ZyBm@$b3Jt@$YXQg@$Ynkg@$dHJh@$bnNs@$YXRp@$bmcg@$aXQg@$aW50@$byBh@$IHJh@$ZGl4@$LTY0@$IHJl@$cHJl@$c2Vu@$dGF0@$aW9u",
+      "mime, no padding, line length: 9 delimiters: @$ %B%" -> "Qg",
+      "mime, no padding, line length: 9 delimiters: @$ %Ba%" -> "QmE",
+      "mime, no padding, line length: 9 delimiters: @$ %Bas%" -> "QmFz",
+      "mime, no padding, line length: 9 delimiters: @$ %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 9 delimiters: @$ %Base64 is %" -> "QmFzZTY0@$IGlzIA",
+      "mime, no padding, line length: 9 delimiters: @$ %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0@$IGlzIGEg@$Z3JvdXAg@$b2Ygc2lt@$aWxhciBi@$aW5hcnkt@$dG8tdGV4@$dCBlbmNv@$ZGluZyBz@$Y2hlbWVz@$IHRoYXQg@$cmVwcmVz@$ZW50IGJp@$bmFyeSBk@$YXRhIGlu@$IGFuIEFT@$Q0lJIHN0@$cmluZyBm@$b3JtYXQg@$YnkgdHJh@$bnNsYXRp@$bmcgaXQg@$aW50byBh@$IHJhZGl4@$LTY0IHJl@$cHJlc2Vu@$dGF0aW9u",
+      "mime, no padding, line length: -1 delimiters: @$* %B%" -> "Qg",
+      "mime, no padding, line length: -1 delimiters: @$* %Ba%" -> "QmE",
+      "mime, no padding, line length: -1 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, no padding, line length: -1 delimiters: @$* %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: -1 delimiters: @$* %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: -1 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 0 delimiters: @$* %B%" -> "Qg",
+      "mime, no padding, line length: 0 delimiters: @$* %Ba%" -> "QmE",
+      "mime, no padding, line length: 0 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, no padding, line length: 0 delimiters: @$* %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 0 delimiters: @$* %Base64 is %" -> "QmFzZTY0IGlzIA",
+      "mime, no padding, line length: 0 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0IGlzIGEgZ3JvdXAgb2Ygc2ltaWxhciBiaW5hcnktdG8tdGV4dCBlbmNvZGluZyBzY2hlbWVzIHRoYXQgcmVwcmVzZW50IGJpbmFyeSBkYXRhIGluIGFuIEFTQ0lJIHN0cmluZyBmb3JtYXQgYnkgdHJhbnNsYXRpbmcgaXQgaW50byBhIHJhZGl4LTY0IHJlcHJlc2VudGF0aW9u",
+      "mime, no padding, line length: 4 delimiters: @$* %B%" -> "Qg",
+      "mime, no padding, line length: 4 delimiters: @$* %Ba%" -> "QmE",
+      "mime, no padding, line length: 4 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, no padding, line length: 4 delimiters: @$* %Base%" -> "QmFz@$*ZQ",
+      "mime, no padding, line length: 4 delimiters: @$* %Base64 is %" -> "QmFz@$*ZTY0@$*IGlz@$*IA",
+      "mime, no padding, line length: 4 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@$*ZTY0@$*IGlz@$*IGEg@$*Z3Jv@$*dXAg@$*b2Yg@$*c2lt@$*aWxh@$*ciBi@$*aW5h@$*cnkt@$*dG8t@$*dGV4@$*dCBl@$*bmNv@$*ZGlu@$*ZyBz@$*Y2hl@$*bWVz@$*IHRo@$*YXQg@$*cmVw@$*cmVz@$*ZW50@$*IGJp@$*bmFy@$*eSBk@$*YXRh@$*IGlu@$*IGFu@$*IEFT@$*Q0lJ@$*IHN0@$*cmlu@$*ZyBm@$*b3Jt@$*YXQg@$*Ynkg@$*dHJh@$*bnNs@$*YXRp@$*bmcg@$*aXQg@$*aW50@$*byBh@$*IHJh@$*ZGl4@$*LTY0@$*IHJl@$*cHJl@$*c2Vu@$*dGF0@$*aW9u",
+      "mime, no padding, line length: 5 delimiters: @$* %B%" -> "Qg",
+      "mime, no padding, line length: 5 delimiters: @$* %Ba%" -> "QmE",
+      "mime, no padding, line length: 5 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, no padding, line length: 5 delimiters: @$* %Base%" -> "QmFz@$*ZQ",
+      "mime, no padding, line length: 5 delimiters: @$* %Base64 is %" -> "QmFz@$*ZTY0@$*IGlz@$*IA",
+      "mime, no padding, line length: 5 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFz@$*ZTY0@$*IGlz@$*IGEg@$*Z3Jv@$*dXAg@$*b2Yg@$*c2lt@$*aWxh@$*ciBi@$*aW5h@$*cnkt@$*dG8t@$*dGV4@$*dCBl@$*bmNv@$*ZGlu@$*ZyBz@$*Y2hl@$*bWVz@$*IHRo@$*YXQg@$*cmVw@$*cmVz@$*ZW50@$*IGJp@$*bmFy@$*eSBk@$*YXRh@$*IGlu@$*IGFu@$*IEFT@$*Q0lJ@$*IHN0@$*cmlu@$*ZyBm@$*b3Jt@$*YXQg@$*Ynkg@$*dHJh@$*bnNs@$*YXRp@$*bmcg@$*aXQg@$*aW50@$*byBh@$*IHJh@$*ZGl4@$*LTY0@$*IHJl@$*cHJl@$*c2Vu@$*dGF0@$*aW9u",
+      "mime, no padding, line length: 9 delimiters: @$* %B%" -> "Qg",
+      "mime, no padding, line length: 9 delimiters: @$* %Ba%" -> "QmE",
+      "mime, no padding, line length: 9 delimiters: @$* %Bas%" -> "QmFz",
+      "mime, no padding, line length: 9 delimiters: @$* %Base%" -> "QmFzZQ",
+      "mime, no padding, line length: 9 delimiters: @$* %Base64 is %" -> "QmFzZTY0@$*IGlzIA",
+      "mime, no padding, line length: 9 delimiters: @$* %Base64 is a group of similar binary-to-text encoding schemes that represent binary data in an ASCII string format by translating it into a radix-64 representation%" -> "QmFzZTY0@$*IGlzIGEg@$*Z3JvdXAg@$*b2Ygc2lt@$*aWxhciBi@$*aW5hcnkt@$*dG8tdGV4@$*dCBlbmNv@$*ZGluZyBz@$*Y2hlbWVz@$*IHRoYXQg@$*cmVwcmVz@$*ZW50IGJp@$*bmFyeSBk@$*YXRhIGlu@$*IGFuIEFT@$*Q0lJIHN0@$*cmluZyBm@$*b3JtYXQg@$*YnkgdHJh@$*bnNsYXRp@$*bmcgaXQg@$*aW50byBh@$*IHJhZGl4@$*LTY0IHJl@$*cHJlc2Vu@$*dGF0aW9u"
+  )
+  // scalastyle:on line.size.limit
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
@@ -284,6 +284,21 @@ trait DataInputStreamTest {
     assertThrows(classOf[UTFDataFormatException], badStream.readUTF)
   }
 
+  @Test def readUTF_with_very_long_string(): Unit = {
+    val length = 40000
+    val inputBytes = new Array[Byte](2 + length)
+    inputBytes(0) = (length >> 8).toByte
+    inputBytes(1) = length.toByte
+    for (i <- 2 until (2 + length))
+      inputBytes(i) = 'a'.toByte
+
+    val stream = new DataInputStream(new ByteArrayInputStream(inputBytes))
+    val result = stream.readUTF()
+    assertEquals(length, result.length)
+    assertTrue(result.forall(_ == 'a'))
+    assertEquals(-1, stream.read())
+  }
+
   @Test def should_provide_readLine(): Unit = {
     val stream = newStream(
         "Hello World\nUNIX\nWindows\r\nMac (old)\rStuff".map(_.toInt): _*)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
@@ -5,6 +5,8 @@ import java.io._
 import org.junit._
 import org.junit.Assert._
 
+import org.scalajs.testsuite.utils.AssertThrows._
+
 object DataOutputStreamTest {
   class DataOutputStreamWrittenAccess(out: OutputStream)
       extends DataOutputStream(out) {
@@ -273,5 +275,17 @@ class DataOutputStreamTest {
         0x2d, 0x3e, 0x20, 0xed, 0xa0, 0xbd, 0xed, 0xb2,
         0xa9, 0x00, 0x03, 0xe6, 0x84, 0x9b
     )
+  }
+
+  @Test def writeUTFTooLong(): Unit = {
+    val (stream, checker) = newStream()
+
+    var longString = "aaa"
+    while (longString.length < 0x10000)
+      longString = longString + longString
+
+    assertThrows(classOf[UTFDataFormatException], {
+      stream.writeUTF(longString)
+    })
   }
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -52,8 +52,25 @@ abstract class GenIncOptimizer private[optimizer] (semantics: Semantics,
 
     callMethods(LongImpl.RuntimeLongClass, LongImpl.AllIntrinsicMethods) ++
     optional(callMethods(LongImpl.RuntimeLongClass, LongImpl.OptionalIntrinsicMethods)) ++
-    callMethods(Definitions.BoxedIntegerClass,
-        Seq("compareTo__jl_Byte__I", "compareTo__jl_Short__I")) ++ // #2184
+    /* #2184 + #2780: we need to keep all methods of j.l.Integer, in case
+     * the corresponding methods are called on j.l.Byte or j.l.Short, and
+     * through optimizations become calls on j.l.Integer.
+     */
+    callMethods(Definitions.BoxedIntegerClass, Seq(
+        "byteValue__B",
+        "shortValue__S",
+        "intValue__I",
+        "longValue__J",
+        "floatValue__F",
+        "doubleValue__D",
+        "equals__O__Z",
+        "hashCode__I",
+        "compareTo__jl_Integer__I",
+        "toString__T",
+        "compareTo__jl_Byte__I",
+        "compareTo__jl_Short__I",
+        "compareTo__O__I"
+    )) ++
     instantiateClass("jl_NullPointerException", "init___")
   }
 


### PR DESCRIPTION
Conflicts:

* js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
  Simple unrelated changes that happened to be in neighboring lines.
* sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
  0.6.x uses `new NodeJSEnv()` instead of `NodeJSEnv().value`.
  master was already using it but had other changes.
  Keep master.

Motivation: bring the fix for the community build to the master branch.

Log:

```
*   d6e8763 Merge '0.6.x' into 'master'.
|\
| *   0f42169 Merge pull request #2881 from sjrd/sys-error-scala-2.13
| |\
| | * cc9b478 Fix #2880: Use our own definition of Sys_error.
| |/
| *   77d12a3 Merge pull request #2872 from sjrd/deprecate-jsenv-initialize-constructors
| |\
| | * b79a605 Deprecate NodeJSEnv().value and JSDOMNodeJSEnv().value.
| | * 83797a1 Unify the parameter names of external JS env constructors.
| |/
| *   ee86166 Merge pull request #2867 from sjrd/deprecate-crossproject-settingsets
| |\
| | * 48984dd Fix #2855: Deprecate CrossProject.settingSets.
| * |   69c5bb4 Merge pull request #2869 from sjrd/data-input-output-stream-long-strings
| |\ \
| | * | e16ae09 Fix #2808: Handle long strings in DataInputStream.
| | |/
| * |   ba7f939 Merge pull request #2868 from sjrd/fix-linking-warnings-after-optimizer
| |\ \
| | * | 808fb7c Fix #2780: Reach all methods of j.l.Integer before the optimizer.
| | |/
| * |   29ccebd Merge pull request #2809 from mvh77/base64
| |\ \
| | |/
| |/|
| | * 2bad0ac Implement java.util.Base64.
| |/
* |   ed53a7d Merge pull request #2873 from sjrd/restore-testing-of-jsdom-env
|\ \
| * | 24669a1 Fix #2871: Restore testing of JSDOMNodeJSEnv.
|/ /
* |   f626fd6 Merge '0.6.x' into 'master'.
|\ \
| |/
| *   08551be Merge pull request #2865 from gzm0/fix-performance
```