### PR TITLE
Fix #2906: Implement j.l.Math.next{Up,Down,After} for Float.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -108,6 +108,18 @@ object Math {
     }
   }
 
+  def nextDown(a: scala.Double): scala.Double = {
+    if (a != a || a == scala.Double.NegativeInfinity) {
+      a
+    } else if (a == 0.0) { // also matches -0.0 but that's fine
+      -scala.Double.MinPositiveValue
+    } else {
+      val abits = Double.doubleToLongBits(a)
+      val rbits = if (a > 0) abits - 1L else abits + 1L
+      Double.longBitsToDouble(rbits)
+    }
+  }
+
   def nextAfter(a: scala.Double, b: scala.Double): scala.Double = {
     if (b < a)
       -nextUp(-a)
@@ -316,7 +328,6 @@ object Math {
   // def getExponent(a: scala.Double): scala.Int
   // def nextAfter(a: scala.Float, b: scala.Double): scala.Float
   // def nextUp(a: scala.Float): scala.Float
-  // def nextDown(a: scala.Double): scala.Double
   // def nextDown(a: scala.Float): scala.Float
   // def scalb(a: scala.Double, scalaFactor: scala.Int): scala.Double
   // def scalb(a: scala.Float, scalaFactor: scala.Int): scala.Float

--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -121,11 +121,11 @@ object Math {
   }
 
   def nextAfter(a: scala.Double, b: scala.Double): scala.Double = {
-    if (b < a)
-      -nextUp(-a)
-    else if (a < b)
+    if (b > a)
       nextUp(a)
-    else if (a != a || b != b)
+    else if (b < a)
+      nextDown(a)
+    else if (a != a)
       scala.Double.NaN
     else
       b

--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -97,37 +97,14 @@ object Math {
   }
 
   def nextUp(a: scala.Double): scala.Double = {
-  // js implementation of nextUp https://gist.github.com/Yaffle/4654250
-    import scala.Double._
-    if (a != a || a == PositiveInfinity)
+    if (a != a || a == scala.Double.PositiveInfinity) {
       a
-    else if (a == NegativeInfinity)
-      MinValue
-    else if (a == MaxValue)
-      PositiveInfinity
-    else if (a == 0)
-      MinPositiveValue
-    else {
-      def iter(x: scala.Double, xi: scala.Double, n: scala.Double): scala.Double = {
-        if (Math.abs(xi - x) >= 1E-16) {
-          val c0 = (xi + x) / 2
-          val c =
-            if (c0 == NegativeInfinity || c0 == PositiveInfinity)
-              x + (xi - x) / 2
-            else
-              c0
-          if (n == c) xi
-          else if (a < c) iter(x = x, xi = c, n = c)
-          else iter(x = c, xi = xi, n = c)
-        }
-        else xi
-      }
-      val d = Math.max(Math.abs(a) * 2E-16, MinPositiveValue)
-      val ad = a + d
-      val xi0 =
-        if (ad == PositiveInfinity) MaxValue
-        else ad
-      iter(x = a, xi = xi0, n = a)
+    } else if (a == -0.0) { // also matches +0.0 but that's fine
+      scala.Double.MinPositiveValue
+    } else {
+      val abits = Double.doubleToLongBits(a)
+      val rbits = if (a > 0) abits + 1L else abits - 1L
+      Double.longBitsToDouble(rbits)
     }
   }
 

--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -108,6 +108,18 @@ object Math {
     }
   }
 
+  def nextUp(a: scala.Float): scala.Float = {
+    if (a != a || a == scala.Float.PositiveInfinity) {
+      a
+    } else if (a == -0.0f) { // also matches +0.0f but that's fine
+      scala.Float.MinPositiveValue
+    } else {
+      val abits = Float.floatToIntBits(a)
+      val rbits = if (a > 0) abits + 1 else abits - 1
+      Float.intBitsToFloat(rbits)
+    }
+  }
+
   def nextDown(a: scala.Double): scala.Double = {
     if (a != a || a == scala.Double.NegativeInfinity) {
       a
@@ -120,6 +132,18 @@ object Math {
     }
   }
 
+  def nextDown(a: scala.Float): scala.Float = {
+    if (a != a || a == scala.Float.NegativeInfinity) {
+      a
+    } else if (a == 0.0f) { // also matches -0.0f but that's fine
+      -scala.Float.MinPositiveValue
+    } else {
+      val abits = Float.floatToIntBits(a)
+      val rbits = if (a > 0) abits - 1 else abits + 1
+      Float.intBitsToFloat(rbits)
+    }
+  }
+
   def nextAfter(a: scala.Double, b: scala.Double): scala.Double = {
     if (b > a)
       nextUp(a)
@@ -129,6 +153,17 @@ object Math {
       scala.Double.NaN
     else
       b
+  }
+
+  def nextAfter(a: scala.Float, b: scala.Double): scala.Float = {
+    if (b > a)
+      nextUp(a)
+    else if (b < a)
+      nextDown(a)
+    else if (a != a)
+      scala.Float.NaN
+    else
+      b.toFloat
   }
 
   def ulp(a: scala.Double): scala.Double = {
@@ -326,9 +361,6 @@ object Math {
   // def copySign(magnitude: scala.Float, sign: scala.Float): scala.Float
   // def getExponent(a: scala.Float): scala.Int
   // def getExponent(a: scala.Double): scala.Int
-  // def nextAfter(a: scala.Float, b: scala.Double): scala.Float
-  // def nextUp(a: scala.Float): scala.Float
-  // def nextDown(a: scala.Float): scala.Float
   // def scalb(a: scala.Double, scalaFactor: scala.Int): scala.Double
   // def scalb(a: scala.Float, scalaFactor: scala.Int): scala.Float
 }

--- a/library/src/main/scala/scala/scalajs/runtime/Bits.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/Bits.scala
@@ -226,7 +226,20 @@ object Bits {
         val twoPowFbits = pow(2, fbits)
 
         var e = min(rawToInt(floor(log(av) / LN2)), 1023)
-        var f = roundToEven(av / pow(2, e) * twoPowFbits)
+        var twoPowE = pow(2, e)
+
+        /* #2911: When av is very close under a power of 2 (e.g.,
+         * 9007199254740991.0 == 2^53 - 1), `log(av) / LN2` will already round
+         * *up* to an `e` which is 1 too much. The `floor()` afterwards comes
+         * too late to fix that.
+         * We now decrement `e` if it ends up being too big.
+         */
+        if (twoPowE > av) {
+          e -= 1
+          twoPowE /= 2
+        }
+
+        var f = roundToEven(av / twoPowE * twoPowFbits)
         if (f / twoPowFbits >= 2) {
           e = e + 1
           f = 1

--- a/scala-test-suite/src/test/resources/2.13.0-M1/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.0-M1/BlacklistedTests.txt
@@ -100,9 +100,6 @@ scala/tools/testing/AssertThrowsTest.scala
 scala/util/SpecVersionTest.scala
 scala/util/SystemPropertiesTest.scala
 
-# Doesn't link because of #2906
-scala/util/RandomUtilTest.scala
-
 ## Tests fail
 
 # Reflection

--- a/scala-test-suite/src/test/resources/2.13.0-M1/WhitelistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.0-M1/WhitelistedTests.txt
@@ -39,5 +39,6 @@ scala/tools/nsc/SampleTest.scala
 scala/tools/testing/AssertUtil.scala
 scala/tools/testing/TempDir.scala
 scala/util/RandomTest.scala
+scala/util/RandomUtilTest.scala
 scala/util/TryTest.scala
 scala/util/control/ExceptionTest.scala

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
@@ -9,6 +9,12 @@ import org.scalajs.testsuite.utils.Platform._
 
 class MathTestOnJDK8 {
 
+  /** Like `assertEquals` with `delta = 0.0`, but positive and negative zeros
+   *  compare not equal.
+   */
+  private def assertSameDouble(expected: Double, actual: Double): Unit =
+    assertTrue(s"expected: $expected but was: $actual", expected.equals(actual))
+
   @Test def addExact(): Unit = {
     assertEquals(0, Math.addExact(0, 0))
     assertEquals(1, Math.addExact(0, 1))
@@ -284,5 +290,28 @@ class MathTestOnJDK8 {
 
     for (n <- Seq(0L, 1L, -1L, Long.MaxValue, Long.MinValue))
       assertThrows(classOf[ArithmeticException], Math.floorMod(n, 0))
+  }
+
+  @Test def nextDown_for_Double(): Unit = {
+    // Specials
+    assertSameDouble(-Double.MinPositiveValue, Math.nextDown(0.0))
+    assertSameDouble(-Double.MinPositiveValue, Math.nextDown(-0.0))
+    assertSameDouble(Double.MaxValue, Math.nextDown(Double.PositiveInfinity))
+    assertSameDouble(Double.NegativeInfinity, Math.nextDown(Double.NegativeInfinity))
+    assertSameDouble(Double.NaN, Math.nextDown(Double.NaN))
+
+    // Corner cases
+    val MinNormal = java.lang.Double.MIN_NORMAL
+    val MaxSubnormal = 2.225073858507201e-308
+    assertSameDouble(1.7976931348623155e+308, Math.nextDown(Double.MaxValue))
+    assertSameDouble(Double.NegativeInfinity, Math.nextDown(Double.MinValue))
+    assertSameDouble(0.0, Math.nextDown(Double.MinPositiveValue))
+    assertSameDouble(MaxSubnormal, Math.nextDown(MinNormal))
+    assertSameDouble(-MinNormal, Math.nextDown(-MaxSubnormal))
+
+    // Random values
+    assertSameDouble(9007199254740991.0, Math.nextDown(9007199254740992.0))
+    assertSameDouble(9007199254740992.0, Math.nextDown(9007199254740994.0))
+    assertSameDouble(0.9999999999999999, Math.nextDown(1.0))
   }
 }

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
@@ -15,6 +15,12 @@ class MathTestOnJDK8 {
   private def assertSameDouble(expected: Double, actual: Double): Unit =
     assertTrue(s"expected: $expected but was: $actual", expected.equals(actual))
 
+  /** Like `assertEquals` with `delta = 0.0f`, but positive and negative zeros
+   *  compare not equal.
+   */
+  private def assertSameFloat(expected: Float, actual: Float): Unit =
+    assertTrue(s"expected: $expected but was: $actual", expected.equals(actual))
+
   @Test def addExact(): Unit = {
     assertEquals(0, Math.addExact(0, 0))
     assertEquals(1, Math.addExact(0, 1))
@@ -313,5 +319,27 @@ class MathTestOnJDK8 {
     assertSameDouble(9007199254740991.0, Math.nextDown(9007199254740992.0))
     assertSameDouble(9007199254740992.0, Math.nextDown(9007199254740994.0))
     assertSameDouble(0.9999999999999999, Math.nextDown(1.0))
+  }
+
+  @Test def nextDown_for_Float(): Unit = {
+    // Specials
+    assertSameFloat(-Float.MinPositiveValue, Math.nextDown(0.0f))
+    assertSameFloat(-Float.MinPositiveValue, Math.nextDown(-0.0f))
+    assertSameFloat(Float.MaxValue, Math.nextDown(Float.PositiveInfinity))
+    assertSameFloat(Float.NegativeInfinity, Math.nextDown(Float.NegativeInfinity))
+    assertSameFloat(Float.NaN, Math.nextDown(Float.NaN))
+
+    // Corner cases
+    val MinNormal = java.lang.Float.MIN_NORMAL
+    val MaxSubnormal = 1.1754942e-38f
+    assertSameFloat(3.4028233e38f, Math.nextDown(Float.MaxValue))
+    assertSameFloat(Float.NegativeInfinity, Math.nextDown(Float.MinValue))
+    assertSameFloat(0.0f, Math.nextDown(Float.MinPositiveValue))
+    assertSameFloat(MaxSubnormal, Math.nextDown(MinNormal))
+    assertSameFloat(-MinNormal, Math.nextDown(-MaxSubnormal))
+
+    // Random values
+    assertSameFloat(9007198700000000.0f, Math.nextDown(9007199300000000.0f))
+    assertSameFloat(0.99999994f, Math.nextDown(1.0f))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -249,6 +249,9 @@ class DoubleTest {
     assertEquals(0xffefffffffffffffL, f(-1.7976931348623157e308))  // largest neg normal form
     assertEquals(0xcd124568bc6584caL, f(-1.8790766677624813e63))   // an arbitrary neg normal form
 
+    // #2911 Normal form very close under a power of 2
+    assertEquals(4845873199050653695L, f(9007199254740991.0))
+
     // Subnormal forms
     assertEquals(0x0000000000000001L, f(Double.MinPositiveValue))  // smallest pos subnormal form
     assertEquals(0x000fffffffffffffL, f(2.225073858507201e-308))   // largest pos subnormal form

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
@@ -23,6 +23,12 @@ class MathTest {
   private def assertSameDouble(expected: Double, actual: Double): Unit =
     assertTrue(s"expected: $expected but was: $actual", expected.equals(actual))
 
+  /** Like `assertEquals` with `delta = 0.0f`, but positive and negative zeros
+   *  compare not equal.
+   */
+  private def assertSameFloat(expected: Float, actual: Float): Unit =
+    assertTrue(s"expected: $expected but was: $actual", expected.equals(actual))
+
   @Test def abs(): Unit = {
     assertEquals(0, Math.abs(0))
     assertEquals(42, Math.abs(42))
@@ -143,6 +149,28 @@ class MathTest {
     assertSameDouble(1.0000000000000002, Math.nextUp(1.0))
   }
 
+  @Test def nextUp_for_Float(): Unit = {
+    // Specials
+    assertSameFloat(Float.MinPositiveValue, Math.nextUp(0.0f))
+    assertSameFloat(Float.MinPositiveValue, Math.nextUp(-0.0f))
+    assertSameFloat(Float.PositiveInfinity, Math.nextUp(Float.PositiveInfinity))
+    assertSameFloat(Float.MinValue, Math.nextUp(Float.NegativeInfinity))
+    assertSameFloat(Float.NaN, Math.nextUp(Float.NaN))
+
+    // Corner cases
+    val MinNormal = java.lang.Float.MIN_NORMAL
+    val MaxSubnormal = 1.1754942e-38f
+    assertSameFloat(Float.PositiveInfinity, Math.nextUp(Float.MaxValue))
+    assertSameFloat(-3.4028233e38f, Math.nextUp(Float.MinValue))
+    assertSameFloat(-0.0f, Math.nextUp(-Float.MinPositiveValue))
+    assertSameFloat(MinNormal, Math.nextUp(MaxSubnormal))
+    assertSameFloat(-MaxSubnormal, Math.nextUp(-MinNormal))
+
+    // Random values
+    assertSameFloat(9007200300000000.0f, Math.nextUp(9007199300000000.0f))
+    assertSameFloat(1.0000001f, Math.nextUp(1.0f))
+  }
+
   @Test def nextAfter_for_Double(): Unit = {
     assertSameDouble(Double.NaN, Math.nextAfter(Double.NaN, Double.NaN))
     assertSameDouble(Double.NaN, Math.nextAfter(1.0, Double.NaN))
@@ -174,6 +202,39 @@ class MathTest {
     assertSameDouble(1.0, Math.nextAfter(1.0, 1.0))
     assertSameDouble(1.0000000000000002, Math.nextAfter(1.0, 2.0))
     assertSameDouble(0.9999999999999999, Math.nextAfter(1.0, 0.5))
+  }
+
+  @Test def nextAfter_for_Float(): Unit = {
+    assertSameFloat(Float.NaN, Math.nextAfter(Float.NaN, Double.NaN))
+    assertSameFloat(Float.NaN, Math.nextAfter(1.0f, Double.NaN))
+    assertSameFloat(Float.NaN, Math.nextAfter(Float.NaN, 1.0))
+
+    assertSameFloat(0.0f, Math.nextAfter(0.0f, 0.0))
+    assertSameFloat(-0.0f, Math.nextAfter(0.0f, -0.0))
+    assertSameFloat(0.0f, Math.nextAfter(-0.0f, 0.0))
+    assertSameFloat(-0.0f, Math.nextAfter(-0.0f, -0.0))
+
+    assertSameFloat(Float.PositiveInfinity,
+        Math.nextAfter(Float.PositiveInfinity, Double.PositiveInfinity))
+    assertSameFloat(Float.NegativeInfinity,
+        Math.nextAfter(Float.NegativeInfinity, Double.NegativeInfinity))
+
+    assertSameFloat(Float.NegativeInfinity,
+        Math.nextAfter(Float.MinValue, Double.NegativeInfinity))
+    assertSameFloat(Float.PositiveInfinity,
+        Math.nextAfter(-Float.MinValue, Double.PositiveInfinity))
+    assertSameFloat(Float.MaxValue,
+        Math.nextAfter(Float.PositiveInfinity, Double.NegativeInfinity))
+    assertSameFloat(Float.MinValue,
+        Math.nextAfter(Float.NegativeInfinity, Double.PositiveInfinity))
+    assertSameFloat(Float.PositiveInfinity,
+        Math.nextAfter(Float.MaxValue, Double.PositiveInfinity))
+    assertSameFloat(Float.NegativeInfinity,
+        Math.nextAfter(-Float.MaxValue, Double.NegativeInfinity))
+
+    assertSameFloat(1.0f, Math.nextAfter(1.0f, 1.0))
+    assertSameFloat(1.0000001f, Math.nextAfter(1.0f, 2.0))
+    assertSameFloat(0.99999994f, Math.nextAfter(1.0f, 0.5))
   }
 
   @Test def ulp_for_Double(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
@@ -144,19 +144,36 @@ class MathTest {
   }
 
   @Test def nextAfter_for_Double(): Unit = {
-    assertTrue(Math.nextAfter(1.0, Double.NaN).isNaN)
-    assertTrue(Math.nextAfter(Double.NaN, 1.0).isNaN)
-    assertEquals(0.0, Math.nextAfter(0.0, 0.0), 0.0)
-    assertEquals(-0.0, Math.nextAfter(0.0, -0.0), 0.0)
-    assertEquals(0.0, Math.nextAfter(-0.0, 0.0), 0.0)
-    assertEquals(-0.0, Math.nextAfter(-0.0, -0.0), 0.0)
-    assertEquals(Double.NegativeInfinity, Math.nextAfter(Double.MinValue, Double.NegativeInfinity), 0.0)
-    assertEquals(Double.PositiveInfinity, Math.nextAfter(-Double.MinValue, Double.PositiveInfinity), 0.0)
-    assertEquals(Double.MaxValue, Math.nextAfter(Double.PositiveInfinity, Double.NegativeInfinity), 0.0)
-    assertEquals(Double.MinValue, Math.nextAfter(Double.NegativeInfinity, Double.PositiveInfinity), 0.0)
-    assertEquals(Double.PositiveInfinity, Math.nextAfter(Double.MaxValue, Double.PositiveInfinity), 0.0)
-    assertEquals(Double.NegativeInfinity, Math.nextAfter(-Double.MaxValue, Double.NegativeInfinity), 0.0)
-    assertEquals(1.0, Math.nextAfter(1.0, 1.0), 0.0)
+    assertSameDouble(Double.NaN, Math.nextAfter(Double.NaN, Double.NaN))
+    assertSameDouble(Double.NaN, Math.nextAfter(1.0, Double.NaN))
+    assertSameDouble(Double.NaN, Math.nextAfter(Double.NaN, 1.0))
+
+    assertSameDouble(0.0, Math.nextAfter(0.0, 0.0))
+    assertSameDouble(-0.0, Math.nextAfter(0.0, -0.0))
+    assertSameDouble(0.0, Math.nextAfter(-0.0, 0.0))
+    assertSameDouble(-0.0, Math.nextAfter(-0.0, -0.0))
+
+    assertSameDouble(Double.PositiveInfinity,
+        Math.nextAfter(Double.PositiveInfinity, Double.PositiveInfinity))
+    assertSameDouble(Double.NegativeInfinity,
+        Math.nextAfter(Double.NegativeInfinity, Double.NegativeInfinity))
+
+    assertSameDouble(Double.NegativeInfinity,
+        Math.nextAfter(Double.MinValue, Double.NegativeInfinity))
+    assertSameDouble(Double.PositiveInfinity,
+        Math.nextAfter(-Double.MinValue, Double.PositiveInfinity))
+    assertSameDouble(Double.MaxValue,
+        Math.nextAfter(Double.PositiveInfinity, Double.NegativeInfinity))
+    assertSameDouble(Double.MinValue,
+        Math.nextAfter(Double.NegativeInfinity, Double.PositiveInfinity))
+    assertSameDouble(Double.PositiveInfinity,
+        Math.nextAfter(Double.MaxValue, Double.PositiveInfinity))
+    assertSameDouble(Double.NegativeInfinity,
+        Math.nextAfter(-Double.MaxValue, Double.NegativeInfinity))
+
+    assertSameDouble(1.0, Math.nextAfter(1.0, 1.0))
+    assertSameDouble(1.0000000000000002, Math.nextAfter(1.0, 2.0))
+    assertSameDouble(0.9999999999999999, Math.nextAfter(1.0, 0.5))
   }
 
   @Test def ulp_for_Double(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
@@ -17,6 +17,12 @@ import org.scalajs.testsuite.utils.Platform._
 
 class MathTest {
 
+  /** Like `assertEquals` with `delta = 0.0`, but positive and negative zeros
+   *  compare not equal.
+   */
+  private def assertSameDouble(expected: Double, actual: Double): Unit =
+    assertTrue(s"expected: $expected but was: $actual", expected.equals(actual))
+
   @Test def abs(): Unit = {
     assertEquals(0, Math.abs(0))
     assertEquals(42, Math.abs(42))
@@ -115,16 +121,26 @@ class MathTest {
   }
 
   @Test def nextUp_for_Double(): Unit = {
-    assertEquals(Double.PositiveInfinity, Math.nextUp(Double.PositiveInfinity), 0.0)
-    assertEquals(Double.MinValue, Math.nextUp(Double.NegativeInfinity), 0.0)
-    assertEquals(Double.PositiveInfinity, Math.nextUp(Double.MaxValue), 0.0)
-    assertEquals(-1.7976931348623155e+308, Math.nextUp(-Double.MaxValue), 0.0)
-    assertEquals(Double.PositiveInfinity, Math.nextUp(-Double.MinValue), 0.0)
-    assertEquals(Double.MinPositiveValue, Math.nextUp(0.0), 0.0)
-    assertEquals(Double.MinPositiveValue, Math.nextUp(-0.0), 0.0)
-    assertEquals(9007199254740992.0, Math.nextUp(9007199254740991.0), 0.0)
-    assertEquals(9007199254740994.0, Math.nextUp(9007199254740992.0), 0.0)
-    assertEquals(1 + 2.2204460492503130808472633361816E-16, Math.nextUp(1.0), 0.0)
+    // Specials
+    assertSameDouble(Double.MinPositiveValue, Math.nextUp(0.0))
+    assertSameDouble(Double.MinPositiveValue, Math.nextUp(-0.0))
+    assertSameDouble(Double.PositiveInfinity, Math.nextUp(Double.PositiveInfinity))
+    assertSameDouble(Double.MinValue, Math.nextUp(Double.NegativeInfinity))
+    assertSameDouble(Double.NaN, Math.nextUp(Double.NaN))
+
+    // Corner cases
+    val MinNormal = java.lang.Double.MIN_NORMAL
+    val MaxSubnormal = 2.225073858507201e-308
+    assertSameDouble(Double.PositiveInfinity, Math.nextUp(Double.MaxValue))
+    assertSameDouble(-1.7976931348623155e+308, Math.nextUp(Double.MinValue))
+    assertSameDouble(-0.0, Math.nextUp(-Double.MinPositiveValue))
+    assertSameDouble(MinNormal, Math.nextUp(MaxSubnormal))
+    assertSameDouble(-MaxSubnormal, Math.nextUp(-MinNormal))
+
+    // Random values
+    assertSameDouble(9007199254740992.0, Math.nextUp(9007199254740991.0))
+    assertSameDouble(9007199254740994.0, Math.nextUp(9007199254740992.0))
+    assertSameDouble(1.0000000000000002, Math.nextUp(1.0))
   }
 
   @Test def nextAfter_for_Double(): Unit = {


### PR DESCRIPTION
In the process, review/implement `j.l.Math.next{Up,Down,After}` for `Double`.