### PR TITLE
Get rid of the workaround to find export annotations on `accessed`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -171,14 +171,8 @@ trait PrepJSExports { this: PrepJSInterop =>
     val trgSym = {
       def isOwnerScalaClass = !sym.owner.isModuleClass && !isJSAny(sym.owner)
 
-      /* For accessors, look on the val/var def, if there is one.
-       * TODO Get rid of this when we can break binary compatibility, as
-       * @JSExport and @JSExportNamed are now annotated with
-       * @field @getter @setter
-       */
-      if (sym.isAccessor && sym.accessed != NoSymbol) sym.accessed
       // For primary Scala class constructors, look on the class itself
-      else if (sym.isPrimaryConstructor && isOwnerScalaClass) sym.owner
+      if (sym.isPrimaryConstructor && isOwnerScalaClass) sym.owner
       else sym
     }
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExportStatic.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExportStatic.scala
@@ -23,6 +23,7 @@ import scala.annotation.meta._
  *
  *  @see [[https://www.scala-js.org/doc/interoperability/sjs-defined-js-classes.html Write JavaScript classes in Scala.js]]
  */
+@field @getter @setter
 class JSExportStatic extends scala.annotation.StaticAnnotation {
   def this(name: String) = this()
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -869,18 +869,6 @@ class ExportsTest {
     assertEquals(7, bar.y)
   }
 
-  @Test def exporting_constructor_parameter_fields_issue_970_old(): Unit = {
-    class Foo(@(JSExport @meta.field) val x: Int)
-    val foo = (new Foo(1)).asInstanceOf[js.Dynamic]
-    assertEquals(1, foo.x)
-  }
-
-  @Test def exporting_case_class_fields_issue_970_old(): Unit = {
-    case class Foo(@(JSExport @meta.field) x: Int)
-    val foo = (new Foo(1)).asInstanceOf[js.Dynamic]
-    assertEquals(1, foo.x)
-  }
-
   @Test def exporting_lazy_values_issue_977(): Unit = {
     class Foo {
       @JSExport


### PR DESCRIPTION
A long time ago, `@JSExport` used not to have `@field @getter @setter`, and that meant we needed a workaround to go look in `sym.accessed` for annotations if `sym` was an accessor. Now that we break binary compatibility, this is not necessary anymore.

Removing the workaround revealed that we had similarly forgot to add the meta-annotations to `@JSExportStatic`, which we also fix here.

The two test that are removed were specifically designed to simulate a scenario in which we were loading things compiled by an old version. They are not relevant anymore.