### PR TITLE
Fix #2943: Fix quadratic behaviors in the optimizer and cap JS array virtualization

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,7 +8,15 @@ object BinaryIncompatibilities {
   val Tools = Seq(
       // private[emitter], not an issue
       ProblemFilters.exclude[DirectMissingMethodProblem](
-          "org.scalajs.core.tools.linker.backend.emitter.JSGen.this")
+          "org.scalajs.core.tools.linker.backend.emitter.JSGen.this"),
+
+      // private[optimizer], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.savedUsedLabelNames"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.savedUsedLocalNames")
   )
 
   val JSEnvs = Seq(

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -11,12 +11,24 @@ object BinaryIncompatibilities {
           "org.scalajs.core.tools.linker.backend.emitter.JSGen.this"),
 
       // private[optimizer], not an issue
-      ProblemFilters.exclude[DirectMissingMethodProblem](
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.savedStatesInUse"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.savedUsedLabelNames"),
       ProblemFilters.exclude[DirectMissingMethodProblem](
-          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.savedUsedLocalNames")
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.savedUsedLocalNames"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#RollbackException.stateBackups"),
+      ProblemFilters.exclude[MissingTypesProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore$SimpleState"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#SimpleState.this"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore#SimpleState.makeBackup"),
+      ProblemFilters.exclude[MissingClassProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore$State")
   )
 
   val JSEnvs = Seq(

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -845,7 +845,11 @@ private[optimizer] abstract class OptimizerCore(
             usePreTransform = true)(cont)
 
       case JSArrayConstr(items) =>
-        if (items.exists(_.isInstanceOf[JSSpread])) {
+        /* Trying to virtualize more than 64 items in a JS array is probably
+         * a bad idea, and will slow down the optimizer for no good reason.
+         * See for example #2943.
+         */
+        if (items.size > 64 || items.exists(_.isInstanceOf[JSSpread])) {
           /* TODO This means spread in array constr does not compose under
            * this optimization. We could improve this with a
            * pretransformExprsOrSpreads() or something like that.


### PR DESCRIPTION
The first two commits do not change the emitted .js file for the test suite (not even by different names being used). The last commit slightly changes the generated code for [the test data array of `Base64Test`](https://github.com/scala-js/scala-js/blob/195452a76760584338949229a85c0e0f9301058b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/Base64Test.scala#L366).

In addition to the improvements seen on the pathological case of #2943, the first commit cuts the time it takes to optimize the test suite from 14 seconds down to ~3.7 s. The other two commits do not bring any measurable difference on the test suite.