### PR TITLE
Remove the deprecated custom output wrapper.

### DIFF
--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -38,9 +38,6 @@ lazy val noDOM = project.settings(baseSettings: _*).
   enablePlugins(ScalaJSJUnitPlugin).
   settings(
     name := "Scala.js sbt test w/o DOM",
-    scalaJSOutputWrapper := (
-        "// Scala.js - noDOM sbt test\n//\n// Compiled with Scala.js\n",
-        "// End of Scala.js generated script"),
     scalaJSUseMainModuleInitializer := true
   ).
   /* This hopefully exposes concurrent uses of the linker. If it fails/gets
@@ -79,9 +76,6 @@ lazy val withDOM = project.settings(baseSettings: _*).
   settings(
     name := "Scala.js sbt test w/ DOM",
     jsEnv := new JSDOMNodeJSEnv(),
-    scalaJSOutputWrapper := (
-        "// Scala.js - withDOM sbt test\n//\n// Compiled with Scala.js\n",
-        "// End of Scala.js generated script"),
     scalaJSUseMainModuleInitializer := true
   )
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -178,20 +178,6 @@ object ScalaJSPlugin extends AutoPlugin {
     val emitSourceMaps = SettingKey[Boolean]("emitSourceMaps",
         "Whether package and optimize stages should emit source maps at all", BPlusSetting)
 
-    /** Non-deprecated alias of `scalaJSOutputWrapper` for internal use. */
-    private[sbtplugin] val scalaJSOutputWrapperInternal = SettingKey[(String, String)](
-        "scalaJSOutputWrapper",
-        "Custom wrapper for the generated .js files. Formatted as tuple (header, footer).",
-        BPlusSetting)
-
-    @deprecated(
-        "The functionality of `scalaJSOutputWrapper` has been superseded by " +
-        "a combination of more direct and more reliable features. Depending " +
-        "on your use case, use `scalaJSUseMainModuleInitializer`, " +
-        "`scalaJSModuleKind` and/or `@JSExportTopLevel` instead.",
-        "0.6.15")
-    val scalaJSOutputWrapper = scalaJSOutputWrapperInternal
-
     val scalaJSSemantics = SettingKey[Semantics]("scalaJSSemantics",
         "Configurable semantics of Scala.js.", BPlusSetting)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -175,7 +175,6 @@ object ScalaJSPluginInternal {
           .withSourceMap(withSourceMap)
           .withRelativizeSourceMapBase(relSourceMapBase)
           .withClosureCompiler(opts.useClosureCompiler)
-          .withCustomOutputWrapperInternal(scalaJSOutputWrapperInternal.value)
           .withPrettyPrint(opts.prettyPrintFullOptJS)
           .withBatchMode(opts.batchMode)
       },
@@ -726,9 +725,6 @@ object ScalaJSPluginInternal {
       relativeSourceMaps := false,
 
       emitSourceMaps := scalaJSLinkerConfig.value.sourceMap,
-
-      scalaJSOutputWrapperInternal :=
-        scalaJSLinkerConfig.value.customOutputWrapper,
 
       scalaJSOptimizerOptions := {
         val config = scalaJSLinkerConfig.value

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
@@ -142,12 +142,11 @@ final class ClosureLinkerBackend(
 
   private def writeResult(result: Result, compiler: ClosureCompiler,
       output: WritableVirtualJSFile): Unit = {
-    def withNewLine(str: String): String = if (str == "") "" else str + "\n"
+
     def ifIIFE(str: String): String = if (needsIIFEWrapper) str else ""
 
-    val (header0, footer0) = config.customOutputWrapper
-    val header = withNewLine(header0) + ifIIFE("(function(){") + "'use strict';\n"
-    val footer = ifIIFE("}).call(this);\n") + withNewLine(footer0)
+    val header = ifIIFE("(function(){") + "'use strict';\n"
+    val footer = ifIIFE("}).call(this);\n")
 
     val outputContent =
       if (result.errors.nonEmpty) "// errors while producing source\n"

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
@@ -24,7 +24,6 @@ object StandardLinker {
 
     val backendConfig = LinkerBackend.Config()
       .withRelativizeSourceMapBase(config.relativizeSourceMapBase)
-      .withCustomOutputWrapperInternal(config.customOutputWrapper)
       .withPrettyPrint(config.prettyPrint)
 
     val oldAPIConfig = Linker.Config()
@@ -60,8 +59,6 @@ object StandardLinker {
       val sourceMap: Boolean,
       /** Base path to relativize paths in the source map. */
       val relativizeSourceMapBase: Option[URI],
-      /** Custom js code that wraps the output */
-      val customOutputWrapper: (String, String),
       /** Whether to use the Google Closure Compiler pass, if it is available.
        *  On the JavaScript platform, this does not have any effect.
        */
@@ -92,7 +89,6 @@ object StandardLinker {
           parallel = true,
           sourceMap = true,
           relativizeSourceMapBase = None,
-          customOutputWrapper = ("", ""),
           closureCompilerIfAvailable = false,
           prettyPrint = false,
           batchMode = false,
@@ -124,20 +120,6 @@ object StandardLinker {
     def withRelativizeSourceMapBase(relativizeSourceMapBase: Option[URI]): Config =
       copy(relativizeSourceMapBase = relativizeSourceMapBase)
 
-    @deprecated(
-        "The functionality of custom output wrappers has been superseded " +
-        "by the support for CommonJS modules, module initializers, and " +
-        "top-level exports.",
-        "0.6.15")
-    def withCustomOutputWrapper(customOutputWrapper: (String, String)): Config =
-      copy(customOutputWrapper = customOutputWrapper)
-
-    // Non-deprecated version to call from the sbt plugin
-    private[scalajs] def withCustomOutputWrapperInternal(
-        customOutputWrapper: (String, String)): Config = {
-      copy(customOutputWrapper = customOutputWrapper)
-    }
-
     def withClosureCompilerIfAvailable(closureCompilerIfAvailable: Boolean): Config =
       copy(closureCompilerIfAvailable = closureCompilerIfAvailable)
 
@@ -159,7 +141,6 @@ object StandardLinker {
          |  parallel                   = $parallel,
          |  sourceMap                  = $sourceMap,
          |  relativizeSourceMapBase    = $relativizeSourceMapBase,
-         |  customOutputWrapper        = $customOutputWrapper,
          |  closureCompilerIfAvailable = $closureCompilerIfAvailable,
          |  prettyPrint                = $prettyPrint,
          |  batchMode                  = $batchMode,
@@ -175,7 +156,6 @@ object StandardLinker {
         parallel: Boolean = parallel,
         sourceMap: Boolean = sourceMap,
         relativizeSourceMapBase: Option[URI] = relativizeSourceMapBase,
-        customOutputWrapper: (String, String) = customOutputWrapper,
         closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
         prettyPrint: Boolean = prettyPrint,
         batchMode: Boolean = batchMode,
@@ -189,7 +169,6 @@ object StandardLinker {
           parallel,
           sourceMap,
           relativizeSourceMapBase,
-          customOutputWrapper,
           closureCompilerIfAvailable,
           prettyPrint,
           batchMode,
@@ -210,7 +189,6 @@ object StandardLinker {
      *  - `parallel`: `true`
      *  - `sourceMap`: `true`
      *  - `relativizeSourceMapBase`: `None`
-     *  - `customOutputWrapper`: `("", "")` (deprecated)
      *  - `closureCompilerIfAvailable`: `false`
      *  - `prettyPrint`: `false`
      *  - `batchMode`: `false`

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala
@@ -54,9 +54,7 @@ final class BasicLinkerBackend(
 
     try {
       logger.time("Emitter (write output)") {
-        emitter.emitCustomHeader(config.customOutputWrapper._1, builder)
         emitter.emitAll(unit, builder, logger)
-        emitter.emitCustomFooter(config.customOutputWrapper._2, builder)
       }
 
       builder.complete()

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala
@@ -69,36 +69,19 @@ object LinkerBackend {
   final class Config private (
       /** Base path to relativize paths in the source map. */
       val relativizeSourceMapBase: Option[URI] = None,
-      /** Custom js code that wraps the output */
-      val customOutputWrapper: (String, String) = ("", ""),
       /** Pretty-print the output. */
       val prettyPrint: Boolean = false
   ) {
     def withRelativizeSourceMapBase(relativizeSourceMapBase: Option[URI]): Config =
       copy(relativizeSourceMapBase = relativizeSourceMapBase)
 
-    @deprecated(
-        "The functionality of custom output wrappers has been superseded " +
-        "by the support for CommonJS modules, module initializers, and " +
-        "top-level exports.",
-        "0.6.15")
-    def withCustomOutputWrapper(customOutputWrapper: (String, String)): Config =
-      copy(customOutputWrapper = customOutputWrapper)
-
-    // Non-deprecated version to call from the sbt plugin
-    private[scalajs] def withCustomOutputWrapperInternal(
-        customOutputWrapper: (String, String)): Config = {
-      copy(customOutputWrapper = customOutputWrapper)
-    }
-
     def withPrettyPrint(prettyPrint: Boolean): Config =
       copy(prettyPrint = prettyPrint)
 
     private def copy(
         relativizeSourceMapBase: Option[URI] = relativizeSourceMapBase,
-        customOutputWrapper: (String, String) = customOutputWrapper,
         prettyPrint: Boolean = prettyPrint): Config = {
-      new Config(relativizeSourceMapBase, customOutputWrapper, prettyPrint)
+      new Config(relativizeSourceMapBase, prettyPrint)
     }
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -125,9 +125,6 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
     }
   }
 
-  def emitCustomHeader(customHeader: String, builder: JSFileBuilder): Unit =
-    emitLines(customHeader, builder)
-
   /** Emits everything but the core JS lib to the builder, and returns the
    *  core JS lib.
    *
@@ -249,9 +246,6 @@ final class Emitter private (semantics: Semantics, outputMode: OutputMode,
         }
     }
   }
-
-  def emitCustomFooter(customFooter: String, builder: JSFileBuilder): Unit =
-    emitLines(customFooter, builder)
 
   private def compareClasses(lhs: LinkedClass, rhs: LinkedClass) = {
     val lhsAC = lhs.ancestors.size


### PR DESCRIPTION
`git grep utputWrapper` does not show anything anymore after this change.