### PR TITLE
FF ONLY Merge 0.6.x into master june 15

### DIFF
--- a/TESTING
+++ b/TESTING
@@ -11,16 +11,16 @@ For each major Scala version on a *NIX distro and a Windows distro:
 5. Create a temporary directory and do:
 
         mkdir bin
-        echo 'import scala.scalajs.js.JSApp
-          object Foo extends JSApp {
-
-            def main() = {
+        echo '
+          object Foo {
+            def main(): Unit = {
               println(s"asdf ${1 + 1}")
               new A
             }
 
             class A
-          }' > foo.scala
+          }
+        ' > foo.scala
         scalajsc -d bin foo.scala
 
         scalajsp bin/Foo$.sjsir
@@ -28,10 +28,9 @@ For each major Scala version on a *NIX distro and a Windows distro:
         scalajsp bin/Foo\$A.sjsir
         # Verify output
 
-        scalajsld -o test.js bin
+        scalajsld -o test.js -mm Foo.main bin
         # Verify output
 
-        echo "Foo().main()" >> test.js
         node test.js # Or your favorite thing to run JS
 
         # Expect "asdf 2"

--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -101,42 +101,42 @@
     setJavaVersion $java
     npm install &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
-        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv().withSourceMap(false)' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test
@@ -182,7 +182,7 @@
         jsEnvs/scalastyle jsEnvsTestKit/scalastyle \
         jsEnvsTestSuite/test:scalastyle testAdapter/scalastyle \
         sbtPlugin/scalastyle testInterface/scalastyle \
-        testSuite/test:scalastyle \
+        testSuite/scalastyle testSuite/test:scalastyle \
         testSuiteJVM/test:scalastyle \
         testSuiteEx/test:scalastyle helloworld/scalastyle \
         reversi/scalastyle testingExample/scalastyle \

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -11,15 +11,13 @@ package org.scalajs.cli
 
 import org.scalajs.core.ir.ScalaJSVersions
 
-import org.scalajs.core.tools.sem._
 import org.scalajs.core.tools.io._
 import org.scalajs.core.tools.logging._
 
-import CheckedBehavior.Compliant
+import org.scalajs.core.tools.linker._
+import org.scalajs.core.tools.linker.standard._
 
-import org.scalajs.core.tools.linker.{ModuleInitializer, Linker}
-import org.scalajs.core.tools.linker.frontend.LinkerFrontend
-import org.scalajs.core.tools.linker.backend.{LinkerBackend, OutputMode, ModuleKind}
+import CheckedBehavior.Compliant
 
 import scala.collection.immutable.Seq
 
@@ -161,24 +159,20 @@ object Scalajsld {
         if (options.fullOpt) options.semantics.optimized
         else options.semantics
 
-      val frontendConfig = LinkerFrontend.Config()
+      val config = StandardLinker.Config()
+        .withSemantics(semantics)
+        .withModuleKind(options.moduleKind)
+        .withOutputMode(options.outputMode)
         .withCheckIR(options.checkIR)
-
-      val backendConfig = LinkerBackend.Config()
-        .withRelativizeSourceMapBase(options.relativizeSourceMap)
-        .withPrettyPrint(options.prettyPrint)
-
-      val config = Linker.Config()
-        .withSourceMap(options.sourceMap)
         .withOptimizer(!options.noOpt)
         .withParallel(true)
+        .withSourceMap(options.sourceMap)
+        .withRelativizeSourceMapBase(options.relativizeSourceMap)
         .withClosureCompiler(options.fullOpt)
-        .withFrontendConfig(frontendConfig)
-        .withBackendConfig(backendConfig)
+        .withPrettyPrint(options.prettyPrint)
+        .withBatchMode(true)
 
-      val linker = Linker(semantics, options.outputMode, options.moduleKind,
-          config)
-
+      val linker = StandardLinker(config)
       val logger = new ScalaConsoleLogger(options.logLevel)
       val outFile = WritableFileVirtualJSFile(options.output)
       val cache = (new IRFileCache).newCache

--- a/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
@@ -120,8 +120,8 @@ trait Compat210Component {
    */
 
   object LowPrioGenBCodeCompat {
-    object genBCode { // scalastyle:ignore
-      object bTypes { // scalastyle:ignore
+    object genBCode {
+      object bTypes {
         def initializeCoreBTypes(): Unit = ()
       }
     }

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -16,7 +16,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
 
   // scalastyle:off line.size.limit
 
-  object jsDefinitions extends JSDefinitionsClass // scalastyle:ignore
+  object jsDefinitions extends JSDefinitionsClass
 
   import definitions._
   import rootMirror._

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -24,7 +24,7 @@ trait JSGlobalAddons extends JSDefinitions
   import definitions._
 
   /** JavaScript primitives, used in jscode */
-  object jsPrimitives extends JSPrimitives { // scalastyle:ignore
+  object jsPrimitives extends JSPrimitives {
     val global: JSGlobalAddons.this.global.type = JSGlobalAddons.this.global
     val jsAddons: ThisJSGlobalAddons =
       JSGlobalAddons.this.asInstanceOf[ThisJSGlobalAddons]
@@ -46,7 +46,7 @@ trait JSGlobalAddons extends JSDefinitions
   }
 
   /** global javascript interop related helpers */
-  object jsInterop { // scalastyle:ignore
+  object jsInterop {
     import scala.reflect.NameTransformer
     import scala.reflect.internal.Flags
 

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSTreeExtractors.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSTreeExtractors.scala
@@ -13,7 +13,7 @@ import org.scalajs.core.ir.Types._
 /** Useful extractors for JavaScript trees */
 object JSTreeExtractors {
 
-  object jse { // scalastyle:ignore
+  object jse {
 
     object BlockOrAlone {
       def unapply(tree: Tree): Some[(List[Tree], Tree)] = Some(tree match {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -62,7 +62,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
   override protected def newTransformer(unit: CompilationUnit): Transformer =
     new JSInteropTransformer(unit)
 
-  private object jsnme { // scalastyle:ignore
+  private object jsnme {
     val hasNext  = newTermName("hasNext")
     val next     = newTermName("next")
     val nextName = newTermName("nextName")
@@ -71,7 +71,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
     val Val      = newTermName("Val")
   }
 
-  private object jstpnme { // scalastyle:ignore
+  private object jstpnme {
     val scala_ = newTypeName("scala") // not defined in 2.10's tpnme
   }
 
@@ -98,7 +98,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
     private def anyEnclosingOwner: OwnerKind = allEnclosingOwners
 
     /** Nicer syntax for `allEnclosingOwners isnt kind`. */
-    private object noEnclosingOwner { // scalastyle:ignore
+    private object noEnclosingOwner {
       @inline def is(kind: OwnerKind): Boolean =
         allEnclosingOwners isnt kind
     }

--- a/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
@@ -37,11 +37,11 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
   def generatedJSAST(clDefs: List[Trees.Tree]): Unit = {}
 
   /** Addons for JavaScript platform */
-  object jsAddons extends { // scalastyle:ignore
+  object jsAddons extends {
     val global: ScalaJSPlugin.this.global.type = ScalaJSPlugin.this.global
   } with JSGlobalAddons with Compat210Component
 
-  object scalaJSOpts extends ScalaJSOptions { // scalastyle:ignore
+  object scalaJSOpts extends ScalaJSOptions {
     import ScalaJSOptions.URIMap
     var fixClassOf: Boolean = false
     lazy val sourceURIMaps: List[URIMap] = {

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSUndefinedParamTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSUndefinedParamTest.scala
@@ -33,7 +33,7 @@ class JSUndefinedParamTest extends DirectTest with TestHelpers {
 
     /** Dummy object to get the right shadowing for cross compilation */
     private object Compat210 {
-      object blackbox { // scalastyle:ignore
+      object blackbox {
         type Context = scala.reflect.macros.Context
       }
     }

--- a/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala
+++ b/js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala
@@ -1,6 +1,6 @@
 package org.scalajs.jsenv.test
 
-import org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv
+import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 
 import org.junit.Test
 import org.junit.Assert._

--- a/js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
@@ -1,0 +1,61 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js JS envs           **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.jsenv.jsdomnodejs
+
+class JSDOMNodeJSEnv(config: JSDOMNodeJSEnv.Config)
+    extends org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv(config.executable,
+        config.args, config.env, internal = ()) {
+
+  def this() = this(JSDOMNodeJSEnv.Config())
+}
+
+object JSDOMNodeJSEnv {
+  final class Config private (
+      val executable: String,
+      val args: List[String],
+      val env: Map[String, String]
+  ) {
+    private def this() = {
+      this(
+          executable = "node",
+          args = Nil,
+          env = Map.empty
+      )
+    }
+
+    def withExecutable(executable: String): Config =
+      copy(executable = executable)
+
+    def withArgs(args: List[String]): Config =
+      copy(args = args)
+
+    def withEnv(env: Map[String, String]): Config =
+      copy(env = env)
+
+    private def copy(
+        executable: String = executable,
+        args: List[String] = args,
+        env: Map[String, String] = env
+    ): Config = {
+      new Config(executable, args, env)
+    }
+  }
+
+  object Config {
+    /** Returns a default configuration for a [[JSDOMNodeJSEnv]].
+     *
+     *  The defaults are:
+     *
+     *  - `executable`: `"node"`
+     *  - `args`: `Nil`
+     *  - `env`: `Map.empty`
+     */
+    def apply(): Config = new Config()
+  }
+}

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
@@ -16,14 +16,24 @@ import org.scalajs.jsenv._
 
 import org.scalajs.core.ir.Utils.escapeJS
 
-class JSDOMNodeJSEnv(
-    @deprecatedName('nodejsPath)
-    executable: String = "node",
-    @deprecatedName('addArgs)
-    args: Seq[String] = Seq.empty,
-    @deprecatedName('addEnv)
-    env: Map[String, String] = Map.empty)
-    extends AbstractNodeJSEnv(executable, args, env, sourceMap = false) {
+class JSDOMNodeJSEnv private[jsenv] (
+    executable: String,
+    args: Seq[String],
+    env: Map[String, String],
+    internal: Unit
+) extends AbstractNodeJSEnv(executable, args, env, sourceMap = false) {
+
+  @deprecated("Use org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv.", "0.6.18")
+  def this(
+      @deprecatedName('nodejsPath)
+      executable: String = "node",
+      @deprecatedName('addArgs)
+      args: Seq[String] = Seq.empty,
+      @deprecatedName('addEnv)
+      env: Map[String, String] = Map.empty
+  ) = {
+    this(executable, args, env, internal = ())
+  }
 
   protected def vmName: String = "Node.js with JSDOM"
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -16,16 +16,13 @@ import org.scalajs.core.tools.logging._
 
 import java.io.{ Console => _, _ }
 
-class NodeJSEnv private (
-    @deprecatedName('nodejsPath)
-    override protected val executable: String, // override val for bin compat
-    @deprecatedName('addArgs)
-    args: Seq[String],
-    @deprecatedName('addEnv)
-    env: Map[String, String],
-    sourceMap: Boolean)
-    extends AbstractNodeJSEnv(executable, args, env, sourceMap) {
+class NodeJSEnv(config: NodeJSEnv.Config)
+    extends AbstractNodeJSEnv(config.executable, config.args, config.env,
+        config.sourceMap) {
 
+  def this() = this(NodeJSEnv.Config())
+
+  @deprecated("Use the overload with a NodeJSEnv.Config.", "0.6.18")
   def this(
       @deprecatedName('nodejsPath)
       executable: String = "node",
@@ -33,11 +30,13 @@ class NodeJSEnv private (
       args: Seq[String] = Seq.empty,
       @deprecatedName('addEnv)
       env: Map[String, String] = Map.empty) = {
-    this(executable, args, env, sourceMap = true)
+    this(NodeJSEnv.Config().withExecutable(executable).withArgs(args.toList).withEnv(env))
   }
 
+  @deprecated("Use the overloaded constructor with a NodeJSEnv.Config.",
+      "0.6.18")
   def withSourceMap(sourceMap: Boolean): NodeJSEnv =
-    new NodeJSEnv(executable, args, env, sourceMap)
+    new NodeJSEnv(config.withSourceMap(sourceMap))
 
   protected def vmName: String = "Node.js"
 
@@ -71,4 +70,56 @@ class NodeJSEnv private (
     }
   }
 
+}
+
+object NodeJSEnv {
+  final class Config private (
+      val executable: String,
+      val args: List[String],
+      val env: Map[String, String],
+      val sourceMap: Boolean
+  ) {
+    private def this() = {
+      this(
+          executable = "node",
+          args = Nil,
+          env = Map.empty,
+          sourceMap = true
+      )
+    }
+
+    def withExecutable(executable: String): Config =
+      copy(executable = executable)
+
+    def withArgs(args: List[String]): Config =
+      copy(args = args)
+
+    def withEnv(env: Map[String, String]): Config =
+      copy(env = env)
+
+    def withSourceMap(sourceMap: Boolean): Config =
+      copy(sourceMap = sourceMap)
+
+    private def copy(
+        executable: String = executable,
+        args: List[String] = args,
+        env: Map[String, String] = env,
+        sourceMap: Boolean = sourceMap
+    ): Config = {
+      new Config(executable, args, env, sourceMap)
+    }
+  }
+
+  object Config {
+    /** Returns a default configuration for a [[NodeJSEnv]].
+     *
+     *  The defaults are:
+     *
+     *  - `executable`: `"node"`
+     *  - `args`: `Nil`
+     *  - `env`: `Map.empty`
+     *  - `sourceMap`: `true`
+     */
+    def apply(): Config = new Config()
+  }
 }

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/utils/JUnitTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/utils/JUnitTest.scala
@@ -206,7 +206,7 @@ abstract class JUnitTest {
 
         remaining.take(maxLen).foreach(appendOut)
         msg.append(")")
-  
+
         throw new Exception(msg.result())
       }
     }

--- a/library/src/main/scala/scala/scalajs/js/Dynamic.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dynamic.scala
@@ -78,7 +78,7 @@ object Dynamic {
   /** Dynamic view of the global scope. */
   @js.native
   @JSGlobalScope
-  object global extends js.Any with scala.Dynamic { // scalastyle:ignore
+  object global extends js.Any with scala.Dynamic {
     /** Calls a top-level method (in the global scope). */
     @JSBracketCall
     def applyDynamic(name: String)(args: js.Any*): js.Dynamic = js.native
@@ -121,7 +121,7 @@ object Dynamic {
    *  {foo: 3, bar: "foobar"}
    *  }}}
    */
-  object literal extends scala.Dynamic { // scalastyle:ignore
+  object literal extends scala.Dynamic {
     /** Literal creation with named arguments.
      *
      *  Example:

--- a/library/src/main/scala/scala/scalajs/js/JSApp.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSApp.scala
@@ -1,6 +1,11 @@
 package scala.scalajs.js
 
-/** Base class for top-level, entry point main objects.
+/** Base class for top-level, entry point main objects (softly deprecated).
+ *
+ *  In Scala.js 1.x, `js.JSApp` will disappear. It is currently "softly"
+ *  deprecated: it is not recommended to use it in new code, but it does not
+ *  cause a deprecation warning (yet). Prefer using a standard main method (see
+ *  below).
  *
  *  [[JSApp]] is typically used to mark the entry point of a Scala.js
  *  application. As such, the sbt plugin also recognizes top-level objects
@@ -8,6 +13,14 @@ package scala.scalajs.js
  *
  *  To execute the [[main]] method immediately when your Scala.js file is
  *  loaded, use the `scalaJSUseMainModuleInitializer` setting in the sbt plugin.
+ *
+ *  Starting with Scala.js 0.6.18, the sbt plugin can also recognize "standard"
+ *  `main` methods of the form
+ *  {{{
+ *  def main(args: Array[String]): Unit = ...
+ *  }}}
+ *  in objects, even if they do not extend `JSApp`. Such main methods are
+ *  cross-platform, and should be preferred over extending `JSApp` in new code.
  */
 trait JSApp {
   def main(): Unit

--- a/library/src/main/scala/scala/scalajs/js/defined.scala
+++ b/library/src/main/scala/scala/scalajs/js/defined.scala
@@ -10,7 +10,7 @@ package scala.scalajs.js
 
 import scala.scalajs.js
 
-object defined { // scalastyle:ignore
+object defined {
   /** Explicitly upcasts an `A` to a `js.UndefOr[A]`.
    *
    *  This method is useful in some cases to drive Scala's type inference.

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -119,7 +119,7 @@ package object js {
    *  The body of all concrete members in a native JS class, trait or object
    *  must be `= js.native`.
    */
-  class native extends scala.annotation.StaticAnnotation // scalastyle:ignore
+  class native extends scala.annotation.StaticAnnotation
 
   /** Denotes a method body as native JavaScript. For use in facade types:
    *

--- a/library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1.scala
@@ -11,7 +11,7 @@ package scala.scalajs.niocharset
 
 import java.nio.charset._
 
-private[niocharset] object ISO_8859_1 extends ISO_8859_1_And_US_ASCII_Common( // scalastyle:ignore
+private[niocharset] object ISO_8859_1 extends ISO_8859_1_And_US_ASCII_Common(
     "ISO-8859-1", Array(
     "csISOLatin1", "IBM-819", "iso-ir-100", "8859_1", "ISO_8859-1", "l1",
     "ISO8859-1", "ISO_8859_1", "cp819", "ISO8859_1", "latin1",

--- a/library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1_And_US_ASCII_Common.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1_And_US_ASCII_Common.scala
@@ -20,7 +20,7 @@ import java.nio.charset._
  *
  *  `maxValue` is therefore either 0xff (ISO_8859_1) or 0x7f (US_ASCII).
  */
-private[niocharset] abstract class ISO_8859_1_And_US_ASCII_Common protected ( // scalastyle:ignore
+private[niocharset] abstract class ISO_8859_1_And_US_ASCII_Common protected (
     name: String, aliases: Array[String],
     private val maxValue: Int) extends Charset(name, aliases) {
 

--- a/library/src/main/scala/scala/scalajs/niocharset/US_ASCII.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/US_ASCII.scala
@@ -11,7 +11,7 @@ package scala.scalajs.niocharset
 
 import java.nio.charset._
 
-private[niocharset] object US_ASCII extends ISO_8859_1_And_US_ASCII_Common( // scalastyle:ignore
+private[niocharset] object US_ASCII extends ISO_8859_1_And_US_ASCII_Common(
     "US-ASCII", Array(
     "cp367", "ascii7", "ISO646-US", "646", "csASCII", "us", "iso_646.irv:1983",
     "ISO_646.irv:1991", "IBM367", "ASCII", "default", "ANSI_X3.4-1986",

--- a/library/src/main/scala/scala/scalajs/niocharset/UTF_16.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/UTF_16.scala
@@ -11,7 +11,7 @@ package scala.scalajs.niocharset
 
 import java.nio.charset._
 
-private[niocharset] object UTF_16 extends UTF_16_Common( // scalastyle:ignore
+private[niocharset] object UTF_16 extends UTF_16_Common(
     "UTF-16", Array(
     "utf16", "UTF_16", "UnicodeBig", "unicode"),
     endianness = UTF_16_Common.AutoEndian)

--- a/library/src/main/scala/scala/scalajs/niocharset/UTF_16BE.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/UTF_16BE.scala
@@ -11,7 +11,7 @@ package scala.scalajs.niocharset
 
 import java.nio.charset._
 
-private[niocharset] object UTF_16BE extends UTF_16_Common( // scalastyle:ignore
+private[niocharset] object UTF_16BE extends UTF_16_Common(
     "UTF-16BE", Array(
     "X-UTF-16BE", "UTF_16BE", "ISO-10646-UCS-2", "UnicodeBigUnmarked"),
     endianness = UTF_16_Common.BigEndian)

--- a/library/src/main/scala/scala/scalajs/niocharset/UTF_16LE.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/UTF_16LE.scala
@@ -11,7 +11,7 @@ package scala.scalajs.niocharset
 
 import java.nio.charset._
 
-private[niocharset] object UTF_16LE extends UTF_16_Common( // scalastyle:ignore
+private[niocharset] object UTF_16LE extends UTF_16_Common(
     "UTF-16LE", Array(
     "UnicodeLittleUnmarked", "UTF_16LE", "X-UTF-16LE"),
     endianness = UTF_16_Common.LittleEndian)

--- a/library/src/main/scala/scala/scalajs/niocharset/UTF_16_Common.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/UTF_16_Common.scala
@@ -16,7 +16,7 @@ import java.nio.charset._
 
 /** This is a very specific common implementation for UTF_16BE and UTF_16LE.
  */
-private[niocharset] abstract class UTF_16_Common protected ( // scalastyle:ignore
+private[niocharset] abstract class UTF_16_Common protected (
     name: String, aliases: Array[String],
     private val endianness: Int) extends Charset(name, aliases) {
 
@@ -198,7 +198,7 @@ private[niocharset] abstract class UTF_16_Common protected ( // scalastyle:ignor
   }
 }
 
-private[niocharset] object UTF_16_Common { // scalastyle:ignore
+private[niocharset] object UTF_16_Common {
   final val AutoEndian = 0
   final val BigEndian = 1
   final val LittleEndian = 2

--- a/library/src/main/scala/scala/scalajs/niocharset/UTF_8.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/UTF_8.scala
@@ -14,7 +14,7 @@ import scala.annotation.{switch, tailrec}
 import java.nio._
 import java.nio.charset._
 
-private[niocharset] object UTF_8 extends Charset("UTF-8", Array( // scalastyle:ignore
+private[niocharset] object UTF_8 extends Charset("UTF-8", Array(
     "UTF8", "unicode-1-1-utf-8")) {
 
   import java.lang.Character._

--- a/sbt-plugin-test/noDOM/src/main/scala/sbttest/noDOM/TestApp.scala
+++ b/sbt-plugin-test/noDOM/src/main/scala/sbttest/noDOM/TestApp.scala
@@ -1,10 +1,8 @@
 package sbttest.noDOM
 
-import scala.scalajs.js
+object TestApp {
 
-object TestApp extends js.JSApp {
-
-  def main(): Unit = {
+  def main(args: Array[String]): Unit = {
     println(Lib.foo("Hello World"))
     println(Lib.sq(10))
   }

--- a/sbt-plugin-test/withDOM/src/main/scala/sbttest/withDOM/TestApp.scala
+++ b/sbt-plugin-test/withDOM/src/main/scala/sbttest/withDOM/TestApp.scala
@@ -1,10 +1,8 @@
 package sbttest.withDOM
 
-import scala.scalajs.js
+object TestApp {
 
-object TestApp extends js.JSApp {
-
-  def main(): Unit = {
+  def main(args: Array[String]): Unit = {
     Lib.appendDocument("Hello World")
     Lib.appendDocument("Still Here!")
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
@@ -87,7 +87,7 @@ object OptimizerOptions {
    * which uses Scala 2.12. We should get rid of that workaround at that point
    * for tidiness, though.
    */
-  private val DefaultParallel: Boolean = {
+  private[sbtplugin] val DefaultParallel: Boolean = {
     try {
       scala.util.Properties.isJavaAtLeast("1.8")
       true

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -17,18 +17,19 @@ import sbtcrossproject._
 
 import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.linker.{ModuleInitializer, LinkingUnit}
-import org.scalajs.core.tools.linker.backend.{ModuleKind, OutputMode}
+import org.scalajs.core.tools.linker._
+import org.scalajs.core.tools.linker.standard._
 
 import org.scalajs.core.ir.ScalaJSVersions
 
 import org.scalajs.jsenv.{JSEnv, JSConsole}
-import org.scalajs.jsenv.nodejs.{NodeJSEnv, JSDOMNodeJSEnv}
+import org.scalajs.jsenv.nodejs.NodeJSEnv
+import org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv
 
 object ScalaJSPlugin extends AutoPlugin {
   override def requires: Plugins = plugins.JvmPlugin
 
-  object autoImport { // scalastyle:ignore
+  object autoImport {
     import KeyRanks._
 
     // Some constants
@@ -85,7 +86,11 @@ object ScalaJSPlugin extends AutoPlugin {
         args: Seq[String] = Seq.empty,
         env: Map[String, String] = Map.empty
     ): Def.Initialize[Task[NodeJSEnv]] = Def.task {
-      new NodeJSEnv(executable, args, env)
+      new NodeJSEnv(
+          org.scalajs.jsenv.nodejs.NodeJSEnv.Config()
+            .withExecutable(executable)
+            .withArgs(args.toList)
+            .withEnv(env))
     }
 
     /**
@@ -105,7 +110,7 @@ object ScalaJSPlugin extends AutoPlugin {
      *  [[sbt.ProjectExtra.inScope[* Project.inScope]].
      */
     @deprecated(
-        "Use `jsEnv := new org.scalajs.jsenv.nodejs.JSDOMNodeJSEnv(...)` " +
+        "Use `jsEnv := new org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv(...)` " +
         "instead.",
         "0.6.16")
     def JSDOMNodeJSEnv(
@@ -113,7 +118,11 @@ object ScalaJSPlugin extends AutoPlugin {
         args: Seq[String] = Seq.empty,
         env: Map[String, String] = Map.empty
     ): Def.Initialize[Task[JSDOMNodeJSEnv]] = Def.task {
-      new JSDOMNodeJSEnv(executable, args, env)
+      new JSDOMNodeJSEnv(
+          org.scalajs.jsenv.jsdomnodejs.JSDOMNodeJSEnv.Config()
+            .withExecutable(executable)
+            .withArgs(args.toList)
+            .withEnv(env))
     }
 
     // ModuleKind
@@ -146,6 +155,11 @@ object ScalaJSPlugin extends AutoPlugin {
         "The main module initializer, used if " +
         "`scalaJSUseMainModuleInitializer` is true",
         CTask)
+
+    val scalaJSLinkerConfig = SettingKey[StandardLinker.Config](
+        "scalaJSLinkerConfig",
+        "Configuration of the Scala.js linker",
+        BPlusSetting)
 
     val scalaJSStage = SettingKey[Stage]("scalaJSStage",
         "The optimization stage at which run and test are executed", APlusSetting)

--- a/scalastyle-config.xml
+++ b/scalastyle-config.xml
@@ -28,12 +28,12 @@
 
   <check level="error" enabled="true" class="org.scalastyle.scalariform.ClassNamesChecker">
     <parameters>
-      <parameter name="regex"><![CDATA[^[A-Z][A-Za-z0-9]*$]]></parameter>
+      <parameter name="regex"><![CDATA[^[A-Za-z][A-Za-z0-9_]*$]]></parameter>
     </parameters>
   </check>
   <check level="error" enabled="true" class="org.scalastyle.scalariform.ObjectNamesChecker">
     <parameters>
-      <parameter name="regex"><![CDATA[^[A-Z][A-Za-z0-9]*$]]></parameter>
+      <parameter name="regex"><![CDATA[^[A-Za-z][A-Za-z0-9_]*$]]></parameter>
     </parameters>
   </check>
   <check level="error" enabled="true" class="org.scalastyle.scalariform.PackageObjectNamesChecker">

--- a/stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala
+++ b/stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala
@@ -4,7 +4,7 @@ import language.experimental.macros
 
 /** Dummy object to get the right shadowing for 2.10 / 2.11 cross compilation */
 private object Compat210 {
-  object blackbox { // scalastyle:ignore
+  object blackbox {
     type Context = scala.reflect.macros.Context
   }
 }

--- a/test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
@@ -432,10 +432,10 @@ protected[testinterface] object HTMLRunner {
   }
 
   // Mini dom facade.
-  private object dom { // scalastyle:ignore
+  private object dom {
     @JSGlobal("document")
     @js.native
-    object document extends js.Object { // scalastyle:ignore
+    object document extends js.Object {
       def body: Element = js.native
       def createElement(tag: String): Element = js.native
       def createTextNode(tag: String): Node = js.native

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/Compat210.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/Compat210.scala
@@ -8,7 +8,7 @@
 package org.scalajs.testsuite
 
 private[testsuite] object Compat210 {
-  object blackbox { // scalastyle:ignore
+  object blackbox {
     type Context = scala.reflect.macros.Context
   }
 }

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/ConsoleTestRunner.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/ConsoleTestRunner.scala
@@ -54,7 +54,7 @@ object ConsoleTestRunner {
 
     def failedEvents: List[Event] = _failedEvents.toList
 
-    def handle(ev: Event) = {
+    def handle(ev: Event): Unit = {
       if (ev.status == Status.Error || ev.status == Status.Failure)
         _failedEvents += ev
     }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
@@ -15,7 +15,13 @@ class ModuleInitializersTest {
 
   @Test def correctInitializers(): Unit = {
     assertArrayEquals(
-        Array[AnyRef](NoConfigMain, TestConfigMain2, TestConfigMain1),
+        Array[AnyRef](
+            NoConfigMain,
+            TestConfigMain2,
+            TestConfigMain1,
+            TestConfigMainArgs1 + "()",
+            TestConfigMainArgs2 + "(foo, bar)"
+        ),
         moduleInitializersEffects.toArray[AnyRef])
   }
 
@@ -26,6 +32,8 @@ object ModuleInitializersTest {
   final val CompileConfigMain = "ModuleInitializerInCompileConfiguration.main"
   final val TestConfigMain1 = "ModuleInitializerInTestConfiguration.main1"
   final val TestConfigMain2 = "ModuleInitializerInTestConfiguration.main2"
+  final val TestConfigMainArgs1 = "ModuleInitializerInTestConfiguration.mainArgs1"
+  final val TestConfigMainArgs2 = "ModuleInitializerInTestConfiguration.mainArgs2"
 
   val moduleInitializersEffects =
     new scala.collection.mutable.ListBuffer[String]
@@ -57,5 +65,15 @@ object ModuleInitializerInTestConfiguration {
 
   def main2(): Unit = {
     moduleInitializersEffects += TestConfigMain2
+  }
+
+  def mainArgs1(args: Array[String]): Unit = {
+    moduleInitializersEffects +=
+      TestConfigMainArgs1 + args.mkString("(", ", ", ")")
+  }
+
+  def mainArgs2(args: Array[String]): Unit = {
+    moduleInitializersEffects +=
+      TestConfigMainArgs2 + args.mkString("(", ", ", ")")
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
@@ -14,6 +14,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class RegressionJSTest {
+  import RegressionJSTest._
 
   @Test def should_not_swallow_Unit_expressions_when_converting_to_js_Any_issue_83(): Unit = {
     var effectHappened = false
@@ -50,6 +51,49 @@ class RegressionJSTest {
 
     assertTrue(js.isUndefined(js.constructorOf[Foo].x))
     assertTrue(js.isUndefined(js.constructorOf[Foo].y))
+  }
+
+  @Test def super_mixin_call_in_2_12_issue_3013_ScalaOuter_JSInner(): Unit = {
+    import Bug3013_ScalaOuter_JSInner._
+
+    val b = new B
+    val c = new b.C
+    assertEquals("A1", c.t1())
+    assertEquals("A2", c.t2())
+    assertEquals("B", c.t3())
+  }
+
+}
+
+object RegressionJSTest {
+
+  /* The combination Scala/Scala is done in the cross-platform RegressionTest.
+   *
+   * The combinations where the outer class is a JS type cannot happen by
+   * construction, because they would require a non-native JS trait with a
+   * concrete method, which is prohibited.
+   */
+  object Bug3013_ScalaOuter_JSInner {
+    trait A1 {
+      private val s = "A1"
+      def f(): String = s
+    }
+
+    trait A2 {
+      private val s = "A2"
+      def f(): String = s
+    }
+
+    class B extends A1 with A2 {
+      override def f(): String = "B"
+
+      @ScalaJSDefined
+      class C extends js.Object {
+        def t1(): String = B.super[A1].f()
+        def t2(): String = B.super[A2].f()
+        def t3(): String = B.this.f()
+      }
+    }
   }
 
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -391,7 +391,7 @@ object JSSymbolTest {
 
   class SJSDefinedInnerObject extends js.Object with InnerObjectTrait {
     @JSName(sym1)
-    object innerObject { // scalastyle:ignore
+    object innerObject {
       override def toString(): String = "SJSDefinedInnerObject.innerObject"
     }
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
@@ -14,7 +14,7 @@ class `1_TestName` { // scalastyle:ignore
   @Test def `a test with name 1_TestName`(): Unit = ()
 }
 
-class eval { // scalastyle:ignore
+class eval {
   @Test def `a test with name eval`(): Unit = ()
 }
 

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/CollectionsTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/CollectionsTestOnJDK7.scala
@@ -26,7 +26,7 @@ class CollectionsTestOnJDK7 {
   }
 
   @Test def should_implement_emptyListIterator(): Unit = {
-    def test[E : ClassTag](toElem: Int => E): Unit = {
+    def test[E: ClassTag](toElem: Int => E): Unit = {
       def freshIter: ju.ListIterator[E] = ju.Collections.emptyListIterator[E]
 
       assertFalse(freshIter.hasNext)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
@@ -96,6 +96,6 @@ object MatchTest {
   }
 
   class ValueClass(val x: Int) extends AnyVal with ValueClassBase[Int] {
-    def f() = x * 2
+    def f(): Int = x * 2
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -385,6 +385,8 @@ class RegressionTest {
   }
 
   @Test def return_x_match_issue_2928(): Unit = {
+    // scalastyle:off return
+
     def testNonUnit(x: String): Boolean = {
       return x match {
         case "True" => true
@@ -409,6 +411,8 @@ class RegressionTest {
     r = None
     testUnit("not true")
     assertEquals(Some(false), r)
+
+    // scalastyle:on return
   }
 
   @Test def null_asInstanceOf_Unit_should_succeed_issue_1691(): Unit = {
@@ -584,6 +588,21 @@ class RegressionTest {
     assertFalse("String", c.isInstanceOf[String])
   }
 
+  @Test def super_mixin_call_in_2_12_issue_3013(): Unit = {
+    assumeTrue(
+        "Super mixin calls are broken in Scala/JVM 2.12.{0-2} and 2.13.0-M1",
+        !Platform.executingInJVM ||
+        !Set("2.12.0", "2.12.1", "2.12.2", "2.13.0-M1").contains(Platform.scalaVersion))
+
+    import Bug3013._
+
+    val b = new B
+    val c = new b.C
+    assertEquals("A1", c.t1)
+    assertEquals("A2", c.t2)
+    assertEquals("B", c.t3)
+  }
+
 }
 
 object RegressionTest {
@@ -610,6 +629,28 @@ object RegressionTest {
       }
 
       if (false) ()
+    }
+  }
+
+  object Bug3013 {
+    trait A1 {
+      private val s = "A1"
+      def f: String = s
+    }
+
+    trait A2 {
+      private val s = "A2"
+      def f: String = s
+    }
+
+    class B extends A1 with A2 {
+      override def f: String = "B"
+
+      class C {
+        def t1: String = B.super[A1].f
+        def t2: String = B.super[A2].f
+        def t3: String = B.this.f
+      }
     }
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -599,7 +599,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertFalse(mp.containsKey("THREE"))
   }
-  
+
 }
 
 object MapFactory {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
@@ -61,7 +61,7 @@ class AllocCharSlicedBufferTest extends CharBufferTest {
 }
 
 class CharBufferWrappingACharSequenceTest extends CharBufferTest {
-  
+
   val factory: CharBufferFactory = new CharBufferWrappingACharSequenceFactory
 
   class CharBufferWrappingACharSequenceFactory extends Factory {

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -9,15 +9,20 @@
 
 package org.scalajs.core.tools.linker
 
-import org.scalajs.core.tools.sem.Semantics
-
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.frontend.optimizer.IncOptimizer
 import org.scalajs.core.tools.linker.backend._
 
 trait LinkerPlatformExtensions { this: Linker.type =>
+  @deprecated("Use StandardLinker.apply() instead.", "0.6.18")
   def apply(semantics: Semantics, outputMode: OutputMode,
       moduleKind: ModuleKind, config: Config): Linker = {
+    applyInternal(semantics, outputMode, moduleKind, config)
+  }
+
+  private[linker] def applyInternal(semantics: Semantics,
+      outputMode: OutputMode, moduleKind: ModuleKind,
+      config: Config): Linker = {
 
     val optOptimizerFactory = {
       if (!config.optimizer) None
@@ -33,7 +38,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
     new Linker(frontend, backend)
   }
 
-  @deprecated("Use the overload with a Config object.", "0.6.13")
+  @deprecated("Use StandardLinker.apply() instead.", "0.6.13")
   def apply(
       semantics: Semantics = Semantics.Defaults,
       outputMode: OutputMode = OutputMode.Default,

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
@@ -1,0 +1,22 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+object StandardLinkerPlatformExtensions {
+  import StandardLinker.Config
+
+  final class ConfigExt(val config: Config) extends AnyVal {
+    /** Whether to actually use the Google Closure Compiler pass.
+     *
+     *  On the JavaScript platform, this always returns `false`, as GCC is not
+     *  available.
+     */
+    def closureCompiler: Boolean = false
+  }
+}

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -2,10 +2,8 @@ package org.scalajs.core.tools.test.js
 
 import java.io.InputStream
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.linker.{ModuleInitializer, Linker}
-import org.scalajs.core.tools.linker.backend.{OutputMode, ModuleKind}
+import org.scalajs.core.tools.linker._
 import org.scalajs.core.tools.logging._
 
 import scala.scalajs.js
@@ -18,30 +16,32 @@ object QuickLinker {
   /** Link a Scala.js application on Node.js */
   @JSExport
   def linkNode(irFilesAndJars: js.Array[String],
-      mainMethods: js.Array[String]): String = {
-    linkNodeInternal(Semantics.Defaults, irFilesAndJars, mainMethods)
+      moduleInitializers: js.Array[String]): String = {
+    linkNodeInternal(Semantics.Defaults, irFilesAndJars, moduleInitializers)
   }
 
   /** Link the Scala.js test suite on Node.js */
   @JSExport
   def linkTestSuiteNode(irFilesAndJars: js.Array[String],
-      mainMethods: js.Array[String]): String = {
+      moduleInitializers: js.Array[String]): String = {
     val semantics = Semantics.Defaults.withRuntimeClassName(_.fullName match {
       case "org.scalajs.testsuite.compiler.ReflectionTest$RenamedTestClass" =>
         "renamed.test.Class"
       case fullName =>
         fullName
     })
-    linkNodeInternal(semantics, irFilesAndJars, mainMethods)
+    linkNodeInternal(semantics, irFilesAndJars, moduleInitializers)
   }
 
   /** Link a Scala.js application on Node.js */
   def linkNodeInternal(semantics: Semantics,
-      irFilesAndJars: Seq[String], mainMethods: Seq[String]): String = {
+      irFilesAndJars: Seq[String], moduleInitializers: Seq[String]): String = {
     val cache = (new IRFileCache).newCache
 
-    val linker = Linker(semantics, OutputMode.ECMAScript51Isolated,
-        ModuleKind.NoModule, Linker.Config())
+    val config = StandardLinker.Config()
+      .withSemantics(semantics)
+      .withBatchMode(true)
+    val linker = StandardLinker(config)
 
     val irContainers = irFilesAndJars.map { file =>
       if (file.endsWith(".jar")) {
@@ -58,18 +58,41 @@ object QuickLinker {
 
     val ir = cache.cached(irContainers)
 
-    val moduleInitializers = mainMethods.map { mainMethod =>
-      val lastDot = mainMethod.lastIndexOf('.')
-      if (lastDot < 0)
-        throw new IllegalArgumentException(s"$mainMethod is not a valid main method")
-      ModuleInitializer.mainMethod(mainMethod.substring(0, lastDot),
-          mainMethod.substring(lastDot + 1))
-    }
+    val parsedModuleInitializers =
+      moduleInitializers.map(parseModuleInitializer)
 
     val out = WritableMemVirtualJSFile("out.js")
-    linker.link(ir, moduleInitializers, out, new ScalaConsoleLogger)
+    linker.link(ir, parsedModuleInitializers, out, new ScalaConsoleLogger)
 
     out.content
+  }
+
+  private def parseModuleInitializer(spec: String): ModuleInitializer = {
+    def fail(): Nothing = {
+      throw new IllegalArgumentException(
+          s"'$spec' is not a valid module initializer spec")
+    }
+
+    def parseObjectAndMain(str: String): (String, String) = {
+      val lastDot = str.lastIndexOf('.')
+      if (lastDot < 0)
+        fail()
+      (str.substring(0, lastDot), str.substring(lastDot + 1))
+    }
+
+    val parenPos = spec.indexOf('(')
+    if (parenPos < 0) {
+      val (objectName, mainMethodName) = parseObjectAndMain(spec)
+      ModuleInitializer.mainMethod(objectName, mainMethodName)
+    } else {
+      if (spec.last != ')')
+        fail()
+      val (objectName, mainMethodName) =
+        parseObjectAndMain(spec.substring(0, parenPos))
+      val args =
+        spec.substring(parenPos + 1, spec.length - 1).split(",", -1).toList
+      ModuleInitializer.mainMethodWithArgs(objectName, mainMethodName, args)
+    }
   }
 
   private class NodeVirtualJarFile(file: String)

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -9,16 +9,21 @@
 
 package org.scalajs.core.tools.linker
 
-import org.scalajs.core.tools.sem.Semantics
-
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend
 import org.scalajs.core.tools.linker.frontend.optimizer.{ParIncOptimizer, IncOptimizer}
 import org.scalajs.core.tools.linker.backend._
 import org.scalajs.core.tools.linker.backend.closure.ClosureLinkerBackend
 
 trait LinkerPlatformExtensions { this: Linker.type =>
+  @deprecated("Use StandardLinker.apply() instead.", "0.6.18")
   def apply(semantics: Semantics, outputMode: OutputMode,
       moduleKind: ModuleKind, config: Config): Linker = {
+    applyInternal(semantics, outputMode, moduleKind, config)
+  }
+
+  private[linker] def applyInternal(semantics: Semantics,
+      outputMode: OutputMode, moduleKind: ModuleKind,
+      config: Config): Linker = {
 
     val optOptimizerFactory = {
       if (!config.optimizer) None
@@ -44,7 +49,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
     new Linker(frontend, backend)
   }
 
-  @deprecated("Use the overload with a Config object.", "0.6.13")
+  @deprecated("Use StandardLinker.apply() instead.", "0.6.13")
   def apply(
       semantics: Semantics = Semantics.Defaults,
       outputMode: OutputMode = OutputMode.Default,

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
@@ -1,0 +1,21 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+object StandardLinkerPlatformExtensions {
+  import StandardLinker.Config
+
+  final class ConfigExt(val config: Config) extends AnyVal {
+    /** Whether to actually use the Google Closure Compiler pass. */
+    def closureCompiler: Boolean = config.closureCompilerIfAvailable
+
+    def withClosureCompiler(closureCompiler: Boolean): Config =
+      config.withClosureCompilerIfAvailable(closureCompiler)
+  }
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/io/IO.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/io/IO.scala
@@ -125,5 +125,5 @@ object IO {
   }
 
   @inline
-  private def newBuffer[T : ClassTag] = new Array[T](4096)
+  private def newBuffer[T: ClassTag] = new Array[T](4096)
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
@@ -34,7 +34,7 @@ object Printers {
 
   class JSTreePrinter(protected val out: Writer) extends IndentationManager {
 
-    def printTopLevelTree(tree: Tree) {
+    def printTopLevelTree(tree: Tree): Unit = {
       tree match {
         case Skip() =>
           // do not print anything

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/SourceMapWriter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/SourceMapWriter.scala
@@ -171,6 +171,8 @@ class SourceMapWriter(
 
   private def startSegment(startColumn: Int, originalPos: Position,
       originalName: String): Unit = {
+    // scalastyle:off return
+
     // There is no point in outputting a segment with the same information
     if ((originalPos == pendingPos) && (originalName == pendingName))
       return
@@ -183,9 +185,13 @@ class SourceMapWriter(
     pendingColumnInGenerated = startColumn
     pendingPos = originalPos
     pendingName = originalName
+
+    // scalastyle:on return
   }
 
-  private def writePendingSegment() {
+  private def writePendingSegment(): Unit = {
+    // scalastyle:off return
+
     if (pendingColumnInGenerated < 0)
       return
 
@@ -231,6 +237,8 @@ class SourceMapWriter(
       writeBase64VLQ(nameIndex-lastNameIndex)
       lastNameIndex = nameIndex
     }
+
+    // scalastyle:on return
   }
 
   def complete(): Unit = {
@@ -263,6 +271,8 @@ class SourceMapWriter(
    *  http://code.google.com/p/closure-compiler/source/browse/src/com/google/debugging/sourcemap/Base64VLQ.java
    */
   private def writeBase64VLQ(value0: Int): Unit = {
+    // scalastyle:off return
+
     /* The sign is encoded in the least significant bit, while the
      * absolute value is shifted one bit to the left.
      * So in theory the "definition" of `value` is:
@@ -303,6 +313,8 @@ class SourceMapWriter(
       }
       writeBase64VLQSlowPath(value)
     }
+
+    // scalastyle:on return
   }
 
   private def writeBase64VLQ0(): Unit =

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
@@ -51,7 +51,7 @@ object Trees {
   }
 
   case class ComputedName(tree: Tree) extends PropertyName {
-    def pos = tree.pos
+    def pos: Position = tree.pos
   }
 
   // Definitions

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONDeserializer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONDeserializer.scala
@@ -18,13 +18,17 @@ object JSONDeserializer {
     def deserialize(x: JSON): Boolean = Impl.toBoolean(x)
   }
 
-  implicit def listJSON[T : JSONDeserializer] = new JSONDeserializer[List[T]] {
-    def deserialize(x: JSON): List[T] = Impl.toList(x).map(fromJSON[T] _)
+  implicit def listJSON[T: JSONDeserializer]: JSONDeserializer[List[T]] = {
+    new JSONDeserializer[List[T]] {
+      def deserialize(x: JSON): List[T] = Impl.toList(x).map(fromJSON[T] _)
+    }
   }
 
-  implicit def mapJSON[V : JSONDeserializer] = new JSONDeserializer[Map[String, V]] {
-    def deserialize(x: JSON): Map[String, V] =
-      Impl.toMap(x).mapValues(fromJSON[V] _)
+  implicit def mapJSON[V: JSONDeserializer]: JSONDeserializer[Map[String, V]] = {
+    new JSONDeserializer[Map[String, V]] {
+      def deserialize(x: JSON): Map[String, V] =
+        Impl.toMap(x).mapValues(fromJSON[V] _)
+    }
   }
 
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjBuilder.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjBuilder.scala
@@ -6,12 +6,12 @@ class JSONObjBuilder {
 
   private val flds = mutable.Map.empty[String, JSON]
 
-  def fld[T : JSONSerializer](name: String, v: T): this.type = {
+  def fld[T: JSONSerializer](name: String, v: T): this.type = {
     flds.put(name, v.toJSON)
     this
   }
 
-  def opt[T : JSONSerializer](name: String, v: Option[T]): this.type = {
+  def opt[T: JSONSerializer](name: String, v: Option[T]): this.type = {
     v.foreach(v => flds.put(name, v.toJSON))
     this
   }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjExtractor.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjExtractor.scala
@@ -5,9 +5,9 @@ import scala.collection.mutable
 class JSONObjExtractor(rawData: JSON) {
   private val data = Impl.toMap(rawData)
 
-  def fld[T : JSONDeserializer](name: String): T =
+  def fld[T: JSONDeserializer](name: String): T =
     fromJSON[T](data(name))
 
-  def opt[T : JSONDeserializer](name: String): Option[T] =
+  def opt[T: JSONDeserializer](name: String): Option[T] =
     data.get(name).map(fromJSON[T] _)
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONSerializer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONSerializer.scala
@@ -18,11 +18,13 @@ object JSONSerializer {
     def serialize(x: Boolean): JSON = Impl.fromBoolean(x)
   }
 
-  implicit def listJSON[T : JSONSerializer] = new JSONSerializer[List[T]] {
-    def serialize(x: List[T]): JSON = Impl.fromList(x.map(_.toJSON))
+  implicit def listJSON[T: JSONSerializer]: JSONSerializer[List[T]] = {
+    new JSONSerializer[List[T]] {
+      def serialize(x: List[T]): JSON = Impl.fromList(x.map(_.toJSON))
+    }
   }
 
-  implicit def mapJSON[V : JSONSerializer] = {
+  implicit def mapJSON[V: JSONSerializer]:JSONSerializer[Map[String, V]] = {
     new JSONSerializer[Map[String, V]] {
       def serialize(x: Map[String, V]): JSON =
         Impl.fromMap(x.mapValues(_.toJSON))

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/json/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/json/package.scala
@@ -11,7 +11,7 @@ import java.io.{Reader, Writer}
 package object json {
   type JSON = Impl.Repr
 
-  implicit class JSONPimp[T : JSONSerializer](x: T) {
+  implicit class JSONPimp[T: JSONSerializer](x: T) {
     def toJSON: JSON = implicitly[JSONSerializer[T]].serialize(x)
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
@@ -12,7 +12,6 @@ package org.scalajs.core.tools.linker
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
@@ -12,7 +12,6 @@ package org.scalajs.core.tools.linker
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
@@ -107,7 +107,7 @@ final class LinkedClass(
       hasInstances: Boolean = this.hasInstances,
       hasInstanceTests: Boolean = this.hasInstanceTests,
       hasRuntimeTypeInfo: Boolean = this.hasRuntimeTypeInfo,
-      version: Option[String] = this.version) = {
+      version: Option[String] = this.version): LinkedClass = {
     new LinkedClass(
         name,
         kind,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
@@ -16,7 +16,6 @@ import java.util.concurrent.atomic.AtomicBoolean
 import org.scalajs.core.tools.logging.Logger
 import org.scalajs.core.tools.io._
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 import org.scalajs.core.tools.linker.analyzer.SymbolRequirement
 import org.scalajs.core.tools.linker.frontend.LinkerFrontend

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala
@@ -1,6 +1,5 @@
 package org.scalajs.core.tools.linker
 
-import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.javascript.ESLevel
 
 import org.scalajs.core.ir

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
@@ -1,0 +1,228 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+import scala.language.implicitConversions
+
+import java.net.URI
+
+import org.scalajs.core.tools.linker.frontend.LinkerFrontend
+import org.scalajs.core.tools.linker.backend.{LinkerBackend, OutputMode}
+
+object StandardLinker {
+  import StandardLinkerPlatformExtensions._
+
+  def apply(config: Config): Linker = {
+    val frontendConfig = LinkerFrontend.Config()
+      .withCheckIR(config.checkIR)
+
+    val backendConfig = LinkerBackend.Config()
+      .withRelativizeSourceMapBase(config.relativizeSourceMapBase)
+      .withCustomOutputWrapperInternal(config.customOutputWrapper)
+      .withPrettyPrint(config.prettyPrint)
+
+    val oldAPIConfig = Linker.Config()
+      .withSourceMap(config.sourceMap)
+      .withOptimizer(config.optimizer)
+      .withParallel(config.parallel)
+      .withClosureCompilerIfAvailable(config.closureCompilerIfAvailable)
+      .withFrontendConfig(frontendConfig)
+      .withBackendConfig(backendConfig)
+
+    Linker.applyInternal(config.semantics, config.outputMode, config.moduleKind,
+        oldAPIConfig)
+  }
+
+  implicit def configExt(config: Config): ConfigExt =
+    new ConfigExt(config)
+
+  /** Configuration of a standard linker. */
+  final class Config private (
+      /** Scala.js semantics. */
+      val semantics: Semantics,
+      /** Module kind. */
+      val moduleKind: ModuleKind,
+      /** If true, performs expensive checks of the IR for the used parts. */
+      val checkIR: Boolean,
+      /** Whether to use the Scala.js optimizer. */
+      val optimizer: Boolean,
+      /** Whether things that can be parallelized should be parallelized.
+       *  On the JavaScript platform, this does not have any effect.
+       */
+      val parallel: Boolean,
+      /** Whether to emit a source map. */
+      val sourceMap: Boolean,
+      /** Base path to relativize paths in the source map. */
+      val relativizeSourceMapBase: Option[URI],
+      /** Custom js code that wraps the output */
+      val customOutputWrapper: (String, String),
+      /** Whether to use the Google Closure Compiler pass, if it is available.
+       *  On the JavaScript platform, this does not have any effect.
+       */
+      val closureCompilerIfAvailable: Boolean,
+      /** Pretty-print the output. */
+      val prettyPrint: Boolean,
+      /** Whether the linker should run in batch mode.
+       *
+       *  In batch mode, the linker can throw away intermediate state that is
+       *  otherwise maintained for incremental runs.
+       *
+       *  This setting is only a hint. A linker and/or its subcomponents may
+       *  ignore it. This applies in both directions: a linker not supporting
+       *  incrementality can ignore `batchMode = false`, and a contrario, a
+       *  linker mainly designed for incremental runs may ignore
+       *  `batchMode = true`.
+       */
+      val batchMode: Boolean,
+      /** Standard output mode. */
+      private[linker] val outputMode: OutputMode
+  ) {
+    private def this() = {
+      this(
+          semantics = Semantics.Defaults,
+          moduleKind = ModuleKind.NoModule,
+          checkIR = false,
+          optimizer = true,
+          parallel = true,
+          sourceMap = true,
+          relativizeSourceMapBase = None,
+          customOutputWrapper = ("", ""),
+          closureCompilerIfAvailable = false,
+          prettyPrint = false,
+          batchMode = false,
+          outputMode = OutputMode.Default
+      )
+    }
+
+    def withSemantics(semantics: Semantics): Config =
+      copy(semantics = semantics)
+
+    def withSemantics(f: Semantics => Semantics): Config =
+      copy(semantics = f(semantics))
+
+    def withModuleKind(moduleKind: ModuleKind): Config =
+      copy(moduleKind = moduleKind)
+
+    def withCheckIR(checkIR: Boolean): Config =
+      copy(checkIR = checkIR)
+
+    def withOptimizer(optimizer: Boolean): Config =
+      copy(optimizer = optimizer)
+
+    def withParallel(parallel: Boolean): Config =
+      copy(parallel = parallel)
+
+    def withSourceMap(sourceMap: Boolean): Config =
+      copy(sourceMap = sourceMap)
+
+    def withRelativizeSourceMapBase(relativizeSourceMapBase: Option[URI]): Config =
+      copy(relativizeSourceMapBase = relativizeSourceMapBase)
+
+    @deprecated(
+        "The functionality of custom output wrappers has been superseded " +
+        "by the support for CommonJS modules, module initializers, and " +
+        "top-level exports.",
+        "0.6.15")
+    def withCustomOutputWrapper(customOutputWrapper: (String, String)): Config =
+      copy(customOutputWrapper = customOutputWrapper)
+
+    // Non-deprecated version to call from the sbt plugin
+    private[scalajs] def withCustomOutputWrapperInternal(
+        customOutputWrapper: (String, String)): Config = {
+      copy(customOutputWrapper = customOutputWrapper)
+    }
+
+    def withClosureCompilerIfAvailable(closureCompilerIfAvailable: Boolean): Config =
+      copy(closureCompilerIfAvailable = closureCompilerIfAvailable)
+
+    def withPrettyPrint(prettyPrint: Boolean): Config =
+      copy(prettyPrint = prettyPrint)
+
+    def withBatchMode(batchMode: Boolean): Config =
+      copy(batchMode = batchMode)
+
+    private[linker] def withOutputMode(outputMode: OutputMode): Config =
+      copy(outputMode = outputMode)
+
+    override def toString(): String = {
+      s"""StandardLinker.Config(
+         |  semantics                  = $semantics,
+         |  moduleKind                 = $moduleKind,
+         |  checkIR                    = $checkIR,
+         |  optimizer                  = $optimizer,
+         |  parallel                   = $parallel,
+         |  sourceMap                  = $sourceMap,
+         |  relativizeSourceMapBase    = $relativizeSourceMapBase,
+         |  customOutputWrapper        = $customOutputWrapper,
+         |  closureCompilerIfAvailable = $closureCompilerIfAvailable,
+         |  prettyPrint                = $prettyPrint,
+         |  batchMode                  = $batchMode,
+         |  outputMode                 = $outputMode,
+         |)""".stripMargin
+    }
+
+    private def copy(
+        semantics: Semantics = semantics,
+        moduleKind: ModuleKind = moduleKind,
+        checkIR: Boolean = checkIR,
+        optimizer: Boolean = optimizer,
+        parallel: Boolean = parallel,
+        sourceMap: Boolean = sourceMap,
+        relativizeSourceMapBase: Option[URI] = relativizeSourceMapBase,
+        customOutputWrapper: (String, String) = customOutputWrapper,
+        closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
+        prettyPrint: Boolean = prettyPrint,
+        batchMode: Boolean = batchMode,
+        outputMode: OutputMode = outputMode
+    ): Config = {
+      new Config(
+          semantics,
+          moduleKind,
+          checkIR,
+          optimizer,
+          parallel,
+          sourceMap,
+          relativizeSourceMapBase,
+          customOutputWrapper,
+          closureCompilerIfAvailable,
+          prettyPrint,
+          batchMode,
+          outputMode
+      )
+    }
+  }
+
+  object Config {
+    /** Returns the default configuration for a [[StandardLinker]].
+     *
+     *  The defaults are:
+     *
+     *  - `semantics`: [[org.scalajs.core.tools.sem.Semantics.Defaults Semantics.Defaults]]
+     *  - `moduleKind`: [[ModuleKind.NoModule]]
+     *  - `checkIR`: `false`
+     *  - `optimizer`: `true`
+     *  - `parallel`: `true`
+     *  - `sourceMap`: `true`
+     *  - `relativizeSourceMapBase`: `None`
+     *  - `customOutputWrapper`: `("", "")` (deprecated)
+     *  - `closureCompilerIfAvailable`: `false`
+     *  - `prettyPrint`: `false`
+     *  - `batchMode`: `false`
+     *
+     *  The following additional options are configurable through
+     *  {{{
+     *  import org.scalajs.core.tools.linker.standard._
+     *  }}}
+     *
+     *  - `outputMode`: [[org.scalajs.core.tools.linker.backend.OutputMode.Default OutputMode.Default]]
+     */
+    def apply(): Config = new Config()
+  }
+
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
@@ -248,7 +248,7 @@ private final class Analyzer(semantics: Semantics,
 
     val delayedCalls = mutable.Map.empty[String, From]
 
-    def isNeededAtAll =
+    def isNeededAtAll: Boolean =
       areInstanceTestsUsed ||
       isDataAccessed ||
       isAnySubclassInstantiated ||
@@ -257,7 +257,7 @@ private final class Analyzer(semantics: Semantics,
       isAnyStaticMethodReachable ||
       isAnyDefaultMethodReachable
 
-    def isAnyStaticMethodReachable =
+    def isAnyStaticMethodReachable: Boolean =
       staticMethodInfos.values.exists(_.isReachable)
 
     private def isAnyDefaultMethodReachable =
@@ -698,7 +698,7 @@ private final class Analyzer(semantics: Semantics,
 
     var syntheticKind: MethodSyntheticKind = MethodSyntheticKind.None
 
-    def isDefaultBridge =
+    def isDefaultBridge: Boolean =
       syntheticKind.isInstanceOf[MethodSyntheticKind.DefaultBridge]
 
     /** Throws MatchError if `!isDefaultBridge`. */

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
@@ -15,12 +15,11 @@ import Transformers._
 import org.scalajs.core.ir.Trees._
 import Types._
 
-import org.scalajs.core.tools.sem._
-import CheckedBehavior.Unchecked
-
 import org.scalajs.core.tools.javascript.{Trees => js}
 import org.scalajs.core.tools.linker._
 import org.scalajs.core.tools.linker.backend.OutputMode
+
+import CheckedBehavior.Unchecked
 
 /** Emitter for the skeleton of classes. */
 private[emitter] final class ClassEmitter(jsGen: JSGen) {
@@ -1185,6 +1184,11 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
     moduleInitializer match {
       case ModuleInitializer.VoidMainMethod(moduleClassName, mainMethodName) =>
         js.Apply(genLoadModule(moduleClassName) DOT mainMethodName, Nil)
+
+      case ModuleInitializer.MainMethodWithArgs(moduleClassName, mainMethodName,
+          args) =>
+        js.Apply(genLoadModule(moduleClassName) DOT mainMethodName,
+            genArrayValue(ArrayType("T", 1), args.map(js.StringLiteral(_))) :: Nil)
     }
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -18,7 +18,6 @@ import org.scalajs.core.ir.Trees.JSNativeLoadSpec
 import org.scalajs.core.ir.Definitions.decodeClassName
 
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.sem._
 import org.scalajs.core.tools.logging._
 
 import org.scalajs.core.tools.javascript.{Trees => js, _}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -1990,9 +1990,9 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             case Double_/ => js.BinaryOp(JSBinaryOp./, newLhs, newRhs)
             case Double_% => js.BinaryOp(JSBinaryOp.%, newLhs, newRhs)
 
-            case Num_<  => js.BinaryOp(JSBinaryOp.< , newLhs, newRhs)
+            case Num_<  => js.BinaryOp(JSBinaryOp.<, newLhs, newRhs)
             case Num_<= => js.BinaryOp(JSBinaryOp.<=, newLhs, newRhs)
-            case Num_>  => js.BinaryOp(JSBinaryOp.> , newLhs, newRhs)
+            case Num_>  => js.BinaryOp(JSBinaryOp.>, newLhs, newRhs)
             case Num_>= => js.BinaryOp(JSBinaryOp.>=, newLhs, newRhs)
 
             case Long_+ => genLongMethodApply(newLhs, LongImpl.+, newRhs)
@@ -2005,23 +2005,23 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             case Long_/ => genLongMethodApply(newLhs, LongImpl./, newRhs)
             case Long_% => genLongMethodApply(newLhs, LongImpl.%, newRhs)
 
-            case Long_|   => genLongMethodApply(newLhs, LongImpl.|,   newRhs)
-            case Long_&   => genLongMethodApply(newLhs, LongImpl.&,   newRhs)
+            case Long_|   => genLongMethodApply(newLhs, LongImpl.|, newRhs)
+            case Long_&   => genLongMethodApply(newLhs, LongImpl.&, newRhs)
             case Long_^   =>
               lhs match {
                 case LongLiteral(-1L) => genLongMethodApply(newRhs, LongImpl.UNARY_~)
                 case _                => genLongMethodApply(newLhs, LongImpl.^, newRhs)
               }
-            case Long_<<  => genLongMethodApply(newLhs, LongImpl.<<,  newRhs)
+            case Long_<<  => genLongMethodApply(newLhs, LongImpl.<<, newRhs)
             case Long_>>> => genLongMethodApply(newLhs, LongImpl.>>>, newRhs)
-            case Long_>>  => genLongMethodApply(newLhs, LongImpl.>>,  newRhs)
+            case Long_>>  => genLongMethodApply(newLhs, LongImpl.>>, newRhs)
 
             case Long_== => genLongMethodApply(newLhs, LongImpl.===, newRhs)
             case Long_!= => genLongMethodApply(newLhs, LongImpl.!==, newRhs)
-            case Long_<  => genLongMethodApply(newLhs, LongImpl.<,   newRhs)
-            case Long_<= => genLongMethodApply(newLhs, LongImpl.<=,  newRhs)
-            case Long_>  => genLongMethodApply(newLhs, LongImpl.>,   newRhs)
-            case Long_>= => genLongMethodApply(newLhs, LongImpl.>=,  newRhs)
+            case Long_<  => genLongMethodApply(newLhs, LongImpl.<, newRhs)
+            case Long_<= => genLongMethodApply(newLhs, LongImpl.<=, newRhs)
+            case Long_>  => genLongMethodApply(newLhs, LongImpl.>, newRhs)
+            case Long_>= => genLongMethodApply(newLhs, LongImpl.>=, newRhs)
 
             case Boolean_| => !(!js.BinaryOp(JSBinaryOp.|, newLhs, newRhs))
             case Boolean_& => !(!js.BinaryOp(JSBinaryOp.&, newLhs, newRhs))
@@ -2032,8 +2032,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
               genClassDataOf(tpe), js.ArrayConstr(lengths map transformExpr))
 
         case ArrayValue(tpe, elems) =>
-          genCallHelper("makeNativeArrayWrapper",
-              genClassDataOf(tpe), js.ArrayConstr(elems map transformExpr))
+          genArrayValue(tpe, elems.map(transformExpr))
 
         case ArrayLength(array) =>
           genIdentBracketSelect(js.DotSelect(transformExpr(array),
@@ -2321,17 +2320,6 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
     private def transformGlobalVarIdent(ident: Ident): js.Ident = {
       referenceGlobalName(ident.name)
       js.Ident(ident.name, ident.originalName)(ident.pos)
-    }
-
-    def genClassDataOf(cls: ReferenceType)(implicit pos: Position): js.Tree = {
-      cls match {
-        case ClassType(className) =>
-          envField("d", className)
-        case ArrayType(base, dims) =>
-          (1 to dims).foldLeft[js.Tree](envField("d", base)) { (prev, _) =>
-            js.Apply(js.DotSelect(prev, js.Ident("getArrayOf")), Nil)
-          }
-      }
     }
 
     /* In FunctionEmitter, we must always keep all global var names, not only

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -220,6 +220,23 @@ private[emitter] final class JSGen(val semantics: Semantics,
     }
   }
 
+  def genArrayValue(tpe: ArrayType, elems: List[Tree])(
+      implicit pos: Position): Tree = {
+    genCallHelper("makeNativeArrayWrapper", genClassDataOf(tpe),
+        ArrayConstr(elems))
+  }
+
+  def genClassDataOf(cls: ReferenceType)(implicit pos: Position): Tree = {
+    cls match {
+      case ClassType(className) =>
+        envField("d", className)
+      case ArrayType(base, dims) =>
+        (1 to dims).foldLeft[Tree](envField("d", base)) { (prev, _) =>
+          Apply(DotSelect(prev, Ident("getArrayOf")), Nil)
+        }
+    }
+  }
+
   def envModuleField(module: String)(implicit pos: Position): VarRef = {
     /* This is written so that the happy path, when `module` contains only
      * valid characters, is fast.
@@ -229,6 +246,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
       (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 
     def containsOnlyValidChars(): Boolean = {
+      // scalastyle:off return
       val len = module.length
       var i = 0
       while (i != len) {
@@ -237,6 +255,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
         i += 1
       }
       true
+      // scalastyle:on return
     }
 
     def buildValidName(): String = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -9,6 +9,9 @@
 
 package org.scalajs.core.tools.linker.checker
 
+// In the IR checker, we allow early returns for improved readability
+// scalastyle:off return
+
 import scala.language.implicitConversions
 
 import scala.annotation.switch

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -135,9 +135,7 @@ abstract class GenIncOptimizer private[optimizer] (semantics: Semantics,
 
       val newLinkedClasses = for (linkedClass <- unit.classDefs) yield {
         def defs(container: Option[MethodContainer]) =
-          container.fold[List[LinkedMember[MethodDef]]](Nil) {
-            _.optimizedDefs.toList
-          }
+          container.fold[List[LinkedMember[MethodDef]]](Nil)(_.optimizedDefs)
 
         val encodedName = linkedClass.encodedName
         val memberNamespace =
@@ -313,10 +311,14 @@ abstract class GenIncOptimizer private[optimizer] (semantics: Semantics,
 
     val methods = mutable.Map.empty[String, MethodImpl]
 
-    def optimizedDefs = for {
-      method <- methods.values
-      if !method.deleted
-    } yield method.optimizedMethodDef
+    def optimizedDefs: List[LinkedMember[MethodDef]] = {
+      (for {
+        method <- methods.values
+        if !method.deleted
+      } yield {
+        method.optimizedMethodDef
+      }).toList
+    }
 
     /** UPDATE PASS ONLY. Global concurrency safe but not on same instance */
     def updateWith(linkedClass: LinkedClass):

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -2796,7 +2796,7 @@ private[optimizer] abstract class OptimizerCore(
 
   /** Translate literals to their Scala.js String representation. */
   private def foldToStringForString_+(preTrans: PreTransform)(
-      implicit pos : Position): PreTransform = preTrans match {
+      implicit pos: Position): PreTransform = preTrans match {
     case PreTransLit(literal) =>
       literal match {
         case LongLiteral(value)    => PreTransLit(StringLiteral(value.toString))
@@ -4114,6 +4114,8 @@ private[optimizer] abstract class OptimizerCore(
 
   /** Trampolines a pretransform */
   private def trampoline(tailrec: => TailRec[Tree]): Tree = {
+    // scalastyle:off return
+
     curTrampolineId += 1
 
     val myTrampolineId = curTrampolineId
@@ -4150,6 +4152,8 @@ private[optimizer] abstract class OptimizerCore(
     } finally {
       curTrampolineId -= 1
     }
+
+    // scalastyle:on return
   }
 }
 
@@ -4455,7 +4459,7 @@ private[optimizer] object OptimizerCore {
   private final class PreTransBlock private (
       val bindingsAndStats: List[BindingOrStat],
       val result: PreTransResult) extends PreTransform {
-    def pos = result.pos
+    def pos: Position = result.pos
     val tpe = result.tpe
 
     assert(bindingsAndStats.nonEmpty)
@@ -4565,7 +4569,7 @@ private[optimizer] object OptimizerCore {
    */
   private final case class PreTransRecordTree(tree: Tree,
       tpe: RefinedType, cancelFun: CancelFun) extends PreTransGenTree {
-    def pos = tree.pos
+    def pos: Position = tree.pos
 
     assert(tree.tpe.isInstanceOf[RecordType],
         s"Cannot create a PreTransRecordTree with non-record type ${tree.tpe}")
@@ -4729,6 +4733,7 @@ private[optimizer] object OptimizerCore {
     final val Float32ArrayToFloatArray  = Int32ArrayToIntArray      + 1
     final val Float64ArrayToDoubleArray = Float32ArrayToFloatArray  + 1
 
+    // scalastyle:off line.size.limit
     val intrinsics: Map[String, Int] = Map(
       "jl_System$.arraycopy__O__I__O__I__I__V" -> ArrayCopy,
       "jl_System$.identityHashCode__O__I"      -> IdentityHashCode,
@@ -4767,6 +4772,7 @@ private[optimizer] object OptimizerCore {
       "sjs_js_typedarray_package$.float32Array2FloatArray__sjs_js_typedarray_Float32Array__AF"  -> Float32ArrayToFloatArray,
       "sjs_js_typedarray_package$.float64Array2DoubleArray__sjs_js_typedarray_Float64Array__AD" -> Float64ArrayToDoubleArray
     ).withDefaultValue(-1)
+    // scalastyle:on line.size.limit
   }
 
   private def getIntrinsicCode(target: AbstractMethodID): Int =

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
@@ -1,0 +1,26 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools
+
+package object linker {
+  type Semantics = org.scalajs.core.tools.sem.Semantics
+
+  val Semantics: org.scalajs.core.tools.sem.Semantics.type =
+    org.scalajs.core.tools.sem.Semantics
+
+  type CheckedBehavior = org.scalajs.core.tools.sem.CheckedBehavior
+
+  val CheckedBehavior: org.scalajs.core.tools.sem.CheckedBehavior.type =
+    org.scalajs.core.tools.sem.CheckedBehavior
+
+  type ModuleKind = org.scalajs.core.tools.linker.backend.ModuleKind
+
+  val ModuleKind: org.scalajs.core.tools.linker.backend.ModuleKind.type =
+    org.scalajs.core.tools.linker.backend.ModuleKind
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
@@ -1,0 +1,28 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker
+
+package object standard {
+  type OutputMode = org.scalajs.core.tools.linker.backend.OutputMode
+
+  val OutputMode: org.scalajs.core.tools.linker.backend.OutputMode.type =
+    org.scalajs.core.tools.linker.backend.OutputMode
+
+  implicit class StandardLinkerConfigStandardOps(
+      val __self: StandardLinker.Config) extends AnyVal {
+
+    import StandardLinker.Config
+
+    /** Standard output mode. */
+    def outputMode: OutputMode = __self.outputMode
+
+    def withOutputMode(outputMode: OutputMode): Config =
+      __self.withOutputMode(outputMode)
+  }
+}

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/logging/Level.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/logging/Level.scala
@@ -13,7 +13,7 @@ import scala.math.Ordered
 
 abstract sealed class Level extends Ordered[Level] { x =>
   protected val order: Int
-  def compare(y: Level) = x.order - y.order
+  def compare(y: Level): Int = x.order - y.order
 }
 
 object Level {

--- a/tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
+++ b/tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
@@ -5,8 +5,7 @@ import org.junit.Assert._
 
 import org.scalajs.core.tools.logging.NullLogger
 import org.scalajs.core.tools.io._
-import org.scalajs.core.tools.sem.Semantics
-import org.scalajs.core.tools.linker.backend.{OutputMode, ModuleKind}
+import org.scalajs.core.tools.linker._
 
 class LinkerTest {
 
@@ -22,8 +21,7 @@ class LinkerTest {
       def length: Int = throw new DummyException()
     }
 
-    val linker = Linker(Semantics.Defaults, OutputMode.ECMAScript51Isolated,
-        ModuleKind.NoModule, Linker.Config())
+    val linker = StandardLinker(StandardLinker.Config())
 
     def callLink(): Unit =
       linker.link(badSeq, Nil, WritableMemVirtualJSFile("some_file"), NullLogger)


### PR DESCRIPTION
Motivation: er, well, because of all that stuff that happened ^^
There were quite a lot of conflicts this time.

```
$ git checkout -b merge-0.6.x-into-master-june-15
Switched to a new branch 'merge-0.6.x-into-master-june-15'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   d5d1fbe (scalajs/0.6.x, 0.6.x) Merge pull request #3012 from gzm0/no-buffering
|\
| * 74c9af0 Fix #2945: Leave it to sbt to buffer logs
* |   d4ab7aa Merge pull request #3015 from sjrd/fix-partest-linker-config
|\ \
| * | 1ae82be (origin/fix-partest-linker-config) Fix #3000: Fix the linker config of partest for `--{no,full}Opt`.
| * | e24fc59 Set the linkers of the CLI, partest and QuickLinker in batch mode.
| * | 7e990da Remove a debugging warning in the sbt plugin.
* | |   cd5aad4 Merge pull request #3014 from sjrd/fix-super-mixin-call-2.12
|\ \ \
| |/ /
|/| |
| * | e02799b (origin/fix-super-mixin-call-2.12) Fix #3013: Use `genExpr()` for the qualifier of super calls.
|/ /
* |   50579f6 Merge pull request #3006 from sjrd/apply-scalastyle-in-shared
|\ \
| * | 9b3598e (origin/apply-scalastyle-in-shared) Enable Scalastyle in shared source directories.
| * | 2131c14 Allow lower-cases and `_` in object and class names in Scalastyle.
|/ /
* |   ae00346 Merge pull request #2999 from sjrd/new-linker-api-0.6.x
|\ \
| |/
|/|
| * 5879054 Expose `StandardLinker.Config` as an sbt setting.
| * a3ff8db Introduce the surface of the new linker API.
|/
*   0d5371c (origin/0.6.x) Merge pull request #3001 from sjrd/new-jsenv-api-0.6.x
|\
| * f4d600c (origin/new-jsenv-api-0.6.x) Introduce a new surface API for JS envs with `Config` objects.
| * c86ed6e [backport] Integrate the setup of Node.js for the bootstrap test in the build.
*   7ffa77e Merge pull request #3008 from sjrd/no-taskdyn
|\
| * e055b83 (origin/no-taskdyn) Replace `Def.taskDyn` by `Def.settingDyn` where possible.
| * 481dfb5 Give some discipline to fetching the `.value`s in `{fast,full}OptJS.
|/
* 85d7870 Merge pull request #2996 from sjrd/standard-main-support-2
* 4270884 (origin/standard-main-support-2) Recognize any "standard" JVM-style main object in the sbt plugin.
* 4868384 Use the new `mainWithArgs` module initiliazer in the partest runner.
* 16e93b4 Add support for module initializers with an `args: Array[String]`.
* 52c498f Update the manual CLI tests for the `-mm` argument.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
CONFLICT (content): Merge conflict in tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
CONFLICT (content): Merge conflict in tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/io/IO.scala
CONFLICT (modify/delete): tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala left in tree.
Auto-merging tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
CONFLICT (content): Merge conflict in tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
Auto-merging test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
CONFLICT (content): Merge conflict in test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
Auto-merging test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
Auto-merging stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala
Auto-merging sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
CONFLICT (content): Merge conflict in sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
Auto-merging sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
CONFLICT (content): Merge conflict in sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
Auto-merging sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
CONFLICT (content): Merge conflict in sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
Auto-merging sbt-plugin-test/withDOM/src/main/scala/sbttest/withDOM/TestApp.scala
Auto-merging sbt-plugin-test/build.sbt
CONFLICT (content): Merge conflict in sbt-plugin-test/build.sbt
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
CONFLICT (content): Merge conflict in partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
Auto-merging library/src/main/scala/scala/scalajs/js/package.scala
Auto-merging library/src/main/scala/scala/scalajs/js/JSApp.scala
CONFLICT (content): Merge conflict in library/src/main/scala/scala/scalajs/js/JSApp.scala
Auto-merging library/src/main/scala/scala/scalajs/js/Dynamic.scala
CONFLICT (content): Merge conflict in library/src/main/scala/scala/scalajs/js/Dynamic.scala
CONFLICT (modify/delete): js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala left in tree.
Auto-merging js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
CONFLICT (content): Merge conflict in js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
Auto-merging js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
Auto-merging cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
CONFLICT (content): Merge conflict in cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
Auto-merging ci/matrix.xml
CONFLICT (content): Merge conflict in ci/matrix.xml
Auto-merging TESTING
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
M  TESTING
UU ci/matrix.xml
UU cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
UU compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSTreeExtractors.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
M  compiler/src/test/scala/org/scalajs/core/compiler/test/JSUndefinedParamTest.scala
M  js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala
A  js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
M  js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
UU js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/utils/JUnitTest.scala
UU library/src/main/scala/scala/scalajs/js/Dynamic.scala
UU library/src/main/scala/scala/scalajs/js/JSApp.scala
M  library/src/main/scala/scala/scalajs/js/defined.scala
M  library/src/main/scala/scala/scalajs/js/package.scala
M  library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1.scala
M  library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1_And_US_ASCII_Common.scala
M  library/src/main/scala/scala/scalajs/niocharset/US_ASCII.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_16.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_16BE.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_16LE.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_16_Common.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_8.scala
UU partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
M  project/BinaryIncompatibilities.scala
UU project/Build.scala
UU sbt-plugin-test/build.sbt
M  sbt-plugin-test/noDOM/src/main/scala/sbttest/noDOM/TestApp.scala
M  sbt-plugin-test/withDOM/src/main/scala/sbttest/withDOM/TestApp.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
M  scalastyle-config.xml
M  stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala
M  test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSTask.scala
M  test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
M  test-suite/js/src/main/scala/org/scalajs/testsuite/Compat210.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/CollectionsTestOnJDK7.scala
UU test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
M  tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
A  tools/js/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
UU tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
DU tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
M  tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
A  tools/jvm/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/io/IO.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/javascript/SourceMapWriter.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONDeserializer.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjBuilder.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjExtractor.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONSerializer.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/package.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/ModuleInitializer.scala
A  tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
UU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
UU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
A  tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
A  tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/logging/Level.scala
M  tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
```
```
$ git checkout master project/BinaryIncompatibilities.scala
```
```
$ git rm tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala: needs merge
rm 'tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala'
```
[...] Transfer to test-suite/.../ConsoleTestRunner.scala the change from TestRunner.scala
```
$ git rm js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala: needs merge
rm 'js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala'
```
[...] Edit conflicting files, fix the compile error, and make it work again
```
$ git st
M  TESTING
UU ci/matrix.xml
UU cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
UU compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSTreeExtractors.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
M  compiler/src/test/scala/org/scalajs/core/compiler/test/JSUndefinedParamTest.scala
M  js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala
A  js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
M  js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
UU js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/utils/JUnitTest.scala
UU library/src/main/scala/scala/scalajs/js/Dynamic.scala
UU library/src/main/scala/scala/scalajs/js/JSApp.scala
M  library/src/main/scala/scala/scalajs/js/defined.scala
M  library/src/main/scala/scala/scalajs/js/package.scala
M  library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1.scala
M  library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1_And_US_ASCII_Common.scala
M  library/src/main/scala/scala/scalajs/niocharset/US_ASCII.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_16.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_16BE.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_16LE.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_16_Common.scala
M  library/src/main/scala/scala/scalajs/niocharset/UTF_8.scala
UU partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
UU project/Build.scala
UU sbt-plugin-test/build.sbt
M  sbt-plugin-test/noDOM/src/main/scala/sbttest/noDOM/TestApp.scala
M  sbt-plugin-test/withDOM/src/main/scala/sbttest/withDOM/TestApp.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
M  scalastyle-config.xml
M  stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala
M  test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSTask.scala
M  test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
M  test-suite/js/src/main/scala/org/scalajs/testsuite/Compat210.scala
 M test-suite/js/src/main/scala/org/scalajs/testsuite/utils/ConsoleTestRunner.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/CollectionsTestOnJDK7.scala
UU test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
M  tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
A  tools/js/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
UU tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
M  tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
A  tools/jvm/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/io/IO.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/javascript/SourceMapWriter.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONDeserializer.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjBuilder.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjExtractor.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONSerializer.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/json/package.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/ModuleInitializer.scala
AM tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
UU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
UU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
A  tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
A  tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/logging/Level.scala
M  tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
```
```
$ git diff -w | cat
```
[...] Omitted, see the gist at https://gist.github.com/sjrd/a60ae67e181d900e1ba52bd18ebdd3ac
```
$ git add .
```
```
$ git commit
[merge-0.6.x-into-master-june-15 60f50d2] Merge '0.6.x' into 'master'.
```