### PR TITLE
Make `js.Dynamic.global` user-defined again.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1762,12 +1762,6 @@ abstract class GenJSCode extends plugins.PluginComponent
             MaybeGlobalScope.NotGlobalScope(genExpr(tree))
           }
 
-        case Apply(fun, _) =>
-          if (fun.symbol == JSDynamic_global)
-            MaybeGlobalScope.GlobalScope(pos)
-          else
-            MaybeGlobalScope.NotGlobalScope(genExpr(tree))
-
         case _ =>
           MaybeGlobalScope.NotGlobalScope(genExpr(tree))
       }
@@ -4095,7 +4089,6 @@ abstract class GenJSCode extends plugins.PluginComponent
       } else (genArgs match {
         case Nil =>
           code match {
-            case DYNGLOBAL    => reportErrorLoadGlobalScope()
             case LINKING_INFO => js.JSLinkingInfo()
             case DEBUGGER     => js.Debugger()
             case UNITVAL      => js.Undefined()

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -79,7 +79,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
       def JSAny_fromFunction(arity: Int): TermSymbol = getMemberMethod(JSAnyModule, newTermName("fromFunction"+arity))
 
     lazy val JSDynamicModule = JSDynamicClass.companionModule
-      lazy val JSDynamic_global = getMemberMethod(JSDynamicModule, newTermName("global"))
       lazy val JSDynamic_newInstance = getMemberMethod(JSDynamicModule, newTermName("newInstance"))
     lazy val JSDynamicLiteral = getMemberModule(JSDynamicModule, newTermName("literal"))
       lazy val JSDynamicLiteral_applyDynamicNamed = getMemberMethod(JSDynamicLiteral, newTermName("applyDynamicNamed"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
@@ -32,8 +32,7 @@ abstract class JSPrimitives {
   val F2JS = 305     // FunctionN to js.FunctionN
   val F2JSTHIS = 306 // FunctionN to js.ThisFunction{N-1}
 
-  val DYNGLOBAL = 320 // js.Dynamic.global
-  val DYNNEW = 321    // Instantiate a new JavaScript object
+  val DYNNEW = 321 // Instantiate a new JavaScript object
 
   val DYNLIT = 334    // js.Dynamic.literal.applyDynamic{,Named}
 
@@ -86,7 +85,6 @@ abstract class JSPrimitives {
     for (i <- 1 to 22)
       addPrimitive(JSThisFunction_fromFunction(i), F2JSTHIS)
 
-    addPrimitive(JSDynamic_global, DYNGLOBAL)
     addPrimitive(JSDynamic_newInstance, DYNNEW)
 
     addPrimitive(JSDynamicLiteral_applyDynamicNamed, DYNLIT)

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSGlobalScopeTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSGlobalScopeTest.scala
@@ -29,6 +29,8 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
 
       def +(that: Int): Int = js.native
 
+      def apply(x: Int): Int = js.native
+
       @JSBracketAccess
       def bracketSelect(name: String): Int = js.native
       @JSBracketAccess
@@ -80,11 +82,11 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     s"""
-      |newSource1.scala:39: error: Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.
+      |newSource1.scala:41: error: Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val g1 = js.Dynamic.global
       |                            ^
-      |newSource1.scala:40: error: Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.
+      |newSource1.scala:42: error: Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val g2 = SomeGlobalScope
       |                 ^
@@ -111,39 +113,39 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     s"""
-      |newSource1.scala:39: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:41: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val a = js.Dynamic.global.`not-a-valid-identifier-var`
       |                           ^
-      |newSource1.scala:40: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:42: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        js.Dynamic.global.`not-a-valid-identifier-var` = 3
       |                   ^
-      |newSource1.scala:41: error: Calling a method of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:43: error: Calling a method of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val b = js.Dynamic.global.`not-a-valid-identifier-def`()
       |                                                              ^
-      |newSource1.scala:43: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:45: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val c = SomeGlobalScope.`not-a-valid-identifier-var`
       |                                ^
-      |newSource1.scala:44: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:46: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        SomeGlobalScope.`not-a-valid-identifier-var` = 3
       |                                                     ^
-      |newSource1.scala:45: error: Calling a method of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:47: error: Calling a method of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val d = SomeGlobalScope.`not-a-valid-identifier-def`()
       |                                                            ^
-      |newSource1.scala:47: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:49: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val e = SomeGlobalScope.bracketSelect("not-a-valid-identifier-var")
       |                                             ^
-      |newSource1.scala:48: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:50: error: Selecting a field of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        SomeGlobalScope.bracketUpdate("not-a-valid-identifier-var", 3)
       |                                     ^
-      |newSource1.scala:49: error: Calling a method of the global scope whose name is not a valid JavaScript identifier is not allowed.
+      |newSource1.scala:51: error: Calling a method of the global scope whose name is not a valid JavaScript identifier is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val f = SomeGlobalScope.bracketCall("not-a-valid-identifier-def")(4)
       |                                                                         ^
@@ -152,23 +154,63 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
 
   @Test
   def rejectJSOperators: Unit = {
-    s"""
+    """
     object Main {
       def main(): Unit = {
         val a = js.Dynamic.global + 3.asInstanceOf[js.Dynamic]
-
-        val b = SomeGlobalScope + 3
       }
     }
     """ hasErrors
     s"""
-      |newSource1.scala:39: error: Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.
-      |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
+      |newSource1.scala:41: error: type mismatch;
+      | found   : scala.scalajs.js.Dynamic
+      | required: String
       |        val a = js.Dynamic.global + 3.asInstanceOf[js.Dynamic]
-      |                           ^
+      |                                                  ^
+    """
+
+    """
+    object Main {
+      def main(): Unit = {
+        val a = SomeGlobalScope + 3
+      }
+    }
+    """ hasErrors
+    s"""
       |newSource1.scala:41: error: Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
-      |        val b = SomeGlobalScope + 3
+      |        val a = SomeGlobalScope + 3
+      |                ^
+    """
+  }
+
+  @Test
+  def rejectApply: Unit = {
+    """
+    object Main {
+      def main(): Unit = {
+        val a = js.Dynamic.global(3)
+      }
+    }
+    """ hasErrors
+    s"""
+      |newSource1.scala:41: error: Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.
+      |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
+      |        val a = js.Dynamic.global(3)
+      |                           ^
+    """
+
+    """
+    object Main {
+      def main(): Unit = {
+        val a = SomeGlobalScope(3)
+      }
+    }
+    """ hasErrors
+    s"""
+      |newSource1.scala:41: error: Loading the global scope as a value (anywhere but as the left-hand-side of a `.`-selection) is not allowed.
+      |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
+      |        val a = SomeGlobalScope(3)
       |                ^
     """
   }
@@ -195,39 +237,39 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     s"""
-      |newSource1.scala:41: error: Selecting a field of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:43: error: Selecting a field of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val a = js.Dynamic.global.selectDynamic(dynName)
       |                                               ^
-      |newSource1.scala:42: error: Selecting a field of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:44: error: Selecting a field of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        js.Dynamic.global.updateDynamic(dynName)(3)
       |                                                ^
-      |newSource1.scala:43: error: Calling a method of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:45: error: Calling a method of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val b = js.Dynamic.global.applyDynamic(dynName)(3)
       |                                                       ^
-      |newSource1.scala:45: error: Selecting a field of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:47: error: Selecting a field of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val e = SomeGlobalScope.bracketSelect(dynName)
       |                                             ^
-      |newSource1.scala:46: error: Selecting a field of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:48: error: Selecting a field of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        SomeGlobalScope.bracketUpdate(dynName, 3)
       |                                     ^
-      |newSource1.scala:47: error: Calling a method of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:49: error: Calling a method of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val f = SomeGlobalScope.bracketCall(dynName)(4)
       |                                                    ^
-      |newSource1.scala:49: error: Selecting a field of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:51: error: Selecting a field of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val i = SomeGlobalScope.symbolVar
       |                                ^
-      |newSource1.scala:50: error: Selecting a field of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:52: error: Selecting a field of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        SomeGlobalScope.symbolVar = 3
       |                                  ^
-      |newSource1.scala:51: error: Calling a method of the global scope with a dynamic name is not allowed.
+      |newSource1.scala:53: error: Calling a method of the global scope with a dynamic name is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val k = SomeGlobalScope.symbolDef()
       |                                         ^
@@ -250,27 +292,27 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     s"""
-      |newSource1.scala:39: error: Selecting a field of the global scope whose name is `arguments` is not allowed.
+      |newSource1.scala:41: error: Selecting a field of the global scope whose name is `arguments` is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val a = js.Dynamic.global.arguments
       |                           ^
-      |newSource1.scala:40: error: Selecting a field of the global scope whose name is `arguments` is not allowed.
+      |newSource1.scala:42: error: Selecting a field of the global scope whose name is `arguments` is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        js.Dynamic.global.arguments = null
       |                   ^
-      |newSource1.scala:41: error: Calling a method of the global scope whose name is `arguments` is not allowed.
+      |newSource1.scala:43: error: Calling a method of the global scope whose name is `arguments` is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val b = js.Dynamic.global.arguments(5)
       |                                           ^
-      |newSource1.scala:43: error: Selecting a field of the global scope whose name is `arguments` is not allowed.
+      |newSource1.scala:45: error: Selecting a field of the global scope whose name is `arguments` is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val c = SomeGlobalScope.arguments
       |                                ^
-      |newSource1.scala:44: error: Selecting a field of the global scope whose name is `arguments` is not allowed.
+      |newSource1.scala:46: error: Selecting a field of the global scope whose name is `arguments` is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        SomeGlobalScope.arguments = null
       |                                  ^
-      |newSource1.scala:45: error: Calling a method of the global scope whose name is `arguments` is not allowed.
+      |newSource1.scala:47: error: Calling a method of the global scope whose name is `arguments` is not allowed.
       |  See https://www.scala-js.org/doc/interoperability/global-scope.html for further information.
       |        val d = SomeGlobalScope.arguments2(5)
       |                                          ^

--- a/library/src/main/scala/scala/scalajs/js/Dynamic.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dynamic.scala
@@ -76,7 +76,35 @@ sealed trait Dynamic extends js.Any with scala.Dynamic {
 /** Factory for dynamically typed JavaScript values. */
 object Dynamic {
   /** Dynamic view of the global scope. */
-  def global: js.Dynamic = throw new java.lang.Error("stub")
+  @js.native
+  @JSGlobalScope
+  object global extends js.Any with scala.Dynamic { // scalastyle:ignore
+    /** Calls a top-level method (in the global scope). */
+    @JSBracketCall
+    def applyDynamic(name: String)(args: js.Any*): js.Dynamic = js.native
+
+    /** Reads a top-level variable (in the global scope). */
+    @JSBracketAccess
+    def selectDynamic(name: String): js.Dynamic = js.native
+
+    /** Writes to a top-level variable (in the global scope). */
+    @JSBracketAccess
+    def updateDynamic(name: String)(value: js.Any): Unit = js.native
+
+    /* The following method is a protection against someone writing
+     * `js.Dynamic.global(args)`. It that method were not there, that call
+     * would silently desugar into
+     * `js.Dynamic.global.applyDynamic("apply")(args)`, which is very
+     * unexpected and will produce confusing run-time errors. Better to have
+     * a straightforward compile-time error.
+     */
+
+    /** Cannot be called--provides a compile-time error instead of a silent
+     *  run-time error if one tries to do `js.Dynamic.global(something)`.
+     */
+    @deprecated("The global scope cannot be called as function.", "forever")
+    def apply(args: js.Any*): js.Dynamic = js.native
+  }
 
   /** Instantiates a new object of a JavaScript class. */
   def newInstance(clazz: js.Dynamic)(args: js.Any*): js.Object with js.Dynamic =


### PR DESCRIPTION
Instead of it being a primitive, it can simply be a user-defined native JS object annotated with `@JSGlobalScope`.