### PR TITLE
Hijack `j.l.Character` and make `char <: Character` in the IR.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -930,21 +930,20 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
       case _ =>
         import ir.{Definitions => Defs}
         (toTypeKind(tpe): @unchecked) match {
-          case VoidKind    => HijackedTypeTest(Defs.BoxedUnitClass,    0)
+          case VoidKind    => HijackedTypeTest(Defs.BoxedUnitClass, 0)
           case BooleanKind => HijackedTypeTest(Defs.BoxedBooleanClass, 1)
-          case ByteKind    => HijackedTypeTest(Defs.BoxedByteClass,    2)
-          case ShortKind   => HijackedTypeTest(Defs.BoxedShortClass,   3)
-          case IntKind     => HijackedTypeTest(Defs.BoxedIntegerClass, 4)
-          case FloatKind   => HijackedTypeTest(Defs.BoxedFloatClass,   5)
-          case DoubleKind  => HijackedTypeTest(Defs.BoxedDoubleClass,  6)
-
-          case CharKind => InstanceOfTypeTest(boxedClass(CharClass).tpe)
-          case LongKind => InstanceOfTypeTest(boxedClass(LongClass).tpe)
+          case CharKind    => HijackedTypeTest(Defs.BoxedCharacterClass, 2)
+          case ByteKind    => HijackedTypeTest(Defs.BoxedByteClass, 3)
+          case ShortKind   => HijackedTypeTest(Defs.BoxedShortClass, 4)
+          case IntKind     => HijackedTypeTest(Defs.BoxedIntegerClass, 5)
+          case LongKind    => HijackedTypeTest(Defs.BoxedLongClass, 6)
+          case FloatKind   => HijackedTypeTest(Defs.BoxedFloatClass, 7)
+          case DoubleKind  => HijackedTypeTest(Defs.BoxedDoubleClass, 8)
 
           case REFERENCE(cls) =>
             cls match {
               case BoxedUnitClass => HijackedTypeTest(Defs.BoxedUnitClass, 0)
-              case StringClass    => HijackedTypeTest(Defs.StringClass, 7)
+              case StringClass    => HijackedTypeTest(Defs.StringClass, 9)
               case ObjectClass    => NoTypeTest
               case _              =>
                 if (isRawJSType(tpe)) NoTypeTest

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -105,6 +105,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
     lazy val RuntimeStringModuleClass = RuntimeStringModule.moduleClass
 
     lazy val BooleanReflectiveCallClass = getRequiredClass("scala.scalajs.runtime.BooleanReflectiveCall")
+    lazy val CharacterReflectiveCallClass = getRequiredClass("scala.scalajs.runtime.CharacterReflectiveCall")
     lazy val NumberReflectiveCallClass = getRequiredClass("scala.scalajs.runtime.NumberReflectiveCall")
     lazy val IntegerReflectiveCallClass = getRequiredClass("scala.scalajs.runtime.IntegerReflectiveCall")
     lazy val LongReflectiveCallClass = getRequiredClass("scala.scalajs.runtime.LongReflectiveCall")

--- a/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
@@ -39,13 +39,16 @@ object Definitions {
   val NumberClass       = "jl_Number"
 
   val HijackedBoxedClasses = Set(
-      BoxedUnitClass, BoxedBooleanClass, BoxedByteClass, BoxedShortClass,
-      BoxedIntegerClass, BoxedLongClass, BoxedFloatClass, BoxedDoubleClass)
+      BoxedUnitClass, BoxedBooleanClass, BoxedCharacterClass, BoxedByteClass,
+      BoxedShortClass, BoxedIntegerClass, BoxedLongClass, BoxedFloatClass,
+      BoxedDoubleClass)
   val HijackedClasses =
     HijackedBoxedClasses + StringClass
 
   val AncestorsOfStringClass = Set(
       CharSequenceClass, ComparableClass, SerializableClass)
+  val AncestorsOfBoxedCharacterClass = Set(
+      ComparableClass, SerializableClass)
   val AncestorsOfHijackedNumberClasses = Set(
       NumberClass, ComparableClass, SerializableClass)
   val AncestorsOfBoxedBooleanClass = Set(

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -451,6 +451,7 @@ object Trees {
       implicit val pos: Position) extends Tree {
     val tpe = (charCode: @switch) match {
       case 'Z' => BooleanType
+      case 'C' => CharType
       case 'B' => ByteType
       case 'S' => ShortType
       case 'I' => IntType

--- a/ir/src/main/scala/org/scalajs/core/ir/Types.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Types.scala
@@ -63,11 +63,6 @@ object Types {
 
   /** `Char` type, a 16-bit UTF-16 code unit.
    *  It does not accept `null` nor `undefined`.
-   *
-   *  `CharType` has the peculiarity that it is *not* a subtype of [[AnyType]].
-   *  As such, no method can be called on a `CharType` either. In fact, very
-   *  few operations manipulate `CharType`s. It is usually necessary to convert
-   *  to/from [[IntType]]s using the appropriate `UnaryOp` conversions.
    */
   case object CharType extends Type
 
@@ -204,7 +199,6 @@ object Types {
     (lhs != NoType && rhs != NoType) && {
       (lhs == rhs) ||
       ((lhs, rhs) match {
-        case (CharType, _)    => false
         case (_, AnyType)     => true
         case (NothingType, _) => true
 
@@ -218,6 +212,8 @@ object Types {
           isSubclass(BoxedUnitClass, cls)
         case (BooleanType, ClassType(cls)) =>
           isSubclass(BoxedBooleanClass, cls)
+        case (CharType, ClassType(cls)) =>
+          isSubclass(BoxedCharacterClass, cls)
         case (ByteType, ClassType(cls)) =>
           isSubclass(BoxedByteClass, cls)
         case (ShortType, ClassType(cls)) =>

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -4,159 +4,34 @@ import scala.scalajs.js
 
 import java.util.Arrays
 
-@inline
-class Character(private val value: scala.Char)
+/* This is a hijacked class. Its instances are primitive chars.
+ *
+ * In fact, "primitive" is only true at the IR level. In JS, there is no such
+ * thing as a primitive character. Turning IR chars into valid JS is the
+ * responsibility of the Emitter.
+ *
+ * Constructors are not emitted.
+ */
+class Character private ()
     extends AnyRef with java.io.Serializable with Comparable[Character] {
 
-  def charValue(): scala.Char = value
+  def this(value: scala.Char) = this()
 
-  override def equals(that: Any): scala.Boolean =
-    that.isInstanceOf[Character] && (value == that.asInstanceOf[Character].charValue)
+  @inline def charValue(): scala.Char =
+    this.asInstanceOf[scala.Char]
 
-  override def compareTo(that: Character): Int =
+  @inline override def hashCode(): Int = charValue.toInt
+
+  @inline override def equals(that: Any): scala.Boolean = {
+    that.isInstanceOf[Character] &&
+    (charValue == that.asInstanceOf[Character].charValue)
+  }
+
+  @inline override def toString(): String =
+    Character.toString(charValue)
+
+  @inline override def compareTo(that: Character): Int =
     Character.compare(charValue, that.charValue)
-
-  override def toString(): String =
-    Character.toString(value)
-
-  override def hashCode(): Int = value.##
-
-  /*
-   * Methods on scala.Char
-   * The following methods are only here to properly support reflective calls
-   * on boxed primitive values. YOU WILL NOT BE ABLE TO USE THESE METHODS, since
-   * we use the true javalib to lookup symbols, this file contains only
-   * implementations.
-   */
-  protected def toByte: scala.Byte     = value.toByte
-  protected def toShort: scala.Short   = value.toShort
-  protected def toChar: scala.Char     = value.toChar
-  protected def toInt: scala.Int       = value
-  protected def toLong: scala.Long     = value.toLong
-  protected def toFloat: scala.Float   = value.toFloat
-  protected def toDouble: scala.Double = value.toDouble
-
-  // scalastyle:off disallow.space.before.token
-  protected def unary_~ : scala.Int = ~value
-  protected def unary_+ : scala.Int = value
-  protected def unary_- : scala.Int = -value
-  // scalastyle:on disallow.space.before.token
-
-  protected def +(x: String): String = value + x
-
-  protected def <<(x: scala.Int): scala.Int = value << x
-  protected def <<(x: scala.Long): scala.Int = value << x
-  protected def >>>(x: scala.Int): scala.Int = value >>> x
-  protected def >>>(x: scala.Long): scala.Int = value >>> x
-  protected def >>(x: scala.Int): scala.Int = value >> x
-  protected def >>(x: scala.Long): scala.Int = value >> x
-
-  protected def ==(x: scala.Byte): scala.Boolean = value == x
-  protected def ==(x: scala.Short): scala.Boolean = value == x
-  protected def ==(x: scala.Char): scala.Boolean = value == x
-  protected def ==(x: scala.Int): scala.Boolean = value == x
-  protected def ==(x: scala.Long): scala.Boolean = value == x
-  protected def ==(x: scala.Float): scala.Boolean = value == x
-  protected def ==(x: scala.Double): scala.Boolean = value == x
-
-  protected def !=(x: scala.Byte): scala.Boolean = value != x
-  protected def !=(x: scala.Short): scala.Boolean = value != x
-  protected def !=(x: scala.Char): scala.Boolean = value != x
-  protected def !=(x: scala.Int): scala.Boolean = value != x
-  protected def !=(x: scala.Long): scala.Boolean = value != x
-  protected def !=(x: scala.Float): scala.Boolean = value != x
-  protected def !=(x: scala.Double): scala.Boolean = value != x
-
-  protected def <(x: scala.Byte): scala.Boolean = value < x
-  protected def <(x: scala.Short): scala.Boolean = value < x
-  protected def <(x: scala.Char): scala.Boolean = value < x
-  protected def <(x: scala.Int): scala.Boolean = value < x
-  protected def <(x: scala.Long): scala.Boolean = value < x
-  protected def <(x: scala.Float): scala.Boolean = value < x
-  protected def <(x: scala.Double): scala.Boolean = value < x
-
-  protected def <=(x: scala.Byte): scala.Boolean = value <= x
-  protected def <=(x: scala.Short): scala.Boolean = value <= x
-  protected def <=(x: scala.Char): scala.Boolean = value <= x
-  protected def <=(x: scala.Int): scala.Boolean = value <= x
-  protected def <=(x: scala.Long): scala.Boolean = value <= x
-  protected def <=(x: scala.Float): scala.Boolean = value <= x
-  protected def <=(x: scala.Double): scala.Boolean = value <= x
-
-  protected def >(x: scala.Byte): scala.Boolean = value > x
-  protected def >(x: scala.Short): scala.Boolean = value > x
-  protected def >(x: scala.Char): scala.Boolean = value > x
-  protected def >(x: scala.Int): scala.Boolean = value > x
-  protected def >(x: scala.Long): scala.Boolean = value > x
-  protected def >(x: scala.Float): scala.Boolean = value > x
-  protected def >(x: scala.Double): scala.Boolean = value > x
-
-  protected def >=(x: scala.Byte): scala.Boolean = value >= x
-  protected def >=(x: scala.Short): scala.Boolean = value >= x
-  protected def >=(x: scala.Char): scala.Boolean = value >= x
-  protected def >=(x: scala.Int): scala.Boolean = value >= x
-  protected def >=(x: scala.Long): scala.Boolean = value >= x
-  protected def >=(x: scala.Float): scala.Boolean = value >= x
-  protected def >=(x: scala.Double): scala.Boolean = value >= x
-
-  protected def |(x: scala.Byte): scala.Int = value | x
-  protected def |(x: scala.Short): scala.Int = value | x
-  protected def |(x: scala.Char): scala.Int = value | x
-  protected def |(x: scala.Int): scala.Int = value | x
-  protected def |(x: scala.Long): scala.Long = value | x
-
-  protected def &(x: scala.Byte): scala.Int = value & x
-  protected def &(x: scala.Short): scala.Int = value & x
-  protected def &(x: scala.Char): scala.Int = value & x
-  protected def &(x: scala.Int): scala.Int = value & x
-  protected def &(x: scala.Long): scala.Long = value & x
-
-  protected def ^(x: scala.Byte): scala.Int = value ^ x
-  protected def ^(x: scala.Short): scala.Int = value ^ x
-  protected def ^(x: scala.Char): scala.Int = value ^ x
-  protected def ^(x: scala.Int): scala.Int = value ^ x
-  protected def ^(x: scala.Long): scala.Long = value ^ x
-
-  protected def +(x: scala.Byte): scala.Int = value + x
-  protected def +(x: scala.Short): scala.Int = value + x
-  protected def +(x: scala.Char): scala.Int = value + x
-  protected def +(x: scala.Int): scala.Int = value + x
-  protected def +(x: scala.Long): scala.Long = value + x
-  protected def +(x: scala.Float): scala.Float = value + x
-  protected def +(x: scala.Double): scala.Double = value + x
-
-  protected def -(x: scala.Byte): scala.Int = value - x
-  protected def -(x: scala.Short): scala.Int = value - x
-  protected def -(x: scala.Char): scala.Int = value - x
-  protected def -(x: scala.Int): scala.Int = value - x
-  protected def -(x: scala.Long): scala.Long = value - x
-  protected def -(x: scala.Float): scala.Float = value - x
-  protected def -(x: scala.Double): scala.Double = value - x
-
-  protected def *(x: scala.Byte): scala.Int = value * x
-  protected def *(x: scala.Short): scala.Int = value * x
-  protected def *(x: scala.Char): scala.Int = value * x
-  protected def *(x: scala.Int): scala.Int = value * x
-  protected def *(x: scala.Long): scala.Long = value * x
-  protected def *(x: scala.Float): scala.Float = value * x
-  protected def *(x: scala.Double): scala.Double = value * x
-
-  protected def /(x: scala.Byte): scala.Int = value / x
-  protected def /(x: scala.Short): scala.Int = value / x
-  protected def /(x: scala.Char): scala.Int = value / x
-  protected def /(x: scala.Int): scala.Int = value / x
-  protected def /(x: scala.Long): scala.Long = value / x
-  protected def /(x: scala.Float): scala.Float = value / x
-  protected def /(x: scala.Double): scala.Double = value / x
-
-  protected def %(x: scala.Byte): scala.Int = value % x
-  protected def %(x: scala.Short): scala.Int = value % x
-  protected def %(x: scala.Char): scala.Int = value % x
-  protected def %(x: scala.Int): scala.Int = value % x
-  protected def %(x: scala.Long): scala.Long = value % x
-  protected def %(x: scala.Float): scala.Float = value % x
-  protected def %(x: scala.Double): scala.Double = value % x
-
 }
 
 object Character {

--- a/library/src/main/scala/scala/scalajs/runtime/CharacterReflectiveCall.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/CharacterReflectiveCall.scala
@@ -1,0 +1,149 @@
+package scala.scalajs.runtime
+
+/** Explicit box for char values when doing a reflective call.
+ *  This class and its methods are only here to properly support reflective
+ *  calls on characters.
+ */
+final class CharacterReflectiveCall(value: Char) {
+
+  // Methods of java.lang.Character
+
+  def charValue(): Char = value
+
+  def compareTo(that: Character): Int =
+    new Character(value).compareTo(that)
+  def compareTo(that: AnyRef): Int =
+    new Character(value).compareTo(that.asInstanceOf[Character])
+
+  // Methods of Char
+
+  def toByte: Byte = value.toByte
+  def toShort: Short = value.toShort
+  def toChar: Char = value.toChar
+  def toInt: Int = value
+  def toLong: Long = value.toLong
+  def toFloat: Float = value.toFloat
+  def toDouble: Double = value.toDouble
+
+  // scalastyle:off disallow.space.before.token
+  def unary_~ : Int = ~value
+  def unary_+ : Int = value
+  def unary_- : Int = -value
+  // scalastyle:on disallow.space.before.token
+
+  def +(x: String): String = value + x
+
+  def <<(x: Int): Int = value << x
+  def <<(x: Long): Int = value << x
+  def >>>(x: Int): Int = value >>> x
+  def >>>(x: Long): Int = value >>> x
+  def >>(x: Int): Int = value >> x
+  def >>(x: Long): Int = value >> x
+
+  def ==(x: Byte): Boolean = value == x
+  def ==(x: Short): Boolean = value == x
+  def ==(x: Char): Boolean = value == x
+  def ==(x: Int): Boolean = value == x
+  def ==(x: Long): Boolean = value == x
+  def ==(x: Float): Boolean = value == x
+  def ==(x: Double): Boolean = value == x
+
+  def !=(x: Byte): Boolean = value != x
+  def !=(x: Short): Boolean = value != x
+  def !=(x: Char): Boolean = value != x
+  def !=(x: Int): Boolean = value != x
+  def !=(x: Long): Boolean = value != x
+  def !=(x: Float): Boolean = value != x
+  def !=(x: Double): Boolean = value != x
+
+  def <(x: Byte): Boolean = value < x
+  def <(x: Short): Boolean = value < x
+  def <(x: Char): Boolean = value < x
+  def <(x: Int): Boolean = value < x
+  def <(x: Long): Boolean = value < x
+  def <(x: Float): Boolean = value < x
+  def <(x: Double): Boolean = value < x
+
+  def <=(x: Byte): Boolean = value <= x
+  def <=(x: Short): Boolean = value <= x
+  def <=(x: Char): Boolean = value <= x
+  def <=(x: Int): Boolean = value <= x
+  def <=(x: Long): Boolean = value <= x
+  def <=(x: Float): Boolean = value <= x
+  def <=(x: Double): Boolean = value <= x
+
+  def >(x: Byte): Boolean = value > x
+  def >(x: Short): Boolean = value > x
+  def >(x: Char): Boolean = value > x
+  def >(x: Int): Boolean = value > x
+  def >(x: Long): Boolean = value > x
+  def >(x: Float): Boolean = value > x
+  def >(x: Double): Boolean = value > x
+
+  def >=(x: Byte): Boolean = value >= x
+  def >=(x: Short): Boolean = value >= x
+  def >=(x: Char): Boolean = value >= x
+  def >=(x: Int): Boolean = value >= x
+  def >=(x: Long): Boolean = value >= x
+  def >=(x: Float): Boolean = value >= x
+  def >=(x: Double): Boolean = value >= x
+
+  def |(x: Byte): Int = value | x
+  def |(x: Short): Int = value | x
+  def |(x: Char): Int = value | x
+  def |(x: Int): Int = value | x
+  def |(x: Long): Long = value | x
+
+  def &(x: Byte): Int = value & x
+  def &(x: Short): Int = value & x
+  def &(x: Char): Int = value & x
+  def &(x: Int): Int = value & x
+  def &(x: Long): Long = value & x
+
+  def ^(x: Byte): Int = value ^ x
+  def ^(x: Short): Int = value ^ x
+  def ^(x: Char): Int = value ^ x
+  def ^(x: Int): Int = value ^ x
+  def ^(x: Long): Long = value ^ x
+
+  def +(x: Byte): Int = value + x
+  def +(x: Short): Int = value + x
+  def +(x: Char): Int = value + x
+  def +(x: Int): Int = value + x
+  def +(x: Long): Long = value + x
+  def +(x: Float): Float = value + x
+  def +(x: Double): Double = value + x
+
+  def -(x: Byte): Int = value - x
+  def -(x: Short): Int = value - x
+  def -(x: Char): Int = value - x
+  def -(x: Int): Int = value - x
+  def -(x: Long): Long = value - x
+  def -(x: Float): Float = value - x
+  def -(x: Double): Double = value - x
+
+  def *(x: Byte): Int = value * x
+  def *(x: Short): Int = value * x
+  def *(x: Char): Int = value * x
+  def *(x: Int): Int = value * x
+  def *(x: Long): Long = value * x
+  def *(x: Float): Float = value * x
+  def *(x: Double): Double = value * x
+
+  def /(x: Byte): Int = value / x
+  def /(x: Short): Int = value / x
+  def /(x: Char): Int = value / x
+  def /(x: Int): Int = value / x
+  def /(x: Long): Long = value / x
+  def /(x: Float): Float = value / x
+  def /(x: Double): Double = value / x
+
+  def %(x: Byte): Int = value % x
+  def %(x: Short): Int = value % x
+  def %(x: Char): Int = value % x
+  def %(x: Int): Int = value % x
+  def %(x: Long): Long = value % x
+  def %(x: Float): Float = value % x
+  def %(x: Double): Double = value % x
+
+}

--- a/scalalib/overrides/scala/runtime/BoxesRunTime.scala
+++ b/scalalib/overrides/scala/runtime/BoxesRunTime.scala
@@ -3,14 +3,6 @@ package scala.runtime
 import scala.math.ScalaNumber
 
 object BoxesRunTime {
-  def boxToCharacter(c: Char): java.lang.Character =
-    java.lang.Character.valueOf(c)
-
-  @inline
-  def unboxToChar(c: Object): Char =
-    if (c eq null) 0
-    else c.asInstanceOf[java.lang.Character].charValue()
-
   def equals(x: Object, y: Object): Boolean =
     if (x eq y) true
     else equals2(x, y)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
@@ -260,7 +260,7 @@ class JSExportStaticTest {
 
     assertEquals('\0',
         JSExportStaticTest.StaticExportFields.uninitializedVarChar)
-    assertEquals(null, statics.uninitializedVarChar)
+    assertEquals('\0', statics.uninitializedVarChar)
   }
 
   @Test def field_also_exists_in_member(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/CharTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/CharTest.scala
@@ -35,4 +35,25 @@ class CharTest {
     // note: expected values are constant-folded by the compiler on the JVM
     test(Char.MaxValue, Char.MaxValue, Char.MaxValue * Char.MaxValue)
   }
+
+  @Test
+  def do_not_box_several_times_in_a_block(): Unit = {
+    @noinline def test(x: Any): Unit =
+      assertEquals('A', x)
+
+    test({
+      test('A')
+      'A'
+    }: Char)
+  }
+
+  @Test
+  def do_not_box_several_times_in_an_if(): Unit = {
+    @noinline def test(x: Any): Unit =
+      assertEquals('A', x)
+
+    @noinline def cond: Boolean = true
+
+    test((if (cond) 'A' else 'B'): Char)
+  }
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
@@ -534,17 +534,10 @@ private final class Analyzer(config: CommonPhaseConfig,
       assert(this.isScalaClass,
           s"Cannot create reflective proxy in non-Scala class $this")
 
-      val returnsChar = targetName.endsWith("__C")
       val syntheticInfo = makeSyntheticMethodInfo(
           encodedName = proxyName,
           methodsCalled = Map(
-              this.encodedName -> List(targetName)),
-          methodsCalledStatically = (
-              if (returnsChar) Map(BoxedCharacterClass -> List("init___C"))
-              else Map.empty),
-          instantiatedClasses = (
-              if (returnsChar) List(BoxedCharacterClass)
-              else Nil))
+              this.encodedName -> List(targetName)))
       val m = new MethodInfo(this, syntheticInfo)
       m.syntheticKind = MethodSyntheticKind.ReflectiveProxy(targetName)
       methodInfos += proxyName -> m

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
@@ -186,6 +186,7 @@ object Infos {
         case AnyType        => addMethodCalled(ObjectClass, method)
         case UndefType      => addMethodCalled(BoxedUnitClass, method)
         case BooleanType    => addMethodCalled(BoxedBooleanClass, method)
+        case CharType       => addMethodCalled(BoxedCharacterClass, method)
         case ByteType       => addMethodCalled(BoxedByteClass, method)
         case ShortType      => addMethodCalled(BoxedShortClass, method)
         case IntType        => addMethodCalled(BoxedIntegerClass, method)
@@ -198,7 +199,7 @@ object Infos {
         case NullType | NothingType =>
           // Nothing to do
 
-        case NoType | CharType | RecordType(_) =>
+        case NoType | RecordType(_) =>
           throw new IllegalArgumentException(
               s"Illegal receiver type: $receiverTpe")
       }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -108,23 +108,25 @@ private[emitter] final class JSGen(val semantics: Semantics,
         if (HijackedBoxedClasses.contains(className)) {
           if (test) {
             className match {
-              case BoxedUnitClass    => expr === Undefined()
-              case BoxedBooleanClass => typeof(expr) === "boolean"
-              case BoxedByteClass    => genCallHelper("isByte", expr)
-              case BoxedShortClass   => genCallHelper("isShort", expr)
-              case BoxedIntegerClass => genCallHelper("isInt", expr)
-              case BoxedFloatClass   => genCallHelper("isFloat", expr)
-              case BoxedDoubleClass  => typeof(expr) === "number"
+              case BoxedUnitClass      => expr === Undefined()
+              case BoxedBooleanClass   => typeof(expr) === "boolean"
+              case BoxedCharacterClass => genCallHelper("isChar", expr)
+              case BoxedByteClass      => genCallHelper("isByte", expr)
+              case BoxedShortClass     => genCallHelper("isShort", expr)
+              case BoxedIntegerClass   => genCallHelper("isInt", expr)
+              case BoxedFloatClass     => genCallHelper("isFloat", expr)
+              case BoxedDoubleClass    => typeof(expr) === "number"
             }
           } else {
             className match {
-              case BoxedUnitClass    => genCallHelper("asUnit", expr)
-              case BoxedBooleanClass => genCallHelper("asBoolean", expr)
-              case BoxedByteClass    => genCallHelper("asByte", expr)
-              case BoxedShortClass   => genCallHelper("asShort", expr)
-              case BoxedIntegerClass => genCallHelper("asInt", expr)
-              case BoxedFloatClass   => genCallHelper("asFloat", expr)
-              case BoxedDoubleClass  => genCallHelper("asDouble", expr)
+              case BoxedUnitClass      => genCallHelper("asUnit", expr)
+              case BoxedBooleanClass   => genCallHelper("asBoolean", expr)
+              case BoxedCharacterClass => genCallHelper("asChar", expr)
+              case BoxedByteClass      => genCallHelper("asByte", expr)
+              case BoxedShortClass     => genCallHelper("asShort", expr)
+              case BoxedIntegerClass   => genCallHelper("asInt", expr)
+              case BoxedFloatClass     => genCallHelper("asFloat", expr)
+              case BoxedDoubleClass    => genCallHelper("asDouble", expr)
             }
           }
         } else {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
@@ -237,11 +237,7 @@ final class BaseLinker(config: CommonPhaseConfig) {
     val call = Apply(This()(currentClassType),
         targetIdent, params.map(_.ref))(targetMDef.resultType)
 
-    val body = if (targetName.endsWith("__C")) {
-      // A Char needs to be boxed
-      New(ClassType(Definitions.BoxedCharacterClass),
-          Ident("init___C"), List(call))
-    } else if (targetName.endsWith("__V")) {
+    val body = if (targetName.endsWith("__V")) {
       // Materialize an `undefined` result for void methods
       Block(call, Undefined())
     } else {


### PR DESCRIPTION
This brings `Char` on par with all the other primitive types as far as the IR is concerned. A primitive `char` (`CharType`) is a subtype of `j.l.Character`. This removes the complexity in the compiler and optimizer related to Chars being "special".

Instead, it is now the Emitter's responsibility to deal with Chars. Indeed, the JS representation of primitive `char`s is *not*, in fact, a subtype of the JS representation of `j.l.Character`s. The root cause being that the `toString()` representation is different. Therefore, now the Emitter auto-boxes primitive `char`s when used in a place where a non-`char` is expected.

This makes the Emitter a bit more complex, and definitely acutely aware of `char`'s. However, it allows the IR to be much cleaner, with no special primitive type that does not behave like the others.