### PR TITLE
Use a fixed structure rather than functions for runtime class name.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,6 +6,9 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.core.tools.sem.Semantics.this")
   )
 
   val JSEnvs = Seq(

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -44,6 +44,12 @@ class ReflectionTest {
 
   @Test def java_lang_Class_getName_renamed_through_semantics(): Unit = {
     assertEquals("renamed.test.Class", classOf[RenamedTestClass].getName)
+    assertEquals("renamed.test.byprefix.RenamedTestClass1",
+        classOf[PrefixRenamedTestClass1].getName)
+    assertEquals("renamed.test.byprefix.RenamedTestClass2",
+        classOf[PrefixRenamedTestClass2].getName)
+    assertEquals("renamed.test.byotherprefix.RenamedTestClass",
+        classOf[OtherPrefixRenamedTestClass].getName)
   }
 
   @Test def should_support_isInstance(): Unit = {
@@ -160,6 +166,11 @@ object ReflectionTest {
   object TestObject
 
   class RenamedTestClass
+
+  class PrefixRenamedTestClass1
+  class PrefixRenamedTestClass2
+
+  class OtherPrefixRenamedTestClass
 
   @JSGlobal("ReflectionTestRawJSClass")
   @js.native

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -22,12 +22,25 @@ object QuickLinker {
   @JSExport
   def linkTestSuiteNode(irFilesAndJars: js.Array[String],
       moduleInitializers: js.Array[String]): String = {
-    val semantics = Semantics.Defaults.withRuntimeClassName(_.fullName match {
-      case "org.scalajs.testsuite.compiler.ReflectionTest$RenamedTestClass" =>
-        "renamed.test.Class"
-      case fullName =>
-        fullName
-    })
+    import Semantics.RuntimeClassNameMapper
+
+    val semantics = Semantics.Defaults.withRuntimeClassNameMapper(
+        RuntimeClassNameMapper.custom(_.fullName match {
+          case "org.scalajs.testsuite.compiler.ReflectionTest$RenamedTestClass" =>
+            "renamed.test.Class"
+          case fullName =>
+            fullName
+        }).andThen(
+            RuntimeClassNameMapper.regexReplace(
+                raw"""^org\.scalajs\.testsuite\.compiler\.ReflectionTest\$$Prefix""".r,
+                "renamed.test.byprefix.")
+        ).andThen(
+            RuntimeClassNameMapper.regexReplace(
+                raw"""^org\.scalajs\.testsuite\.compiler\.ReflectionTest\$$OtherPrefix""".r,
+                "renamed.test.byotherprefix.")
+        )
+    )
+
     linkNodeInternal(semantics, irFilesAndJars, moduleInitializers)
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
@@ -808,7 +808,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
     val allParams = List(
         js.ObjectConstr(List(classIdent -> js.IntLiteral(0))),
         js.BooleanLiteral(kind == ClassKind.Interface),
-        js.StringLiteral(semantics.runtimeClassName(tree)),
+        js.StringLiteral(semantics.runtimeClassNameMapper(tree)),
         ancestorsRecord,
         isRawJSTypeParam,
         parentData,


### PR DESCRIPTION
Arbitrary functions cannot be compared for equality, which means that currently, there is no way to correctly determine whether two instances of `Semantics` are equivalent. This is an issue for caches, which cannot invalidate their outputs if the input `Semantics` have changed.

Moreover, the existing `Semantics.runtimeClassName` field was a function from `LinkedClass` to `String`, but `LinkedClass`es are a concept of `linker.standard._` whereas `Semantics` is in `linker._`.

We replace the unconstrained `LinkedClass => String` function by an ADT `RuntimeClassNameMapper`. Ultimately, it will only have 3 possibilities, plus an `andThen` combinator:

* Keep all class names unchanged
* Discard all class names and replace everything by `""`
* Replace a prefix by another prefix (typically, both would end with `.` to match packages).

In 0.6.x, however, we have a "custom" combinator to keep supporting the deprecated arbitrary `LinkedClass => String`.