### PR TITLE
Fix #2936: Remove deserialization hacks.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
@@ -104,11 +104,6 @@ object InfoSerializers {
 
       import input._
 
-      val useHacks065 =
-        Set("0.6.0", "0.6.3", "0.6.4", "0.6.5").contains(version)
-      val useHacks0614 =
-        useHacks065 || Set("0.6.6", "0.6.8", "0.6.13", "0.6.14").contains(version)
-
       val encodedName = readUTF()
       val isExported = readBoolean()
       val kind = ClassKind.fromByte(readByte())
@@ -124,12 +119,8 @@ object InfoSerializers {
         val isStatic = readBoolean()
         val isAbstract = readBoolean()
         val isExported = readBoolean()
-        val staticFieldsRead =
-          if (useHacks0614) Map.empty[String, List[String]]
-          else readPerClassStrings()
-        val staticFieldsWritten =
-          if (useHacks0614) Map.empty[String, List[String]]
-          else readPerClassStrings()
+        val staticFieldsRead = readPerClassStrings()
+        val staticFieldsWritten = readPerClassStrings()
         val methodsCalled = readPerClassStrings()
         val methodsCalledStatically = readPerClassStrings()
         val staticMethodsCalled = readPerClassStrings()
@@ -144,12 +135,7 @@ object InfoSerializers {
             accessedClassData)
       }
 
-      val methods0 = readList(readMethod())
-      val methods = if (useHacks065) {
-        methods0.filter(m => !Definitions.isReflProxyName(m.encodedName))
-      } else {
-        methods0
-      }
+      val methods = readList(readMethod())
 
       val info = ClassInfo(encodedName, isExported, kind,
           superClass, interfaces, methods)

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -29,10 +29,7 @@ private[ir] object Tags {
   final val TagWhile = TagIf + 1
   final val TagDoWhile = TagWhile + 1
 
-  // TODO remove when we can break binary compat.
-  final val TagTry = TagDoWhile + 1
-
-  final val TagThrow = TagTry + 1
+  final val TagThrow = TagDoWhile + 1
   final val TagContinue = TagThrow + 1
   final val TagMatch = TagContinue + 1
   final val TagDebugger = TagMatch + 1
@@ -68,9 +65,8 @@ private[ir] object Tags {
   final val TagJSBinaryOp = TagJSUnaryOp + 1
   final val TagJSArrayConstr = TagJSBinaryOp + 1
   final val TagJSObjectConstr = TagJSArrayConstr + 1
-  final val TagJSEnvInfo = TagJSObjectConstr + 1
 
-  final val TagUndefined = TagJSEnvInfo + 1
+  final val TagUndefined = TagJSObjectConstr + 1
   final val TagUndefinedParam = TagUndefined + 1 // TODO Move this
   final val TagNull = TagUndefinedParam + 1
   final val TagBooleanLiteral = TagNull + 1
@@ -95,8 +91,7 @@ private[ir] object Tags {
   // TODO Reorganize these when we can break binary compatibility
   final val TagJSSpread = TagModuleExportDef + 1
   final val TagJSLinkingInfo = TagJSSpread + 1
-  final val TagStringLitFieldDef = TagJSLinkingInfo + 1
-  final val TagJSSuperBracketSelect = TagStringLitFieldDef + 1
+  final val TagJSSuperBracketSelect = TagJSLinkingInfo + 1
   final val TagJSSuperBracketCall = TagJSSuperBracketSelect + 1
   final val TagJSSuperConstructorCall = TagJSSuperBracketCall + 1
   final val TagLoadJSConstructor = TagJSSuperConstructorCall + 1

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analysis.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analysis.scala
@@ -117,20 +117,6 @@ object Analysis {
     /** Not a synthetic method. */
     final case object None extends MethodSyntheticKind
 
-    // TODO Get rid of InheritedConstructor when we can break binary compat
-    /** An explicit call-super constructor.
-     *
-     *  In a class `Foo` with parent class `Bar`, an inherited
-     *  constructor `init___xyz` looks like
-     *
-     *  {{{
-     *  def init___xyz(p1: T1, ..., pn: TN) {
-     *    this.Bar::init___xyz(p1, ..., pn)
-     *  }
-     *  }}}
-     */
-    final case object InheritedConstructor extends MethodSyntheticKind
-
     /** A reflective proxy bridge to the appropriate target method.
      *
      *  A reflective proxy `method__xyz__` dynamically calls some `target`

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
@@ -271,32 +271,8 @@ private final class Analyzer(semantics: Semantics,
     }
 
     def lookupConstructor(ctorName: String): MethodInfo = {
-      /* As of 0.6.6, constructors are not inherited, and so must be found
-       * directly in this class. However, to be able to read sjsir files from
-       * before 0.6.6, we tolerate finding it in a superclass, in which case
-       * we materialize a new constructor in this class. We only allow this
-       * during the initial link. In a refiner, this must not happen anymore.
-       */
       methodInfos.get(ctorName).getOrElse {
-        if (!allowAddingSyntheticMethods) {
-          createNonExistentMethod(ctorName)
-        } else {
-          val inherited = lookupMethod(ctorName)
-          if (inherited.owner eq this) {
-            // Can happen only for non-existent constructors, at this point
-            assert(inherited.nonExistent)
-            inherited
-          } else {
-            val syntheticInfo = makeSyntheticMethodInfo(
-                encodedName = ctorName,
-                methodsCalledStatically = Map(
-                    superClass.encodedName -> List(ctorName)))
-            val m = new MethodInfo(this, syntheticInfo)
-            m.syntheticKind = MethodSyntheticKind.InheritedConstructor
-            methodInfos += ctorName -> m
-            m
-          }
-        }
+        createNonExistentMethod(ctorName)
       }
     }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/InfoChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/InfoChecker.scala
@@ -43,22 +43,9 @@ private final class InfoChecker(
   private def checkClassInfo(info: ClassInfo, expectedInfo: ClassInfo): Unit = {
     val className = expectedInfo.encodedName
 
-    /* Due to the hack for AbstractJSType and NativeJSClass in the
-     * deserializer, it is possible to get info where `kind == AbstractJSType`
-     * but `expectedInfo == NativeJSClass`. We need to tolerate that here.
-     * TODO Get rid of this when we break binary compatibility.
-     */
-    val patchedInfoKind = {
-      import ClassKind._
-      if (info.kind == AbstractJSType && expectedInfo.kind == NativeJSClass)
-        NativeJSClass
-      else
-        info.kind
-    }
-
     if (info.encodedName != expectedInfo.encodedName ||
         info.isExported != expectedInfo.isExported ||
-        patchedInfoKind != expectedInfo.kind ||
+        info.kind != expectedInfo.kind ||
         info.superClass != expectedInfo.superClass ||
         info.interfaces.toSet != expectedInfo.interfaces.toSet) {
       errorCount += 1


### PR DESCRIPTION
Remove both hacks actually happening during deserialization and those happening during the first linking step.

These changes are a prerequisite to implementing #2800 in the master branch.