### PR TITLE
[no-master] Migrate to sbt-platform-deps to provide `%%%`.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -774,6 +774,8 @@ object Build {
           previousArtifactSetting,
           mimaBinaryIssueFilters ++= BinaryIncompatibilities.SbtPlugin,
 
+          addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0"),
+
           /* TODO Remove this in 1.x, since there are no macros in sbt-plugin
            * anymore.
            */

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -4,6 +4,8 @@ addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 
+addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
+
 libraryDependencies += "org.scala-js" % "closure-compiler-java-6" % "v20160517"
 
 libraryDependencies += "io.apigee" % "rhino" % "1.7R5pre4"

--- a/sbt-plugin-test/project/build.properties
+++ b/sbt-plugin-test/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.16
+sbt.version=0.13.17

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -9,6 +9,8 @@
 
 package org.scalajs.sbtplugin
 
+import scala.language.implicitConversions
+
 import sbt._
 import sbt.Keys._
 
@@ -489,6 +491,19 @@ object ScalaJSPlugin extends AutoPlugin {
     val scalaJSSourceMap = AttributeKey[File]("scalaJSSourceMap",
         "Source map file attached to an Attributed .js file.",
         BSetting)
+
+    /* This is here instead of in impl.DependencyBuilders for binary
+     * compatibility reasons (impl.DependencyBuilders is a non-sealed trait).
+     */
+    @deprecated(
+        """Use %%% if possible, or '"com.example" % "foo" % "1.0.0" cross """ +
+        """ScalaJSCrossVersion.binary"'""",
+        "0.6.23")
+    final implicit def toScalaJSGroupeIDForce(
+        groupID: String): impl.ScalaJSGroupIDForce = {
+      require(groupID.trim.nonEmpty, "Group ID cannot be empty.")
+      new impl.ScalaJSGroupIDForce(groupID)
+    }
   }
 
   import autoImport._

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -62,7 +62,12 @@ object ScalaJSPlugin extends AutoPlugin {
     val FullOptStage = Stage.FullOpt
 
     // CrossType
-    val CrossType = cross.CrossType
+    @deprecated(
+        "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+        "Use the separate sbt plugin sbt-crossproject instead: " +
+        "https://github.com/portable-scala/sbt-crossproject",
+        "0.6.23")
+    lazy val CrossType = cross.CrossType
 
     // Factory methods for JSEnvs
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -15,6 +15,8 @@ import SBTCompat._
 import SBTCompat.formatImplicits._
 import SBTCompat.formatImplicits.seqFormat
 
+import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
+
 import org.scalajs.core.tools.sem.Semantics
 import org.scalajs.core.tools.io.{IO => toolsIO, _}
 import org.scalajs.core.tools.jsdep._
@@ -1124,6 +1126,7 @@ object ScalaJSPluginInternal {
   val PhantomJSJetty = config("phantom-js-jetty").hide
 
   val scalaJSProjectBaseSettings = Seq(
+      platformDepsCrossVersion := ScalaJSCrossVersion.binary,
       isScalaJSProject := true,
 
       /* We first define scalaJSLinkerConfig in the project scope, with all

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossClasspathDependency.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossClasspathDependency.scala
@@ -11,6 +11,11 @@ package org.scalajs.sbtplugin.cross
 
 import sbt._
 
+@deprecated(
+    "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+    "Use the separate sbt plugin sbt-crossproject instead: " +
+    "https://github.com/portable-scala/sbt-crossproject",
+    "0.6.23")
 final class CrossClasspathDependency(
     val project: CrossProject,
     val configuration: Option[String]
@@ -19,6 +24,11 @@ final class CrossClasspathDependency(
   def js: ClasspathDependency = ClasspathDependency(project.js, configuration)
 }
 
+@deprecated(
+    "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+    "Use the separate sbt plugin sbt-crossproject instead: " +
+    "https://github.com/portable-scala/sbt-crossproject",
+    "0.6.23")
 object CrossClasspathDependency {
   final class Constructor(crossProject: CrossProject) {
     def %(conf: Configuration): CrossClasspathDependency = %(conf.name)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
@@ -206,6 +206,11 @@ import java.io.File
  *  Implement your own subclass (sub-object) of [[CrossType]].
  *
  */
+@deprecated(
+    "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+    "Use the separate sbt plugin sbt-crossproject instead: " +
+    "https://github.com/portable-scala/sbt-crossproject",
+    "0.6.23")
 final class CrossProject private (
     crossType: CrossType,
     val jvm: Project,
@@ -282,6 +287,11 @@ final class CrossProject private (
 
 }
 
+@deprecated(
+    "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+    "Use the separate sbt plugin sbt-crossproject instead: " +
+    "https://github.com/portable-scala/sbt-crossproject",
+    "0.6.23")
 object CrossProject extends CrossProjectExtra {
 
   def apply(id: String, base: File, crossType: CrossType): CrossProject = {
@@ -343,19 +353,44 @@ object CrossProject extends CrossProjectExtra {
 
 }
 
+/** *Deprecated*.
+ *
+ *  Not marked as `@deprecated` for technical reasons, but should be considered
+ *  as such. All the members are deprecated.
+ */
 trait CrossProjectExtra {
 
+  @deprecated(
+      "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+      "Use the separate sbt plugin sbt-crossproject instead: " +
+      "https://github.com/portable-scala/sbt-crossproject",
+      "0.6.23")
   def crossProject: CrossProject.Builder = macro CrossProject.crossProject_impl
 
+  @deprecated(
+      "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+      "Use the separate sbt plugin sbt-crossproject instead: " +
+      "https://github.com/portable-scala/sbt-crossproject",
+      "0.6.23")
   implicit def crossProjectFromBuilder(
       builder: CrossProject.Builder): CrossProject = {
     builder.crossType(CrossType.Full)
   }
 
+  @deprecated(
+      "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+      "Use the separate sbt plugin sbt-crossproject instead: " +
+      "https://github.com/portable-scala/sbt-crossproject",
+      "0.6.23")
   implicit def crossClasspathDependencyConstructor(
       cp: CrossProject): CrossClasspathDependency.Constructor =
     new CrossClasspathDependency.Constructor(cp)
 
+  @deprecated(
+      "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+      "Use the separate sbt plugin sbt-crossproject instead: " +
+      "https://github.com/portable-scala/sbt-crossproject",
+      "0.6.23")
   implicit def crossClasspathDependency(
       cp: CrossProject): CrossClasspathDependency =
     new CrossClasspathDependency(cp, None)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossType.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossType.scala
@@ -13,6 +13,11 @@ import sbt._
 
 import java.io.File
 
+@deprecated(
+    "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+    "Use the separate sbt plugin sbt-crossproject instead: " +
+    "https://github.com/portable-scala/sbt-crossproject",
+    "0.6.23")
 abstract class CrossType {
 
   /** The base directory for a (true sbt) Project
@@ -36,6 +41,11 @@ abstract class CrossType {
 
 }
 
+@deprecated(
+    "The built-in cross-project feature of sbt-scalajs is deprecated. " +
+    "Use the separate sbt plugin sbt-crossproject instead: " +
+    "https://github.com/portable-scala/sbt-crossproject",
+    "0.6.23")
 object CrossType {
 
   object Full extends CrossType {

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/DependencyBuilders.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/DependencyBuilders.scala
@@ -16,7 +16,11 @@ import scala.language.experimental.macros
 import sbt._
 
 trait DependencyBuilders {
-  final implicit def toScalaJSGroupID(groupID: String): ScalaJSGroupID = {
+  @deprecated(
+      "Use org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport." +
+      "toPlatformDepsGroupID",
+      "0.6.23")
+  final def toScalaJSGroupID(groupID: String): ScalaJSGroupID = {
     require(groupID.trim.nonEmpty, "Group ID cannot be empty.")
     new ScalaJSGroupID(groupID)
   }
@@ -58,6 +62,13 @@ trait DependencyBuilders {
    */
   implicit class JSModuleIDBuilder(module: ModuleID) {
     def /(name: String): JarJSModuleID = JarJSModuleID(module, name)
+  }
+}
+
+final class ScalaJSGroupIDForce private[sbtplugin] (private val groupID: String) {
+  def %%%!(artifactID: String): CrossGroupArtifactID = {
+    require(artifactID.trim.nonEmpty, "Artifact ID cannot be empty.")
+    new CrossGroupArtifactID(groupID, artifactID, ScalaJSCrossVersion.binary)
   }
 }
 


### PR DESCRIPTION
~~At this point this is an experiment~~

We preserve binary compatibility and source compatibility by simply de-implicit-ify the conversion from `String` to the class providing `%%%`. This means that existing binaries will keep linking, while recompiled sources will resolve to the new implicit provided by sbt-platform-deps.

We preserve `%%%!` by introducing *another* implicit conversion to a class that has only `%%%!`, but not `%%%`. That implicit conversion is immediately deprecated, since Scala.js 1.x will not support `%%%!`.