### PR TITLE
Pass `remoteArgs` to `Slave` in test interface

### DIFF
--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
@@ -193,7 +193,7 @@ final class ScalaJSRunner private[testadapter] (
     val prefix = framework.optionalExportsNamespacePrefix
     val frameworkJS = jsonToString(framework.frameworkName.toJSON)
     val argsJS = jsonToString(args.toList.toJSON)
-    val remoteArgsJS = jsonToString(args.toList.toJSON)
+    val remoteArgsJS = jsonToString(remoteArgs.toList.toJSON)
     val code = s"""
       new ${prefix}org.scalajs.testinterface.internal.Slave($frameworkJS,
         $argsJS, $remoteArgsJS).init();


### PR DESCRIPTION
I guess this was a typo.