### PR TITLE
Fix #3065: Cross-compile the sbt plugin for sbt 1.0.0-RC2.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -260,14 +260,18 @@
   ]]></task>
 
   <task id="sbtplugin-test"><![CDATA[
+    setJavaVersion $java
+    SBT_VER_OVERRIDE=$sbt_version_override
     # Publish Scala.js artifacts locally
     # Then go into standalone project and test
     sbt ++2.11.11 compiler/publishLocal library/publishLocal javalibEx/publishLocal \
                   testInterface/publishLocal stubs/publishLocal \
                   jUnitPlugin/publishLocal jUnitRuntime/publishLocal &&
-    sbt ++2.10.6 ir/publishLocal tools/publishLocal jsEnvs/publishLocal \
-                 testAdapter/publishLocal sbtPlugin/publishLocal &&
+    sbt ++$toolsscala ${SBT_VER_OVERRIDE:+^^$SBT_VER_OVERRIDE} \
+        ir/publishLocal tools/publishLocal jsEnvs/publishLocal \
+        testAdapter/publishLocal sbtPlugin/publishLocal &&
     cd sbt-plugin-test &&
+    if [ -n "$SBT_VER_OVERRIDE" ]; then echo "sbt.version=$SBT_VER_OVERRIDE" > ./project/build.properties; fi &&
     sbt noDOM/run noDOM/testHtmlFastOpt noDOM/testHtmlFullOpt \
         withDOM/run withDOM/testHtmlFastOpt withDOM/testHtmlFullOpt \
         multiTestJS/test:run multiTestJS/testHtmlFastOpt multiTestJS/testHtmlFullOpt \
@@ -473,7 +477,17 @@
       <v n="java">1.8</v>
     </run>
 
-    <run task="sbtplugin-test" />
+    <!-- The PhantomJS tests require Java 7 for jetty. -->
+    <run task="sbtplugin-test">
+      <v n="java">1.7</v>
+      <v n="toolsscala">2.10.6</v>
+      <v n="sbt_version_override"></v>
+    </run>
+    <run task="sbtplugin-test">
+      <v n="java">1.8</v>
+      <v n="toolsscala">2.12.2</v>
+      <v n="sbt_version_override">1.0.0-RC2</v>
+    </run>
   </matrix>
 
   <matrix id="nightly">

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -22,6 +22,9 @@ object BinaryIncompatibilities {
   )
 
   val SbtPlugin = Seq(
+      // Breaking! Removal of `CrossProject.settingSets`, deprecated since 0.6.16
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.sbtplugin.cross.CrossProject.settingSets")
   )
 
   val TestAdapter = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -806,6 +806,11 @@ object Build {
           previousArtifactSetting,
           mimaBinaryIssueFilters ++= BinaryIncompatibilities.SbtPlugin,
 
+          /* TODO Remove this in 1.x, since there are no macros in sbt-plugin
+           * anymore.
+           */
+          scalacOptions -= "-Xfatal-warnings",
+
           // Add API mappings for sbt (seems they don't export their API URL)
           apiMappings ++= {
             val deps = (externalDependencyClasspath in Compile).value
@@ -821,7 +826,7 @@ object Build {
             sbtJars.map(_.data -> docUrl).toMap
           }
       )
-  ).dependsOn(tools, jsEnvs, testAdapter)
+  ).dependsOn(tools, jsEnvs, testAdapter).enableScalastyleInSharedSources
 
   lazy val delambdafySetting = {
     scalacOptions ++= (

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -34,7 +34,8 @@ unmanagedSourceDirectories in Compile ++= {
     root / "tools/jvm/src/main/scala",
     root / "js-envs/src/main/scala",
     root / "test-adapter/src/main/scala",
-    root / "sbt-plugin/src/main/scala"
+    root / "sbt-plugin/src/main/scala",
+    root / "sbt-plugin/src/main/scala-sbt-0.13"
   )
 }
 

--- a/sbt-plugin-test/project/Jetty9Test.scala
+++ b/sbt-plugin-test/project/Jetty9Test.scala
@@ -3,7 +3,7 @@ import Keys._
 
 import org.scalajs.sbtplugin._
 import ScalaJSPlugin.autoImport._
-import Implicits._
+import Loggers._
 
 import org.scalajs.jsenv._
 import org.scalajs.core.tools.io._
@@ -20,7 +20,7 @@ object Jetty9Test {
 
   private val jettyPort = 23548
 
-  val runSetting = run <<= Def.inputTask {
+  val runSetting = run := Def.inputTask {
     val jsEnv = (loadedJSEnv in Compile).value.asInstanceOf[ComJSEnv]
     val jsConsole = scalaJSConsole.value
 
@@ -44,7 +44,7 @@ object Jetty9Test {
 
     val runner = jsEnv.comRunner(code)
 
-    runner.start(streams.value.log, jsConsole)
+    runner.start(sbtLogger2ToolsLogger(streams.value.log), jsConsole)
 
     val jetty = setupJetty((resourceDirectory in Compile).value)
 
@@ -66,7 +66,7 @@ object Jetty9Test {
     jetty.start()
     runner.await(30.seconds)
     jetty.join()
-  }
+  }.evaluated
 
   private def setupJetty(dir: File): Server = {
     val server = new Server(jettyPort)

--- a/sbt-plugin-test/project/build.properties
+++ b/sbt-plugin-test/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.16

--- a/sbt-plugin/src/main/scala-sbt-0.13/org/scalajs/sbtplugin/SBTCompat.scala
+++ b/sbt-plugin/src/main/scala-sbt-0.13/org/scalajs/sbtplugin/SBTCompat.scala
@@ -1,0 +1,61 @@
+package org.scalajs.sbtplugin
+
+import sbt._
+
+import org.scalajs.core.tools.io.FileVirtualFile
+
+private[sbtplugin] object SBTCompat {
+  type IncOptions = sbt.inc.IncOptions
+
+  type CompileAnalysis = sbt.inc.Analysis
+
+  val formatImplicits: sbt.Cache.type = sbt.Cache
+
+  def moduleIDWithConfigurations(moduleID: ModuleID,
+      configurations: Option[String]): ModuleID = {
+    moduleID.copy(configurations = configurations)
+  }
+
+  def crossVersionAddScalaJSPart(cross: CrossVersion,
+      part: String): CrossVersion = {
+    cross match {
+      case CrossVersion.Disabled =>
+        CrossVersion.binaryMapped(_ => part)
+      case cross: CrossVersion.Binary =>
+        CrossVersion.binaryMapped(
+            cross.remapVersion.andThen(part + "_" + _))
+      case cross: CrossVersion.Full =>
+        CrossVersion.fullMapped(
+            cross.remapVersion.andThen(part + "_" + _))
+    }
+  }
+
+  /** Patches the IncOptions so that .sjsir files are pruned as needed.
+   *
+   *  This complicated logic patches the ClassfileManager factory of the given
+   *  IncOptions with one that is aware of .sjsir files emitted by the Scala.js
+   *  compiler. This makes sure that, when a .class file must be deleted, the
+   *  corresponding .sjsir file are also deleted.
+   */
+  def scalaJSPatchIncOptions(incOptions: IncOptions): IncOptions = {
+    val inheritedNewClassfileManager = incOptions.newClassfileManager
+    val newClassfileManager = () => new sbt.inc.ClassfileManager {
+      private[this] val inherited = inheritedNewClassfileManager()
+
+      def delete(classes: Iterable[File]): Unit = {
+        inherited.delete(classes flatMap { classFile =>
+          val scalaJSFiles = if (classFile.getPath endsWith ".class") {
+            val f = FileVirtualFile.withExtension(classFile, ".class", ".sjsir")
+            if (f.exists) List(f)
+            else Nil
+          } else Nil
+          classFile :: scalaJSFiles
+        })
+      }
+
+      def generated(classes: Iterable[File]): Unit = inherited.generated(classes)
+      def complete(success: Boolean): Unit = inherited.complete(success)
+    }
+    incOptions.withNewClassfileManager(newClassfileManager)
+  }
+}

--- a/sbt-plugin/src/main/scala-sbt-1.0/org/scalajs/sbtplugin/SBTCompat.scala
+++ b/sbt-plugin/src/main/scala-sbt-1.0/org/scalajs/sbtplugin/SBTCompat.scala
@@ -1,0 +1,68 @@
+package org.scalajs.sbtplugin
+
+import sbt._
+
+import org.scalajs.core.tools.io.FileVirtualFile
+
+private[sbtplugin] object SBTCompat {
+  type IncOptions = xsbti.compile.IncOptions
+
+  type CompileAnalysis = xsbti.compile.CompileAnalysis
+
+  val formatImplicits: sjsonnew.BasicJsonProtocol.type =
+    sjsonnew.BasicJsonProtocol
+
+  def moduleIDWithConfigurations(moduleID: ModuleID,
+      configurations: Option[String]): ModuleID = {
+    moduleID.withConfigurations(configurations)
+  }
+
+  def crossVersionAddScalaJSPart(cross: CrossVersion,
+      part: String): CrossVersion = {
+    cross match {
+      case CrossVersion.Disabled =>
+        CrossVersion.constant(part)
+      case cross: sbt.librarymanagement.Constant =>
+        cross.withValue(part + "_" + cross.value)
+      case cross: CrossVersion.Binary =>
+        cross.withPrefix(part + "_" + cross.prefix)
+      case cross: CrossVersion.Full =>
+        cross.withPrefix(part + "_" + cross.prefix)
+    }
+  }
+
+  /** Patches the IncOptions so that .sjsir files are pruned as needed.
+   *
+   *  This complicated logic patches the ClassfileManager factory of the given
+   *  IncOptions with one that is aware of .sjsir files emitted by the Scala.js
+   *  compiler. This makes sure that, when a .class file must be deleted, the
+   *  corresponding .sjsir file are also deleted.
+   */
+  def scalaJSPatchIncOptions(incOptions: IncOptions): IncOptions = {
+    import xsbti.compile.{ClassFileManager, ClassFileManagerUtil}
+
+    val sjsirFileManager = new ClassFileManager {
+      private[this] val inherited =
+        ClassFileManagerUtil.getDefaultClassFileManager(incOptions)
+
+      def delete(classes: Array[File]): Unit = {
+        inherited.delete(classes.flatMap { classFile =>
+          if (classFile.getPath.endsWith(".class")) {
+            val f = FileVirtualFile.withExtension(classFile, ".class", ".sjsir")
+            if (f.exists) List(f)
+            else Nil
+          } else {
+            Nil
+          }
+        })
+      }
+
+      def generated(classes: Array[File]): Unit = {}
+      def complete(success: Boolean): Unit = {}
+    }
+
+    val newExternalHooks =
+      incOptions.externalHooks.withExternalClassFileManager(sjsirFileManager)
+    incOptions.withExternalHooks(newExternalHooks)
+  }
+}

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/AbstractJSDeps.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/AbstractJSDeps.scala
@@ -2,8 +2,6 @@ package org.scalajs.sbtplugin
 
 import sbt._
 
-import StringUtilities.nonEmpty
-
 import org.scalajs.core.tools.jsdep.JSDependency
 
 /** Something JavaScript related a project may depend on. Either a JavaScript
@@ -17,7 +15,7 @@ sealed trait AbstractJSDep {
   def %(configurations: String): AbstractJSDep = {
     require(this.configurations.isEmpty,
         "Configurations already specified for jsModule " + this)
-    nonEmpty(configurations, "Configurations")
+    require(configurations.trim.nonEmpty, "Configurations cannot be empty.")
     withConfigs(Some(configurations))
   }
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/AbstractJSDeps.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/AbstractJSDeps.scala
@@ -4,6 +4,8 @@ import sbt._
 
 import org.scalajs.core.tools.jsdep.JSDependency
 
+import SBTCompat._
+
 /** Something JavaScript related a project may depend on. Either a JavaScript
  *  module/library, or the DOM at runtime. */
 sealed trait AbstractJSDep {
@@ -45,7 +47,8 @@ final case class JarJSModuleID(
   def configurations: Option[String] = module.configurations
 
   protected def withConfigs(configs: Option[String]): JSModuleID =
-    copy(module = module.copy(configurations = configs))
+    copy(module = moduleIDWithConfigurations(module, configs))
+
   protected def withJSDep(jsDep: JSDependency): JSModuleID =
     copy(jsDep = jsDep)
 }

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
@@ -13,13 +13,9 @@ import sbt._
 
 import org.scalajs.core.ir.ScalaJSVersions
 
+import SBTCompat._
+
 object ScalaJSCrossVersion {
-  private val scalaJSVersionUnmapped: String => String =
-    _ => s"sjs$currentBinaryVersion"
-
-  private val scalaJSVersionMap: String => String =
-    version => s"sjs${currentBinaryVersion}_$version"
-
   private final val ReleaseVersion =
     raw"""(\d+)\.(\d+)\.(\d+)""".r
   private final val MinorSnapshotVersion =
@@ -33,14 +29,8 @@ object ScalaJSCrossVersion {
     case _                                     => full
   }
 
-  def scalaJSMapped(cross: CrossVersion): CrossVersion = cross match {
-    case CrossVersion.Disabled =>
-      CrossVersion.binaryMapped(scalaJSVersionUnmapped)
-    case cross: CrossVersion.Binary =>
-      CrossVersion.binaryMapped(cross.remapVersion andThen scalaJSVersionMap)
-    case cross: CrossVersion.Full =>
-      CrossVersion.fullMapped(cross.remapVersion andThen scalaJSVersionMap)
-  }
+  def scalaJSMapped(cross: CrossVersion): CrossVersion =
+    crossVersionAddScalaJSPart(cross, "sjs" + currentBinaryVersion)
 
   val binary: CrossVersion = scalaJSMapped(CrossVersion.binary)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
@@ -16,12 +16,17 @@ object ScalaJSJUnitPlugin extends AutoPlugin {
 
   import ScalaJSPlugin.autoImport._
 
+  /* As of sbt 1, a `config()` must be assigned to a `val` starting with an
+   * uppercase letter, which will become the "id" of the configuration.
+   */
+  val ScalaJSTestPlugin = config("scala-js-test-plugin").hide
+
   override def projectSettings: Seq[Setting[_]] = Seq(
     /* The `scala-js-test-plugin` configuration adds a plugin only to the `test`
      * configuration. It is a refinement of the `plugin` configuration which adds
      * it to both `compile` and `test`.
      */
-    ivyConfigurations += config("scala-js-test-plugin").hide,
+    ivyConfigurations += ScalaJSTestPlugin,
     libraryDependencies ++= Seq(
         "org.scala-js" % "scalajs-junit-test-plugin" % scalaJSVersion %
         "scala-js-test-plugin" cross CrossVersion.full,

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -3,14 +3,14 @@ package org.scalajs.sbtplugin
 import java.util.IllegalFormatException
 
 import sbt._
-import sbt.inc.{IncOptions, ClassfileManager}
 import Keys._
-import sbinary.DefaultProtocol._
-import Cache.seqFormat
 import complete.Parser
 import complete.DefaultParsers._
 
 import Loggers._
+import SBTCompat._
+import SBTCompat.formatImplicits._
+import SBTCompat.formatImplicits.seqFormat
 
 import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.io.{IO => toolsIO, _}
@@ -118,34 +118,9 @@ object ScalaJSPluginInternal {
     logger.debug("Global IR cache stats: " + globalIRCache.stats.logLine)
   }
 
-  /** Patches the IncOptions so that .sjsir files are pruned as needed.
-   *
-   *  This complicated logic patches the ClassfileManager factory of the given
-   *  IncOptions with one that is aware of .sjsir files emitted by the Scala.js
-   *  compiler. This makes sure that, when a .class file must be deleted, the
-   *  corresponding .sjsir file are also deleted.
-   */
-  def scalaJSPatchIncOptions(incOptions: IncOptions): IncOptions = {
-    val inheritedNewClassfileManager = incOptions.newClassfileManager
-    val newClassfileManager = () => new ClassfileManager {
-      private[this] val inherited = inheritedNewClassfileManager()
-
-      def delete(classes: Iterable[File]): Unit = {
-        inherited.delete(classes flatMap { classFile =>
-          val scalaJSFiles = if (classFile.getPath endsWith ".class") {
-            val f = FileVirtualFile.withExtension(classFile, ".class", ".sjsir")
-            if (f.exists) List(f)
-            else Nil
-          } else Nil
-          classFile :: scalaJSFiles
-        })
-      }
-
-      def generated(classes: Iterable[File]): Unit = inherited.generated(classes)
-      def complete(success: Boolean): Unit = inherited.complete(success)
-    }
-    incOptions.withNewClassfileManager(newClassfileManager)
-  }
+  /** Patches the IncOptions so that .sjsir files are pruned as needed. */
+  def scalaJSPatchIncOptions(incOptions: IncOptions): IncOptions =
+    SBTCompat.scalaJSPatchIncOptions(incOptions)
 
   private def packageJSDependenciesSetting(taskKey: TaskKey[File], cacheName: String,
       getLib: ResolvedJSDependency => VirtualJSFile): Setting[Task[File]] = {
@@ -458,15 +433,16 @@ object ScalaJSPluginInternal {
             ((moduleName in packageScalaJSLauncherInternal).value + "-launcher.js")),
 
       skip in packageScalaJSLauncherInternal := {
+        // @sbtUnchecked because of https://github.com/sbt/sbt/issues/3299
         val value = !persistLauncherInternal.value
         if (!value) {
-          if (scalaJSUseMainModuleInitializer.value) {
+          if (scalaJSUseMainModuleInitializer.value: @sbtUnchecked) {
             throw new MessageOnlyException(
                 "persistLauncher := true is not compatible with using a main " +
                 "module initializer (scalaJSUseMainModuleInitializer := " +
                 "true), nor is it necessary, since fastOptJS/fullOptJS " +
                 "includes the call to the main method")
-          } else if (scalaJSModuleKind.value != ModuleKind.NoModule) {
+          } else if ((scalaJSModuleKind.value: @sbtUnchecked) != ModuleKind.NoModule) {
             throw new MessageOnlyException(
                 "persistLauncher := true is not compatible with emitting " +
                 "JavaScript modules")
@@ -600,7 +576,8 @@ object ScalaJSPluginInternal {
            * unreasonably overridden values for the fastOptJS and fullOptJS
            * tasks. Otherwise, this check is bogus.
            */
-          checkCompliance(requirements, scalaJSSemantics.value)
+          // @sbtUnchecked because of https://github.com/sbt/sbt/issues/3299
+          checkCompliance(requirements, scalaJSSemantics.value: @sbtUnchecked)
         }
 
         // Collect originating files
@@ -772,14 +749,14 @@ object ScalaJSPluginInternal {
   }
 
   @deprecated("js.JSApps are going away, and this method with them.", "0.6.18")
-  def discoverJSApps(analysis: inc.Analysis): Seq[String] = {
+  def discoverJSApps(analysis: CompileAnalysis): Seq[String] = {
     discoverScalaJSMainClasses(analysis).collect {
       case (name, false) => name
     }.toList
   }
 
   private def discoverScalaJSMainClasses(
-      analysis: inc.Analysis): Map[String, Boolean] = {
+      analysis: CompileAnalysis): Map[String, Boolean] = {
     import xsbt.api.{Discovered, Discovery}
 
     val jsApp = "scala.scalajs.js.JSApp"
@@ -1038,6 +1015,11 @@ object ScalaJSPluginInternal {
       "org.eclipse.jetty" % "jetty-server" % "8.1.16.v20140903"
   )
 
+  /* As of sbt 1, a `config()` must be assigned to a `val` starting with an
+   * uppercase letter, which will become the "id" of the configuration.
+   */
+  val PhantomJSJetty = config("phantom-js-jetty").hide
+
   val scalaJSProjectBaseSettings = Seq(
       isScalaJSProject := true,
 
@@ -1127,7 +1109,7 @@ object ScalaJSPluginInternal {
        * them into the PhantomJS runner if necessary.
        * See scalaJSPhantomJSClassLoader
        */
-      ivyConfigurations += config("phantom-js-jetty").hide,
+      ivyConfigurations += PhantomJSJetty,
       libraryDependencies ++= phantomJSJettyModules.map(_ % "phantom-js-jetty"),
       scalaJSPhantomJSClassLoader := {
         val report = update.value

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
@@ -270,19 +270,6 @@ final class CrossProject private (
   def overrideConfigs(cs: Configuration*): CrossProject =
     copy(jvm.overrideConfigs(cs: _*), js.overrideConfigs(cs: _*))
 
-  /** Configures how settings from other sources, such as .sbt files, are
-   *  appended to the explicitly specified settings for this project.
-   *
-   *  Note: If you disable AutoPlugins here, Scala.js will not work
-   */
-  @deprecated(
-      "Project#settingSets will be removed from sbt 1.0, hence " +
-      "CrossProject#settingSets will be removed from Scala.js 1.0. " +
-      "As a temporary measure, use `.configureAll(_.settingSets(select))`.",
-      "0.6.16")
-  def settingSets(select: AddSettings*): CrossProject =
-    copy(jvm.settingSets(select: _*), js.settingSets(select: _*))
-
   def settings(ss: Def.SettingsDefinition*): CrossProject =
     copy(jvm.settings(ss: _*), js.settings(ss: _*))
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/DependencyBuilders.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/DependencyBuilders.scala
@@ -15,11 +15,9 @@ import scala.language.experimental.macros
 
 import sbt._
 
-import StringUtilities.nonEmpty
-
 trait DependencyBuilders {
   final implicit def toScalaJSGroupID(groupID: String): ScalaJSGroupID = {
-    nonEmpty(groupID, "Group ID")
+    require(groupID.trim.nonEmpty, "Group ID cannot be empty.")
     new ScalaJSGroupID(groupID)
   }
 
@@ -76,7 +74,7 @@ object ScalaJSGroupID {
    */
   def withCross(groupID: ScalaJSGroupID, artifactID: String,
       cross: CrossVersion): CrossGroupArtifactID = {
-    nonEmpty(artifactID, "Artifact ID")
+    require(artifactID.trim.nonEmpty, "Artifact ID cannot be empty.")
     new CrossGroupArtifactID(groupID.groupID, artifactID, cross)
   }
 
@@ -106,7 +104,7 @@ object ScalaJSGroupID {
 final class CrossGroupArtifactID(groupID: String,
     artifactID: String, crossVersion: CrossVersion) {
   def %(revision: String): ModuleID = {
-    nonEmpty(revision, "Revision")
+    require(revision.trim.nonEmpty, "Revision cannot be empty.")
     ModuleID(groupID, artifactID, revision).cross(crossVersion)
   }
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,6 +12,8 @@ FULL_VERSIONS="2.10.2 2.10.3 2.10.4 2.10.5 2.10.6 2.11.0 2.11.1 2.11.2 2.11.4 2.
 BIN_VERSIONS="2.10.6 2.11.11 2.12.2 2.13.0-M1"
 CLI_VERSIONS="2.10.6 2.11.11 2.12.2"
 SBT_VERSION="2.10.6"
+SBT1_VERSION="2.12.2"
+SBT1_SBTVERSION="1.0.0-RC2"
 
 COMPILER="compiler jUnitPlugin"
 LIBS="library javalibEx ir irJS tools toolsJS jsEnvs jsEnvsTestKit testAdapter stubs testInterface jUnitRuntime"
@@ -41,3 +43,4 @@ done
 
 # Publish sbt-plugin
 $CMD "++$SBT_VERSION" "sbtPlugin/publishSigned"
+$CMD "++$SBT1_VERSION" "^^$SBT1_SBTVERSION" "sbtPlugin/publishSigned"

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -1732,8 +1732,16 @@ private[optimizer] abstract class OptimizerCore(
   private def transformExprsOrSpreads(trees: List[Tree])(
       implicit scope: Scope): List[Tree] = {
 
-    trees match {
-      case (spread: JSSpread) :: rest =>
+    /* This is basically a flatMap, but we do it manually because flatMap would
+     * generate many garbage intermediate lists, when in fact the case JSSpread
+     * should be fairly rare. In general, we avoid flatMaps over collections in
+     * OptimizerCore.
+     */
+
+    val builder = List.newBuilder[Tree]
+
+    trees.foreach {
+      case spread: JSSpread =>
         implicit val pos = spread.pos
 
         val newSpreadItems = trampoline {
@@ -1752,19 +1760,16 @@ private[optimizer] abstract class OptimizerCore(
           }
         }
 
-        val newRest = transformExprsOrSpreads(rest)
-
         newSpreadItems match {
-          case JSArrayConstr(newFirsts) => newFirsts ::: newRest
-          case _                        => JSSpread(newSpreadItems) :: newRest
+          case JSArrayConstr(newFirsts) => builder ++= newFirsts
+          case _                        => builder += JSSpread(newSpreadItems)
         }
 
-      case first :: rest =>
-        transformExpr(first) :: transformExprsOrSpreads(rest)
-
-      case Nil =>
-        Nil
+      case tree =>
+        builder += transformExpr(tree)
     }
+
+    builder.result()
   }
 
   private val ClassNamesThatShouldBeInlined = Set(


### PR DESCRIPTION
Revival of #3068 after the rolled back merge.

After discussion, this is waiting for sbt 0.13.16 final to be released, so that we don't have our stable artifacts depend on sbt's pre-release artifacts.

/cc @dwijnand @eed3si9n