### PR TITLE
Fix #2804: Transform receiver of js.Dynamic#x

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -337,7 +337,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
         case Select(Select(trg, jsnme.x), nme.apply) if isJSDynamic(trg) =>
           val newTree = atPos(tree.pos) {
             Apply(
-                Select(super.transform(trg), newTermName("applyDynamic")),
+                Select(transform(trg), newTermName("applyDynamic")),
                 List(Literal(Constant("x")))
             )
           }
@@ -349,7 +349,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
         case Select(trg, jsnme.x) if isJSDynamic(trg) =>
           val newTree = atPos(tree.pos) {
             Apply(
-                Select(super.transform(trg), newTermName("selectDynamic")),
+                Select(transform(trg), newTermName("selectDynamic")),
                 List(Literal(Constant("x")))
             )
           }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
@@ -73,4 +73,12 @@ class RegressionJSTest {
       js.debugger()
   }
 
+  @Test def should_transform_js_dynamic_x_receiver_issue_2804(): Unit = {
+    @ScalaJSDefined
+    class Foo extends js.Object
+
+    assertTrue(js.isUndefined(js.constructorOf[Foo].x))
+    assertTrue(js.isUndefined(js.constructorOf[Foo].y))
+  }
+
 }


### PR DESCRIPTION
This caused expressions like `js.constructorOf[Foo].x` to blow up with a "stub" error.