### PR TITLE
FF ONLY Merge 0.6.x into master, September 1

### DIFF
--- a/javalanglib/src/main/scala/java/lang/AutoCloseable.scala
+++ b/javalanglib/src/main/scala/java/lang/AutoCloseable.scala
@@ -1,5 +1,0 @@
-package java.lang
-
-trait AutoCloseable {
-  def close(): Unit
-}

--- a/javalib/src/main/scala/java/io/Closeable.scala
+++ b/javalib/src/main/scala/java/io/Closeable.scala
@@ -1,6 +1,5 @@
 package java.io
 
-/** Note that Closeable doesn't extend AutoCloseable for Java6 compat */
-trait Closeable {
+trait Closeable extends AutoCloseable {
   def close(): Unit
 }

--- a/javalib/src/main/scala/java/lang/AutoCloseable.scala
+++ b/javalib/src/main/scala/java/lang/AutoCloseable.scala
@@ -1,0 +1,11 @@
+package java.lang
+
+/* Even though this trait belongs to the java.lang package, we compile it as
+ * part of javalib instead of javalanglib, so that classes and interfaces in
+ * the javalib can inherit from AutoCloseable, even when we compile with JDK 6.
+ * It turns out that no class in java.lang needs to inherit from this trait,
+ * fortunately.
+ */
+trait AutoCloseable {
+  def close(): Unit
+}

--- a/javalib/src/main/scala/java/util/SplittableRandom.scala
+++ b/javalib/src/main/scala/java/util/SplittableRandom.scala
@@ -1,0 +1,120 @@
+package java.util
+
+/*
+ * This is a clean room implementation derived from the original paper
+ * and Java implementation mentioned there:
+ *
+ * Fast Splittable Pseudorandom Number Generators
+ * by Guy L. Steele Jr., Doug Lea, Christine H. Flood
+ * http://gee.cs.oswego.edu/dl/papers/oopsla14.pdf
+ *
+ */
+private object SplittableRandom {
+
+  private final val DoubleULP = 1.0 / (1L << 53)
+  private final val GoldenGamma = 0x9e3779b97f4a7c15L
+
+  private var defaultGen: Long = new Random().nextLong()
+
+  private def nextDefaultGen(): Long = {
+    val s = defaultGen
+    defaultGen = s + (2 * GoldenGamma)
+    s
+  }
+
+  // This function implements the original MurmurHash 3 finalizer
+  private final def mix64ForGamma(z: Long): Long = {
+    val z1 = (z ^ (z >>> 33)) * 0xff51afd7ed558ccdL
+    val z2 = (z1 ^ (z1 >>> 33)) * 0xc4ceb9fe1a85ec53L
+    z2 ^ (z2 >>> 33)
+  }
+
+  /*
+   * This function implements David Stafford's variant 4,
+   * while the paper version uses the original MurmurHash3 finalizer
+   * reference:
+   * http://zimbry.blogspot.pt/2011/09/better-bit-mixing-improving-on.html
+   */
+  private final def mix32(z: Long): Int = {
+    val z1 = (z ^ (z >>> 33)) * 0x62a9d9ed799705f5L
+    val z2 = (z1 ^ (z1 >>> 28)) * 0xcb24d0a5c88c35b3L
+    (z2 >>> 32).toInt
+  }
+
+  /*
+   * This function implements Stafford's variant 13,
+   * whereas the paper uses the original MurmurHash3 finalizer
+   */
+  private final def mix64(z: Long): Long = {
+    val z1 = (z ^ (z >>> 30)) * 0xbf58476d1ce4e5b9L
+    val z2 = (z1 ^ (z1 >>> 27)) * 0x94d049bb133111ebL
+    z2 ^ (z2 >>> 31)
+  }
+
+  private final def mixGamma(z: Long): Long = {
+    val z1 = mix64ForGamma(z) | 1L
+    val n = java.lang.Long.bitCount(z1 ^ (z1 >>> 1))
+    /* Reference implementation is wrong since we can read in the paper:
+     *
+     * ... Therefore we require that the number of such
+     * pairs, as computed by Long.bitCount(z ^ (z >>> 1)),
+     * exceed 24; if it does not, then the candidate z is replaced by
+     * the XOR of z and 0xaaaaaaaaaaaaaaaaL ...
+     * ... so the new value necessarily has more than 24 bit pairs whose bits differ
+     */
+    if (n <= 24) z1 ^ 0xaaaaaaaaaaaaaaaaL
+    else z1
+  }
+
+}
+
+final class SplittableRandom private (private var seed: Long, gamma: Long) {
+  import SplittableRandom._
+
+  def this(seed: Long) = {
+    this(seed, SplittableRandom.GoldenGamma)
+  }
+
+  private def this(ll: (Long, Long)) = this(ll._1, ll._2)
+
+  def this() = {
+    this({
+      val s = SplittableRandom.nextDefaultGen()
+
+      (SplittableRandom.mix64(s),
+          SplittableRandom.mixGamma(s + SplittableRandom.GoldenGamma))
+    })
+  }
+
+  def split(): SplittableRandom =
+    new SplittableRandom(mix64(nextSeed()), mixGamma(nextSeed()))
+
+  private def nextSeed(): Long = {
+    seed += gamma
+    seed
+  }
+
+  def nextInt(): Int = mix32(nextSeed())
+
+  //def nextInt(bound: Int): Int
+
+  //def nextInt(origin: Int, bound: Int): Int
+
+  def nextLong(): Long = mix64(nextSeed())
+
+  //def nextLong(bound: Long): Long
+
+  //def nextLong(origin: Long, bound: Long): Long
+
+  def nextDouble(): Double =
+    (nextLong() >>> 11).toDouble * DoubleULP
+
+  //def nextDouble(bound: Double): Double
+
+  //def nextDouble(origin: Double, bound: Double): Double
+
+  // this should be properly tested
+  // looks to work but just by chance maybe
+  def nextBoolean(): Boolean = nextInt < 0
+
+}

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -24,12 +24,6 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
-      /* RuntimeLong lost its `with java.io.Serializable`, but that is not a
-       * problem because it also extends `java.lang.Number`, which itself
-       * implements `java.io.Serializable` anyway.
-       */
-      ProblemFilters.exclude[MissingTypesProblem](
-          "scala.scalajs.runtime.RuntimeLong")
   )
 
   val TestInterface = Seq(

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,15 +1,8 @@
-resolvers += Resolver.url(
-    "bintray-sbt-plugin-releases",
-    url("http://dl.bintray.com/content/sbt/sbt-plugin-releases"))(
-    Resolver.ivyStylePatterns)
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 
-addSbtPlugin("me.lessis" % "bintray-sbt" % "0.1.2")
+addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.4")
-
-addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.13")
-
-addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "0.8.0")
+addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.scala-native" % "sbt-crossproject" % "0.2.1")
 

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -1,7 +1,6 @@
 #! /bin/sh
 
 if [ $# -eq 1 -a "$1" = "-x" ]; then
-    export PUBLISH_TO_BINTRAY=true
     CMD="sbt"
 else
     echo "Showing commands that would be executed. Use -x to run."

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
@@ -1,0 +1,41 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.javalib.io
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.io.Closeable
+
+class AutoCloseableTest {
+  import AutoCloseableTest._
+
+  private def close(x: AutoCloseable): Unit = x.close()
+
+  @Test
+  def closeableExtendsAutoCloseable(): Unit = {
+    val x = new SomeCloseable
+    assertFalse(x.closed)
+    close(x)
+    assertTrue(x.closed)
+  }
+
+  @Test
+  def byteArrayOutputStreamIsAnAutoCloseable_issue_3107(): Unit = {
+    val x = new java.io.ByteArrayOutputStream
+    close(x)
+  }
+}
+
+object AutoCloseableTest {
+  class SomeCloseable extends Closeable {
+    var closed: Boolean = false
+
+    def close(): Unit = closed = true
+  }
+}

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/SplittableRandom.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/SplittableRandom.scala
@@ -1,0 +1,157 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.javalib.util
+
+import org.junit.Assert._
+import org.junit.Test
+
+import java.util.SplittableRandom
+
+import org.scalajs.testsuite.utils.AssertThrows._
+
+class SplittableRandomTest {
+
+  @Test def should_correctly_implement_nextLong(): Unit = {
+    val sr1 = new SplittableRandom(205620432625028L)
+    assertEquals(-546649510716590878L, sr1.nextLong())
+    assertEquals(5574037117696891406L, sr1.nextLong())
+    assertEquals(-2877648745898596966L, sr1.nextLong())
+    assertEquals(5734720902145206190L, sr1.nextLong())
+    assertEquals(1684781725002208217L, sr1.nextLong())
+    assertEquals(687902890032948154L, sr1.nextLong())
+    assertEquals(176280366443457561L, sr1.nextLong())
+    assertEquals(-2944062288620903198L, sr1.nextLong())
+    assertEquals(6872063775710978746L, sr1.nextLong())
+    assertEquals(-7374959378916621341L, sr1.nextLong())
+
+    val sr2 = new SplittableRandom(-7374959378916621341L)
+    assertEquals(3241340805431811560L, sr2.nextLong())
+    assertEquals(-2124831722811234979L, sr2.nextLong())
+    assertEquals(7339249063279462363L, sr2.nextLong())
+    assertEquals(1969867631102365324L, sr2.nextLong())
+    assertEquals(81632902222022867L, sr2.nextLong())
+    assertEquals(3451014011249622471L, sr2.nextLong())
+    assertEquals(-1727223780574897556L, sr2.nextLong())
+    assertEquals(-5128686556801302975L, sr2.nextLong())
+    assertEquals(-6412221907719417908L, sr2.nextLong())
+    assertEquals(-110482401893286265L, sr2.nextLong())
+  }
+
+  @Test def should_correctly_implement_nextInt(): Unit = {
+    val sr1 = new SplittableRandom(-84638)
+    assertEquals(962946964, sr1.nextInt())
+    assertEquals(1723227640, sr1.nextInt())
+    assertEquals(-621790539, sr1.nextInt())
+    assertEquals(-1848500421, sr1.nextInt())
+    assertEquals(-614898617, sr1.nextInt())
+    assertEquals(-628601850, sr1.nextInt())
+    assertEquals(-463597391, sr1.nextInt())
+    assertEquals(1874082924, sr1.nextInt())
+    assertEquals(-1206032701, sr1.nextInt())
+    assertEquals(1549874426, sr1.nextInt())
+
+    val sr2 = new SplittableRandom(1549874426)
+    assertEquals(-495782737, sr2.nextInt())
+    assertEquals(-1487672352, sr2.nextInt())
+    assertEquals(-538628223, sr2.nextInt())
+    assertEquals(1117712970, sr2.nextInt())
+    assertEquals(2081437683, sr2.nextInt())
+    assertEquals(2134440938, sr2.nextInt())
+    assertEquals(-2102672277, sr2.nextInt())
+    assertEquals(832521577, sr2.nextInt())
+    assertEquals(518494223, sr2.nextInt())
+    assertEquals(-42114979, sr2.nextInt())
+  }
+
+  @Test def should_correctly_implement_nextDouble(): Unit = {
+    val sr1 = new SplittableRandom(-45)
+    assertEquals(0.8229662358649753, sr1.nextDouble(), 0.0)
+    assertEquals(0.43324117570991283, sr1.nextDouble(), 0.0)
+    assertEquals(0.2639712712295723, sr1.nextDouble(), 0.0)
+    assertEquals(0.5576376282289696, sr1.nextDouble(), 0.0)
+    assertEquals(0.5505810186639037, sr1.nextDouble(), 0.0)
+    assertEquals(0.3944509738261206, sr1.nextDouble(), 0.0)
+    assertEquals(0.3108138671457821, sr1.nextDouble(), 0.0)
+    assertEquals(0.585951421265481, sr1.nextDouble(), 0.0)
+    assertEquals(0.2009547438834305, sr1.nextDouble(), 0.0)
+    assertEquals(0.8317691736686829, sr1.nextDouble(), 0.0)
+
+    val sr2 = new SplittableRandom(45)
+    assertEquals(0.9684135896502549, sr2.nextDouble(), 0.0)
+    assertEquals(0.9819686323309464, sr2.nextDouble(), 0.0)
+    assertEquals(0.5311927268453047, sr2.nextDouble(), 0.0)
+    assertEquals(0.8521356026917833, sr2.nextDouble(), 0.0)
+    assertEquals(0.01880601374789126, sr2.nextDouble(), 0.0)
+    assertEquals(0.37792881248018584, sr2.nextDouble(), 0.0)
+    assertEquals(0.7179744490511354, sr2.nextDouble(), 0.0)
+    assertEquals(0.3448879713662756, sr2.nextDouble(), 0.0)
+    assertEquals(0.023020123407108684, sr2.nextDouble(), 0.0)
+    assertEquals(0.6454709437764473, sr2.nextDouble(), 0.0)
+  }
+
+  @Test def should_correctly_implement_nextBoolean(): Unit = {
+    val sr1 = new SplittableRandom(4782934)
+    assertFalse(sr1.nextBoolean())
+    assertFalse(sr1.nextBoolean())
+    assertTrue(sr1.nextBoolean())
+    assertTrue(sr1.nextBoolean())
+    assertTrue(sr1.nextBoolean())
+    assertFalse(sr1.nextBoolean())
+    assertFalse(sr1.nextBoolean())
+    assertTrue(sr1.nextBoolean())
+    assertTrue(sr1.nextBoolean())
+    assertTrue(sr1.nextBoolean())
+
+    val sr2 = new SplittableRandom(-4782934)
+    assertFalse(sr2.nextBoolean())
+    assertFalse(sr2.nextBoolean())
+    assertTrue(sr2.nextBoolean())
+    assertTrue(sr2.nextBoolean())
+    assertTrue(sr2.nextBoolean())
+    assertFalse(sr2.nextBoolean())
+    assertFalse(sr2.nextBoolean())
+    assertTrue(sr2.nextBoolean())
+    assertTrue(sr2.nextBoolean())
+    assertTrue(sr2.nextBoolean())
+  }
+
+  @Test def should_correctly_implement_split(): Unit = {
+    val sr1 = new SplittableRandom(205620432625028L).split()
+    assertEquals(-2051870635339219700L, sr1.nextLong())
+    assertEquals(-4512002368431042276L, sr1.nextLong())
+
+    val sr2 = new SplittableRandom(-4512002368431042276L).split()
+    assertEquals(7607532382842316154L, sr2.nextLong())
+    assertEquals(-1011899051174066375L, sr2.nextLong())
+
+    val sr3 = new SplittableRandom(7607532382842316154L).split()
+    assertEquals(-1531465968943756660L, sr3.nextLong())
+    assertEquals(948449286892387518L, sr3.nextLong())
+
+    val sr4 = new SplittableRandom(948449286892387518L).split()
+    assertEquals(2486448889230464769L, sr4.nextLong())
+    assertEquals(4550542803092639410L, sr4.nextLong())
+
+    val sr5 = sr4.split()
+    assertEquals(8668601242423591169L, sr5.nextLong())
+    assertEquals(-986244092642826172L, sr5.nextLong())
+
+    val sr6 = sr4.split()
+    assertEquals(274792684182118046L, sr6.nextLong())
+    assertEquals(683259797650761389L, sr6.nextLong())
+
+    val sr7 = sr6.split()
+    assertEquals(1682793527903105269L, sr7.nextLong())
+    assertEquals(2140483520539013019L, sr7.nextLong())
+
+    val sr8 = sr6.split()
+    assertEquals(-7468768144124082123L, sr8.nextLong())
+    assertEquals(6163667569279435512L, sr8.nextLong())
+  }
+
+}


### PR DESCRIPTION
Motivation: after 0.6.20.
```
$ git checkout -b merge-0.6.x-into-master-september-1
Switched to a new branch 'merge-0.6.x-into-master-september-1'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* 9371fa9 (scalajs/0.6.x, origin/0.6.x, 0.6.x) Towards 0.6.21.
* 2fd375d (tag: v0.6.20) Version 0.6.20.
*   b9c7532 Merge pull request #3104 from andreaTP/splittableRandom
|\  
| * c395416 Implementation of SplittableRandom
|/  
*   708d0c3 Merge pull request #3114 from sjrd/sanitize-state-persistence-in-sbt-plugin
|\  
| * 6bbb4ee (origin/sanitize-state-persistence-in-sbt-plugin) Fix #2171: Sanitize state persistence in the sbt plugin.
| * 4486da6 Hide `globalIRCache` back inside `ScalaJSPluginInternal`.
|/  
*   7e799af Merge pull request #3113 from sjrd/get-rid-of-bintray-sbt
|\  
| * 23747d6 (origin/get-rid-of-bintray-sbt) Do It Ourselves publishing to Bintray; remove bintray-sbt.
| * fa5bccf Remove `publishToScalaJSRepoSettings`.
|/  
*   ef8b04c Merge pull request #3112 from sjrd/upgrade-sbt-plugins
|\  
| * b536865 (origin/upgrade-sbt-plugins) Upgrade to scalastyle-sbt-plugin 1.0.0.
| * 15cca37 Upgrade to sbt-mima-plugin 0.1.18.
| * 037d0ae Upgrade to sbt-assembly 0.14.5.
| * 826e889 Remove the bintray-sbt-plugin-releases resolver.
|/  
* efcbdd4 Merge pull request #3111 from sjrd/closeable-extends-autocloseable
* 670144b (origin/closeable-extends-autocloseable) Fix #3107: Make Closeable extend AutoCloseable.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging scripts/publish.sh
Auto-merging sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
CONFLICT (content): Merge conflict in sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
Auto-merging sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
CONFLICT (content): Merge conflict in sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
Auto-merging project/build.sbt
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging project/BinaryIncompatibilities.scala
Removing javalanglib/src/main/scala/java/lang/AutoCloseable.scala
Auto-merging ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
D  javalanglib/src/main/scala/java/lang/AutoCloseable.scala
M  javalib/src/main/scala/java/io/Closeable.scala
A  javalib/src/main/scala/java/lang/AutoCloseable.scala
A  javalib/src/main/scala/java/util/SplittableRandom.scala
M  project/BinaryIncompatibilities.scala
UU project/Build.scala
M  project/build.sbt
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
M  scripts/publish.sh
A  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
A  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/SplittableRandom.scala
```
[...] Resolve conflicts.
```
$ git diff -w > ../resolve-conflicts.diff
```
https://gist.github.com/sjrd/4fb843629b7acd1917b0e005576211c7
```
$ git add -u
```
```
$ git commit
[merge-0.6.x-into-master-september-1 5aa5ff4] Merge '0.6.x' into 'master'.
```
