### PR TITLE
DO NOT MERGE Complete review of Linker.Config and friends

### DIFF
--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -195,12 +195,12 @@ object Scalajsld {
       val backendConfig = LinkerBackend.Config()
         .withSourceMap(options.sourceMap)
         .withRelativizeSourceMapBase(options.relativizeSourceMap)
+        .withClosureCompiler(options.fullOpt)
         .withPrettyPrint(options.prettyPrint)
 
       val config = Linker.Config()
         .withOptimizer(!options.noOpt)
         .withParallel(true)
-        .withClosureCompiler(options.fullOpt)
         .withFrontendConfig(frontendConfig)
         .withBackendConfig(backendConfig)
 

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -193,11 +193,11 @@ object Scalajsld {
         .withCheckIR(options.checkIR)
 
       val backendConfig = LinkerBackend.Config()
+        .withSourceMap(options.sourceMap)
         .withRelativizeSourceMapBase(options.relativizeSourceMap)
         .withPrettyPrint(options.prettyPrint)
 
       val config = Linker.Config()
-        .withSourceMap(options.sourceMap)
         .withOptimizer(!options.noOpt)
         .withParallel(true)
         .withClosureCompiler(options.fullOpt)

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -200,12 +200,8 @@ object Scalajsld {
         .withClosureCompiler(options.fullOpt)
         .withPrettyPrint(options.prettyPrint)
 
-      val config = Linker.Config()
-        .withFrontendConfig(frontendConfig)
-        .withBackendConfig(backendConfig)
-
       val linker = Linker(semantics, options.outputMode, options.moduleKind,
-          config)
+          frontendConfig, backendConfig)
 
       val logger = new ScalaConsoleLogger(options.logLevel)
       val outFile = WritableFileVirtualJSFile(options.output)

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -191,6 +191,8 @@ object Scalajsld {
       val frontendConfig = LinkerFrontend.Config()
         .withBypassLinkingErrorsInternal(options.bypassLinkingErrors)
         .withCheckIR(options.checkIR)
+        .withOptimizer(!options.noOpt)
+        .withParallel(true)
 
       val backendConfig = LinkerBackend.Config()
         .withSourceMap(options.sourceMap)
@@ -199,8 +201,6 @@ object Scalajsld {
         .withPrettyPrint(options.prettyPrint)
 
       val config = Linker.Config()
-        .withOptimizer(!options.noOpt)
-        .withParallel(true)
         .withFrontendConfig(frontendConfig)
         .withBackendConfig(backendConfig)
 

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -70,7 +70,7 @@ class MainGenericRunner {
       Seq(ModuleInitializer.mainMethod("PartestLauncher", "main"))
 
     val linkerConfig = Linker.Config()
-      .withSourceMap(false)
+      .withBackendConfig(_.withSourceMap(false))
       .withClosureCompiler(optMode == FullOpt)
 
     val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -71,7 +71,7 @@ class MainGenericRunner {
 
     val linkerConfig = Linker.Config()
       .withBackendConfig(_.withSourceMap(false))
-      .withClosureCompiler(optMode == FullOpt)
+      .withBackendConfig(_.withClosureCompiler(optMode == FullOpt))
 
     val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,
         ModuleKind.NoModule, linkerConfig)

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -8,7 +8,8 @@ import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.linker.{Linker, ModuleInitializer}
-import org.scalajs.core.tools.linker.backend.{OutputMode, ModuleKind}
+import org.scalajs.core.tools.linker.frontend.LinkerFrontend
+import org.scalajs.core.tools.linker.backend._
 
 import org.scalajs.core.ir
 
@@ -69,12 +70,14 @@ class MainGenericRunner {
     val moduleInitializers =
       Seq(ModuleInitializer.mainMethod("PartestLauncher", "main"))
 
-    val linkerConfig = Linker.Config()
-      .withBackendConfig(_.withSourceMap(false))
-      .withBackendConfig(_.withClosureCompiler(optMode == FullOpt))
+    val frontendConfig = LinkerFrontend.Config()
+
+    val backendConfig = LinkerBackend.Config()
+      .withSourceMap(false)
+      .withClosureCompiler(optMode == FullOpt)
 
     val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,
-        ModuleKind.NoModule, linkerConfig)
+        ModuleKind.NoModule, frontendConfig, backendConfig)
 
     val sjsCode = {
       val output = WritableMemVirtualJSFile("partest.js")

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -12,6 +12,10 @@ object BinaryIncompatibilities {
 
       // private, not an issue
       ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.LinkerFrontend#Config.this"),
+
+      // private, not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.LinkerBackend#Config.this"),
 
       // private[optimizer], not an issue

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,17 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.Linker#Config.this"),
+
+      // private, not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.LinkerBackend#Config.this"),
+
+      // private[optimizer], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.GenIncOptimizer.this")
   )
 
   val JSEnvs = Seq(

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -194,12 +194,12 @@ object ScalaJSPluginInternal {
           .withSourceMap(withSourceMap)
           .withRelativizeSourceMapBase(relSourceMapBase)
           .withCustomOutputWrapperInternal(scalaJSOutputWrapperInternal.value)
+          .withClosureCompiler(opts.useClosureCompiler)
           .withPrettyPrint(opts.prettyPrintFullOptJS)
 
         val config = Linker.Config()
           .withOptimizer(!opts.disableOptimizer)
           .withParallel(opts.parallel)
-          .withClosureCompiler(opts.useClosureCompiler)
           .withFrontendConfig(frontendConfig)
           .withBackendConfig(backendConfig)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -199,12 +199,9 @@ object ScalaJSPluginInternal {
           .withClosureCompiler(opts.useClosureCompiler)
           .withPrettyPrint(opts.prettyPrintFullOptJS)
 
-        val config = Linker.Config()
-          .withFrontendConfig(frontendConfig)
-          .withBackendConfig(backendConfig)
-
         val newLinker = { () =>
-          Linker(semantics, outputMode, moduleKind, config)
+          Linker(semantics, outputMode, moduleKind, frontendConfig,
+              backendConfig)
         }
 
         new ClearableLinker(newLinker, opts.batchMode)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -189,6 +189,8 @@ object ScalaJSPluginInternal {
         val frontendConfig = LinkerFrontend.Config()
           .withBypassLinkingErrorsInternal(opts.bypassLinkingErrors)
           .withCheckIR(opts.checkScalaJSIR)
+          .withOptimizer(!opts.disableOptimizer)
+          .withParallel(opts.parallel)
 
         val backendConfig = LinkerBackend.Config()
           .withSourceMap(withSourceMap)
@@ -198,8 +200,6 @@ object ScalaJSPluginInternal {
           .withPrettyPrint(opts.prettyPrintFullOptJS)
 
         val config = Linker.Config()
-          .withOptimizer(!opts.disableOptimizer)
-          .withParallel(opts.parallel)
           .withFrontendConfig(frontendConfig)
           .withBackendConfig(backendConfig)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -191,12 +191,12 @@ object ScalaJSPluginInternal {
           .withCheckIR(opts.checkScalaJSIR)
 
         val backendConfig = LinkerBackend.Config()
+          .withSourceMap(withSourceMap)
           .withRelativizeSourceMapBase(relSourceMapBase)
           .withCustomOutputWrapperInternal(scalaJSOutputWrapperInternal.value)
           .withPrettyPrint(opts.prettyPrintFullOptJS)
 
         val config = Linker.Config()
-          .withSourceMap(withSourceMap)
           .withOptimizer(!opts.disableOptimizer)
           .withParallel(opts.parallel)
           .withClosureCompiler(opts.useClosureCompiler)

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -25,7 +25,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
     }
 
     val frontend = new LinkerFrontend(semantics, outputMode.esLevel,
-        config.sourceMap, config.frontendConfig, optOptimizerFactory)
+        config.frontendConfig, optOptimizerFactory)
 
     val backend = new BasicLinkerBackend(semantics, outputMode, moduleKind,
         config.sourceMap, config.backendConfig)

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -16,6 +16,8 @@ import org.scalajs.core.tools.linker.frontend.optimizer.IncOptimizer
 import org.scalajs.core.tools.linker.backend._
 
 trait LinkerPlatformExtensions { this: Linker.type =>
+  @deprecated("Use the overload with frontendConfig and backendConfig.",
+      "0.6.17")
   def apply(semantics: Semantics, outputMode: OutputMode,
       moduleKind: ModuleKind, config: Config): Linker = {
 
@@ -50,6 +52,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
 object LinkerPlatformExtensions {
   import Linker.Config
 
+  @deprecated("Use LinkerFrontend.Config and LinkerBackend.Config.", "0.6.17")
   final class ConfigExt(val config: Config) extends AnyVal {
     /** Whether to actually use the Google Closure Compiler pass.
      *

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -19,13 +19,8 @@ trait LinkerPlatformExtensions { this: Linker.type =>
   def apply(semantics: Semantics, outputMode: OutputMode,
       moduleKind: ModuleKind, config: Config): Linker = {
 
-    val optOptimizerFactory = {
-      if (!config.optimizer) None
-      else Some(IncOptimizer.factory)
-    }
-
-    val frontend = new LinkerFrontend(semantics, outputMode.esLevel,
-        config.frontendConfig, optOptimizerFactory)
+    val frontend = LinkerFrontend(semantics, outputMode.esLevel,
+        config.frontendConfig)
 
     val backend = LinkerBackend(semantics, outputMode, moduleKind,
         config.backendConfig)

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -28,7 +28,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
         config.frontendConfig, optOptimizerFactory)
 
     val backend = new BasicLinkerBackend(semantics, outputMode, moduleKind,
-        config.sourceMap, config.backendConfig)
+        config.backendConfig)
 
     new Linker(frontend, backend)
   }

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -27,7 +27,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
     val frontend = new LinkerFrontend(semantics, outputMode.esLevel,
         config.frontendConfig, optOptimizerFactory)
 
-    val backend = new BasicLinkerBackend(semantics, outputMode, moduleKind,
+    val backend = LinkerBackend(semantics, outputMode, moduleKind,
         config.backendConfig)
 
     new Linker(frontend, backend)
@@ -61,6 +61,7 @@ object LinkerPlatformExtensions {
      *  On the JavaScript platform, this always returns `false`, as GCC is not
      *  available.
      */
+    @deprecated("Use config.backendConfig.closureCompiler.", "0.6.17")
     def closureCompiler: Boolean = false
   }
 }

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackendPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackendPlatformExtensions.scala
@@ -1,0 +1,32 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker.backend
+
+import org.scalajs.core.tools.sem.Semantics
+
+trait LinkerBackendPlatformExtensions { this: LinkerBackend.type =>
+  def apply(semantics: Semantics, outputMode: OutputMode,
+      moduleKind: ModuleKind, config: Config): LinkerBackend = {
+
+    new BasicLinkerBackend(semantics, outputMode, moduleKind, config)
+  }
+}
+
+object LinkerBackendPlatformExtensions {
+  import LinkerBackend.Config
+
+  final class ConfigExt(val config: Config) extends AnyVal {
+    /** Whether to actually use the Google Closure Compiler pass.
+     *
+     *  On the JavaScript platform, this always returns `false`, as GCC is not
+     *  available.
+     */
+    def closureCompiler: Boolean = false
+  }
+}

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontendPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontendPlatformExtensions.scala
@@ -1,0 +1,26 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker.frontend
+
+import org.scalajs.core.tools.javascript.ESLevel
+import org.scalajs.core.tools.sem.Semantics
+import org.scalajs.core.tools.linker.frontend.optimizer.IncOptimizer
+
+trait LinkerFrontendPlatformExtensions { this: LinkerFrontend.type =>
+  def apply(semantics: Semantics, esLevel: ESLevel,
+      config: Config): LinkerFrontend = {
+
+    val optOptimizerFactory = {
+      if (!config.optimizer) None
+      else Some(IncOptimizer.factory)
+    }
+
+    new LinkerFrontend(semantics, esLevel, config, optOptimizerFactory)
+  }
+}

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -4,7 +4,8 @@ import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
 import org.scalajs.core.tools.linker.{ModuleInitializer, Linker}
-import org.scalajs.core.tools.linker.backend.{OutputMode, ModuleKind}
+import org.scalajs.core.tools.linker.frontend.LinkerFrontend
+import org.scalajs.core.tools.linker.backend._
 import org.scalajs.core.tools.logging._
 
 import scala.scalajs.js
@@ -39,7 +40,7 @@ object QuickLinker {
     val cache = (new IRFileCache).newCache
 
     val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,
-        ModuleKind.NoModule, Linker.Config())
+        ModuleKind.NoModule, LinkerFrontend.Config(), LinkerBackend.Config())
 
     val irContainers = irFilesAndJars.map { file =>
       if (file.endsWith(".jar")) {

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -17,6 +17,8 @@ import org.scalajs.core.tools.linker.backend._
 import org.scalajs.core.tools.linker.backend.closure.ClosureLinkerBackend
 
 trait LinkerPlatformExtensions { this: Linker.type =>
+  @deprecated("Use the overload with frontendConfig and backendConfig.",
+      "0.6.17")
   def apply(semantics: Semantics, outputMode: OutputMode,
       moduleKind: ModuleKind, config: Config): Linker = {
 
@@ -55,6 +57,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
 object LinkerPlatformExtensions {
   import Linker.Config
 
+  @deprecated("Use LinkerFrontend.Config and LinkerBackend.Config.", "0.6.17")
   final class ConfigExt(val config: Config) extends AnyVal {
     /** Whether to actually use the Google Closure Compiler pass. */
     @deprecated("Use config.backendConfig.closureCompiler.", "0.6.17")

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -33,11 +33,10 @@ trait LinkerPlatformExtensions { this: Linker.type =>
       if (config.closureCompiler) {
         require(outputMode == OutputMode.ECMAScript51Isolated,
             s"Cannot use output mode $outputMode with the Closure Compiler")
-        new ClosureLinkerBackend(semantics, moduleKind,
-            config.sourceMap, config.backendConfig)
+        new ClosureLinkerBackend(semantics, moduleKind, config.backendConfig)
       } else {
         new BasicLinkerBackend(semantics, outputMode, moduleKind,
-            config.sourceMap, config.backendConfig)
+            config.backendConfig)
       }
     }
 

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -20,14 +20,8 @@ trait LinkerPlatformExtensions { this: Linker.type =>
   def apply(semantics: Semantics, outputMode: OutputMode,
       moduleKind: ModuleKind, config: Config): Linker = {
 
-    val optOptimizerFactory = {
-      if (!config.optimizer) None
-      else if (config.parallel) Some(ParIncOptimizer.factory)
-      else Some(IncOptimizer.factory)
-    }
-
-    val frontend = new LinkerFrontend(semantics, outputMode.esLevel,
-        config.frontendConfig, optOptimizerFactory)
+    val frontend = LinkerFrontend(semantics, outputMode.esLevel,
+        config.frontendConfig)
 
     val backend = LinkerBackend(semantics, outputMode, moduleKind,
         config.backendConfig)

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -27,7 +27,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
     }
 
     val frontend = new LinkerFrontend(semantics, outputMode.esLevel,
-        config.sourceMap, config.frontendConfig, optOptimizerFactory)
+        config.frontendConfig, optOptimizerFactory)
 
     val backend = {
       if (config.closureCompiler) {

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -29,16 +29,8 @@ trait LinkerPlatformExtensions { this: Linker.type =>
     val frontend = new LinkerFrontend(semantics, outputMode.esLevel,
         config.frontendConfig, optOptimizerFactory)
 
-    val backend = {
-      if (config.closureCompiler) {
-        require(outputMode == OutputMode.ECMAScript51Isolated,
-            s"Cannot use output mode $outputMode with the Closure Compiler")
-        new ClosureLinkerBackend(semantics, moduleKind, config.backendConfig)
-      } else {
-        new BasicLinkerBackend(semantics, outputMode, moduleKind,
-            config.backendConfig)
-      }
-    }
+    val backend = LinkerBackend(semantics, outputMode, moduleKind,
+        config.backendConfig)
 
     new Linker(frontend, backend)
   }
@@ -71,9 +63,13 @@ object LinkerPlatformExtensions {
 
   final class ConfigExt(val config: Config) extends AnyVal {
     /** Whether to actually use the Google Closure Compiler pass. */
-    def closureCompiler: Boolean = config.closureCompilerIfAvailable
+    @deprecated("Use config.backendConfig.closureCompiler.", "0.6.17")
+    def closureCompiler: Boolean = config.backendConfig.closureCompiler
 
+    @deprecated(
+        "Use config.withBackendConfig(_.withClosureCompiler(...)).",
+        "0.6.17")
     def withClosureCompiler(closureCompiler: Boolean): Config =
-      config.withClosureCompilerIfAvailable(closureCompiler)
+      config.withBackendConfig(_.withClosureCompiler(closureCompiler))
   }
 }

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackendPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackendPlatformExtensions.scala
@@ -1,0 +1,39 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker.backend
+
+import org.scalajs.core.tools.sem.Semantics
+
+import org.scalajs.core.tools.linker.backend.closure.ClosureLinkerBackend
+
+trait LinkerBackendPlatformExtensions { this: LinkerBackend.type =>
+  def apply(semantics: Semantics, outputMode: OutputMode,
+      moduleKind: ModuleKind, config: Config): LinkerBackend = {
+
+    if (config.closureCompiler) {
+      require(outputMode == OutputMode.ECMAScript51Isolated,
+          s"Cannot use output mode $outputMode with the Closure Compiler")
+      new ClosureLinkerBackend(semantics, moduleKind, config)
+    } else {
+      new BasicLinkerBackend(semantics, outputMode, moduleKind, config)
+    }
+  }
+}
+
+object LinkerBackendPlatformExtensions {
+  import LinkerBackend.Config
+
+  final class ConfigExt(val config: Config) extends AnyVal {
+    /** Whether to actually use the Google Closure Compiler pass. */
+    def closureCompiler: Boolean = config.closureCompilerIfAvailable
+
+    def withClosureCompiler(closureCompiler: Boolean): Config =
+      config.withClosureCompilerIfAvailable(closureCompiler)
+  }
+}

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
@@ -36,10 +36,17 @@ import org.scalajs.core.tools.linker.backend.emitter.{Emitter, CoreJSLibs}
 final class ClosureLinkerBackend(
     semantics: Semantics,
     moduleKind: ModuleKind,
-    withSourceMap: Boolean,
     config: LinkerBackend.Config
-) extends LinkerBackend(semantics, ESLevel.ES5, moduleKind, withSourceMap,
-    config) {
+) extends LinkerBackend(semantics, ESLevel.ES5, moduleKind, config) {
+
+  @deprecated(
+      "Use the overload without 'withSourceMap'. " +
+      "The parameter can be configured in the 'config'.",
+      "0.6.17")
+  def this(semantics: Semantics, moduleKind: ModuleKind,
+      withSourceMap: Boolean, config: LinkerBackend.Config) = {
+    this(semantics, moduleKind, config.withSourceMap(withSourceMap))
+  }
 
   @deprecated("Use the overload with an explicit ModuleKind", "0.6.13")
   def this(semantics: Semantics, withSourceMap: Boolean,
@@ -182,7 +189,7 @@ final class ClosureLinkerBackend(
     options.setLanguageIn(ClosureOptions.LanguageMode.ECMASCRIPT5)
     options.setCheckGlobalThisLevel(CheckLevel.OFF)
 
-    if (withSourceMap) {
+    if (config.sourceMap) {
       options.setSourceMapOutputPath(outputName + ".map")
       options.setSourceMapDetailLevel(SourceMap.DetailLevel.ALL)
     }

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontendPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontendPlatformExtensions.scala
@@ -1,0 +1,27 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker.frontend
+
+import org.scalajs.core.tools.javascript.ESLevel
+import org.scalajs.core.tools.sem.Semantics
+import org.scalajs.core.tools.linker.frontend.optimizer.{ParIncOptimizer, IncOptimizer}
+
+trait LinkerFrontendPlatformExtensions { this: LinkerFrontend.type =>
+  def apply(semantics: Semantics, esLevel: ESLevel,
+      config: Config): LinkerFrontend = {
+
+    val optOptimizerFactory = {
+      if (!config.optimizer) None
+      else if (config.parallel) Some(ParIncOptimizer.factory)
+      else Some(IncOptimizer.factory)
+    }
+
+    new LinkerFrontend(semantics, esLevel, config, optOptimizerFactory)
+  }
+}

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/ParIncOptimizer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/ParIncOptimizer.scala
@@ -21,9 +21,15 @@ import org.scalajs.core.tools.javascript.ESLevel
 
 import ConcurrencyUtils._
 
-final class ParIncOptimizer(semantics: Semantics, esLevel: ESLevel,
-    considerPositions: Boolean)
-    extends GenIncOptimizer(semantics, esLevel, considerPositions) {
+final class ParIncOptimizer(semantics: Semantics, esLevel: ESLevel)
+    extends GenIncOptimizer(semantics, esLevel) {
+
+  @deprecated(
+      "The considerPositions parameter is ignored." +
+      "Use the overload without it.",
+      "0.6.17")
+  def this(semantics: Semantics, esLevel: ESLevel, considerPositions: Boolean) =
+    this(semantics, esLevel)
 
   private[optimizer] object CollOps extends GenIncOptimizer.AbsCollOps {
     type Map[K, V] = TrieMap[K, V]
@@ -202,5 +208,6 @@ final class ParIncOptimizer(semantics: Semantics, esLevel: ESLevel,
 }
 
 object ParIncOptimizer {
-  val factory: GenIncOptimizer.OptimizerFactory = new ParIncOptimizer(_, _, _)
+  val factory: GenIncOptimizer.OptimizerFactory =
+    (semantics, esLevel, _) => new ParIncOptimizer(semantics, esLevel)
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
@@ -27,8 +27,6 @@ import org.scalajs.core.tools.linker.backend.{LinkerBackend, BasicLinkerBackend}
 final class Linker(frontend: LinkerFrontend, backend: LinkerBackend)
     extends GenLinker {
 
-  require(!backend.withSourceMap || frontend.withSourceMap,
-      "Frontend must have source maps enabled if backend has them enabled")
   require(frontend.semantics == backend.semantics,
       "Frontend and backend must agree on semantics")
   require(frontend.esLevel == backend.esLevel,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
@@ -21,7 +21,7 @@ import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.frontend.optimizer.IncOptimizer
-import org.scalajs.core.tools.linker.backend.{LinkerBackend, BasicLinkerBackend}
+import org.scalajs.core.tools.linker.backend._
 
 /** The Scala.js linker */
 final class Linker(frontend: LinkerFrontend, backend: LinkerBackend)
@@ -77,7 +77,19 @@ final class Linker(frontend: LinkerFrontend, backend: LinkerBackend)
 }
 
 object Linker extends LinkerPlatformExtensions {
+  def apply(semantics: Semantics, outputMode: OutputMode,
+      moduleKind: ModuleKind, frontendConfig: LinkerFrontend.Config,
+      backendConfig: LinkerBackend.Config): Linker = {
+
+    val frontend = LinkerFrontend(semantics, outputMode.esLevel,
+        frontendConfig)
+    val backend = LinkerBackend(semantics, outputMode, moduleKind,
+        backendConfig)
+    new Linker(frontend, backend)
+  }
+
   /** Configuration to be passed to the `apply()` method. */
+  @deprecated("Use LinkerFrontend.Config and LinkerBackend.Config.", "0.6.17")
   final class Config private (
       /** Additional configuration for the linker frontend. */
       val frontendConfig: LinkerFrontend.Config,
@@ -139,6 +151,7 @@ object Linker extends LinkerPlatformExtensions {
     }
   }
 
+  @deprecated("Use LinkerFrontend.Config and LinkerBackend.Config.", "0.6.17")
   object Config {
     import LinkerPlatformExtensions._
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
@@ -79,8 +79,6 @@ final class Linker(frontend: LinkerFrontend, backend: LinkerBackend)
 object Linker extends LinkerPlatformExtensions {
   /** Configuration to be passed to the `apply()` method. */
   final class Config private (
-      /** Whether to generate source maps. */
-      val sourceMap: Boolean,
       /** Whether to use the Scala.js optimizer. */
       val optimizer: Boolean,
       /** Whether things that can be parallelized should be parallelized.
@@ -96,8 +94,13 @@ object Linker extends LinkerPlatformExtensions {
       /** Additional configuration for the linker backend. */
       val backendConfig: LinkerBackend.Config
   ) {
+    @deprecated("Use config.backendConfig.sourceMap.", "0.6.17")
+    val sourceMap: Boolean = backendConfig.sourceMap
+
+    @deprecated("Use config.withBackendConfig(_.withSourceMap(sourceMap)).",
+        "0.6.17")
     def withSourceMap(sourceMap: Boolean): Config =
-      copy(sourceMap = sourceMap)
+      withBackendConfig(_.withSourceMap(sourceMap))
 
     def withOptimizer(optimizer: Boolean): Config =
       copy(optimizer = optimizer)
@@ -111,18 +114,22 @@ object Linker extends LinkerPlatformExtensions {
     def withFrontendConfig(frontendConfig: LinkerFrontend.Config): Config =
       copy(frontendConfig = frontendConfig)
 
+    def withFrontendConfig(f: LinkerFrontend.Config => LinkerFrontend.Config): Config =
+      copy(frontendConfig = f(frontendConfig))
+
     def withBackendConfig(backendConfig: LinkerBackend.Config): Config =
       copy(backendConfig = backendConfig)
 
+    def withBackendConfig(f: LinkerBackend.Config => LinkerBackend.Config): Config =
+      copy(backendConfig = f(backendConfig))
+
     private def copy(
-        sourceMap: Boolean = sourceMap,
         optimizer: Boolean = optimizer,
         parallel: Boolean = parallel,
         closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
         frontendConfig: LinkerFrontend.Config = frontendConfig,
         backendConfig: LinkerBackend.Config = backendConfig): Config = {
       new Config(
-          sourceMap = sourceMap,
           optimizer = optimizer,
           parallel = parallel,
           closureCompilerIfAvailable = closureCompilerIfAvailable,
@@ -139,7 +146,6 @@ object Linker extends LinkerPlatformExtensions {
 
     /** Default configuration.
      *
-     *  - `sourceMap`: true
      *  - `optimizer`: true
      *  - `parallel`: true
      *  - `closureCompilerIfAvailable`: false
@@ -150,7 +156,6 @@ object Linker extends LinkerPlatformExtensions {
      */
     def apply(): Config = {
       new Config(
-          sourceMap = true,
           optimizer = true,
           parallel = true,
           closureCompilerIfAvailable = false,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
@@ -85,10 +85,6 @@ object Linker extends LinkerPlatformExtensions {
        *  On the JavaScript platform, this does not have any effect.
        */
       val parallel: Boolean,
-      /** Whether to use the Google Closure Compiler pass, if it is available.
-       *  On the JavaScript platform, this does not have any effect.
-       */
-      val closureCompilerIfAvailable: Boolean,
       /** Additional configuration for the linker frontend. */
       val frontendConfig: LinkerFrontend.Config,
       /** Additional configuration for the linker backend. */
@@ -96,6 +92,10 @@ object Linker extends LinkerPlatformExtensions {
   ) {
     @deprecated("Use config.backendConfig.sourceMap.", "0.6.17")
     val sourceMap: Boolean = backendConfig.sourceMap
+
+    @deprecated("Use config.backendConfig.closureCompilerIfAvailable.",
+        "0.6.17")
+    val closureCompilerIfAvailable = backendConfig.closureCompilerIfAvailable
 
     @deprecated("Use config.withBackendConfig(_.withSourceMap(sourceMap)).",
         "0.6.17")
@@ -108,8 +108,11 @@ object Linker extends LinkerPlatformExtensions {
     def withParallel(parallel: Boolean): Config =
       copy(parallel = parallel)
 
+    @deprecated(
+        "Use config.withBackendConfig(_.withClosureCompilerIfAvailable(...)).",
+        "0.6.17")
     def withClosureCompilerIfAvailable(closureCompilerIfAvailable: Boolean): Config =
-      copy(closureCompilerIfAvailable = closureCompilerIfAvailable)
+      withBackendConfig(_.withClosureCompilerIfAvailable(closureCompilerIfAvailable))
 
     def withFrontendConfig(frontendConfig: LinkerFrontend.Config): Config =
       copy(frontendConfig = frontendConfig)
@@ -126,13 +129,11 @@ object Linker extends LinkerPlatformExtensions {
     private def copy(
         optimizer: Boolean = optimizer,
         parallel: Boolean = parallel,
-        closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
         frontendConfig: LinkerFrontend.Config = frontendConfig,
         backendConfig: LinkerBackend.Config = backendConfig): Config = {
       new Config(
           optimizer = optimizer,
           parallel = parallel,
-          closureCompilerIfAvailable = closureCompilerIfAvailable,
           frontendConfig = frontendConfig,
           backendConfig = backendConfig)
     }
@@ -148,7 +149,6 @@ object Linker extends LinkerPlatformExtensions {
      *
      *  - `optimizer`: true
      *  - `parallel`: true
-     *  - `closureCompilerIfAvailable`: false
      *  - `frontendConfig`: default frontend configuration as returned by
      *    [[org.scalajs.core.tools.linker.frontend.LinkerFrontend.Config.apply]]
      *  - `backendConfig`: default backend configuration as returned by
@@ -158,7 +158,6 @@ object Linker extends LinkerPlatformExtensions {
       new Config(
           optimizer = true,
           parallel = true,
-          closureCompilerIfAvailable = false,
           frontendConfig = LinkerFrontend.Config(),
           backendConfig = LinkerBackend.Config())
     }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
@@ -79,17 +79,17 @@ final class Linker(frontend: LinkerFrontend, backend: LinkerBackend)
 object Linker extends LinkerPlatformExtensions {
   /** Configuration to be passed to the `apply()` method. */
   final class Config private (
-      /** Whether to use the Scala.js optimizer. */
-      val optimizer: Boolean,
-      /** Whether things that can be parallelized should be parallelized.
-       *  On the JavaScript platform, this does not have any effect.
-       */
-      val parallel: Boolean,
       /** Additional configuration for the linker frontend. */
       val frontendConfig: LinkerFrontend.Config,
       /** Additional configuration for the linker backend. */
       val backendConfig: LinkerBackend.Config
   ) {
+    @deprecated("Use config.frontendConfig.optimizer.", "0.6.17")
+    val optimizer: Boolean = frontendConfig.optimizer
+
+    @deprecated("Use config.frontendConfig.parallel.", "0.6.17")
+    val parallel: Boolean = frontendConfig.parallel
+
     @deprecated("Use config.backendConfig.sourceMap.", "0.6.17")
     val sourceMap: Boolean = backendConfig.sourceMap
 
@@ -102,11 +102,15 @@ object Linker extends LinkerPlatformExtensions {
     def withSourceMap(sourceMap: Boolean): Config =
       withBackendConfig(_.withSourceMap(sourceMap))
 
+    @deprecated("Use config.withFrontendConfig(_.withOptimizer(optimizer)).",
+        "0.6.17")
     def withOptimizer(optimizer: Boolean): Config =
-      copy(optimizer = optimizer)
+      withFrontendConfig(_.withOptimizer(optimizer))
 
+    @deprecated("Use config.withFrontendConfig(_.withParallel(parallel)).",
+        "0.6.17")
     def withParallel(parallel: Boolean): Config =
-      copy(parallel = parallel)
+      withFrontendConfig(_.withParallel(parallel))
 
     @deprecated(
         "Use config.withBackendConfig(_.withClosureCompilerIfAvailable(...)).",
@@ -127,13 +131,9 @@ object Linker extends LinkerPlatformExtensions {
       copy(backendConfig = f(backendConfig))
 
     private def copy(
-        optimizer: Boolean = optimizer,
-        parallel: Boolean = parallel,
         frontendConfig: LinkerFrontend.Config = frontendConfig,
         backendConfig: LinkerBackend.Config = backendConfig): Config = {
       new Config(
-          optimizer = optimizer,
-          parallel = parallel,
           frontendConfig = frontendConfig,
           backendConfig = backendConfig)
     }
@@ -147,8 +147,6 @@ object Linker extends LinkerPlatformExtensions {
 
     /** Default configuration.
      *
-     *  - `optimizer`: true
-     *  - `parallel`: true
      *  - `frontendConfig`: default frontend configuration as returned by
      *    [[org.scalajs.core.tools.linker.frontend.LinkerFrontend.Config.apply]]
      *  - `backendConfig`: default backend configuration as returned by
@@ -156,8 +154,6 @@ object Linker extends LinkerPlatformExtensions {
      */
     def apply(): Config = {
       new Config(
-          optimizer = true,
-          parallel = true,
           frontendConfig = LinkerFrontend.Config(),
           backendConfig = LinkerBackend.Config())
     }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala
@@ -25,10 +25,17 @@ final class BasicLinkerBackend(
     semantics: Semantics,
     outputMode: OutputMode,
     moduleKind: ModuleKind,
-    withSourceMap: Boolean,
     config: LinkerBackend.Config
-) extends LinkerBackend(semantics, outputMode.esLevel, moduleKind,
-    withSourceMap, config) {
+) extends LinkerBackend(semantics, outputMode.esLevel, moduleKind, config) {
+
+  @deprecated(
+      "Use the overload without 'withSourceMap'. " +
+      "The parameter can be configured in the 'config'.",
+      "0.6.17")
+  def this(semantics: Semantics, outputMode: OutputMode, moduleKind: ModuleKind,
+      withSourceMap: Boolean, config: LinkerBackend.Config) = {
+    this(semantics, outputMode, moduleKind, config.withSourceMap(withSourceMap))
+  }
 
   @deprecated("Use the overload with an explicit ModuleKind", "0.6.13")
   def this(semantics: Semantics, outputMode: OutputMode, withSourceMap: Boolean,
@@ -66,7 +73,7 @@ final class BasicLinkerBackend(
   }
 
   private def newBuilder(output: WritableVirtualJSFile): JSFileBuilder = {
-    if (withSourceMap) {
+    if (config.sourceMap) {
       new JSFileBuilderWithSourceMap(output.name, output.contentWriter,
           output.sourceMapWriter, config.relativizeSourceMapBase)
     } else {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala
@@ -29,14 +29,25 @@ abstract class LinkerBackend(
     val semantics: Semantics,
     val esLevel: ESLevel,
     val moduleKind: ModuleKind,
-    val withSourceMap: Boolean,
     protected val config: LinkerBackend.Config) {
+
+  @deprecated(
+      "Use the overload without 'withSourceMap'. " +
+      "The parameter can be configured in the 'config'.",
+      "0.6.17")
+  def this(semantics: Semantics, esLevel: ESLevel, moduleKind: ModuleKind,
+      withSourceMap: Boolean, config: LinkerBackend.Config) = {
+    this(semantics, esLevel, moduleKind, config.withSourceMap(withSourceMap))
+  }
 
   @deprecated("Use the overload with an explicit ModuleKind", "0.6.13")
   def this(semantics: Semantics, esLevel: ESLevel, withSourceMap: Boolean,
       config: LinkerBackend.Config) {
     this(semantics, esLevel, ModuleKind.NoModule, withSourceMap, config)
   }
+
+  @deprecated("Use config.sourceMap.", "0.6.17")
+  val withSourceMap: Boolean = config.sourceMap
 
   /** Symbols this backend needs to be present in the linking unit. */
   val symbolRequirements: SymbolRequirement
@@ -67,6 +78,8 @@ abstract class LinkerBackend(
 object LinkerBackend {
   /** Configurations relevant to the backend */
   final class Config private (
+      /** Whether to emit a source map. */
+      val sourceMap: Boolean = true,
       /** Base path to relativize paths in the source map. */
       val relativizeSourceMapBase: Option[URI] = None,
       /** Custom js code that wraps the output */
@@ -74,6 +87,9 @@ object LinkerBackend {
       /** Pretty-print the output. */
       val prettyPrint: Boolean = false
   ) {
+    def withSourceMap(sourceMap: Boolean): Config =
+      copy(sourceMap = sourceMap)
+
     def withRelativizeSourceMapBase(relativizeSourceMapBase: Option[URI]): Config =
       copy(relativizeSourceMapBase = relativizeSourceMapBase)
 
@@ -95,10 +111,12 @@ object LinkerBackend {
       copy(prettyPrint = prettyPrint)
 
     private def copy(
+        sourceMap: Boolean = sourceMap,
         relativizeSourceMapBase: Option[URI] = relativizeSourceMapBase,
         customOutputWrapper: (String, String) = customOutputWrapper,
         prettyPrint: Boolean = prettyPrint): Config = {
-      new Config(relativizeSourceMapBase, customOutputWrapper, prettyPrint)
+      new Config(sourceMap, relativizeSourceMapBase, customOutputWrapper,
+          prettyPrint)
     }
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -37,8 +37,14 @@ import Analysis._
 /** Links the information from [[io.VirtualScalaJSIRFile]]s into
  *  [[LinkedClass]]es. Does a dead code elimination pass.
  */
-final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
-    considerPositions: Boolean) {
+final class BaseLinker(semantics: Semantics, esLevel: ESLevel) {
+
+  @deprecated(
+      "The considerPositions parameter is ignored. " +
+      "Use the overload without it.",
+      "0.6.17")
+  def this(semantics: Semantics, esLevel: ESLevel, considerPositions: Boolean) =
+    this(semantics, esLevel)
 
   private type TreeProvider = String => (ClassDef, Option[String])
 
@@ -232,7 +238,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
 
     def linkedMethod(m: MethodDef) = {
       val info = memberInfoByStaticAndName((m.static, m.name.encodedName))
-      val version = m.hash.map(Hashers.hashAsVersion(_, considerPositions))
+      val version = m.hash.map(Hashers.hashAsVersion(_, considerPos = true))
       new LinkedMember(info, m, version)
     }
 
@@ -243,7 +249,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
 
     def linkedSyntheticMethod(m: MethodDef) = {
       val info = Infos.generateMethodInfo(m)
-      val version = m.hash.map(Hashers.hashAsVersion(_, considerPositions))
+      val version = m.hash.map(Hashers.hashAsVersion(_, considerPos = true))
       new LinkedMember(info, m, version)
     }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontend.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontend.scala
@@ -30,15 +30,27 @@ import org.scalajs.core.tools.linker.frontend.optimizer.{GenIncOptimizer, IncOpt
 final class LinkerFrontend(
     val semantics: Semantics,
     val esLevel: ESLevel,
-    val withSourceMap: Boolean,
     config: LinkerFrontend.Config,
     optimizerFactory: Option[GenIncOptimizer.OptimizerFactory]) {
 
+  @deprecated(
+      "The withSourceMap parameter is ignored. " +
+      "Use the overload without it.",
+      "0.6.17")
+  def this(semantics: Semantics, esLevel: ESLevel, withSourceMap: Boolean,
+      config: LinkerFrontend.Config,
+      optimizerFactory: Option[GenIncOptimizer.OptimizerFactory]) = {
+    this(semantics, esLevel, config, optimizerFactory)
+  }
+
+  @deprecated("withSourceMap is always true", "0.6.17")
+  val withSourceMap: Boolean = true
+
   private[this] val linker: BaseLinker =
-    new BaseLinker(semantics, esLevel, withSourceMap)
+    new BaseLinker(semantics, esLevel)
 
   private[this] val optOptimizer: Option[GenIncOptimizer] =
-    optimizerFactory.map(_(semantics, esLevel, withSourceMap))
+    optimizerFactory.map(_(semantics, esLevel, true))
 
   private[this] val refiner: Refiner = new Refiner
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -38,11 +38,9 @@ import org.scalajs.core.tools.linker.backend.emitter.LongImpl
  *
  *  @param semantics Required Scala.js Semantics
  *  @param esLevel ECMAScript level
- *  @param considerPositions Should positions be considered when comparing tree
- *                           hashes
  */
 abstract class GenIncOptimizer private[optimizer] (semantics: Semantics,
-    esLevel: ESLevel, considerPositions: Boolean) {
+    esLevel: ESLevel) {
 
   import GenIncOptimizer._
 
@@ -904,7 +902,7 @@ abstract class GenIncOptimizer private[optimizer] (semantics: Semantics,
         val changed = {
           originalDef == null ||
           (methodDef.hash zip originalDef.hash).forall {
-            case (h1, h2) => !Hashers.hashesEqual(h1, h2, considerPositions)
+            case (h1, h2) => !Hashers.hashesEqual(h1, h2, considerPos = true)
           }
         }
 
@@ -1015,6 +1013,7 @@ abstract class GenIncOptimizer private[optimizer] (semantics: Semantics,
 
 object GenIncOptimizer {
 
+  // TODO Remove the third argument when we can break compatibility
   type OptimizerFactory = (Semantics, ESLevel, Boolean) => GenIncOptimizer
 
   private val isAdHocElidableModuleAccessor =

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/IncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/IncOptimizer.scala
@@ -15,9 +15,15 @@ import scala.collection.mutable
 import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 
-final class IncOptimizer(semantics: Semantics, esLevel: ESLevel,
-    considerPositions: Boolean)
-    extends GenIncOptimizer(semantics, esLevel, considerPositions) {
+final class IncOptimizer(semantics: Semantics, esLevel: ESLevel)
+    extends GenIncOptimizer(semantics, esLevel) {
+
+  @deprecated(
+      "The considerPositions parameter is ignored." +
+      "Use the overload without it.",
+      "0.6.17")
+  def this(semantics: Semantics, esLevel: ESLevel, considerPositions: Boolean) =
+    this(semantics, esLevel)
 
   private[optimizer] object CollOps extends GenIncOptimizer.AbsCollOps {
     type Map[K, V] = mutable.Map[K, V]
@@ -169,5 +175,6 @@ final class IncOptimizer(semantics: Semantics, esLevel: ESLevel,
 }
 
 object IncOptimizer {
-  val factory: GenIncOptimizer.OptimizerFactory = new IncOptimizer(_, _, _)
+  val factory: GenIncOptimizer.OptimizerFactory =
+    (semantics, esLevel, _) => new IncOptimizer(semantics, esLevel)
 }

--- a/tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
+++ b/tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
@@ -6,7 +6,8 @@ import org.junit.Assert._
 import org.scalajs.core.tools.logging.NullLogger
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.linker.backend.{OutputMode, ModuleKind}
+import org.scalajs.core.tools.linker.frontend.LinkerFrontend
+import org.scalajs.core.tools.linker.backend._
 
 class LinkerTest {
 
@@ -23,7 +24,7 @@ class LinkerTest {
     }
 
     val linker = Linker(Semantics.Defaults, OutputMode.ECMAScript51Isolated,
-        ModuleKind.NoModule, Linker.Config())
+        ModuleKind.NoModule, LinkerFrontend.Config(), LinkerBackend.Config())
 
     def callLink(): Unit =
       linker.link(badSeq, Nil, WritableMemVirtualJSFile("some_file"), NullLogger)


### PR DESCRIPTION
I started with the desire to simplify those things so that they could legitimately be exposed as sbt settings (instead of `scalaJSOptimizerOptions` which is a bag of "stuff"), and one thing led me to another, until there was no `Linker.Config` at all anymore ^^

Not sure about all of that, especially the last commit. Discussion welcome.