### PR TITLE
FF ONLY Merge 0.6.x into master june 27

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -108,7 +108,7 @@ object Build {
     "Whether we should partest the current scala version (and fail if we can't)")
 
   /* MiMa configuration -- irrelevant while in 1.0.0-SNAPSHOT.
-  val previousVersion = "0.6.17"
+  val previousVersion = "0.6.18"
   val previousSJSBinaryVersion =
     ScalaJSCrossVersion.binaryScalaJSVersion(previousVersion)
   val previousBinaryCrossVersion =

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/io/IRFileCache.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/io/IRFileCache.scala
@@ -60,7 +60,6 @@ final class IRFileCache {
 
   /** A cache to use for individual runs. Not threadsafe */
   final class Cache private[IRFileCache] {
-    private[this] var readyToUse: Boolean = false
     private[this] var localCache: Seq[PersistedFiles] = _
 
     /** Extract and cache IR.

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -1454,7 +1454,7 @@ private[optimizer] abstract class OptimizerCore(
 
   private def canMultiInline(impls: List[MethodID]): Boolean = {
     // TODO? Inline multiple non-forwarders with the exact same body?
-    impls.forall(_.isForwarder) &&
+    impls.forall(impl => impl.isForwarder && impl.inlineable) &&
     (getMethodBody(impls.head).body.get match {
       // Trait impl forwarder
       case ApplyStatic(ClassType(staticCls), Ident(methodName, _), _) =>


### PR DESCRIPTION
Motivation: one last merge before publishing 1.0.0-M1 :D
```
$ git checkout -b merge-0.6.x-into-master-june-27
Switched to a new branch 'merge-0.6.x-into-master-june-27'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* b54a26c (scalajs/0.6.x, origin/0.6.x, 0.6.x) Towards 0.6.19.
* 764c286 (tag: v0.6.18) Version 0.6.18.
*   3c7b5c6 Merge pull request #3027 from sjrd/fix-noinline-crasher
|\
| * 917afe3 Fix #3025: Honor `@noinline` when trying to multi-inline.
|/
* d30a723 Merge pull request #3020 from gzm0/remove-unused-var
* 75cc34b Fix #3017: Remove unused var
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
Auto-merging tools/shared/src/main/scala/org/scalajs/core/tools/io/IRFileCache.scala
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
UU project/Build.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/io/IRFileCache.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
```
[...] resolve conflicts (trivial, only affected places where the version number is written down)
```diff
$ git diff | cat
diff --cc ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
index f7c6b68,e7169e5..0000000
--- a/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
diff --cc project/Build.scala
index 580f1fe,aa160f5..0000000
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -108,7 +108,7 @@ object Build {
     "Whether we should partest the current scala version (and fail if we can't)")

   /* MiMa configuration -- irrelevant while in 1.0.0-SNAPSHOT.
-  val previousVersion = "0.6.17"
+  val previousVersion = "0.6.18"
   val previousSJSBinaryVersion =
     ScalaJSCrossVersion.binaryScalaJSVersion(previousVersion)
   val previousBinaryCrossVersion =
```
```
$ git add .
```
```
$ git st
M  tools/shared/src/main/scala/org/scalajs/core/tools/io/IRFileCache.scala
M  tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
```
```
$ git commit
[merge-0.6.x-into-master-june-27 1d366d2] Merge '0.6.x' into 'master'.
```
