### PR TITLE
Disallow @JSName on non js-native classes

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -1008,10 +1008,9 @@ abstract class PrepJSInterop extends plugins.PluginComponent
 
       for (annot <- sym.annotations) {
         if (annot.symbol == JSNameAnnotation && !allowJSName) {
-          reporter.warning(annot.pos,
-              "Non JS-native classes, traits and objects should not have an " +
-              "@JSName annotation, as it does not have any effect. " +
-              "This will be enforced in 1.0.")
+          reporter.error(annot.pos,
+              "Non JS-native classes, traits and objects may not have an " +
+              "@JSName annotation.")
         } else if (annot.symbol == JSGlobalAnnotation) {
           reporter.error(annot.pos,
               "Non JS-native classes, traits and objects may not have an " +

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
@@ -52,12 +52,12 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
       @JSName(Sym.sym)
       $obj B extends js.Object
-      """ hasWarns
+      """ hasErrors
       s"""
-        |newSource1.scala:5: warning: Non JS-native classes, traits and objects should not have an @JSName annotation, as it does not have any effect. This will be enforced in 1.0.
+        |newSource1.scala:5: error: Non JS-native classes, traits and objects may not have an @JSName annotation.
         |      @JSName("foo")
         |       ^
-        |newSource1.scala:12: warning: Non JS-native classes, traits and objects should not have an @JSName annotation, as it does not have any effect. This will be enforced in 1.0.
+        |newSource1.scala:12: error: Non JS-native classes, traits and objects may not have an @JSName annotation.
         |      @JSName(Sym.sym)
         |       ^
       """
@@ -76,12 +76,12 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
       @JSName(Sym.sym)
       $obj B
-      """ hasWarns
+      """ hasErrors
       s"""
-        |newSource1.scala:5: warning: Non JS-native classes, traits and objects should not have an @JSName annotation, as it does not have any effect. This will be enforced in 1.0.
+        |newSource1.scala:5: error: Non JS-native classes, traits and objects may not have an @JSName annotation.
         |      @JSName("foo")
         |       ^
-        |newSource1.scala:12: warning: Non JS-native classes, traits and objects should not have an @JSName annotation, as it does not have any effect. This will be enforced in 1.0.
+        |newSource1.scala:12: error: Non JS-native classes, traits and objects may not have an @JSName annotation.
         |      @JSName(Sym.sym)
         |       ^
       """
@@ -110,12 +110,12 @@ class JSInteropTest extends DirectTest with TestHelpers {
       @JSName("bar")
       private object tata extends js.Object
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:6: warning: Non JS-native classes, traits and objects should not have an @JSName annotation, as it does not have any effect. This will be enforced in 1.0.
+      |newSource1.scala:6: error: Non JS-native classes, traits and objects may not have an @JSName annotation.
       |      @JSName("foo")
       |       ^
-      |newSource1.scala:9: warning: Non JS-native classes, traits and objects should not have an @JSName annotation, as it does not have any effect. This will be enforced in 1.0.
+      |newSource1.scala:9: error: Non JS-native classes, traits and objects may not have an @JSName annotation.
       |      @JSName("bar")
       |       ^
     """


### PR DESCRIPTION
This (hopefully) is the last step for #1111.