### PR TITLE
Fix #2901: Do not crash the compiler for `Int.box(???)`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -2258,7 +2258,7 @@ abstract class GenJSCode extends plugins.PluginComponent
           } else if (currentRun.runDefinitions.isBox(sym)) {
             // Box a primitive value (cannot be Unit)
             val arg = args.head
-            makePrimitiveBox(genExpr(arg), arg.tpe)
+            makePrimitiveBox(genExpr(arg), sym.firstParam.tpe)
           } else if (currentRun.runDefinitions.isUnbox(sym)) {
             // Unbox a primitive value (cannot be Unit)
             val arg = args.head

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/BuglistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/BuglistedTests.txt
@@ -5,6 +5,3 @@
 
 # Broken by GCC, filed as #2815
 run/Predef.readLine.scala
-
-# `Int.box(???)` crashes the compiler, filed as #2901
-run/t10069b.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/WhitelistedTests.txt
@@ -3265,6 +3265,7 @@ run/t10097.scala
 run/t10072.scala
 run/t10261
 run/t9114.scala
+run/t10069b.scala
 
 # Adapt checkfiles for (1.0).toString == "1"
 run/Course-2002-01.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.0-M1/BuglistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.0-M1/BuglistedTests.txt
@@ -5,6 +5,3 @@
 
 # Broken by GCC, filed as #2815
 run/Predef.readLine.scala
-
-# `Int.box(???)` crashes the compiler, filed as #2901
-run/t10069b.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.0-M1/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.0-M1/WhitelistedTests.txt
@@ -3265,6 +3265,7 @@ run/t10072.scala
 run/t10261
 run/t9114.scala
 run/InferOverloadedPartialFunction.scala
+run/t10069b.scala
 
 # Adapt checkfiles for (1.0).toString == "1"
 run/Course-2002-01.scala


### PR DESCRIPTION
This fixes the partest `run/t10069b.scala`. We do not add any test in our own test suite, because a relevant test would crash the JVM back-end in all Scala versions < 2.12.2. We rely on the partest to provide a regression test.