### PR TITLE
Make testSuiteJVM/test pass on all system configurations.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1677,6 +1677,17 @@ object Build {
     settings = commonSettings ++ testSuiteCommonSettings(isJSTest = false) ++ Seq(
       name := "Scala.js test suite on JVM",
 
+      /* Scala.js always assumes en-US, UTF-8 and NL as line separator by
+       * default. Since some of our tests rely on these defaults (notably to
+       * test them), we have to force the same values on the JVM.
+       */
+      fork in Test := true,
+      javaOptions in Test ++= Seq(
+          "-Dfile.encoding=UTF-8",
+          "-Duser.country=US", "-Duser.language=en",
+          "-Dline.separator=\n"
+      ),
+
       libraryDependencies +=
         "com.novocode" % "junit-interface" % "0.11" % "test"
     )


### PR DESCRIPTION
This commit forces testSuiteJVM to use

* UTF-8 as default encoding
* en-US as default locale
* `\n` as line separator

This ensures that it succeeds on all system configurations, e.g., on Windows or on a system configured with a non-English default locale.

It is necessary because Scala.js ensures those defaults "by spec", and hence our test suite relies on these defaults, notably to test them.