### PR TITLE
FF ONLY Merge '0.6.x' into 'master'.

### DIFF
--- a/cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
@@ -42,7 +42,7 @@ object Scalajsp {
         .action { (_, c) => c.copy(infos = true) }
         .text("Show DCE infos instead of trees")
       opt[Unit]('s', "supported")
-        .action { (_,_) => printSupported(); sys.exit() }
+        .action { (_,_) => printSupported(); exit(0) }
         .text("Show supported Scala.js IR versions")
       version("version")
         .abbr("v")
@@ -85,9 +85,14 @@ object Scalajsp {
     stdout.flush()
   }
 
-  private def fail(msg: String) = {
+  private def fail(msg: String): Nothing = {
     Console.err.println(msg)
-    sys.exit(1)
+    exit(1)
+  }
+
+  private def exit(code: Int): Nothing = {
+    System.exit(code)
+    throw new AssertionError("unreachable")
   }
 
   private def readFromFile(fileName: String) = {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -211,7 +211,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       }
 
       optDef.getOrElse {
-        sys.error("Couldn't find tree for lazily generated anonymous class " +
+        abort("Couldn't find tree for lazily generated anonymous class " +
             s"${sym.fullName} at ${sym.pos}")
       }
     }
@@ -632,7 +632,7 @@ abstract class GenJSCode extends plugins.PluginComponent
           classMembers += property
 
         case tree =>
-          sys.error("Unexpected tree: " + tree)
+          abort("Unexpected tree: " + tree)
       }
 
       // Make new class def with static members only
@@ -703,7 +703,7 @@ abstract class GenJSCode extends plugins.PluginComponent
               List(selfRef, name, descriptor))
 
         case tree =>
-          sys.error("Unexpected tree: " + tree)
+          abort("Unexpected tree: " + tree)
       }
 
       // Transform the constructor body.
@@ -715,7 +715,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
             val newTree = {
               val ident =
-                origJsClass.superClass.getOrElse(sys.error("No superclass"))
+                origJsClass.superClass.getOrElse(abort("No superclass"))
               if (args.isEmpty && ident.name == "sjs_js_Object") {
                 js.JSObjectConstr(Nil)
               } else {
@@ -1864,7 +1864,7 @@ abstract class GenJSCode extends plugins.PluginComponent
               js.VarRef(encodeLocalSym(sym))(toIRType(sym.tpe))
             }
           } else {
-            sys.error("Cannot use package as value: " + tree)
+            abort("Cannot use package as value: " + tree)
           }
 
         case Literal(value) =>

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -130,10 +130,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val BoxesRunTime_boxToCharacter = getMemberMethod(BoxesRunTimeModule, newTermName("boxToCharacter"))
     lazy val BoxesRunTime_unboxToChar    = getMemberMethod(BoxesRunTimeModule, newTermName("unboxToChar"))
 
-    // Copy-pasted from `Definitions.scala`, because it was removed in 2.13.
-    lazy val SysPackage = getPackageObject("scala.sys")
-      def Sys_error: Symbol = getMemberMethod(SysPackage, nme.error)
-
     lazy val ReflectModule = getRequiredModule("scala.scalajs.reflect.Reflect")
       lazy val Reflect_registerLoadableModuleClass = getMemberMethod(ReflectModule, newTermName("registerLoadableModuleClass"))
       lazy val Reflect_registerInstantiatableClass = getMemberMethod(ReflectModule, newTermName("registerInstantiatableClass"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -123,9 +123,12 @@ trait JSGlobalAddons extends JSDefinitions
         } else None
       }
 
-      dropPrefix(methodExportPrefix).map((_,false)) orElse
-      dropPrefix(propExportPrefix).map((_,true)) getOrElse
-      sys.error("non-exported name passed to jsInfoSpec")
+      dropPrefix(methodExportPrefix).map((_,false)).orElse {
+        dropPrefix(propExportPrefix).map((_,true))
+      }.getOrElse {
+        throw new IllegalArgumentException(
+            "non-exported name passed to jsExportInfo")
+      }
     }
 
     def isJSProperty(sym: Symbol): Boolean = isJSGetter(sym) || isJSSetter(sym)

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSSAMTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSSAMTest.scala
@@ -1,0 +1,73 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+
+import org.junit.Assume._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+class JSSAMTest extends DirectTest with TestHelpers {
+
+  override def preamble: String =
+    """
+    import scala.scalajs.js
+    import scala.scalajs.js.annotation._
+    """
+
+  @Test
+  def noSAMAsJSTypeGeneric: Unit = {
+
+    """
+    @js.native
+    trait Foo extends js.Object {
+      def foo(x: Int): Int
+    }
+
+    @ScalaJSDefined
+    trait Bar extends js.Object {
+      def bar(x: Int): Int
+    }
+
+    class A {
+      val foo: Foo = x => x + 1
+      val Bar: Bar = x => x + 1
+    }
+    """.fails()
+
+  }
+
+  @Test
+  def noSAMAsJSType212: Unit = {
+
+    val version = scala.util.Properties.versionNumberString
+    assumeTrue(!version.startsWith("2.10.") && !version.startsWith("2.11."))
+
+    """
+    @js.native
+    trait Foo extends js.Object {
+      def foo(x: Int): Int
+    }
+
+    @ScalaJSDefined
+    trait Bar extends js.Object {
+      def bar(x: Int): Int
+    }
+
+    class A {
+      val foo: Foo = x => x + 1
+      val Bar: Bar = x => x + 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:16: error: Using an anonymous function as a SAM for the JavaScript type Foo is not allowed. Use an anonymous class instead.
+      |      val foo: Foo = x => x + 1
+      |                       ^
+      |newSource1.scala:17: error: Using an anonymous function as a SAM for the JavaScript type Bar is not allowed. Use an anonymous class instead.
+      |      val Bar: Bar = x => x + 1
+      |                       ^
+    """
+
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
@@ -47,7 +47,8 @@ abstract class DirectTest {
 
       override lazy val plugins = {
         val scalaJSPlugin = newScalaJSPlugin(global)
-        scalaJSPlugin.processOptions(scalaJSPlugin.options, sys.error(_))
+        scalaJSPlugin.processOptions(scalaJSPlugin.options,
+            msg => throw new IllegalArgumentException(msg))
         scalaJSPlugin :: Nil
       }
     }
@@ -88,15 +89,20 @@ abstract class DirectTest {
   def defaultGlobal: Global = newScalaJSCompiler()
 
   def testOutputPath: String = {
-    val baseDir = sys.props("scala.scalajs.compiler.test.output")
+    val baseDir = System.getProperty("scala.scalajs.compiler.test.output")
     val outDir = new File(baseDir, getClass.getName)
     outDir.mkdirs()
     outDir.getAbsolutePath
   }
 
-  def scalaJSLibPath: String = sys.props("scala.scalajs.compiler.test.scalajslib")
-  def scalaLibPath: String   = sys.props("scala.scalajs.compiler.test.scalalib")
-  def scalaReflectPath: String = sys.props("scala.scalajs.compiler.test.scalareflect")
+  def scalaJSLibPath: String =
+    System.getProperty("scala.scalajs.compiler.test.scalajslib")
+
+  def scalaLibPath: String =
+    System.getProperty("scala.scalajs.compiler.test.scalalib")
+
+  def scalaReflectPath: String =
+    System.getProperty("scala.scalajs.compiler.test.scalareflect")
 
   def classpath: List[String] = List(scalaJSLibPath)
 }

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -440,8 +440,8 @@ object Hashers {
           mixTrees(captureValues)
 
         case _ =>
-          sys.error(s"Unable to hash tree of class ${tree.getClass}")
-
+          throw new IllegalArgumentException(
+              s"Unable to hash tree of class ${tree.getClass}")
       }
     }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -687,7 +687,7 @@ object Serializers {
       import input._
       val result = (tag: @switch) match {
         case TagEmptyTree =>
-          sys.error("Found invalid TagEmptyTree")
+          throw new IOException("Found invalid TagEmptyTree")
 
         case TagVarDef   => VarDef(readIdent(), readType(), readBoolean(), readTree())
         case TagParamDef => ParamDef(readIdent(), readType(), readBoolean(), readBoolean())

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -200,7 +200,8 @@ object Transformers {
           tree
 
         case _ =>
-          sys.error(s"Invalid tree in transform() of class ${tree.getClass}")
+          throw new IllegalArgumentException(
+              s"Invalid tree in transform() of class ${tree.getClass}")
       }
     }
   }
@@ -245,7 +246,8 @@ object Transformers {
               transformDef(methodDef).asInstanceOf[MethodDef])
 
         case _ =>
-          sys.error(s"Invalid tree in transformDef() of class ${tree.getClass}")
+          throw new IllegalArgumentException(
+              s"Invalid tree in transformDef() of class ${tree.getClass}")
       }
     }
   }

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -223,7 +223,8 @@ object Traversers {
           _:TopLevelFieldExportDef =>
 
       case _ =>
-        sys.error(s"Invalid tree in traverse() of class ${tree.getClass}")
+        throw new IllegalArgumentException(
+            s"Invalid tree in traverse() of class ${tree.getClass}")
     }
   }
 

--- a/javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
+++ b/javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
@@ -21,54 +21,54 @@
 package java.lang
 
 private[java] object MathJDK8Bridge {
-  def addExact(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def addExact(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def addExact(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def addExact(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def subtractExact(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def subtractExact(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def subtractExact(a: scala.Long, b: scala.Long): scala.Long =
-    sys.error("stub")
+  def subtractExact(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def multiplyExact(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def multiplyExact(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def multiplyExact(a: scala.Long, b: scala.Long): scala.Long =
-    sys.error("stub")
+  def multiplyExact(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def incrementExact(a: scala.Int): scala.Int = sys.error("stub")
+  def incrementExact(a: scala.Int): scala.Int = stub()
 
-  def incrementExact(a: scala.Long): scala.Long = sys.error("stub")
+  def incrementExact(a: scala.Long): scala.Long = stub()
 
-  def decrementExact(a: scala.Int): scala.Int = sys.error("stub")
+  def decrementExact(a: scala.Int): scala.Int = stub()
 
-  def decrementExact(a: scala.Long): scala.Long = sys.error("stub")
+  def decrementExact(a: scala.Long): scala.Long = stub()
 
-  def negateExact(a: scala.Int): scala.Int = sys.error("stub")
+  def negateExact(a: scala.Int): scala.Int = stub()
 
-  def negateExact(a: scala.Long): scala.Long = sys.error("stub")
+  def negateExact(a: scala.Long): scala.Long = stub()
 
-  def toIntExact(a: scala.Long): scala.Int = sys.error("stub")
+  def toIntExact(a: scala.Long): scala.Int = stub()
 
-  def floorDiv(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def floorDiv(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def floorDiv(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def floorDiv(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def floorMod(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def floorMod(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def floorMod(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def floorMod(a: scala.Long, b: scala.Long): scala.Long = stub()
 
   // A few other Math-related methods that are not really in Math
 
-  def toUnsignedString(i: scala.Int): String = sys.error("stub")
+  def toUnsignedString(i: scala.Int): String = stub()
 
-  def toUnsignedString(i: scala.Long): String = sys.error("stub")
+  def toUnsignedString(i: scala.Long): String = stub()
 
-  def divideUnsigned(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def divideUnsigned(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def divideUnsigned(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def divideUnsigned(a: scala.Long, b: scala.Long): scala.Long = stub()
 
-  def remainderUnsigned(a: scala.Int, b: scala.Int): scala.Int = sys.error("stub")
+  def remainderUnsigned(a: scala.Int, b: scala.Int): scala.Int = stub()
 
-  def remainderUnsigned(a: scala.Long, b: scala.Long): scala.Long = sys.error("stub")
+  def remainderUnsigned(a: scala.Long, b: scala.Long): scala.Long = stub()
 
+  private def stub(): Nothing =
+    throw new Error("stub")
 }

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -179,7 +179,7 @@ object Pattern {
     case 'u' => UNICODE_CASE
     case 'x' => COMMENTS
     case 'U' => UNICODE_CHARACTER_CLASS
-    case _   => sys.error("bad in-pattern flag")
+    case _   => throw new IllegalArgumentException("bad in-pattern flag")
   }
 
   /** matches \Q<char>\E to support StringLike.split */

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -6,6 +6,7 @@ import org.scalajs.core.tools.logging.Logger
 import java.io.{ Console => _, _ }
 import scala.io.Source
 
+import scala.collection.JavaConverters._
 import scala.concurrent.{Future, Promise}
 import scala.util.Try
 
@@ -65,10 +66,11 @@ abstract class ExternalJSEnv(
 
     /** VM environment. Override to adapt.
      *
-     *  The default value in `ExternalJSEnv` is `sys.env ++ env`.
+     *  The default value in `ExternalJSEnv` is
+     *  `System.getenv().asScala.toMap ++ env`.
      */
     protected def getVMEnv(): Map[String, String] =
-      sys.env ++ env
+      System.getenv().asScala.toMap ++ env
 
     /** All the JS files that are passed to the VM.
      *

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
@@ -18,6 +18,7 @@ import org.scalajs.core.tools.logging.NullLogger
 import org.scalajs.jsenv._
 import org.scalajs.jsenv.Utils.OptDeadline
 
+import scala.collection.JavaConverters._
 import scala.concurrent.TimeoutException
 import scala.concurrent.duration._
 
@@ -138,14 +139,14 @@ abstract class AbstractNodeJSEnv(
 
     // Node.js specific (system) environment
     override protected def getVMEnv(): Map[String, String] = {
-      val baseNodePath = sys.env.get("NODE_PATH").filter(_.nonEmpty)
+      val baseNodePath = Option(System.getenv("NODE_PATH")).filter(_.nonEmpty)
       val nodePath = libCache.cacheDir.getAbsolutePath +
           baseNodePath.fold("")(p => File.pathSeparator + p)
 
-      sys.env ++ Seq(
+      System.getenv().asScala.toMap ++ Seq(
         "NODE_MODULE_CONTEXTS" -> "0",
         "NODE_PATH" -> nodePath
-      ) ++ additionalEnv
+      ) ++ env
     }
   }
 

--- a/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
+++ b/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
@@ -131,7 +131,8 @@ object JSDependenciesPlugin extends AutoPlugin {
           results += collectFile(file, relPath)
         }
       } else {
-        sys.error("Illegal classpath entry: " + cpEntry.getPath)
+        throw new IllegalArgumentException(
+            "Illegal classpath entry: " + cpEntry.getPath)
       }
     }
 

--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -91,6 +91,26 @@ object Assert {
   def assertNotEquals(unexpected: Float, actual: Float, delta: Float): Unit =
     assertNotEquals(null, unexpected, actual, delta)
 
+  @deprecated("Use assertEquals(double expected, double actual, double " +
+      "epsilon) instead", "")
+  def assertEquals(expected: Double, actual: Double): Unit = {
+    fail("Use assertEquals(expected, actual, delta) to compare " +
+        "floating-point numbers")
+  }
+
+  @deprecated("Use assertEquals(String message, double expected, double " +
+      "actual, double epsilon) instead", "")
+  def assertEquals(message: String, expected: Double, actual: Double): Unit = {
+    fail("Use assertEquals(expected, actual, delta) to compare " +
+        "floating-point numbers")
+  }
+
+  def assertEquals(expected: Long, actual: Long): Unit =
+    assertEquals(null, expected, actual)
+
+  def assertEquals(message: String, expected: Long, actual: Long): Unit =
+    assertEquals(message, expected: Any, actual: Any)
+
   def assertArrayEquals(message: String, expecteds: Array[AnyRef],
       actuals: Array[AnyRef]): Unit = {
     internalArrayEquals(message, expecteds, actuals)

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsDoubleTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsDoubleTest.scala
@@ -1,0 +1,50 @@
+package org.scalajs.junit
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.junit.utils._
+
+class AssertEqualsDoubleTest {
+  @Test def failsWithDouble(): Unit = {
+    assertEquals(1.0, 1.0)
+  }
+
+  @Test def failsWithDoubleMessage(): Unit = {
+    assertEquals("Message", 1.0, 1.0)
+  }
+
+  @Test def worksWithEpsilon(): Unit = {
+    assertEquals(1.0, 1.0, 0.1)
+    assertEquals("Message", 1.0, 1.0, 0.1)
+  }
+
+  @Test def worksWithByte(): Unit = {
+    // This is supposed to take the (long, long) overload.
+    assertEquals(1.toByte, 1.toByte)
+  }
+
+  @Test def worksWithShort(): Unit = {
+    // This is supposed to take the (long, long) overload.
+    assertEquals(2.toShort, 2.toShort)
+  }
+
+  @Test def worksWithInt(): Unit = {
+    // This is supposed to take the (long, long) overload.
+    assertEquals(1, 1)
+  }
+}
+
+class AssertEqualsDoubleTestAssertions extends JUnitTest {
+  protected def expectedOutput(builder: OutputBuilder): OutputBuilder = {
+    builder
+      .success("worksWithEpsilon")
+      .assertion("failsWithDouble",
+          "Use assertEquals(expected, actual, delta) to compare floating-point numbers")
+      .assertion("failsWithDoubleMessage",
+          "Use assertEquals(expected, actual, delta) to compare floating-point numbers")
+      .success("worksWithByte")
+      .success("worksWithShort")
+      .success("worksWithInt")
+  }
+}

--- a/library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
+++ b/library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
@@ -13,7 +13,7 @@ class BoxedUnit private () extends AnyRef with java.io.Serializable {
 }
 
 object BoxedUnit {
-  def UNIT: BoxedUnit = sys.error("stub")
+  def UNIT: BoxedUnit = throw new Error("stub")
 
   final val TYPE = classOf[Unit]
 }

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -176,7 +176,7 @@ object Array extends Object {
   // def apply[A](arrayLength: Int): Array[A] = native
 
   /** Creates a new array with the given items. */
-  def apply[A](items: A*): Array[A] = sys.error("stub")
+  def apply[A](items: A*): Array[A] = throw new java.lang.Error("stub")
 
   /** Returns true if the given value is an array. */
   def isArray(arg: Any): Boolean = native

--- a/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
+++ b/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
@@ -35,5 +35,6 @@ object ConstructorTag {
    *  This method has the same preconditions as
    *  [[constructorOf js.constructorOf]].
    */
-  implicit def materialize[T <: Any]: ConstructorTag[T] = sys.error("stub")
+  implicit def materialize[T <: Any]: ConstructorTag[T] =
+    throw new java.lang.Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/js/Dictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dictionary.scala
@@ -62,7 +62,7 @@ sealed trait Dictionary[A] extends Any {
    *  Since we are using strict mode, this throws an exception, if the property
    *  isn't configurable.
    */
-  def delete(key: String): Unit = sys.error("stub")
+  def delete(key: String): Unit = throw new java.lang.Error("stub")
 }
 
 /** Factory for [[Dictionary]] instances. */

--- a/library/src/main/scala/scala/scalajs/js/Dynamic.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dynamic.scala
@@ -78,7 +78,8 @@ object Dynamic {
   @inline def global: Dynamic = scala.scalajs.runtime.environmentInfo.global
 
   /** Instantiates a new object of a JavaScript class. */
-  def newInstance(clazz: Dynamic)(args: Any*): Object with Dynamic = sys.error("stub")
+  def newInstance(clazz: Dynamic)(args: Any*): Object with Dynamic =
+    throw new java.lang.Error("stub")
 
   /** Creates a new object with a literal syntax.
    *
@@ -91,8 +92,8 @@ object Dynamic {
     /** literal creation like this:
      *  js.Dynamic.literal(name1 = "value", name2 = "value")
      */
-    def applyDynamicNamed(name: String)(
-        fields: (String, Any)*): Object with Dynamic = sys.error("stub")
+    def applyDynamicNamed(name: String)(fields: (String, Any)*): Object with Dynamic =
+      throw new java.lang.Error("stub")
 
     /** literal creation like this:
      *  js.Dynamic.literal("name1" -> "value", "name2" -> "value")
@@ -101,8 +102,7 @@ object Dynamic {
      *  applyDynamicNamed fail, since a call with named arguments would
      *  be routed to the `def apply`, rather than def dynamic version.
      */
-    def applyDynamic(name: String)(
-        fields: (String, Any)*): Object with Dynamic = sys.error("stub")
-
+    def applyDynamic(name: String)(fields: (String, Any)*): Object with Dynamic =
+      throw new java.lang.Error("stub")
   }
 }

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -57,7 +57,8 @@ object Object extends Object {
   /** Tests whether the object has a property on itself or in its prototype
    *  chain. This method is the equivalent of `p in o` in JavaScript.
    */
-  def hasProperty(o: Object, p: String): Boolean = sys.error("stub")
+  def hasProperty(o: Object, p: String): Boolean =
+    throw new java.lang.Error("stub")
 
   /**
    * The Object.getPrototypeOf() method returns the prototype (i.e. the
@@ -220,5 +221,5 @@ object Object extends Object {
    *  that the list returned by [[keys]] is a sublist of the list returned by
    *  this method (not just a subset).
    */
-  def properties(o: Any): Array[String] = sys.error("stub")
+  def properties(o: Any): Array[String] = throw new java.lang.Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -72,7 +72,7 @@ package object js {
     v.asInstanceOf[scala.AnyRef] eq undefined
 
   /** Returns the type of `x` as identified by `typeof x` in JavaScript. */
-  def typeOf(x: Any): String = sys.error("stub")
+  def typeOf(x: Any): String = throw new java.lang.Error("stub")
 
   /** Returns the constructor function of a JavaScript class.
    *
@@ -80,7 +80,7 @@ package object js {
    *  `classOf[T]`) and represent a class extending `js.Any` (not a trait nor
    *  an object).
    */
-  def constructorOf[T <: js.Any]: js.Dynamic = sys.error("stub")
+  def constructorOf[T <: js.Any]: js.Dynamic = throw new java.lang.Error("stub")
 
   /** Makes explicit an implicitly available `ConstructorTag[T]`. */
   def constructorTag[T <: js.Any](implicit tag: ConstructorTag[T]): ConstructorTag[T] =
@@ -96,7 +96,7 @@ package object js {
    *  - In Chrome, it has no effect unless the developer tools are opened
    *    beforehand.
    */
-  def debugger(): Unit = sys.error("stub")
+  def debugger(): Unit = throw new java.lang.Error("stub")
 
   /** Evaluates JavaScript code and returns the result. */
   @inline def eval(x: String): Any =
@@ -125,9 +125,12 @@ package object js {
    *  }
    *  }}}
    */
-  def native: Nothing = sys.error("A method defined in a JavaScript raw " +
-      "type of a Scala.js library has been called. This is most likely " +
-      "because you tried to run Scala.js binaries on the JVM. Make sure you " +
-      "are using the JVM version of the libraries.")
+  def native: Nothing = {
+    throw new java.lang.Error(
+        "A method defined in a JavaScript raw type of a Scala.js library has " +
+        "been called. This is most likely because you tried to run Scala.js " +
+        "binaries on the JVM. Make sure you are using the JVM version of the " +
+        "libraries.")
+  }
 
 }

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
@@ -34,45 +34,34 @@ package scala.scalajs.js.typedarray
 import java.nio._
 
 private[typedarray] object TypedArrayBufferBridge {
-  def wrap(array: ArrayBuffer): ByteBuffer =
-    sys.error("stub")
+  def wrap(array: ArrayBuffer): ByteBuffer = stub()
 
-  def wrap(array: ArrayBuffer, byteOffset: Int, length: Int): ByteBuffer =
-    sys.error("stub")
+  def wrap(array: ArrayBuffer, byteOffset: Int, length: Int): ByteBuffer = stub()
 
-  def wrap(array: Int8Array): ByteBuffer =
-    sys.error("stub")
+  def wrap(array: Int8Array): ByteBuffer = stub()
 
-  def wrap(array: Uint16Array): CharBuffer =
-    sys.error("stub")
+  def wrap(array: Uint16Array): CharBuffer = stub()
 
-  def wrap(array: Int16Array): ShortBuffer =
-    sys.error("stub")
+  def wrap(array: Int16Array): ShortBuffer = stub()
 
-  def wrap(array: Int32Array): IntBuffer =
-    sys.error("stub")
+  def wrap(array: Int32Array): IntBuffer = stub()
 
-  def wrap(array: Float32Array): FloatBuffer =
-    sys.error("stub")
+  def wrap(array: Float32Array): FloatBuffer = stub()
 
-  def wrap(array: Float64Array): DoubleBuffer =
-    sys.error("stub")
+  def wrap(array: Float64Array): DoubleBuffer = stub()
 
-  def Buffer_hasArrayBuffer(buffer: Buffer): Boolean =
-    sys.error("stub")
+  def Buffer_hasArrayBuffer(buffer: Buffer): Boolean = stub()
 
-  def Buffer_arrayBuffer(buffer: Buffer): ArrayBuffer =
-    sys.error("stub")
+  def Buffer_arrayBuffer(buffer: Buffer): ArrayBuffer = stub()
 
-  def Buffer_arrayBufferOffset(buffer: Buffer): Int =
-    sys.error("stub")
+  def Buffer_arrayBufferOffset(buffer: Buffer): Int = stub()
 
-  def Buffer_dataView(buffer: Buffer): DataView =
-    sys.error("stub")
+  def Buffer_dataView(buffer: Buffer): DataView = stub()
 
-  def Buffer_hasTypedArray(buffer: Buffer): Boolean =
-    sys.error("stub")
+  def Buffer_hasTypedArray(buffer: Buffer): Boolean = stub()
 
-  def Buffer_typedArray(buffer: Buffer): TypedArray[_, _] =
-    sys.error("stub")
+  def Buffer_typedArray(buffer: Buffer): TypedArray[_, _] = stub()
+
+  private def stub(): Nothing =
+    throw new Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -73,7 +73,8 @@ package object runtime {
    *  The `clazz` parameter must be a literal `classOf[T]` constant such that
    *  `T` represents a class extending `js.Any` (not a trait nor an object).
    */
-  def constructorOf(clazz: Class[_ <: js.Any]): js.Dynamic = sys.error("stub")
+  def constructorOf(clazz: Class[_ <: js.Any]): js.Dynamic =
+    throw new Error("stub")
 
   /** Public access to `new ConstructorTag` for the codegen of
    *  `js.ConstructorTag.materialize`.
@@ -140,7 +141,7 @@ package object runtime {
    *
    *  See [[LinkingInfo]] for details.
    */
-  def linkingInfo: LinkingInfo = sys.error("stub")
+  def linkingInfo: LinkingInfo = throw new Error("stub")
 
   /** Polyfill for fround in case we use strict Floats and even Typed Arrays
    *  are not available.

--- a/partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -185,10 +185,10 @@ class ScalaJSSBTRunner(
 
   // The test root for partest is read out through the system properties,
   // not passed as an argument
-  sys.props("partest.root") = testRoot.getAbsolutePath()
+  System.setProperty("partest.root", testRoot.getAbsolutePath())
 
   // Partests take at least 5h. We double, just to be sure. (default is 4 hours)
-  sys.props("partest.timeout") = "10 hours"
+  System.setProperty("partest.timeout", "10 hours")
 
   // Set showDiff on global UI module
   if (options.showDiff)

--- a/partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -187,10 +187,10 @@ class ScalaJSSBTRunner(
 
   // The test root for partest is read out through the system properties,
   // not passed as an argument
-  sys.props("partest.root") = testRoot.getAbsolutePath()
+  System.setProperty("partest.root", testRoot.getAbsolutePath())
 
   // Partests take at least 5h. We double, just to be sure. (default is 4 hours)
-  sys.props("partest.timeout") = "10 hours"
+  System.setProperty("partest.timeout", "10 hours")
 
   override val suiteRunner = new SuiteRunner(
       testSourcePath = config.optSourcePath orElse Option("test/files") getOrElse PartestDefaults.sourcePath,

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -36,12 +36,12 @@ class MainGenericRunner {
     false
   }
 
-  val optMode = OptMode.fromId(sys.props("scalajs.partest.optMode"))
+  val optMode = OptMode.fromId(System.getProperty("scalajs.partest.optMode"))
 
   def readSemantics() = {
     import org.scalajs.core.tools.sem.CheckedBehavior.Compliant
 
-    val opt = sys.props.get("scalajs.partest.compliantSems")
+    val opt = Option(System.getProperty("scalajs.partest.compliantSems"))
     val compliantSems =
       opt.fold[List[String]](Nil)(_.split(',').toList.filter(_.nonEmpty))
 
@@ -172,8 +172,8 @@ class MainGenericRunner {
 }
 
 object MainGenericRunner extends MainGenericRunner {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     if (!process(args))
-      sys.exit(1)
+      System.exit(1)
   }
 }

--- a/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
+++ b/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
@@ -35,10 +35,10 @@ object ScalaJSPartestOptions {
   }
   object OptMode {
     def fromId(id: String): OptMode = id match {
-      case "none"  => NoOpt
-      case "fast"  => FastOpt
-      case "full"  => FullOpt
-      case _       => sys.error(s"Unknown optimization mode: $id")
+      case "none" => NoOpt
+      case "fast" => FastOpt
+      case "full" => FullOpt
+      case _      => throw new IllegalArgumentException(s"Unknown optimization mode: $id")
     }
   }
   case object NoOpt extends OptMode {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1133,7 +1133,6 @@ object Build {
 
   val commonJUnitTestOutputsSettings = Def.settings(
       commonSettings,
-      fatalWarningsSettings,
       publishArtifact in Compile := false,
       parallelExecution in Test := false,
       unmanagedSourceDirectories in Test +=

--- a/project/ExternalCompile.scala
+++ b/project/ExternalCompile.scala
@@ -71,12 +71,13 @@ object ExternalCompile {
 
           def doCompile(sourcesArgs: List[String]): Unit = {
             val run = (runner in compile).value
-            run.run("scala.tools.nsc.Main", compilerCp,
+            val optErrorMsg = run.run("scala.tools.nsc.Main", compilerCp,
                 "-cp" :: cpStr ::
                 "-d" :: classesDirectory.getAbsolutePath() ::
                 options ++:
                 sourcesArgs,
-                patchedLogger) foreach sys.error
+                patchedLogger)
+            optErrorMsg.foreach(errorMsg => throw new Exception(errorMsg))
           }
 
           /* Crude way of overcoming the Windows limitation on command line

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -322,7 +322,8 @@ object ScalaJSPluginInternal {
           results += collectFile(file, relPath)
         }
       } else {
-        sys.error("Illegal classpath entry: " + cpEntry.getPath)
+        throw new IllegalArgumentException(
+            "Illegal classpath entry: " + cpEntry.getPath)
       }
     }
 
@@ -379,7 +380,7 @@ object ScalaJSPluginInternal {
       // Give tasks ability to check we are not forking at build reading time
       scalaJSEnsureUnforked := {
         if (fork.value)
-          sys.error("Scala.js cannot be run in a forked JVM")
+          throw new MessageOnlyException("Scala.js cannot be run in a forked JVM")
         else
           true
       },
@@ -389,7 +390,8 @@ object ScalaJSPluginInternal {
         javaOptions.value.map {
           case javaSysPropsPattern(propName, propValue) => (propName, propValue)
           case opt =>
-            sys.error("Scala.js javaOptions can only be \"-D<key>=<value>\"," +
+            throw new MessageOnlyException(
+                "Scala.js javaOptions can only be \"-D<key>=<value>\"," +
                 " but received: " + opt)
         }.toMap
       },
@@ -536,7 +538,8 @@ object ScalaJSPluginInternal {
           case env: ComJSEnv => env
 
           case env =>
-            sys.error(s"You need a ComJSEnv to test (found ${env.name})")
+            throw new MessageOnlyException(
+                s"You need a ComJSEnv to test (found ${env.name})")
         }
 
         val files = jsExecutionFiles.value

--- a/scalalib/overrides-2.10/scala/Array.scala
+++ b/scalalib/overrides-2.10/scala/Array.scala
@@ -11,7 +11,7 @@ package scala
 import scala.collection.generic._
 import scala.collection.{ mutable, immutable }
 import mutable.{ ArrayBuilder, ArraySeq }
-import scala.compat.Platform.arraycopy
+import java.lang.System.arraycopy
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime.{ array_apply, array_update }
 

--- a/scalalib/overrides-2.10/scala/collection/immutable/RedBlackTree.scala
+++ b/scalalib/overrides-2.10/scala/collection/immutable/RedBlackTree.scala
@@ -168,7 +168,7 @@ object RedBlackTree {
     }
     def subl(t: Tree[A, B]) =
       if (t.isInstanceOf[BlackTree[_, _]]) t.red
-      else sys.error("Defect: invariance violation; expected black, got "+t)
+      else throw new IllegalStateException("Defect: invariance violation; expected black, got "+t)
 
     def balLeft(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
       RedTree(x, xv, tl.black, tr)
@@ -177,7 +177,7 @@ object RedBlackTree {
     } else if (isRedTree(tr) && isBlackTree(tr.left)) {
       RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), balance(tr.key, tr.value, tr.left.right, subl(tr.right)))
     } else {
-      sys.error("Defect: invariance violation")
+      throw new IllegalStateException("Defect: invariance violation")
     }
     def balRight(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tr)) {
       RedTree(x, xv, tl, tr.black)
@@ -186,7 +186,7 @@ object RedBlackTree {
     } else if (isRedTree(tl) && isBlackTree(tl.right)) {
       RedTree(tl.right.key, tl.right.value, balance(tl.key, tl.value, subl(tl.left), tl.right.left), BlackTree(x, xv, tl.right.right, tr))
     } else {
-      sys.error("Defect: invariance violation")
+      throw new IllegalStateException("Defect: invariance violation")
     }
     def delLeft = if (isBlackTree(tree.left)) balLeft(tree.key, tree.value, del(tree.left, k), tree.right) else RedTree(tree.key, tree.value, del(tree.left, k), tree.right)
     def delRight = if (isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, del(tree.right, k)) else RedTree(tree.key, tree.value, tree.left, del(tree.right, k))
@@ -213,7 +213,7 @@ object RedBlackTree {
     } else if (isRedTree(tl)) {
       RedTree(tl.key, tl.value, tl.left, append(tl.right, tr))
     } else {
-      sys.error("unmatched tree on append: " + tl + ", " + tr)
+      throw new IllegalStateException("unmatched tree on append: " + tl + ", " + tr)
     }
 
     val cmp = ordering.compare(k, tree.key)
@@ -334,7 +334,7 @@ object RedBlackTree {
         val leftMost = false
         (unzip(left :: leftZipper, leftMost), false, leftMost, smallerDepth)
       } else {
-        sys.error("unmatched trees in unzip: " + left + ", " + right)
+        throw new IllegalStateException("unmatched trees in unzip: " + left + ", " + right)
       }
     }
     unzipBoth(left, right, Nil, Nil, 0)
@@ -346,7 +346,7 @@ object RedBlackTree {
       case head :: tail if isBlackTree(head) =>
         if (depth == 1) zipper else findDepth(tail, depth - 1)
       case _ :: tail => findDepth(tail, depth)
-      case Nil => sys.error("Defect: unexpected empty zipper while computing range")
+      case Nil => throw new IllegalStateException("Defect: unexpected empty zipper while computing range")
     }
 
     // Blackening the smaller tree avoids balancing problems on union;

--- a/scalalib/overrides-2.10/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.10/scala/runtime/ScalaRunTime.scala
@@ -340,7 +340,7 @@ object ScalaRunTime {
     nl + s + "\n"
   }
   private[scala] def checkZip(what: String, coll1: TraversableOnce[_], coll2: TraversableOnce[_]) {
-    if (sys.props contains "scala.debug.zip") {
+    if (System.getProperty("scala.debug.zip") != null) {
       val xs = coll1.toIndexedSeq
       val ys = coll2.toIndexedSeq
       if (xs.length != ys.length) {

--- a/scalalib/overrides/scala/App.scala
+++ b/scalalib/overrides/scala/App.scala
@@ -8,7 +8,7 @@
 
 package scala
 
-import scala.compat.Platform.currentTime
+import java.lang.System.{currentTimeMillis => currentTime}
 import scala.collection.mutable.ListBuffer
 
 import scala.scalajs.js.annotation.JSExport

--- a/scalalib/overrides/scala/Array.scala
+++ b/scalalib/overrides/scala/Array.scala
@@ -11,7 +11,7 @@ package scala
 import scala.collection.generic._
 import scala.collection.{ mutable, immutable }
 import mutable.{ ArrayBuilder, ArraySeq }
-import scala.compat.Platform.arraycopy
+import java.lang.System.arraycopy
 import scala.reflect.ClassTag
 import scala.runtime.ScalaRunTime.{ array_apply, array_update }
 

--- a/scalalib/overrides/scala/collection/immutable/RedBlackTree.scala
+++ b/scalalib/overrides/scala/collection/immutable/RedBlackTree.scala
@@ -194,7 +194,7 @@ object RedBlackTree {
     }
     def subl(t: Tree[A, B]) =
       if (t.isInstanceOf[BlackTree[_, _]]) t.red
-      else sys.error("Defect: invariance violation; expected black, got "+t)
+      else throw new IllegalStateException("Defect: invariance violation; expected black, got "+t)
 
     def balLeft(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
       RedTree(x, xv, tl.black, tr)
@@ -203,7 +203,7 @@ object RedBlackTree {
     } else if (isRedTree(tr) && isBlackTree(tr.left)) {
       RedTree(tr.left.key, tr.left.value, BlackTree(x, xv, tl, tr.left.left), balance(tr.key, tr.value, tr.left.right, subl(tr.right)))
     } else {
-      sys.error("Defect: invariance violation")
+      throw new IllegalStateException("Defect: invariance violation")
     }
     def balRight(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tr)) {
       RedTree(x, xv, tl, tr.black)
@@ -212,7 +212,7 @@ object RedBlackTree {
     } else if (isRedTree(tl) && isBlackTree(tl.right)) {
       RedTree(tl.right.key, tl.right.value, balance(tl.key, tl.value, subl(tl.left), tl.right.left), BlackTree(x, xv, tl.right.right, tr))
     } else {
-      sys.error("Defect: invariance violation")
+      throw new IllegalStateException("Defect: invariance violation")
     }
     def delLeft = if (isBlackTree(tree.left)) balLeft(tree.key, tree.value, del(tree.left, k), tree.right) else RedTree(tree.key, tree.value, del(tree.left, k), tree.right)
     def delRight = if (isBlackTree(tree.right)) balRight(tree.key, tree.value, tree.left, del(tree.right, k)) else RedTree(tree.key, tree.value, tree.left, del(tree.right, k))
@@ -239,7 +239,7 @@ object RedBlackTree {
     } else if (isRedTree(tl)) {
       RedTree(tl.key, tl.value, tl.left, append(tl.right, tr))
     } else {
-      sys.error("unmatched tree on append: " + tl + ", " + tr)
+      throw new IllegalStateException("unmatched tree on append: " + tl + ", " + tr)
     }
 
     val cmp = ordering.compare(k, tree.key)
@@ -359,7 +359,7 @@ object RedBlackTree {
         val leftMost = false
         (unzip(cons(left, leftZipper), leftMost), false, leftMost, smallerDepth)
       } else {
-        sys.error("unmatched trees in unzip: " + left + ", " + right)
+        throw new IllegalStateException("unmatched trees in unzip: " + left + ", " + right)
       }
     }
     unzipBoth(left, right, null, null, 0)
@@ -370,7 +370,7 @@ object RedBlackTree {
     @tailrec
     def  findDepth(zipper: NList[Tree[A, B]], depth: Int): NList[Tree[A, B]] =
       if (zipper eq null) {
-        sys.error("Defect: unexpected empty zipper while computing range")
+        throw new IllegalStateException("Defect: unexpected empty zipper while computing range")
       } else if (isBlackTree(zipper.head)) {
         if (depth == 1) zipper else findDepth(zipper.tail, depth - 1)
       } else {

--- a/scalalib/overrides/scala/util/control/NoStackTrace.scala
+++ b/scalalib/overrides/scala/util/control/NoStackTrace.scala
@@ -29,5 +29,5 @@ object NoStackTrace {
   // two-stage init to make checkinit happy, since sys.SystemProperties.noTraceSupression.value calls back into NoStackTrace.noSuppression
   final private var _noSuppression = false
   // !!! Disabled in Scala.js because SystemProperties is not supported
-  //_noSuppression = sys.SystemProperties.noTraceSupression.value
+  //_noSuppression = System.getProperty("scala.control.noTraceSuppression", "").equalsIgnoreCase("true")
 }

--- a/test-suite/js/src/test/resources/SourceMapTestTemplate.scala
+++ b/test-suite/js/src/test/resources/SourceMapTestTemplate.scala
@@ -40,14 +40,14 @@ object SourceMapTest {
 
 class SourceMapTest {
 
-  @Test def workTest(): Unit = sys.error("stubs")
+  @Test def workTest(): Unit = ???
 
   def test(i: Int): Unit = {
     TC.testNum = i
 
     try {
       run()
-      sys.error("No exception thrown")
+      throw new AssertionError("No exception thrown")
     } catch {
       case e @ TestException(lineNo) =>
         def normFileName(e: StackTraceElement): String =

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
@@ -21,25 +21,25 @@ class FloatJSTest {
 
   @Test def fround_for_special_values(): Unit = {
     assertTrue(froundNotInlined(Double.NaN).isNaN)
-    assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(0.0).toDouble)
-    assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-0.0).toDouble)
-    assertEquals(Float.PositiveInfinity, froundNotInlined(Double.PositiveInfinity))
-    assertEquals(Float.NegativeInfinity, froundNotInlined(Double.NegativeInfinity))
+    assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(0.0).toDouble, 0.0)
+    assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-0.0).toDouble, 0.0)
+    assertEquals(Float.PositiveInfinity, froundNotInlined(Double.PositiveInfinity), 0.0)
+    assertEquals(Float.NegativeInfinity, froundNotInlined(Double.NegativeInfinity), 0.0)
   }
 
   @Test def fround_overflows(): Unit = {
-    assertEquals(Double.PositiveInfinity, froundNotInlined(1e200))
-    assertEquals(Double.NegativeInfinity, froundNotInlined(-1e200))
+    assertEquals(Double.PositiveInfinity, froundNotInlined(1e200), 0.0)
+    assertEquals(Double.NegativeInfinity, froundNotInlined(-1e200), 0.0)
   }
 
   @Test def fround_underflows(): Unit = {
-    assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(1e-300).toDouble)
-    assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-1e-300).toDouble)
+    assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(1e-300).toDouble, 0.0)
+    assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-1e-300).toDouble, 0.0)
   }
 
   @Test def fround_normal_cases(): Unit = {
     def test(input: Double, expected: Double): Unit =
-      assertEquals(expected, input.toFloat.toDouble)
+      assertEquals(expected, input.toFloat.toDouble, 0.0)
 
     // From MDN documentation
     test(0.0, 0.0)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
@@ -108,7 +108,7 @@ class InstanceTestsHijackedBoxedClassesTest {
 
   @Test def asInstanceOf_Float_with_non_strict_floats(): Unit = {
     assumeFalse("Assumed strict floats", hasStrictFloats)
-    assertEquals(1.2, (1.2: Any).asInstanceOf[Float])
+    assertEquals(1.2, (1.2: Any).asInstanceOf[Float], 0.0)
   }
 
   @Test def should_support_isInstanceOf_via_java_lang_Class_positive(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -49,11 +49,11 @@ class OptimizerTest {
   @Test def `must_not_break_*_(-1)_for_Float_and_Double_issue_1478`(): Unit = {
     @noinline
     def a: Float = (() => 5.0f) ()
-    assertEquals(-5.0f, a * -1.0f)
+    assertEquals(-5.0f, a * -1.0f, 0.0)
 
     @noinline
     def b: Double = (() => 7.0) ()
-    assertEquals(-7.0, b * -1.0)
+    assertEquals(-7.0, b * -1.0, 0.0)
   }
 
   @Test def must_not_break_foreach_on_downward_Range_issue_1453(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -63,7 +63,7 @@ class OptimizerTest {
     val elements = js.Array[Int]()
     for (i <- start0 to 2 by -1) {
       if (i < 0)
-        sys.error("Going into infinite loop")
+        throw new AssertionError("Going into infinite loop")
       elements.push(i)
     }
     assertArrayEquals(Array(10, 9, 8, 7, 6, 5, 4, 3, 2), elements.toArray)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -920,8 +920,8 @@ class ExportsTest {
       def doShort(x: Short): Unit = assertEquals(0, x)
       def doInt(x: Int): Unit = assertEquals(0, x)
       def doLong(x: Long): Unit = assertTrue(x.equals(0L))
-      def doFloat(x: Float): Unit = assertEquals(0.0f, x)
-      def doDouble(x: Double): Unit = assertEquals(0.0, x)
+      def doFloat(x: Float): Unit = assertEquals(0.0f, x, 0.0)
+      def doDouble(x: Double): Unit = assertEquals(0.0, x, 0.0)
       def doUnit(x: Unit): Unit = assertTrue((x: Any) == null)
     }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
@@ -28,9 +28,9 @@ class JSNameTest {
 
   @Test def should_work_with_vars(): Unit = {
     val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarFacade]
-    assertEquals(0.1, obj.internalVar)
+    assertEquals(0.1, obj.internalVar, 0.0)
     obj.internalVar = 0.2
-    assertEquals(0.2, obj.internalVar)
+    assertEquals(0.2, obj.internalVar, 0.0)
   }
 
   @Test def should_work_with_defs_that_are_properties_in_Scala_js_defined_trait_issue_2197(): Unit = {
@@ -45,9 +45,9 @@ class JSNameTest {
 
   @Test def should_work_with_vars_in_Scala_js_defined_trait_issue_2197(): Unit = {
     val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarSJSDefined]
-    assertEquals(0.1, obj.internalVar)
+    assertEquals(0.1, obj.internalVar, 0.0)
     obj.internalVar = 0.2
-    assertEquals(0.2, obj.internalVar)
+    assertEquals(0.2, obj.internalVar, 0.0)
   }
 
   @Test def should_allow_names_ending_in__=(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -56,14 +56,14 @@ class JSSymbolTest {
 
   @Test def native_with_vars(): Unit = {
     val obj0 = mkObject(sym1 -> 0.1).asInstanceOf[PropVarClass]
-    assertEquals(0.1, obj0.internalVar)
+    assertEquals(0.1, obj0.internalVar, 0.0)
     obj0.internalVar = 0.2
-    assertEquals(0.2, obj0.internalVar)
+    assertEquals(0.2, obj0.internalVar, 0.0)
 
     val obj1 = mkObject(sym1 -> 8.0).asInstanceOf[PropVarTrait]
-    assertEquals(8.0, obj1.internalVar)
+    assertEquals(8.0, obj1.internalVar, 0.0)
     obj1.internalVar = 8.2
-    assertEquals(8.2, obj1.internalVar)
+    assertEquals(8.2, obj1.internalVar, 0.0)
 
     val obj2 = mkObject(sym1 -> 8.0)
     assertEquals(8.0, selectSymbol(obj2, sym1))
@@ -73,14 +73,14 @@ class JSSymbolTest {
 
   @Test def sjsdefined_with_vars(): Unit = {
     val obj0 = new SJSDefinedPropVar
-    assertEquals(1511.1989, obj0.internalVar)
+    assertEquals(1511.1989, obj0.internalVar, 0.0)
     obj0.internalVar = 0.2
-    assertEquals(0.2, obj0.internalVar)
+    assertEquals(0.2, obj0.internalVar, 0.0)
 
     val obj1: PropVarTrait = new SJSDefinedPropVar
-    assertEquals(1511.1989, obj1.internalVar)
+    assertEquals(1511.1989, obj1.internalVar, 0.0)
     obj1.internalVar = 8.2
-    assertEquals(8.2, obj1.internalVar)
+    assertEquals(8.2, obj1.internalVar, 0.0)
 
     val obj2 = new SJSDefinedPropVar
     assertEquals(1511.1989, selectSymbol(obj2, sym1))

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
@@ -408,73 +408,65 @@ class RuntimeLongTest {
 
   @Test def toFloat_strict(): Unit = {
     assumeTrue("Assumed strict floats", hasStrictFloats)
-    assertEquals(0, lg(0).toFloat)
-    assertEquals(-1, lg(-1).toFloat)
+    assertEquals(0, lg(0).toFloat, 0.0)
+    assertEquals(-1, lg(-1).toFloat, 0.0)
 
-    if (!isInFullOpt) {
-      assertEquals(9.223372E18f, MaxVal.toFloat)
-      assertEquals(-9.223372E18f, MinVal.toFloat)
-    } else {
-      // Closure seems to incorrectly rewrite the constant on the right :-(
-      assertEquals(9.223372E18f, MaxVal.toFloat, 1E4f)
-      assertEquals(-9.223372E18f, MinVal.toFloat, 1E4f)
-    }
+    // Closure seems to incorrectly rewrite the constant on the right :-(
+    val epsilon = if (isInFullOpt) 1E4f else 0.0f
+    assertEquals(9.223372E18f, MaxVal.toFloat, epsilon)
+    assertEquals(-9.223372E18f, MinVal.toFloat, epsilon)
 
-    assertEquals(4.7971489E18f, lg(-1026388143, 1116923232).toFloat)
-    assertEquals(-2.24047663E18f, lg(-1288678667, -521651607).toFloat)
-    assertEquals(4.59211416E18f, lg(1192262605, 1069184891).toFloat)
-    assertEquals(3.38942079E18f, lg(-180353617, 789161022).toFloat)
-    assertEquals(-6.8076878E18f, lg(-1158443188, -1585038363).toFloat)
-    assertEquals(7.4159717E18f, lg(906981906, 1726665521).toFloat)
-    assertEquals(-1.85275997E18f, lg(2042933575, -431379283).toFloat)
-    assertEquals(5.7344188E18f, lg(599900903, 1335148382).toFloat)
-    assertEquals(3.20410168E18f, lg(1458166084, 746013039).toFloat)
-    assertEquals(-7.2310311E18f, lg(1956524672, -1683605603).toFloat)
-    assertEquals(7.7151362E18f, lg(478583639, 1796320118).toFloat)
-    assertEquals(1.41365268E18f, lg(-1645816617, 329141676).toFloat)
-    assertEquals(-3.03197918E18f, lg(184187116, -705937657).toFloat)
-    assertEquals(-4.04287594E18f, lg(659513335, -941305424).toFloat)
-    assertEquals(-7.8204678E18f, lg(770505156, -1820844549).toFloat)
-    assertEquals(-5.9733025E18f, lg(929928858, -1390767911).toFloat)
-    assertEquals(1.1261721E18f, lg(-1475096259, 262207373).toFloat)
-    assertEquals(4.00884963E18f, lg(787691795, 933383012).toFloat)
-    assertEquals(-1.43511611E18f, lg(1189057493, -334139018).toFloat)
-    assertEquals(3.81415059E18f, lg(-618946450, 888051141).toFloat)
+    assertEquals(4.7971489E18f, lg(-1026388143, 1116923232).toFloat, 0.0)
+    assertEquals(-2.24047663E18f, lg(-1288678667, -521651607).toFloat, 0.0)
+    assertEquals(4.59211416E18f, lg(1192262605, 1069184891).toFloat, 0.0)
+    assertEquals(3.38942079E18f, lg(-180353617, 789161022).toFloat, 0.0)
+    assertEquals(-6.8076878E18f, lg(-1158443188, -1585038363).toFloat, 0.0)
+    assertEquals(7.4159717E18f, lg(906981906, 1726665521).toFloat, 0.0)
+    assertEquals(-1.85275997E18f, lg(2042933575, -431379283).toFloat, 0.0)
+    assertEquals(5.7344188E18f, lg(599900903, 1335148382).toFloat, 0.0)
+    assertEquals(3.20410168E18f, lg(1458166084, 746013039).toFloat, 0.0)
+    assertEquals(-7.2310311E18f, lg(1956524672, -1683605603).toFloat, 0.0)
+    assertEquals(7.7151362E18f, lg(478583639, 1796320118).toFloat, 0.0)
+    assertEquals(1.41365268E18f, lg(-1645816617, 329141676).toFloat, 0.0)
+    assertEquals(-3.03197918E18f, lg(184187116, -705937657).toFloat, 0.0)
+    assertEquals(-4.04287594E18f, lg(659513335, -941305424).toFloat, 0.0)
+    assertEquals(-7.8204678E18f, lg(770505156, -1820844549).toFloat, 0.0)
+    assertEquals(-5.9733025E18f, lg(929928858, -1390767911).toFloat, 0.0)
+    assertEquals(1.1261721E18f, lg(-1475096259, 262207373).toFloat, 0.0)
+    assertEquals(4.00884963E18f, lg(787691795, 933383012).toFloat, 0.0)
+    assertEquals(-1.43511611E18f, lg(1189057493, -334139018).toFloat, 0.0)
+    assertEquals(3.81415059E18f, lg(-618946450, 888051141).toFloat, 0.0)
   }
 
   @Test def toDouble(): Unit = {
-    assertEquals(0, lg(0).toDouble)
-    assertEquals(-1, lg(-1).toDouble)
+    assertEquals(0, lg(0).toDouble, 0.0)
+    assertEquals(-1, lg(-1).toDouble, 0.0)
 
-    if (!isInFullOpt) {
-      assertEquals(9.223372036854776E18, MaxVal.toDouble)
-      assertEquals(-9.223372036854776E18, MinVal.toDouble)
-    } else {
-      // Closure seems to incorrectly rewrite the constant on the right :-(
-      assertEquals(9.223372036854776E18, MaxVal.toDouble, 1E4)
-      assertEquals(-9.223372036854776E18, MinVal.toDouble, 1E4)
-    }
+    // Closure seems to incorrectly rewrite the constant on the right :-(
+    val epsilon = if (isInFullOpt) 1E4 else 0.0
+    assertEquals(9.223372036854776E18, MaxVal.toDouble, epsilon)
+    assertEquals(-9.223372036854776E18, MinVal.toDouble, epsilon)
 
-    assertEquals(3.4240179834317537E18, lg(-151011088, 797216310).toDouble)
-    assertEquals(8.5596043411285968E16, lg(-508205099, 19929381).toDouble)
-    assertEquals(-3.1630346897289943E18, lg(1249322201, -736451403).toDouble)
-    assertEquals(-4.4847682439933604E18, lg(483575860, -1044191477).toDouble)
-    assertEquals(-6.4014772289576371E17, lg(-1526343930, -149046007).toDouble)
-    assertEquals(-1.76968119148756736E18, lg(531728928, -412036011).toDouble)
-    assertEquals(-8.5606671350959739E18, lg(-734111585, -1993185640).toDouble)
-    assertEquals(-9.0403963253949932E18, lg(-1407864332, -2104881296).toDouble)
-    assertEquals(-6.4988752582247977E18, lg(-1712351423, -1513137310).toDouble)
-    assertEquals(-7.7788492399114394E17, lg(1969244733, -181115448).toDouble)
-    assertEquals(7.6357174849871442E18, lg(-907683842, 1777829016).toDouble)
-    assertEquals(1.25338659134517658E18, lg(-815927209, 291826806).toDouble)
-    assertEquals(-3.1910241505692349E18, lg(463523496, -742968207).toDouble)
-    assertEquals(7.4216510087652332E18, lg(1482622807, 1727987781).toDouble)
-    assertEquals(-8.189046896086654E18, lg(1170040143, -1906661060).toDouble)
-    assertEquals(6.8316272807487539E18, lg(-85609173, 1590612176).toDouble)
-    assertEquals(-8.0611115909320561E18, lg(-1212811257, -1876873801).toDouble)
-    assertEquals(1.7127521901359959E18, lg(-648802816, 398781194).toDouble)
-    assertEquals(-6.4442523492577423E18, lg(-1484519186, -1500419423).toDouble)
-    assertEquals(-1.71264450938175027E18, lg(-2016996893, -398756124).toDouble)
+    assertEquals(3.4240179834317537E18, lg(-151011088, 797216310).toDouble, 0.0)
+    assertEquals(8.5596043411285968E16, lg(-508205099, 19929381).toDouble, 0.0)
+    assertEquals(-3.1630346897289943E18, lg(1249322201, -736451403).toDouble, 0.0)
+    assertEquals(-4.4847682439933604E18, lg(483575860, -1044191477).toDouble, 0.0)
+    assertEquals(-6.4014772289576371E17, lg(-1526343930, -149046007).toDouble, 0.0)
+    assertEquals(-1.76968119148756736E18, lg(531728928, -412036011).toDouble, 0.0)
+    assertEquals(-8.5606671350959739E18, lg(-734111585, -1993185640).toDouble, 0.0)
+    assertEquals(-9.0403963253949932E18, lg(-1407864332, -2104881296).toDouble, 0.0)
+    assertEquals(-6.4988752582247977E18, lg(-1712351423, -1513137310).toDouble, 0.0)
+    assertEquals(-7.7788492399114394E17, lg(1969244733, -181115448).toDouble, 0.0)
+    assertEquals(7.6357174849871442E18, lg(-907683842, 1777829016).toDouble, 0.0)
+    assertEquals(1.25338659134517658E18, lg(-815927209, 291826806).toDouble, 0.0)
+    assertEquals(-3.1910241505692349E18, lg(463523496, -742968207).toDouble, 0.0)
+    assertEquals(7.4216510087652332E18, lg(1482622807, 1727987781).toDouble, 0.0)
+    assertEquals(-8.189046896086654E18, lg(1170040143, -1906661060).toDouble, 0.0)
+    assertEquals(6.8316272807487539E18, lg(-85609173, 1590612176).toDouble, 0.0)
+    assertEquals(-8.0611115909320561E18, lg(-1212811257, -1876873801).toDouble, 0.0)
+    assertEquals(1.7127521901359959E18, lg(-648802816, 398781194).toDouble, 0.0)
+    assertEquals(-6.4442523492577423E18, lg(-1484519186, -1500419423).toDouble, 0.0)
+    assertEquals(-1.71264450938175027E18, lg(-2016996893, -398756124).toDouble, 0.0)
   }
 
   @Test def fromDouble(): Unit = {
@@ -2226,8 +2218,8 @@ class RuntimeLongOldTest {
   }
 
   @Test def should_correctly_implement_toDouble(): Unit = {
-    assertEquals(5.0, fromInt(5).toDouble)
-    assertEquals(2147483648.0, (maxInt+one).toDouble)
+    assertEquals(5.0, fromInt(5).toDouble, 0.0)
+    assertEquals(2147483648.0, (maxInt+one).toDouble, 0.0)
   }
 
   @Test def should_correctly_implement_numberOfLeadingZeros(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
@@ -141,10 +141,10 @@ class DataViewTest {
     view.setUint8(3, 0x30)
     view.setUint8(4, 0x1A)
 
-    assertEquals(0x01FFB330, view.getUint32(0))
-    assertEquals(0x30B3FF01, view.getUint32(0, true))
-    assertEquals(0xFFB3301AL.toDouble, view.getUint32(1))
-    assertEquals(0x1A30B3FF, view.getUint32(1, true))
+    assertEquals(0x01FFB330, view.getUint32(0), 0.0)
+    assertEquals(0x30B3FF01, view.getUint32(0, true), 0.0)
+    assertEquals(0xFFB3301AL.toDouble, view.getUint32(1), 0.0)
+    assertEquals(0x1A30B3FF, view.getUint32(1, true), 0.0)
   }
 
   @Test def getFloat32(): Unit = {
@@ -163,7 +163,7 @@ class DataViewTest {
 
     view.setFloat64(0, 0.5)
 
-    assertEquals(0.5, view.getFloat64(0))
+    assertEquals(0.5, view.getFloat64(0), 0.0)
     assertNotEquals(0.5, view.getFloat64(1), 0.0)
     assertNotEquals(0.5, view.getFloat64(0, true), 0.0)
     assertNotEquals(0.5, view.getFloat64(1, true), 0.0)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
@@ -28,11 +28,11 @@ class TypedArrayConversionTest {
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Byte]])
-    assertEquals(sum(1), y.sum)
+    assertEquals(sum(1), y.sum, 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(sum(1), y.sum)
+    assertEquals(sum(1), y.sum, 0.0)
   }
 
   @Test def convert_an_Int16Array_to_a_scala_Array_Short(): Unit = {
@@ -40,11 +40,11 @@ class TypedArrayConversionTest {
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Short]])
-    assertEquals(sum(100), y.sum)
+    assertEquals(sum(100), y.sum, 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(sum(100), y.sum)
+    assertEquals(sum(100), y.sum, 0.0)
   }
 
   @Test def convert_an_Uint16Array_to_a_scala_Array_Char(): Unit = {
@@ -67,11 +67,11 @@ class TypedArrayConversionTest {
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Int]])
-    assertEquals(sum(10000), y.sum)
+    assertEquals(sum(10000), y.sum, 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(sum(10000), y.sum)
+    assertEquals(sum(10000), y.sum, 0.0)
   }
 
   @Test def convert_a_Float32Array_to_a_scala_Array_Float(): Unit = {
@@ -91,11 +91,11 @@ class TypedArrayConversionTest {
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Double]])
-    assertEquals(sum(0.2), y.sum)
+    assertEquals(sum(0.2), y.sum, 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(sum(0.2), y.sum)
+    assertEquals(sum(0.2), y.sum, 0.0)
   }
 
   @Test def convert_a_scala_Array_Byte__to_an_Int8Array(): Unit = {
@@ -168,11 +168,11 @@ class TypedArrayConversionTest {
     assertEquals(x.length, y.length)
 
     for (i <- 0 until y.length)
-      assertEquals(x(i), y(i))
+      assertEquals(x(i), y(i), 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(1.0f, y(0))
+    assertEquals(1.0f, y(0), 0.0)
   }
 
   @Test def convert_a_scala_Array_Double__to_a_Float64Array(): Unit = {
@@ -180,13 +180,13 @@ class TypedArrayConversionTest {
     val y = x.toTypedArray
 
     assertTrue(y.isInstanceOf[Float64Array])
-    assertEquals(x.length, y.length)
+    assertEquals(x.length, y.length, 0.0)
 
     for (i <- 0 until y.length)
-      assertEquals(x(i), y(i))
+      assertEquals(x(i), y(i), 0.0)
 
     // Ensure its a copy
     x(0) = 0
-    assertEquals(1.0, y(0))
+    assertEquals(1.0, y(0), 0.0)
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -253,7 +253,7 @@ class RegressionTest {
     assertThrows(classOf[Exception], (giveMeANull(): StringBuilder).append(5))
     assertThrows(classOf[Exception], (giveMeANull(): scala.runtime.IntRef).elem)
 
-    def giveMeANothing(): Nothing = sys.error("boom")
+    def giveMeANothing(): Nothing = throw new Exception("boom")
     assertThrows(classOf[Exception], (giveMeANothing(): StringBuilder).append(5))
     assertThrows(classOf[Exception], (giveMeANothing(): scala.runtime.IntRef).elem)
   }

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -52,7 +52,7 @@ object QuickLinker {
           def relativePath: String = s"<dummy relative path from $getClass>"
         }
       } else {
-        sys.error("Illegal IR file / Jar: " + file)
+        throw new IllegalArgumentException("Illegal IR file / Jar: " + file)
       }
     }
 

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
@@ -36,7 +36,7 @@ object TestRunner {
     }
 
     if (eventHandler.hasFailed)
-      sys.error("Some tests have failed")
+      throw new AssertionError("Some tests have failed")
   }
 
   private class SimpleEventHandler extends EventHandler {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
@@ -184,7 +184,8 @@ object LinkedClass {
         classExports += e
 
       case tree =>
-        sys.error(s"Illegal tree in ClassDef of class ${tree.getClass}")
+        throw new IllegalArgumentException(
+            s"Illegal tree in ClassDef of class ${tree.getClass}")
     }
 
     val classExportInfo = memberInfoByName.get(Definitions.ClassExportsName)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingException.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingException.scala
@@ -1,0 +1,21 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+/** Thrown by the linker when linking cannot be performed. */
+class LinkingException(message: String, cause: Throwable)
+    extends Exception(message, cause) {
+
+  def this(message: String) = this(message, null)
+
+  def this(cause: Throwable) =
+    this(if (cause == null) null else cause.toString(), cause)
+
+  def this() = this(null, null)
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -151,7 +151,7 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
         }
 
         if (importsFound) {
-          sys.error(
+          throw new LinkingException(
               "There were module imports without fallback to global " +
               "variables, but module support is disabled.\n" +
               "To enable module support, set scalaJSModuleKind := " +

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -448,7 +448,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           pushLhsInto(Lhs.Assign(lhs), rhs, tailPosLabels)
 
         case Assign(_, _) =>
-          sys.error(s"Illegal Assign in transformStat: $tree")
+          throw new IllegalArgumentException(
+              s"Illegal Assign in transformStat: $tree")
 
         case StoreModule(cls, value) =>
           unnest(value) { (newValue, env0) =>
@@ -516,7 +517,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             implicit val env = env0
 
             val enclosingClassName = env.enclosingClassName.getOrElse {
-              sys.error("Need enclosing class for super constructor call.")
+              throw new AssertionError(
+                  "Need enclosing class for super constructor call.")
             }
 
             val superCtorCall = {
@@ -1624,14 +1626,16 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                   _:StoreModule | _:ClassDef =>
                 transformStat(rhs, tailPosLabels)
               case _ =>
-                sys.error("Illegal tree in JSDesugar.pushLhsInto():\n" +
-                    "lhs = " + lhs + "\n" + "rhs = " + rhs +
-                    " of class " + rhs.getClass)
+                throw new IllegalArgumentException(
+                    "Illegal tree in JSDesugar.pushLhsInto():\n" +
+                    "lhs = " + lhs + "\n" +
+                    "rhs = " + rhs + " of class " + rhs.getClass)
             }
           } else {
-            sys.error("Illegal tree in JSDesugar.pushLhsInto():\n" +
-                "lhs = " + lhs + "\n" + "rhs = " + rhs +
-                " of class " + rhs.getClass)
+            throw new IllegalArgumentException(
+                "Illegal tree in JSDesugar.pushLhsInto():\n" +
+                "lhs = " + lhs + "\n" +
+                "rhs = " + rhs + " of class " + rhs.getClass)
           }
       })
     }
@@ -2143,8 +2147,9 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
         // Invalid trees
 
         case _ =>
-          sys.error("Invalid tree in JSDesugar.transformExpr() "+
-              s"of class ${tree.getClass}")
+          throw new IllegalArgumentException(
+              "Invalid tree in JSDesugar.transformExpr() of class " +
+              tree.getClass)
       }
     }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -86,8 +86,10 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
         val infoAndTrees =
           infoInput.map(info => (info, getTree(info.encodedName)._1))
         val errorCount = InfoChecker.check(infoAndTrees, logger)
-        if (errorCount != 0)
-          sys.error(s"There were $errorCount Info checking errors.")
+        if (errorCount != 0) {
+          throw new LinkingException(
+              s"There were $errorCount Info checking errors.")
+        }
       }
     }
 
@@ -114,7 +116,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
       if (skipped > 0)
         logger.log(Level.Error, s"Not showing $skipped more linking errors")
 
-      sys.error("There were linking errors")
+      throw new LinkingException("There were linking errors")
     }
 
     val linkResult = logger.time("Linker: Assemble LinkedClasses") {
@@ -127,8 +129,10 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
     if (checkIR) {
       logger.time("Linker: Check IR") {
         val errorCount = IRChecker.check(linkResult, logger)
-        if (errorCount != 0)
-          sys.error(s"There were $errorCount IR checking errors.")
+        if (errorCount != 0) {
+          throw new LinkingException(
+              s"There were $errorCount IR checking errors.")
+        }
       }
     }
 
@@ -238,7 +242,8 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
         classExports += e
 
       case tree =>
-        sys.error(s"Illegal tree in ClassDef of class ${tree.getClass}")
+        throw new IllegalArgumentException(
+            s"Illegal tree in ClassDef of class ${tree.getClass}")
     }
 
     // Synthetic members
@@ -418,8 +423,7 @@ final class BaseLinker(semantics: Semantics, esLevel: ESLevel,
       ()
     }
 
-    if (errors.nonEmpty) {
-      sys.error("There were conflicting exports.")
-    }
+    if (errors.nonEmpty)
+      throw new LinkingException("There were conflicting exports.")
   }
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -673,7 +673,8 @@ private[optimizer] abstract class OptimizerCore(
         tree
 
       case _ =>
-        sys.error(s"Invalid tree in transform of class ${tree.getClass.getName}: $tree")
+        throw new IllegalArgumentException(
+            s"Invalid tree in transform of class ${tree.getClass.getName}: $tree")
     }
 
     if (isStat) keepOnlySideEffects(result)
@@ -778,17 +779,23 @@ private[optimizer] abstract class OptimizerCore(
         pretransformBlock(tree)(cont)
 
       case VarRef(Ident(name, _)) =>
-        val localDef = scope.env.localDefs.getOrElse(name,
-            sys.error(s"Cannot find local def '$name' at $pos\n" +
-                s"While optimizing $myself\n" +
-                s"Env is ${scope.env}\nInlining ${scope.implsBeingInlined}"))
+        val localDef = scope.env.localDefs.getOrElse(name, {
+          throw new AssertionError(
+              s"Cannot find local def '$name' at $pos\n" +
+              s"While optimizing $myself\n" +
+              s"Env is ${scope.env}\n" +
+              s"Inlining ${scope.implsBeingInlined}")
+        })
         cont(localDef.toPreTransform)
 
       case This() =>
-        val localDef = scope.env.localDefs.getOrElse("this",
-            sys.error(s"Found invalid 'this' at $pos\n" +
-                s"While optimizing $myself\n" +
-                s"Env is ${scope.env}\nInlining ${scope.implsBeingInlined}"))
+        val localDef = scope.env.localDefs.getOrElse("this", {
+          throw new AssertionError(
+              s"Found invalid 'this' at $pos\n" +
+              s"While optimizing $myself\n" +
+              s"Env is ${scope.env}\n" +
+              s"Inlining ${scope.implsBeingInlined}")
+        })
         cont(localDef.toPreTransform)
 
       case tree: If =>
@@ -4159,7 +4166,7 @@ private[optimizer] abstract class OptimizerCore(
         }
       }
 
-      sys.error("Reached end of infinite loop")
+      throw new AssertionError("Reached end of infinite loop")
     } finally {
       curTrampolineId -= 1
     }


### PR DESCRIPTION
Motivation: get #2968 in master, because it touches plenty of code that we're working on a daily basis in master.

```
$ git checkout -b merge-0.6.x-into-master-may-29
Switched to a new branch 'merge-0.6.x-into-master-may-29'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   08119ab (scalajs/0.6.x, origin/0.6.x, 0.6.x) Merge pull request #2958 from gzm0/fix-junit
|\  
| * c1cc9d5 Fix #2927: Fail on assertEquals on floats/doubles
* |   8632e4c Merge pull request #2967 from sjrd/sjs-defined-by-default-0.6.x-option
|\ \  
| * | 46923ba (origin/sjs-defined-by-default-0.6.x-option) [no-master] Add an option -P:scalajs:sjsDefinedByDefault.
|/ /  
* |   152909f Merge pull request #2968 from sjrd/cut-deps-on-future-scala-modules
|\ \  
| |/  
|/|   
| * 03ed07a Avoid using `sys.env`.
| * 92fd5e2 Avoid `scala.compat._`.
| * fb49b7d Avoid `sys.error`.
| * 6a413ca Use a custom `LinkingException` for all user-space linking errors.
| * 614f409 Avoid `sys.exit`.
| * 615994b Avoid `sys.props`.
|/  
* 6452168 Merge pull request #2966 from sjrd/no-sam-of-js-type
* a470134 (origin/no-sam-of-js-type) Fix #2921: Forbid SAMs of JS types (except js.{This,}Function).
```
Uh oh! There's this `[no-master]` commit coming from #2967 over there. So the plan is:

1. Merge its parent 152909f as usual
2. Merge its merge commit 8632e4c with the `-s ours` strategy
3. Merge the remaining of the 0.6.x branch as usual

Here we go.

## First step

```
$ git merge --no-commit 152909f
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
CONFLICT (content): Merge conflict in tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
Auto-merging tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
Auto-merging tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
Auto-merging sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
CONFLICT (content): Merge conflict in sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
CONFLICT (modify/delete): sbt-plugin-test/project/Jetty9Test.scala deleted in HEAD and modified in 152909f. Version 152909f of sbt-plugin-test/project/Jetty9Test.scala left in tree.
Auto-merging project/ExternalCompile.scala
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
CONFLICT (content): Merge conflict in partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
CONFLICT (modify/delete): library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala deleted in HEAD and modified in 152909f. Version 152909f of library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala left in tree.
Auto-merging library/src/main/scala/scala/scalajs/js/package.scala
CONFLICT (modify/delete): js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala deleted in HEAD and modified in 152909f. Version 152909f of js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala left in tree.
Auto-merging js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
Auto-merging js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
CONFLICT (modify/delete): js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala deleted in HEAD and modified in 152909f. Version 152909f of js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala left in tree.
Auto-merging ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
M  cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
A  compiler/src/test/scala/org/scalajs/core/compiler/test/JSSAMTest.scala
M  compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
M  ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
UU ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
M  ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
M  ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
M  javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
M  javalib/src/main/scala/java/util/regex/Pattern.scala
DU js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
M  js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
M  js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
M  library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
M  library/src/main/scala/scala/scalajs/js/Array.scala
M  library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
M  library/src/main/scala/scala/scalajs/js/Dictionary.scala
M  library/src/main/scala/scala/scalajs/js/Dynamic.scala
M  library/src/main/scala/scala/scalajs/js/Object.scala
M  library/src/main/scala/scala/scalajs/js/package.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
DU library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala
M  library/src/main/scala/scala/scalajs/runtime/package.scala
M  partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
M  partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
UU partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
M  partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
UU project/Build.scala
M  project/ExternalCompile.scala
DU sbt-plugin-test/project/Jetty9Test.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
M  scalalib/overrides-2.10/scala/Array.scala
M  scalalib/overrides-2.10/scala/collection/immutable/RedBlackTree.scala
M  scalalib/overrides-2.10/scala/runtime/ScalaRunTime.scala
M  scalalib/overrides/scala/App.scala
M  scalalib/overrides/scala/Array.scala
M  scalalib/overrides/scala/collection/immutable/RedBlackTree.scala
M  scalalib/overrides/scala/util/control/NoStackTrace.scala
M  test-suite/js/src/test/resources/SourceMapTestTemplate.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
M  tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
M  tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
A  tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingException.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
UU tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
```
```
$ git rm --cached sbt-plugin-test/project/Jetty9Test.scala library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala 
js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala: needs merge
library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala: needs merge
sbt-plugin-test/project/Jetty9Test.scala: needs merge
rm 'js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala'
rm 'library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala'
rm 'sbt-plugin-test/project/Jetty9Test.scala'
```
```
$ rm sbt-plugin-test/project/Jetty9Test.scala library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala 
```
```
$ git st
M  cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
A  compiler/src/test/scala/org/scalajs/core/compiler/test/JSSAMTest.scala
M  compiler/src/test/scala/org/scalajs/core/compiler/test/util/DirectTest.scala
M  ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
UU ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
M  ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
M  ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
M  javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
M  javalib/src/main/scala/java/util/regex/Pattern.scala
M  js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
M  js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
M  library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
M  library/src/main/scala/scala/scalajs/js/Array.scala
M  library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
M  library/src/main/scala/scala/scalajs/js/Dictionary.scala
M  library/src/main/scala/scala/scalajs/js/Dynamic.scala
M  library/src/main/scala/scala/scalajs/js/Object.scala
M  library/src/main/scala/scala/scalajs/js/package.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
M  library/src/main/scala/scala/scalajs/runtime/package.scala
M  partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
M  partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
UU partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
M  partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
UU project/Build.scala
M  project/ExternalCompile.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
M  scalalib/overrides-2.10/scala/Array.scala
M  scalalib/overrides-2.10/scala/collection/immutable/RedBlackTree.scala
M  scalalib/overrides-2.10/scala/runtime/ScalaRunTime.scala
M  scalalib/overrides/scala/App.scala
M  scalalib/overrides/scala/Array.scala
M  scalalib/overrides/scala/collection/immutable/RedBlackTree.scala
M  scalalib/overrides/scala/util/control/NoStackTrace.scala
M  test-suite/js/src/test/resources/SourceMapTestTemplate.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
M  tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
M  tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
A  tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingException.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
UU tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
```
[...] Edit conflicting files + JSDependenciesPlugin.scala to remove a `sys.error`
```diff
$ git diff -w | cat
diff --cc ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
index 81936cb,b78b473..0000000
--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@@ -687,10 -699,13 +687,10 @@@ object Serializers 
        import input._
        val result = (tag: @switch) match {
          case TagEmptyTree =>
-           sys.error("Found invalid TagEmptyTree")
+           throw new IOException("Found invalid TagEmptyTree")
  
          case TagVarDef   => VarDef(readIdent(), readType(), readBoolean(), readTree())
 -        case TagParamDef =>
 -          ParamDef(readIdent(), readType(), readBoolean(),
 -              rest = if (useHacks060) false else readBoolean())
 -
 +        case TagParamDef => ParamDef(readIdent(), readType(), readBoolean(), readBoolean())
          case TagSkip     => Skip()
          case TagBlock    => Block(readTrees())
          case TagLabeled  => Labeled(readIdent(), readType(), readTree())
diff --cc partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
index 12c9f01,dc6774c..0000000
--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@@ -36,22 -38,13 +36,22 @@@ class MainGenericRunner 
      false
    }
  
-   val optMode = OptMode.fromId(sys.props("scalajs.partest.optMode"))
+   val optMode = OptMode.fromId(System.getProperty("scalajs.partest.optMode"))
  
    def readSemantics() = {
 +    import org.scalajs.core.tools.sem.CheckedBehavior.Compliant
 +
-     val opt = sys.props.get("scalajs.partest.compliantSems")
+     val opt = Option(System.getProperty("scalajs.partest.compliantSems"))
 -    opt.fold(Semantics.Defaults) { str =>
 -      val sems = str.split(',')
 -      Semantics.compliantTo(sems.toList)
 +    val compliantSems =
 +      opt.fold[List[String]](Nil)(_.split(',').toList.filter(_.nonEmpty))
 +
 +    compliantSems.foldLeft(Semantics.Defaults) { (prev, compliantSem) =>
 +      compliantSem match {
 +        case "asInstanceOfs"         => prev.withAsInstanceOfs(Compliant)
 +        case "arrayIndexOutOfBounds" => prev.withArrayIndexOutOfBounds(Compliant)
 +        case "moduleInit"            => prev.withModuleInit(Compliant)
 +        case "strictFloats"          => prev.withStrictFloats(true)
 +      }
      }
    }
  
diff --cc project/Build.scala
index d0fa603,628330d..0000000
--- a/project/Build.scala
+++ b/project/Build.scala
@@@ -552,10 -538,10 +554,10 @@@ object Build 
        testOptions += Tests.Setup { () =>
          val testOutDir = (streams.value.cacheDirectory / "scalajs-compiler-test")
          IO.createDirectory(testOutDir)
-         sys.props("scala.scalajs.compiler.test.output") =
-           testOutDir.getAbsolutePath
-         sys.props("scala.scalajs.compiler.test.scalajslib") =
-           (packageBin in (LocalProject("library"), Compile)).value.getAbsolutePath
+         System.setProperty("scala.scalajs.compiler.test.output",
+             testOutDir.getAbsolutePath)
+         System.setProperty("scala.scalajs.compiler.test.scalajslib",
 -                (packageBin in (library, Compile)).value.getAbsolutePath)
++            (packageBin in (LocalProject("library"), Compile)).value.getAbsolutePath)
  
          def scalaArtifact(name: String): String = {
            def isTarget(att: Attributed[File]) = {
@@@ -574,19 -560,19 +576,19 @@@
            }
          }
  
-         sys.props("scala.scalajs.compiler.test.scalalib") =
-           scalaArtifact("scala-library")
+         System.setProperty("scala.scalajs.compiler.test.scalalib",
+             scalaArtifact("scala-library"))
  
-         sys.props("scala.scalajs.compiler.test.scalareflect") =
-           scalaArtifact("scala-reflect")
+         System.setProperty("scala.scalajs.compiler.test.scalareflect",
+             scalaArtifact("scala-reflect"))
        },
        exportJars := true
 -      )
    ).dependsOnSource(irProject)
  
 -  val commonToolsSettings = (
 -      commonSettings ++ publishSettings ++ fatalWarningsSettings
 -  ) ++ Seq(
 +  val commonToolsSettings = Def.settings(
 +      commonSettings,
 +      publishSettings,
 +      fatalWarningsSettings,
        name := "Scala.js tools",
  
        unmanagedSourceDirectories in Compile +=
@@@ -636,16 -624,13 +638,16 @@@
          IO.write(outFile, testDefinitions)
          Seq(outFile)
        }.taskValue,
 -          jsDependencies += ProvidedJS / "js-test-definitions.js" % "test"
 -      ) ++ inConfig(Test) {
 +
 +      jsDependencies += ProvidedJS / "js-test-definitions.js" % "test",
 +      jsDependencies +=
 +        "org.webjars" % "jszip" % "2.4.0" % "test" / "jszip.min.js" commonJSName "JSZip",
 +
 +      inConfig(Test) {
          // Redefine test to run Node.js and link HelloWorld
          test := {
 -          val jsEnv = resolvedJSEnv.value
 -          if (!jsEnv.isInstanceOf[NodeJSEnv])
 +          if (!jsEnv.value.isInstanceOf[NodeJSEnv])
-             sys.error("toolsJS/test must be run with Node.js")
+             throw new MessageOnlyException("toolsJS/test must be run with Node.js")
  
            /* Collect IR relevant files from the classpath
             * We assume here that the classpath is valid. This is checked by the
diff --cc sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
index 6d969a2,f21cd12..0000000
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@@ -532,15 -855,14 +534,16 @@@ object ScalaJSPluginInternal 
          val toolsLogger = sbtLogger2ToolsLogger(logger)
          val frameworks = testFrameworks.value
  
 -        val jsEnv = loadedJSEnv.value match {
 -          case jsEnv: ComJSEnv => jsEnv
 +        val env = jsEnv.value match {
 +          case env: ComJSEnv => env
  
 -          case jsEnv =>
 +          case env =>
-             sys.error(s"You need a ComJSEnv to test (found ${env.name})")
+             throw new MessageOnlyException(
 -                s"You need a ComJSEnv to test (found ${jsEnv.name})")
++                s"You need a ComJSEnv to test (found ${env.name})")
          }
  
 +        val files = jsExecutionFiles.value
 +
          val moduleKind = scalaJSModuleKind.value
          val moduleIdentifier = scalaJSModuleIdentifier.value
  
diff --cc tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
index ea26ae5,cb589bc..0000000
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@@ -112,9 -154,10 +114,9 @@@ final class BaseLinker(semantics: Seman
  
        val skipped = analysis.errors.size - maxDisplayErrors
        if (skipped > 0)
 -        logger.log(linkingErrLevel, s"Not showing $skipped more linking errors")
 +        logger.log(Level.Error, s"Not showing $skipped more linking errors")
  
-       sys.error("There were linking errors")
 -      if (fatal)
+       throw new LinkingException("There were linking errors")
      }
  
      val linkResult = logger.time("Linker: Assemble LinkedClasses") {
@@@ -126,9 -169,16 +128,11 @@@
  
      if (checkIR) {
        logger.time("Linker: Check IR") {
 -        if (linkResult.isComplete) {
          val errorCount = IRChecker.check(linkResult, logger)
-         if (errorCount != 0)
-           sys.error(s"There were $errorCount IR checking errors.")
+         if (errorCount != 0) {
+           throw new LinkingException(
+               s"There were $errorCount IR checking errors.")
+         }
 -        } else {
 -          throw new LinkingException(
 -              "Could not check IR because there were linking errors.")
 -        }
        }
      }
  
@@@ -418,8 -508,7 +423,7 @@@
        ()
      }
  
-     if (errors.nonEmpty) {
-       sys.error("There were conflicting exports.")
-     }
 -    if (errors.nonEmpty && !bypassLinkingErrors)
++    if (errors.nonEmpty)
+       throw new LinkingException("There were conflicting exports.")
    }
  }
diff --git a/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala b/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
index 6aef486..f54fd4f 100644
--- a/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
+++ b/jsdependencies-sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
@@ -131,7 +131,8 @@ object JSDependenciesPlugin extends AutoPlugin {
           results += collectFile(file, relPath)
         }
       } else {
-        sys.error("Illegal classpath entry: " + cpEntry.getPath)
+        throw new IllegalArgumentException(
+            "Illegal classpath entry: " + cpEntry.getPath)
       }
     }
 
```
```
$ git add .
```
```
$ git commit
[merge-0.6.x-into-master-may-29 dcbbe8a] Merge '0.6.x' into 'master'.
```

## Second step.

```
$ export mb=$(git merge-base scalajs/0.6.x HEAD)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   08119ab (scalajs/0.6.x, origin/0.6.x, 0.6.x) Merge pull request #2958 from gzm0/fix-junit
|\  
| * c1cc9d5 Fix #2927: Fail on assertEquals on floats/doubles
* 8632e4c Merge pull request #2967 from sjrd/sjs-defined-by-default-0.6.x-option
* 46923ba (origin/sjs-defined-by-default-0.6.x-option) [no-master] Add an option -P:scalajs:sjsDefinedByDefault.
```
```
$ git merge -s ours 8632e4c
Merge made by the 'ours' strategy.
```
```
$ git show --stat
commit f8f2dc0744d0edfa04eb7738252a697c3447c2b9
Merge: dcbbe8a 8632e4c
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Mon May 29 16:41:27 2017 +0200

    Skip the [no-master] commit 46923ba.
    
    Merge commit '8632e4c' and its parent '46923ba' with the `-s ours`
    merge strategy, so their content do not make it into the `master`
    branch.
```

## Third step

```
$ export mb=$(git merge-base scalajs/0.6.x HEAD)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* 08119ab (scalajs/0.6.x, origin/0.6.x, 0.6.x) Merge pull request #2958 from gzm0/fix-junit
* c1cc9d5 Fix #2927: Fail on assertEquals on floats/doubles
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
M  junit-runtime/src/main/scala/org/junit/Assert.scala
A  junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsDoubleTest.scala
UU project/Build.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
```
[...] Edit conflicting files
```diff
$ git diff -w | cat
diff --cc project/Build.scala
index 8efc23a,4081c53..0000000
--- a/project/Build.scala
+++ b/project/Build.scala
@@@ -1120,20 -1160,17 +1120,19 @@@ object Build 
        delambdafySetting,
        previousArtifactSetting,
        mimaBinaryIssueFilters ++= BinaryIncompatibilities.TestInterface
 -      )
    ).withScalaJSCompiler.dependsOn(library)
  
 -  lazy val jUnitRuntime = Project(
 -    id = "jUnitRuntime",
 -    base = file("junit-runtime"),
 -    settings = commonSettings ++ publishSettings ++ myScalaJSSettings ++
 -      fatalWarningsSettings ++ Seq(name := "Scala.js JUnit test runtime")
 +  lazy val jUnitRuntime = (project in file("junit-runtime")).enablePlugins(
 +      MyScalaJSPlugin
 +  ).settings(
 +      commonSettings,
 +      publishSettings,
 +      fatalWarningsSettings,
 +      name := "Scala.js JUnit test runtime"
    ).withScalaJSCompiler.dependsOn(testInterface)
  
 -  val commonJUnitTestOutputsSettings = commonSettings ++ Seq(
 +  val commonJUnitTestOutputsSettings = Def.settings(
 +      commonSettings,
-       fatalWarningsSettings,
        publishArtifact in Compile := false,
        parallelExecution in Test := false,
        unmanagedSourceDirectories in Test +=
```
```
$ git add .
```
```
$ git commit
[merge-0.6.x-into-master-may-29 bf0b6f4] Merge '0.6.x' into 'master'.
```