### PR TITLE
Recognize any "standard" JVM-style main object in the sbt plugin.

### DIFF
--- a/TESTING
+++ b/TESTING
@@ -11,16 +11,16 @@ For each major Scala version on a *NIX distro and a Windows distro:
 5. Create a temporary directory and do:
 
         mkdir bin
-        echo 'import scala.scalajs.js.JSApp
-          object Foo extends JSApp {
-
-            def main() = {
+        echo '
+          object Foo {
+            def main(): Unit = {
               println(s"asdf ${1 + 1}")
               new A
             }
 
             class A
-          }' > foo.scala
+          }
+        ' > foo.scala
         scalajsc -d bin foo.scala
 
         scalajsp bin/Foo$.sjsir
@@ -28,10 +28,9 @@ For each major Scala version on a *NIX distro and a Windows distro:
         scalajsp bin/Foo\$A.sjsir
         # Verify output
 
-        scalajsld -o test.js bin
+        scalajsld -o test.js -mm Foo.main bin
         # Verify output
 
-        echo "Foo().main()" >> test.js
         node test.js # Or your favorite thing to run JS
 
         # Expect "asdf 2"

--- a/library/src/main/scala/scala/scalajs/js/JSApp.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSApp.scala
@@ -2,7 +2,12 @@ package scala.scalajs.js
 
 import annotation.{JSExport, JSExportDescendentObjects}
 
-/** Base class for top-level, entry point main objects.
+/** Base class for top-level, entry point main objects (softly deprecated).
+ *
+ *  In Scala.js 1.x, `js.JSApp` will disappear. It is currently "softly"
+ *  deprecated: it is not recommended to use it in new code, but it does not
+ *  cause a deprecation warning (yet). Prefer using a standard main method (see
+ *  below).
  *
  *  Objects inheriting from [[JSApp]] are automatically exported to JavaScript
  *  under their fully qualified name, and their [[main]] method as well.
@@ -12,6 +17,18 @@ import annotation.{JSExport, JSExportDescendentObjects}
  *  extending [[JSApp]]. It allows to run their [[main]] method with `sbt run`,
  *  and can also generate a tiny JavaScript launcher snippet executing the
  *  [[main]] method of one specific [[JSApp]] object.
+ *
+ *  Starting with Scala.js 0.6.18, the sbt plugin can also recognize "standard"
+ *  `main` methods of the form
+ *  {{{
+ *  def main(args: Array[String]): Unit = ...
+ *  }}}
+ *  in objects, even if they do not extend `JSApp`. Such main methods are
+ *  cross-platform, and should be preferred over extending `JSApp` in new code.
+ *  Note however that:
+ *
+ *  - the sbt plugin cannot create a launcher snippet for such objects, and
+ *  - these objects are not automatically exported to JavaScript.
  */
 @JSExportDescendentObjects
 trait JSApp {

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,9 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private[emitter], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.backend.emitter.FunctionEmitter#JSDesugar.genClassDataOf")
   )
 
   val JSEnvs = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -659,7 +659,9 @@ object Build {
             val unescapedMainMethods = List(
                 "org.scalajs.testsuite.compiler.ModuleInitializerInNoConfiguration.main",
                 "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.main2",
-                "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.main1"
+                "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.main1",
+                "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.mainArgs1()",
+                "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration.mainArgs2(foo,bar)"
             )
             seqOfStringsToJSArrayCode(unescapedMainMethods)
           }
@@ -1587,6 +1589,16 @@ object Build {
           ModuleInitializer.mainMethod(
               "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration",
               "main1")
+        },
+        scalaJSModuleInitializers in Test += {
+          ModuleInitializer.mainMethodWithArgs(
+              "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration",
+              "mainArgs1")
+        },
+        scalaJSModuleInitializers in Test += {
+          ModuleInitializer.mainMethodWithArgs(
+              "org.scalajs.testsuite.compiler.ModuleInitializerInTestConfiguration",
+              "mainArgs2", List("foo", "bar"))
         }
       )
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -49,7 +49,8 @@ lazy val noDOM = project.settings(baseSettings: _*).
     name := "Scala.js sbt test w/o DOM",
     scalaJSOutputWrapper := (
         "// Scala.js - noDOM sbt test\n//\n// Compiled with Scala.js\n",
-        "// End of Scala.js generated script")
+        "// End of Scala.js generated script"),
+    scalaJSUseMainModuleInitializer := true
   ).
   /* This hopefully exposes concurrent uses of the linker. If it fails/gets
    * flaky, there is a bug somewhere - #2202
@@ -66,7 +67,8 @@ lazy val withDOM = project.settings(baseSettings: _*).
         "org.webjars" % "jquery" % "1.10.2" / "jquery.js"),
     scalaJSOutputWrapper := (
         "// Scala.js - withDOM sbt test\n//\n// Compiled with Scala.js\n",
-        "// End of Scala.js generated script")
+        "// End of Scala.js generated script"),
+    scalaJSUseMainModuleInitializer := true
   )
 
 lazy val jetty9 = project.settings(baseSettings: _*).

--- a/sbt-plugin-test/noDOM/src/main/scala/sbttest/noDOM/TestApp.scala
+++ b/sbt-plugin-test/noDOM/src/main/scala/sbttest/noDOM/TestApp.scala
@@ -1,10 +1,8 @@
 package sbttest.noDOM
 
-import scala.scalajs.js
+object TestApp {
 
-object TestApp extends js.JSApp {
-
-  def main(): Unit = {
+  def main(args: Array[String]): Unit = {
     println(Lib.foo("Hello World"))
     println(Lib.sq(10))
   }

--- a/sbt-plugin-test/withDOM/src/main/scala/sbttest/withDOM/TestApp.scala
+++ b/sbt-plugin-test/withDOM/src/main/scala/sbttest/withDOM/TestApp.scala
@@ -1,10 +1,8 @@
 package sbttest.withDOM
 
-import scala.scalajs.js
+object TestApp {
 
-object TestApp extends js.JSApp {
-
-  def main(): Unit = {
+  def main(args: Array[String]): Unit = {
     Lib.appendDocument("Hello World")
     Lib.appendDocument("Still Here!")
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
@@ -15,7 +15,13 @@ class ModuleInitializersTest {
 
   @Test def correctInitializers(): Unit = {
     assertArrayEquals(
-        Array[AnyRef](NoConfigMain, TestConfigMain2, TestConfigMain1),
+        Array[AnyRef](
+            NoConfigMain,
+            TestConfigMain2,
+            TestConfigMain1,
+            TestConfigMainArgs1 + "()",
+            TestConfigMainArgs2 + "(foo, bar)"
+        ),
         moduleInitializersEffects.toArray[AnyRef])
   }
 
@@ -26,6 +32,8 @@ object ModuleInitializersTest {
   final val CompileConfigMain = "ModuleInitializerInCompileConfiguration.main"
   final val TestConfigMain1 = "ModuleInitializerInTestConfiguration.main1"
   final val TestConfigMain2 = "ModuleInitializerInTestConfiguration.main2"
+  final val TestConfigMainArgs1 = "ModuleInitializerInTestConfiguration.mainArgs1"
+  final val TestConfigMainArgs2 = "ModuleInitializerInTestConfiguration.mainArgs2"
 
   val moduleInitializersEffects =
     new scala.collection.mutable.ListBuffer[String]
@@ -57,5 +65,15 @@ object ModuleInitializerInTestConfiguration {
 
   def main2(): Unit = {
     moduleInitializersEffects += TestConfigMain2
+  }
+
+  def mainArgs1(args: Array[String]): Unit = {
+    moduleInitializersEffects +=
+      TestConfigMainArgs1 + args.mkString("(", ", ", ")")
+  }
+
+  def mainArgs2(args: Array[String]): Unit = {
+    moduleInitializersEffects +=
+      TestConfigMainArgs2 + args.mkString("(", ", ", ")")
   }
 }

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -16,26 +16,26 @@ object QuickLinker {
   /** Link a Scala.js application on Node.js */
   @JSExport
   def linkNode(irFilesAndJars: js.Array[String],
-      mainMethods: js.Array[String]): String = {
-    linkNodeInternal(Semantics.Defaults, irFilesAndJars, mainMethods)
+      moduleInitializers: js.Array[String]): String = {
+    linkNodeInternal(Semantics.Defaults, irFilesAndJars, moduleInitializers)
   }
 
   /** Link the Scala.js test suite on Node.js */
   @JSExport
   def linkTestSuiteNode(irFilesAndJars: js.Array[String],
-      mainMethods: js.Array[String]): String = {
+      moduleInitializers: js.Array[String]): String = {
     val semantics = Semantics.Defaults.withRuntimeClassName(_.fullName match {
       case "org.scalajs.testsuite.compiler.ReflectionTest$RenamedTestClass" =>
         "renamed.test.Class"
       case fullName =>
         fullName
     })
-    linkNodeInternal(semantics, irFilesAndJars, mainMethods)
+    linkNodeInternal(semantics, irFilesAndJars, moduleInitializers)
   }
 
   /** Link a Scala.js application on Node.js */
   def linkNodeInternal(semantics: Semantics,
-      irFilesAndJars: Seq[String], mainMethods: Seq[String]): String = {
+      irFilesAndJars: Seq[String], moduleInitializers: Seq[String]): String = {
     val cache = (new IRFileCache).newCache
 
     val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,
@@ -58,18 +58,41 @@ object QuickLinker {
 
     val ir = cache.cached(irContainers)
 
-    val moduleInitializers = mainMethods.map { mainMethod =>
-      val lastDot = mainMethod.lastIndexOf('.')
-      if (lastDot < 0)
-        throw new IllegalArgumentException(s"$mainMethod is not a valid main method")
-      ModuleInitializer.mainMethod(mainMethod.substring(0, lastDot),
-          mainMethod.substring(lastDot + 1))
-    }
+    val parsedModuleInitializers =
+      moduleInitializers.map(parseModuleInitializer)
 
     val out = WritableMemVirtualJSFile("out.js")
-    linker.link(ir, moduleInitializers, out, new ScalaConsoleLogger)
+    linker.link(ir, parsedModuleInitializers, out, new ScalaConsoleLogger)
 
     out.content
+  }
+
+  private def parseModuleInitializer(spec: String): ModuleInitializer = {
+    def fail(): Nothing = {
+      throw new IllegalArgumentException(
+          s"'$spec' is not a valid module initializer spec")
+    }
+
+    def parseObjectAndMain(str: String): (String, String) = {
+      val lastDot = str.lastIndexOf('.')
+      if (lastDot < 0)
+        fail()
+      (str.substring(0, lastDot), str.substring(lastDot + 1))
+    }
+
+    val parenPos = spec.indexOf('(')
+    if (parenPos < 0) {
+      val (objectName, mainMethodName) = parseObjectAndMain(spec)
+      ModuleInitializer.mainMethod(objectName, mainMethodName)
+    } else {
+      if (spec.last != ')')
+        fail()
+      val (objectName, mainMethodName) =
+        parseObjectAndMain(spec.substring(0, parenPos))
+      val args =
+        spec.substring(parenPos + 1, spec.length - 1).split(",", -1).toList
+      ModuleInitializer.mainMethodWithArgs(objectName, mainMethodName, args)
+    }
   }
 
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
@@ -1174,6 +1174,11 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
     moduleInitializer match {
       case ModuleInitializer.VoidMainMethod(moduleClassName, mainMethodName) =>
         js.Apply(genLoadModule(moduleClassName) DOT mainMethodName, Nil)
+
+      case ModuleInitializer.MainMethodWithArgs(moduleClassName, mainMethodName,
+          args) =>
+        js.Apply(genLoadModule(moduleClassName) DOT mainMethodName,
+            genArrayValue(ArrayType("T", 1), args.map(js.StringLiteral(_))) :: Nil)
     }
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -1932,8 +1932,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
               genClassDataOf(tpe), js.ArrayConstr(lengths map transformExpr))
 
         case ArrayValue(tpe, elems) =>
-          genCallHelper("makeNativeArrayWrapper",
-              genClassDataOf(tpe), js.ArrayConstr(elems map transformExpr))
+          genArrayValue(tpe, elems.map(transformExpr))
 
         case ArrayLength(array) =>
           genIdentBracketSelect(js.DotSelect(transformExpr(array),
@@ -2208,17 +2207,6 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
         case name: Ident           => transformIdent(name)
         case StringLiteral(s)      => js.StringLiteral(s)
         case ComputedName(tree, _) => js.ComputedName(transformExpr(tree))
-      }
-    }
-
-    def genClassDataOf(cls: ReferenceType)(implicit pos: Position): js.Tree = {
-      cls match {
-        case ClassType(className) =>
-          envField("d", className)
-        case ArrayType(base, dims) =>
-          (1 to dims).foldLeft(envField("d", base)) { (prev, _) =>
-            js.Apply(js.DotSelect(prev, js.Ident("getArrayOf")), Nil)
-          }
       }
     }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -202,6 +202,23 @@ private[emitter] final class JSGen(val semantics: Semantics,
     }
   }
 
+  def genArrayValue(tpe: ArrayType, elems: List[Tree])(
+      implicit pos: Position): Tree = {
+    genCallHelper("makeNativeArrayWrapper", genClassDataOf(tpe),
+        ArrayConstr(elems))
+  }
+
+  def genClassDataOf(cls: ReferenceType)(implicit pos: Position): Tree = {
+    cls match {
+      case ClassType(className) =>
+        envField("d", className)
+      case ArrayType(base, dims) =>
+        (1 to dims).foldLeft[Tree](envField("d", base)) { (prev, _) =>
+          Apply(DotSelect(prev, Ident("getArrayOf")), Nil)
+        }
+    }
+  }
+
   def envModuleField(module: String)(implicit pos: Position): VarRef = {
     /* This is written so that the happy path, when `module` contains only
      * valid characters, is fast.


### PR DESCRIPTION
In addition to recognizing objects extending `js.JSApp`, the sbt plugin now recognizes "standard" main methods as well, i.e., objects with a method of the form
```scala
def main(args: Array[String]): Unit = ...
```
If such an object is used as main class, its main method is called using the new `ModuleInitializer.mainMethodWithArgs`.

This has the nice benefit that we can finally write a cross-platform main object.

We "softly" deprecate `js.JSApp`: its documentation says not to use anymore, but it does not cause a deprecation warning yet.

For backward compatibility, objects extending `js.JSApp` are still recognized, and their `main(): Unit` method will be called.

There are some subtle scenarios regarding backward compatibility:

* If an object *both* extends `js.JSApp` and has a standard main method, the `main()` method of `js.JSApp` is preferred, for backward compatibility.
* If an object has a `main(): Unit` method but does not extend `js.JSApp`, it will not be *discovered*. In that case, we assume the old style and call `main()`. This can happen if the user explicitly sets the `mainClass` setting.
* If an object has *both* a `main(): Unit` method and a `main(args: Array[String]): Unit` method, it *will* now be discovered, and the new style will be assumed. This can potentially break compatibility, as now the standard main will be called. This only happens in case the user has explicitly set `mainClass`. Moreover, it is only problematic if `main()` does not behave the same as `main(Array())`, in which case the codebase is arguably in a bad shape to begin with.
* The very fact of recognizing *more* objects as potential main objects means that the sbt build can break because it cannot automatically choose between several discovered objects. This will however fail to link with a nice error message, so it is not too bad.

Here are some examples.

* Old-style only, `main()` is selected

      object OldStyleOnly extends js.JSApp {
        def main(): Unit = ...
      }

* New-style only, `main(Array[String])` is selected

      object NewStyleOnly {
        def main(args: Array[String]): Unit = ...
      }

* Old and new style combined, `main()` is selected

      object OldAndNewStyle extends js.JSApp {
        def main(): Unit = ...
        def main(args: Array[String]): Unit = ...
      }

* `def main(): Unit` without `js.JSApp` only, `main()` is selected

      object OldStyleNonJSApp {
        def main(): Unit = ...
      }

* Both styles of methods without `js.JSApp`, `main(Array[String])` is selected (potentially silently breaking)

      object OldAndNewStyleNonJSApp {
        def main(): Unit = ...
        def main(args: Array[String]): Unit = ...
      }

* Both styles exist in two different objects, sbt reports an ambiguity and demands that `mainClass` be set explicitly

      object OldStyle extends js.JSApp {
        def main(): Unit = ...
      }
      object NewStyle {
        def main(args: Array[String]): Unit = ...
      }