### PR TITLE
[no-master] Fix #3135: Relativize source map URIs against the .js file.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -208,7 +208,7 @@ object ScalaJSPluginInternal {
          */
         val oldConfigRelSourceMapBase = {
           if ((relativeSourceMaps in key).value)
-            Some((artifactPath in key).value.getParentFile.toURI())
+            Some((artifactPath in key).value.toURI())
           else
             None
         }


### PR DESCRIPTION
Instead of the parent directory of the .js file. This solves the issue that the parent directory did not have a trailing `/` in some cases.