### PR TITLE
Remove the JSDependencies plugin from our own build.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -141,10 +141,8 @@
 
   <task id="bootstrap"><![CDATA[
     setJavaVersion $java
-    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false)' \
-        ++$scala irJS/test toolsJS/test &&
-    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false)' \
-        'set scalaJSStage in Global := FullOptStage' \
+    sbt ++$scala irJS/test toolsJS/test &&
+    sbt 'set scalaJSStage in Global := FullOptStage' \
         ++$scala irJS/test toolsJS/test
   ]]></task>
 

--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -15,6 +15,7 @@
 
   <task id="main"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbtretry ++$scala helloworld/run &&
     sbtretry 'set scalaJSStage in Global := FullOptStage' \
         ++$scala helloworld/run \
@@ -58,6 +59,7 @@
 
   <task id="test-suite-ecma-script5"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbtretry ++$scala jUnitTestOutputsJVM/test jUnitTestOutputsJS/test \
         'set scalaJSStage in Global := FullOptStage' jUnitTestOutputsJS/test &&
     sbtretry ++$scala $testSuite/test &&
@@ -97,6 +99,7 @@
 
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         ++$scala $testSuite/test \
@@ -141,6 +144,7 @@
 
   <task id="bootstrap"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbt ++$scala irJS/test toolsJS/test &&
     sbt 'set scalaJSStage in Global := FullOptStage' \
         ++$scala irJS/test toolsJS/test
@@ -148,6 +152,7 @@
 
   <task id="tools-cli-stubs"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbt ++$scala tools/package ir/test tools/test cli/package cli/assembly \
         stubs/package jsEnvsTestSuite/test jsDependenciesCore/test \
         ir/mimaReportBinaryIssues tools/mimaReportBinaryIssues \
@@ -161,6 +166,7 @@
 
   <task id="tools-cli-stubs-sbtplugin"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbt ++$scala tools/package ir/test tools/test cli/package cli/assembly \
         stubs/package jsEnvsTestSuite/test jsDependenciesCore/test \
         sbtPlugin/package jsDependenciesPlugin/package \
@@ -191,12 +197,14 @@
 
   <task id="partestc"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbt ++$scala partest/compile
   ]]></task>
 
   <task id="sbtplugin-test"><![CDATA[
     # Publish Scala.js artifacts locally
     # Then go into standalone project and test
+    npm install &&
     sbt ++2.11.11 compiler/publishLocal library/publishLocal \
                   testInterface/publishLocal stubs/publishLocal \
                   jUnitPlugin/publishLocal jUnitRuntime/publishLocal &&
@@ -218,16 +226,19 @@
 
   <task id="partest-noopt"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbt ++$scala package "partestSuite/testOnly -- --showDiff"
   ]]></task>
 
   <task id="partest-fastopt"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbt ++$scala package "partestSuite/testOnly -- --fastOpt --showDiff"
   ]]></task>
 
   <task id="partest-fullopt"><![CDATA[
     setJavaVersion $java
+    npm install &&
     sbt ++$scala package "partestSuite/testOnly -- --fullOpt --showDiff"
   ]]></task>
 

--- a/package.json
+++ b/package.json
@@ -1,0 +1,8 @@
+{
+  "private": true,
+  "devDependencies": {
+    "source-map-support": "0.4.15",
+    "jszip": "2.4.0",
+    "jsdom": "9.12.0"
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -639,6 +639,9 @@ object Build {
         Seq(outFile)
       }.taskValue,
 
+      // Give more memory to Node.js, and deactivate source maps
+      jsEnv := new NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false),
+
       jsDependencies += ProvidedJS / "js-test-definitions.js" % "test",
       jsDependencies +=
         "org.webjars" % "jszip" % "2.4.0" % "test" / "jszip.min.js" commonJSName "JSZip",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -624,25 +624,25 @@ object Build {
   ).settings(
       commonToolsSettings,
       crossVersion := ScalaJSCrossVersion.binary,
-      resourceGenerators in Test += Def.task {
-        val base = (resourceManaged in Compile).value
-        IO.createDirectory(base)
-        val outFile = base / "js-test-definitions.js"
 
+      jsExecutionFiles in Test := {
         val testDefinitions = {
           org.scalajs.build.HTMLRunnerTemplateAccess.renderTestDefinitions(
               (loadedTestFrameworks in testSuite in Test).value,
               (definedTests in testSuite in Test).value)
         }
 
-        IO.write(outFile, testDefinitions)
-        Seq(outFile)
-      }.taskValue,
+        val testDefinitionsFile = {
+          new MemVirtualJSFile("js-test-definitions.js")
+            .withContent(testDefinitions)
+        }
+
+        testDefinitionsFile +: (jsExecutionFiles in Test).value
+      },
 
       // Give more memory to Node.js, and deactivate source maps
       jsEnv := new NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false),
 
-      jsDependencies += ProvidedJS / "js-test-definitions.js" % "test",
       jsDependencies +=
         "org.webjars" % "jszip" % "2.4.0" % "test" / "jszip.min.js" commonJSName "JSZip",
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -689,7 +689,12 @@ object Build {
           val scalaJSEnv = {
             s"""
             {"javaSystemProperties": {
-              "scalajs.scalaVersion": "${scalaVersion.value}"
+              "scalajs.scalaVersion": "${scalaVersion.value}",
+              "scalajs.testsuite.testtag": "testtag.value",
+              "scalajs.nodejs": "true",
+              "scalajs.typedarray": "true",
+              "scalajs.fastopt-stage": "true",
+              "scalajs.modulekind-nomodule": "true"
             }}
             """
           }

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/ConsoleTestRunner.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/ConsoleTestRunner.scala
@@ -1,4 +1,4 @@
-package org.scalajs.core.tools.test.js
+package org.scalajs.testsuite.utils
 
 import scala.collection.mutable
 
@@ -9,8 +9,8 @@ import org.scalajs.testinterface.{ScalaJSClassLoader, TestDetector}
 
 import sbt.testing._
 
-@JSExportTopLevel("scalajs.TestRunner")
-object TestRunner {
+@JSExportTopLevel("scalajs.ConsoleTestRunner")
+object ConsoleTestRunner {
 
   @JSExport
   def runTests(): Unit = {

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -118,7 +118,7 @@ object QuickLinker {
   }
 
   @js.native
-  @JSGlobal("JSZip")
+  @JSImport("jszip", JSImport.Default)
   private class JSZip(data: Uint8Array) extends js.Object {
     def files: js.Dictionary[JSZipEntry] = js.native
   }

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
@@ -12,12 +12,6 @@ object TestRunner {
 
   @JSExport
   def runTests(): Unit = {
-    System.setProperty("scalajs.testsuite.testtag", "testtag.value")
-    System.setProperty("scalajs.nodejs", "true")
-    System.setProperty("scalajs.typedarray", "true")
-    System.setProperty("scalajs.fastopt-stage", "true")
-    System.setProperty("scalajs.modulekind-nomodule", "true")
-
     val eventHandler = new SimpleEventHandler
     val loggers = Array[Logger](new SimpleLogger)
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala
@@ -37,6 +37,12 @@ trait VirtualFile {
         null           // Fragment
     )
   }
+
+  override def toString(): String = {
+    val className = getClass.getName
+    val shortClassName = className.substring(className.lastIndexOf('.') + 1)
+    shortClassName + "(" + path + ")"
+  }
 }
 
 object VirtualFile {


### PR DESCRIPTION
This is of course required before we can actually move that plugin in a separate repo, and remove from the core repo.