### PR TITLE
DO NOT MERGE Optimize the constructor of `RuntimeLong` with a hack.

### DIFF
--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
@@ -551,9 +551,6 @@ object RuntimeLong {
   /** The hi part of a (lo, hi) return value. */
   private[this] var hiReturn: Int = _
 
-  /** The instance of 0L, which is used by the `Emitter` in various places. */
-  val Zero = new RuntimeLong(0, 0)
-
   private def toString(lo: Int, hi: Int): String = {
     if (isInt32(lo, hi)) {
       lo.toString()

--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
@@ -39,9 +39,6 @@ final class RuntimeLong(val lo: Int, val hi: Int)
   import RuntimeLong._
   import Utils._
 
-  /** Constructs a Long from an Int. */
-  def this(value: Int) = this(value, value >> 31)
-
   // Universal equality
 
   @inline
@@ -595,6 +592,10 @@ object RuntimeLong {
       hi * TwoPow32 + lo.toUint
     }
   }
+
+  @inline
+  def fromInt(value: Int): RuntimeLong =
+    new RuntimeLong(value, value >> 31)
 
   @inline
   def fromDouble(value: Double): RuntimeLong = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
@@ -28,7 +28,7 @@ class RuntimeLongTest {
 
   // Short builders
   def lg(lo: Int, hi: Int): RuntimeLong = new RuntimeLong(lo, hi)
-  def lg(i: Int): RuntimeLong = new RuntimeLong(i)
+  def lg(i: Int): RuntimeLong = RuntimeLong.fromInt(i)
 
   // Common values
   val MaxVal = lg(0xffffffff, 0x7fffffff)

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -114,6 +114,9 @@ const $clz32 = Math["clz32"] || (function(i) {
 });
 //!endif
 
+// Cached instance of RuntimeLong for 0L
+let $L0;
+
 // identityHashCode support
 let $lastIDHash = 0; // last value attributed to an id hash code
 //!if outputMode == ECMAScript6
@@ -708,8 +711,7 @@ function $uI(value) {
   return $asInt(value) | 0;
 };
 function $uJ(value) {
-  return null === value ? $m_sjsr_RuntimeLong$().Zero$1
-                        : $as_sjsr_RuntimeLong(value);
+  return null === value ? $L0 : $as_sjsr_RuntimeLong(value);
 };
 function $uF(value) {
   /* Here, it is fine to use + instead of fround, because asFloat already
@@ -725,7 +727,7 @@ function $uC(value) {
   return null === value ? 0 : value.c;
 }
 function $uJ(value) {
-  return null === value ? $m_sjsr_RuntimeLong$().Zero$1 : value;
+  return null === value ? $L0 : value;
 };
 //!endif
 
@@ -860,10 +862,8 @@ initArray(
 
   // The zero for the Long runtime representation
   // is a special case here, since the class has not
-  // been defined yet, when this file is read
-  const componentZero = (componentZero0 == "longZero")
-    ? $m_sjsr_RuntimeLong$().Zero$1
-    : componentZero0;
+  // been defined yet when this constructor is called.
+  const componentZero = (componentZero0 == "longZero") ? $L0 : componentZero0;
 
 //!if outputMode != ECMAScript6
   /** @constructor */
@@ -1015,7 +1015,7 @@ $TypeData.prototype["getFakeInstance"] = function() {
            this === $d_jl_Double)
     return 0;
   else if (this === $d_jl_Long)
-    return $m_sjsr_RuntimeLong$().Zero$1;
+    return $L0;
   else if (this === $d_sr_BoxedUnit)
     return void 0;
   else

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -167,12 +167,10 @@ final class Emitter private (config: CommonPhaseConfig,
 
       // $L0 = new RuntimeLong(0, 0)
       builder.addJSTree({
-        import TreeDSL._
         implicit val pos = Position.NoPosition
         js.Assign(
             jsGen.envField("L0"),
-            js.Apply(
-                js.New(jsGen.encodeClassVar(LongImpl.RuntimeLongClass), Nil) DOT LongImpl.initFromParts,
+            js.New(jsGen.encodeClassVar(LongImpl.RuntimeLongClass),
                 List(js.IntLiteral(0), js.IntLiteral(0)))
         )
       })

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
@@ -165,6 +165,18 @@ final class Emitter private (config: CommonPhaseConfig,
       for (generatedClass <- generatedClasses)
         emitJSTrees(generatedClass.main)
 
+      // $L0 = new RuntimeLong(0, 0)
+      builder.addJSTree({
+        import TreeDSL._
+        implicit val pos = Position.NoPosition
+        js.Assign(
+            jsGen.envField("L0"),
+            js.Apply(
+                js.New(jsGen.encodeClassVar(LongImpl.RuntimeLongClass), Nil) DOT LongImpl.initFromParts,
+                List(js.IntLiteral(0), js.IntLiteral(0)))
+        )
+      })
+
       for (generatedClass <- generatedClasses)
         emitJSTrees(generatedClass.staticFields)
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -1955,7 +1955,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                 FloatToDouble =>
               newLhs
             case IntToLong =>
-              genNewLong(LongImpl.initFromInt, newLhs)
+              genLongModuleApply(LongImpl.fromInt, newLhs)
 
             // Narrowing conversions
             case IntToChar =>
@@ -2267,8 +2267,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           genLongZero()
         case LongLiteral(value) =>
           val (lo, hi) = LongImpl.extractParts(value)
-          genNewLong(LongImpl.initFromParts,
-              js.IntLiteral(lo), js.IntLiteral(hi))
+          js.New(encodeClassVar(LongImpl.RuntimeLongClass),
+              List(js.IntLiteral(lo), js.IntLiteral(hi)))
 
         case ClassOf(cls) =>
           js.Apply(js.DotSelect(genClassDataOf(cls), js.Ident("getClassOf")),
@@ -2408,14 +2408,6 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
 
     private def genFround(arg: js.Tree)(implicit pos: Position): js.Tree = {
       genCallHelper("fround", arg)
-    }
-
-    private def genNewLong(ctor: String, args: js.Tree*)(
-        implicit pos: Position): js.Tree = {
-      import TreeDSL._
-      js.Apply(
-          js.New(encodeClassVar(LongImpl.RuntimeLongClass), Nil) DOT ctor,
-          args.toList)
     }
 
     private def genLongMethodApply(receiver: js.Tree, methodName: String,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -50,9 +50,8 @@ private[emitter] final class JSGen(val semantics: Semantics,
     }
   }
 
-  def genLongZero()(implicit pos: Position): Tree = {
-    genLongModuleApply(LongImpl.Zero)
-  }
+  def genLongZero()(implicit pos: Position): Tree =
+    envField("L0")
 
   def genLongModuleApply(methodName: String, args: Tree*)(
       implicit pos: Position): Tree = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/LongImpl.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/LongImpl.scala
@@ -81,17 +81,17 @@ private[linker] object LongImpl {
   // Constructors
 
   final val initFromParts = "init___I__I"
-  final val initFromInt   = "init___I"
 
   val AllConstructors = Set(
-      initFromParts, initFromInt)
+      initFromParts)
 
   // Methods on the companion
 
+  final val fromInt    = "fromInt__I__sjsr_RuntimeLong"
   final val fromDouble = "fromDouble__D__sjsr_RuntimeLong"
 
   val AllModuleMethods = Set(
-      fromDouble)
+      fromInt, fromDouble)
 
   // Extract the parts to give to the initFromParts constructor
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/LongImpl.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/LongImpl.scala
@@ -90,10 +90,8 @@ private[linker] object LongImpl {
 
   final val fromDouble = "fromDouble__D__sjsr_RuntimeLong"
 
-  final val Zero = "Zero__sjsr_RuntimeLong"
-
   val AllModuleMethods = Set(
-      fromDouble, Zero)
+      fromDouble)
 
   // Extract the parts to give to the initFromParts constructor
 


### PR DESCRIPTION
We avoid generating the super constructor call and creating the fields with the zero of their types. This leaves only the content of the init method (which we know is inlined for RuntimeLong), which directly assigns `this.lo` and `this.hi`.

We can do this because the superclasses of RuntimeLong do not declare any fields (hence the super constructor call is unnecessary) and because the init method is known to "behave well" wrt. the initialization of its fields (which means there is no need to initialize them first to their zero).

This optimization brings a 17% improvement on the SHA-512 benchmark.

We cannot apply this trick in ECMAScript 2015, because calling the `super()` constructor is mandatory for non-root classes.