### PR TITLE
FF ONLY Merge 0.6.x into master, July 21

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
@@ -129,6 +129,7 @@ class RangesTest {
       def toFloat(x: A): Float = x.v.toFloat
       def toInt(x: A): Int = x.v
       def toLong(x: A): Long = x.v.toLong
+      def parseString(str: String): Option[A] = Some(A(str.toInt))
     }
 
     val r = NumericRange(A(1), A(10), A(1))


### PR DESCRIPTION
Motivation: to bring the community build fix from #3067 to master, so that it actually fixes the community build.
```
doeraene@lamppc18:~/projects/scalajs$ git checkout -b merge-0.6.x-into-master-july-21
Switched to a new branch 'merge-0.6.x-into-master-july-21'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* d33457b (scalajs/0.6.x, origin/0.6.x, 0.6.x) Merge pull request #3067 from SethTisue/numeric-has-parsestring-now
* 481660f Fix 2.13 community build: add Numeric#parseString in RangesTest
```
```
$ git merge --no-commit scalajs/0.6.x
Automatic merge went well; stopped before committing as requested
```
```
$ git commit
[merge-0.6.x-into-master-july-21 e4ab4b2] Merge '0.6.x' into 'master'.
```
Given the trivial merge, no review needed.