### PR TITLE
Forbid top-level exports to invalid JS identifiers.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -7,6 +7,8 @@ package org.scalajs.core.compiler
 
 import scala.collection.mutable
 
+import org.scalajs.core.ir.Trees.isValidIdentifier
+
 /**
  *  Prepare export generation
  *
@@ -315,6 +317,13 @@ trait PrepJSExports { this: PrepJSInterop =>
           if (sym.isMethod && (!symOwner.isStatic || !symOwner.isModuleClass)) {
             reporter.error(annot.pos,
                 "Only static objects may export their members to the top level")
+          }
+
+          // The top-level name must be a valid JS identifier
+          if (!isValidIdentifier(name.split('.').head)) {
+            reporter.error(annot.pos,
+                "The top-level export name must be a valid JavaScript " +
+                "identifier")
           }
 
         case ExportDestination.Static =>

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -931,6 +931,66 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
+  def noExportTopLevelInvalidJSIdentifier: Unit = {
+    """
+    @JSExportTopLevel("not-a-valid-JS-identifier-1")
+    object A
+
+    @JSExportTopLevel("not-a-valid-JS-identifier-2")
+    class B
+
+    object C {
+      @JSExportTopLevel("not-a-valid-JS-identifier-3")
+      val a: Int = 1
+
+      @JSExportTopLevel("not-a-valid-JS-identifier-4")
+      var b: Int = 1
+
+      @JSExportTopLevel("not-a-valid-JS-identifier-5")
+      def c(): Int = 1
+    }
+
+    @JSExportTopLevel("")
+    object D
+
+    @JSExportTopLevel("not-a-valid-JS-identifier-6.foo")
+    object E
+
+    @JSExportTopLevel("foo.not-a-valid-JS-identifier-7") // valid
+    object F
+
+    @JSExportTopLevel(".tricky")
+    object G
+    """ hasErrors
+    """
+      |newSource1.scala:3: error: The top-level export name must be a valid JavaScript identifier
+      |    @JSExportTopLevel("not-a-valid-JS-identifier-1")
+      |     ^
+      |newSource1.scala:6: error: The top-level export name must be a valid JavaScript identifier
+      |    @JSExportTopLevel("not-a-valid-JS-identifier-2")
+      |     ^
+      |newSource1.scala:10: error: The top-level export name must be a valid JavaScript identifier
+      |      @JSExportTopLevel("not-a-valid-JS-identifier-3")
+      |       ^
+      |newSource1.scala:13: error: The top-level export name must be a valid JavaScript identifier
+      |      @JSExportTopLevel("not-a-valid-JS-identifier-4")
+      |       ^
+      |newSource1.scala:16: error: The top-level export name must be a valid JavaScript identifier
+      |      @JSExportTopLevel("not-a-valid-JS-identifier-5")
+      |       ^
+      |newSource1.scala:20: error: The top-level export name must be a valid JavaScript identifier
+      |    @JSExportTopLevel("")
+      |     ^
+      |newSource1.scala:23: error: The top-level export name must be a valid JavaScript identifier
+      |    @JSExportTopLevel("not-a-valid-JS-identifier-6.foo")
+      |     ^
+      |newSource1.scala:29: error: The top-level export name must be a valid JavaScript identifier
+      |    @JSExportTopLevel(".tricky")
+      |     ^
+    """
+  }
+
+  @Test
   def noExportTopLevelGetter: Unit = {
     """
     object A {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -1043,16 +1043,6 @@ class ExportsTest {
     assertThrows(classOf[Exception], foo.doA("a"))
   }
 
-  @Test def `exports_for_classes_ending_in__=_issue_1090`(): Unit = {
-    val constr = exportsNamespace.ExportClassSetterNamed_=
-    val obj = js.Dynamic.newInstance(constr)()
-    assertEquals(obj.x, 1)
-  }
-
-  @Test def `exports_for_objects_ending_in__=_issue_1090`(): Unit = {
-    assertEquals(exportsNamespace.ExportObjSetterNamed_=.x, 1)
-  }
-
   @Test def should_expose_public_members_of_new_js_Object_issue_1899(): Unit = {
 
     // Test that the bug is fixed for js.Any classes.
@@ -1345,18 +1335,6 @@ class ExportedDefaultArgClass(x: Int, y: Int, z: Int) {
 object ExportedUnderOrgObject
 
 class SomeValueClass(val i: Int) extends AnyVal
-
-@JSExportTopLevel("ExportClassSetterNamed_=")
-class ExportClassSetterNamed_= { // scalastyle:ignore
-  @JSExport
-  val x = 1
-}
-
-@JSExportTopLevel("ExportObjSetterNamed_=")
-object ExportObjSetterNamed_= { // scalastyle:ignore
-  @JSExport
-  val x = 1
-}
 
 object ExportHolder {
   @JSExportTopLevel("qualified.nested.ExportedClass")

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -732,6 +732,15 @@ class ExportsTest {
     assertTrue((obj: Any).isInstanceOf[ExportHolder.SJSDefinedExportedClass])
   }
 
+  @Test def toplevel_exports_under_nested_invalid_js_identifier(): Unit = {
+    val constr = exportsNamespace.qualified.selectDynamic("not-a-JS-identifier")
+    assertJSNotUndefined(constr)
+    assertEquals("function", js.typeOf(constr))
+    val obj = js.Dynamic.newInstance(constr)()
+    assertTrue(
+        (obj: Any).isInstanceOf[ExportHolder.ClassExportedUnderNestedInvalidJSIdentifier])
+  }
+
   @Test def exports_for_classes_with_constant_folded_name(): Unit = {
     val constr = exportsNamespace.ConstantFoldedClassExport
     assertJSNotUndefined(constr)
@@ -1189,6 +1198,11 @@ class ExportsTest {
     assertEquals(10, jsPackage.toplevel.overload(1, 2, 3, 4))
   }
 
+  @Test def method_top_level_export_under_invalid_js_identifier(): Unit = {
+    assertEquals("not an identifier",
+        jsPackage.toplevel.applyDynamic("not-a-JS-identifier")())
+  }
+
   @Test def top_level_export_uses_unique_object(): Unit = {
     jsPackage.toplevel.set(3)
     assertEquals(3, TopLevelExports.myVar)
@@ -1345,6 +1359,9 @@ object ExportHolder {
 
   @JSExportTopLevel("qualified.nested.SJSDefinedExportedClass")
   class SJSDefinedExportedClass extends js.Object
+
+  @JSExportTopLevel("qualified.not-a-JS-identifier")
+  class ClassExportedUnderNestedInvalidJSIdentifier
 }
 
 object TopLevelExports {
@@ -1356,6 +1373,9 @@ object TopLevelExports {
 
   @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.overload")
   def overload(x: Int, y: Int*): Int = x + y.sum
+
+  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.not-a-JS-identifier")
+  def methodExportedUnderNestedInvalidJSIdentifier(): String = "not an identifier"
 
   var myVar: Int = _
 


### PR DESCRIPTION
It won't be possible to export things as invalid JS identifiers when we export to the global scope or to ECMAScript 2015 modules. Therefore, we prevent that in the source code.

In the rare cases that someone does want to do something like that, they can do it manually. For example, in a CommonJS module, one could use
```scala
js.Dynamic.global.exports.`not-an-identifier` = 42;
```
in a module initializer to export under a non-identifier.