### PR TITLE
Fix #3025: Honor `@noinline` when trying to multi-inline.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -1466,7 +1466,7 @@ private[optimizer] abstract class OptimizerCore(
 
   private def canMultiInline(impls: List[MethodID]): Boolean = {
     // TODO? Inline multiple non-forwarders with the exact same body?
-    impls.forall(_.isForwarder) &&
+    impls.forall(impl => impl.isForwarder && impl.inlineable) &&
     (getMethodBody(impls.head).body.get match {
       // Trait impl forwarder
       case ApplyStatic(ClassType(staticCls), Ident(methodName, _), _) =>


### PR DESCRIPTION
The optimizer was disregarding the `inlineable` flag when deciding whether or not to perform multi-inlining. This was caught later by a `require` statement ensuring that only `inlineable` methods are indeed inlined.