### PR TITLE
Fix #3000: Fix the linker config of partest for `--{no,full}Opt`.

### DIFF
--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -198,6 +198,7 @@ object Scalajsld {
         .withRelativizeSourceMapBase(options.relativizeSourceMap)
         .withClosureCompiler(options.fullOpt)
         .withPrettyPrint(options.prettyPrint)
+        .withBatchMode(true)
 
       val linker = StandardLinker(config)
       val logger = new ScalaConsoleLogger(options.logLevel)

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -57,7 +57,8 @@ class MainGenericRunner {
 
     val logger = new ScalaConsoleLogger(Level.Warn)
     val jsConsole = new ScalaConsoleJSConsole
-    val semantics = readSemantics()
+    val semantics0 = readSemantics()
+    val semantics = if (optMode == FullOpt) semantics0.optimized else semantics0
     val ir = loadIR(command.settings.classpathURLs)
 
     val moduleInitializers = Seq(ModuleInitializer.mainMethodWithArgs(
@@ -66,6 +67,7 @@ class MainGenericRunner {
     val linkerConfig = StandardLinker.Config()
       .withSemantics(semantics)
       .withSourceMap(false)
+      .withOptimizer(optMode != NoOpt)
       .withClosureCompiler(optMode == FullOpt)
       .withBatchMode(true)
 

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -67,6 +67,7 @@ class MainGenericRunner {
       .withSemantics(semantics)
       .withSourceMap(false)
       .withClosureCompiler(optMode == FullOpt)
+      .withBatchMode(true)
 
     val linker = StandardLinker(linkerConfig)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -270,7 +270,6 @@ object ScalaJSPluginInternal {
           val log = s.log
           val realFiles = irInfo.get(scalaJSSourceFiles).get
           val ir = irInfo.data
-          log.warn(s.cacheDirectory.toString)
 
           FileFunction.cached(s.cacheDirectory, FilesInfo.lastModified,
               FilesInfo.exists) { _ => // We don't need the files

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -36,8 +36,10 @@ object QuickLinker {
       irFilesAndJars: Seq[String], moduleInitializers: Seq[String]): String = {
     val cache = (new IRFileCache).newCache
 
-    val linker =
-      StandardLinker(StandardLinker.Config().withSemantics(semantics))
+    val config = StandardLinker.Config()
+      .withSemantics(semantics)
+      .withBatchMode(true)
+    val linker = StandardLinker(config)
 
     val irContainers = irFilesAndJars.map { file =>
       if (file.endsWith(".jar")) {


### PR DESCRIPTION
* `--noOpt` was not honored at all: the optimizer was not disabled
* `--fullOpt` enabled GCC but did not use the optimized semantics