### PR TITLE
Introduce the surface of the new linker API.

### DIFF
--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -11,15 +11,13 @@ package org.scalajs.cli
 
 import org.scalajs.core.ir.ScalaJSVersions
 
-import org.scalajs.core.tools.sem._
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.logging._
 
-import CheckedBehavior.Compliant
+import org.scalajs.core.tools.linker._
+import org.scalajs.core.tools.linker.standard._
 
-import org.scalajs.core.tools.linker.{ModuleInitializer, Linker}
-import org.scalajs.core.tools.linker.frontend.LinkerFrontend
-import org.scalajs.core.tools.linker.backend.{LinkerBackend, OutputMode, ModuleKind}
+import CheckedBehavior.Compliant
 
 import scala.collection.immutable.Seq
 
@@ -188,25 +186,20 @@ object Scalajsld {
         if (options.fullOpt) options.semantics.optimized
         else options.semantics
 
-      val frontendConfig = LinkerFrontend.Config()
+      val config = StandardLinker.Config()
+        .withSemantics(semantics)
+        .withModuleKind(options.moduleKind)
+        .withOutputMode(options.outputMode)
         .withBypassLinkingErrorsInternal(options.bypassLinkingErrors)
         .withCheckIR(options.checkIR)
-
-      val backendConfig = LinkerBackend.Config()
-        .withRelativizeSourceMapBase(options.relativizeSourceMap)
-        .withPrettyPrint(options.prettyPrint)
-
-      val config = Linker.Config()
-        .withSourceMap(options.sourceMap)
         .withOptimizer(!options.noOpt)
         .withParallel(true)
+        .withSourceMap(options.sourceMap)
+        .withRelativizeSourceMapBase(options.relativizeSourceMap)
         .withClosureCompiler(options.fullOpt)
-        .withFrontendConfig(frontendConfig)
-        .withBackendConfig(backendConfig)
+        .withPrettyPrint(options.prettyPrint)
 
-      val linker = Linker(semantics, options.outputMode, options.moduleKind,
-          config)
-
+      val linker = StandardLinker(config)
       val logger = new ScalaConsoleLogger(options.logLevel)
       val outFile = WritableFileVirtualJSFile(options.output)
       val cache = (new IRFileCache).newCache

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -2,13 +2,10 @@ package scala.tools.nsc
 
 /* Super hacky overriding of the MainGenericRunner used by partest */
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.logging._
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
-import org.scalajs.core.tools.linker.{Linker, ModuleInitializer}
-import org.scalajs.core.tools.linker.backend.{OutputMode, ModuleKind}
+import org.scalajs.core.tools.linker._
 
 import org.scalajs.core.ir
 
@@ -66,12 +63,12 @@ class MainGenericRunner {
     val moduleInitializers = Seq(ModuleInitializer.mainMethodWithArgs(
         command.thingToRun, "main", command.arguments))
 
-    val linkerConfig = Linker.Config()
+    val linkerConfig = StandardLinker.Config()
+      .withSemantics(semantics)
       .withSourceMap(false)
       .withClosureCompiler(optMode == FullOpt)
 
-    val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,
-        ModuleKind.NoModule, linkerConfig)
+    val linker = StandardLinker(linkerConfig)
 
     val sjsCode = {
       val output = WritableMemVirtualJSFile("partest.js")

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,10 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // New method in a trait sealed via self-type, not an issue
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "org.scalajs.core.tools.linker.LinkerPlatformExtensions.applyInternal"),
+
       // private[emitter], not an issue
       ProblemFilters.exclude[DirectMissingMethodProblem](
           "org.scalajs.core.tools.linker.backend.emitter.FunctionEmitter#JSDesugar.genClassDataOf")

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
@@ -42,6 +42,12 @@ final class OptimizerOptions private (
   def withBypassLinkingErrors(bypassLinkingErrors: Boolean): OptimizerOptions =
     copy(bypassLinkingErrors = bypassLinkingErrors)
 
+  // Non-deprecated version to call from the sbt plugin
+  private[sbtplugin] def withBypassLinkingErrorsInternal(
+      bypassLinkingErrors: Boolean): OptimizerOptions = {
+    copy(bypassLinkingErrors = bypassLinkingErrors)
+  }
+
   def withParallel(parallel: Boolean): OptimizerOptions =
     copy(parallel = parallel)
 
@@ -97,7 +103,7 @@ object OptimizerOptions {
    * which uses Scala 2.12. We should get rid of that workaround at that point
    * for tidiness, though.
    */
-  private val DefaultParallel: Boolean = {
+  private[sbtplugin] val DefaultParallel: Boolean = {
     try {
       scala.util.Properties.isJavaAtLeast("1.8")
       true

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -13,8 +13,8 @@ import sbt._
 
 import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.linker.{ModuleInitializer, LinkingUnit}
-import org.scalajs.core.tools.linker.backend.{ModuleKind, OutputMode}
+import org.scalajs.core.tools.linker._
+import org.scalajs.core.tools.linker.standard._
 import org.scalajs.core.tools.jsdep.{JSDependencyManifest, ResolvedJSDependency}
 import org.scalajs.core.tools.jsdep.ManifestFilters.ManifestFilter
 import org.scalajs.core.tools.jsdep.DependencyResolver.DependencyFilter

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -232,6 +232,11 @@ object ScalaJSPlugin extends AutoPlugin {
         "`scalaJSUseMainModuleInitializer` is true",
         CTask)
 
+    val scalaJSLinkerConfig = SettingKey[StandardLinker.Config](
+        "scalaJSLinkerConfig",
+        "Configuration of the Scala.js linker",
+        BPlusSetting)
+
     val scalaJSNativeLibraries = TaskKey[Attributed[Seq[VirtualJSFile with RelativeVirtualFile]]](
         "scalaJSNativeLibraries", "All the *.js files on the classpath", CTask)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -179,7 +179,8 @@ object ScalaJSPluginInternal {
   /** Settings for the production key (e.g. fastOptJS) of a given stage */
   private def scalaJSStageSettings(stage: Stage,
       key: TaskKey[Attributed[File]]): Seq[Setting[_]] = Seq(
-      scalaJSLinker in key := {
+
+      scalaJSLinkerConfig in key := {
         val opts = (scalaJSOptimizerOptions in key).value
 
         val semantics = (scalaJSSemantics in key).value
@@ -187,14 +188,21 @@ object ScalaJSPluginInternal {
         val moduleKind = scalaJSModuleKind.value // intentionally not 'in key'
         val withSourceMap = (emitSourceMaps in key).value
 
-        val relSourceMapBase = {
+        /* For `relativizeSourceMapBase`, preserve the one in the new config
+         * if it is set, otherwise fall back on the old config.
+         */
+        val oldConfigRelSourceMapBase = {
           if ((relativeSourceMaps in key).value)
             Some((artifactPath in key).value.getParentFile.toURI())
           else
             None
         }
+        val newConfigRelSourceMapBase =
+          (scalaJSLinkerConfig in key).value.relativizeSourceMapBase
+        val relSourceMapBase =
+          newConfigRelSourceMapBase.orElse(oldConfigRelSourceMapBase)
 
-        val config = StandardLinker.Config()
+        StandardLinker.Config()
           .withSemantics(semantics)
           .withModuleKind(moduleKind)
           .withOutputMode(outputMode)
@@ -208,6 +216,21 @@ object ScalaJSPluginInternal {
           .withCustomOutputWrapperInternal(scalaJSOutputWrapperInternal.value)
           .withPrettyPrint(opts.prettyPrintFullOptJS)
           .withBatchMode(opts.batchMode)
+      },
+
+      scalaJSLinker in key := {
+        val config = (scalaJSLinkerConfig in key).value
+
+        if (config.moduleKind != scalaJSModuleKind.value) {
+          val projectID = thisProject.value.id
+          val configName = configuration.value.name
+          val keyName = key.key.label
+          sLog.value.warn(
+              s"The module kind in `scalaJSLinkerConfig in ($projectID, " +
+              s"$configName, $keyName)` is different than the value of " +
+              s"`scalaJSModuleKind in ($projectID, $configName)`. " +
+              "Some things will go wrong.")
+        }
 
         new ClearableLinker(() => StandardLinker(config), config.batchMode)
       },
@@ -1012,23 +1035,66 @@ object ScalaJSPluginInternal {
   val scalaJSProjectBaseSettings = Seq(
       isScalaJSProject := true,
 
+      /* We first define scalaJSLinkerConfig in the project scope, with all
+       * the defaults. Later, we derive all the old config options in the
+       * project scope from scalaJSLinkerConfig.
+       *
+       * At the end of the day, in the fully qualified scope
+       * (project, config, linkKey), we re-derive scalaJSLinkerConfig from all
+       * the old config keys.
+       *
+       * This effectively gives meaning to scalaJSLinkerConfig in the project
+       * scope and in the fully qualified scope, but not in-between. Changes
+       * to `scalaJSLinkerConfig in (project, config)` will not have any
+       * effect.
+       *
+       * This is a compromise to ensure backward compatibility of using the old
+       * options in all cases, and a reasonable way to use the new options
+       * for typical use cases.
+       *
+       * `relativeSourceMaps`/`scalaJSLinkerConfig.relativizeSourceMapBase` is
+       * an exception. We cannot derive `relativizeSourceMapBase` only from
+       * `relativeSourceMaps`, and deriving `relativeSourceMaps` from
+       * `relativizeSourceMapBase` would lose information. Instead, we keep
+       * `relativeSourceMaps` to its default `false` in the project scope,
+       * irrespective of `scalaJSLinkerConfig`. And in the fully qualified
+       * scope, *if* `relativeSourceMaps` is true, we set
+       * `relativeSourceMapBase`, otherwise we leave it untouched. This
+       * provides the same compatibility/usability features.
+       */
+      scalaJSLinkerConfig := {
+        StandardLinker.Config()
+          .withParallel(OptimizerOptions.DefaultParallel)
+      },
+
       relativeSourceMaps := false,
       persistLauncherInternal := false,
       persistLauncherInternal in Test := false,
 
-      emitSourceMaps := true,
+      emitSourceMaps := scalaJSLinkerConfig.value.sourceMap,
 
-      scalaJSOutputWrapperInternal := ("", ""),
+      scalaJSOutputWrapperInternal :=
+        scalaJSLinkerConfig.value.customOutputWrapper,
 
-      scalaJSOptimizerOptions := OptimizerOptions(),
+      scalaJSOptimizerOptions := {
+        val config = scalaJSLinkerConfig.value
+        OptimizerOptions()
+          .withBypassLinkingErrorsInternal(config.bypassLinkingErrors)
+          .withParallel(config.parallel)
+          .withBatchMode(config.batchMode)
+          .withDisableOptimizer(!config.optimizer)
+          .withPrettyPrintFullOptJS(config.prettyPrint)
+          .withCheckScalaJSIR(config.checkIR)
+          .withUseClosureCompiler(config.closureCompiler)
+      },
 
       jsDependencies := Seq(),
       jsDependencyFilter := identity,
       jsManifestFilter := identity,
 
-      scalaJSSemantics := Semantics.Defaults,
-      scalaJSOutputMode := OutputMode.ECMAScript51Isolated,
-      scalaJSModuleKind := ModuleKind.NoModule,
+      scalaJSSemantics := scalaJSLinkerConfig.value.semantics,
+      scalaJSOutputMode := scalaJSLinkerConfig.value.outputMode,
+      scalaJSModuleKind := scalaJSLinkerConfig.value.moduleKind,
       checkScalaJSSemantics := true,
 
       scalaJSModuleInitializers := Seq(),

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -9,15 +9,20 @@
 
 package org.scalajs.core.tools.linker
 
-import org.scalajs.core.tools.sem.Semantics
-
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.frontend.optimizer.IncOptimizer
 import org.scalajs.core.tools.linker.backend._
 
 trait LinkerPlatformExtensions { this: Linker.type =>
+  @deprecated("Use StandardLinker.apply() instead.", "0.6.18")
   def apply(semantics: Semantics, outputMode: OutputMode,
       moduleKind: ModuleKind, config: Config): Linker = {
+    applyInternal(semantics, outputMode, moduleKind, config)
+  }
+
+  private[linker] def applyInternal(semantics: Semantics,
+      outputMode: OutputMode, moduleKind: ModuleKind,
+      config: Config): Linker = {
 
     val optOptimizerFactory = {
       if (!config.optimizer) None
@@ -33,7 +38,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
     new Linker(frontend, backend)
   }
 
-  @deprecated("Use the overload with a Config object.", "0.6.13")
+  @deprecated("Use StandardLinker.apply() instead.", "0.6.13")
   def apply(
       semantics: Semantics = Semantics.Defaults,
       outputMode: OutputMode = OutputMode.Default,

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
@@ -1,0 +1,22 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+object StandardLinkerPlatformExtensions {
+  import StandardLinker.Config
+
+  final class ConfigExt(val config: Config) extends AnyVal {
+    /** Whether to actually use the Google Closure Compiler pass.
+     *
+     *  On the JavaScript platform, this always returns `false`, as GCC is not
+     *  available.
+     */
+    def closureCompiler: Boolean = false
+  }
+}

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -1,10 +1,8 @@
 package org.scalajs.core.tools.test.js
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.io.IRFileCache.IRContainer
-import org.scalajs.core.tools.linker.{ModuleInitializer, Linker}
-import org.scalajs.core.tools.linker.backend.{OutputMode, ModuleKind}
+import org.scalajs.core.tools.linker._
 import org.scalajs.core.tools.logging._
 
 import scala.scalajs.js
@@ -38,8 +36,8 @@ object QuickLinker {
       irFilesAndJars: Seq[String], moduleInitializers: Seq[String]): String = {
     val cache = (new IRFileCache).newCache
 
-    val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,
-        ModuleKind.NoModule, Linker.Config())
+    val linker =
+      StandardLinker(StandardLinker.Config().withSemantics(semantics))
 
     val irContainers = irFilesAndJars.map { file =>
       if (file.endsWith(".jar")) {

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -9,16 +9,21 @@
 
 package org.scalajs.core.tools.linker
 
-import org.scalajs.core.tools.sem.Semantics
-
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.frontend.optimizer.{ParIncOptimizer, IncOptimizer}
 import org.scalajs.core.tools.linker.backend._
 import org.scalajs.core.tools.linker.backend.closure.ClosureLinkerBackend
 
 trait LinkerPlatformExtensions { this: Linker.type =>
+  @deprecated("Use StandardLinker.apply() instead.", "0.6.18")
   def apply(semantics: Semantics, outputMode: OutputMode,
       moduleKind: ModuleKind, config: Config): Linker = {
+    applyInternal(semantics, outputMode, moduleKind, config)
+  }
+
+  private[linker] def applyInternal(semantics: Semantics,
+      outputMode: OutputMode, moduleKind: ModuleKind,
+      config: Config): Linker = {
 
     val optOptimizerFactory = {
       if (!config.optimizer) None
@@ -44,7 +49,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
     new Linker(frontend, backend)
   }
 
-  @deprecated("Use the overload with a Config object.", "0.6.13")
+  @deprecated("Use StandardLinker.apply() instead.", "0.6.13")
   def apply(
       semantics: Semantics = Semantics.Defaults,
       outputMode: OutputMode = OutputMode.Default,

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
@@ -1,0 +1,21 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+object StandardLinkerPlatformExtensions {
+  import StandardLinker.Config
+
+  final class ConfigExt(val config: Config) extends AnyVal {
+    /** Whether to actually use the Google Closure Compiler pass. */
+    def closureCompiler: Boolean = config.closureCompilerIfAvailable
+
+    def withClosureCompiler(closureCompiler: Boolean): Config =
+      config.withClosureCompilerIfAvailable(closureCompiler)
+  }
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
@@ -12,7 +12,6 @@ package org.scalajs.core.tools.linker
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
@@ -12,7 +12,6 @@ package org.scalajs.core.tools.linker
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
@@ -16,7 +16,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala
@@ -1,6 +1,5 @@
 package org.scalajs.core.tools.linker
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 
 import org.scalajs.core.ir

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
@@ -1,0 +1,248 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+import scala.language.implicitConversions
+
+import java.net.URI
+
+import org.scalajs.core.tools.linker.frontend.LinkerFrontend
+import org.scalajs.core.tools.linker.backend.{LinkerBackend, OutputMode}
+
+object StandardLinker {
+  import StandardLinkerPlatformExtensions._
+
+  def apply(config: Config): Linker = {
+    val frontendConfig = LinkerFrontend.Config()
+      .withBypassLinkingErrorsInternal(config.bypassLinkingErrors)
+      .withCheckIR(config.checkIR)
+
+    val backendConfig = LinkerBackend.Config()
+      .withRelativizeSourceMapBase(config.relativizeSourceMapBase)
+      .withCustomOutputWrapperInternal(config.customOutputWrapper)
+      .withPrettyPrint(config.prettyPrint)
+
+    val oldAPIConfig = Linker.Config()
+      .withSourceMap(config.sourceMap)
+      .withOptimizer(config.optimizer)
+      .withParallel(config.parallel)
+      .withClosureCompilerIfAvailable(config.closureCompilerIfAvailable)
+      .withFrontendConfig(frontendConfig)
+      .withBackendConfig(backendConfig)
+
+    Linker.applyInternal(config.semantics, config.outputMode, config.moduleKind,
+        oldAPIConfig)
+  }
+
+  implicit def configExt(config: Config): ConfigExt =
+    new ConfigExt(config)
+
+  /** Configuration of a standard linker. */
+  final class Config private (
+      /** Scala.js semantics. */
+      val semantics: Semantics,
+      /** Module kind. */
+      val moduleKind: ModuleKind,
+      /** Whether to only warn if the linker has errors. */
+      val bypassLinkingErrors: Boolean,
+      /** If true, performs expensive checks of the IR for the used parts. */
+      val checkIR: Boolean,
+      /** Whether to use the Scala.js optimizer. */
+      val optimizer: Boolean,
+      /** Whether things that can be parallelized should be parallelized.
+       *  On the JavaScript platform, this does not have any effect.
+       */
+      val parallel: Boolean,
+      /** Whether to emit a source map. */
+      val sourceMap: Boolean,
+      /** Base path to relativize paths in the source map. */
+      val relativizeSourceMapBase: Option[URI],
+      /** Custom js code that wraps the output */
+      val customOutputWrapper: (String, String),
+      /** Whether to use the Google Closure Compiler pass, if it is available.
+       *  On the JavaScript platform, this does not have any effect.
+       */
+      val closureCompilerIfAvailable: Boolean,
+      /** Pretty-print the output. */
+      val prettyPrint: Boolean,
+      /** Whether the linker should run in batch mode.
+       *
+       *  In batch mode, the linker can throw away intermediate state that is
+       *  otherwise maintained for incremental runs.
+       *
+       *  This setting is only a hint. A linker and/or its subcomponents may
+       *  ignore it. This applies in both directions: a linker not supporting
+       *  incrementality can ignore `batchMode = false`, and a contrario, a
+       *  linker mainly designed for incremental runs may ignore
+       *  `batchMode = true`.
+       */
+      val batchMode: Boolean,
+      /** Standard output mode. */
+      private[linker] val outputMode: OutputMode
+  ) {
+    private def this() = {
+      this(
+          semantics = Semantics.Defaults,
+          moduleKind = ModuleKind.NoModule,
+          bypassLinkingErrors = false,
+          checkIR = false,
+          optimizer = true,
+          parallel = true,
+          sourceMap = true,
+          relativizeSourceMapBase = None,
+          customOutputWrapper = ("", ""),
+          closureCompilerIfAvailable = false,
+          prettyPrint = false,
+          batchMode = false,
+          outputMode = OutputMode.Default
+      )
+    }
+
+    def withSemantics(semantics: Semantics): Config =
+      copy(semantics = semantics)
+
+    def withSemantics(f: Semantics => Semantics): Config =
+      copy(semantics = f(semantics))
+
+    def withModuleKind(moduleKind: ModuleKind): Config =
+      copy(moduleKind = moduleKind)
+
+    @deprecated(
+        "Bypassing linking errors will not be possible in the next major version.",
+        "0.6.6")
+    def withBypassLinkingErrors(bypassLinkingErrors: Boolean): Config =
+      copy(bypassLinkingErrors = bypassLinkingErrors)
+
+    // Non-deprecated version to call from the sbt plugin
+    private[scalajs] def withBypassLinkingErrorsInternal(
+        bypassLinkingErrors: Boolean): Config = {
+      copy(bypassLinkingErrors = bypassLinkingErrors)
+    }
+
+    def withCheckIR(checkIR: Boolean): Config =
+      copy(checkIR = checkIR)
+
+    def withOptimizer(optimizer: Boolean): Config =
+      copy(optimizer = optimizer)
+
+    def withParallel(parallel: Boolean): Config =
+      copy(parallel = parallel)
+
+    def withSourceMap(sourceMap: Boolean): Config =
+      copy(sourceMap = sourceMap)
+
+    def withRelativizeSourceMapBase(relativizeSourceMapBase: Option[URI]): Config =
+      copy(relativizeSourceMapBase = relativizeSourceMapBase)
+
+    @deprecated(
+        "The functionality of custom output wrappers has been superseded " +
+        "by the support for CommonJS modules, module initializers, and " +
+        "top-level exports.",
+        "0.6.15")
+    def withCustomOutputWrapper(customOutputWrapper: (String, String)): Config =
+      copy(customOutputWrapper = customOutputWrapper)
+
+    // Non-deprecated version to call from the sbt plugin
+    private[scalajs] def withCustomOutputWrapperInternal(
+        customOutputWrapper: (String, String)): Config = {
+      copy(customOutputWrapper = customOutputWrapper)
+    }
+
+    def withClosureCompilerIfAvailable(closureCompilerIfAvailable: Boolean): Config =
+      copy(closureCompilerIfAvailable = closureCompilerIfAvailable)
+
+    def withPrettyPrint(prettyPrint: Boolean): Config =
+      copy(prettyPrint = prettyPrint)
+
+    def withBatchMode(batchMode: Boolean): Config =
+      copy(batchMode = batchMode)
+
+    private[linker] def withOutputMode(outputMode: OutputMode): Config =
+      copy(outputMode = outputMode)
+
+    override def toString(): String = {
+      s"""StandardLinker.Config(
+         |  semantics                  = $semantics,
+         |  moduleKind                 = $moduleKind,
+         |  bypassLinkingErrors        = $bypassLinkingErrors,
+         |  checkIR                    = $checkIR,
+         |  optimizer                  = $optimizer,
+         |  parallel                   = $parallel,
+         |  sourceMap                  = $sourceMap,
+         |  relativizeSourceMapBase    = $relativizeSourceMapBase,
+         |  customOutputWrapper        = $customOutputWrapper,
+         |  closureCompilerIfAvailable = $closureCompilerIfAvailable,
+         |  prettyPrint                = $prettyPrint,
+         |  batchMode                  = $batchMode,
+         |  outputMode                 = $outputMode,
+         |)""".stripMargin
+    }
+
+    private def copy(
+        semantics: Semantics = semantics,
+        moduleKind: ModuleKind = moduleKind,
+        bypassLinkingErrors: Boolean = bypassLinkingErrors,
+        checkIR: Boolean = checkIR,
+        optimizer: Boolean = optimizer,
+        parallel: Boolean = parallel,
+        sourceMap: Boolean = sourceMap,
+        relativizeSourceMapBase: Option[URI] = relativizeSourceMapBase,
+        customOutputWrapper: (String, String) = customOutputWrapper,
+        closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
+        prettyPrint: Boolean = prettyPrint,
+        batchMode: Boolean = batchMode,
+        outputMode: OutputMode = outputMode
+    ): Config = {
+      new Config(
+          semantics,
+          moduleKind,
+          bypassLinkingErrors,
+          checkIR,
+          optimizer,
+          parallel,
+          sourceMap,
+          relativizeSourceMapBase,
+          customOutputWrapper,
+          closureCompilerIfAvailable,
+          prettyPrint,
+          batchMode,
+          outputMode
+      )
+    }
+  }
+
+  object Config {
+    /** Returns the default configuration for a [[StandardLinker]].
+     *
+     *  The defaults are:
+     *
+     *  - `semantics`: [[org.scalajs.core.tools.sem.Semantics.Defaults Semantics.Defaults]]
+     *  - `moduleKind`: [[ModuleKind.NoModule]]
+     *  - `bypassLinkingErrors`: `false` (deprecated)
+     *  - `checkIR`: `false`
+     *  - `optimizer`: `true`
+     *  - `parallel`: `true`
+     *  - `sourceMap`: `true`
+     *  - `relativizeSourceMapBase`: `None`
+     *  - `customOutputWrapper`: `("", "")` (deprecated)
+     *  - `closureCompilerIfAvailable`: `false`
+     *  - `prettyPrint`: `false`
+     *  - `batchMode`: `false`
+     *
+     *  The following additional options are configurable through
+     *  {{{
+     *  import org.scalajs.core.tools.linker.standard._
+     *  }}}
+     *
+     *  - `outputMode`: [[org.scalajs.core.tools.linker.backend.OutputMode.Default OutputMode.Default]]
+     */
+    def apply(): Config = new Config()
+  }
+
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
@@ -15,12 +15,11 @@ import Transformers._
 import org.scalajs.core.ir.Trees._
 import Types._
 
-import org.scalajs.core.tools.sem._
-import CheckedBehavior.Unchecked
-
 import org.scalajs.core.tools.javascript.{Trees => js}
 import org.scalajs.core.tools.linker._
 import org.scalajs.core.tools.linker.backend.OutputMode
+
+import CheckedBehavior.Unchecked
 
 /** Emitter for the skeleton of classes. */
 private[emitter] final class ClassEmitter(jsGen: JSGen) {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -17,7 +17,6 @@ import org.scalajs.core.ir.{ClassKind, Position}
 import org.scalajs.core.ir.Trees.JSNativeLoadSpec
 import org.scalajs.core.ir.Definitions.decodeClassName
 
-import org.scalajs.core.tools.sem._
 import org.scalajs.core.tools.logging._
 
 import org.scalajs.core.tools.javascript.{Trees => js, _}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
@@ -1,0 +1,26 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools
+
+package object linker {
+  type Semantics = org.scalajs.core.tools.sem.Semantics
+
+  val Semantics: org.scalajs.core.tools.sem.Semantics.type =
+    org.scalajs.core.tools.sem.Semantics
+
+  type CheckedBehavior = org.scalajs.core.tools.sem.CheckedBehavior
+
+  val CheckedBehavior: org.scalajs.core.tools.sem.CheckedBehavior.type =
+    org.scalajs.core.tools.sem.CheckedBehavior
+
+  type ModuleKind = org.scalajs.core.tools.linker.backend.ModuleKind
+
+  val ModuleKind: org.scalajs.core.tools.linker.backend.ModuleKind.type =
+    org.scalajs.core.tools.linker.backend.ModuleKind
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
@@ -1,0 +1,28 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+package object standard {
+  type OutputMode = org.scalajs.core.tools.linker.backend.OutputMode
+
+  val OutputMode: org.scalajs.core.tools.linker.backend.OutputMode.type =
+    org.scalajs.core.tools.linker.backend.OutputMode
+
+  implicit class StandardLinkerConfigStandardOps(
+      val __self: StandardLinker.Config) extends AnyVal {
+
+    import StandardLinker.Config
+
+    /** Standard output mode. */
+    def outputMode: OutputMode = __self.outputMode
+
+    def withOutputMode(outputMode: OutputMode): Config =
+      __self.withOutputMode(outputMode)
+  }
+}

--- a/tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
+++ b/tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
@@ -5,8 +5,7 @@ import org.junit.Assert._
 
 import org.scalajs.core.tools.logging.NullLogger
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.linker.backend.{OutputMode, ModuleKind}
+import org.scalajs.core.tools.linker._
 
 class LinkerTest {
 
@@ -22,8 +21,7 @@ class LinkerTest {
       def length: Int = throw new DummyException()
     }
 
-    val linker = Linker(Semantics.Defaults, OutputMode.ECMAScript51Isolated,
-        ModuleKind.NoModule, Linker.Config())
+    val linker = StandardLinker(StandardLinker.Config())
 
     def callLink(): Unit =
       linker.link(badSeq, Nil, WritableMemVirtualJSFile("some_file"), NullLogger)


### PR DESCRIPTION
This commit introduces the portion of the new linker API described
in #2998 that is targeted for the 0.6.x series. It contains:

* `linker.StandardLinker._`
* `linker.Semantics`
* `linker.ModuleKind`
* `linker.standard.OutputMode`
* `linker.standard.StandardLinkerConfigStandardOps`

This is enough to implement the CLI, the sbt plugin, the `QuickLinker` and
partest's `MainGenericRunner` entirely in terms of the new API.

We deprecate `Linker.apply` in favor of `StandardLinker.apply` in order to
nudge other users of the linker towards the new API, assuming they use that
"easy" entry point (instead of manually manipulating front-end and back-end).