### PR TITLE
Remove the scalaJSConsole sbt setting.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -20,7 +20,7 @@ import org.scalajs.core.ir
 import org.scalajs.core.ir.Utils.escapeJS
 
 import org.scalajs.sbtplugin._
-import org.scalajs.jsenv.JSEnv
+import org.scalajs.jsenv.{ConsoleJSConsole, JSEnv}
 import org.scalajs.jsenv.nodejs.{NodeJSEnv, JSDOMNodeJSEnv}
 
 import ScalaJSPlugin.autoImport._
@@ -721,7 +721,7 @@ object Build {
 
           val runner = jsEnv.value.jsRunner(executionFiles :+ launcher)
 
-          runner.run(sbtLogger2ToolsLogger(streams.value.log), scalaJSConsole.value)
+          runner.run(sbtLogger2ToolsLogger(streams.value.log), ConsoleJSConsole)
         }
       }
   ).withScalaJSCompiler.dependsOn(

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -157,9 +157,6 @@ object ScalaJSPlugin extends AutoPlugin {
         "Linked Scala.js file. This is the result of fastOptJS or fullOptJS, " +
         "depending on the stage.", DTask)
 
-    val scalaJSConsole = TaskKey[JSConsole]("scalaJSConsole",
-        "The JS console used by the Scala.js runner/tester", DTask)
-
     val jsEnv = TaskKey[JSEnv]("jsEnv",
         "The JavaScript environment in which to run and test Scala.js applications.",
         AMinusTask)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -510,8 +510,7 @@ object ScalaJSPluginInternal {
         log.info("Running " + mainClass.value.getOrElse("<unknown class>"))
         log.debug(s"with JSEnv ${env.name}")
 
-        env.jsRunner(files).run(
-            sbtLogger2ToolsLogger(log), scalaJSConsole.value)
+        env.jsRunner(files).run(sbtLogger2ToolsLogger(log), ConsoleJSConsole)
       },
 
       runMain := {
@@ -529,7 +528,6 @@ object ScalaJSPluginInternal {
         // use assert to prevent warning about pure expr in stat pos
         assert(scalaJSEnsureUnforked.value)
 
-        val console = scalaJSConsole.value
         val logger = streams.value.log
         val toolsLogger = sbtLogger2ToolsLogger(logger)
         val frameworks = testFrameworks.value
@@ -552,7 +550,7 @@ object ScalaJSPluginInternal {
 
         detector.detect(frameworks, toolsLogger) map { case (tf, name) =>
           (tf, new ScalaJSFramework(name, env, files, moduleKind,
-              moduleIdentifier, toolsLogger, console))
+              moduleIdentifier, toolsLogger, ConsoleJSConsole))
         }
       },
       // Override default to avoid triggering a test:fastOptJS in a test:compile
@@ -690,8 +688,6 @@ object ScalaJSPluginInternal {
       jsExecutionFiles in Compile := jsExecutionFiles.value,
       // Do not inherit jsExecutionFiles in Test from Compile
       jsExecutionFiles in Test := jsExecutionFiles.value,
-
-      scalaJSConsole := ConsoleJSConsole,
 
       clean := {
         // have clean reset incremental linker state

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -550,7 +550,7 @@ object ScalaJSPluginInternal {
 
         detector.detect(frameworks, toolsLogger) map { case (tf, name) =>
           (tf, new ScalaJSFramework(name, env, files, moduleKind,
-              moduleIdentifier, toolsLogger, ConsoleJSConsole))
+              moduleIdentifier, toolsLogger))
         }
       },
       // Override default to avoid triggering a test:fastOptJS in a test:compile

--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala
@@ -26,14 +26,12 @@ final class ScalaJSFramework(
     private val jsFiles: Seq[VirtualJSFile],
     private[testadapter] val moduleKind: ModuleKind,
     private[testadapter] val moduleIdentifier: Option[String],
-    private[testadapter] val logger: Logger,
-    private[testadapter] val jsConsole: JSConsole
+    private[testadapter] val logger: Logger
 ) extends Framework {
 
   def this(frameworkName: String, jsEnv: ComJSEnv, jsFiles: Seq[VirtualJSFile],
-      logger: Logger, jsConsole: JSConsole) = {
-    this(frameworkName, jsEnv, jsFiles, ModuleKind.NoModule, None, logger,
-        jsConsole)
+      logger: Logger) = {
+    this(frameworkName, jsEnv, jsFiles, ModuleKind.NoModule, None, logger)
   }
 
   private[this] val frameworkInfo = fetchFrameworkInfo()
@@ -64,7 +62,7 @@ final class ScalaJSFramework(
 
   private def fetchFrameworkInfo() = {
     val runner = newComRunner(frameworkInfoLauncher :: Nil)
-    runner.start(logger, jsConsole)
+    runner.start(logger, ConsoleJSConsole)
 
     try {
       val msg = readJSON(runner.receive())

--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
@@ -178,7 +178,7 @@ final class ScalaJSRunner private[testadapter] (
 
     // Launch the slave
     val slave = framework.newComRunner(slaveLauncher :: Nil)
-    slave.start(framework.logger, framework.jsConsole)
+    slave.start(framework.logger, ConsoleJSConsole)
 
     // Create a runner on the slave
     slave.send("newRunner")
@@ -219,7 +219,7 @@ final class ScalaJSRunner private[testadapter] (
     assert(master == null)
 
     master = framework.newComRunner(masterLauncher :: Nil)
-    master.start(framework.logger, framework.jsConsole)
+    master.start(framework.logger, ConsoleJSConsole)
 
     val data = {
       val bld = new JSONObjBuilder


### PR DESCRIPTION
sbt does not provide JVM projects with any similar setting, allowing to redirect the output of the processes. Providing one in Scala.js project is therefore useless complexity.

Consequently, we also remove the `JSConsole` argument to `new ScalaJSFramework`, as it is not used anymore. Moreover, the sbt testing interface for the JVM does not offer a similar mechanism allowing to redirect the standard output. Therefore, providing it to the Scala.js testing framework adapter is useless complexity.