### PR TITLE
Blacklist neg/patmatexhaust-huge.scala.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/BlacklistedTests.txt
@@ -27,6 +27,9 @@ neg/t7622-cyclic-dependency
 # Uses some strange macro cross compile mechanism.
 neg/macro-incompatible-macro-engine-c.scala
 
+# Spurious failures
+neg/patmatexhaust-huge.scala
+
 # Uses .java files
 neg/t6289
 

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/WhitelistedTests.txt
@@ -1060,7 +1060,6 @@ neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
 neg/inlineMaxSize.scala
-neg/patmatexhaust-huge.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
@@ -27,6 +27,9 @@ neg/t7622-cyclic-dependency
 # Uses some strange macro cross compile mechanism.
 neg/macro-incompatible-macro-engine-c.scala
 
+# Spurious failures
+neg/patmatexhaust-huge.scala
+
 # Uses .java files
 neg/t6289
 

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
@@ -1061,7 +1061,6 @@ neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
 neg/inlineMaxSize.scala
-neg/patmatexhaust-huge.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/BlacklistedTests.txt
@@ -27,6 +27,9 @@ neg/t7622-cyclic-dependency
 # Uses some strange macro cross compile mechanism.
 neg/macro-incompatible-macro-engine-c.scala
 
+# Spurious failures
+neg/patmatexhaust-huge.scala
+
 # Uses .java files
 neg/t6289
 

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/WhitelistedTests.txt
@@ -1060,7 +1060,6 @@ neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
 neg/inlineMaxSize.scala
-neg/patmatexhaust-huge.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/BlacklistedTests.txt
@@ -22,6 +22,9 @@ neg/t7622-cyclic-dependency
 # Uses some strange macro cross compile mechanism.
 neg/macro-incompatible-macro-engine-c.scala
 
+# Spurious failures
+neg/patmatexhaust-huge.scala
+
 # Uses .java files
 run/t9200
 run/noInlineUnknownIndy

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/WhitelistedTests.txt
@@ -1047,7 +1047,6 @@ neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
 neg/inlineMaxSize.scala
-neg/patmatexhaust-huge.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/BlacklistedTests.txt
@@ -22,6 +22,9 @@ neg/t7622-cyclic-dependency
 # Uses some strange macro cross compile mechanism.
 neg/macro-incompatible-macro-engine-c.scala
 
+# Spurious failures
+neg/patmatexhaust-huge.scala
+
 # Uses .java files
 run/t9200
 run/noInlineUnknownIndy

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/WhitelistedTests.txt
@@ -1045,7 +1045,6 @@ neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
 neg/inlineMaxSize.scala
-neg/patmatexhaust-huge.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/BlacklistedTests.txt
@@ -22,6 +22,9 @@ neg/t7622-cyclic-dependency
 # Uses some strange macro cross compile mechanism.
 neg/macro-incompatible-macro-engine-c.scala
 
+# Spurious failures
+neg/patmatexhaust-huge.scala
+
 # Uses .java files
 run/t9200
 run/noInlineUnknownIndy

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/WhitelistedTests.txt
@@ -1045,7 +1045,6 @@ neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
 neg/inlineMaxSize.scala
-neg/patmatexhaust-huge.scala
 
 run/t7249.scala
 run/t3563.scala


### PR DESCRIPTION
It exhibits spurious failures, and anyway it's testing the pattern matcher exhaustivity checks, which does not concern Scala.js.