### PR TITLE
Do It Ourselves publishing to Bintray; remove bintray-sbt.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -312,23 +312,6 @@ object Build {
       }
   )
 
-  private def publishToScalaJSRepoSettings = Seq(
-      publishTo := {
-        Seq("PUBLISH_USER", "PUBLISH_PASS").map(Properties.envOrNone) match {
-          case Seq(Some(user), Some(pass)) =>
-            val snapshotsOrReleases =
-              if (scalaJSIsSnapshotVersion) "snapshots" else "releases"
-            Some(Resolver.sftp(
-                s"scala-js-$snapshotsOrReleases",
-                "repo.scala-js.org",
-                s"/home/scalajsrepo/www/repo/$snapshotsOrReleases")(
-                Resolver.ivyStylePatterns) as (user, pass))
-          case _ =>
-            None
-        }
-      }
-  )
-
   private def publishToBintraySettings = (
       bintrayPublishSettings
   ) ++ Seq(
@@ -337,10 +320,7 @@ object Build {
   )
 
   val publishIvySettings = (
-      if (Properties.envOrNone("PUBLISH_TO_BINTRAY") == Some("true"))
-        publishToBintraySettings
-      else
-        publishToScalaJSRepoSettings
+      publishToBintraySettings
   ) ++ Seq(
       publishMavenStyle := false
   )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,9 +3,6 @@ import Keys._
 
 import scala.annotation.tailrec
 
-import bintray.Plugin.bintrayPublishSettings
-import bintray.Keys.{repository, bintrayOrganization, bintray}
-
 import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
 
 import java.io.{
@@ -50,6 +47,9 @@ object Build {
 
   val isGeneratingEclipse =
     Properties.envOrElse("GENERATING_ECLIPSE", "false").toBoolean
+
+  val bintrayProjectName = settingKey[String](
+      "Project name on Bintray")
 
   val fetchScalaSource = taskKey[File](
     "Fetches the scala source for the current scala version")
@@ -312,11 +312,19 @@ object Build {
       }
   )
 
-  private def publishToBintraySettings = (
-      bintrayPublishSettings
-  ) ++ Seq(
-      repository in bintray := "scala-js-releases",
-      bintrayOrganization in bintray := Some("scala-js")
+  private def publishToBintraySettings = Seq(
+      publishTo := {
+        val proj = bintrayProjectName.value
+        val ver = version.value
+        if (isSnapshot.value) {
+          None // Bintray does not support snapshots
+        } else {
+          val url = new java.net.URL(
+              s"https://api.bintray.com/content/scala-js/scala-js-releases/$proj/$ver")
+          val patterns = Resolver.ivyStylePatterns
+          Some(Resolver.url("bintray", url)(patterns))
+        }
+      }
   )
 
   val publishIvySettings = (
@@ -772,7 +780,7 @@ object Build {
       ) ++ Seq(
           name := "Scala.js sbt plugin",
           normalizedName := "sbt-scalajs",
-          name in bintray := "sbt-scalajs-plugin", // "sbt-scalajs" was taken
+          bintrayProjectName := "sbt-scalajs-plugin", // "sbt-scalajs" was taken
           sbtPlugin := true,
           scalaBinaryVersion :=
             CrossVersion.binaryScalaVersion(scalaVersion.value),

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,5 +1,3 @@
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.2")
-
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,7 +1,6 @@
 #! /bin/sh
 
 if [ $# -eq 1 -a "$1" = "-x" ]; then
-    export PUBLISH_TO_BINTRAY=true
     CMD="sbt"
 else
     echo "Showing commands that would be executed. Use -x to run."


### PR DESCRIPTION
Since we're not quite happy with the current state of bintray-sbt (see sbt/sbt-bintray#130), this commit
gets rid of it. Instead, we configure publishing to Bintray by hand. This turns out to be only slightly more complex than configuring Sonatype.

The new behavior will not automatically *release* the newly published files. Instead, a manual intervention in the Bintray Web UI will be necessary. This actually brings our Bintray publishing more in line with Sonatype, so that's also a win.