### PR TITLE
Fix #3058: Use the proper type for the "thisLocalVar" of tailrec.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -603,6 +603,42 @@ class RegressionTest {
     assertEquals("B", c.t3)
   }
 
+  @Test def tailrec_in_trait_with_self_type_scala_2_12_issue_3058(): Unit = {
+    trait Parent { this: Child =>
+      @tailrec final def bar(i: Int, acc: Int): Int = {
+        println(s"bar($i, $acc)")
+        if (i <= count)
+          bar(i + 1, acc + i)
+        else
+          acc
+      }
+    }
+
+    class Child extends Parent {
+      def count: Int = 5
+    }
+
+    assertEquals(15, new Child().bar(1, 0))
+  }
+
+  @Test def tailrec_in_class_with_self_type_scala_2_12_issue_3058(): Unit = {
+    class Parent { this: Child =>
+      @tailrec final def bar(i: Int, acc: Int): Int = {
+        println(s"bar($i, $acc)")
+        if (i <= count)
+          bar(i + 1, acc + i)
+        else
+          acc
+      }
+    }
+
+    class Child extends Parent {
+      def count: Int = 5
+    }
+
+    assertEquals(15, new Child().bar(1, 0))
+  }
+
 }
 
 object RegressionTest {


### PR DESCRIPTION
In Scala 2.12, if a tail-recursive method is in a class or trait with a self-type, the type of the `_$this` local variable is the self type. We previously assumed it was always the current class type, which produced invalid IR in that case.