### PR TITLE
Fix #2874: Remove the distinction libs/code in the JSEnv API.

### DIFF
--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/AsyncTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/AsyncTests.scala
@@ -20,7 +20,7 @@ trait AsyncTests extends BasicJSEnvTests {
 
   protected def asyncRunner(code: String): AsyncJSRunner = {
     val codeVF = new MemVirtualJSFile("testScript.js").withContent(code)
-    newJSEnv.asyncRunner(codeVF)
+    newJSEnv.asyncRunner(codeVF :: Nil)
   }
 
   protected def start(runner: AsyncJSRunner): Future[Unit] = {

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
@@ -16,7 +16,7 @@ trait ComTests extends AsyncTests {
 
   protected def comRunner(code: String): ComJSRunner = {
     val codeVF = new MemVirtualJSFile("testScript.js").withContent(code)
-    newJSEnv.comRunner(codeVF)
+    newJSEnv.comRunner(codeVF :: Nil)
   }
 
   private def assertThrowClosed(msg: String, body: => Unit): Unit = {

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvTest.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvTest.scala
@@ -22,7 +22,7 @@ abstract class JSEnvTest {
       val console = new StoreJSConsole()
       val logger  = new StoreLogger()
 
-      newJSEnv.jsRunner(code).run(logger, console)
+      newJSEnv.jsRunner(code :: Nil).run(logger, console)
 
       val log = logger.getLog
       val hasBadLog = log exists {
@@ -38,7 +38,7 @@ abstract class JSEnvTest {
 
     def fails(): Unit = {
       try {
-        newJSEnv.jsRunner(code).run(NullLogger, NullJSConsole)
+        newJSEnv.jsRunner(code :: Nil).run(NullLogger, NullJSConsole)
         assertTrue("Code snipped should fail", false)
       } catch {
         case e: Exception =>

--- a/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala
@@ -12,18 +12,14 @@ package org.scalajs.jsenv
 import org.scalajs.core.tools.io.VirtualJSFile
 
 trait AsyncJSEnv extends JSEnv {
-  def asyncRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): AsyncJSRunner
-
-  final def asyncRunner(code: VirtualJSFile): AsyncJSRunner =
-    asyncRunner(Nil, code)
+  def asyncRunner(files: Seq[VirtualJSFile]): AsyncJSRunner
 
   override def loadLibs(libs: Seq[VirtualJSFile]): AsyncJSEnv =
     new AsyncLoadedLibs { val loadedLibs = libs }
 
   private[jsenv] trait AsyncLoadedLibs extends LoadedLibs with AsyncJSEnv {
-    def asyncRunner(libs: Seq[VirtualJSFile],
-        code: VirtualJSFile): AsyncJSRunner = {
-      AsyncJSEnv.this.asyncRunner(loadedLibs ++ libs, code)
+    def asyncRunner(files: Seq[VirtualJSFile]): AsyncJSRunner = {
+      AsyncJSEnv.this.asyncRunner(loadedLibs ++ files)
     }
   }
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala
@@ -27,17 +27,14 @@ import org.scalajs.core.tools.io.VirtualJSFile
  *  }}}
  */
 trait ComJSEnv extends AsyncJSEnv {
-  def comRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): ComJSRunner
-
-  final def comRunner(code: VirtualJSFile): ComJSRunner = comRunner(Nil, code)
+  def comRunner(files: Seq[VirtualJSFile]): ComJSRunner
 
   override def loadLibs(libs: Seq[VirtualJSFile]): ComJSEnv =
     new ComLoadedLibs { val loadedLibs = libs }
 
   private[jsenv] trait ComLoadedLibs extends AsyncLoadedLibs with ComJSEnv {
-    def comRunner(libs: Seq[VirtualJSFile],
-        code: VirtualJSFile): ComJSRunner = {
-      ComJSEnv.this.comRunner(loadedLibs ++ libs, code)
+    def comRunner(files: Seq[VirtualJSFile]): ComJSRunner = {
+      ComJSEnv.this.comRunner(loadedLibs ++ files)
     }
   }
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -36,8 +36,7 @@ abstract class ExternalJSEnv(
   protected def customInitFiles(): Seq[VirtualJSFile] = Nil
 
   protected class AbstractExtRunner(
-      protected val libs: Seq[VirtualJSFile],
-      protected val code: VirtualJSFile) extends JSInitFiles {
+      protected val files: Seq[VirtualJSFile]) extends JSInitFiles {
 
     private[this] var _logger: Logger = _
     private[this] var _console: JSConsole = _
@@ -71,13 +70,15 @@ abstract class ExternalJSEnv(
     protected def getVMEnv(): Map[String, String] =
       sys.env ++ env
 
-    /** Get files that are a library (i.e. that do not run anything) */
-    protected def getLibJSFiles(): Seq[VirtualJSFile] =
-      initFiles() ++ customInitFiles() ++ libs
-
-    /** Get all files that are passed to VM (libraries and code) */
+    /** All the JS files that are passed to the VM.
+     *
+     *  This method can overridden to provide custom behavior in subclasses.
+     *
+     *  The default value in `ExternalJSEnv` is
+     *  `initFiles() ++ customInitFiles() ++ files`.
+     */
     protected def getJSFiles(): Seq[VirtualJSFile] =
-      getLibJSFiles() :+ code
+      initFiles() ++ customInitFiles() ++ files
 
     /** write a single JS file to a writer using an include fct if appropriate */
     protected def writeJSFile(file: VirtualJSFile, writer: Writer): Unit = {
@@ -153,8 +154,8 @@ abstract class ExternalJSEnv(
 
   }
 
-  protected class ExtRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
-      extends AbstractExtRunner(libs, code) with JSRunner {
+  protected class ExtRunner(files: Seq[VirtualJSFile])
+      extends AbstractExtRunner(files) with JSRunner {
 
     def run(logger: Logger, console: JSConsole): Unit = {
       setupLoggerAndConsole(logger, console)
@@ -166,8 +167,8 @@ abstract class ExternalJSEnv(
     }
   }
 
-  protected class AsyncExtRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
-      extends AbstractExtRunner(libs, code) with AsyncJSRunner {
+  protected class AsyncExtRunner(files: Seq[VirtualJSFile])
+      extends AbstractExtRunner(files) with AsyncJSRunner {
 
     private[this] var vmInst: Process = null
     private[this] var ioThreadEx: Throwable = null

--- a/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
@@ -15,24 +15,15 @@ trait JSEnv {
   /** Human-readable name for this [[JSEnv]] */
   def name: String
 
-  /** Prepare a runner for the code in the virtual file. */
-  def jsRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): JSRunner
-
-  /** Prepare a runner without any libraries.
-   *
-   *  Strictly equivalent to:
-   *  {{{
-   *  this.jsRunner(Nil, code)
-   *  }}}
-   */
-  final def jsRunner(code: VirtualJSFile): JSRunner = jsRunner(Nil, code)
+  /** Prepare a runner with the specified JavaScript files. */
+  def jsRunner(files: Seq[VirtualJSFile]): JSRunner
 
   /** Return this [[JSEnv]] with the given libraries already loaded.
    *
    *  The following two are equivalent:
    *  {{{
-   *  jsEnv.loadLibs(a).jsRunner(b, c)
-   *  jsEnv.jsRunner(a ++ b, c)
+   *  jsEnv.loadLibs(a).jsRunner(b)
+   *  jsEnv.jsRunner(a ++ b)
    *  }}}
    */
   def loadLibs(libs: Seq[VirtualJSFile]): JSEnv =
@@ -43,7 +34,7 @@ trait JSEnv {
 
     def name: String = JSEnv.this.name
 
-    def jsRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): JSRunner =
-      JSEnv.this.jsRunner(loadedLibs ++ libs, code)
+    def jsRunner(files: Seq[VirtualJSFile]): JSRunner =
+      JSEnv.this.jsRunner(loadedLibs ++ files)
   }
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
@@ -41,7 +41,7 @@ abstract class AbstractNodeJSEnv(
       .withContent("""require('source-map-support').install();""")
 
     try {
-      jsRunner(code).run(NullLogger, NullJSConsole)
+      jsRunner(Seq(code)).run(NullLogger, NullJSConsole)
       true
     } catch {
       case t: ExternalJSEnv.NonZeroExitException =>

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -41,29 +41,23 @@ class NodeJSEnv private (
 
   protected def vmName: String = "Node.js"
 
-  override def jsRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile): JSRunner = {
-    new NodeRunner(libs, code)
-  }
+  override def jsRunner(files: Seq[VirtualJSFile]): JSRunner =
+    new NodeRunner(files)
 
-  override def asyncRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile): AsyncJSRunner = {
-    new AsyncNodeRunner(libs, code)
-  }
+  override def asyncRunner(files: Seq[VirtualJSFile]): AsyncJSRunner =
+    new AsyncNodeRunner(files)
 
-  override def comRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile): ComJSRunner = {
-    new ComNodeRunner(libs, code)
-  }
+  override def comRunner(files: Seq[VirtualJSFile]): ComJSRunner =
+    new ComNodeRunner(files)
 
-  protected class NodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
-      extends ExtRunner(libs, code) with AbstractBasicNodeRunner
+  protected class NodeRunner(files: Seq[VirtualJSFile])
+      extends ExtRunner(files) with AbstractBasicNodeRunner
 
-  protected class AsyncNodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
-      extends AsyncExtRunner(libs, code) with AbstractBasicNodeRunner
+  protected class AsyncNodeRunner(files: Seq[VirtualJSFile])
+      extends AsyncExtRunner(files) with AbstractBasicNodeRunner
 
-  protected class ComNodeRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile)
-      extends AsyncNodeRunner(libs, code) with NodeComJSRunner
+  protected class ComNodeRunner(files: Seq[VirtualJSFile])
+      extends AsyncNodeRunner(files) with NodeComJSRunner
 
   protected trait AbstractBasicNodeRunner extends AbstractNodeRunner {
 

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -82,7 +82,7 @@ class MainGenericRunner {
       output
     }
 
-    new NodeJSEnv().jsRunner(sjsCode).run(logger, jsConsole)
+    new NodeJSEnv().jsRunner(sjsCode :: Nil).run(logger, jsConsole)
 
     true
   }

--- a/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
+++ b/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
@@ -41,32 +41,23 @@ class PhantomJSEnv(
 
   protected def vmName: String = "PhantomJS"
 
-  override def jsRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile): JSRunner = {
-    new PhantomRunner(libs, code)
-  }
+  override def jsRunner(files: Seq[VirtualJSFile]): JSRunner =
+    new PhantomRunner(files)
 
-  override def asyncRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile): AsyncJSRunner = {
-    new AsyncPhantomRunner(libs, code)
-  }
+  override def asyncRunner(files: Seq[VirtualJSFile]): AsyncJSRunner =
+    new AsyncPhantomRunner(files)
 
-  override def comRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile): ComJSRunner = {
-    new ComPhantomRunner(libs, code)
-  }
+  override def comRunner(files: Seq[VirtualJSFile]): ComJSRunner =
+    new ComPhantomRunner(files)
 
-  protected class PhantomRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile) extends ExtRunner(libs, code)
-      with AbstractPhantomRunner
+  protected class PhantomRunner(files: Seq[VirtualJSFile])
+      extends ExtRunner(files) with AbstractPhantomRunner
 
-  protected class AsyncPhantomRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile) extends AsyncExtRunner(libs, code)
-      with AbstractPhantomRunner
+  protected class AsyncPhantomRunner(files: Seq[VirtualJSFile])
+      extends AsyncExtRunner(files) with AbstractPhantomRunner
 
-  protected class ComPhantomRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile) extends AsyncPhantomRunner(libs, code)
-      with ComJSRunner {
+  protected class ComPhantomRunner(files: Seq[VirtualJSFile])
+      extends AsyncPhantomRunner(files) with ComJSRunner {
 
     private var mgrIsRunning: Boolean = false
 
@@ -403,9 +394,8 @@ class PhantomJSEnv(
       out.write(s"""<html><head>
           <title>Phantom.js Launcher</title>
           <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />""")
-      sendJS(getLibJSFiles(), out)
-      writeCodeLauncher(code, out)
-      out.write(s"</head>\n<body onload='$launcherName()'></body>\n</html>\n")
+      sendJS(getJSFiles(), out)
+      out.write(s"</head>\n<body></body>\n</html>\n")
     }
 
     protected def createTmpLauncherFile(): File = {
@@ -486,17 +476,6 @@ class PhantomJSEnv(
 
       webTmpF
     }
-
-    protected def writeCodeLauncher(code: VirtualJSFile, out: Writer): Unit = {
-      // Create a file with the launcher function.
-      val launcherFile = new MemVirtualJSFile("phantomjs-launcher.js")
-      launcherFile.content = s"""
-        // Phantom.js code launcher
-        // Origin: ${code.path}
-        function $launcherName() {${code.content}}
-      """
-      writeJSFile(launcherFile, out)
-    }
   }
 
   protected def htmlEscape(str: String): String = str.flatMap {
@@ -513,6 +492,4 @@ private object PhantomJSEnv {
   private final val MaxByteMessageSize = 32768 // 32 KB
   private final val MaxCharMessageSize = MaxByteMessageSize / 2 // 2B per char
   private final val MaxCharPayloadSize = MaxCharMessageSize - 1 // frag flag
-
-  private final val launcherName = "scalaJSPhantomJSEnvLauncher"
 }

--- a/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/RetryingComJSEnv.scala
+++ b/phantomjs-env/src/main/scala/org/scalajs/jsenv/phantomjs/RetryingComJSEnv.scala
@@ -42,26 +42,26 @@ final class RetryingComJSEnv(val baseEnv: ComJSEnv,
 
   def name: String = s"Retrying ${baseEnv.name}"
 
-  def jsRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): JSRunner =
-    baseEnv.jsRunner(libs, code)
+  def jsRunner(files: Seq[VirtualJSFile]): JSRunner =
+    baseEnv.jsRunner(files)
 
-  def asyncRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): AsyncJSRunner =
-    baseEnv.asyncRunner(libs, code)
+  def asyncRunner(files: Seq[VirtualJSFile]): AsyncJSRunner =
+    baseEnv.asyncRunner(files)
 
-  def comRunner(libs: Seq[VirtualJSFile], code: VirtualJSFile): ComJSRunner =
-    new RetryingComJSRunner(libs, code)
+  def comRunner(files: Seq[VirtualJSFile]): ComJSRunner =
+    new RetryingComJSRunner(files)
 
   /** Hack to work around abstract override in ComJSRunner */
   private trait DummyJSRunner {
     def stop(): Unit = ()
   }
 
-  private class RetryingComJSRunner(libs: Seq[VirtualJSFile],
-      code: VirtualJSFile) extends DummyJSRunner with ComJSRunner {
+  private class RetryingComJSRunner(files: Seq[VirtualJSFile])
+      extends DummyJSRunner with ComJSRunner {
 
     private[this] val promise = Promise[Unit]
 
-    private[this] var curRunner = baseEnv.comRunner(libs, code)
+    private[this] var curRunner = baseEnv.comRunner(files)
 
     private[this] var hasReceived = false
     private[this] var retryCount = 0
@@ -135,7 +135,7 @@ final class RetryingComJSEnv(val baseEnv: ComJSEnv,
         val oldRunner = curRunner
 
         curRunner = try {
-          baseEnv.comRunner(libs, code)
+          baseEnv.comRunner(files)
         } catch {
           case NonFatal(t) =>
             _logger.error("Could not retry: creating an new runner failed: " +

--- a/phantomjs-env/src/test/scala/org/scalajs/jsenv/phantomjs/RetryingComJSEnvTest.scala
+++ b/phantomjs-env/src/test/scala/org/scalajs/jsenv/phantomjs/RetryingComJSEnvTest.scala
@@ -28,20 +28,14 @@ class RetryingComJSEnvTest extends JSEnvTest with ComTests {
     private[this] var fails = 0
     private[this] var failedReceive = false
 
-    def jsRunner(libs: Seq[VirtualJSFile],
-        code: VirtualJSFile): JSRunner = {
-      baseEnv.jsRunner(libs, code)
-    }
+    def jsRunner(files: Seq[VirtualJSFile]): JSRunner =
+      baseEnv.jsRunner(files)
 
-    def asyncRunner(libs: Seq[VirtualJSFile],
-        code: VirtualJSFile): AsyncJSRunner = {
-      baseEnv.asyncRunner(libs, code)
-    }
+    def asyncRunner(files: Seq[VirtualJSFile]): AsyncJSRunner =
+      baseEnv.asyncRunner(files)
 
-    def comRunner(libs: Seq[VirtualJSFile],
-        code: VirtualJSFile): ComJSRunner = {
-      new FailingComJSRunner(baseEnv.comRunner(libs, code))
-    }
+    def comRunner(files: Seq[VirtualJSFile]): ComJSRunner =
+      new FailingComJSRunner(baseEnv.comRunner(files))
 
     /** Hack to work around abstract override in ComJSRunner */
     private trait DummyJSRunner {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -676,7 +676,7 @@ object Build {
           val launcher = new MemVirtualJSFile("Generated launcher file")
             .withContent(code)
 
-          val runner = loadedJSEnv.value.jsRunner(launcher)
+          val runner = loadedJSEnv.value.jsRunner(launcher :: Nil)
 
           runner.run(sbtLogger2ToolsLogger(streams.value.log), scalaJSConsole.value)
         }

--- a/sbt-plugin-test/project/Jetty9Test.scala
+++ b/sbt-plugin-test/project/Jetty9Test.scala
@@ -42,7 +42,7 @@ object Jetty9Test {
       """
     )
 
-    val runner = jsEnv.comRunner(code)
+    val runner = jsEnv.comRunner(code :: Nil)
 
     runner.start(streams.value.log, jsConsole)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
@@ -67,7 +67,7 @@ private[sbtplugin] final class FrameworkDetector(jsEnv: JSEnv,
     val vf = new MemVirtualJSFile("frameworkDetector.js").withContent(code)
     val console = new StoreConsole
 
-    val runner = jsEnv.jsRunner(vf)
+    val runner = jsEnv.jsRunner(vf :: Nil)
     runner.run(logger, console)
 
     // Filter jsDependencies unexpected output

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -710,9 +710,7 @@ object ScalaJSPluginInternal {
         log.info("Running " + mainClass.value.getOrElse("<unknown class>"))
         log.debug(s"with JSEnv ${jsEnv.name}")
 
-        val dummyLauncher = new MemVirtualJSFile("No-op generated launcher file")
-
-        jsEnv.jsRunner(dummyLauncher).run(
+        jsEnv.jsRunner(Nil).run(
             sbtLogger2ToolsLogger(log), scalaJSConsole.value)
       },
 

--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala
@@ -58,7 +58,7 @@ final class ScalaJSFramework(
   private[testadapter] def runDone(): Unit = synchronized(_isRunning = false)
 
   private def fetchFrameworkInfo() = {
-    val runner = libEnv.comRunner(frameworkInfoLauncher)
+    val runner = libEnv.comRunner(frameworkInfoLauncher :: Nil)
     runner.start(logger, jsConsole)
 
     try {

--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
@@ -177,7 +177,7 @@ final class ScalaJSRunner private[testadapter] (
     ensureNotDone()
 
     // Launch the slave
-    val slave = framework.libEnv.comRunner(slaveLauncher)
+    val slave = framework.libEnv.comRunner(slaveLauncher :: Nil)
     slave.start(framework.logger, framework.jsConsole)
 
     // Create a runner on the slave
@@ -218,7 +218,7 @@ final class ScalaJSRunner private[testadapter] (
   private def createRemoteRunner(): Unit = {
     assert(master == null)
 
-    master = framework.libEnv.comRunner(masterLauncher)
+    master = framework.libEnv.comRunner(masterLauncher :: Nil)
     master.start(framework.logger, framework.jsConsole)
 
     val data = {


### PR DESCRIPTION
`JSEnv#jsRunner` and friends `asyncRunner` and `comRunner` now only take a `Seq[VirtualJSFiles]`, containing all JS files to be given to the JS environment.

The JS environments therefore make no distinction between "library" files and the "code" file. The disinction was arbitrary anyway, and unifying them makes sure that all the JS files are first-class. In particular, it forced to solve shortcomings in terms of error handling in `JSDOMNodeJSEnv`.