### PR TITLE
Fix #3125: Do not pretty-print '\u0007' as '\a'.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/Utils.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Utils.scala
@@ -16,7 +16,7 @@ import scala.annotation.switch
 
 object Utils {
 
-  private final val EscapeJSChars = "\\a\\b\\t\\n\\v\\f\\r\\\"\\\\"
+  private final val EscapeJSChars = "\\b\\t\\n\\v\\f\\r\\\"\\\\"
 
   /** Relativize target URI w.r.t. base URI */
   def relativize(base0: URI, trgt0: URI): URI = {
@@ -104,15 +104,15 @@ object Utils {
       // Print next non ASCII printable character
       if (i != end) {
         def escapeJSEncoded(c: Int): Unit = {
-          if (6 < c && c < 14) {
-            val i = 2 * (c - 7)
+          if (7 < c && c < 14) {
+            val i = 2 * (c - 8)
             out.append(EscapeJSChars, i, i + 2)
             writtenChars += 2
           } else if (c == 34) {
-            out.append(EscapeJSChars, 14, 16)
+            out.append(EscapeJSChars, 12, 14)
             writtenChars += 2
           } else if (c == 92) {
-            out.append(EscapeJSChars, 16, 18)
+            out.append(EscapeJSChars, 14, 16)
             writtenChars += 2
           } else {
             out.append(f"\\u$c%04x")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -52,6 +52,22 @@ class RegressionTest {
     assertEquals("65 8704 55349 56491 ", s)
   }
 
+  @Test def characterEscapes_issue_3125(): Unit = {
+    val str = {
+      // The space at the end is intended. It is 0x20.
+      "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000a" +
+      "\u000b\u000c\u000d\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015" +
+      "\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f "
+    }
+
+    for (i <- 0 until str.length)
+      assertEquals(i, str.charAt(i).toInt)
+
+    val strQuotes = "\"'"
+    assertEquals(34, strQuotes.charAt(0).toInt)
+    assertEquals(39, strQuotes.charAt(1).toInt)
+  }
+
   @Test def String_concatenation_with_null_issue_26(): Unit = {
     val x: Object = null
     assertEquals("nullcheck", x + "check")


### PR DESCRIPTION
Unlike in Java, '\a' is not a valid escape sequence in JavaScript.