### PR TITLE
[no-master] Further reduce the pressure on PhantomJS in the test suite.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1610,9 +1610,13 @@ object Build {
           val sourceFiles = (sources in Test).value
           if ((jsEnv in Test).?.value.exists(isPhantomJS)) {
             sourceFiles.filter { f =>
-              !f.getAbsolutePath
-                .replace('\\', '/')
-                .contains("/org/scalajs/testsuite/javalib/math/")
+              val path = f.getAbsolutePath.replace('\\', '/')
+
+              {
+                !path.contains("/org/scalajs/testsuite/javalib/math/") &&
+                !path.contains("/org/scalajs/testsuite/niocharset/") &&
+                !path.contains("/src/test/require-")
+              }
             }
           } else {
             sourceFiles


### PR DESCRIPTION
Once again, we are forced to reduce the test suite on PhantomJS, as we initially did in 8166c6c782a13ea117c01b9d0761418671b69c9b.

This time, we remove the tests for charset encoders and decoders, as well as all tests that require specific versions of Scala or of the JDK. Those should also not be sensitive to their environment.