### PR TITLE
Fix #2927: Fail on assertEquals on floats/doubles

### DIFF
--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -91,6 +91,26 @@ object Assert {
   def assertNotEquals(unexpected: Float, actual: Float, delta: Float): Unit =
     assertNotEquals(null, unexpected, actual, delta)
 
+  @deprecated("Use assertEquals(double expected, double actual, double " +
+      "epsilon) instead", "")
+  def assertEquals(expected: Double, actual: Double): Unit = {
+    fail("Use assertEquals(expected, actual, delta) to compare " +
+        "floating-point numbers")
+  }
+
+  @deprecated("Use assertEquals(String message, double expected, double " +
+      "actual, double epsilon) instead", "")
+  def assertEquals(message: String, expected: Double, actual: Double): Unit = {
+    fail("Use assertEquals(expected, actual, delta) to compare " +
+        "floating-point numbers")
+  }
+
+  def assertEquals(expected: Long, actual: Long): Unit =
+    assertEquals(null, expected, actual)
+
+  def assertEquals(message: String, expected: Long, actual: Long): Unit =
+    assertEquals(message, expected: Any, actual: Any)
+
   def assertArrayEquals(message: String, expecteds: Array[AnyRef],
       actuals: Array[AnyRef]): Unit = {
     internalArrayEquals(message, expecteds, actuals)

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsDoubleTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsDoubleTest.scala
@@ -1,0 +1,50 @@
+package org.scalajs.junit
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.junit.utils._
+
+class AssertEqualsDoubleTest {
+  @Test def failsWithDouble(): Unit = {
+    assertEquals(1.0, 1.0)
+  }
+
+  @Test def failsWithDoubleMessage(): Unit = {
+    assertEquals("Message", 1.0, 1.0)
+  }
+
+  @Test def worksWithEpsilon(): Unit = {
+    assertEquals(1.0, 1.0, 0.1)
+    assertEquals("Message", 1.0, 1.0, 0.1)
+  }
+
+  @Test def worksWithByte(): Unit = {
+    // This is supposed to take the (long, long) overload.
+    assertEquals(1.toByte, 1.toByte)
+  }
+
+  @Test def worksWithShort(): Unit = {
+    // This is supposed to take the (long, long) overload.
+    assertEquals(2.toShort, 2.toShort)
+  }
+
+  @Test def worksWithInt(): Unit = {
+    // This is supposed to take the (long, long) overload.
+    assertEquals(1, 1)
+  }
+}
+
+class AssertEqualsDoubleTestAssertions extends JUnitTest {
+  protected def expectedOutput(builder: OutputBuilder): OutputBuilder = {
+    builder
+      .success("worksWithEpsilon")
+      .assertion("failsWithDouble",
+          "Use assertEquals(expected, actual, delta) to compare floating-point numbers")
+      .assertion("failsWithDoubleMessage",
+          "Use assertEquals(expected, actual, delta) to compare floating-point numbers")
+      .success("worksWithByte")
+      .success("worksWithShort")
+      .success("worksWithInt")
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1167,7 +1167,7 @@ object Build {
       fatalWarningsSettings ++ Seq(name := "Scala.js JUnit test runtime")
   ).withScalaJSCompiler.dependsOn(testInterface)
 
-  val commonJUnitTestOutputsSettings = commonSettings ++ fatalWarningsSettings ++ Seq(
+  val commonJUnitTestOutputsSettings = commonSettings ++ Seq(
       publishArtifact in Compile := false,
       parallelExecution in Test := false,
       unmanagedSourceDirectories in Test +=

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
@@ -21,25 +21,25 @@ class FloatJSTest {
 
   @Test def fround_for_special_values(): Unit = {
     assertTrue(froundNotInlined(Double.NaN).isNaN)
-    assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(0.0).toDouble)
-    assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-0.0).toDouble)
-    assertEquals(Float.PositiveInfinity, froundNotInlined(Double.PositiveInfinity))
-    assertEquals(Float.NegativeInfinity, froundNotInlined(Double.NegativeInfinity))
+    assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(0.0).toDouble, 0.0)
+    assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-0.0).toDouble, 0.0)
+    assertEquals(Float.PositiveInfinity, froundNotInlined(Double.PositiveInfinity), 0.0)
+    assertEquals(Float.NegativeInfinity, froundNotInlined(Double.NegativeInfinity), 0.0)
   }
 
   @Test def fround_overflows(): Unit = {
-    assertEquals(Double.PositiveInfinity, froundNotInlined(1e200))
-    assertEquals(Double.NegativeInfinity, froundNotInlined(-1e200))
+    assertEquals(Double.PositiveInfinity, froundNotInlined(1e200), 0.0)
+    assertEquals(Double.NegativeInfinity, froundNotInlined(-1e200), 0.0)
   }
 
   @Test def fround_underflows(): Unit = {
-    assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(1e-300).toDouble)
-    assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-1e-300).toDouble)
+    assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(1e-300).toDouble, 0.0)
+    assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-1e-300).toDouble, 0.0)
   }
 
   @Test def fround_normal_cases(): Unit = {
     def test(input: Double, expected: Double): Unit =
-      assertEquals(expected, input.toFloat.toDouble)
+      assertEquals(expected, input.toFloat.toDouble, 0.0)
 
     // From MDN documentation
     test(0.0, 0.0)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
@@ -108,7 +108,7 @@ class InstanceTestsHijackedBoxedClassesTest {
 
   @Test def asInstanceOf_Float_with_non_strict_floats(): Unit = {
     assumeFalse("Assumed strict floats", hasStrictFloats)
-    assertEquals(1.2, (1.2: Any).asInstanceOf[Float])
+    assertEquals(1.2, (1.2: Any).asInstanceOf[Float], 0.0)
   }
 
   @Test def should_support_isInstanceOf_via_java_lang_Class_positive(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -49,11 +49,11 @@ class OptimizerTest {
   @Test def `must_not_break_*_(-1)_for_Float_and_Double_issue_1478`(): Unit = {
     @noinline
     def a: Float = (() => 5.0f) ()
-    assertEquals(-5.0f, a * -1.0f)
+    assertEquals(-5.0f, a * -1.0f, 0.0)
 
     @noinline
     def b: Double = (() => 7.0) ()
-    assertEquals(-7.0, b * -1.0)
+    assertEquals(-7.0, b * -1.0, 0.0)
   }
 
   @Test def must_not_break_foreach_on_downward_Range_issue_1453(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -1081,8 +1081,8 @@ class ExportsTest {
       def doShort(x: Short): Unit = assertEquals(0, x)
       def doInt(x: Int): Unit = assertEquals(0, x)
       def doLong(x: Long): Unit = assertTrue(x.equals(0L))
-      def doFloat(x: Float): Unit = assertEquals(0.0f, x)
-      def doDouble(x: Double): Unit = assertEquals(0.0, x)
+      def doFloat(x: Float): Unit = assertEquals(0.0f, x, 0.0)
+      def doDouble(x: Double): Unit = assertEquals(0.0, x, 0.0)
       def doUnit(x: Unit): Unit = assertTrue((x: Any) == null)
     }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
@@ -28,9 +28,9 @@ class JSNameTest {
 
   @Test def should_work_with_vars(): Unit = {
     val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarFacade]
-    assertEquals(0.1, obj.internalVar)
+    assertEquals(0.1, obj.internalVar, 0.0)
     obj.internalVar = 0.2
-    assertEquals(0.2, obj.internalVar)
+    assertEquals(0.2, obj.internalVar, 0.0)
   }
 
   @Test def should_work_with_defs_that_are_properties_in_Scala_js_defined_trait_issue_2197(): Unit = {
@@ -45,9 +45,9 @@ class JSNameTest {
 
   @Test def should_work_with_vars_in_Scala_js_defined_trait_issue_2197(): Unit = {
     val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarSJSDefined]
-    assertEquals(0.1, obj.internalVar)
+    assertEquals(0.1, obj.internalVar, 0.0)
     obj.internalVar = 0.2
-    assertEquals(0.2, obj.internalVar)
+    assertEquals(0.2, obj.internalVar, 0.0)
   }
 
   @Test def should_allow_names_ending_in__=(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -56,14 +56,14 @@ class JSSymbolTest {
 
   @Test def native_with_vars(): Unit = {
     val obj0 = mkObject(sym1 -> 0.1).asInstanceOf[PropVarClass]
-    assertEquals(0.1, obj0.internalVar)
+    assertEquals(0.1, obj0.internalVar, 0.0)
     obj0.internalVar = 0.2
-    assertEquals(0.2, obj0.internalVar)
+    assertEquals(0.2, obj0.internalVar, 0.0)
 
     val obj1 = mkObject(sym1 -> 8.0).asInstanceOf[PropVarTrait]
-    assertEquals(8.0, obj1.internalVar)
+    assertEquals(8.0, obj1.internalVar, 0.0)
     obj1.internalVar = 8.2
-    assertEquals(8.2, obj1.internalVar)
+    assertEquals(8.2, obj1.internalVar, 0.0)
 
     val obj2 = mkObject(sym1 -> 8.0)
     assertEquals(8.0, selectSymbol(obj2, sym1))
@@ -73,14 +73,14 @@ class JSSymbolTest {
 
   @Test def sjsdefined_with_vars(): Unit = {
     val obj0 = new SJSDefinedPropVar
-    assertEquals(1511.1989, obj0.internalVar)
+    assertEquals(1511.1989, obj0.internalVar, 0.0)
     obj0.internalVar = 0.2
-    assertEquals(0.2, obj0.internalVar)
+    assertEquals(0.2, obj0.internalVar, 0.0)
 
     val obj1: PropVarTrait = new SJSDefinedPropVar
-    assertEquals(1511.1989, obj1.internalVar)
+    assertEquals(1511.1989, obj1.internalVar, 0.0)
     obj1.internalVar = 8.2
-    assertEquals(8.2, obj1.internalVar)
+    assertEquals(8.2, obj1.internalVar, 0.0)
 
     val obj2 = new SJSDefinedPropVar
     assertEquals(1511.1989, selectSymbol(obj2, sym1))

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
@@ -408,73 +408,65 @@ class RuntimeLongTest {
 
   @Test def toFloat_strict(): Unit = {
     assumeTrue("Assumed strict floats", hasStrictFloats)
-    assertEquals(0, lg(0).toFloat)
-    assertEquals(-1, lg(-1).toFloat)
+    assertEquals(0, lg(0).toFloat, 0.0)
+    assertEquals(-1, lg(-1).toFloat, 0.0)
 
-    if (!isInFullOpt) {
-      assertEquals(9.223372E18f, MaxVal.toFloat)
-      assertEquals(-9.223372E18f, MinVal.toFloat)
-    } else {
-      // Closure seems to incorrectly rewrite the constant on the right :-(
-      assertEquals(9.223372E18f, MaxVal.toFloat, 1E4f)
-      assertEquals(-9.223372E18f, MinVal.toFloat, 1E4f)
-    }
+    // Closure seems to incorrectly rewrite the constant on the right :-(
+    val epsilon = if (isInFullOpt) 1E4f else 0.0f
+    assertEquals(9.223372E18f, MaxVal.toFloat, epsilon)
+    assertEquals(-9.223372E18f, MinVal.toFloat, epsilon)
 
-    assertEquals(4.7971489E18f, lg(-1026388143, 1116923232).toFloat)
-    assertEquals(-2.24047663E18f, lg(-1288678667, -521651607).toFloat)
-    assertEquals(4.59211416E18f, lg(1192262605, 1069184891).toFloat)
-    assertEquals(3.38942079E18f, lg(-180353617, 789161022).toFloat)
-    assertEquals(-6.8076878E18f, lg(-1158443188, -1585038363).toFloat)
-    assertEquals(7.4159717E18f, lg(906981906, 1726665521).toFloat)
-    assertEquals(-1.85275997E18f, lg(2042933575, -431379283).toFloat)
-    assertEquals(5.7344188E18f, lg(599900903, 1335148382).toFloat)
-    assertEquals(3.20410168E18f, lg(1458166084, 746013039).toFloat)
-    assertEquals(-7.2310311E18f, lg(1956524672, -1683605603).toFloat)
-    assertEquals(7.7151362E18f, lg(478583639, 1796320118).toFloat)
-    assertEquals(1.41365268E18f, lg(-1645816617, 329141676).toFloat)
-    assertEquals(-3.03197918E18f, lg(184187116, -705937657).toFloat)
-    assertEquals(-4.04287594E18f, lg(659513335, -941305424).toFloat)
-    assertEquals(-7.8204678E18f, lg(770505156, -1820844549).toFloat)
-    assertEquals(-5.9733025E18f, lg(929928858, -1390767911).toFloat)
-    assertEquals(1.1261721E18f, lg(-1475096259, 262207373).toFloat)
-    assertEquals(4.00884963E18f, lg(787691795, 933383012).toFloat)
-    assertEquals(-1.43511611E18f, lg(1189057493, -334139018).toFloat)
-    assertEquals(3.81415059E18f, lg(-618946450, 888051141).toFloat)
+    assertEquals(4.7971489E18f, lg(-1026388143, 1116923232).toFloat, 0.0)
+    assertEquals(-2.24047663E18f, lg(-1288678667, -521651607).toFloat, 0.0)
+    assertEquals(4.59211416E18f, lg(1192262605, 1069184891).toFloat, 0.0)
+    assertEquals(3.38942079E18f, lg(-180353617, 789161022).toFloat, 0.0)
+    assertEquals(-6.8076878E18f, lg(-1158443188, -1585038363).toFloat, 0.0)
+    assertEquals(7.4159717E18f, lg(906981906, 1726665521).toFloat, 0.0)
+    assertEquals(-1.85275997E18f, lg(2042933575, -431379283).toFloat, 0.0)
+    assertEquals(5.7344188E18f, lg(599900903, 1335148382).toFloat, 0.0)
+    assertEquals(3.20410168E18f, lg(1458166084, 746013039).toFloat, 0.0)
+    assertEquals(-7.2310311E18f, lg(1956524672, -1683605603).toFloat, 0.0)
+    assertEquals(7.7151362E18f, lg(478583639, 1796320118).toFloat, 0.0)
+    assertEquals(1.41365268E18f, lg(-1645816617, 329141676).toFloat, 0.0)
+    assertEquals(-3.03197918E18f, lg(184187116, -705937657).toFloat, 0.0)
+    assertEquals(-4.04287594E18f, lg(659513335, -941305424).toFloat, 0.0)
+    assertEquals(-7.8204678E18f, lg(770505156, -1820844549).toFloat, 0.0)
+    assertEquals(-5.9733025E18f, lg(929928858, -1390767911).toFloat, 0.0)
+    assertEquals(1.1261721E18f, lg(-1475096259, 262207373).toFloat, 0.0)
+    assertEquals(4.00884963E18f, lg(787691795, 933383012).toFloat, 0.0)
+    assertEquals(-1.43511611E18f, lg(1189057493, -334139018).toFloat, 0.0)
+    assertEquals(3.81415059E18f, lg(-618946450, 888051141).toFloat, 0.0)
   }
 
   @Test def toDouble(): Unit = {
-    assertEquals(0, lg(0).toDouble)
-    assertEquals(-1, lg(-1).toDouble)
+    assertEquals(0, lg(0).toDouble, 0.0)
+    assertEquals(-1, lg(-1).toDouble, 0.0)
 
-    if (!isInFullOpt) {
-      assertEquals(9.223372036854776E18, MaxVal.toDouble)
-      assertEquals(-9.223372036854776E18, MinVal.toDouble)
-    } else {
-      // Closure seems to incorrectly rewrite the constant on the right :-(
-      assertEquals(9.223372036854776E18, MaxVal.toDouble, 1E4)
-      assertEquals(-9.223372036854776E18, MinVal.toDouble, 1E4)
-    }
+    // Closure seems to incorrectly rewrite the constant on the right :-(
+    val epsilon = if (isInFullOpt) 1E4 else 0.0
+    assertEquals(9.223372036854776E18, MaxVal.toDouble, epsilon)
+    assertEquals(-9.223372036854776E18, MinVal.toDouble, epsilon)
 
-    assertEquals(3.4240179834317537E18, lg(-151011088, 797216310).toDouble)
-    assertEquals(8.5596043411285968E16, lg(-508205099, 19929381).toDouble)
-    assertEquals(-3.1630346897289943E18, lg(1249322201, -736451403).toDouble)
-    assertEquals(-4.4847682439933604E18, lg(483575860, -1044191477).toDouble)
-    assertEquals(-6.4014772289576371E17, lg(-1526343930, -149046007).toDouble)
-    assertEquals(-1.76968119148756736E18, lg(531728928, -412036011).toDouble)
-    assertEquals(-8.5606671350959739E18, lg(-734111585, -1993185640).toDouble)
-    assertEquals(-9.0403963253949932E18, lg(-1407864332, -2104881296).toDouble)
-    assertEquals(-6.4988752582247977E18, lg(-1712351423, -1513137310).toDouble)
-    assertEquals(-7.7788492399114394E17, lg(1969244733, -181115448).toDouble)
-    assertEquals(7.6357174849871442E18, lg(-907683842, 1777829016).toDouble)
-    assertEquals(1.25338659134517658E18, lg(-815927209, 291826806).toDouble)
-    assertEquals(-3.1910241505692349E18, lg(463523496, -742968207).toDouble)
-    assertEquals(7.4216510087652332E18, lg(1482622807, 1727987781).toDouble)
-    assertEquals(-8.189046896086654E18, lg(1170040143, -1906661060).toDouble)
-    assertEquals(6.8316272807487539E18, lg(-85609173, 1590612176).toDouble)
-    assertEquals(-8.0611115909320561E18, lg(-1212811257, -1876873801).toDouble)
-    assertEquals(1.7127521901359959E18, lg(-648802816, 398781194).toDouble)
-    assertEquals(-6.4442523492577423E18, lg(-1484519186, -1500419423).toDouble)
-    assertEquals(-1.71264450938175027E18, lg(-2016996893, -398756124).toDouble)
+    assertEquals(3.4240179834317537E18, lg(-151011088, 797216310).toDouble, 0.0)
+    assertEquals(8.5596043411285968E16, lg(-508205099, 19929381).toDouble, 0.0)
+    assertEquals(-3.1630346897289943E18, lg(1249322201, -736451403).toDouble, 0.0)
+    assertEquals(-4.4847682439933604E18, lg(483575860, -1044191477).toDouble, 0.0)
+    assertEquals(-6.4014772289576371E17, lg(-1526343930, -149046007).toDouble, 0.0)
+    assertEquals(-1.76968119148756736E18, lg(531728928, -412036011).toDouble, 0.0)
+    assertEquals(-8.5606671350959739E18, lg(-734111585, -1993185640).toDouble, 0.0)
+    assertEquals(-9.0403963253949932E18, lg(-1407864332, -2104881296).toDouble, 0.0)
+    assertEquals(-6.4988752582247977E18, lg(-1712351423, -1513137310).toDouble, 0.0)
+    assertEquals(-7.7788492399114394E17, lg(1969244733, -181115448).toDouble, 0.0)
+    assertEquals(7.6357174849871442E18, lg(-907683842, 1777829016).toDouble, 0.0)
+    assertEquals(1.25338659134517658E18, lg(-815927209, 291826806).toDouble, 0.0)
+    assertEquals(-3.1910241505692349E18, lg(463523496, -742968207).toDouble, 0.0)
+    assertEquals(7.4216510087652332E18, lg(1482622807, 1727987781).toDouble, 0.0)
+    assertEquals(-8.189046896086654E18, lg(1170040143, -1906661060).toDouble, 0.0)
+    assertEquals(6.8316272807487539E18, lg(-85609173, 1590612176).toDouble, 0.0)
+    assertEquals(-8.0611115909320561E18, lg(-1212811257, -1876873801).toDouble, 0.0)
+    assertEquals(1.7127521901359959E18, lg(-648802816, 398781194).toDouble, 0.0)
+    assertEquals(-6.4442523492577423E18, lg(-1484519186, -1500419423).toDouble, 0.0)
+    assertEquals(-1.71264450938175027E18, lg(-2016996893, -398756124).toDouble, 0.0)
   }
 
   @Test def fromDouble(): Unit = {
@@ -2226,8 +2218,8 @@ class RuntimeLongOldTest {
   }
 
   @Test def should_correctly_implement_toDouble(): Unit = {
-    assertEquals(5.0, fromInt(5).toDouble)
-    assertEquals(2147483648.0, (maxInt+one).toDouble)
+    assertEquals(5.0, fromInt(5).toDouble, 0.0)
+    assertEquals(2147483648.0, (maxInt+one).toDouble, 0.0)
   }
 
   @Test def should_correctly_implement_numberOfLeadingZeros(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
@@ -141,10 +141,10 @@ class DataViewTest {
     view.setUint8(3, 0x30)
     view.setUint8(4, 0x1A)
 
-    assertEquals(0x01FFB330, view.getUint32(0))
-    assertEquals(0x30B3FF01, view.getUint32(0, true))
-    assertEquals(0xFFB3301AL.toDouble, view.getUint32(1))
-    assertEquals(0x1A30B3FF, view.getUint32(1, true))
+    assertEquals(0x01FFB330, view.getUint32(0), 0.0)
+    assertEquals(0x30B3FF01, view.getUint32(0, true), 0.0)
+    assertEquals(0xFFB3301AL.toDouble, view.getUint32(1), 0.0)
+    assertEquals(0x1A30B3FF, view.getUint32(1, true), 0.0)
   }
 
   @Test def getFloat32(): Unit = {
@@ -163,7 +163,7 @@ class DataViewTest {
 
     view.setFloat64(0, 0.5)
 
-    assertEquals(0.5, view.getFloat64(0))
+    assertEquals(0.5, view.getFloat64(0), 0.0)
     assertNotEquals(0.5, view.getFloat64(1), 0.0)
     assertNotEquals(0.5, view.getFloat64(0, true), 0.0)
     assertNotEquals(0.5, view.getFloat64(1, true), 0.0)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
@@ -28,11 +28,11 @@ class TypedArrayConversionTest {
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Byte]])
-    assertEquals(sum(1), y.sum)
+    assertEquals(sum(1), y.sum, 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(sum(1), y.sum)
+    assertEquals(sum(1), y.sum, 0.0)
   }
 
   @Test def convert_an_Int16Array_to_a_scala_Array_Short(): Unit = {
@@ -40,11 +40,11 @@ class TypedArrayConversionTest {
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Short]])
-    assertEquals(sum(100), y.sum)
+    assertEquals(sum(100), y.sum, 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(sum(100), y.sum)
+    assertEquals(sum(100), y.sum, 0.0)
   }
 
   @Test def convert_an_Uint16Array_to_a_scala_Array_Char(): Unit = {
@@ -67,11 +67,11 @@ class TypedArrayConversionTest {
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Int]])
-    assertEquals(sum(10000), y.sum)
+    assertEquals(sum(10000), y.sum, 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(sum(10000), y.sum)
+    assertEquals(sum(10000), y.sum, 0.0)
   }
 
   @Test def convert_a_Float32Array_to_a_scala_Array_Float(): Unit = {
@@ -91,11 +91,11 @@ class TypedArrayConversionTest {
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Double]])
-    assertEquals(sum(0.2), y.sum)
+    assertEquals(sum(0.2), y.sum, 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(sum(0.2), y.sum)
+    assertEquals(sum(0.2), y.sum, 0.0)
   }
 
   @Test def convert_a_scala_Array_Byte__to_an_Int8Array(): Unit = {
@@ -168,11 +168,11 @@ class TypedArrayConversionTest {
     assertEquals(x.length, y.length)
 
     for (i <- 0 until y.length)
-      assertEquals(x(i), y(i))
+      assertEquals(x(i), y(i), 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(1.0f, y(0))
+    assertEquals(1.0f, y(0), 0.0)
   }
 
   @Test def convert_a_scala_Array_Double__to_a_Float64Array(): Unit = {
@@ -180,13 +180,13 @@ class TypedArrayConversionTest {
     val y = x.toTypedArray
 
     assertTrue(y.isInstanceOf[Float64Array])
-    assertEquals(x.length, y.length)
+    assertEquals(x.length, y.length, 0.0)
 
     for (i <- 0 until y.length)
-      assertEquals(x(i), y(i))
+      assertEquals(x(i), y(i), 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(1.0, y(0))
+    assertEquals(1.0, y(0), 0.0)
   }
 }


### PR DESCRIPTION
#2960 needs to go in first and the issues discussed in https://github.com/scala-js/scala-js/issues/2927#issuecomment-302926675 need to be solved.