### PR TITLE
Redesign primitive numeric types in the IR.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala
@@ -91,7 +91,12 @@ trait TypeKinds extends SubComponent { this: GenJSCode =>
 
   /** Integer number (Byte, Short, Char or Int). */
   case class INT private[TypeKinds] (typeSymbol: Symbol) extends ValueTypeKind {
-    def toIRType: Types.IntType.type = Types.IntType
+    val toIRType: Types.Type = typeSymbol match {
+      case CharClass  => Types.CharType
+      case ByteClass  => Types.ByteType
+      case ShortClass => Types.ShortType
+      case IntClass   => Types.IntType
+    }
   }
 
   /** Long */
@@ -102,9 +107,10 @@ trait TypeKinds extends SubComponent { this: GenJSCode =>
 
   /** Floating-point number (Float or Double). */
   case class FLOAT private[TypeKinds] (typeSymbol: Symbol) extends ValueTypeKind {
-    def toIRType: Types.Type =
-      if (typeSymbol == FloatClass) Types.FloatType
-      else Types.DoubleType
+    val toIRType: Types.Type = typeSymbol match {
+      case FloatClass  => Types.FloatType
+      case DoubleClass => Types.DoubleType
+    }
   }
 
   /** Boolean */

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -395,6 +395,18 @@ object Hashers {
           mixTag(TagBooleanLiteral)
           mixBoolean(value)
 
+        case CharLiteral(value) =>
+          mixTag(TagCharLiteral)
+          mixChar(value)
+
+        case ByteLiteral(value) =>
+          mixTag(TagByteLiteral)
+          mixByte(value)
+
+        case ShortLiteral(value) =>
+          mixTag(TagShortLiteral)
+          mixShort(value)
+
         case IntLiteral(value) =>
           mixTag(TagIntLiteral)
           mixInt(value)
@@ -459,6 +471,9 @@ object Hashers {
       case NothingType => mixTag(TagNothingType)
       case UndefType   => mixTag(TagUndefType)
       case BooleanType => mixTag(TagBooleanType)
+      case CharType    => mixTag(TagCharType)
+      case ByteType    => mixTag(TagByteType)
+      case ShortType   => mixTag(TagShortType)
       case IntType     => mixTag(TagIntType)
       case LongType    => mixTag(TagLongType)
       case FloatType   => mixTag(TagFloatType)
@@ -520,6 +535,15 @@ object Hashers {
 
     @inline
     final def mixString(str: String): Unit = digestStream.writeUTF(str)
+
+    @inline
+    final def mixChar(c: Char): Unit = digestStream.writeChar(c)
+
+    @inline
+    final def mixByte(b: Byte): Unit = digestStream.writeByte(b)
+
+    @inline
+    final def mixShort(s: Short): Unit = digestStream.writeShort(s)
 
     @inline
     final def mixInt(i: Int): Unit = digestStream.writeInt(i)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -329,11 +329,22 @@ object Printers {
           import UnaryOp._
           print('(')
           print((op: @switch) match {
-            case Boolean_!                 => "!"
-            case IntToLong | DoubleToLong  => "(long)"
-            case DoubleToInt | LongToInt   => "(int)"
-            case DoubleToFloat             => "(float)"
-            case LongToDouble              => "(double)"
+            case Boolean_! =>
+              "!"
+            case IntToChar =>
+              "(char)"
+            case IntToByte =>
+              "(byte)"
+            case IntToShort =>
+              "(short)"
+            case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt =>
+              "(int)"
+            case IntToLong | DoubleToLong =>
+              "(long)"
+            case DoubleToFloat =>
+              "(float)"
+            case IntToDouble | LongToDouble | FloatToDouble =>
+              "(double)"
           })
           print(lhs)
           print(')')
@@ -380,6 +391,11 @@ object Printers {
 
             case String_+ => "+[string]"
 
+            case Boolean_== => "==[bool]"
+            case Boolean_!= => "!=[bool]"
+            case Boolean_|  => "|[bool]"
+            case Boolean_&  => "&[bool]"
+
             case Int_+ => "+[int]"
             case Int_- => "-[int]"
             case Int_* => "*[int]"
@@ -393,24 +409,12 @@ object Printers {
             case Int_>>> => ">>>[int]"
             case Int_>>  => ">>[int]"
 
-            case Float_+ => "+[float]"
-            case Float_- => "-[float]"
-            case Float_* => "*[float]"
-            case Float_/ => "/[float]"
-            case Float_% => "%[float]"
-
-            case Double_+ => "+[double]"
-            case Double_- => "-[double]"
-            case Double_* => "*[double]"
-            case Double_/ => "/[double]"
-            case Double_% => "%[double]"
-
-            case Num_== => "=="
-            case Num_!= => "!="
-            case Num_<  => "<"
-            case Num_<= => "<="
-            case Num_>  => ">"
-            case Num_>= => ">="
+            case Int_== => "==[int]"
+            case Int_!= => "!=[int]"
+            case Int_<  => "<[int]"
+            case Int_<= => "<=[int]"
+            case Int_>  => ">[int]"
+            case Int_>= => ">=[int]"
 
             case Long_+ => "+[long]"
             case Long_- => "-[long]"
@@ -432,10 +436,24 @@ object Printers {
             case Long_>  => ">[long]"
             case Long_>= => ">=[long]"
 
-            case Boolean_== => "==[bool]"
-            case Boolean_!= => "!=[bool]"
-            case Boolean_|  => "|[bool]"
-            case Boolean_&  => "&[bool]"
+            case Float_+ => "+[float]"
+            case Float_- => "-[float]"
+            case Float_* => "*[float]"
+            case Float_/ => "/[float]"
+            case Float_% => "%[float]"
+
+            case Double_+ => "+[double]"
+            case Double_- => "-[double]"
+            case Double_* => "*[double]"
+            case Double_/ => "/[double]"
+            case Double_% => "%[double]"
+
+            case Double_== => "==[double]"
+            case Double_!= => "!=[double]"
+            case Double_<  => "<[double]"
+            case Double_<= => "<=[double]"
+            case Double_>  => ">[double]"
+            case Double_>= => ">=[double]"
           })
           print(' ')
           print(rhs)
@@ -688,6 +706,31 @@ object Printers {
         case BooleanLiteral(value) =>
           print(if (value) "true" else "false")
 
+        case CharLiteral(value) =>
+          print('\'')
+          printEscapeJS(value.toString(), out)
+          print('\'')
+
+        case ByteLiteral(value) =>
+          if (value >= 0) {
+            print(value.toString)
+            print("_b")
+          } else {
+            print('(')
+            print(value.toString)
+            print("_b)")
+          }
+
+        case ShortLiteral(value) =>
+          if (value >= 0) {
+            print(value.toString)
+            print("_s")
+          } else {
+            print('(')
+            print(value.toString)
+            print("_s)")
+          }
+
         case IntLiteral(value) =>
           if (value >= 0) {
             print(value.toString)
@@ -906,6 +949,9 @@ object Printers {
       case NothingType          => print("nothing")
       case UndefType            => print("void")
       case BooleanType          => print("boolean")
+      case CharType             => print("char")
+      case ByteType             => print("byte")
+      case ShortType            => print("short")
       case IntType              => print("int")
       case LongType             => print("long")
       case FloatType            => print("float")

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -375,6 +375,18 @@ object Serializers {
           writeByte(TagBooleanLiteral)
           writeBoolean(value)
 
+        case CharLiteral(value) =>
+          writeByte(TagCharLiteral)
+          writeChar(value)
+
+        case ByteLiteral(value) =>
+          writeByte(TagByteLiteral)
+          writeByte(value)
+
+        case ShortLiteral(value) =>
+          writeByte(TagShortLiteral)
+          writeShort(value)
+
         case IntLiteral(value) =>
           writeByte(TagIntLiteral)
           writeInt(value)
@@ -572,6 +584,9 @@ object Serializers {
         case NothingType => buffer.write(TagNothingType)
         case UndefType   => buffer.write(TagUndefType)
         case BooleanType => buffer.write(TagBooleanType)
+        case CharType    => buffer.write(TagCharType)
+        case ByteType    => buffer.write(TagByteType)
+        case ShortType   => buffer.write(TagShortType)
         case IntType     => buffer.write(TagIntType)
         case LongType    => buffer.write(TagLongType)
         case FloatType   => buffer.write(TagFloatType)
@@ -863,6 +878,9 @@ object Serializers {
         case TagUndefined      => Undefined()
         case TagNull           => Null()
         case TagBooleanLiteral => BooleanLiteral(readBoolean())
+        case TagCharLiteral    => CharLiteral(readChar())
+        case TagByteLiteral    => ByteLiteral(readByte())
+        case TagShortLiteral   => ShortLiteral(readShort())
         case TagIntLiteral     => IntLiteral(readInt())
         case TagLongLiteral    => LongLiteral(readLong())
         case TagFloatLiteral   => FloatLiteral(readFloat())
@@ -989,6 +1007,9 @@ object Serializers {
         case TagNothingType => NothingType
         case TagUndefType   => UndefType
         case TagBooleanType => BooleanType
+        case TagCharType    => CharType
+        case TagByteType    => ByteType
+        case TagShortType   => ShortType
         case TagIntType     => IntType
         case TagLongType    => LongType
         case TagFloatType   => FloatType

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -78,7 +78,10 @@ private[ir] object Tags {
   final val TagUndefined = TagJSLinkingInfo + 1
   final val TagNull = TagUndefined + 1
   final val TagBooleanLiteral = TagNull + 1
-  final val TagIntLiteral = TagBooleanLiteral + 1
+  final val TagCharLiteral = TagBooleanLiteral + 1
+  final val TagByteLiteral = TagCharLiteral + 1
+  final val TagShortLiteral = TagByteLiteral + 1
+  final val TagIntLiteral = TagShortLiteral + 1
   final val TagLongLiteral = TagIntLiteral + 1
   final val TagFloatLiteral = TagLongLiteral + 1
   final val TagDoubleLiteral = TagFloatLiteral + 1
@@ -109,7 +112,10 @@ private[ir] object Tags {
   final val TagNothingType = TagAnyType + 1
   final val TagUndefType = TagNothingType + 1
   final val TagBooleanType = TagUndefType + 1
-  final val TagIntType = TagBooleanType + 1
+  final val TagCharType = TagBooleanType + 1
+  final val TagByteType = TagCharType + 1
+  final val TagShortType = TagByteType + 1
+  final val TagIntType = TagShortType + 1
   final val TagLongType = TagIntType + 1
   final val TagFloatType = TagLongType + 1
   final val TagDoubleType = TagFloatType + 1

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -272,19 +272,43 @@ object Trees {
 
     final val Boolean_! = 1
 
-    final val IntToLong     = 2
-    final val LongToInt     = 3
-    final val LongToDouble  = 4
-    final val DoubleToInt   = 5
-    final val DoubleToFloat = 6
-    final val DoubleToLong  = 7
+    // Widening conversions
+    final val CharToInt = 2
+    final val ByteToInt = 3
+    final val ShortToInt = 4
+    final val IntToLong = 5
+    final val IntToDouble = 6
+    final val FloatToDouble = 7
+
+    // Narrowing conversions
+    final val IntToChar = 8
+    final val IntToByte = 9
+    final val IntToShort = 10
+    final val LongToInt = 11
+    final val DoubleToInt = 12
+    final val DoubleToFloat = 13
+
+    // Long <-> Double (neither widening nor narrowing)
+    final val LongToDouble = 14
+    final val DoubleToLong = 15
 
     def resultTypeOf(op: Code): Type = (op: @switch) match {
-      case LongToInt | DoubleToInt  => IntType
-      case IntToLong | DoubleToLong => LongType
-      case DoubleToFloat            => FloatType
-      case LongToDouble             => DoubleType
-      case Boolean_!                => BooleanType
+      case Boolean_! =>
+        BooleanType
+      case IntToChar =>
+        CharType
+      case IntToByte =>
+        ByteType
+      case IntToShort =>
+        ShortType
+      case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt =>
+        IntType
+      case IntToLong | DoubleToLong =>
+        LongType
+      case DoubleToFloat =>
+        FloatType
+      case IntToDouble | LongToDouble | FloatToDouble =>
+        DoubleType
     }
   }
 
@@ -304,81 +328,89 @@ object Trees {
 
     final val String_+ = 3
 
-    final val Int_+ = 4
-    final val Int_- = 5
-    final val Int_* = 6
-    final val Int_/ = 7
-    final val Int_% = 8
+    final val Boolean_== = 4
+    final val Boolean_!= = 5
+    final val Boolean_|  = 6
+    final val Boolean_&  = 7
 
-    final val Int_|   = 9
-    final val Int_&   = 10
-    final val Int_^   = 11
-    final val Int_<<  = 12
-    final val Int_>>> = 13
-    final val Int_>>  = 14
+    final val Int_+ = 8
+    final val Int_- = 9
+    final val Int_* = 10
+    final val Int_/ = 11
+    final val Int_% = 12
 
-    final val Float_+ = 15
-    final val Float_- = 16
-    final val Float_* = 17
-    final val Float_/ = 18
-    final val Float_% = 19
+    final val Int_|   = 13
+    final val Int_&   = 14
+    final val Int_^   = 15
+    final val Int_<<  = 16
+    final val Int_>>> = 17
+    final val Int_>>  = 18
 
-    final val Double_+ = 20
-    final val Double_- = 21
-    final val Double_* = 22
-    final val Double_/ = 23
-    final val Double_% = 24
+    final val Int_== = 19
+    final val Int_!= = 20
+    final val Int_<  = 21
+    final val Int_<= = 22
+    final val Int_>  = 23
+    final val Int_>= = 24
 
-    final val Num_== = 25
-    final val Num_!= = 26
-    final val Num_<  = 27
-    final val Num_<= = 28
-    final val Num_>  = 29
-    final val Num_>= = 30
+    final val Long_+ = 25
+    final val Long_- = 26
+    final val Long_* = 27
+    final val Long_/ = 28
+    final val Long_% = 29
 
-    final val Long_+ = 31
-    final val Long_- = 32
-    final val Long_* = 33
-    final val Long_/ = 34
-    final val Long_% = 35
+    final val Long_|   = 30
+    final val Long_&   = 31
+    final val Long_^   = 32
+    final val Long_<<  = 33
+    final val Long_>>> = 34
+    final val Long_>>  = 35
 
-    final val Long_|   = 36
-    final val Long_&   = 37
-    final val Long_^   = 38
-    final val Long_<<  = 39
-    final val Long_>>> = 40
-    final val Long_>>  = 41
+    final val Long_== = 36
+    final val Long_!= = 37
+    final val Long_<  = 38
+    final val Long_<= = 39
+    final val Long_>  = 40
+    final val Long_>= = 41
 
-    final val Long_== = 42
-    final val Long_!= = 43
-    final val Long_<  = 44
-    final val Long_<= = 45
-    final val Long_>  = 46
-    final val Long_>= = 47
+    final val Float_+ = 42
+    final val Float_- = 43
+    final val Float_* = 44
+    final val Float_/ = 45
+    final val Float_% = 46
 
-    final val Boolean_== = 48
-    final val Boolean_!= = 49
-    final val Boolean_|  = 50
-    final val Boolean_&  = 51
+    final val Double_+ = 47
+    final val Double_- = 48
+    final val Double_* = 49
+    final val Double_/ = 50
+    final val Double_% = 51
+
+    final val Double_== = 52
+    final val Double_!= = 53
+    final val Double_<  = 54
+    final val Double_<= = 55
+    final val Double_>  = 56
+    final val Double_>= = 57
 
     def resultTypeOf(op: Code): Type = (op: @switch) match {
       case === | !== |
-          Num_== | Num_!= | Num_< | Num_<= | Num_> | Num_>= |
+          Boolean_== | Boolean_!= | Boolean_| | Boolean_& |
+          Int_== | Int_!= | Int_< | Int_<= | Int_> | Int_>= |
           Long_== | Long_!= | Long_< | Long_<= | Long_> | Long_>= |
-          Boolean_== | Boolean_!= | Boolean_| | Boolean_& =>
+          Double_== | Double_!= | Double_< | Double_<= | Double_> | Double_>= =>
         BooleanType
       case String_+ =>
         StringType
       case Int_+ | Int_- | Int_* | Int_/ | Int_% |
           Int_| | Int_& | Int_^ | Int_<< | Int_>>> | Int_>> =>
         IntType
+      case Long_+ | Long_- | Long_* | Long_/ | Long_% |
+          Long_| | Long_& | Long_^ | Long_<< | Long_>>> | Long_>> =>
+        LongType
       case Float_+ | Float_- | Float_* | Float_/ | Float_% =>
         FloatType
       case Double_+ | Double_- | Double_* | Double_/ | Double_% =>
         DoubleType
-      case Long_+ | Long_- | Long_* | Long_/ | Long_% |
-          Long_| | Long_& | Long_^ | Long_<< | Long_>>> | Long_>> =>
-        LongType
     }
   }
 
@@ -418,11 +450,13 @@ object Trees {
   case class Unbox(expr: Tree, charCode: Char)(
       implicit val pos: Position) extends Tree {
     val tpe = (charCode: @switch) match {
-      case 'Z'             => BooleanType
-      case 'B' | 'S' | 'I' => IntType
-      case 'J'             => LongType
-      case 'F'             => FloatType
-      case 'D'             => DoubleType
+      case 'Z' => BooleanType
+      case 'B' => ByteType
+      case 'S' => ShortType
+      case 'I' => IntType
+      case 'J' => LongType
+      case 'F' => FloatType
+      case 'D' => DoubleType
     }
   }
 
@@ -749,6 +783,21 @@ object Trees {
   case class BooleanLiteral(value: Boolean)(
       implicit val pos: Position) extends Literal {
     val tpe = BooleanType
+  }
+
+  case class CharLiteral(value: Char)(
+      implicit val pos: Position) extends Literal {
+    val tpe = CharType
+  }
+
+  case class ByteLiteral(value: Byte)(
+      implicit val pos: Position) extends Literal {
+    val tpe = ByteType
+  }
+
+  case class ShortLiteral(value: Short)(
+      implicit val pos: Position) extends Literal {
+    val tpe = ShortType
   }
 
   case class IntLiteral(value: Int)(

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -52,6 +52,9 @@ class PrintersTest {
     assertPrintEquals("nothing", NothingType)
     assertPrintEquals("void", UndefType)
     assertPrintEquals("boolean", BooleanType)
+    assertPrintEquals("char", CharType)
+    assertPrintEquals("byte", ByteType)
+    assertPrintEquals("short", ShortType)
     assertPrintEquals("int", IntType)
     assertPrintEquals("long", LongType)
     assertPrintEquals("float", FloatType)
@@ -349,11 +352,22 @@ class PrintersTest {
     import UnaryOp._
 
     assertPrintEquals("(!x)", UnaryOp(Boolean_!, ref("x", BooleanType)))
+
+    assertPrintEquals("((int)x)", UnaryOp(CharToInt, ref("x", CharType)))
+    assertPrintEquals("((int)x)", UnaryOp(ByteToInt, ref("x", ByteType)))
+    assertPrintEquals("((int)x)", UnaryOp(ShortToInt, ref("x", ShortType)))
     assertPrintEquals("((long)x)", UnaryOp(IntToLong, ref("x", IntType)))
+    assertPrintEquals("((double)x)", UnaryOp(IntToDouble, ref("x", IntType)))
+    assertPrintEquals("((double)x)", UnaryOp(FloatToDouble, ref("x", FloatType)))
+
+    assertPrintEquals("((char)x)", UnaryOp(IntToChar, ref("x", IntType)))
+    assertPrintEquals("((byte)x)", UnaryOp(IntToByte, ref("x", IntType)))
+    assertPrintEquals("((short)x)", UnaryOp(IntToShort, ref("x", IntType)))
     assertPrintEquals("((int)x)", UnaryOp(LongToInt, ref("x", LongType)))
-    assertPrintEquals("((double)x)", UnaryOp(LongToDouble, ref("x", LongType)))
     assertPrintEquals("((int)x)", UnaryOp(DoubleToInt, ref("x", DoubleType)))
     assertPrintEquals("((float)x)", UnaryOp(DoubleToFloat, ref("x", DoubleType)))
+
+    assertPrintEquals("((double)x)", UnaryOp(LongToDouble, ref("x", LongType)))
     assertPrintEquals("((long)x)", UnaryOp(DoubleToLong, ref("x", DoubleType)))
   }
 
@@ -380,6 +394,15 @@ class PrintersTest {
     assertPrintEquals("(x +[string] y)",
         BinaryOp(String_+, ref("x", AnyType), ref("y", AnyType)))
 
+    assertPrintEquals("(x ==[bool] y)",
+        BinaryOp(Boolean_==, ref("x", BooleanType), ref("y", BooleanType)))
+    assertPrintEquals("(x !=[bool] y)",
+        BinaryOp(Boolean_!=, ref("x", BooleanType), ref("y", BooleanType)))
+    assertPrintEquals("(x |[bool] y)",
+        BinaryOp(Boolean_|, ref("x", BooleanType), ref("y", BooleanType)))
+    assertPrintEquals("(x &[bool] y)",
+        BinaryOp(Boolean_&, ref("x", BooleanType), ref("y", BooleanType)))
+
     assertPrintEquals("(x +[int] y)",
         BinaryOp(Int_+, ref("x", IntType), ref("y", IntType)))
     assertPrintEquals("(x -[int] y)",
@@ -404,40 +427,18 @@ class PrintersTest {
     assertPrintEquals("(x >>[int] y)",
         BinaryOp(Int_>>, ref("x", IntType), ref("y", IntType)))
 
-    assertPrintEquals("(x +[float] y)",
-        BinaryOp(Float_+, ref("x", FloatType), ref("y", FloatType)))
-    assertPrintEquals("(x -[float] y)",
-        BinaryOp(Float_-, ref("x", FloatType), ref("y", FloatType)))
-    assertPrintEquals("(x *[float] y)",
-        BinaryOp(Float_*, ref("x", FloatType), ref("y", FloatType)))
-    assertPrintEquals("(x /[float] y)",
-        BinaryOp(Float_/, ref("x", FloatType), ref("y", FloatType)))
-    assertPrintEquals("(x %[float] y)",
-        BinaryOp(Float_%, ref("x", FloatType), ref("y", FloatType)))
-
-    assertPrintEquals("(x +[double] y)",
-        BinaryOp(Double_+, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x -[double] y)",
-        BinaryOp(Double_-, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x *[double] y)",
-        BinaryOp(Double_*, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x /[double] y)",
-        BinaryOp(Double_/, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x %[double] y)",
-        BinaryOp(Double_%, ref("x", DoubleType), ref("y", DoubleType)))
-
-    assertPrintEquals("(x == y)",
-        BinaryOp(Num_==, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x != y)",
-        BinaryOp(Num_!=, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x < y)",
-        BinaryOp(Num_<, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x <= y)",
-        BinaryOp(Num_<=, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x > y)",
-        BinaryOp(Num_>, ref("x", DoubleType), ref("y", DoubleType)))
-    assertPrintEquals("(x >= y)",
-        BinaryOp(Num_>=, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x ==[int] y)",
+        BinaryOp(Int_==, ref("x", IntType), ref("y", IntType)))
+    assertPrintEquals("(x !=[int] y)",
+        BinaryOp(Int_!=, ref("x", IntType), ref("y", IntType)))
+    assertPrintEquals("(x <[int] y)",
+        BinaryOp(Int_<, ref("x", IntType), ref("y", IntType)))
+    assertPrintEquals("(x <=[int] y)",
+        BinaryOp(Int_<=, ref("x", IntType), ref("y", IntType)))
+    assertPrintEquals("(x >[int] y)",
+        BinaryOp(Int_>, ref("x", IntType), ref("y", IntType)))
+    assertPrintEquals("(x >=[int] y)",
+        BinaryOp(Int_>=, ref("x", IntType), ref("y", IntType)))
 
     assertPrintEquals("(x +[long] y)",
         BinaryOp(Long_+, ref("x", LongType), ref("y", LongType)))
@@ -463,14 +464,53 @@ class PrintersTest {
     assertPrintEquals("(x >>[long] y)",
         BinaryOp(Long_>>, ref("x", LongType), ref("y", IntType)))
 
-    assertPrintEquals("(x ==[bool] y)",
-        BinaryOp(Boolean_==, ref("x", BooleanType), ref("y", BooleanType)))
-    assertPrintEquals("(x !=[bool] y)",
-        BinaryOp(Boolean_!=, ref("x", BooleanType), ref("y", BooleanType)))
-    assertPrintEquals("(x |[bool] y)",
-        BinaryOp(Boolean_|, ref("x", BooleanType), ref("y", BooleanType)))
-    assertPrintEquals("(x &[bool] y)",
-        BinaryOp(Boolean_&, ref("x", BooleanType), ref("y", BooleanType)))
+    assertPrintEquals("(x ==[long] y)",
+        BinaryOp(Long_==, ref("x", LongType), ref("y", LongType)))
+    assertPrintEquals("(x !=[long] y)",
+        BinaryOp(Long_!=, ref("x", LongType), ref("y", LongType)))
+    assertPrintEquals("(x <[long] y)",
+        BinaryOp(Long_<, ref("x", LongType), ref("y", LongType)))
+    assertPrintEquals("(x <=[long] y)",
+        BinaryOp(Long_<=, ref("x", LongType), ref("y", LongType)))
+    assertPrintEquals("(x >[long] y)",
+        BinaryOp(Long_>, ref("x", LongType), ref("y", LongType)))
+    assertPrintEquals("(x >=[long] y)",
+        BinaryOp(Long_>=, ref("x", LongType), ref("y", LongType)))
+
+    assertPrintEquals("(x +[float] y)",
+        BinaryOp(Float_+, ref("x", FloatType), ref("y", FloatType)))
+    assertPrintEquals("(x -[float] y)",
+        BinaryOp(Float_-, ref("x", FloatType), ref("y", FloatType)))
+    assertPrintEquals("(x *[float] y)",
+        BinaryOp(Float_*, ref("x", FloatType), ref("y", FloatType)))
+    assertPrintEquals("(x /[float] y)",
+        BinaryOp(Float_/, ref("x", FloatType), ref("y", FloatType)))
+    assertPrintEquals("(x %[float] y)",
+        BinaryOp(Float_%, ref("x", FloatType), ref("y", FloatType)))
+
+    assertPrintEquals("(x +[double] y)",
+        BinaryOp(Double_+, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x -[double] y)",
+        BinaryOp(Double_-, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x *[double] y)",
+        BinaryOp(Double_*, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x /[double] y)",
+        BinaryOp(Double_/, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x %[double] y)",
+        BinaryOp(Double_%, ref("x", DoubleType), ref("y", DoubleType)))
+
+    assertPrintEquals("(x ==[double] y)",
+        BinaryOp(Double_==, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x !=[double] y)",
+        BinaryOp(Double_!=, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x <[double] y)",
+        BinaryOp(Double_<, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x <=[double] y)",
+        BinaryOp(Double_<=, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x >[double] y)",
+        BinaryOp(Double_>, ref("x", DoubleType), ref("y", DoubleType)))
+    assertPrintEquals("(x >=[double] y)",
+        BinaryOp(Double_>=, ref("x", DoubleType), ref("y", DoubleType)))
   }
 
   @Test def printNewArray(): Unit = {
@@ -712,6 +752,22 @@ class PrintersTest {
   @Test def printBoolean(): Unit = {
     assertPrintEquals("true", BooleanLiteral(true))
     assertPrintEquals("false", BooleanLiteral(false))
+  }
+
+  @Test def printCharLiteral(): Unit = {
+    assertPrintEquals("'A'", CharLiteral('A'))
+    assertPrintEquals("'\\u0005'", CharLiteral('\u0005'))
+    assertPrintEquals("'\\ufffb'", CharLiteral('\ufffb'))
+  }
+
+  @Test def printByteLiteral(): Unit = {
+    assertPrintEquals("5_b", ByteLiteral(5))
+    assertPrintEquals("(-5_b)", ByteLiteral(-5))
+  }
+
+  @Test def printShortLiteral(): Unit = {
+    assertPrintEquals("5_s", ShortLiteral(5))
+    assertPrintEquals("(-5_s)", ShortLiteral(-5))
   }
 
   @Test def printIntLiteral(): Unit = {

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -30,22 +30,6 @@ final class Integer private () extends Number with Comparable[Integer] {
 
   @inline override def toString(): String =
     Integer.toString(intValue)
-
-  /* Methods of java.lang.Byte and java.lang.Short.
-   * When calling a method of j.l.Byte or j.l.Short on a primitive value,
-   * it appears to be called directly on the primitive value, which has type
-   * IntType. Call resolution, by the analyzer and the optimizer, will then
-   * look for the method in the class j.l.Integer instead of j.l.Byte or
-   * j.l.Short. This is why we add here the methods of these two classes that
-   * are not already in j.l.Integer.
-   */
-
-  @inline def compareTo(that: Byte): Int =
-    Integer.compare(intValue, that.intValue)
-
-  @inline def compareTo(that: Short): Int =
-    Integer.compare(intValue, that.intValue)
-
 }
 
 object Integer {

--- a/project/JavaLangString.scala
+++ b/project/JavaLangString.scala
@@ -106,14 +106,14 @@ object JavaLangString {
           Ident("charAt__I__C", Some("charAt__I__C")),
           List(ParamDef(Ident("i", Some("i")), IntType,
             mutable = false, rest = false)),
-          IntType,
+          CharType,
           Some {
             Apply(
               LoadModule(ClassType("sjsr_RuntimeString$")),
               Ident("charAt__T__I__C", Some("charAt__T__I__C")),
               List(
                 This()(ThisType),
-                VarRef(Ident("i", Some("i")))(IntType)))(IntType)
+                VarRef(Ident("i", Some("i")))(IntType)))(CharType)
           })(OptimizerHints.empty.withInline(true), None),
 
         /* def length(): Int = RuntimeString.length(this) */

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
@@ -34,6 +34,10 @@ class InstanceTestsHijackedBoxedClassesTest {
     assertTrue((5.0: Any).isInstanceOf[Int])
     assertTrue((5.0: Any).isInstanceOf[Float])
 
+    assertTrue((5.toByte: Any).isInstanceOf[Int])
+    assertTrue((5.toShort: Any).isInstanceOf[Int])
+    assertTrue((5: Any).isInstanceOf[Byte])
+    assertTrue((5: Any).isInstanceOf[Short])
     assertTrue((0.0: Any).isInstanceOf[Int])
     assertTrue((0.0: Any).isInstanceOf[Float])
     assertTrue((-0.0: Any).isInstanceOf[Float])

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -151,6 +151,73 @@ class OptimizerTest {
     // scalastyle:on return
   }
 
+  // === constant folding
+
+  @Test def constant_folding_===(): Unit = {
+    @inline def test(expectEq: Boolean, lhs: Any, rhs: Any): Unit = {
+      assertEquals(expectEq,
+          lhs.asInstanceOf[AnyRef] eq rhs.asInstanceOf[AnyRef])
+      assertEquals(!expectEq,
+          lhs.asInstanceOf[AnyRef] ne rhs.asInstanceOf[AnyRef])
+    }
+
+    test(true, false, false)
+    test(true, 5, 5)
+    test(true, 5.toByte, 5.toByte)
+    test(true, 5.toByte, 5)
+    test(true, 5.0, 5)
+    test(true, 5.0f, 5.toShort)
+    test(true, classOf[String], classOf[String])
+    test(true, "hello", "hello")
+
+    test(false, false, true)
+    test(false, 'A', 'A') // they're boxed, so not ===
+    test(false, 5, 6)
+    test(false, 5.toByte, 6.toByte)
+    test(false, 5.toByte, 5L)
+    test(false, 5, 5L)
+    test(false, 5L, 6L)
+    test(false, 5L, 5L) // they're instances of RuntimeLong, so not ===
+    test(false, false, 0)
+    test(false, 65, 'A')
+    test(false, classOf[String], classOf[Boolean])
+    test(false, "hello", "world")
+  }
+
+  @Test def constant_folding_==(): Unit = {
+    @inline def testChar(expectEq: Boolean, lhs: Char, rhs: Char): Unit = {
+      assertEquals(expectEq, lhs == rhs)
+      assertEquals(!expectEq, lhs != rhs)
+    }
+
+    testChar(true, 'A', 'A')
+    testChar(false, 'A', 'B')
+
+    @inline def testInt(expectEq: Boolean, lhs: Int, rhs: Int): Unit = {
+      assertEquals(expectEq, lhs == rhs)
+      assertEquals(!expectEq, lhs != rhs)
+    }
+
+    testInt(true, 5, 5)
+    testInt(false, 5, 6)
+
+    @inline def testLong(expectEq: Boolean, lhs: Long, rhs: Long): Unit = {
+      assertEquals(expectEq, lhs == rhs)
+      assertEquals(!expectEq, lhs != rhs)
+    }
+
+    testLong(true, 5L, 5L)
+    testLong(false, 5L, 6L)
+
+    @inline def testDouble(expectEq: Boolean, lhs: Double, rhs: Double): Unit = {
+      assertEquals(expectEq, lhs == rhs)
+      assertEquals(!expectEq, lhs != rhs)
+    }
+
+    testDouble(true, 5.5, 5.5)
+    testDouble(false, 5.5, 6.5)
+  }
+
   // +[string] constant folding
 
   @Test def must_not_break_when_folding_two_constant_strings(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -148,6 +148,24 @@ class DoubleTest {
     assertTrue(compare(0.0, -0.0) > 0)
   }
 
+  @Test def compareToConvertedFromInt_issue_3085(): Unit = {
+    @noinline
+    def foo(x: Int): Unit =
+      bar(x.toDouble)
+
+    @inline
+    def bar(x: Double): Unit = {
+      assertTrue(x.compareTo(5.5) < 0)
+      foobar(x)
+    }
+
+    @inline
+    def foobar(x: Comparable[java.lang.Double]): Unit =
+      assertTrue(x.compareTo(5.5) < 0)
+
+    foo(5)
+  }
+
   @Test def should_be_a_Comparable(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
@@ -186,6 +186,8 @@ object Infos {
         case AnyType        => addMethodCalled(ObjectClass, method)
         case UndefType      => addMethodCalled(BoxedUnitClass, method)
         case BooleanType    => addMethodCalled(BoxedBooleanClass, method)
+        case ByteType       => addMethodCalled(BoxedByteClass, method)
+        case ShortType      => addMethodCalled(BoxedShortClass, method)
         case IntType        => addMethodCalled(BoxedIntegerClass, method)
         case LongType       => addMethodCalled(BoxedLongClass, method)
         case FloatType      => addMethodCalled(BoxedFloatClass, method)
@@ -196,7 +198,7 @@ object Infos {
         case NullType | NothingType =>
           // Nothing to do
 
-        case NoType | RecordType(_) =>
+        case NoType | CharType | RecordType(_) =>
           throw new IllegalArgumentException(
               s"Illegal receiver type: $receiverTpe")
       }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -37,6 +37,9 @@ private[emitter] final class JSGen(val semantics: Semantics,
   def genZeroOf(tpe: Type)(implicit pos: Position): Tree = {
     tpe match {
       case BooleanType => BooleanLiteral(false)
+      case CharType    => IntLiteral(0)
+      case ByteType    => IntLiteral(0)
+      case ShortType   => IntLiteral(0)
       case IntType     => IntLiteral(0)
       case LongType    => genLongZero()
       case FloatType   => DoubleLiteral(0.0)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -47,25 +47,6 @@ abstract class GenIncOptimizer private[optimizer] (config: CommonPhaseConfig) {
     import factory._
 
     callMethods(LongImpl.RuntimeLongClass, LongImpl.AllIntrinsicMethods) ++
-    /* #2184 + #2780: we need to keep all methods of j.l.Integer, in case
-     * the corresponding methods are called on j.l.Byte or j.l.Short, and
-     * through optimizations become calls on j.l.Integer.
-     */
-    callMethods(Definitions.BoxedIntegerClass, Seq(
-        "byteValue__B",
-        "shortValue__S",
-        "intValue__I",
-        "longValue__J",
-        "floatValue__F",
-        "doubleValue__D",
-        "equals__O__Z",
-        "hashCode__I",
-        "compareTo__jl_Integer__I",
-        "toString__T",
-        "compareTo__jl_Byte__I",
-        "compareTo__jl_Short__I",
-        "compareTo__O__I"
-    )) ++
     instantiateClass("jl_NullPointerException", "init___")
   }
 


### PR DESCRIPTION
* Add types for `char`, `byte` and `short` in the IR.
* Remove the subtyping relationships between primitive types, for example `int <: double`.

Instead of the subtyping relationships, we introduce explicit widening conversions as `UnaryOp`s. In order to avoid widening `int`s to `double`s for the purpose of comparing them, we separate `Num_<` and friends into `Int_<` and `Double_<`. For floats, we do introduce the conversions in that case.

There is one subtlety for `char` (`CharType`): it is *not* a subtype of `any`. That's because `char`s must always be boxed in `j.l.Character` when they are assigned to an `any`.

This fixes #3085, and provides a cleaner solution to the old issues #2184 and #2780.