### PR TITLE
Fix #3154: Avoid calling `AssertionError(String, Throwable)`.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Throwables.scala
+++ b/javalanglib/src/main/scala/java/lang/Throwables.scala
@@ -128,15 +128,27 @@ class AbstractMethodError(s: String) extends IncompatibleClassChangeError(s) {
   def this() = this(null)
 }
 
-class AssertionError private (s: String) extends Error(s) {
-  def this() = this(null)
-  def this(o: Object) = this(o.toString)
-  def this(b: scala.Boolean) = this(b.toString)
-  def this(c: scala.Char) = this(c.toString)
-  def this(i: scala.Int) = this(i.toString)
-  def this(l: scala.Long) = this(l.toString)
-  def this(f: scala.Float) = this(f.toString)
-  def this(d: scala.Double) = this(d.toString)
+class AssertionError(message: String, cause: Throwable)
+    extends Error(message, cause) {
+
+  def this() = this(null, null)
+
+  def this(detailMessage: Object) = {
+    this(
+        String.valueOf(detailMessage),
+        detailMessage match {
+          case cause: Throwable => cause
+          case _                => null
+        }
+    )
+  }
+
+  def this(detailMessage: scala.Boolean) = this(String.valueOf(detailMessage), null)
+  def this(detailMessage: scala.Char) = this(String.valueOf(detailMessage), null)
+  def this(detailMessage: scala.Int) = this(String.valueOf(detailMessage), null)
+  def this(detailMessage: scala.Long) = this(String.valueOf(detailMessage), null)
+  def this(detailMessage: scala.Float) = this(String.valueOf(detailMessage), null)
+  def this(detailMessage: scala.Double) = this(String.valueOf(detailMessage), null)
 }
 
 class BootstrapMethodError(s: String, e: Throwable) extends LinkageError(s) {

--- a/junit-runtime/src/main/scala/org/junit/internal/ArrayComparisonFailure.scala
+++ b/junit-runtime/src/main/scala/org/junit/internal/ArrayComparisonFailure.scala
@@ -5,8 +5,14 @@ package org.junit.internal
 
 object ArrayComparisonFailure
 
+/* Attention: AssertionError does not have a (String, Throwable) constructor
+ * in JDK 6. If we try to call that one, compilation *succeeds* because of
+ * auto-boxing, but it does not do the right thing. See #3154.
+ */
 class ArrayComparisonFailure(message: String, cause: AssertionError, index: Int)
-    extends AssertionError(message, cause) {
+    extends AssertionError(message) {
+
+  initCause(cause)
 
   private var fIndices: List[Int] = index :: Nil
 
@@ -23,7 +29,7 @@ class ArrayComparisonFailure(message: String, cause: AssertionError, index: Int)
     val indices =
       if (fIndices == null) s"[$index]" // see #3148
       else fIndices.map(index => s"[$index]").mkString
-    val causeMessage = getCause.getMessage
+    val causeMessage = cause.getMessage // do not use getCause(), see #3148
     s"${msg}arrays first differed at element $indices; $causeMessage"
   }
 

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/ThrowablesTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/ThrowablesTestOnJDK7.scala
@@ -47,6 +47,12 @@ class ThrowablesTestOnJDK7 {
     test1(new ReflectiveOperationException(_))
     test2(new ReflectiveOperationException(_))
     test3(new ReflectiveOperationException(_, _))
+  }
 
+  @Test def assertionErrorCtorWithStringThrowable(): Unit = {
+    val th = new RuntimeException("kaboom")
+    val e = new AssertionError("boom", th)
+    assertEquals("boom", e.getMessage)
+    assertSame(th, e.getCause)
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
@@ -143,4 +143,30 @@ class ThrowablesTest {
     test2(new ExecutionException(_))
     test3(new ExecutionException(_, _))
   }
+
+  @Test def assertionErrorsPeculiarConstructors(): Unit = {
+    def assertMessageNoCause(expectedMessage: String, e: AssertionError): Unit = {
+      assertEquals(expectedMessage, e.getMessage)
+      assertNull(e.getCause)
+    }
+
+    assertMessageNoCause(null, new AssertionError())
+
+    assertMessageNoCause("boom", new AssertionError("boom"))
+    assertMessageNoCause("Some(5)", new AssertionError(Some(5)))
+    assertMessageNoCause("null", new AssertionError(null: Object))
+
+    assertMessageNoCause("true", new AssertionError(true))
+    assertMessageNoCause("5", new AssertionError(5.toByte))
+    assertMessageNoCause("6", new AssertionError(6.toShort))
+    assertMessageNoCause("7", new AssertionError(7))
+    assertMessageNoCause("8", new AssertionError(8L))
+    assertMessageNoCause("1.5", new AssertionError(1.5f))
+    assertMessageNoCause("2.5", new AssertionError(2.5))
+
+    val th = new RuntimeException("kaboom")
+    val e = new AssertionError(th)
+    assertEquals(th.toString, e.getMessage)
+    assertSame(th, e.getCause)
+  }
 }


### PR DESCRIPTION
Also fix #3155: Add the constructor `AssertionError(String, Throwable)`.