### PR TITLE
Fix the artifact name of the Node.js environment.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -776,6 +776,7 @@ object Build {
       fatalWarningsSettings,
       name := "Scala.js Node.js env",
       normalizedName := "scalajs-nodejs-env",
+      moduleName := "scalajs-env-nodejs",
       libraryDependencies +=
         "com.novocode" % "junit-interface" % "0.9" % "test",
       previousArtifactSetting


### PR DESCRIPTION
It was `scalajs-nodejs-env`, but it should be `scalajs-env-nodejs` to be consistent with `scalajs-env-selenium` which is already public.