### PR TITLE
Fix #3072: Enable the IR checker by default.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/StandardLinker.scala
@@ -91,7 +91,7 @@ object StandardLinker {
       this(
           semantics = Semantics.Defaults,
           moduleKind = ModuleKind.NoModule,
-          checkIR = false,
+          checkIR = true,
           optimizer = true,
           parallel = true,
           sourceMap = true,
@@ -191,7 +191,7 @@ object StandardLinker {
      *
      *  - `semantics`: [[Semantics.Defaults]]
      *  - `moduleKind`: [[ModuleKind.NoModule]]
-     *  - `checkIR`: `false`
+     *  - `checkIR`: `true`
      *  - `optimizer`: `true`
      *  - `parallel`: `true`
      *  - `sourceMap`: `true`


### PR DESCRIPTION
This will help catching potential internal bugs during the Milestones and RC cycles.