### PR TITLE
Fix #2902: Adapt to jsdom v10.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
@@ -63,7 +63,13 @@ class JSDOMNodeJSEnv(
       val jsDOMCode = {
         s"""
            |(function () {
-           |  const jsdom = require("jsdom");
+           |  var jsdom;
+           |  try {
+           |    jsdom = require("jsdom/lib/old-api.js"); // jsdom >= 10.x
+           |  } catch (e) {
+           |    jsdom = require("jsdom"); // jsdom <= 9.x
+           |  }
+           |
            |  var windowKeys = [];
            |
            |  jsdom.env({


### PR DESCRIPTION
While still retaining compatibility with jsdom v9.