### PR TITLE
Add `js.special.instanceof(a, b)` for `a instanceof b`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -4230,6 +4230,10 @@ abstract class GenJSCode extends plugins.PluginComponent
                   js.Unbox(js.JSBinaryOp(js.JSBinaryOp.in, arg2,
                       js.VarRef(temp)(jstpe.AnyType)), 'Z'))
 
+            case INSTANCEOF =>
+              // js.special.instanceof(arg1, arg2)
+              js.Unbox(js.JSBinaryOp(js.JSBinaryOp.instanceof, arg1, arg2), 'Z')
+
             case DELETE =>
               // js.special.delete(arg1, arg2)
               js.JSDelete(js.JSBracketSelect(arg1, arg2))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -98,6 +98,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val JSConstructorTag_materialize = getMemberMethod(JSConstructorTagModule, newTermName("materialize"))
 
     lazy val SpecialPackageModule = getPackageObject("scala.scalajs.js.special")
+      lazy val Special_instanceof = getMemberMethod(SpecialPackageModule, newTermName("instanceof"))
       lazy val Special_delete = getMemberMethod(SpecialPackageModule, newTermName("delete"))
       lazy val Special_debugger = getMemberMethod(SpecialPackageModule, newTermName("debugger"))
 

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
@@ -48,8 +48,9 @@ abstract class JSPrimitives {
   val CONSTRUCTOROF = 352 // runtime.constructorOf(clazz)
   val LINKING_INFO = 354  // $linkingInfo
 
-  val DELETE = 355   // js.special.delete
-  val DEBUGGER = 356 // js.special.debugger
+  val INSTANCEOF = 355 // js.special.instanceof
+  val DELETE = 356     // js.special.delete
+  val DEBUGGER = 357   // js.special.debugger
 
   /** Initialize the map of primitive methods (for GenJSCode) */
   def init(): Unit = initWithPrimitives(addPrimitive)
@@ -103,6 +104,7 @@ abstract class JSPrimitives {
     addPrimitive(Runtime_constructorOf, CONSTRUCTOROF)
     addPrimitive(Runtime_linkingInfo, LINKING_INFO)
 
+    addPrimitive(Special_instanceof, INSTANCEOF)
     addPrimitive(Special_delete, DELETE)
     addPrimitive(Special_debugger, DEBUGGER)
   }

--- a/library/src/main/scala/scala/scalajs/js/special/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/special/package.scala
@@ -22,6 +22,25 @@ package scala.scalajs.js
  */
 package object special {
 
+  /** Dynamically tests whether a value is an instance of a JavaScript class.
+   *
+   *  This method is the exact equivalent of `x instanceof clazz` in
+   *  JavaScript.
+   *
+   *  Using this method is only necessary when `clazz` is only known at
+   *  run-time. In most cases, you should use
+   *  {{{
+   *  x.isInstanceOf[C]
+   *  }}}
+   *  instead, where `C` is the statically defined class corresponding to
+   *  `clazz`. In particular, the following identity holds for all `x` and `C`:
+   *  {{{
+   *  x.isInstanceOf[C] == js.special.instanceof(x, js.constructorOf[C])
+   *  }}}
+   */
+  def instanceof(x: scala.Any, clazz: scala.Any): Boolean =
+    throw new java.lang.Error("stub")
+
   /** Deletes a property of an object.
    *
    *  This method is the exact equivalent of the `delete obj[key]` statement

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
@@ -17,6 +17,31 @@ import org.scalajs.testsuite.utils.AssertThrows._
 class SpecialTest {
   import SpecialTest._
 
+  // scala.scalajs.js.special.instanceof
+
+  @Test def instanceofTest(): Unit = {
+    import js.special.instanceof
+
+    val ObjectCtor = js.constructorOf[js.Object]
+    val DateCtor = js.constructorOf[js.Date]
+
+    val obj = new js.Object
+    assertTrue(instanceof(obj, ObjectCtor))
+    assertFalse(instanceof(obj, DateCtor))
+
+    val date = new js.Date
+    assertTrue(instanceof(date, ObjectCtor))
+    assertTrue(instanceof(date, DateCtor))
+
+    val functionCtor: js.ThisFunction0[js.Dynamic, Unit] = {
+      (thiz: js.Dynamic) =>
+        thiz.foo = 5
+    }
+    assertFalse(instanceof(obj, functionCtor))
+    val bar = js.Dynamic.newInstance(functionCtor.asInstanceOf[js.Dynamic])()
+    assertTrue(instanceof(bar, functionCtor))
+  }
+
   // scala.scalajs.js.special.delete
 
   @Test def should_provide_an_equivalent_of_the_JS_delete_keyword_issue_255(): Unit = {


### PR DESCRIPTION
Previously, we had no way to write code equivalent to `a instanceof b` where `b` is a dynamic value (rather than something directly available as `js.constructorOf[C]` for some `C`). Adding this method fills up a hole in our interoperability features.

This will also be necessary to desugar `.isInstanceOf`s on nested JS classes.