### PR TITLE
Fix #2875: Remove JSEnv.loadLibs, resolvedJSEnv and loadedJSEnv.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -233,6 +233,7 @@
         withDOM/run withDOM/testHtmlFastOpt withDOM/testHtmlFullOpt \
         multiTestJS/testHtmlFastOpt multiTestJS/testHtmlFullOpt \
         jetty9/run test \
+        noDOM/clean noDOM/concurrentUseOfLinkerTest \
         jsDependenciesTest/packageJSDependencies \
         jsDependenciesTest/packageMinifiedJSDependencies \
         jsDependenciesTest/regressionTestForIssue2243 \

--- a/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala
@@ -13,13 +13,4 @@ import org.scalajs.core.tools.io.VirtualJSFile
 
 trait AsyncJSEnv extends JSEnv {
   def asyncRunner(files: Seq[VirtualJSFile]): AsyncJSRunner
-
-  override def loadLibs(libs: Seq[VirtualJSFile]): AsyncJSEnv =
-    new AsyncLoadedLibs { val loadedLibs = libs }
-
-  private[jsenv] trait AsyncLoadedLibs extends LoadedLibs with AsyncJSEnv {
-    def asyncRunner(files: Seq[VirtualJSFile]): AsyncJSRunner = {
-      AsyncJSEnv.this.asyncRunner(loadedLibs ++ files)
-    }
-  }
 }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala
@@ -28,15 +28,6 @@ import org.scalajs.core.tools.io.VirtualJSFile
  */
 trait ComJSEnv extends AsyncJSEnv {
   def comRunner(files: Seq[VirtualJSFile]): ComJSRunner
-
-  override def loadLibs(libs: Seq[VirtualJSFile]): ComJSEnv =
-    new ComLoadedLibs { val loadedLibs = libs }
-
-  private[jsenv] trait ComLoadedLibs extends AsyncLoadedLibs with ComJSEnv {
-    def comRunner(files: Seq[VirtualJSFile]): ComJSRunner = {
-      ComJSEnv.this.comRunner(loadedLibs ++ files)
-    }
-  }
 }
 
 object ComJSEnv {

--- a/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
@@ -17,24 +17,4 @@ trait JSEnv {
 
   /** Prepare a runner with the specified JavaScript files. */
   def jsRunner(files: Seq[VirtualJSFile]): JSRunner
-
-  /** Return this [[JSEnv]] with the given libraries already loaded.
-   *
-   *  The following two are equivalent:
-   *  {{{
-   *  jsEnv.loadLibs(a).jsRunner(b)
-   *  jsEnv.jsRunner(a ++ b)
-   *  }}}
-   */
-  def loadLibs(libs: Seq[VirtualJSFile]): JSEnv =
-    new LoadedLibs { val loadedLibs = libs }
-
-  private[jsenv] trait LoadedLibs extends JSEnv {
-    val loadedLibs: Seq[VirtualJSFile]
-
-    def name: String = JSEnv.this.name
-
-    def jsRunner(files: Seq[VirtualJSFile]): JSRunner =
-      JSEnv.this.jsRunner(loadedLibs ++ files)
-  }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -636,7 +636,7 @@ object Build {
       inConfig(Test) {
         // Redefine test to run Node.js and link HelloWorld
         test := {
-          if (!resolvedJSEnv.value.isInstanceOf[NodeJSEnv])
+          if (!jsEnv.value.isInstanceOf[NodeJSEnv])
             sys.error("toolsJS/test must be run with Node.js")
 
           /* Collect IR relevant files from the classpath
@@ -696,7 +696,7 @@ object Build {
           val launcher = new MemVirtualJSFile("Generated launcher file")
             .withContent(code)
 
-          val runner = loadedJSEnv.value.jsRunner(launcher :: Nil)
+          val runner = jsEnv.value.jsRunner(jsExecutionFiles.value :+ launcher)
 
           runner.run(sbtLogger2ToolsLogger(streams.value.log), scalaJSConsole.value)
         }
@@ -1277,7 +1277,7 @@ object Build {
                 "don't know what tags to specify for the test suite")
         }
 
-        val envTags = envTagsFor((resolvedJSEnv in Test).value)
+        val envTags = envTagsFor((jsEnv in Test).value)
 
         val stage = (scalaJSStage in Test).value
 

--- a/sbt-plugin-test/project/Jetty9Test.scala
+++ b/sbt-plugin-test/project/Jetty9Test.scala
@@ -21,7 +21,8 @@ object Jetty9Test {
   private val jettyPort = 23548
 
   val runSetting = run <<= Def.inputTask {
-    val jsEnv = (loadedJSEnv in Compile).value.asInstanceOf[ComJSEnv]
+    val env = (jsEnv in Compile).value.asInstanceOf[ComJSEnv]
+    val files = (jsExecutionFiles in Compile).value
     val jsConsole = scalaJSConsole.value
 
     val code = new MemVirtualJSFile("runner.js").withContent(
@@ -42,7 +43,7 @@ object Jetty9Test {
       """
     )
 
-    val runner = jsEnv.comRunner(code :: Nil)
+    val runner = env.comRunner(files :+ code)
 
     runner.start(streams.value.log, jsConsole)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
@@ -12,7 +12,8 @@ import org.scalajs.jsenv._
 import scala.collection.mutable
 
 private[sbtplugin] final class FrameworkDetector(jsEnv: JSEnv,
-    moduleKind: ModuleKind, moduleIdentifier: Option[String]) {
+    jsFiles: Seq[VirtualJSFile], moduleKind: ModuleKind,
+    moduleIdentifier: Option[String]) {
 
   import FrameworkDetector._
 
@@ -67,7 +68,7 @@ private[sbtplugin] final class FrameworkDetector(jsEnv: JSEnv,
     val vf = new MemVirtualJSFile("frameworkDetector.js").withContent(code)
     val console = new StoreConsole
 
-    val runner = jsEnv.jsRunner(vf :: Nil)
+    val runner = jsEnv.jsRunner(jsFiles :+ vf)
     runner.run(logger, console)
 
     // Filter jsDependencies unexpected output

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -180,17 +180,8 @@ object ScalaJSPlugin extends AutoPlugin {
         "The JS console used by the Scala.js runner/tester", DTask)
 
     val jsEnv = TaskKey[JSEnv]("jsEnv",
-        "A JVM-like environment where Scala.js files can be run and tested.", AMinusTask)
-
-    val resolvedJSEnv = TaskKey[JSEnv]("resolvedJSEnv",
-        "The JSEnv used for execution. This equals the setting of jsEnv or a " +
-        "reasonable default value if jsEnv is not set.", DTask)
-
-    @deprecated("Use jsEnv instead.", "0.6.6")
-    val preLinkJSEnv = jsEnv
-
-    @deprecated("Use jsEnv instead.", "0.6.6")
-    val postLinkJSEnv = jsEnv
+        "The JavaScript environment in which to run and test Scala.js applications.",
+        AMinusTask)
 
     val requiresDOM = SettingKey[Boolean]("requiresDOM",
         "Whether this projects needs the DOM. Overrides anything inherited through dependencies.", AMinusSetting)
@@ -242,9 +233,6 @@ object ScalaJSPlugin extends AutoPlugin {
 
     val scalaJSOptimizerOptions = SettingKey[OptimizerOptions]("scalaJSOptimizerOptions",
         "All kinds of options for the Scala.js optimizer stages", DSetting)
-
-    val loadedJSEnv = TaskKey[JSEnv]("loadedJSEnv",
-        "A JSEnv already loaded up with library and Scala.js code. Ready to run.", DTask)
 
     /** Prints the content of a .sjsir file in human readable form. */
     val scalajsp = InputKey[Unit]("scalajsp",

--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala
@@ -22,16 +22,18 @@ import sbt.testing.{Logger => _, _}
 
 final class ScalaJSFramework(
     private[testadapter] val frameworkName: String,
-    private[testadapter] val libEnv: ComJSEnv,
+    private val jsEnv: ComJSEnv,
+    private val jsFiles: Seq[VirtualJSFile],
     private[testadapter] val moduleKind: ModuleKind,
     private[testadapter] val moduleIdentifier: Option[String],
     private[testadapter] val logger: Logger,
     private[testadapter] val jsConsole: JSConsole
 ) extends Framework {
 
-  def this(frameworkName: String, libEnv: ComJSEnv, logger: Logger,
-      jsConsole: JSConsole) = {
-    this(frameworkName, libEnv, ModuleKind.NoModule, None, logger, jsConsole)
+  def this(frameworkName: String, jsEnv: ComJSEnv, jsFiles: Seq[VirtualJSFile],
+      logger: Logger, jsConsole: JSConsole) = {
+    this(frameworkName, jsEnv, jsFiles, ModuleKind.NoModule, None, logger,
+        jsConsole)
   }
 
   private[this] val frameworkInfo = fetchFrameworkInfo()
@@ -57,8 +59,11 @@ final class ScalaJSFramework(
 
   private[testadapter] def runDone(): Unit = synchronized(_isRunning = false)
 
+  private[testadapter] def newComRunner(files: Seq[VirtualJSFile]): ComJSRunner =
+    jsEnv.comRunner(jsFiles ++ files)
+
   private def fetchFrameworkInfo() = {
-    val runner = libEnv.comRunner(frameworkInfoLauncher :: Nil)
+    val runner = newComRunner(frameworkInfoLauncher :: Nil)
     runner.start(logger, jsConsole)
 
     try {

--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
@@ -177,7 +177,7 @@ final class ScalaJSRunner private[testadapter] (
     ensureNotDone()
 
     // Launch the slave
-    val slave = framework.libEnv.comRunner(slaveLauncher :: Nil)
+    val slave = framework.newComRunner(slaveLauncher :: Nil)
     slave.start(framework.logger, framework.jsConsole)
 
     // Create a runner on the slave
@@ -218,7 +218,7 @@ final class ScalaJSRunner private[testadapter] (
   private def createRemoteRunner(): Unit = {
     assert(master == null)
 
-    master = framework.libEnv.comRunner(masterLauncher :: Nil)
+    master = framework.newComRunner(masterLauncher :: Nil)
     master.start(framework.logger, framework.jsConsole)
 
     val data = {


### PR DESCRIPTION
We remove `resolvedJSEnv` simply by initializing `jsEnv` by default in the project scope, and using `jsEnv` instead of `resolvedJSEnv`.

We remove `loadedJSEnv` by using instead the pair `jsEnv` + `jsExecutionFiles` explicitly.

Finally, we can remove `JSEnv.loadLibs`, as it was only useful for `loadedJSEnv`.