### PR TITLE
Convert last warnings to errors

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -257,10 +257,9 @@ trait PrepJSExports { this: PrepJSInterop =>
               // Get position for error message
               val pos = if (isExportAll) trgSym.pos else annot.pos
 
-              reporter.warning(pos, "Member cannot be exported to function " +
-                  "application. It is available under the name apply " +
-                  "instead. Add @JSExport(\"apply\") to silence this " +
-                  "warning. This will be enforced in 1.0.")
+              reporter.error(pos, "A member cannot be exported to function " +
+                  "application. Add @JSExport(\"apply\") to export under the " +
+                  "name apply.")
             }
 
           case ExportDestination.TopLevel =>

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -601,7 +601,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
             memberDefStringWithJSName(high) + "\n"
           }
 
-          reporter.warning(errorPos, msg)
+          reporter.error(errorPos, msg)
         }
 
         /* Cannot override a non-@JSOptional with an @JSOptional. Unfortunately

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -820,9 +820,9 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def apply(): Int = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:4: warning: Member cannot be exported to function application. It is available under the name apply instead. Add @JSExport("apply") to silence this warning. This will be enforced in 1.0.
+      |newSource1.scala:4: error: A member cannot be exported to function application. Add @JSExport("apply") to export under the name apply.
       |      @JSExport
       |       ^
     """
@@ -832,9 +832,9 @@ class JSExportTest extends DirectTest with TestHelpers {
     class A {
       def apply(): Int = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:5: warning: Member cannot be exported to function application. It is available under the name apply instead. Add @JSExport("apply") to silence this warning. This will be enforced in 1.0.
+      |newSource1.scala:5: error: A member cannot be exported to function application. Add @JSExport("apply") to export under the name apply.
       |      def apply(): Int = 1
       |          ^
     """
@@ -845,9 +845,9 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport("foo")
       def apply(): Int = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:6: warning: Member cannot be exported to function application. It is available under the name apply instead. Add @JSExport("apply") to silence this warning. This will be enforced in 1.0.
+      |newSource1.scala:6: error: A member cannot be exported to function application. Add @JSExport("apply") to export under the name apply.
       |      def apply(): Int = 1
       |          ^
     """

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
@@ -1742,7 +1742,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def scalaJSDefinedJSNameOverrideWarnings: Unit = {
+  def scalaJSDefinedJSNameOverrideErrors: Unit = {
     """
     abstract class A extends js.Object {
       def bar(): Int
@@ -1783,9 +1783,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       @JSName("baz")
       override def bar() = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:11: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:11: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): Int in class B with JSName 'baz'
       |    is conflicting with
@@ -1803,9 +1803,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class B extends A {
       override def bar() = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): Int in class B with JSName 'bar'
       |    is conflicting with
@@ -1826,9 +1826,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class C extends B {
       override def bar() = "1"
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): String in class B with JSName 'bar'
       |    is conflicting with
@@ -1836,7 +1836,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      override def bar(): String
       |                   ^
-      |newSource1.scala:13: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:13: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): String in class C with JSName 'bar'
       |    is conflicting with
@@ -1857,9 +1857,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class C extends B {
       override def bar() = "1"
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): String in class B with JSName 'foo'
       |    is conflicting with
@@ -1867,7 +1867,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      override def bar(): String
       |                   ^
-      |newSource1.scala:13: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:13: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): String in class C with JSName 'bar'
       |    is conflicting with
@@ -1886,9 +1886,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       def foo: Int
     }
     class C extends B
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in class A with JSName 'foo'
       |    is conflicting with
@@ -1907,9 +1907,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       def foo: Int
     }
     class C extends B
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in class A with JSName 'bar'
       |    is conflicting with
@@ -1927,9 +1927,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class B extends A[Int] {
       override def foo(x: Int): Int = x
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def foo(x: Int): Int in class B with JSName 'foo'
       |    is conflicting with
@@ -1947,9 +1947,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class B extends A[Int] {
       override def foo(x: Int): Int = x
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def foo(x: Int): Int in class B with JSName 'foo'
       |    is conflicting with
@@ -1970,9 +1970,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class C extends B {
       override def foo(x: Int): Int = x
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo(x: Int): Int in class A with JSName 'bar'
       |    is conflicting with
@@ -1980,7 +1980,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      def foo(x: Int): Int
       |          ^
-      |newSource1.scala:13: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:13: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def foo(x: Int): Int in class C with JSName 'foo'
       |    is conflicting with
@@ -2001,9 +2001,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class C extends B {
       override def foo(x: Int): Int = x
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:10: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo(x: Int): Int in class A with JSName 'foo'
       |    is conflicting with
@@ -2011,7 +2011,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      def foo(x: Int): Int
       |          ^
-      |newSource1.scala:13: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:13: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def foo(x: Int): Int in class C with JSName 'foo'
       |    is conflicting with
@@ -2030,9 +2030,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       def foo: Int
     }
     trait C extends A with B
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:12: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:12: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in trait B with JSName 'bar'
       |    is conflicting with
@@ -2051,9 +2051,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       def foo: Int
     }
     abstract class C extends A with B
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:12: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:12: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in trait B with JSName 'bar'
       |    is conflicting with
@@ -2065,7 +2065,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def scalaJSDefinedJSNameWithSymbolOverrideWarnings: Unit = {
+  def scalaJSDefinedJSNameWithSymbolOverrideErrors: Unit = {
     """
     object Syms {
       val sym1 = js.Symbol()
@@ -2110,9 +2110,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       @JSName(Syms.sym2)
       override def bar() = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:16: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:16: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): Int in class B with JSName 'Syms.sym2'
       |    is conflicting with
@@ -2135,9 +2135,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       @JSName("baz")
       override def bar() = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:15: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:15: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): Int in class B with JSName 'baz'
       |    is conflicting with
@@ -2160,9 +2160,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       @JSName(Syms.sym1)
       override def bar() = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:15: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:15: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): Int in class B with JSName 'Syms.sym1'
       |    is conflicting with
@@ -2184,9 +2184,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class B extends A {
       override def bar() = 1
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): Int in class B with JSName 'bar'
       |    is conflicting with
@@ -2211,9 +2211,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class C extends B {
       override def bar() = "1"
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): String in class B with JSName 'bar'
       |    is conflicting with
@@ -2221,7 +2221,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      override def bar(): String
       |                   ^
-      |newSource1.scala:17: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:17: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): String in class C with JSName 'bar'
       |    is conflicting with
@@ -2246,9 +2246,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class C extends B {
       override def bar() = "1"
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): String in class B with JSName 'Syms.sym1'
       |    is conflicting with
@@ -2256,7 +2256,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      override def bar(): String
       |                   ^
-      |newSource1.scala:17: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:17: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def bar(): String in class C with JSName 'bar'
       |    is conflicting with
@@ -2279,9 +2279,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       def foo: Int
     }
     class C extends B
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in class A with JSName 'foo'
       |    is conflicting with
@@ -2304,9 +2304,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       def foo: Int
     }
     class C extends B
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in class A with JSName 'Syms.sym1'
       |    is conflicting with
@@ -2328,9 +2328,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class B extends A[Int] {
       override def foo(x: Int): Int = x
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def foo(x: Int): Int in class B with JSName 'foo'
       |    is conflicting with
@@ -2352,9 +2352,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class B extends A[Int] {
       override def foo(x: Int): Int = x
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def foo(x: Int): Int in class B with JSName 'foo'
       |    is conflicting with
@@ -2379,9 +2379,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class C extends B {
       override def foo(x: Int): Int = x
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo(x: Int): Int in class A with JSName 'Syms.sym1'
       |    is conflicting with
@@ -2389,7 +2389,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      def foo(x: Int): Int
       |          ^
-      |newSource1.scala:17: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:17: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def foo(x: Int): Int in class C with JSName 'foo'
       |    is conflicting with
@@ -2414,9 +2414,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
     class C extends B {
       override def foo(x: Int): Int = x
     }
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:14: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo(x: Int): Int in class A with JSName 'foo'
       |    is conflicting with
@@ -2424,7 +2424,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      def foo(x: Int): Int
       |          ^
-      |newSource1.scala:17: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:17: error: A member of a JS class is overriding another member with a different JS name.
       |
       |override def foo(x: Int): Int in class C with JSName 'foo'
       |    is conflicting with
@@ -2447,9 +2447,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       def foo: Int
     }
     trait C extends A with B
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:16: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:16: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in trait B with JSName 'Syms.sym1'
       |    is conflicting with
@@ -2472,9 +2472,9 @@ class JSInteropTest extends DirectTest with TestHelpers {
       def foo: Int
     }
     abstract class C extends A with B
-    """ hasWarns
+    """ hasErrors
     """
-      |newSource1.scala:16: warning: A member of a JS class is overriding another member with a different JS name.
+      |newSource1.scala:16: error: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in trait B with JSName 'Syms.sym1'
       |    is conflicting with

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala
@@ -112,6 +112,7 @@ class UseAsScalaTypesTest {
   @Test def should_work_with_JSExportAll_with_an_apply_method(): Unit = {
     @JSExportAll
     class A {
+      @JSExport("apply")
       @JSExport("bar")
       def apply(x: Int): Int = x * 2
     }


### PR DESCRIPTION
After this PR, the only remaining occurrences of `reporter.warning` are:

- Duplicate object literal key warning ([GenJSCode.scala#L3941](https://github.com/scala-js/scala-js/blob/b4e00f5e0074a2afdba8f166f12af1aa2e0865ac/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala#L3941))
- `scala.Enumeration` transformation warnings ([PrepJSInterop.scala#L246-L272](https://github.com/scala-js/scala-js/blob/b4e00f5e0074a2afdba8f166f12af1aa2e0865ac/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala#L246-L272))
- Inferred `Nothing` return type for native JS types ([PrepJSInterop.scala#L978](https://github.com/scala-js/scala-js/blob/b4e00f5e0074a2afdba8f166f12af1aa2e0865ac/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala#L978))
- Symbol stack overflow warning ([PrepJSInterop.scala#L1048](https://github.com/scala-js/scala-js/blob/b4e00f5e0074a2afdba8f166f12af1aa2e0865ac/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala#L1048))

Therefore, this finally fixes #1111.