### PR TITLE
Fix #3107: Make Closeable extend AutoCloseable.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/AutoCloseable.scala
+++ b/javalanglib/src/main/scala/java/lang/AutoCloseable.scala
@@ -1,5 +1,0 @@
-package java.lang
-
-trait AutoCloseable {
-  def close(): Unit
-}

--- a/javalib/src/main/scala/java/io/Closeable.scala
+++ b/javalib/src/main/scala/java/io/Closeable.scala
@@ -1,6 +1,5 @@
 package java.io
 
-/** Note that Closeable doesn't extend AutoCloseable for Java6 compat */
-trait Closeable {
+trait Closeable extends AutoCloseable {
   def close(): Unit
 }

--- a/javalib/src/main/scala/java/lang/AutoCloseable.scala
+++ b/javalib/src/main/scala/java/lang/AutoCloseable.scala
@@ -1,0 +1,11 @@
+package java.lang
+
+/* Even though this trait belongs to the java.lang package, we compile it as
+ * part of javalib instead of javalanglib, so that classes and interfaces in
+ * the javalib can inherit from AutoCloseable, even when we compile with JDK 6.
+ * It turns out that no class in java.lang needs to inherit from this trait,
+ * fortunately.
+ */
+trait AutoCloseable {
+  def close(): Unit
+}

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
@@ -1,0 +1,41 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.javalib.io
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.io.Closeable
+
+class AutoCloseableTest {
+  import AutoCloseableTest._
+
+  private def close(x: AutoCloseable): Unit = x.close()
+
+  @Test
+  def closeableExtendsAutoCloseable(): Unit = {
+    val x = new SomeCloseable
+    assertFalse(x.closed)
+    close(x)
+    assertTrue(x.closed)
+  }
+
+  @Test
+  def byteArrayOutputStreamIsAnAutoCloseable_issue_3107(): Unit = {
+    val x = new java.io.ByteArrayOutputStream
+    close(x)
+  }
+}
+
+object AutoCloseableTest {
+  class SomeCloseable extends Closeable {
+    var closed: Boolean = false
+
+    def close(): Unit = closed = true
+  }
+}


### PR DESCRIPTION
Because `AutoCloseable` does not exist on JDK6, we have to move the definition of `java.lang.AutoCloseable` from the javalanglib to the javalib. It so happens that no class or trait in the javalanglib needs to extend `AutoCloseable`, so we're fine.