### PR TITLE
Fix #3036: Workaround GCC's dce being too enthusiastic.

### DIFF
--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -13,6 +13,8 @@ const $e = exports;
 //!else
 // TODO Do not use global object detection, and rather export with actual `var` declarations
 const $e = (typeof global === "object" && global && global["Object"] === Object) ? global : this;
+// #3036 - convince GCC that $e must not be dce'ed away
+this["__ScalaJSWorkaroundToRetainExportsInGCC"] = $e;
 //!endif
 
 // Linking info - must be in sync with scala.scalajs.runtime.LinkingInfo


### PR DESCRIPTION
In `NoModule`, sometimes GCC thinks that `$e` is not used and can therefore be dce'ed away ... along with all our exports. We work around that bug by forcing a non-dce'able read of `$e`.

This workaround existed in the past. It was first introduced in 6680f72e8167af954d58797d26e943cf3326c4af. It was later removed in d28845a866bca1968658de1556577564cf9b74b3 to fix #2708, as it appeared not to be necessary anymore. However, we later broke what it was solving in d07af7c79b0ecca3498c0fe96c8fc223ad4abdb4. This commit reintroduces the previous workaround, but only in `NoModule` so that we do not recreate #2708.