### PR TITLE
Fix #2953: Avoid calling toString() in primitive isInstanceOf's.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -535,6 +535,28 @@ class RegressionTest {
     assertTrue(f3A != f4B)
   }
 
+  @Test def isInstanceOf_must_not_call_toString_issue_2953(): Unit = {
+    class C {
+      override def toString(): String =
+        throw new AssertionError("C.toString must not be called by isInstanceOf")
+    }
+
+    @noinline def makeC(): Any = new C
+
+    val c = makeC()
+
+    assertFalse("Boolean", c.isInstanceOf[Boolean])
+    assertFalse("Char", c.isInstanceOf[Char])
+    assertFalse("Byte", c.isInstanceOf[Byte])
+    assertFalse("Short", c.isInstanceOf[Short])
+    assertFalse("Int", c.isInstanceOf[Int])
+    assertFalse("Long", c.isInstanceOf[Long])
+    assertFalse("Float", c.isInstanceOf[Float])
+    assertFalse("Double", c.isInstanceOf[Double])
+    assertFalse("Unit", c.isInstanceOf[Unit])
+    assertFalse("String", c.isInstanceOf[String])
+  }
+
 }
 
 object RegressionTest {

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -602,20 +602,20 @@ ScalaJS.systemIdentityHashCode =
 // is/as for hijacked boxed classes (the non-trivial ones)
 
 ScalaJS.isByte = function(v) {
-  return (v << 24 >> 24) === v && 1/v !== 1/-0;
+  return typeof v === "number" && (v << 24 >> 24) === v && 1/v !== 1/-0;
 };
 
 ScalaJS.isShort = function(v) {
-  return (v << 16 >> 16) === v && 1/v !== 1/-0;
+  return typeof v === "number" && (v << 16 >> 16) === v && 1/v !== 1/-0;
 };
 
 ScalaJS.isInt = function(v) {
-  return (v | 0) === v && 1/v !== 1/-0;
+  return typeof v === "number" && (v | 0) === v && 1/v !== 1/-0;
 };
 
 ScalaJS.isFloat = function(v) {
 //!if floats == Strict
-  return v !== v || ScalaJS.fround(v) === v;
+  return typeof v === "number" && (v !== v || ScalaJS.fround(v) === v);
 //!else
   return typeof v === "number";
 //!endif


### PR DESCRIPTION
Even though `(v | 0) === v` will indeed return `false` when `v` is not even a `number`, the part `v | 0` will cause the internal spec function `ToPrimitive(v, hint Number)` to be called. That function (section 7.1.1 of the ES 2015 specification) will first try to call `v.valueOf()` if it exists, and otherwise will try `v.toString()`.

We must avoid this scenario by preemptively ruling out values that are not `number`s, which we do with a simple `typeof` test.