### PR TITLE
Fix #2939: Fix `%g` formatting for exact powers of 10.

### DIFF
--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -220,7 +220,16 @@ final class Formatter(private val dest: Appendable) extends Closeable with Flush
                 else precision
               // between 1e-4 and 10e(p): display as fixed
               if (m >= 1e-4 && m < Math.pow(10, p)) {
-                val sig = Math.ceil(Math.log10(m)).toInt
+                /* First approximation of the smallest power of 10 that is >= m.
+                 * Due to rounding errors in the event of an imprecise `log10`
+                 * function, sig0 could actually be the smallest power of 10
+                 * that is > m.
+                 */
+                val sig0 = Math.ceil(Math.log10(m)).toInt
+                /* Increment sig0 so that it is always the first power of 10
+                 * that is > m.
+                 */
+                val sig = if (Math.pow(10, sig0) <= m) sig0 + 1 else sig0
                 with_+(numberArg.toFixed(Math.max(p - sig, 0)))
               } else sciNotation(p - 1)
             case 'f' =>

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
@@ -199,6 +199,8 @@ class FormatterTest {
     assertF("5.00000e-05", "%g", new JDouble(.5e-4))
     assertF("0.000300000", "%g", new JDouble(3e-4))
     assertF("0.000300", "%.3g", new JDouble(3e-4))
+    assertF("10.0000", "%g", new JDouble(10.0))
+    assertF("10.00", "%.4g", new JDouble(10.0))
     assertF("0.0010", "%.2g", new JDouble(1e-3))
     assertF("300000", "%g", new JDouble(3e5))
     assertF("3.00e+05", "%.3g", new JDouble(3e5))


### PR DESCRIPTION
The temporary variable `sig` needs to be the smallest value such 10^sig is *strictly* greater than `m`. It used to, sometimes (depending on rounding errors) be such that `10^sig = m`.