### PR TITLE
Fix #3123: Avoid context switches in test receiver

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -17,7 +17,22 @@ object BinaryIncompatibilities {
   val SbtPlugin = Seq(
   )
 
-  val TestAdapter = Seq(
+  val TestCommon = Seq(
+      // private[scalajs], not an issue.
+      ProblemFilters.exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.testcommon.RPCCore.call"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "org.scalajs.testcommon.RPCCore.toFuture")
+  )
+
+  val TestAdapter = TestCommon ++ Seq(
+      // private, not an issue.
+      ProblemFilters.exclude[MissingClassProblem](
+          "org.scalajs.testadapter.ScalaJSRunner$"),
+      ProblemFilters.exclude[MissingClassProblem](
+          "org.scalajs.testadapter.ScalaJSRunner$RichFuture"),
+      ProblemFilters.exclude[MissingClassProblem](
+          "org.scalajs.testadapter.ScalaJSRunner$RichFuture$")
   )
 
   val CLI = Seq(
@@ -26,6 +41,6 @@ object BinaryIncompatibilities {
   val Library = Seq(
   )
 
-  val TestInterface = Seq(
+  val TestInterface = TestCommon ++ Seq(
   )
 }

--- a/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSTask.scala
+++ b/test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSTask.scala
@@ -12,7 +12,6 @@ package org.scalajs.testadapter
 import org.scalajs.jsenv._
 import org.scalajs.testcommon._
 
-import scala.concurrent.Await
 import scala.concurrent.duration.Duration
 import scala.collection.mutable
 import scala.util.Try
@@ -58,8 +57,7 @@ final class ScalaJSTask private[testadapter] (
       // Execute task. No (!) timeout.
       val req =
         new ExecuteRequest(taskInfo, loggers.map(_.ansiCodesSupported).toList)
-      val taskInfos = Await.result(
-          slave.call(JSSlaveEndpoints.execute)(req), Duration.Inf)
+      val taskInfos = slave.call(JSSlaveEndpoints.execute)(req).await()
 
       // Flush log buffer
       if (shouldBufferLog) {

--- a/test-common/src/test/scala/org/scalajs/testcommon/RPCCoreTest.scala
+++ b/test-common/src/test/scala/org/scalajs/testcommon/RPCCoreTest.scala
@@ -162,8 +162,9 @@ class RPCCoreTest {
 }
 
 object RPCCoreTest {
-  class TestRPC(otherThunk: => TestRPC) extends RPCCore {
+  class TestRPC(otherThunk: => TestRPC) extends RPCCore[Future] {
     private lazy val other = otherThunk
     protected def send(msg: String): Unit = other.handleMessage(msg)
+    protected def toFuture[T](p: Promise[T]): Future[T] = p.future
   }
 }

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/JSRPC.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/JSRPC.scala
@@ -3,15 +3,18 @@ package org.scalajs.testinterface.internal
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
+import scala.concurrent.{Future, Promise}
 import scala.concurrent.duration._
 
 import org.scalajs.testcommon.RPCCore
 
 /** JS RPC Core. Uses `scalajsCom`. */
-private[internal] final object JSRPC extends RPCCore {
+private[internal] final object JSRPC extends RPCCore[Future] {
   Com.init(handleMessage _)
 
   override protected def send(msg: String): Unit = Com.send(msg)
+
+  override protected def toFuture[T](p: Promise[T]): Future[T] = p.future
 
   override def close(): Unit = {
     super.close()


### PR DESCRIPTION
The new RPC interface for the test
adapter (bf2c835982198310b2793204e6c6c194e624772d)
has introduced a performance regression while running tests
(see #3123). This regression was caused by threads overly context
switching (due to the blocking interface of sbt.testing._).

We fix the performance regression by introducing our own future type
that can *only* be awaited. However, instead of simply waiting, it
"helps" the underlying com to perform I/O. As a result, the thread need
not context switch anymore: It will perform I/O until the requested
message has been received.

This commit introduces a little caveat however: The JVM side cannot
arbitrarily receive callbacks anymore. In fact, it can only receive
callbacks while a call is pending. Since all current usages of callbacks
are during pending calls (and will likely be in the future), this is not
a problem.

As a side-effect, this also fixes #3143, by not having timeouts at all
anymore.