### PR TITLE
Introduce a new surface API for JS envs with `Config` objects.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -156,46 +156,46 @@
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in noIrCheckTest := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in noIrCheckTest := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         ++$scala noIrCheckTest/test \
         noIrCheckTest/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test

--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -203,10 +203,8 @@
 
   <task id="bootstrap"><![CDATA[
     setJavaVersion $java
-    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false)' \
-        ++$scala irJS/test toolsJS/test &&
-    sbt 'set jsEnv in toolsJS := new org.scalajs.jsenv.nodejs.NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false)' \
-        'set scalaJSStage in Global := FullOptStage' \
+    sbt ++$scala irJS/test toolsJS/test &&
+    sbt 'set scalaJSStage in Global := FullOptStage' \
         ++$scala irJS/test toolsJS/test
   ]]></task>
 

--- a/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala
+++ b/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala
@@ -1,6 +1,6 @@
 package org.scalajs.jsenv.test
 
-import org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv
+import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 
 import org.junit.Test
 import org.junit.Assert._

--- a/js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
@@ -1,0 +1,61 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js JS envs           **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.jsenv.jsdomnodejs
+
+class JSDOMNodeJSEnv(config: JSDOMNodeJSEnv.Config)
+    extends org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv(config.executable,
+        config.args, config.env, internal = ()) {
+
+  def this() = this(JSDOMNodeJSEnv.Config())
+}
+
+object JSDOMNodeJSEnv {
+  final class Config private (
+      val executable: String,
+      val args: List[String],
+      val env: Map[String, String]
+  ) {
+    private def this() = {
+      this(
+          executable = "node",
+          args = Nil,
+          env = Map.empty
+      )
+    }
+
+    def withExecutable(executable: String): Config =
+      copy(executable = executable)
+
+    def withArgs(args: List[String]): Config =
+      copy(args = args)
+
+    def withEnv(env: Map[String, String]): Config =
+      copy(env = env)
+
+    private def copy(
+        executable: String = executable,
+        args: List[String] = args,
+        env: Map[String, String] = env
+    ): Config = {
+      new Config(executable, args, env)
+    }
+  }
+
+  object Config {
+    /** Returns a default configuration for a [[JSDOMNodeJSEnv]].
+     *
+     *  The defaults are:
+     *
+     *  - `executable`: `"node"`
+     *  - `args`: `Nil`
+     *  - `env`: `Map.empty`
+     */
+    def apply(): Config = new Config()
+  }
+}

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
@@ -17,14 +17,24 @@ import org.scalajs.jsenv._
 
 import org.scalajs.core.ir.Utils.escapeJS
 
-class JSDOMNodeJSEnv(
-    @deprecatedName('nodejsPath)
-    executable: String = "node",
-    @deprecatedName('addArgs)
-    args: Seq[String] = Seq.empty,
-    @deprecatedName('addEnv)
-    env: Map[String, String] = Map.empty)
-    extends AbstractNodeJSEnv(executable, args, env, sourceMap = false) {
+class JSDOMNodeJSEnv private[jsenv] (
+    executable: String,
+    args: Seq[String],
+    env: Map[String, String],
+    internal: Unit
+) extends AbstractNodeJSEnv(executable, args, env, sourceMap = false) {
+
+  @deprecated("Use org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv.", "0.6.18")
+  def this(
+      @deprecatedName('nodejsPath)
+      executable: String = "node",
+      @deprecatedName('addArgs)
+      args: Seq[String] = Seq.empty,
+      @deprecatedName('addEnv)
+      env: Map[String, String] = Map.empty
+  ) = {
+    this(executable, args, env, internal = ())
+  }
 
   protected def vmName: String = "Node.js with JSDOM"
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -624,6 +624,10 @@ object Build {
             IO.write(outFile, testDefinitions)
             Seq(outFile)
           }.taskValue,
+
+          // Give more memory to Node.js, and deactivate source maps
+          jsEnv := new NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false),
+
           jsDependencies += ProvidedJS / "js-test-definitions.js" % "test"
       ) ++ inConfig(Test) {
         // Redefine test to run Node.js and link HelloWorld

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -626,7 +626,12 @@ object Build {
           }.taskValue,
 
           // Give more memory to Node.js, and deactivate source maps
-          jsEnv := new NodeJSEnv(args = Seq("--max_old_space_size=3072")).withSourceMap(false),
+          jsEnv := {
+            new NodeJSEnv(
+                NodeJSEnv.Config()
+                  .withArgs(List("--max_old_space_size=3072"))
+                  .withSourceMap(false))
+          },
 
           jsDependencies += ProvidedJS / "js-test-definitions.js" % "test"
       ) ++ inConfig(Test) {

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -23,7 +23,8 @@ import org.scalajs.core.ir.ScalaJSVersions
 
 import org.scalajs.jsenv.{JSEnv, JSConsole}
 import org.scalajs.jsenv.rhino.RhinoJSEnv
-import org.scalajs.jsenv.nodejs.{NodeJSEnv, JSDOMNodeJSEnv}
+import org.scalajs.jsenv.nodejs.NodeJSEnv
+import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 import org.scalajs.jsenv.phantomjs.PhantomJSEnv
 
 object ScalaJSPlugin extends AutoPlugin {
@@ -121,7 +122,11 @@ object ScalaJSPlugin extends AutoPlugin {
         args: Seq[String] = Seq.empty,
         env: Map[String, String] = Map.empty
     ): Def.Initialize[Task[NodeJSEnv]] = Def.task {
-      new NodeJSEnv(executable, args, env)
+      new NodeJSEnv(
+          org.scalajs.jsenv.nodejs.NodeJSEnv.Config()
+            .withExecutable(executable)
+            .withArgs(args.toList)
+            .withEnv(env))
     }
 
     /**
@@ -141,7 +146,7 @@ object ScalaJSPlugin extends AutoPlugin {
      *  [[sbt.ProjectExtra.inScope[* Project.inScope]].
      */
     @deprecated(
-        "Use `jsEnv := new org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv(...)` " +
+        "Use `jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(...)` " +
         "instead.",
         "0.6.16")
     def JSDOMNodeJSEnv(
@@ -149,7 +154,11 @@ object ScalaJSPlugin extends AutoPlugin {
         args: Seq[String] = Seq.empty,
         env: Map[String, String] = Map.empty
     ): Def.Initialize[Task[JSDOMNodeJSEnv]] = Def.task {
-      new JSDOMNodeJSEnv(executable, args, env)
+      new JSDOMNodeJSEnv(
+          org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv.Config()
+            .withExecutable(executable)
+            .withArgs(args.toList)
+            .withEnv(env))
     }
 
     /**
@@ -175,7 +184,13 @@ object ScalaJSPlugin extends AutoPlugin {
         autoExit: Boolean = true
     ): Def.Initialize[Task[PhantomJSEnv]] = Def.task {
       val loader = scalaJSPhantomJSClassLoader.value
-      new PhantomJSEnv(executable, args, env, autoExit, loader)
+      new PhantomJSEnv(
+          org.scalajs.jsenv.phantomjs.PhantomJSEnv.Config()
+            .withExecutable(executable)
+            .withArgs(args.toList)
+            .withEnv(env)
+            .withAutoExit(autoExit)
+            .withJettyClassLoader(loader))
     }
 
     // ModuleKind

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -608,7 +608,7 @@ object ScalaJSPluginInternal {
         if (scalaJSUseRhinoInternal.value) {
           RhinoJSEnvInternal().value
         } else if (scalaJSRequestsDOM.value) {
-          new org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv()
+          new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv()
         } else {
           new org.scalajs.jsenv.nodejs.NodeJSEnv()
         }


### PR DESCRIPTION
This only changes the surface API of concrete JS envs. Their existing constructors are deprecated in favor of an overload with a `Config` object.

This change provides in the 0.6.x series an API that can be used in a source-compatible way between 0.6.x and 1.x. In 1.x, deeper changes to the internal API of JS envs will be done.

We also take this opportunity to "move" `JSDOMNodeJSEnv` in a different package `org.scalajs.jsenv.jsdomnodejs`. Since this JS env is scheduled to be moved in a different repository in 1.x, it should eventually be in a different package anyway.