### PR TITLE
Fix 2.13 community build: add Numeric#parseString in RangesTest

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
@@ -129,6 +129,7 @@ class RangesTest {
       def toFloat(x: A): Float = x.v.toFloat
       def toInt(x: A): Int = x.v
       def toLong(x: A): Long = x.v.toLong
+      def parseString(str: String): Option[A] = Some(A(str.toInt))
     }
 
     val r = NumericRange(A(1), A(10), A(1))


### PR DESCRIPTION
Numeric#parseString got newly added in 2.13 (see scala/community-builds#572).

reference: https://github.com/scala/community-builds/issues/572