### PR TITLE
Fix #3148: Make our test suite pass on Node.js 8.

### DIFF
--- a/javalib/src/main/scala/java/util/Throwables.scala
+++ b/javalib/src/main/scala/java/util/Throwables.scala
@@ -42,16 +42,15 @@ class IllegalFormatCodePointException(private val c: Int) extends IllegalFormatE
   override def getMessage(): String = s"Code point = $c"
 }
 
-class IllegalFormatConversionException private(private val c: Char) extends IllegalFormatException {
-  private var arg: Class[_] = null
-  def this(c: Char, arg: Class[_]) = {
-    this(c)
-    if (arg == null)
-      throw new NullPointerException()
-    this.arg = arg
-  }
+class IllegalFormatConversionException(c: Char, arg: Class[_])
+    extends IllegalFormatException {
+
+  if (arg == null)
+    throw new NullPointerException()
+
   def getConversion(): Char = c
   def getArgumentClass(): Class[_] = arg
+
   override def getMessage(): String = s"$c != ${arg.getName()}"
 }
 

--- a/junit-runtime/src/main/scala/org/junit/internal/ArrayComparisonFailure.scala
+++ b/junit-runtime/src/main/scala/org/junit/internal/ArrayComparisonFailure.scala
@@ -5,24 +5,26 @@ package org.junit.internal
 
 object ArrayComparisonFailure
 
-class ArrayComparisonFailure(fMessage: String) extends AssertionError {
-  private var fIndices: List[Int] = Nil
+class ArrayComparisonFailure(message: String, cause: AssertionError, index: Int)
+    extends AssertionError(message, cause) {
 
-  def this(message: String, cause: AssertionError, index: Int) = {
-    this(message)
-    initCause(cause)
-    addDimension(index)
-  }
+  private var fIndices: List[Int] = index :: Nil
+
+  @deprecated("This constructor is not used and will be removed", "0.6.21")
+  def this(fMessage: String) =
+    this(fMessage, new AssertionError, 0)
 
   def addDimension(index: Int): Unit = {
     fIndices = index :: fIndices
   }
 
   override def getMessage(): String = {
-    val message = if (fMessage != null) fMessage else ""
-    val indices = fIndices.map(index => s"[$index]").mkString
+    val msg = if (message != null) message else ""
+    val indices =
+      if (fIndices == null) s"[$index]" // see #3148
+      else fIndices.map(index => s"[$index]").mkString
     val causeMessage = getCause.getMessage
-    s"${message}arrays first differed at element $indices; $causeMessage"
+    s"${msg}arrays first differed at element $indices; $causeMessage"
   }
 
   override def toString(): String = getMessage


### PR DESCRIPTION
This commit adapts two classes of exceptions, namely `j.u.IllegalFormatConversionException` and
`org.junit.internal.ArrayComparisonFailure`, so that their `toString()` does not crash if it is called before their respective constructors have finished executing.