### PR TITLE
Fuse `testHtml{Fast,Full}Opt` in a unique `testHtml` task.

### DIFF
--- a/TESTING
+++ b/TESTING
@@ -43,11 +43,11 @@ The following HTML-runners must be manually tested:
     examples/helloworld/helloworld-{2.10|2.11}{|-fastopt}.html
     examples/reversi/reversi-{2.10|2.11}{|-fastopt}.html
 
-The following sbt-plugin generated test runners must be manually tested (in both
-2.10 and 2.11):
+The following sbt-plugin generated test runners must be manually tested (with
+Scala 2.10, 2.11 and 2.12, and in `FastOptStage` and `FullOptStage`):
 
-    testingExample/testHtml{Fast,Full}Opt
-    testSuite/testHtml{Fast,Full}Opt
+    testingExample/testHtml
+    testSuite/testHtml
 
 ## Sourcemaps
 

--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -211,12 +211,13 @@
     sbt ++2.10.6 ir/publishLocal tools/publishLocal jsEnvs/publishLocal \
                  testAdapter/publishLocal sbtPlugin/publishLocal &&
     cd sbt-plugin-test &&
-    sbt noDOM/run noDOM/testHtmlFastOpt noDOM/testHtmlFullOpt \
-        withDOM/run withDOM/testHtmlFastOpt withDOM/testHtmlFullOpt \
-        multiTestJS/testHtmlFastOpt multiTestJS/testHtmlFullOpt \
+    sbt noDOM/run withDOM/run \
+        noDOM/testHtml withDOM/testHtml multiTestJS/testHtml \
         test \
         noDOM/clean noDOM/concurrentUseOfLinkerTest \
-        multiTestJS/test:testScalaJSSourceMapAttribute
+        multiTestJS/test:testScalaJSSourceMapAttribute &&
+    sbt 'set scalaJSStage in Global := FullOptStage' \
+        noDOM/testHtml withDOM/testHtml multiTestJS/testHtml
   ]]></task>
 
   <task id="partest-noopt"><![CDATA[

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -127,11 +127,8 @@ object ScalaJSPlugin extends AutoPlugin {
     val fullOptJS = TaskKey[Attributed[File]]("fullOptJS",
         "Link all compiled JavaScript into a single file and fully optimize", APlusTask)
 
-    val testHtmlFastOpt = TaskKey[Attributed[File]]("testHtmlFastOpt",
-        "Create an HTML test runner for fastOptJS", AMinusTask)
-
-    val testHtmlFullOpt = TaskKey[Attributed[File]]("testHtmlFullOpt",
-        "Create an HTML test runner for fullOptJS", AMinusTask)
+    val testHtml = TaskKey[Attributed[File]]("testHtml",
+        "Create an HTML test runner. Honors `scalaJSStage`.", AMinusTask)
 
     val scalaJSIR = TaskKey[Attributed[Seq[VirtualScalaJSIRFile with RelativeVirtualFile]]](
         "scalaJSIR", "All the *.sjsir files on the classpath", CTask)


### PR DESCRIPTION
The new task honors `scalaJSStage` to decide which stage to use.

This gets rid of 2 hacks in our repo: one in our build, and one in the sbt plugin itself. It also allows `testHtml` to correctly use `jsExecutionFiles` that are dependent on the `scalaJSStage`, such as those produced by the `jsDependencies` plugin. Or more generally, correctly integrate with any custom tasks that produce different results depending on the stage.

The new behavior also makes more sense when we regard the HTML test runners as a peculiar form of JS envs. In that sense, `testHtml` is more similar to `test` than it was before.