### PR TITLE
Remove dead code related to the test interface and exportsNamespace.

### DIFF
--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkDetector.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkDetector.scala
@@ -10,28 +10,11 @@ private[internal] object FrameworkDetector {
   def detectFrameworks(
       frameworksData: js.Array[js.Array[String]]): js.Array[js.UndefOr[String]] = {
 
-    def frameworkExistsInReflect(name: String): Boolean = {
+    def frameworkExists(name: String): Boolean = {
       Reflect.lookupInstantiatableClass(name).exists { clazz =>
         classOf[sbt.testing.Framework].isAssignableFrom(clazz.runtimeClass)
       }
     }
-
-    def frameworkExistsInExportsNamespace(name: String): Boolean = {
-      /* This happens for testing frameworks developed before 0.6.15 that have
-       * not yet updated to using reflective instantiation, and are still
-       * using exports.
-       * Note that here, we have to assume that whatever we find is indeed a
-       * proper class export for a class extending sbt.testing.Framework.
-       */
-      val exportsNamespace =
-        scala.scalajs.runtime.environmentInfo.exportsNamespace
-      name.split('.').foldLeft[js.UndefOr[js.Dynamic]](exportsNamespace) {
-        (prev, part) => prev.map(_.selectDynamic(part))
-      }.isDefined
-    }
-
-    def frameworkExists(name: String): Boolean =
-      frameworkExistsInReflect(name) || frameworkExistsInExportsNamespace(name)
 
     for (frameworkNames <- frameworksData)
       yield frameworkNames.find(frameworkExists(_)).orUndefined

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkLoader.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkLoader.scala
@@ -8,15 +8,10 @@ import sbt.testing.Framework
 private[internal] object FrameworkLoader {
 
   def loadFramework(frameworkName: String): Framework = {
-    Reflect.lookupInstantiatableClass(frameworkName).fold[Framework] {
-      val exportsNamespace =
-        scala.scalajs.runtime.environmentInfo.exportsNamespace
-      val parts = frameworkName.split('.')
-      val ctor = parts.foldLeft(exportsNamespace)(_.selectDynamic(_))
-      js.Dynamic.newInstance(ctor)().asInstanceOf[Framework]
-    } { clazz =>
-      clazz.newInstance().asInstanceOf[Framework]
+    val clazz = Reflect.lookupInstantiatableClass(frameworkName).getOrElse {
+      throw new InstantiationError(frameworkName)
     }
+    clazz.newInstance().asInstanceOf[Framework]
   }
 
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
@@ -11,8 +11,7 @@ object JUnitUtil {
   def loadBootstrapper(classFullName: String): JUnitTestBootstrapper = {
     val fullName = s"$classFullName$BootstrapperSuffix"
     try {
-      val loader = new ScalaJSClassLoader(
-          scala.scalajs.runtime.environmentInfo.exportsNamespace)
+      val loader = new ScalaJSClassLoader()
       TestUtils.loadModule(fullName, loader).asInstanceOf[JUnitTestBootstrapper]
     } catch {
       case ex: Throwable =>


### PR DESCRIPTION
This is a follow up to #2932. The changes in this commit were forgotten in that PR.