### PR TITLE
Small compiler refactorings before nested JS classes

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -114,7 +114,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
   override def newPhase(p: Phase): StdPhase = new JSCodePhase(p)
 
-  private object jsnme {
+  object jsnme {
     val anyHash = newTermName("anyHash")
     val arg_outer = newTermName("arg$outer")
     val newString = newTermName("newString")

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1265,28 +1265,32 @@ abstract class GenJSCode extends plugins.PluginComponent
      */
     private def mkOverloadSelection(jsConstructorBuilder: JSConstructorBuilder,
         overloadIdent: js.Ident, dispatchResolution: js.Tree)(
-        implicit pos: Position): List[js.Tree]= {
-      if (!jsConstructorBuilder.hasSubConstructors) {
-        dispatchResolution match {
-          /* Dispatch to constructor with no arguments.
-           * Contains trivial parameterless call to the constructor.
-           */
-          case js.ApplyStatic(_, mtd, js.This() :: Nil)
-              if ir.Definitions.isConstructorName(mtd.name) =>
-            Nil
+        implicit pos: Position): List[js.Tree] = {
 
-          /* Dispatch to constructor with at least one argument.
-           * Where js.Block's stats.init corresponds to the parameter casts and
-           * js.Block's stats.last contains the call to the constructor.
-           */
-          case js.Block(stats) =>
-            val js.ApplyStatic(_, method, _) = stats.last
-            val refs = jsConstructorBuilder.getParamRefsFor(method.name)
-            val paramCasts = stats.init.map(_.asInstanceOf[js.VarDef])
-            zipMap(refs, paramCasts) { (ref, paramCast) =>
-              js.VarDef(ref.ident, ref.tpe, mutable = false, paramCast.rhs)
-            }
+      def deconstructApplyCtor(body: js.Tree): (List[js.Tree], String, List[js.Tree]) = {
+        val (prepStats, applyCtor) = body match {
+          case applyCtor: js.ApplyStatic =>
+            (Nil, applyCtor)
+          case js.Block(prepStats :+ (applyCtor: js.ApplyStatic)) =>
+            (prepStats, applyCtor)
         }
+        val js.ApplyStatic(_, js.Ident(ctorName, _), js.This() :: ctorArgs) =
+          applyCtor
+        assert(ir.Definitions.isConstructorName(ctorName))
+        (prepStats, ctorName, ctorArgs)
+      }
+
+      if (!jsConstructorBuilder.hasSubConstructors) {
+        val (prepStats, ctorName, ctorArgs) =
+          deconstructApplyCtor(dispatchResolution)
+
+        val refs = jsConstructorBuilder.getParamRefsFor(ctorName)
+        assert(refs.size == ctorArgs.size, currentClassSym.fullName)
+        val assignCtorParams = zipMap(refs, ctorArgs) { (ref, ctorArg) =>
+          js.VarDef(ref.ident, ref.tpe, mutable = false, ctorArg)
+        }
+
+        prepStats ::: assignCtorParams
       } else {
         val overloadRef = js.VarRef(overloadIdent)(jstpe.IntType)
 
@@ -1294,30 +1298,6 @@ abstract class GenJSCode extends plugins.PluginComponent
          * `genJSConstructorExport` and transform it recursively.
          */
         def transformDispatch(tree: js.Tree): js.Tree = tree match {
-          /* Dispatch to constructor with no arguments.
-           * Contains trivial parameterless call to the constructor.
-           */
-          case js.ApplyStatic(_, method, js.This() :: Nil)
-              if ir.Definitions.isConstructorName(method.name) =>
-            js.Assign(overloadRef,
-              js.IntLiteral(jsConstructorBuilder.getOverrideNum(method.name)))
-
-          /* Dispatch to constructor with at least one argument.
-           * Where js.Block's stats.init corresponds to the parameter casts and
-           * js.Block's stats.last contains the call to the constructor.
-           */
-          case js.Block(stats) =>
-            val js.ApplyStatic(_, method, _) = stats.last
-
-            val num = jsConstructorBuilder.getOverrideNum(method.name)
-            val overloadAssign = js.Assign(overloadRef, js.IntLiteral(num))
-
-            val refs = jsConstructorBuilder.getParamRefsFor(method.name)
-            val paramCasts = stats.init.map(_.asInstanceOf[js.VarDef].rhs)
-            val parameterAssigns = zipMap(refs, paramCasts)(js.Assign(_, _))
-
-            js.Block(overloadAssign :: parameterAssigns)
-
           // Parameter count resolution
           case js.Match(selector, cases, default) =>
             val newCases = cases.map {
@@ -1334,6 +1314,19 @@ abstract class GenJSCode extends plugins.PluginComponent
           // Throw(StringLiteral(No matching overload))
           case tree: js.Throw =>
             tree
+
+          // Overload resolution done, apply the constructor
+          case _ =>
+            val (prepStats, ctorName, ctorArgs) = deconstructApplyCtor(tree)
+
+            val num = jsConstructorBuilder.getOverrideNum(ctorName)
+            val overloadAssign = js.Assign(overloadRef, js.IntLiteral(num))
+
+            val refs = jsConstructorBuilder.getParamRefsFor(ctorName)
+            assert(refs.size == ctorArgs.size, currentClassSym.fullName)
+            val assignCtorParams = zipMap(refs, ctorArgs)(js.Assign(_, _))
+
+            js.Block(overloadAssign :: prepStats ::: assignCtorParams)
         }
 
         val newDispatchResolution = transformDispatch(dispatchResolution)

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/DiverseErrorsTest.scala
@@ -262,25 +262,25 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     }
     """ hasErrors
     """
-      |newSource1.scala:17: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |newSource1.scala:17: error: constructorOf must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
       |      val a = runtime.constructorOf(classOf[ScalaClass].asInstanceOf[Class[_ <: js.Any]])
       |                                   ^
-      |newSource1.scala:18: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |newSource1.scala:18: error: constructorOf must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
       |      val b = runtime.constructorOf(classOf[ScalaTrait].asInstanceOf[Class[_ <: js.Any]])
       |                                   ^
-      |newSource1.scala:20: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |newSource1.scala:20: error: constructorOf must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
       |      val c = runtime.constructorOf(classOf[NativeJSTrait])
       |                                   ^
-      |newSource1.scala:21: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |newSource1.scala:21: error: constructorOf must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
       |      val d = runtime.constructorOf(classOf[JSTrait])
       |                                   ^
-      |newSource1.scala:24: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |newSource1.scala:24: error: constructorOf must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
       |      val e = runtime.constructorOf(jsClassClass)
       |                                   ^
-      |newSource1.scala:26: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |newSource1.scala:26: error: constructorOf must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
       |      val f = runtime.constructorOf(NativeJSObject.getClass)
       |                                   ^
-      |newSource1.scala:27: error: runtime.constructorOf() must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
+      |newSource1.scala:27: error: constructorOf must be called with a constant classOf[T] representing a class extending js.Any (not a trait nor an object)
       |      val g = runtime.constructorOf(JSObject.getClass)
       |                                   ^
     """


### PR DESCRIPTION
This PR contains a series of small refactorings in the compiler, extracted from the work on nested JS classes. The main purpose of doing those separately is so that the diff for nested JS classes does not contain irrelevant changes.