### PR TITLE
Fix #2382 for good, on all Scala versions.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1528,22 +1528,6 @@ object Build {
         Seq(outFile)
       }.taskValue,
 
-      // Exclude tests based on version-dependent bugs
-      sources in Test := {
-        val sourceFiles = (sources in Test).value
-        val v = scalaVersion.value
-
-        val hasBug2382 = v.startsWith("2.10.") || v.startsWith("2.11.")
-        val sourceFiles1 = {
-          if (hasBug2382)
-            sourceFiles.filterNot(_.getName == "OuterClassTest.scala")
-          else
-            sourceFiles
-        }
-
-        sourceFiles1
-      },
-
       // Module initializers. Duplicated in toolsJS/test
       scalaJSModuleInitializers += {
         ModuleInitializer.mainMethod(

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/OuterClassTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/OuterClassTest.scala
@@ -3,9 +3,6 @@ package org.scalajs.testsuite.compiler
 import org.junit.Test
 import org.junit.Assert._
 
-/* This test only works with 2.12.0-RC2 onwards. With previous versions of
- * Scala, it suffers from #2382.
- */
 class OuterClassTest {
 
   @Test def `Test code variant 1 from #2382`(): Unit = {


### PR DESCRIPTION
We simply remove the guard that prevented the fix from being applied in 2.10 and 2.11. It was necessary in 0.6.x not to break backward binary compatibility, but we can now fix it for good.