### PR TITLE
Fix #2798: Tolerate Java 9.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
@@ -22,8 +22,8 @@ import OptimizerOptions._
 final class OptimizerOptions private (
     /** Whether to only warn if the linker has errors */
     val bypassLinkingErrors: Boolean = false,
-    /** Whether to parallelize the optimizer (currently fastOptJS only) **/
-    val parallel: Boolean = true,
+    /** Whether to parallelize the optimizer **/
+    val parallel: Boolean = OptimizerOptions.DefaultParallel,
     /** Whether to run the optimizer in batch (i.e. non-incremental) mode */
     val batchMode: Boolean = false,
     /** Whether to run the Scala.js optimizer */
@@ -86,5 +86,25 @@ final class OptimizerOptions private (
 }
 
 object OptimizerOptions {
+  /* #2798 -- On Java 9+, the parallel collections on 2.10 die with a
+   * `NumberFormatException` and prevent the linker from working.
+   *
+   * By default, we therefore pre-emptively disable the parallel optimizer in
+   * case the parallel collections cannot deal with the current version of
+   * Java.
+   *
+   * TODO This will automatically "fix itself" once we upgrade to sbt 1.x,
+   * which uses Scala 2.12. We should get rid of that workaround at that point
+   * for tidiness, though.
+   */
+  private val DefaultParallel: Boolean = {
+    try {
+      scala.util.Properties.isJavaAtLeast("1.8")
+      true
+    } catch {
+      case _: NumberFormatException => false
+    }
+  }
+
   def apply(): OptimizerOptions = new OptimizerOptions()
 }


### PR DESCRIPTION
Using the parallel optimizer does not work on Java 9, because the parallel collections of Scala 2.10 cannot parse its version number, and die.

This commit falls back on the sequential optimizer in cases where parallel collections are not supported.