### PR TITLE
Fix #2979: Allow `%%%` in builds that contain no Scala.js project.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -392,8 +392,7 @@ object ScalaJSPlugin extends AutoPlugin {
   import ScalaJSPluginInternal._
 
   override def globalSettings: Seq[Setting[_]] = {
-    super.globalSettings ++ Seq(
-        isScalaJSProject := false,
+    Seq(
         scalaJSStage := Stage.FastOpt,
         scalaJSUseRhinoInternal := false,
         scalaJSClearCacheStats := globalIRCache.clearStats()

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/internal/ScalaJSGlobalPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/internal/ScalaJSGlobalPlugin.scala
@@ -1,0 +1,41 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.sbtplugin.internal
+
+import sbt._
+
+import org.scalajs.sbtplugin.ScalaJSPlugin.autoImport.isScalaJSProject
+
+/* Additional note about the deprecation below. Even though we are in the
+ * `internal` package, ScalaJSGlobalPlugin will be imported by default in the
+ * scope of `.sbt` files because it is an `AutoPlugin`. We do not want users to
+ * refer to it by accident, without noticing they are using something from
+ * `internal`.
+ *
+ * Since it will be loaded by sbt using reflection anyway, the deprecation will
+ * not creep into legitimate builds.
+ */
+
+/** An `AutoPlugin` setting up some global settings that must be present in the
+ *  build even if no project enables [[ScalaJSPlugin]].
+ *
+ *  This plugin should never be directly referenced in source code, and is
+ *  therefore "deprecated forever".
+ */
+@deprecated("Do not explicitly mention ScalaJSGlobalPlugin in source code",
+    "forever")
+object ScalaJSGlobalPlugin extends AutoPlugin {
+  override def trigger: PluginTrigger = allRequirements
+
+  override def globalSettings: Seq[Setting[_]] = {
+    Seq(
+        isScalaJSProject := false
+    )
+  }
+}


### PR DESCRIPTION
In a build that declares a dependency on `sbt-scalajs`, but does not actually *enable* the `ScalaJSPlugin` in any project, its `globalSettings` will not be considered. This means that the setting `isScalaJSProject` is not initialized, and the `%%%` macro produces references to an undefined setting.

We fix this by declaring a separate `AutoPlugin` that is *always* triggered, and only initializes that setting. That plugin should never be referred to in user code, so we put it in an `internal` package. Additionally, we deprecate it "since forever" so that users do not refer to it by accident in a `.sbt` file (which will import it due to it being an `AutoPlugin`).