### PR TITLE
Fix #3060: Do not check field existence for classes with no instances.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,7 +8,11 @@ object BinaryIncompatibilities {
   val Tools = Seq(
       // private, not an issue
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
-          "org.scalajs.core.tools.sem.Semantics.this")
+          "org.scalajs.core.tools.sem.Semantics.this"),
+
+      // private, not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.checker.IRChecker#CheckedClass.this")
   )
 
   val JSEnvs = Seq(

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -258,6 +258,51 @@ class RegressionTest {
     assertThrows(classOf[Exception], (giveMeANothing(): scala.runtime.IntRef).elem)
   }
 
+  @Test def IR_checker_must_not_check_field_existence_on_non_existent_classes(): Unit = {
+    // In this test, Outer is not "needed at all"
+
+    class Outer(x: Int) {
+      class Inner {
+        def get(): Int = x
+      }
+    }
+
+    def test(outer: Outer): Int = {
+      if (outer == null) {
+        3
+      } else {
+        val inner = new outer.Inner
+        inner.get()
+      }
+    }
+
+    assertEquals(3, test(null))
+  }
+
+  @Test def IR_checker_must_not_check_field_existence_on_classes_with_no_instance_issue_3060(): Unit = {
+    // In this test, Outer is "needed at all", but does not have any instance
+
+    class Outer(x: Int) {
+      class Inner {
+        def get(): Int = x
+      }
+    }
+
+    def test(outer: Outer): Int = {
+      if (outer == null) {
+        3
+      } else {
+        val inner = new outer.Inner
+        inner.get()
+      }
+    }
+
+    // make sure Outer is "needed at all"
+    assertFalse(classOf[Outer].isInterface)
+
+    assertEquals(3, test(null))
+  }
+
   @Test def should_properly_order_ctor_statements_when_inlining_issue_1369(): Unit = {
     trait Bar {
       def x: Int


### PR DESCRIPTION
If a class has no instances, the `BaseLinker` will trim it down and remove all its fields. However, it is still possible that there is some reachable code that reads or writes those fields (although such code would inevitably crash with an NPE if actually executed). The IR checker must not complain in such cases.