### PR TITLE
DO NOT MERGE Recognize any "standard" JVM-style main object in the sbt plugin.

### DIFF
--- a/TESTING
+++ b/TESTING
@@ -11,16 +11,16 @@ For each major Scala version on a *NIX distro and a Windows distro:
 5. Create a temporary directory and do:
 
         mkdir bin
-        echo 'import scala.scalajs.js.JSApp
-          object Foo extends JSApp {
-
-            def main() = {
+        echo '
+          object Foo {
+            def main(args: Array[String]): Unit = {
               println(s"asdf ${1 + 1}")
               new A
             }
 
             class A
-          }' > foo.scala
+          }
+        ' > foo.scala
         scalajsc -d bin foo.scala
 
         scalajsp bin/Foo$.sjsir
@@ -28,10 +28,9 @@ For each major Scala version on a *NIX distro and a Windows distro:
         scalajsp bin/Foo\$A.sjsir
         # Verify output
 
-        scalajsld -o test.js bin
+        scalajsld -o test.js -mm Foo.main bin
         # Verify output
 
-        echo "Foo().main()" >> test.js
         node test.js # Or your favorite thing to run JS
 
         # Expect "asdf 2"

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -50,7 +50,7 @@ object Scalajsld {
       val lastDot = s.lastIndexOf('.')
       if (lastDot < 0)
         throw new IllegalArgumentException(s"$s is not a valid main method")
-      ModuleInitializer.mainMethod(s.substring(0, lastDot),
+      ModuleInitializer.mainMethodWithArgs(s.substring(0, lastDot),
           s.substring(lastDot + 1))
     }
   }
@@ -83,7 +83,7 @@ object Scalajsld {
         .abbr("mm")
         .unbounded()
         .action { (x, c) => c.copy(moduleInitializers = c.moduleInitializers :+ x) }
-        .text("Execute the specified main method on startup")
+        .text("Execute the specified main(Array[String]) method on startup")
       opt[File]('o', "output")
         .valueName("<file>")
         .required()

--- a/examples/helloworld/HelloWorld.scala
+++ b/examples/helloworld/HelloWorld.scala
@@ -8,8 +8,8 @@ package helloworld
 import scala.scalajs.js
 import js.annotation._
 
-object HelloWorld extends js.JSApp {
-  def main() {
+object HelloWorld {
+  def main(args: Array[String]) {
     import js.DynamicImplicits.truthValue
 
     if (js.Dynamic.global.document &&

--- a/library/src/main/scala/scala/scalajs/js/JSApp.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSApp.scala
@@ -2,13 +2,28 @@ package scala.scalajs.js
 
 /** Base class for top-level, entry point main objects.
  *
- *  [[JSApp]] is typically used to mark the entry point of a Scala.js
- *  application. As such, the sbt plugin also recognizes top-level objects
- *  extending [[JSApp]]. It allows to run their [[main]] method with `sbt run`.
+ *  In Scala.js 0.6.x, an top-level object had to extend `js.JSApp` to be
+ *  recognized by the sbt plugin as a "main" object, to be executed with `run`.
+ *  Starting with Scala.js 1.0.0, any object with a standard main method of the
+ *  form
+ *  {{{
+ *  def main(args: Array[String]): Unit = ???
+ *  }}}
+ *  will be recognized by the sbt plugin, just like for a JVM project.
  *
- *  To execute the [[main]] method immediately when your Scala.js file is
- *  loaded, use the `scalaJSUseMainModuleInitializer` setting in the sbt plugin.
+ *  [[JSApp]] is therefore deprecated, and should not be used anymore.
  */
+@deprecated(
+    "Extending js.JSApp is not necessary anymore for an object to be " +
+    "recognized by the Scala.js sbt plugin. " +
+    "Use a normal object with a `def main(args: Array[String]): Unit` " +
+    "instead, which will also be cross-platform. " +
+    "Note that js.JSApp objects and their main() method are not " +
+    "automatically exported to JavaScript either; explicitly export your " +
+    "object if you relied on this behavior.",
+    "1.0.0")
 trait JSApp {
+  def main(args: scala.Array[String]): Unit = main()
+
   def main(): Unit
 }

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -68,13 +68,10 @@ class MainGenericRunner {
     val logger = new ScalaConsoleLogger(Level.Warn)
     val jsConsole = new ScalaConsoleJSConsole
     val semantics = readSemantics()
-    val ir = (
-        loadIR(command.settings.classpathURLs) :+
-        runnerIR(command.thingToRun, command.arguments)
-    )
+    val ir = loadIR(command.settings.classpathURLs)
 
-    val moduleInitializers =
-      Seq(ModuleInitializer.mainMethod("PartestLauncher", "main"))
+    val moduleInitializers = Seq(ModuleInitializer.mainMethodWithArgs(
+        command.thingToRun, "main", command.arguments))
 
     val linkerConfig = Linker.Config()
       .withSourceMap(false)
@@ -99,67 +96,6 @@ class MainGenericRunner {
       FileScalaJSIRContainer.fromClasspath(classpathURLs.map(urlToFile))
     val cache = (new IRFileCache).newCache
     cache.cached(irContainers)
-  }
-
-  private def runnerIR(mainObj: String, args: List[String]) = {
-    import ir.Infos._
-    import ir.ClassKind
-    import ir.Trees._
-    import ir.Types._
-
-    val mainModuleClassName = ir.Definitions.encodeClassName(mainObj + "$")
-    val className = "PartestLauncher$"
-    val encodedClassName = ir.Definitions.encodeClassName(className)
-
-    val definition = {
-      implicit val DummyPos = ir.Position.NoPosition
-      ClassDef(
-        Ident(encodedClassName, Some(className)),
-        ClassKind.ModuleClass,
-        Some(Ident("O", Some("java.lang.Object"))),
-        Nil,
-        None,
-        List(
-          MethodDef(
-            static = false,
-            Ident("init___", Some("<init>")),
-            Nil,
-            NoType,
-            Some(
-              ApplyStatically(This()(ClassType(encodedClassName)),
-                ClassType(ir.Definitions.ObjectClass),
-                Ident("init___"),
-                Nil
-              )(NoType)
-            )
-          )(OptimizerHints.empty, None),
-          MethodDef(
-            static = false,
-            Ident("main__V", Some("main")),
-            Nil,
-            NoType,
-            Some(
-              Apply(LoadModule(ClassType(mainModuleClassName)),
-                Ident("main__AT__V"),
-                List(
-                  ArrayValue(ArrayType("T", 1), args.map(StringLiteral(_)))
-                )
-              )(NoType)
-            )
-          )(OptimizerHints.empty, None)
-        )
-      )(OptimizerHints.empty)
-    }
-
-    val info = generateClassInfo(definition)
-
-    val infoAndDefinition = (info, definition)
-
-    new VirtualScalaJSIRFile {
-      def exists: Boolean = true
-      def path: String = "PartestLauncher$.sjsir"
-      def infoAndTree: (ClassInfo, ClassDef) = infoAndDefinition
-    }
   }
 
   private def urlToFile(url: java.net.URL) = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -684,7 +684,9 @@ object Build {
             val unescapedMainMethods = List(
                 "org.scalajs.testsuite.compiler.ModuleInitializerInNoConfiguration.main",
                 "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.main2",
-                "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.main1"
+                "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.main1",
+                "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.mainArgs1()",
+                "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.mainArgs2(foo,bar)"
             )
             seqOfStringsToJSArrayCode(unescapedMainMethods)
           }
@@ -1564,6 +1566,16 @@ object Build {
         ModuleInitializer.mainMethod(
             "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration",
             "main1")
+      },
+      scalaJSModuleInitializers in Test += {
+        ModuleInitializer.mainMethodWithArgs(
+            "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration",
+            "mainArgs1")
+      },
+      scalaJSModuleInitializers in Test += {
+        ModuleInitializer.mainMethodWithArgs(
+            "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration",
+            "mainArgs2", List("foo", "bar"))
       }
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
       library, jUnitRuntime

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -448,31 +448,10 @@ object ScalaJSPluginInternal {
     }
   }
 
-  def discoverJSApps(analysis: inc.Analysis): Seq[String] = {
-    import xsbt.api.{Discovered, Discovery}
-
-    val jsApp = "scala.scalajs.js.JSApp"
-
-    def isJSApp(discovered: Discovered) =
-      discovered.isModule && discovered.baseClasses.contains(jsApp)
-
-    Discovery(Set(jsApp), Set.empty)(Tests.allDefs(analysis)) collect {
-      case (definition, discovered) if isJSApp(discovered) =>
-        definition.name
-    }
-  }
-
-  private val runMainParser = {
-    Defaults.loadForParser(discoveredMainClasses) { (_, names) =>
-      val mainClasses = names.getOrElse(Nil).toSet
-      Space ~> token(NotSpace examples mainClasses)
-    }
-  }
-
   // These settings will be filtered by the stage dummy tasks
   val scalaJSRunSettings = Seq(
       scalaJSMainModuleInitializer := {
-        mainClass.value.map(ModuleInitializer.mainMethod(_, "main"))
+        mainClass.value.map(ModuleInitializer.mainMethodWithArgs(_, "main"))
       },
 
       scalaJSModuleInitializers ++= {
@@ -490,9 +469,6 @@ object ScalaJSPluginInternal {
           Seq.empty
         }
       },
-
-      discoveredMainClasses := compile.map(discoverJSApps).
-        storeAs(discoveredMainClasses).triggeredBy(compile).value,
 
       run := {
         // use assert to prevent warning about pure expr in stat pos

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
@@ -15,7 +15,13 @@ class ModuleInitializersTest {
 
   @Test def correctInitializers(): Unit = {
     assertArrayEquals(
-        Array[AnyRef](NoConfigMain, TestConfigMain2, TestConfigMain1),
+        Array[AnyRef](
+            NoConfigMain,
+            TestConfigMain2,
+            TestConfigMain1,
+            TestConfigMainArgs1 + "()",
+            TestConfigMainArgs2 + "(foo, bar)"
+        ),
         moduleInitializersEffects.toArray[AnyRef])
   }
 
@@ -26,6 +32,8 @@ object ModuleInitializersTest {
   final val CompileConfigMain = "ModuleInitializerInCompileConfiguration.main"
   final val TestConfigMain1 = "ModuleInitializerInTestConfiguration.main1"
   final val TestConfigMain2 = "ModuleInitializerInTestConfiguration.main2"
+  final val TestConfigMainArgs1 = "ModuleInitializerInTestConfiguration.mainArgs1"
+  final val TestConfigMainArgs2 = "ModuleInitializerInTestConfiguration.mainArgs2"
 
   val moduleInitializersEffects =
     new scala.collection.mutable.ListBuffer[String]
@@ -57,5 +65,15 @@ object ModuleInitializerInTestConfiguration {
 
   def main2(): Unit = {
     moduleInitializersEffects += TestConfigMain2
+  }
+
+  def mainArgs1(args: Array[String]): Unit = {
+    moduleInitializersEffects +=
+      TestConfigMainArgs1 + args.mkString("(", ", ", ")")
+  }
+
+  def mainArgs2(args: Array[String]): Unit = {
+    moduleInitializersEffects +=
+      TestConfigMainArgs2 + args.mkString("(", ", ", ")")
   }
 }

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -18,26 +18,26 @@ object QuickLinker {
   /** Link a Scala.js application on Node.js */
   @JSExport
   def linkNode(irFilesAndJars: js.Array[String],
-      mainMethods: js.Array[String]): String = {
-    linkNodeInternal(Semantics.Defaults, irFilesAndJars, mainMethods)
+      moduleInitializers: js.Array[String]): String = {
+    linkNodeInternal(Semantics.Defaults, irFilesAndJars, moduleInitializers)
   }
 
   /** Link the Scala.js test suite on Node.js */
   @JSExport
   def linkTestSuiteNode(irFilesAndJars: js.Array[String],
-      mainMethods: js.Array[String]): String = {
+      moduleInitializers: js.Array[String]): String = {
     val semantics = Semantics.Defaults.withRuntimeClassName(_.fullName match {
       case "org.scalajs.testsuite.compiler.ReflectionTest$RenamedTestClass" =>
         "renamed.test.Class"
       case fullName =>
         fullName
     })
-    linkNodeInternal(semantics, irFilesAndJars, mainMethods)
+    linkNodeInternal(semantics, irFilesAndJars, moduleInitializers)
   }
 
   /** Link a Scala.js application on Node.js */
   def linkNodeInternal(semantics: Semantics,
-      irFilesAndJars: Seq[String], mainMethods: Seq[String]): String = {
+      irFilesAndJars: Seq[String], moduleInitializers: Seq[String]): String = {
     val cache = (new IRFileCache).newCache
 
     val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,
@@ -58,18 +58,41 @@ object QuickLinker {
 
     val ir = cache.cached(irContainers)
 
-    val moduleInitializers = mainMethods.map { mainMethod =>
-      val lastDot = mainMethod.lastIndexOf('.')
-      if (lastDot < 0)
-        throw new IllegalArgumentException(s"$mainMethod is not a valid main method")
-      ModuleInitializer.mainMethod(mainMethod.substring(0, lastDot),
-          mainMethod.substring(lastDot + 1))
-    }
+    val parsedModuleInitializers =
+      moduleInitializers.map(parseModuleInitializer)
 
     val out = WritableMemVirtualJSFile("out.js")
-    linker.link(ir, moduleInitializers, out, new ScalaConsoleLogger)
+    linker.link(ir, parsedModuleInitializers, out, new ScalaConsoleLogger)
 
     out.content
+  }
+
+  private def parseModuleInitializer(spec: String): ModuleInitializer = {
+    def fail(): Nothing = {
+      throw new IllegalArgumentException(
+          s"'$spec' is not a valid module initializer spec")
+    }
+
+    def parseObjectAndMain(str: String): (String, String) = {
+      val lastDot = str.lastIndexOf('.')
+      if (lastDot < 0)
+        fail()
+      (str.substring(0, lastDot), str.substring(lastDot + 1))
+    }
+
+    val parenPos = spec.indexOf('(')
+    if (parenPos < 0) {
+      val (objectName, mainMethodName) = parseObjectAndMain(spec)
+      ModuleInitializer.mainMethod(objectName, mainMethodName)
+    } else {
+      if (spec.last != ')')
+        fail()
+      val (objectName, mainMethodName) =
+        parseObjectAndMain(spec.substring(0, parenPos))
+      val args =
+        spec.substring(parenPos + 1, spec.length - 1).split(",", -1).toList
+      ModuleInitializer.mainMethodWithArgs(objectName, mainMethodName, args)
+    }
   }
 
   private class NodeVirtualJarFile(file: String)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
@@ -1123,6 +1123,11 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
     moduleInitializer match {
       case ModuleInitializer.VoidMainMethod(moduleClassName, mainMethodName) =>
         js.Apply(genLoadModule(moduleClassName) DOT mainMethodName, Nil)
+
+      case ModuleInitializer.MainMethodWithArgs(moduleClassName, mainMethodName,
+          args) =>
+        js.Apply(genLoadModule(moduleClassName) DOT mainMethodName,
+            genArrayValue(ArrayType("T", 1), args.map(js.StringLiteral(_))) :: Nil)
     }
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -1932,8 +1932,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
               genClassDataOf(tpe), js.ArrayConstr(lengths map transformExpr))
 
         case ArrayValue(tpe, elems) =>
-          genCallHelper("makeNativeArrayWrapper",
-              genClassDataOf(tpe), js.ArrayConstr(elems map transformExpr))
+          genArrayValue(tpe, elems.map(transformExpr))
 
         case ArrayLength(array) =>
           genIdentBracketSelect(js.DotSelect(transformExpr(array),
@@ -2208,17 +2207,6 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
         case name: Ident           => transformIdent(name)
         case StringLiteral(s)      => js.StringLiteral(s)
         case ComputedName(tree, _) => js.ComputedName(transformExpr(tree))
-      }
-    }
-
-    def genClassDataOf(cls: ReferenceType)(implicit pos: Position): js.Tree = {
-      cls match {
-        case ClassType(className) =>
-          envField("d", className)
-        case ArrayType(base, dims) =>
-          (1 to dims).foldLeft[js.Tree](envField("d", base)) { (prev, _) =>
-            js.Apply(js.DotSelect(prev, js.Ident("getArrayOf")), Nil)
-          }
       }
     }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -202,6 +202,23 @@ private[emitter] final class JSGen(val semantics: Semantics,
     }
   }
 
+  def genArrayValue(tpe: ArrayType, elems: List[Tree])(
+      implicit pos: Position): Tree = {
+    genCallHelper("makeNativeArrayWrapper", genClassDataOf(tpe),
+        ArrayConstr(elems))
+  }
+
+  def genClassDataOf(cls: ReferenceType)(implicit pos: Position): Tree = {
+    cls match {
+      case ClassType(className) =>
+        envField("d", className)
+      case ArrayType(base, dims) =>
+        (1 to dims).foldLeft[Tree](envField("d", base)) { (prev, _) =>
+          Apply(DotSelect(prev, Ident("getArrayOf")), Nil)
+        }
+    }
+  }
+
   def envModuleField(module: String)(implicit pos: Position): VarRef = {
     /* This is written so that the happy path, when `module` contains only
      * valid characters, is fast.


### PR DESCRIPTION
Instead of recognizing objects extending `js.JSApp` as main objects in the sbt plugin, we now recognize any object with a JVM-style `main` method (with an `Array[String]` parameter). We use a new kind of module initializer, namely `ModuleInitializer.mainMethodWithArgs`, to call them.

This has the nice benefit that we can finally write a cross-platform main object.

For backward source compatibility, we add in `js.JSApp` a forwarder
```scala
def main(args: Array[String]): Unit = main()
```
which allows existing `js.JSApp` to still be recognized and run. `js.JSApp` is nevertheless deprecated, as there is no reason to use it anymore.