### PR TITLE
Fix #2921: Forbid SAMs of JS types (except js.{This,}Function).

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -246,6 +246,20 @@ abstract class PrepJSInterop extends plugins.PluginComponent
           }
           super.transform(tree)
 
+        /* Anonymous function, need to check that it is not used as a SAM for a
+         * JS type, unless it is js.FunctionN or js.ThisFunctionN.
+         * See #2921.
+         */
+        case tree: Function =>
+          val tpeSym = tree.tpe.typeSymbol
+          if (isJSAny(tpeSym) && !AllJSFunctionClasses.contains(tpeSym)) {
+            reporter.error(tree.pos,
+                "Using an anonymous function as a SAM for the JavaScript " +
+                "type " + tpeSym.fullNameString + " is not allowed. " +
+                "Use an anonymous class instead.")
+          }
+          super.transform(tree)
+
         // Catch Select on Enumeration.Value we couldn't transform but need to
         // we ignore the implementation of scala.Enumeration itself
         case ScalaEnumValue.NoName(_) if noEnclosingOwner is OwnerKind.EnumImpl =>

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSSAMTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSSAMTest.scala
@@ -1,0 +1,73 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+
+import org.junit.Assume._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+class JSSAMTest extends DirectTest with TestHelpers {
+
+  override def preamble: String =
+    """
+    import scala.scalajs.js
+    import scala.scalajs.js.annotation._
+    """
+
+  @Test
+  def noSAMAsJSTypeGeneric: Unit = {
+
+    """
+    @js.native
+    trait Foo extends js.Object {
+      def foo(x: Int): Int
+    }
+
+    @ScalaJSDefined
+    trait Bar extends js.Object {
+      def bar(x: Int): Int
+    }
+
+    class A {
+      val foo: Foo = x => x + 1
+      val Bar: Bar = x => x + 1
+    }
+    """.fails()
+
+  }
+
+  @Test
+  def noSAMAsJSType212: Unit = {
+
+    val version = scala.util.Properties.versionNumberString
+    assumeTrue(!version.startsWith("2.10.") && !version.startsWith("2.11."))
+
+    """
+    @js.native
+    trait Foo extends js.Object {
+      def foo(x: Int): Int
+    }
+
+    @ScalaJSDefined
+    trait Bar extends js.Object {
+      def bar(x: Int): Int
+    }
+
+    class A {
+      val foo: Foo = x => x + 1
+      val Bar: Bar = x => x + 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:16: error: Using an anonymous function as a SAM for the JavaScript type Foo is not allowed. Use an anonymous class instead.
+      |      val foo: Foo = x => x + 1
+      |                       ^
+      |newSource1.scala:17: error: Using an anonymous function as a SAM for the JavaScript type Bar is not allowed. Use an anonymous class instead.
+      |      val Bar: Bar = x => x + 1
+      |                       ^
+    """
+
+  }
+
+}


### PR DESCRIPTION
Since using such a SAM before would produce invalid IR that sent the optimizer crashing, we directly make this into an *error*, rather than a warning.

In theory, we could support SAMs of Scala.js-defined JS types, if they do not have an `apply` method. But that would require more work in the compiler backend. This commit does not attempt to do so.