### PR TITLE
Fix #2797: Add an optional global fallback to `@JSImport`.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -966,6 +966,11 @@ object Printers {
           print(module)
           print(')')
           printPath(path)
+
+        case JSNativeLoadSpec.ImportWithGlobalFallback(importSpec, globalSpec) =>
+          print(importSpec)
+          print(" fallback ")
+          print(globalSpec)
       }
     }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -609,18 +609,31 @@ object Serializers {
     def writeJSNativeLoadSpec(jsNativeLoadSpec: Option[JSNativeLoadSpec]): Unit = {
       import buffer._
 
+      def writeGlobalSpec(spec: JSNativeLoadSpec.Global): Unit = {
+        writeStrings(spec.path)
+      }
+
+      def writeImportSpec(spec: JSNativeLoadSpec.Import): Unit = {
+        writeString(spec.module)
+        writeStrings(spec.path)
+      }
+
       jsNativeLoadSpec.fold {
         writeByte(TagJSNativeLoadSpecNone)
       } { spec =>
         spec match {
-          case JSNativeLoadSpec.Global(path) =>
+          case spec: JSNativeLoadSpec.Global =>
             writeByte(TagJSNativeLoadSpecGlobal)
-            writeStrings(path)
+            writeGlobalSpec(spec)
 
-          case JSNativeLoadSpec.Import(module, path) =>
+          case spec: JSNativeLoadSpec.Import =>
             writeByte(TagJSNativeLoadSpecImport)
-            writeString(module)
-            writeStrings(path)
+            writeImportSpec(spec)
+
+          case JSNativeLoadSpec.ImportWithGlobalFallback(importSpec, globalSpec) =>
+            writeByte(TagJSNativeLoadSpecImportWithGlobalFallback)
+            writeImportSpec(importSpec)
+            writeGlobalSpec(globalSpec)
         }
       }
     }
@@ -1045,13 +1058,22 @@ object Serializers {
           JSNativeLoadSpec.Global(jsFullName.split("\\.").toList)
         }
       } else {
+        def readGlobalSpec(): JSNativeLoadSpec.Global =
+          JSNativeLoadSpec.Global(readStrings())
+
+        def readImportSpec(): JSNativeLoadSpec.Import =
+          JSNativeLoadSpec.Import(readString(), readStrings())
+
         (input.readByte(): @switch) match {
           case TagJSNativeLoadSpecNone =>
             None
           case TagJSNativeLoadSpecGlobal =>
-            Some(JSNativeLoadSpec.Global(readStrings()))
+            Some(readGlobalSpec())
           case TagJSNativeLoadSpecImport =>
-            Some(JSNativeLoadSpec.Import(readString(), readStrings()))
+            Some(readImportSpec())
+          case TagJSNativeLoadSpecImportWithGlobalFallback =>
+            Some(JSNativeLoadSpec.ImportWithGlobalFallback(
+                readImportSpec(), readGlobalSpec()))
         }
       }
     }

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -137,5 +137,6 @@ private[ir] object Tags {
   final val TagJSNativeLoadSpecNone = 0
   final val TagJSNativeLoadSpecGlobal = TagJSNativeLoadSpecNone + 1
   final val TagJSNativeLoadSpecImport = TagJSNativeLoadSpecGlobal + 1
+  final val TagJSNativeLoadSpecImportWithGlobalFallback = TagJSNativeLoadSpecImport + 1
 
 }

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -946,6 +946,16 @@ object Trees {
     final case class Import(module: String, path: List[String])
         extends JSNativeLoadSpec
 
+    /** Like [[Import]], but with a [[Global]] fallback when linking without
+     *  modules.
+     *
+     *  When linking with a module kind that supports modules, the `importSpec`
+     *  is used. When modules are not supported, use the fallback `globalSpec`.
+     */
+    final case class ImportWithGlobalFallback(importSpec: Import,
+        globalSpec: Global)
+        extends JSNativeLoadSpec
+
   }
 
   /** A hash of a tree (usually a MethodDef). Contains two SHA-1 hashes */

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -895,6 +895,17 @@ class PrintersTest {
         ClassDef("LTest", ClassKind.NativeJSClass, Some(ObjectClass), Nil,
             Some(JSNativeLoadSpec.Import("foo", List("Bar"))), Nil)(
             NoOptHints))
+
+    assertPrintEquals(
+        """
+          |native js class LTest extends O loadfrom import(foo).Bar fallback <global>.Foo {
+          |}
+        """,
+        ClassDef("LTest", ClassKind.NativeJSClass, Some(ObjectClass), Nil,
+            Some(JSNativeLoadSpec.ImportWithGlobalFallback(
+                JSNativeLoadSpec.Import("foo", List("Bar")),
+                JSNativeLoadSpec.Global(List("Foo")))), Nil)(
+            NoOptHints))
   }
 
   @Test def printClassDefOptimizerHints(): Unit = {

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSImport.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSImport.scala
@@ -11,21 +11,28 @@ package scala.scalajs.js.annotation
 
 /** Marks the annotated class or object as imported from another JS module.
  *
- *  Intuitively, this corresponds to the following ECMAScript import
- *  directive:
- *  {{{
- *  import { <name> as AnnotatedClassOrObject } from <module>
- *  }}}
- *
- *  To import the default export of a module, use `JSImport.Default` as `name`.
+ *  Intuitively, this corresponds to ECMAScript import directives. See the
+ *  documentation of the various constructors.
  *
  *  `@JSImport` is not compatible with the `jsDependencies` mechanism offered
  *  by the Scala.js sbt plugin. You are responsible for resolving and/or
  *  bundling the JavaScript modules that you are importing using other
  *  mechanisms.
  */
-class JSImport(module: String, name: String)
-    extends scala.annotation.StaticAnnotation {
+class JSImport private () extends scala.annotation.StaticAnnotation {
+
+  /** Named import of a member of the module.
+   *
+   *  Intuitively, this corresponds to the following ECMAScript import
+   *  directive:
+   *  {{{
+   *  import { <name> as AnnotatedClassOrObject } from <module>
+   *  }}}
+   *
+   *  To import the default export of a module, use `JSImport.Default` as
+   *  `name`.
+   */
+  def this(module: String, name: String) = this()
 
   /** Namespace import (import the module itself).
    *
@@ -36,8 +43,30 @@ class JSImport(module: String, name: String)
    *  import * as AnnotatedObject from <module>
    *  }}}
    */
-  def this(module: String, name: JSImport.Namespace.type) =
-    this(module, null: String)
+  def this(module: String, name: JSImport.Namespace.type) = this()
+
+  /** Named import of a member of the module, with a fallback on a global
+   *  variable.
+   *
+   *  When linking with module support, this is equivalent to
+   *  `@JSImport(module, name)`.
+   *
+   *  When linking without module support, this is equivalent to
+   *  `@JSGlobal(globalFallback)`.
+   */
+  def this(module: String, name: String, globalFallback: String) = this()
+
+  /** Namespace import (import the module itself), with a fallback on a global
+   *  variable.
+   *
+   *  When linking with module support, this is equivalent to
+   *  `@JSImport(module, name)`.
+   *
+   *  When linking without module support, this is equivalent to
+   *  `@JSGlobal(globalFallback)`.
+   */
+  def this(module: String, name: JSImport.Namespace.type,
+      globalFallback: String) = this()
 }
 
 object JSImport {

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,9 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private[emitter], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.JSGen.this")
   )
 
   val JSEnvs = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1342,7 +1342,12 @@ object Build {
           case FullOptStage => "fullopt-stage"
         }
 
-        envTags ++ (semTags :+ stageTag)
+        val moduleKindTag = scalaJSModuleKind.value match {
+          case ModuleKind.NoModule       => "modulekind-nomodule"
+          case ModuleKind.CommonJSModule => "modulekind-commonjs"
+        }
+
+        envTags ++ (semTags :+ stageTag :+ moduleKindTag)
       },
       javaOptions in Test ++= {
         def scalaJSProp(name: String): String =

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -54,6 +54,9 @@ object Platform {
   def hasCompliantModule: Boolean = sysProp("compliant-moduleinit")
   def hasStrictFloats: Boolean = sysProp("strict-floats")
 
+  def isNoModule: Boolean = sysProp("modulekind-nomodule")
+  def isCommonJSModule: Boolean = sysProp("modulekind-commonjs")
+
   private def sysProp(key: String): Boolean =
     System.getProperty("scalajs." + key, "false") == "true"
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -142,5 +142,10 @@ class SystemJSTest {
     assertEquals(isInFastOpt, Platform.isInFastOpt)
     assertEquals(isInFullOpt, Platform.isInFullOpt)
 
+    val isNoModule = get("scalajs.modulekind-nomodule") == "true"
+    val isCommonJSModule = get("scalajs.modulekind-commonjs") == "true"
+    assertEquals(isNoModule, Platform.isNoModule)
+    assertEquals(isCommonJSModule, Platform.isCommonJSModule)
+    assertTrue(isNoModule ^ isCommonJSModule)
   }
 }

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
@@ -16,6 +16,7 @@ object TestRunner {
     System.setProperty("scalajs.nodejs", "true")
     System.setProperty("scalajs.typedarray", "true")
     System.setProperty("scalajs.fastopt-stage", "true")
+    System.setProperty("scalajs.modulekind-nomodule", "true")
 
     val eventHandler = new SimpleEventHandler
     val loggers = Array[Logger](new SimpleLogger)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -47,7 +47,8 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
 
   private val knowledgeGuardian = new KnowledgeGuardian
 
-  private val jsGen = new JSGen(semantics, outputMode, internalOptions)
+  private val jsGen =
+    new JSGen(semantics, outputMode, moduleKind, internalOptions)
   private val classEmitter = new ClassEmitter(jsGen)
 
   private val classCaches = mutable.Map.empty[List[String], ClassCache]
@@ -162,27 +163,38 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
         }
 
         if (importsFound) {
-          sys.error("There were module imports, but module support is " +
-              "disabled.\nTo enable module support, set scalaJSModuleKind := " +
+          sys.error(
+              "There were module imports without fallback to global " +
+              "variables, but module support is disabled.\n" +
+              "To enable module support, set scalaJSModuleKind := " +
               "ModuleKind.CommonJSModule.")
         }
 
       case ModuleKind.CommonJSModule =>
         val encounteredModuleNames = mutable.Set.empty[String]
+
         for (classDef <- orderedClasses) {
+          def addModuleRef(module: String): Unit = {
+            if (encounteredModuleNames.add(module)) {
+              implicit val pos = classDef.pos
+              val rhs = js.Apply(js.VarRef(js.Ident("require")),
+                  List(js.StringLiteral(module)))
+              val lhs = jsGen.envModuleField(module)
+              val decl = jsGen.genLet(lhs.ident, mutable = false, rhs)
+              builder.addJSTree(decl)
+            }
+          }
+
           classDef.jsNativeLoadSpec match {
             case None =>
             case Some(JSNativeLoadSpec.Global(_)) =>
 
             case Some(JSNativeLoadSpec.Import(module, _)) =>
-              if (encounteredModuleNames.add(module)) {
-                implicit val pos = classDef.pos
-                val rhs = js.Apply(js.VarRef(js.Ident("require")),
-                    List(js.StringLiteral(module)))
-                val lhs = jsGen.envModuleField(module)
-                val decl = jsGen.genLet(lhs.ident, mutable = false, rhs)
-                builder.addJSTree(decl)
-              }
+              addModuleRef(module)
+
+            case Some(JSNativeLoadSpec.ImportWithGlobalFallback(
+                JSNativeLoadSpec.Import(module, _), _)) =>
+              addModuleRef(module)
           }
         }
     }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -17,7 +17,7 @@ import ir.Types._
 import ir.{Trees => irt}
 
 import org.scalajs.core.tools.sem._
-import org.scalajs.core.tools.linker.backend.OutputMode
+import org.scalajs.core.tools.linker.backend.{ModuleKind, OutputMode}
 import org.scalajs.core.tools.javascript.Trees._
 
 /** Collection of tree generators that are used accross the board.
@@ -26,7 +26,8 @@ import org.scalajs.core.tools.javascript.Trees._
  *  Also carries around config (semantics and outputMode).
  */
 private[emitter] final class JSGen(val semantics: Semantics,
-    val outputMode: OutputMode, internalOptions: InternalOptions) {
+    val outputMode: OutputMode, val moduleKind: ModuleKind,
+    internalOptions: InternalOptions) {
   import JSGen._
 
   implicit def transformIdent(ident: irt.Ident): Ident =
@@ -189,6 +190,14 @@ private[emitter] final class JSGen(val semantics: Semantics,
             pathSelection(defaultField, rest)
           case _ =>
             pathSelection(moduleValue, path)
+        }
+
+      case irt.JSNativeLoadSpec.ImportWithGlobalFallback(importSpec, globalSpec) =>
+        moduleKind match {
+          case ModuleKind.NoModule =>
+            genLoadJSFromSpec(globalSpec)
+          case ModuleKind.CommonJSModule =>
+            genLoadJSFromSpec(importSpec)
         }
     }
   }


### PR DESCRIPTION
If the codebase refers to an `@JSImport` entity, such as

```scala
@js.native
@JSImport("foo.js", "Bar")
class Bar extends js.Object
```

the codebase must be linked with `CommonJSModule` (or, in the future, other `ModuleKind`s supporting modules). Linking without module support causes a linking error.

This causes facades for JS libraries supporting both module-style and script-style to be faced with an early choice:

* either support linking with modules and use `@JSImport`, or
* support linking without module support, and use `@JSGlobal` with whatever global names the JS library uses.

It is however impossible to write a facade library that supports both use cases for their end users.

This commit addresses this issue by adding an optional "global fallback" to `@JSImport`. We can now define a facade as follows:

```scala
@js.native
@JSImport("foo.js", "Bar", globalFallback = "Foo.Bar")
class Bar extends js.Object
```

That facade will successfully link both with and without module support. With module support, it links as if declared like in the first snippet. Without module support, it links as if declared as

```scala
@js.native
@JSGlobal("Foo.Bar")
class Bar extends js.Object
```

Using this global fallback, a facade library can cater both for users who want to take advantages of modules, and users who want to stick to the script style.

---

Implementation-wise, this is quite easy to implement. We simply add a new `JSNativeLoadSpec.ImportWithGlobalFallback`. It wraps both a `JSNativeLoadSpec.Import` and `Global`. That JS native load spec goes through the entire pipeline and reaches the emitter as is. The emitter decides which one to use depending on the `moduleKind`.