### PR TITLE
Directly expose everything useful as public in `ScalaJSPlugin`.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -44,7 +44,8 @@ object ScalaJSPluginInternal {
   import ScalaJSPlugin.autoImport.{ModuleKind => _, _}
 
   /** The global Scala.js IR cache */
-  val globalIRCache: IRFileCache = new IRFileCache()
+  val globalIRCache: ScalaJSPlugin.globalIRCache.type =
+    ScalaJSPlugin.globalIRCache
 
   val scalaJSClearCacheStats = TaskKey[Unit]("scalaJSClearCacheStats",
       "Scala.js internal: Clear the global IR cache's statistics. Used to " +
@@ -54,25 +55,18 @@ object ScalaJSPluginInternal {
   val scalaJSEnsureUnforked = SettingKey[Boolean]("ensureUnforked",
       "Scala.js internal: Fails if fork is true.", KeyRanks.Invisible)
 
-  /** Dummy setting to persist a Scala.js linker. */
-  val scalaJSLinker = SettingKey[ClearableLinker]("scalaJSLinker",
-      "Scala.js internal: Setting to persist a linker", KeyRanks.Invisible)
+  val scalaJSLinker: SettingKey[ClearableLinker] =
+    ScalaJSPlugin.autoImport.scalaJSLinker
 
-  /** A tag to indicate that a task is using the value of [[scalaJSLinker]]
-   *
-   *  This setting's value should always be retrieved from the same scope than
-   *  [[scalaJSLinker]] was retrieved from.
-   */
-  val usesScalaJSLinkerTag = SettingKey[Tags.Tag]("usesScalaJSLinkerTag",
-      "Scala.js internal: Tag to indicate that a task uses the link or " +
-      "linkUnit method of the value of scalaJSLinker", KeyRanks.Invisible)
+  val usesScalaJSLinkerTag: SettingKey[Tags.Tag] =
+    ScalaJSPlugin.autoImport.usesScalaJSLinkerTag
 
   val scalaJSIRCacheHolder = SettingKey[globalIRCache.Cache]("scalaJSIRCacheHolder",
       "Scala.js internal: Setting to persist a cache. Do NOT use this directly. " +
       "Use scalaJSIRCache instead.", KeyRanks.Invisible)
 
-  val scalaJSIRCache = TaskKey[globalIRCache.Cache]("scalaJSIRCache",
-      "Scala.js internal: Task to access a cache.", KeyRanks.Invisible)
+  val scalaJSIRCache: TaskKey[globalIRCache.Cache] =
+    ScalaJSPlugin.autoImport.scalaJSIRCache
 
   /** Non-deprecated alias of `scalaJSRequestsDOM` for internal use. */
   private[sbtplugin] val scalaJSRequestsDOMInternal = TaskKey[Boolean](
@@ -92,9 +86,8 @@ object ScalaJSPluginInternal {
   val scalaJSRequestsDOM = scalaJSRequestsDOMInternal
 
   /** All .sjsir files on the fullClasspath, used by scalajsp. */
-  val sjsirFilesOnClasspath = TaskKey[Seq[String]]("sjsirFilesOnClasspath",
-      "All .sjsir files on the fullClasspath, used by scalajsp",
-      KeyRanks.Invisible)
+  val sjsirFilesOnClasspath: TaskKey[Seq[String]] =
+    ScalaJSPlugin.autoImport.sjsirFilesOnClasspath
 
   /** Internal task to map discovered main classes to whether they are in the
    *  "new" style (true, standard main method) or the "old" style (false,
@@ -110,14 +103,11 @@ object ScalaJSPluginInternal {
       "An identifier for the module which contains the exports of Scala.js",
       KeyRanks.Invisible)
 
-  val scalaJSSourceFiles = AttributeKey[Seq[File]]("scalaJSSourceFiles",
-      "Files used to compute this value (can be used in FileFunctions later).",
-      KeyRanks.Invisible)
+  val scalaJSSourceFiles: AttributeKey[Seq[File]] =
+    ScalaJSPlugin.autoImport.scalaJSSourceFiles
 
-  val stageKeys: Map[Stage, TaskKey[Attributed[File]]] = Map(
-    Stage.FastOpt -> fastOptJS,
-    Stage.FullOpt -> fullOptJS
-  )
+  val stageKeys: Map[Stage, TaskKey[Attributed[File]]] =
+    ScalaJSPlugin.stageKeys
 
   /** A JS expression that detects the global scope just like Scala.js */
   val jsGlobalExpr: String = {
@@ -125,9 +115,8 @@ object ScalaJSPluginInternal {
          global["Object"] === Object) ? global : this)"""
   }
 
-  def logIRCacheStats(logger: Logger): Unit = {
-    logger.debug("Global IR cache stats: " + globalIRCache.stats.logLine)
-  }
+  def logIRCacheStats(logger: Logger): Unit =
+    ScalaJSPlugin.logIRCacheStats(logger)
 
   /** Patches the IncOptions so that .sjsir files are pruned as needed. */
   def scalaJSPatchIncOptions(incOptions: IncOptions): IncOptions =


### PR DESCRIPTION
By "useful", we mean everything that is still public in `ScalaJSPluginInternal` in Scala.js 1.x. Exposing them directly in `ScalaJSPlugin` will allow us to not expose `ScalaJSPluginInternal` at all in Scala.js 1.x anymore.

There are two exceptions:
* the duo `scalaJSClearCacheStats` and `scalaJSIRCacheHolder`, because we still hope to be able to remove them (see #2171)
* `scalaJSPatchIncOptions`, which we'll silently not expose in 1.x anymore (we can reintroduce it later if asked for)