### PR TITLE
Define `js.UndefOr[A]` as a mere alias to `A | Unit`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -36,7 +36,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val JSObjectClass    = getRequiredClass("scala.scalajs.js.Object")
     lazy val JSThisFunctionClass = getRequiredClass("scala.scalajs.js.ThisFunction")
 
-    lazy val UndefOrClass = getRequiredClass("scala.scalajs.js.UndefOr")
     lazy val UnionClass = getRequiredClass("scala.scalajs.js.$bar")
 
     lazy val JSArrayClass = getRequiredClass("scala.scalajs.js.Array")

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -194,7 +194,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
 
           checkJSAnySpecificAnnotsOnNonJSAny(cldef)
 
-          if (sym == UndefOrClass || sym == UnionClass)
+          if (sym == UnionClass)
             sym.addAnnotation(RawJSTypeAnnot)
 
           if (shouldPrepareExports)

--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -49,7 +49,7 @@ final class URI(origStr: String) extends Serializable with Comparable[URI] {
   private val _path = {
     val useNetPath = fld(AbsAuthority, RelAuthority).isDefined
     if (useNetPath)
-      fld(AbsNetPath, RelNetPath) orElse ""
+      fld(AbsNetPath, RelNetPath) orElse ("": js.UndefOr[String]) // 2.10 wants the type ascription
     else if (_isAbsolute)
       fld(AbsAbsPath)
     else

--- a/library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
@@ -14,41 +14,6 @@ import scala.language.implicitConversions
 import scala.scalajs.js
 import scala.scalajs.js.|.Evidence
 
-/** Value of type A or the JS undefined value.
- *
- *  `js.UndefOr[A]` is the type of a value that can be either `undefined` or
- *  an `A`. It provides an API similar to that of [[scala.Option]] through the
- *  [[UndefOrOps]] implicit class, where `undefined` take the role of [[None]].
- *
- *  By extension, this type is also suited to typing optional fields in native
- *  JS types, i.e., fields that may not exist on the object.
- */
-sealed trait UndefOr[+A]
-
-sealed abstract class UndefOrLowPrioImplicits { this: js.UndefOr.type =>
-  /** Upcast `A` to `UndefOr[B1 | B2]`.
-   *
-   *  This needs evidence that `A <: B1 | B2`.
-   */
-  implicit def any2undefOrUnion[A, B1, B2](a: A)(
-      implicit ev: Evidence[A, B1 | B2]): js.UndefOr[B1 | B2] = {
-    a.asInstanceOf[js.UndefOr[B1 | B2]]
-  }
-}
-
-object UndefOr extends js.UndefOrLowPrioImplicits {
-  implicit def any2undefOrA[A](value: A): js.UndefOr[A] =
-    value.asInstanceOf[js.UndefOr[A]]
-
-  implicit def undefOr2ops[A](value: js.UndefOr[A]): js.UndefOrOps[A] =
-    new js.UndefOrOps(value)
-
-  implicit def undefOr2jsAny[A](value: js.UndefOr[A])(
-      implicit ev: A => js.Any): js.Any = {
-    value.map(ev).asInstanceOf[js.Any]
-  }
-}
-
 /** @define option [[js.UndefOr]]
  *  @define none [[js.undefined]]
  */

--- a/library/src/main/scala/scala/scalajs/js/Union.scala
+++ b/library/src/main/scala/scala/scalajs/js/Union.scala
@@ -60,10 +60,6 @@ object | { // scalastyle:ignore
     /** If `A <: B1`, then `A <: B1 | B2`. */
     implicit def left[A, B1, B2](implicit ev: Evidence[A, B1]): Evidence[A, B1 | B2] =
       ReusableEvidence.asInstanceOf[Evidence[A, B1 | B2]]
-
-    /** If `A <: B`, then `A <: js.UndefOr[B]`. */
-    implicit def undefOr[A, B](implicit ev: Evidence[A, B]): Evidence[A, js.UndefOr[B]] =
-      ReusableEvidence.asInstanceOf[Evidence[A, js.UndefOr[B]]]
   }
 
   object Evidence extends EvidenceLowPrioImplicits {
@@ -101,5 +97,19 @@ object | { // scalastyle:ignore
      */
     def merge[B](implicit ev: |.Evidence[A, B]): B =
       self.asInstanceOf[B]
+  }
+
+  /** Provides an [[Option]]-like API to [[js.UndefOr]]. */
+  implicit def undefOr2ops[A](value: js.UndefOr[A]): js.UndefOrOps[A] =
+    new js.UndefOrOps(value)
+
+  /* This one is not very "in the spirit" of the union type, but it used to be
+   * available for `js.UndefOr[A]`, so we keep it for backward source
+   * compatibility. It is not really harmful, and has some perks in certain
+   * interoperability scenarios.
+   */
+  implicit def undefOr2jsAny[A](value: js.UndefOr[A])(
+      implicit ev: A => js.Any): js.Any = {
+    value.map(ev).asInstanceOf[js.Any]
   }
 }

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -10,6 +10,8 @@
 
 package scala.scalajs
 
+import scala.annotation.unchecked.uncheckedVariance
+
 // Can't link to Null - #1969
 /** Types, methods and values for interoperability with JavaScript libraries.
  *
@@ -63,6 +65,22 @@ package scala.scalajs
  *  admit several unrelated types in facade types.
  */
 package object js {
+
+  /** Value of type A or the JS undefined value.
+   *
+   *  This type is actually strictly equivalent to `A | Unit`, since `Unit` is
+   *  the type of the `undefined` value.
+   *
+   *  `js.UndefOr[A]` is the type of a value that can be either `undefined` or
+   *  an `A`. It provides an API similar to that of [[scala.Option]] through
+   *  the [[UndefOrOps]] implicit class, where `undefined` take the role of
+   *  [[None]].
+   *
+   *  By extension, this type is also suited to typing optional fields in
+   *  native JS types, i.e., fields that may not exist on the object.
+   */
+  type UndefOr[+A] = (A @uncheckedVariance) | Unit
+
   /** The undefined value. */
   @inline def undefined: js.UndefOr[Nothing] =
     ().asInstanceOf[js.UndefOr[Nothing]]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1497,6 +1497,21 @@ object Build {
         Seq(outFile)
       }.taskValue,
 
+      // Exclude tests based on version-dependent limitations
+      sources in Test := {
+        val sourceFiles = (sources in Test).value
+        val v = scalaVersion.value
+
+        val sourceFiles1 = {
+          if (v.startsWith("2.10."))
+            sourceFiles.filterNot(_.getName.endsWith("Require211.scala"))
+          else
+            sourceFiles
+        }
+
+        sourceFiles1
+      },
+
       // Module initializers. Duplicated in toolsJS/test
       scalaJSModuleInitializers += {
         ModuleInitializer.mainMethod(

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
@@ -171,9 +171,11 @@ class UndefOrTest {
     assertEquals("yes", none orElse some("yes"))
     assertJSUndefined(none orElse none)
 
-    // #2095
-    assertEquals("ok", some("ok") orElse "yes")
-    assertEquals("yes", none orElse "yes")
+    /* #2095
+     * Scala 2.10 requires the type ascriptions (see also UndefOrTestRequire211)
+     */
+    assertEquals("ok", some("ok") orElse ("yes": js.UndefOr[String]))
+    assertEquals("yes", none orElse ("yes": js.UndefOr[String]))
   }
 
   @Test def toList(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTestRequire211.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTestRequire211.scala
@@ -1,0 +1,31 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.JSAssert._
+
+class UndefOrTestRequire211 {
+
+  def some[A](v: A): js.UndefOr[A] = v
+  def none[A]: js.UndefOr[A] = js.undefined
+
+  // scala.scalajs.js.UndefOr[A]
+
+  @Test def orElse(): Unit = {
+    // #2095
+    assertEquals("ok", some("ok") orElse "yes")
+    assertEquals("yes", none orElse "yes")
+  }
+
+}


### PR DESCRIPTION
This will give a much better status to `js.UndefOr` in a compiler that supports true union types (understand, Dotty).