### PR TITLE
CI: Only run `npm install` if not up-to-date.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -15,7 +15,7 @@
 
   <task id="main"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbtretry ++$scala helloworld/run &&
     sbtretry 'set scalaJSStage in Global := FullOptStage' \
         ++$scala helloworld/run \
@@ -59,7 +59,7 @@
 
   <task id="test-suite-ecma-script5"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbtretry ++$scala jUnitTestOutputsJVM/test jUnitTestOutputsJS/test \
         'set scalaJSStage in Global := FullOptStage' jUnitTestOutputsJS/test &&
     sbtretry ++$scala $testSuite/test &&
@@ -99,7 +99,7 @@
 
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
         ++$scala $testSuite/test \
@@ -144,7 +144,7 @@
 
   <task id="bootstrap"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbt ++$scala irJS/test toolsJS/test &&
     sbt 'set scalaJSStage in Global := FullOptStage' \
         ++$scala irJS/test toolsJS/test
@@ -152,7 +152,7 @@
 
   <task id="tools-cli-stubs"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbt ++$scala tools/package ir/test tools/test cli/package cli/assembly \
         stubs/package jsEnvsTestSuite/test jsDependenciesCore/test \
         ir/mimaReportBinaryIssues tools/mimaReportBinaryIssues \
@@ -166,7 +166,7 @@
 
   <task id="tools-cli-stubs-sbtplugin"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbt ++$scala tools/package ir/test tools/test cli/package cli/assembly \
         stubs/package jsEnvsTestSuite/test jsDependenciesCore/test \
         sbtPlugin/package jsDependenciesPlugin/package \
@@ -197,14 +197,14 @@
 
   <task id="partestc"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbt ++$scala partest/compile
   ]]></task>
 
   <task id="sbtplugin-test"><![CDATA[
     # Publish Scala.js artifacts locally
     # Then go into standalone project and test
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbt ++2.11.11 compiler/publishLocal library/publishLocal \
                   testInterface/publishLocal stubs/publishLocal \
                   jUnitPlugin/publishLocal jUnitRuntime/publishLocal &&
@@ -226,19 +226,19 @@
 
   <task id="partest-noopt"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbt ++$scala package "partestSuite/testOnly -- --showDiff"
   ]]></task>
 
   <task id="partest-fastopt"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbt ++$scala package "partestSuite/testOnly -- --fastOpt --showDiff"
   ]]></task>
 
   <task id="partest-fullopt"><![CDATA[
     setJavaVersion $java
-    npm install &&
+    (touch npm-install-cache.txt && sha1sum package.json | diff -q - npm-install-cache.txt || npm install && sha1sum package.json > npm-install-cache.txt) &&
     sbt ++$scala package "partestSuite/testOnly -- --fullOpt --showDiff"
   ]]></task>
 


### PR DESCRIPTION
Since `npm install` seems to have a high failure rate on the CI servers, we explicitly avoid running it if there is nothing to do. We test that by comparing the sha1 hash of `package.json` to a cache file.