### PR TITLE
Reduce the maximum memory consumption in the bootstrap test.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -205,7 +205,10 @@
     setJavaVersion $java
     sbt ++$scala irJS/test toolsJS/test &&
     sbt 'set scalaJSStage in Global := FullOptStage' \
-        ++$scala irJS/test toolsJS/test
+        ++$scala irJS/test &&
+    sbt ++$scala testSuite/test:fullOptJS &&
+    sbt 'set scalaJSStage in Global := FullOptStage' \
+        ++$scala toolsJS/test
   ]]></task>
 
   <task id="tools-cli-stubs"><![CDATA[


### PR DESCRIPTION
We do this by restarting sbt more often, so that irJS, testSuite and toolsJS are full-optimized in 3 separate VMs.