### PR TITLE
Fix #3128: Avoid a binary incompatibility on JDK 7.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -260,7 +260,7 @@
   ]]></task>
 
   <task id="sbtplugin-test"><![CDATA[
-    setJavaVersion $java
+    setJavaVersion 1.8
     SBT_VER_OVERRIDE=$sbt_version_override
     # Publish Scala.js artifacts locally
     # Then go into standalone project and test
@@ -271,6 +271,7 @@
         ir/publishLocal tools/publishLocal jsEnvs/publishLocal \
         testAdapter/publishLocal sbtPlugin/publishLocal &&
     cd sbt-plugin-test &&
+    setJavaVersion $java &&
     if [ -n "$SBT_VER_OVERRIDE" ]; then echo "sbt.version=$SBT_VER_OVERRIDE" > ./project/build.properties; fi &&
     sbt noDOM/run noDOM/testHtmlFastOpt noDOM/testHtmlFullOpt \
         withDOM/run withDOM/testHtmlFastOpt withDOM/testHtmlFullOpt \

--- a/test-common/src/main/scala/org/scalajs/testcommon/RPCCore.scala
+++ b/test-common/src/main/scala/org/scalajs/testcommon/RPCCore.scala
@@ -151,8 +151,13 @@ private[scalajs] abstract class RPCCore {
 
   /** Close the communication channel. */
   def close(): Unit = {
+    /* Fix for #3128: explicitly upcast to java.util.Map so that the keySet()
+     * method is binary compatible on JDK7.
+     */
+    val pendingCallIDs = (pending: java.util.Map[Long, _]).keySet()
+
     for {
-      callID <- pending.keySet().asScala
+      callID <- pendingCallIDs.asScala
       failing <- Option(pending.remove(callID))
     } {
       failing.promise.failure(new IOException("Channel got closed"))


### PR DESCRIPTION
The method `java.util.concurrent.ConcurrentHashMap.keySet()` got a more precise result type in JDK 8. Since we build the distribution on JDK 8, the compiler links to the more precise signature, which then fails to link at run-time on a JDK 7. We work around the problem by an explicit upcast to `java.util.Map`, to force the compiler to resolve to the binary compatible bridge.