### PR TITLE
Fix #2876: Cut dependencies on code that will move to modules

### DIFF
--- a/cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
@@ -42,7 +42,7 @@ object Scalajsp {
         .action { (_, c) => c.copy(infos = true) }
         .text("Show DCE infos instead of trees")
       opt[Unit]('s', "supported")
-        .action { (_,_) => printSupported(); sys.exit() }
+        .action { (_,_) => printSupported(); exit(0) }
         .text("Show supported Scala.js IR versions")
       version("version")
         .abbr("v")
@@ -85,9 +85,14 @@ object Scalajsp {
     stdout.flush()
   }
 
-  private def fail(msg: String) = {
+  private def fail(msg: String): Nothing = {
     Console.err.println(msg)
-    sys.exit(1)
+    exit(1)
+  }
+
+  private def exit(code: Int): Nothing = {
+    System.exit(code)
+    throw new AssertionError("unreachable")
   }
 
   private def readFromFile(fileName: String) = {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -211,7 +211,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       }
 
       optDef.getOrElse {
-        sys.error("Couldn't find tree for lazily generated anonymous class " +
+        abort("Couldn't find tree for lazily generated anonymous class " +
             s"${sym.fullName} at ${sym.pos}")
       }
     }
@@ -635,7 +635,7 @@ abstract class GenJSCode extends plugins.PluginComponent
           classMembers += property
 
         case tree =>
-          sys.error("Unexpected tree: " + tree)
+          abort("Unexpected tree: " + tree)
       }
 
       // Make new class def with static members only
@@ -706,7 +706,7 @@ abstract class GenJSCode extends plugins.PluginComponent
               List(selfRef, name, descriptor))
 
         case tree =>
-          sys.error("Unexpected tree: " + tree)
+          abort("Unexpected tree: " + tree)
       }
 
       // Transform the constructor body.
@@ -718,7 +718,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
             val newTree = {
               val ident =
-                origJsClass.superClass.getOrElse(sys.error("No superclass"))
+                origJsClass.superClass.getOrElse(abort("No superclass"))
               if (args.isEmpty && ident.name == "sjs_js_Object") {
                 js.JSObjectConstr(Nil)
               } else {
@@ -1869,7 +1869,7 @@ abstract class GenJSCode extends plugins.PluginComponent
               js.VarRef(encodeLocalSym(sym))(toIRType(sym.tpe))
             }
           } else {
-            sys.error("Cannot use package as value: " + tree)
+            abort("Cannot use package as value: " + tree)
           }
 
         case Literal(value) =>

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -138,10 +138,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val BoxesRunTime_boxToCharacter = getMemberMethod(BoxesRunTimeModule, newTermName("boxToCharacter"))
     lazy val BoxesRunTime_unboxToChar    = getMemberMethod(BoxesRunTimeModule, newTermName("unboxToChar"))
 
-    // Copy-pasted from `Definitions.scala`, because it was removed in 2.13.
-    lazy val SysPackage = getPackageObject("scala.sys")
-      def Sys_error: Symbol = getMemberMethod(SysPackage, nme.error)
-
     lazy val ReflectModule = getRequiredModule("scala.scalajs.reflect.Reflect")
       lazy val Reflect_registerLoadableModuleClass = getMemberMethod(ReflectModule, newTermName("registerLoadableModuleClass"))
       lazy val Reflect_registerInstantiatableClass = getMemberMethod(ReflectModule, newTermName("registerInstantiatableClass"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -124,9 +124,12 @@ trait JSGlobalAddons extends JSDefinitions
         } else None
       }
 
-      dropPrefix(methodExportPrefix).map((_,false)) orElse
-      dropPrefix(propExportPrefix).map((_,true)) getOrElse
-      sys.error("non-exported name passed to jsInfoSpec")
+      dropPrefix(methodExportPrefix).map((_,false)).orElse {
+        dropPrefix(propExportPrefix).map((_,true))
+      }.getOrElse {
+        throw new IllegalArgumentException(
+            "non-exported name passed to jsExportInfo")
+      }
     }
 
     def isJSProperty(sym: Symbol): Boolean = isJSGetter(sym) || isJSSetter(sym)

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -1100,17 +1100,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
          * JS class/trait.
          */
       } else if (jsPrimitives.isJavaScriptPrimitive(sym)) {
-        // Force rhs of a primitive to be `sys.error("stub")` except for the
-        // js.native primitive which displays an elaborate error message
-        if (sym != JSPackage_native) {
-          tree.rhs match {
-            case Apply(trg, Literal(Constant("stub")) :: Nil)
-                if trg.symbol == jsDefinitions.Sys_error =>
-            case _ =>
-              reporter.error(tree.pos,
-                  "The body of a primitive must be `sys.error(\"stub\")`.")
-          }
-        }
+        // No check for primitives. We trust our own standard library.
       } else if (sym.isConstructor) {
         // Force secondary ctor to have only a call to the primary ctor inside
         tree.rhs match {

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
@@ -88,15 +88,20 @@ abstract class DirectTest {
   def defaultGlobal: Global = newScalaJSCompiler()
 
   def testOutputPath: String = {
-    val baseDir = sys.props("scala.scalajs.compiler.test.output")
+    val baseDir = System.getProperty("scala.scalajs.compiler.test.output")
     val outDir = new File(baseDir, getClass.getName)
     outDir.mkdirs()
     outDir.getAbsolutePath
   }
 
-  def scalaJSLibPath: String = sys.props("scala.scalajs.compiler.test.scalajslib")
-  def scalaLibPath: String   = sys.props("scala.scalajs.compiler.test.scalalib")
-  def scalaReflectPath: String = sys.props("scala.scalajs.compiler.test.scalareflect")
+  def scalaJSLibPath: String =
+    System.getProperty("scala.scalajs.compiler.test.scalajslib")
+
+  def scalaLibPath: String =
+    System.getProperty("scala.scalajs.compiler.test.scalalib")
+
+  def scalaReflectPath: String =
+    System.getProperty("scala.scalajs.compiler.test.scalareflect")
 
   def classpath: List[String] = List(scalaJSLibPath)
 }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
@@ -47,7 +47,8 @@ abstract class DirectTest {
 
       override lazy val plugins = {
         val scalaJSPlugin = newScalaJSPlugin(global)
-        scalaJSPlugin.processOptions(scalaJSPlugin.options, sys.error(_))
+        scalaJSPlugin.processOptions(scalaJSPlugin.options,
+            msg => throw new IllegalArgumentException(msg))
         scalaJSPlugin :: Nil
       }
     }

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -440,8 +440,8 @@ object Hashers {
           mixTrees(captureValues)
 
         case _ =>
-          sys.error(s"Unable to hash tree of class ${tree.getClass}")
-
+          throw new IllegalArgumentException(
+              s"Unable to hash tree of class ${tree.getClass}")
       }
     }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -699,7 +699,7 @@ object Serializers {
       import input._
       val result = (tag: @switch) match {
         case TagEmptyTree =>
-          sys.error("Found invalid TagEmptyTree")
+          throw new IOException("Found invalid TagEmptyTree")
 
         case TagVarDef   => VarDef(readIdent(), readType(), readBoolean(), readTree())
         case TagParamDef =>
@@ -716,9 +716,8 @@ object Serializers {
         case TagDoWhile  => DoWhile(readTree(), readTree(), readOptIdent())
 
         case TagTry =>
-          if (!useHacks068) {
-            sys.error("Invalid tag TagTry")
-          }
+          if (!useHacks068)
+            throw new IOException("Invalid tag TagTry")
 
           val block = readTree()
           val errVar = readIdent()

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -200,7 +200,8 @@ object Transformers {
           tree
 
         case _ =>
-          sys.error(s"Invalid tree in transform() of class ${tree.getClass}")
+          throw new IllegalArgumentException(
+              s"Invalid tree in transform() of class ${tree.getClass}")
       }
     }
   }
@@ -245,7 +246,8 @@ object Transformers {
               transformDef(methodDef).asInstanceOf[MethodDef])
 
         case _ =>
-          sys.error(s"Invalid tree in transformDef() of class ${tree.getClass}")
+          throw new IllegalArgumentException(
+              s"Invalid tree in transformDef() of class ${tree.getClass}")
       }
     }
   }

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -223,7 +223,8 @@ object Traversers {
           _:TopLevelFieldExportDef =>
 
       case _ =>
-        sys.error(s"Invalid tree in traverse() of class ${tree.getClass}")
+        throw new IllegalArgumentException(
+            s"Invalid tree in traverse() of class ${tree.getClass}")
     }
   }
 

--- a/javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
+++ b/javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
@@ -21,54 +21,54 @@
 package java.lang
 
 private[java] object MathJDK8Bridge {
-  def addExact(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def addExact(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def addExact(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def addExact(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def subtractExact(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def subtractExact(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def subtractExact(a: scala.Long, b: scala.Long): scala.Long =
-    sys.error("stub")
+  def subtractExact(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def multiplyExact(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def multiplyExact(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def multiplyExact(a: scala.Long, b: scala.Long): scala.Long =
-    sys.error("stub")
+  def multiplyExact(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def incrementExact(a: scala.Int): scala.Int = sys.error("stub")
+  def incrementExact(a: scala.Int): scala.Int = stub()
 
-  def incrementExact(a: scala.Long): scala.Long = sys.error("stub")
+  def incrementExact(a: scala.Long): scala.Long = stub()
 
-  def decrementExact(a: scala.Int): scala.Int = sys.error("stub")
+  def decrementExact(a: scala.Int): scala.Int = stub()
 
-  def decrementExact(a: scala.Long): scala.Long = sys.error("stub")
+  def decrementExact(a: scala.Long): scala.Long = stub()
 
-  def negateExact(a: scala.Int): scala.Int = sys.error("stub")
+  def negateExact(a: scala.Int): scala.Int = stub()
 
-  def negateExact(a: scala.Long): scala.Long = sys.error("stub")
+  def negateExact(a: scala.Long): scala.Long = stub()
 
-  def toIntExact(a: scala.Long): scala.Int = sys.error("stub")
+  def toIntExact(a: scala.Long): scala.Int = stub()
 
-  def floorDiv(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def floorDiv(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def floorDiv(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def floorDiv(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def floorMod(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def floorMod(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def floorMod(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def floorMod(a: scala.Long, b: scala.Long): scala.Long = stub()
 
   // A few other Math-related methods that are not really in Math
 
-  def toUnsignedString(i: scala.Int): String = sys.error("stub")
+  def toUnsignedString(i: scala.Int): String = stub()
 
-  def toUnsignedString(i: scala.Long): String = sys.error("stub")
+  def toUnsignedString(i: scala.Long): String = stub()
 
-  def divideUnsigned(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def divideUnsigned(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def divideUnsigned(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def divideUnsigned(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def remainderUnsigned(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def remainderUnsigned(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def remainderUnsigned(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def remainderUnsigned(a: scala.Long, b: scala.Long): scala.Long = stub()
 
+  private def stub(): Nothing =
+    throw new Error("stub")
 }

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -179,7 +179,7 @@ object Pattern {
     case 'u' => UNICODE_CASE
     case 'x' => COMMENTS
     case 'U' => UNICODE_CHARACTER_CLASS
-    case _   => sys.error("bad in-pattern flag")
+    case _   => throw new IllegalArgumentException("bad in-pattern flag")
   }
 
   /** matches \Q<char>\E to support StringLike.split */

--- a/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
+++ b/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
@@ -89,7 +89,7 @@ class RetryingComJSEnvTest extends JSEnvTest with ComTests {
 
       private def fail() = {
         fails += 1
-        sys.error("Dummy fail for testing purposes")
+        throw new Exception("Dummy fail for testing purposes")
       }
     }
   }

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -7,6 +7,7 @@ import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import java.io.{ Console => _, _ }
 import scala.io.Source
 
+import scala.collection.JavaConverters._
 import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
@@ -67,10 +68,11 @@ abstract class ExternalJSEnv(
 
     /** VM environment. Override to adapt.
      *
-     *  The default value in `ExternalJSEnv` is `sys.env ++ env`.
+     *  The default value in `ExternalJSEnv` is
+     *  `System.getenv().asScala.toMap ++ env`.
      */
     protected def getVMEnv(): Map[String, String] =
-      sys.env ++ env
+      System.getenv().asScala.toMap ++ env
 
     /** Get files that are a library (i.e. that do not run anything) */
     protected def getLibJSFiles(): Seq[VirtualJSFile] =

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
@@ -19,6 +19,7 @@ import org.scalajs.core.tools.logging.NullLogger
 import org.scalajs.jsenv._
 import org.scalajs.jsenv.Utils.OptDeadline
 
+import scala.collection.JavaConverters._
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
@@ -139,14 +140,14 @@ abstract class AbstractNodeJSEnv(
 
     // Node.js specific (system) environment
     override protected def getVMEnv(): Map[String, String] = {
-      val baseNodePath = sys.env.get("NODE_PATH").filter(_.nonEmpty)
+      val baseNodePath = Option(System.getenv("NODE_PATH")).filter(_.nonEmpty)
       val nodePath = libCache.cacheDir.getAbsolutePath +
           baseNodePath.fold("")(p => File.pathSeparator + p)
 
-      sys.env ++ Seq(
+      System.getenv().asScala.toMap ++ Seq(
         "NODE_MODULE_CONTEXTS" -> "0",
         "NODE_PATH" -> nodePath
-      ) ++ additionalEnv
+      ) ++ env
     }
   }
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
@@ -238,7 +238,8 @@ final class RhinoJSEnv private (
         case e: RhinoException =>
           // Trace here, since we want to be in the context to trace.
           logger.trace(e)
-          sys.error(s"Exception while running JS code: ${e.getMessage}")
+          throw new Exception(
+              s"Exception while running JS code: ${e.getMessage}")
       }
     } finally {
       // Ensure the channel is closed to release JVM side
@@ -292,9 +293,9 @@ final class RhinoJSEnv private (
     val ordering = Ordering.by[TimedTask, Deadline](_.deadline).reverse
     val taskQ = mutable.PriorityQueue.empty(ordering)
 
-    def ensure[T: ClassTag](v: AnyRef, errMsg: String) = v match {
+    def ensure[T: ClassTag](v: AnyRef, errMsg: String): T = v match {
       case v: T => v
-      case _    => sys.error(errMsg)
+      case _    => throw new IllegalArgumentException(errMsg)
     }
 
     scope.addFunction("setTimeout", args => {
@@ -356,7 +357,8 @@ final class RhinoJSEnv private (
           msg => f.call(context, scope, scope, Array(msg))
         setCallback(cb)
       case _ =>
-        sys.error("First argument to init must be a function")
+        throw new IllegalArgumentException(
+            "First argument to init must be a function")
     })
 
     comObj.addFunction("close", _ => {

--- a/library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
+++ b/library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
@@ -13,7 +13,7 @@ class BoxedUnit private () extends AnyRef with java.io.Serializable {
 }
 
 object BoxedUnit {
-  def UNIT: BoxedUnit = sys.error("stub")
+  def UNIT: BoxedUnit = throw new Error("stub")
 
   final val TYPE = classOf[Unit]
 }

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -176,7 +176,7 @@ object Array extends Object {
   // def apply[A](arrayLength: Int): Array[A] = native
 
   /** Creates a new array with the given items. */
-  def apply[A](items: A*): Array[A] = sys.error("stub")
+  def apply[A](items: A*): Array[A] = throw new java.lang.Error("stub")
 
   /** Returns true if the given value is an array. */
   def isArray(arg: Any): Boolean = native

--- a/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
+++ b/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
@@ -35,5 +35,6 @@ object ConstructorTag {
    *  This method has the same preconditions as
    *  [[constructorOf js.constructorOf]].
    */
-  implicit def materialize[T <: Any]: ConstructorTag[T] = sys.error("stub")
+  implicit def materialize[T <: Any]: ConstructorTag[T] =
+    throw new java.lang.Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/js/Dictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dictionary.scala
@@ -62,7 +62,7 @@ sealed trait Dictionary[A] extends Any {
    *  Since we are using strict mode, this throws an exception, if the property
    *  isn't configurable.
    */
-  def delete(key: String): Unit = sys.error("stub")
+  def delete(key: String): Unit = throw new java.lang.Error("stub")
 }
 
 /** Factory for [[Dictionary]] instances. */

--- a/library/src/main/scala/scala/scalajs/js/Dynamic.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dynamic.scala
@@ -78,7 +78,8 @@ object Dynamic {
   @inline def global: Dynamic = scala.scalajs.runtime.environmentInfo.global
 
   /** Instantiates a new object of a JavaScript class. */
-  def newInstance(clazz: Dynamic)(args: Any*): Object with Dynamic = sys.error("stub")
+  def newInstance(clazz: Dynamic)(args: Any*): Object with Dynamic =
+    throw new java.lang.Error("stub")
 
   /** Creates a new object with a literal syntax.
    *
@@ -91,8 +92,8 @@ object Dynamic {
     /** literal creation like this:
      *  js.Dynamic.literal(name1 = "value", name2 = "value")
      */
-    def applyDynamicNamed(name: String)(
-        fields: (String, Any)*): Object with Dynamic = sys.error("stub")
+    def applyDynamicNamed(name: String)(fields: (String, Any)*): Object with Dynamic =
+      throw new java.lang.Error("stub")
 
     /** literal creation like this:
      *  js.Dynamic.literal("name1" -> "value", "name2" -> "value")
@@ -101,8 +102,7 @@ object Dynamic {
      *  applyDynamicNamed fail, since a call with named arguments would
      *  be routed to the `def apply`, rather than def dynamic version.
      */
-    def applyDynamic(name: String)(
-        fields: (String, Any)*): Object with Dynamic = sys.error("stub")
-
+    def applyDynamic(name: String)(fields: (String, Any)*): Object with Dynamic =
+      throw new java.lang.Error("stub")
   }
 }

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -57,7 +57,8 @@ object Object extends Object {
   /** Tests whether the object has a property on itself or in its prototype
    *  chain. This method is the equivalent of `p in o` in JavaScript.
    */
-  def hasProperty(o: Object, p: String): Boolean = sys.error("stub")
+  def hasProperty(o: Object, p: String): Boolean =
+    throw new java.lang.Error("stub")
 
   /**
    * The Object.getPrototypeOf() method returns the prototype (i.e. the
@@ -220,5 +221,5 @@ object Object extends Object {
    *  that the list returned by [[keys]] is a sublist of the list returned by
    *  this method (not just a subset).
    */
-  def properties(o: Any): Array[String] = sys.error("stub")
+  def properties(o: Any): Array[String] = throw new java.lang.Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -72,7 +72,7 @@ package object js {
     v.asInstanceOf[scala.AnyRef] eq undefined
 
   /** Returns the type of `x` as identified by `typeof x` in JavaScript. */
-  def typeOf(x: Any): String = sys.error("stub")
+  def typeOf(x: Any): String = throw new java.lang.Error("stub")
 
   /** Returns the constructor function of a JavaScript class.
    *
@@ -80,7 +80,7 @@ package object js {
    *  `classOf[T]`) and represent a class extending `js.Any` (not a trait nor
    *  an object).
    */
-  def constructorOf[T <: js.Any]: js.Dynamic = sys.error("stub")
+  def constructorOf[T <: js.Any]: js.Dynamic = throw new java.lang.Error("stub")
 
   /** Makes explicit an implicitly available `ConstructorTag[T]`. */
   def constructorTag[T <: js.Any](implicit tag: ConstructorTag[T]): ConstructorTag[T] =
@@ -96,7 +96,7 @@ package object js {
    *  - In Chrome, it has no effect unless the developer tools are opened
    *    beforehand.
    */
-  def debugger(): Unit = sys.error("stub")
+  def debugger(): Unit = throw new java.lang.Error("stub")
 
   /** Evaluates JavaScript code and returns the result. */
   @inline def eval(x: String): Any =
@@ -125,10 +125,13 @@ package object js {
    *  }
    *  }}}
    */
-  def native: Nothing = sys.error("A method defined in a JavaScript raw " +
-      "type of a Scala.js library has been called. This is most likely " +
-      "because you tried to run Scala.js binaries on the JVM. Make sure you " +
-      "are using the JVM version of the libraries.")
+  def native: Nothing = {
+    throw new java.lang.Error(
+        "A method defined in a JavaScript raw type of a Scala.js library has " +
+        "been called. This is most likely because you tried to run Scala.js " +
+        "binaries on the JVM. Make sure you are using the JVM version of the " +
+        "libraries.")
+  }
 
   /** Allows to cast a value to a facade trait in a type-safe way.
    *

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
@@ -34,45 +34,34 @@ package scala.scalajs.js.typedarray
 import java.nio._
 
 private[typedarray] object TypedArrayBufferBridge {
-  def wrap(array: ArrayBuffer): ByteBuffer =
-    sys.error("stub")
+  def wrap(array: ArrayBuffer): ByteBuffer = stub()
 
-  def wrap(array: ArrayBuffer, byteOffset: Int, length: Int): ByteBuffer =
-    sys.error("stub")
+  def wrap(array: ArrayBuffer, byteOffset: Int, length: Int): ByteBuffer = stub()
 
-  def wrap(array: Int8Array): ByteBuffer =
-    sys.error("stub")
+  def wrap(array: Int8Array): ByteBuffer = stub()
 
-  def wrap(array: Uint16Array): CharBuffer =
-    sys.error("stub")
+  def wrap(array: Uint16Array): CharBuffer = stub()
 
-  def wrap(array: Int16Array): ShortBuffer =
-    sys.error("stub")
+  def wrap(array: Int16Array): ShortBuffer = stub()
 
-  def wrap(array: Int32Array): IntBuffer =
-    sys.error("stub")
+  def wrap(array: Int32Array): IntBuffer = stub()
 
-  def wrap(array: Float32Array): FloatBuffer =
-    sys.error("stub")
+  def wrap(array: Float32Array): FloatBuffer = stub()
 
-  def wrap(array: Float64Array): DoubleBuffer =
-    sys.error("stub")
+  def wrap(array: Float64Array): DoubleBuffer = stub()
 
-  def Buffer_hasArrayBuffer(buffer: Buffer): Boolean =
-    sys.error("stub")
+  def Buffer_hasArrayBuffer(buffer: Buffer): Boolean = stub()
 
-  def Buffer_arrayBuffer(buffer: Buffer): ArrayBuffer =
-    sys.error("stub")
+  def Buffer_arrayBuffer(buffer: Buffer): ArrayBuffer = stub()
 
-  def Buffer_arrayBufferOffset(buffer: Buffer): Int =
-    sys.error("stub")
+  def Buffer_arrayBufferOffset(buffer: Buffer): Int = stub()
 
-  def Buffer_dataView(buffer: Buffer): DataView =
-    sys.error("stub")
+  def Buffer_dataView(buffer: Buffer): DataView = stub()
 
-  def Buffer_hasTypedArray(buffer: Buffer): Boolean =
-    sys.error("stub")
+  def Buffer_hasTypedArray(buffer: Buffer): Boolean = stub()
 
-  def Buffer_typedArray(buffer: Buffer): TypedArray[_, _] =
-    sys.error("stub")
+  def Buffer_typedArray(buffer: Buffer): TypedArray[_, _] = stub()
+
+  private def stub(): Nothing =
+    throw new Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala
+++ b/library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala
@@ -95,7 +95,8 @@ private[scalajs] object UseAsMacros {
                 "likely caused by an abstract type in the method signature"
 
               case _ =>
-                sys.error("Unknown type in unsupported member. " +
+                throw new NotImplementedError(
+                    "Unknown type in unsupported member. " +
                     "Report this as a bug.\n" +
                      s"Offending method: ${sym.fullName}\n" +
                      s"Offending type: ${showRaw(tpe)}")

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -73,7 +73,8 @@ package object runtime {
    *  The `clazz` parameter must be a literal `classOf[T]` constant such that
    *  `T` represents a class extending `js.Any` (not a trait nor an object).
    */
-  def constructorOf(clazz: Class[_ <: js.Any]): js.Dynamic = sys.error("stub")
+  def constructorOf(clazz: Class[_ <: js.Any]): js.Dynamic =
+    throw new Error("stub")
 
   /** Public access to `new ConstructorTag` for the codegen of
    *  `js.ConstructorTag.materialize`.
@@ -140,7 +141,7 @@ package object runtime {
    *
    *  See [[LinkingInfo]] for details.
    */
-  def linkingInfo: LinkingInfo = sys.error("stub")
+  def linkingInfo: LinkingInfo = throw new Error("stub")
 
   /** Polyfill for fround in case we use strict Floats and even Typed Arrays
    *  are not available.

--- a/partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -185,10 +185,10 @@ class ScalaJSSBTRunner(
 
   // The test root for partest is read out through the system properties,
   // not passed as an argument
-  sys.props("partest.root") = testRoot.getAbsolutePath()
+  System.setProperty("partest.root", testRoot.getAbsolutePath())
 
   // Partests take at least 5h. We double, just to be sure. (default is 4 hours)
-  sys.props("partest.timeout") = "10 hours"
+  System.setProperty("partest.timeout", "10 hours")
 
   // Set showDiff on global UI module
   if (options.showDiff)

--- a/partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -187,10 +187,10 @@ class ScalaJSSBTRunner(
 
   // The test root for partest is read out through the system properties,
   // not passed as an argument
-  sys.props("partest.root") = testRoot.getAbsolutePath()
+  System.setProperty("partest.root", testRoot.getAbsolutePath())
 
   // Partests take at least 5h. We double, just to be sure. (default is 4 hours)
-  sys.props("partest.timeout") = "10 hours"
+  System.setProperty("partest.timeout", "10 hours")
 
   override val suiteRunner = new SuiteRunner(
       testSourcePath = config.optSourcePath orElse Option("test/files") getOrElse PartestDefaults.sourcePath,

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -38,10 +38,10 @@ class MainGenericRunner {
     false
   }
 
-  val optMode = OptMode.fromId(sys.props("scalajs.partest.optMode"))
+  val optMode = OptMode.fromId(System.getProperty("scalajs.partest.optMode"))
 
   def readSemantics() = {
-    val opt = sys.props.get("scalajs.partest.compliantSems")
+    val opt = Option(System.getProperty("scalajs.partest.compliantSems"))
     opt.fold(Semantics.Defaults) { str =>
       val sems = str.split(',')
       Semantics.compliantTo(sems.toList)

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -165,8 +165,8 @@ class MainGenericRunner {
 }
 
 object MainGenericRunner extends MainGenericRunner {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     if (!process(args))
-      sys.exit(1)
+      System.exit(1)
   }
 }

--- a/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
+++ b/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
@@ -35,10 +35,10 @@ object ScalaJSPartestOptions {
   }
   object OptMode {
     def fromId(id: String): OptMode = id match {
-      case "none"  => NoOpt
-      case "fast"  => FastOpt
-      case "full"  => FullOpt
-      case _       => sys.error(s"Unknown optimization mode: $id")
+      case "none" => NoOpt
+      case "fast" => FastOpt
+      case "full" => FullOpt
+      case _      => throw new IllegalArgumentException(s"Unknown optimization mode: $id")
     }
   }
   case object NoOpt extends OptMode {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -536,10 +536,10 @@ object Build {
           testOptions += Tests.Setup { () =>
             val testOutDir = (streams.value.cacheDirectory / "scalajs-compiler-test")
             IO.createDirectory(testOutDir)
-            sys.props("scala.scalajs.compiler.test.output") =
-              testOutDir.getAbsolutePath
-            sys.props("scala.scalajs.compiler.test.scalajslib") =
-              (packageBin in (library, Compile)).value.getAbsolutePath
+            System.setProperty("scala.scalajs.compiler.test.output",
+                testOutDir.getAbsolutePath)
+            System.setProperty("scala.scalajs.compiler.test.scalajslib",
+                (packageBin in (library, Compile)).value.getAbsolutePath)
 
             def scalaArtifact(name: String): String = {
               def isTarget(att: Attributed[File]) = {
@@ -558,11 +558,11 @@ object Build {
               }
             }
 
-            sys.props("scala.scalajs.compiler.test.scalalib") =
-              scalaArtifact("scala-library")
+            System.setProperty("scala.scalajs.compiler.test.scalalib",
+                scalaArtifact("scala-library"))
 
-            sys.props("scala.scalajs.compiler.test.scalareflect") =
-              scalaArtifact("scala-reflect")
+            System.setProperty("scala.scalajs.compiler.test.scalareflect",
+                scalaArtifact("scala-reflect"))
           },
           exportJars := true
       )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -242,8 +242,10 @@ object Build {
           }
         } (docPaths.keySet + additionalStylesFile)
 
-        if (errorsSeen.size > 0) sys.error("ScalaDoc patching had errors")
-        else outDir
+        if (errorsSeen.size > 0)
+          throw new MessageOnlyException("ScalaDoc patching had errors")
+
+        outDir
       }
   )
 
@@ -628,7 +630,7 @@ object Build {
         test := {
           val jsEnv = resolvedJSEnv.value
           if (!jsEnv.isInstanceOf[NodeJSEnv])
-            sys.error("toolsJS/test must be run with Node.js")
+            throw new MessageOnlyException("toolsJS/test must be run with Node.js")
 
           /* Collect IR relevant files from the classpath
            * We assume here that the classpath is valid. This is checked by the
@@ -906,7 +908,8 @@ object Build {
                 configuration = Set("compile"),
                 module = moduleFilter(name = "scala-library"),
                 artifact = artifactFilter(classifier = "sources")).headOption.getOrElse {
-              sys.error(s"Could not fetch scala-library sources for version $ver")
+              throw new Exception(
+                  s"Could not fetch scala-library sources for version $ver")
             }
 
             FileFunction.cached(cacheDir / s"fetchScalaSource-$ver",
@@ -1279,7 +1282,8 @@ object Build {
             val baseArgs = Seq("nodejs", "typedarray")
             if (env.sourceMap) {
               if (!env.hasSourceMapSupport) {
-                sys.error("You must install Node.js source map support to " +
+                throw new MessageOnlyException(
+                    "You must install Node.js source map support to " +
                     "run the full Scala.js test suite (npm install " +
                     "source-map-support). To deactivate source map " +
                     "tests, do: set jsEnv in " + thisProject.value.id +
@@ -1430,7 +1434,8 @@ object Build {
       // Fail if we are not in the right stage.
       testHtmlKey in Test := (testHtmlKey in Test).dependsOn(Def.task {
         if (scalaJSStage.value != targetStage) {
-          sys.error("In the Scala.js test-suite, the testHtml* tasks need " +
+          throw new MessageOnlyException(
+              "In the Scala.js test-suite, the testHtml* tasks need " +
               "scalaJSStage to be set to their respecitve stage. Stage is: " +
               scalaJSStage.value)
         }
@@ -1511,7 +1516,7 @@ object Build {
           val unitTests =
             (0 until i).map(i => s"@Test def workTest$i(): Unit = test($i)").mkString("; ")
           IO.write(outFile,
-              replaced.replace("@Test def workTest(): Unit = sys.error(\"stubs\")", unitTests))
+              replaced.replace("@Test def workTest(): Unit = ???", unitTests))
           Seq(outFile)
         }.taskValue,
 

--- a/project/ExternalCompile.scala
+++ b/project/ExternalCompile.scala
@@ -72,12 +72,13 @@ object ExternalCompile {
 
           def doCompile(sourcesArgs: List[String]): Unit = {
             val run = (runner in compile).value
-            run.run("scala.tools.nsc.Main", compilerCp,
+            val optErrorMsg = run.run("scala.tools.nsc.Main", compilerCp,
                 "-cp" :: cpStr ::
                 "-d" :: classesDirectory.getAbsolutePath() ::
                 options ++:
                 sourcesArgs,
-                patchedLogger) foreach sys.error
+                patchedLogger)
+            optErrorMsg.foreach(errorMsg => throw new Exception(errorMsg))
           }
 
           /* Crude way of overcoming the Windows limitation on command line

--- a/sbt-plugin-test/project/Jetty9Test.scala
+++ b/sbt-plugin-test/project/Jetty9Test.scala
@@ -55,7 +55,7 @@ object Jetty9Test {
           val msg = runner.receive()
           val expected = "It works!"
           if (msg != expected)
-            sys.error(s"""received "$msg" instead of "$expected"""")
+            throw new AssertionError(s"""received "$msg" instead of "$expected"""")
         } finally {
           runner.close()
           jetty.stop()

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -363,7 +363,8 @@ object ScalaJSPluginInternal {
           results += collectFile(file, relPath)
         }
       } else {
-        sys.error("Illegal classpath entry: " + cpEntry.getPath)
+        throw new IllegalArgumentException(
+            "Illegal classpath entry: " + cpEntry.getPath)
       }
     }
 
@@ -459,7 +460,9 @@ object ScalaJSPluginInternal {
               // Attach the name of the main class used, (ab?)using the name key
               Attributed(file)(AttributeMap.empty.put(name.key, mainCl))
             } getOrElse {
-              sys.error("Cannot write launcher file, since there is no or multiple mainClasses")
+              throw new MessageOnlyException(
+                  "Cannot write launcher file, since there is no or multiple " +
+                  "mainClasses")
             }
           }
         }
@@ -591,7 +594,7 @@ object ScalaJSPluginInternal {
       // Give tasks ability to check we are not forking at build reading time
       scalaJSEnsureUnforked := {
         if (fork.value)
-          sys.error("Scala.js cannot be run in a forked JVM")
+          throw new MessageOnlyException("Scala.js cannot be run in a forked JVM")
         else
           true
       },
@@ -616,7 +619,8 @@ object ScalaJSPluginInternal {
         javaOptions.value.map {
           case javaSysPropsPattern(propName, propValue) => (propName, propValue)
           case opt =>
-            sys.error("Scala.js javaOptions can only be \"-D<key>=<value>\"," +
+            throw new MessageOnlyException(
+                "Scala.js javaOptions can only be \"-D<key>=<value>\"," +
                 " but received: " + opt)
         }.toMap
       },
@@ -789,7 +793,7 @@ object ScalaJSPluginInternal {
         } else {
           Def.task {
             (mainClass in scalaJSLauncherInternal).value.fold {
-              sys.error("No main class detected.")
+              throw new MessageOnlyException("No main class detected.")
             } { mainClass =>
               val moduleKind = scalaJSModuleKind.value
               val moduleIdentifier = scalaJSModuleIdentifier.value
@@ -855,7 +859,8 @@ object ScalaJSPluginInternal {
           case jsEnv: ComJSEnv => jsEnv
 
           case jsEnv =>
-            sys.error(s"You need a ComJSEnv to test (found ${jsEnv.name})")
+            throw new MessageOnlyException(
+                s"You need a ComJSEnv to test (found ${jsEnv.name})")
         }
 
         val moduleKind = scalaJSModuleKind.value

--- a/scalalib/overrides-2.10/scala/Array.scala
+++ b/scalalib/overrides-2.10/scala/Array.scala
@@ -11,7 +11,7 @@ package scala
 import scala.collection.generic._
 import scala.collection.{ mutable, immutable }
 import mutable.{ ArrayBuilder, ArraySeq }
-import scala.compat.Platform.arraycopy
+import java.lang.System.arraycopy
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime.{ array_apply, array_update }
 

--- a/scalalib/overrides-2.10/scala/collection/immutable/RedBlackTree.scala
+++ b/scalalib/overrides-2.10/scala/collection/immutable/RedBlackTree.scala
@@ -168,7 +168,7 @@ object RedBlackTree {
     }
     def subl(t: Tree[A, B]) =
       if (t.isInstanceOf[BlackTree[_, _]]) t.red
-      else sys.error("Defect: invariance violation; expected black, got "+t)
+      else throw new IllegalStateException("Defect: invariance violation; expected black, got "+t)
 
     def balLeft(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
       RedTree(x, xv, tl.black, tr)
@@ -177,7 +177,7 @@ object RedBlackTree {
     } else if (isRedTree(tr) && isBlackTree(tr.left)) {
       RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), balance(tr.key, tr.value, tr.left.right, subl(tr.right)))
     } else {
-      sys.error("Defect: invariance violation")
+      throw new IllegalStateException("Defect: invariance violation")
     }
     def balRight(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tr)) {
       RedTree(x, xv, tl, tr.black)
@@ -186,7 +186,7 @@ object RedBlackTree {
     } else if (isRedTree(tl) && isBlackTree(tl.right)) {
       RedTree(tl.right.key, tl.right.value, balance(tl.key, tl.value, subl(tl.left), tl.right.left), BlackTree(x, xv, tl.right.right, tr))
     } else {
-      sys.error("Defect: invariance violation")
+      throw new IllegalStateException("Defect: invariance violation")
     }
     def delLeft = if (isBlackTree(tree.left)) balLeft(tree.key, tree.value, del(tree.left, k), tree.right) else RedTree(tree.key, tree.value, del(tree.left, k), tree.right)
     def delRight = if (isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, del(tree.right, k)) else RedTree(tree.key, tree.value, tree.left, del(tree.right, k))
@@ -213,7 +213,7 @@ object RedBlackTree {
     } else if (isRedTree(tl)) {
       RedTree(tl.key, tl.value, tl.left, append(tl.right, tr))
     } else {
-      sys.error("unmatched tree on append: " + tl + ", " + tr)
+      throw new IllegalStateException("unmatched tree on append: " + tl + ", " + tr)
     }
 
     val cmp = ordering.compare(k, tree.key)
@@ -334,7 +334,7 @@ object RedBlackTree {
         val leftMost = false
         (unzip(left :: leftZipper, leftMost), false, leftMost, smallerDepth)
       } else {
-        sys.error("unmatched trees in unzip: " + left + ", " + right)
+        throw new IllegalStateException("unmatched trees in unzip: " + left + ", " + right)
       }
     }
     unzipBoth(left, right, Nil, Nil, 0)
@@ -346,7 +346,7 @@ object RedBlackTree {
       case head :: tail if isBlackTree(head) =>
         if (depth == 1) zipper else findDepth(tail, depth - 1)
       case _ :: tail => findDepth(tail, depth)
-      case Nil => sys.error("Defect: unexpected empty zipper while computing range")
+      case Nil => throw new IllegalStateException("Defect: unexpected empty zipper while computing range")
     }
 
     // Blackening the smaller tree avoids balancing problems on union;

--- a/scalalib/overrides-2.10/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.10/scala/runtime/ScalaRunTime.scala
@@ -340,7 +340,7 @@ object ScalaRunTime {
     nl + s + "\n"
   }
   private[scala] def checkZip(what: String, coll1: TraversableOnce[_], coll2: TraversableOnce[_]) {
-    if (sys.props contains "scala.debug.zip") {
+    if (System.getProperty("scala.debug.zip") != null) {
       val xs = coll1.toIndexedSeq
       val ys = coll2.toIndexedSeq
       if (xs.length != ys.length) {

--- a/scalalib/overrides/scala/App.scala
+++ b/scalalib/overrides/scala/App.scala
@@ -8,7 +8,7 @@
 
 package scala
 
-import scala.compat.Platform.currentTime
+import java.lang.System.{currentTimeMillis => currentTime}
 import scala.collection.mutable.ListBuffer
 
 import scala.scalajs.js.annotation.JSExport

--- a/scalalib/overrides/scala/Array.scala
+++ b/scalalib/overrides/scala/Array.scala
@@ -11,7 +11,7 @@ package scala
 import scala.collection.generic._
 import scala.collection.{ mutable, immutable }
 import mutable.{ ArrayBuilder, ArraySeq }
-import scala.compat.Platform.arraycopy
+import java.lang.System.arraycopy
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime.{ array_apply, array_update }
 

--- a/scalalib/overrides/scala/collection/immutable/RedBlackTree.scala
+++ b/scalalib/overrides/scala/collection/immutable/RedBlackTree.scala
@@ -194,7 +194,7 @@ object RedBlackTree {
     }
     def subl(t: Tree[A, B]) =
       if (t.isInstanceOf[BlackTree[_, _]]) t.red
-      else sys.error("Defect: invariance violation; expected black, got "+t)
+      else throw new IllegalStateException("Defect: invariance violation; expected black, got "+t)
 
     def balLeft(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
       RedTree(x, xv, tl.black, tr)
@@ -203,7 +203,7 @@ object RedBlackTree {
     } else if (isRedTree(tr) && isBlackTree(tr.left)) {
       RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), balance(tr.key, tr.value, tr.left.right, subl(tr.right)))
     } else {
-      sys.error("Defect: invariance violation")
+      throw new IllegalStateException("Defect: invariance violation")
     }
     def balRight(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tr)) {
       RedTree(x, xv, tl, tr.black)
@@ -212,7 +212,7 @@ object RedBlackTree {
     } else if (isRedTree(tl) && isBlackTree(tl.right)) {
       RedTree(tl.right.key, tl.right.value, balance(tl.key, tl.value, subl(tl.left), tl.right.left), BlackTree(x, xv, tl.right.right, tr))
     } else {
-      sys.error("Defect: invariance violation")
+      throw new IllegalStateException("Defect: invariance violation")
     }
     def delLeft = if (isBlackTree(tree.left)) balLeft(tree.key, tree.value, del(tree.left, k), tree.right) else RedTree(tree.key, tree.value, del(tree.left, k), tree.right)
     def delRight = if (isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, del(tree.right, k)) else RedTree(tree.key, tree.value, tree.left, del(tree.right, k))
@@ -239,7 +239,7 @@ object RedBlackTree {
     } else if (isRedTree(tl)) {
       RedTree(tl.key, tl.value, tl.left, append(tl.right, tr))
     } else {
-      sys.error("unmatched tree on append: " + tl + ", " + tr)
+      throw new IllegalStateException("unmatched tree on append: " + tl + ", " + tr)
     }
 
     val cmp = ordering.compare(k, tree.key)
@@ -359,7 +359,7 @@ object RedBlackTree {
         val leftMost = false
         (unzip(cons(left, leftZipper), leftMost), false, leftMost, smallerDepth)
       } else {
-        sys.error("unmatched trees in unzip: " + left + ", " + right)
+        throw new IllegalStateException("unmatched trees in unzip: " + left + ", " + right)
       }
     }
     unzipBoth(left, right, null, null, 0)
@@ -370,7 +370,7 @@ object RedBlackTree {
     @tailrec
     def  findDepth(zipper: NList[Tree[A, B]], depth: Int): NList[Tree[A, B]] =
       if (zipper eq null) {
-        sys.error("Defect: unexpected empty zipper while computing range")
+        throw new IllegalStateException("Defect: unexpected empty zipper while computing range")
       } else if (isBlackTree(zipper.head)) {
         if (depth == 1) zipper else findDepth(zipper.tail, depth - 1)
       } else {

--- a/scalalib/overrides/scala/util/control/NoStackTrace.scala
+++ b/scalalib/overrides/scala/util/control/NoStackTrace.scala
@@ -29,5 +29,5 @@ object NoStackTrace {
   // two-stage init to make checkinit happy, since sys.SystemProperties.noTraceSupression.value calls back into NoStackTrace.noSuppression
   final private var _noSuppression = false
   // !!! Disabled in Scala.js because SystemProperties is not supported
-  //_noSuppression = sys.SystemProperties.noTraceSupression.value
+  //_noSuppression = System.getProperty("scala.control.noTraceSuppression", "").equalsIgnoreCase("true")
 }

--- a/test-suite/js/src/test/resources/SourceMapTestTemplate.scala
+++ b/test-suite/js/src/test/resources/SourceMapTestTemplate.scala
@@ -40,14 +40,14 @@ object SourceMapTest {
 
 class SourceMapTest {
 
-  @Test def workTest(): Unit = sys.error("stubs")
+  @Test def workTest(): Unit = ???
 
   def test(i: Int): Unit = {
     TC.testNum = i
 
     try {
       run()
-      sys.error("No exception thrown")
+      throw new AssertionError("No exception thrown")
     } catch {
       case e @ TestException(lineNo) =>
         def normFileName(e: StackTraceElement): String =

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -63,7 +63,7 @@ class OptimizerTest {
     val elements = js.Array[Int]()
     for (i <- start0 to 2 by -1) {
       if (i < 0)
-        sys.error("Going into infinite loop")
+        throw new AssertionError("Going into infinite loop")
       elements.push(i)
     }
     assertArrayEquals(Array(10, 9, 8, 7, 6, 5, 4, 3, 2), elements.toArray)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -253,7 +253,7 @@ class RegressionTest {
     assertThrows(classOf[Exception], (giveMeANull(): StringBuilder).append(5))
     assertThrows(classOf[Exception], (giveMeANull(): scala.runtime.IntRef).elem)
 
-    def giveMeANothing(): Nothing = sys.error("boom")
+    def giveMeANothing(): Nothing = throw new Exception("boom")
     assertThrows(classOf[Exception], (giveMeANothing(): StringBuilder).append(5))
     assertThrows(classOf[Exception], (giveMeANothing(): scala.runtime.IntRef).elem)
   }

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -52,7 +52,7 @@ object QuickLinker {
         }
         IRContainer.File(vf)
       } else {
-        sys.error("Illegal IR file / Jar: " + file)
+        throw new IllegalArgumentException("Illegal IR file / Jar: " + file)
       }
     }
 

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
@@ -37,7 +37,7 @@ object TestRunner {
     }
 
     if (eventHandler.hasFailed)
-      sys.error("Some tests have failed")
+      throw new AssertionError("Some tests have failed")
   }
 
   private class SimpleEventHandler extends EventHandler {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
@@ -184,7 +184,8 @@ object LinkedClass {
         classExports += e
 
       case tree =>
-        sys.error(s"Illegal tree in ClassDef of class ${tree.getClass}")
+        throw new IllegalArgumentException(
+            s"Illegal tree in ClassDef of class ${tree.getClass}")
     }
 
     val classExportInfo = memberInfoByName.get(Definitions.ClassExportsName)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingException.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingException.scala
@@ -1,0 +1,21 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+/** Thrown by the linker when linking cannot be performed. */
+class LinkingException(message: String, cause: Throwable)
+    extends Exception(message, cause) {
+
+  def this(message: String) = this(message, null)
+
+  def this(cause: Throwable) =
+    this(if (cause == null) null else cause.toString(), cause)
+
+  def this() = this(null, null)
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -163,7 +163,7 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
         }
 
         if (importsFound) {
-          sys.error(
+          throw new LinkingException(
               "There were module imports without fallback to global " +
               "variables, but module support is disabled.\n" +
               "To enable module support, set scalaJSModuleKind := " +

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -448,7 +448,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           pushLhsInto(Lhs.Assign(lhs), rhs, tailPosLabels)
 
         case Assign(_, _) =>
-          sys.error(s"Illegal Assign in transformStat: $tree")
+          throw new IllegalArgumentException(
+              s"Illegal Assign in transformStat: $tree")
 
         case StoreModule(cls, value) =>
           unnest(value) { (newValue, env0) =>
@@ -516,7 +517,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             implicit val env = env0
 
             val enclosingClassName = env.enclosingClassName.getOrElse {
-              sys.error("Need enclosing class for super constructor call.")
+              throw new AssertionError(
+                  "Need enclosing class for super constructor call.")
             }
 
             val superCtorCall = {
@@ -1624,14 +1626,16 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                   _:StoreModule | _:ClassDef =>
                 transformStat(rhs, tailPosLabels)
               case _ =>
-                sys.error("Illegal tree in JSDesugar.pushLhsInto():\n" +
-                    "lhs = " + lhs + "\n" + "rhs = " + rhs +
-                    " of class " + rhs.getClass)
+                throw new IllegalArgumentException(
+                    "Illegal tree in JSDesugar.pushLhsInto():\n" +
+                    "lhs = " + lhs + "\n" +
+                    "rhs = " + rhs + " of class " + rhs.getClass)
             }
           } else {
-            sys.error("Illegal tree in JSDesugar.pushLhsInto():\n" +
-                "lhs = " + lhs + "\n" + "rhs = " + rhs +
-                " of class " + rhs.getClass)
+            throw new IllegalArgumentException(
+                "Illegal tree in JSDesugar.pushLhsInto():\n" +
+                "lhs = " + lhs + "\n" +
+                "rhs = " + rhs + " of class " + rhs.getClass)
           }
       })
     }
@@ -2143,8 +2147,9 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
         // Invalid trees
 
         case _ =>
-          sys.error("Invalid tree in JSDesugar.transformExpr() "+
-              s"of class ${tree.getClass}")
+          throw new IllegalArgumentException(
+              "Invalid tree in JSDesugar.transformExpr() of class " +
+              tree.getClass)
       }
     }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -118,8 +118,10 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
         val infoAndTrees =
           infoInput.map(info => (info, getTree(info.encodedName)._1))
         val errorCount = InfoChecker.check(infoAndTrees, logger)
-        if (errorCount != 0)
-          sys.error(s"There were $errorCount Info checking errors.")
+        if (errorCount != 0) {
+          throw new LinkingException(
+              s"There were $errorCount Info checking errors.")
+        }
       }
     }
 
@@ -155,7 +157,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
         logger.log(linkingErrLevel, s"Not showing $skipped more linking errors")
 
       if (fatal)
-        sys.error("There were linking errors")
+        throw new LinkingException("There were linking errors")
     }
 
     val linkResult = logger.time("Linker: Assemble LinkedClasses") {
@@ -169,10 +171,13 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
       logger.time("Linker: Check IR") {
         if (linkResult.isComplete) {
           val errorCount = IRChecker.check(linkResult, logger)
-          if (errorCount != 0)
-            sys.error(s"There were $errorCount IR checking errors.")
+          if (errorCount != 0) {
+            throw new LinkingException(
+                s"There were $errorCount IR checking errors.")
+          }
         } else {
-          sys.error("Could not check IR because there were linking errors.")
+          throw new LinkingException(
+              "Could not check IR because there were linking errors.")
         }
       }
     }
@@ -502,8 +507,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
       ()
     }
 
-    if (errors.nonEmpty && !bypassLinkingErrors) {
-      sys.error("There were conflicting exports.")
-    }
+    if (errors.nonEmpty && !bypassLinkingErrors)
+      throw new LinkingException("There were conflicting exports.")
   }
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -298,7 +298,8 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
         classExports += e
 
       case tree =>
-        sys.error(s"Illegal tree in ClassDef of class ${tree.getClass}")
+        throw new IllegalArgumentException(
+            s"Illegal tree in ClassDef of class ${tree.getClass}")
     }
 
     // Synthetic members

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -673,7 +673,8 @@ private[optimizer] abstract class OptimizerCore(
         tree
 
       case _ =>
-        sys.error(s"Invalid tree in transform of class ${tree.getClass.getName}: $tree")
+        throw new IllegalArgumentException(
+            s"Invalid tree in transform of class ${tree.getClass.getName}: $tree")
     }
 
     if (isStat) keepOnlySideEffects(result)
@@ -778,17 +779,23 @@ private[optimizer] abstract class OptimizerCore(
         pretransformBlock(tree)(cont)
 
       case VarRef(Ident(name, _)) =>
-        val localDef = scope.env.localDefs.getOrElse(name,
-            sys.error(s"Cannot find local def '$name' at $pos\n" +
-                s"While optimizing $myself\n" +
-                s"Env is ${scope.env}\nInlining ${scope.implsBeingInlined}"))
+        val localDef = scope.env.localDefs.getOrElse(name, {
+          throw new AssertionError(
+              s"Cannot find local def '$name' at $pos\n" +
+              s"While optimizing $myself\n" +
+              s"Env is ${scope.env}\n" +
+              s"Inlining ${scope.implsBeingInlined}")
+        })
         cont(localDef.toPreTransform)
 
       case This() =>
-        val localDef = scope.env.localDefs.getOrElse("this",
-            sys.error(s"Found invalid 'this' at $pos\n" +
-                s"While optimizing $myself\n" +
-                s"Env is ${scope.env}\nInlining ${scope.implsBeingInlined}"))
+        val localDef = scope.env.localDefs.getOrElse("this", {
+          throw new AssertionError(
+              s"Found invalid 'this' at $pos\n" +
+              s"While optimizing $myself\n" +
+              s"Env is ${scope.env}\n" +
+              s"Inlining ${scope.implsBeingInlined}")
+        })
         cont(localDef.toPreTransform)
 
       case tree: If =>
@@ -4159,7 +4166,7 @@ private[optimizer] abstract class OptimizerCore(
         }
       }
 
-      sys.error("Reached end of infinite loop")
+      throw new AssertionError("Reached end of infinite loop")
     } finally {
       curTrampolineId -= 1
     }


### PR DESCRIPTION
Ref: #2876

This is "ideologically" a port from https://github.com/scala/scala/pull/5830, except of course it is applied on our codebase.

After these changes, we have:
```
$ git grep 'sys\.'
scalalib/overrides/scala/util/control/NoStackTrace.scala: *  [[scala.sys.SystemProperties]].
scalalib/overrides/scala/util/control/NoStackTrace.scala:  // two-stage init to make checkinit happy, since sys.SystemProperties.noTraceSupression.value calls back into NoStackTrace.noSuppression
```
i.e., only in comments of overrides, and
```
$ git grep 'scala\.compat'
scalalib/overrides-2.10/scala/compat/Platform.scala:package scala.compat
scalalib/overrides-2.10/scala/compat/Platform.scala:   *  For example, the following code `scala.compat.Platform.createArray(classOf[Int], 4)` returns an array of the java primitive type `int`.
scalalib/overrides-2.10/scala/compat/Platform.scala:   *  val a = scala.compat.Platform.createArray(classOf[Int], 4).asInstanceOf[Array[Int]] // returns Array[Int](0, 0, 0, 0)
scalalib/overrides-2.10/scala/compat/Platform.scala:   *  val a = scala.compat.Platform.getClassForName("java.lang.Integer")  // returns the Class[_] for java.lang.Integer
scalalib/overrides-2.11/scala/compat/Platform.scala:   *  For example, the following code `scala.compat.Platform.createArray(classOf[Int], 4)` returns an array of the java primitive type `int`.
scalalib/overrides-2.11/scala/compat/Platform.scala:   *  val a = scala.compat.Platform.createArray(classOf[Int], 4).asInstanceOf[Array[Int]] // returns Array[Int](0, 0, 0, 0)
scalalib/overrides-2.11/scala/compat/Platform.scala:   *  val a = scala.compat.Platform.getClassForName("java.lang.Integer")  // returns the Class[_] for java.lang.Integer
scalalib/overrides-2.12/scala/compat/Platform.scala:   *  For example, the following code `scala.compat.Platform.createArray(classOf[Int], 4)` returns an array of the java primitive type `int`.
scalalib/overrides-2.12/scala/compat/Platform.scala:   *  val a = scala.compat.Platform.createArray(classOf[Int], 4).asInstanceOf[Array[Int]] // returns Array[Int](0, 0, 0, 0)
scalalib/overrides-2.12/scala/compat/Platform.scala:   *  val a = scala.compat.Platform.getClassForName("java.lang.Integer")  // returns the Class[_] for java.lang.Integer
scalalib/overrides-2.13/scala/compat/Platform.scala:   *  For example, the following code `scala.compat.Platform.createArray(classOf[Int], 4)` returns an array of the java primitive type `int`.
scalalib/overrides-2.13/scala/compat/Platform.scala:   *  val a = scala.compat.Platform.createArray(classOf[Int], 4).asInstanceOf[Array[Int]] // returns Array[Int](0, 0, 0, 0)
scalalib/overrides-2.13/scala/compat/Platform.scala:   *  val a = scala.compat.Platform.getClassForName("java.lang.Integer")  // returns the Class[_] for java.lang.Integer
```
i.e., only in the overrides of `scala.compat.Platform` itself.