### PR TITLE
Fix #3013: Use `genExpr()` for the qualifier of super calls.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class RegressionJSTest {
+  import RegressionJSTest._
 
   @Test def should_not_swallow_Unit_expressions_when_converting_to_js_Any_issue_83(): Unit = {
     var effectHappened = false
@@ -51,6 +52,49 @@ class RegressionJSTest {
 
     assertTrue(js.isUndefined(js.constructorOf[Foo].x))
     assertTrue(js.isUndefined(js.constructorOf[Foo].y))
+  }
+
+  @Test def super_mixin_call_in_2_12_issue_3013_ScalaOuter_JSInner(): Unit = {
+    import Bug3013_ScalaOuter_JSInner._
+
+    val b = new B
+    val c = new b.C
+    assertEquals("A1", c.t1())
+    assertEquals("A2", c.t2())
+    assertEquals("B", c.t3())
+  }
+
+}
+
+object RegressionJSTest {
+
+  /* The combination Scala/Scala is done in the cross-platform RegressionTest.
+   *
+   * The combinations where the outer class is a JS type cannot happen by
+   * construction, because they would require a non-native JS trait with a
+   * concrete method, which is prohibited.
+   */
+  object Bug3013_ScalaOuter_JSInner {
+    trait A1 {
+      private val s = "A1"
+      def f(): String = s
+    }
+
+    trait A2 {
+      private val s = "A2"
+      def f(): String = s
+    }
+
+    class B extends A1 with A2 {
+      override def f(): String = "B"
+
+      @ScalaJSDefined
+      class C extends js.Object {
+        def t1(): String = B.super[A1].f()
+        def t2(): String = B.super[A2].f()
+        def t3(): String = B.this.f()
+      }
+    }
   }
 
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -588,6 +588,21 @@ class RegressionTest {
     assertFalse("String", c.isInstanceOf[String])
   }
 
+  @Test def super_mixin_call_in_2_12_issue_3013(): Unit = {
+    assumeTrue(
+        "Super mixin calls are broken in Scala/JVM 2.12.{0-2} and 2.13.0-M1",
+        !Platform.executingInJVM ||
+        !Set("2.12.0", "2.12.1", "2.12.2", "2.13.0-M1").contains(Platform.scalaVersion))
+
+    import Bug3013._
+
+    val b = new B
+    val c = new b.C
+    assertEquals("A1", c.t1)
+    assertEquals("A2", c.t2)
+    assertEquals("B", c.t3)
+  }
+
 }
 
 object RegressionTest {
@@ -614,6 +629,28 @@ object RegressionTest {
       }
 
       if (false) ()
+    }
+  }
+
+  object Bug3013 {
+    trait A1 {
+      private val s = "A1"
+      def f: String = s
+    }
+
+    trait A2 {
+      private val s = "A2"
+      def f: String = s
+    }
+
+    class B extends A1 with A2 {
+      override def f: String = "B"
+
+      class C {
+        def t1: String = B.super[A1].f
+        def t2: String = B.super[A2].f
+        def t3: String = B.this.f
+      }
     }
   }
 }


### PR DESCRIPTION
Since Scala 2.12, the `qual` part of a super call is not always `this`. It can be `this.$outer()` or similar things. Therefore, we cannot blindly assume that the receiver is `this`, nor that the super call is a JS super call iff the current class is a JS class.

Instead, we correctly use `genExpr(qual)` and inspect `isRawJSType(qual.tpe)`.