### PR TITLE
[no-master] Fix #3102: Provide a shim for JSDependenciesPlugin.

### DIFF
--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -170,6 +170,7 @@ lazy val multiTestJVM = multiTest.jvm
 lazy val jsDependenciesTest = withRegretionTestForIssue2243(
   project.settings(versionSettings: _*).
   enablePlugins(ScalaJSPlugin).
+  enablePlugins(JSDependenciesPlugin).
   settings(
     jsDependencies ++= Seq(
         "org.webjars" % "historyjs" % "1.8.0" / "uncompressed/history.js",

--- a/sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
@@ -1,0 +1,32 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.jsdependencies.sbtplugin
+
+import sbt._
+
+import org.scalajs.sbtplugin.ScalaJSPlugin
+
+/** Shim for [[https://github.com/scala-js/jsdependencies sbt-jsdependencies]]
+ *  in Scala.js 0.6.x.
+ *
+ *  This sbt plugin is empty. It only serves as a source-compatible shim to
+ *  be able to cross-compile builds across `sbt-scalajs` 0.6.x and
+ *  `sbt-jsdependencies` 1.x.
+ */
+object JSDependenciesPlugin extends AutoPlugin {
+  override def requires: Plugins = ScalaJSPlugin
+
+  object autoImport
+
+  lazy val configSettings: Seq[Setting[_]] = Nil
+
+  lazy val compileSettings: Seq[Setting[_]] = Nil
+
+  lazy val testSettings: Seq[Setting[_]] = Nil
+}


### PR DESCRIPTION
This will make it easier to write builds cross-compiling against sbt-scalajs 0.6.x and sbt-jsdependencies 1.x.