### PR TITLE
Remove all primitives from JS types

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -4214,13 +4214,6 @@ abstract class GenJSCode extends plugins.PluginComponent
               // js.typeOf(arg)
               genAsInstanceOf(js.JSUnaryOp(js.JSUnaryOp.typeof, arg),
                   StringClass.tpe)
-
-            case OBJPROPS =>
-              // js.Object.properties(arg)
-              genApplyMethod(
-                  genLoadModule(RuntimePackageModule),
-                  Runtime_propertiesOf,
-                  List(arg))
           }
 
         case List(arg1, arg2) =>

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -4218,19 +4218,9 @@ abstract class GenJSCode extends plugins.PluginComponent
 
         case List(arg1, arg2) =>
           code match {
-            case HASPROP =>
-              // js.Object.hasProperty(arg1, arg2)
-              /* Here we have an issue with evaluation order of arg1 and arg2,
-               * since the obvious translation is `arg2 in arg1`, but then
-               * arg2 is evaluated before arg1. Since this is not a commonly
-               * used operator, we don't try to avoid unnecessary temp vars, and
-               * simply always evaluate arg1 in a temp before doing the `in`.
-               */
-              val temp = freshLocalIdent()
-              js.Block(
-                  js.VarDef(temp, jstpe.AnyType, mutable = false, arg1),
-                  js.Unbox(js.JSBinaryOp(js.JSBinaryOp.in, arg2,
-                      js.VarRef(temp)(jstpe.AnyType)), 'Z'))
+            case IN =>
+              // js.special.in(arg1, arg2)
+              js.Unbox(js.JSBinaryOp(js.JSBinaryOp.in, arg1, arg2), 'Z')
 
             case INSTANCEOF =>
               // js.special.instanceof(arg1, arg2)

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -84,9 +84,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val JSDynamicLiteral_applyDynamicNamed = getMemberMethod(JSDynamicLiteral, newTermName("applyDynamicNamed"))
       lazy val JSDynamicLiteral_applyDynamic = getMemberMethod(JSDynamicLiteral, newTermName("applyDynamic"))
 
-    lazy val JSObjectModule = JSObjectClass.companionModule
-      lazy val JSObject_hasProperty = getMemberMethod(JSObjectModule, newTermName("hasProperty"))
-
     lazy val JSArrayModule = JSArrayClass.companionModule
       lazy val JSArray_create = getMemberMethod(JSArrayModule, newTermName("apply"))
 
@@ -97,6 +94,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val JSConstructorTag_materialize = getMemberMethod(JSConstructorTagModule, newTermName("materialize"))
 
     lazy val SpecialPackageModule = getPackageObject("scala.scalajs.js.special")
+      lazy val Special_in = getMemberMethod(SpecialPackageModule, newTermName("in"))
       lazy val Special_instanceof = getMemberMethod(SpecialPackageModule, newTermName("instanceof"))
       lazy val Special_delete = getMemberMethod(SpecialPackageModule, newTermName("delete"))
       lazy val Special_debugger = getMemberMethod(SpecialPackageModule, newTermName("debugger"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -86,7 +86,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
 
     lazy val JSObjectModule = JSObjectClass.companionModule
       lazy val JSObject_hasProperty = getMemberMethod(JSObjectModule, newTermName("hasProperty"))
-      lazy val JSObject_properties  = getMemberMethod(JSObjectModule, newTermName("properties"))
 
     lazy val JSArrayModule = JSArrayClass.companionModule
       lazy val JSArray_create = getMemberMethod(JSArrayModule, newTermName("apply"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
@@ -40,7 +40,6 @@ abstract class JSPrimitives {
 
   val TYPEOF = 344    // typeof x
   val HASPROP = 346   // js.Object.hasProperty(o, p), equiv to `p in o` in JS
-  val OBJPROPS = 347  // js.Object.properties(o), equiv to `for (p in o)` in JS
   val JS_NATIVE = 348 // js.native. Marker method. Fails if tried to be emitted.
 
   val UNITVAL = 349 // () value, which is undefined
@@ -97,7 +96,6 @@ abstract class JSPrimitives {
     addPrimitive(JSPackage_native, JS_NATIVE)
 
     addPrimitive(JSObject_hasProperty, HASPROP)
-    addPrimitive(JSObject_properties, OBJPROPS)
 
     addPrimitive(BoxedUnit_UNIT, UNITVAL)
 

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
@@ -39,14 +39,14 @@ abstract class JSPrimitives {
   val ARR_CREATE = 337 // js.Array.apply (array literal syntax)
 
   val TYPEOF = 344    // typeof x
-  val HASPROP = 346   // js.Object.hasProperty(o, p), equiv to `p in o` in JS
   val JS_NATIVE = 348 // js.native. Marker method. Fails if tried to be emitted.
 
   val UNITVAL = 349 // () value, which is undefined
 
   val CONSTRUCTOROF = 352 // runtime.constructorOf(clazz)
-  val LINKING_INFO = 354  // $linkingInfo
+  val LINKING_INFO = 353  // $linkingInfo
 
+  val IN = 354         // js.special.in
   val INSTANCEOF = 355 // js.special.instanceof
   val DELETE = 356     // js.special.delete
   val DEBUGGER = 357   // js.special.debugger
@@ -95,13 +95,12 @@ abstract class JSPrimitives {
     addPrimitive(JSPackage_typeOf, TYPEOF)
     addPrimitive(JSPackage_native, JS_NATIVE)
 
-    addPrimitive(JSObject_hasProperty, HASPROP)
-
     addPrimitive(BoxedUnit_UNIT, UNITVAL)
 
     addPrimitive(Runtime_constructorOf, CONSTRUCTOROF)
     addPrimitive(Runtime_linkingInfo, LINKING_INFO)
 
+    addPrimitive(Special_in, IN)
     addPrimitive(Special_instanceof, INSTANCEOF)
     addPrimitive(Special_delete, DELETE)
     addPrimitive(Special_debugger, DEBUGGER)

--- a/library/src/main/scala/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala/scala/scalajs/js/Any.scala
@@ -195,6 +195,14 @@ object Any extends js.LowPrioAnyImplicits {
     value.asInstanceOf[js.Any]
 
   implicit class ObjectCompanionOps(val __self: js.Object.type) extends AnyVal {
+    /** Tests whether the specified object `o` has a property `p` on itself or
+     *  in its prototype chain.
+     *
+     *  This method is the equivalent of `p in o` in JavaScript.
+     */
+    def hasProperty(o: js.Object, p: String): Boolean =
+      js.special.in(p, o)
+
     /** Returns the names of all the enumerable properties of the specified
      *  object `o`, including properties in its prototype chain.
      *

--- a/library/src/main/scala/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala/scala/scalajs/js/Any.scala
@@ -193,6 +193,22 @@ object Any extends js.LowPrioAnyImplicits {
     value.asInstanceOf[js.Any]
   @inline implicit def fromJDouble(value: java.lang.Double): js.Any =
     value.asInstanceOf[js.Any]
+
+  implicit class ObjectCompanionOps(val __self: js.Object.type) extends AnyVal {
+    /** Returns the names of all the enumerable properties of the specified
+     *  object `o`, including properties in its prototype chain.
+     *
+     *  This method returns the same set of names that would be enumerated by
+     *  a for-in loop in JavaScript, but not necessarily in the same order.
+     *
+     *  If the underlying implementation guarantees an order for for-in loops,
+     *  then this is guaranteed to be consistent with [[js.Object.keys]], in
+     *  the sense that the list returned by [[js.Object.keys]] is a sublist of
+     *  the list returned by this method (not just a subset).
+     */
+    def properties(o: js.Any): js.Array[String] =
+      scala.scalajs.runtime.propertiesOf(o)
+  }
 }
 
 sealed trait LowPrioAnyImplicits extends js.LowestPrioAnyImplicits {

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -170,15 +170,17 @@ class Array[A] extends js.Object with js.Iterable[A] {
 }
 
 /** Factory for [[js.Array]] objects. */
-@js.native
-@JSGlobal
-object Array extends js.Object {
-  // Do not expose this one - use new js.Array(len) instead
-  // def apply[A](arrayLength: Int): js.Array[A] = js.native
+object Array {
+  @js.native
+  @JSGlobal("Array")
+  private object NativeArray extends js.Object {
+    def isArray(arg: scala.Any): Boolean = js.native
+  }
 
   /** Creates a new array with the given items. */
   def apply[A](items: A*): js.Array[A] = throw new java.lang.Error("stub")
 
   /** Returns true if the given value is an array. */
-  def isArray(arg: scala.Any): Boolean = js.native
+  @inline
+  def isArray(arg: scala.Any): Boolean = NativeArray.isArray(arg)
 }

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -39,9 +39,11 @@ class Object extends js.Any {
   def isPrototypeOf(v: Object): Boolean = js.native
 
   /** Tests whether the specified property in an object can be enumerated by a
-   *  call to [[js.Object.properties]], with the exception of properties
-   *  inherited through the prototype chain. If the object does not have the
-   *  specified property, this method returns false.
+   *  call to [[js.Any.ObjectCompanionOps.properties js.Object.properties]],
+   *  with the exception of properties inherited through the prototype chain.
+   *
+   *  If the object does not have the specified property, this method returns
+   *  false.
    *
    *  MDN
    */
@@ -212,18 +214,4 @@ object Object extends js.Object {
    * MDN
    */
   def keys(o: js.Object): js.Array[String] = js.native
-
-  /** Returns the names of all the enumerable properties of this object,
-   *  including properties in its prototype chain.
-   *
-   *  This method returns the same set of names that would be enumerated by
-   *  a for-in loop in JavaScript, but not necessarily in the same order.
-   *
-   *  If the underlying implementation guarantees an order for for-in loops,
-   *  then this is guaranteed to be consistent with [[keys]], in the sense
-   *  that the list returned by [[keys]] is a sublist of the list returned by
-   *  this method (not just a subset).
-   */
-  def properties(o: js.Any): js.Array[String] =
-    throw new java.lang.Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -28,8 +28,8 @@ class Object extends js.Any {
 
   /** Tests whether this object has the specified property as a direct property.
    *
-   *  Unlike [[js.Object.hasProperty]], this method does not check down the
-   *  object's prototype chain.
+   *  Unlike [[js.Any.ObjectCompanionOps.hasProperty js.Object.hasProperty]],
+   *  this method does not check down the object's prototype chain.
    *
    * MDN
    */
@@ -56,12 +56,6 @@ class Object extends js.Any {
 object Object extends js.Object {
   def apply(): js.Object = js.native
   def apply(value: scala.Any): js.Object = js.native
-
-  /** Tests whether the object has a property on itself or in its prototype
-   *  chain. This method is the equivalent of `p in o` in JavaScript.
-   */
-  def hasProperty(o: js.Object, p: String): Boolean =
-    throw new java.lang.Error("stub")
 
   /**
    * The Object.getPrototypeOf() method returns the prototype (i.e. the

--- a/library/src/main/scala/scala/scalajs/js/special/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/special/package.scala
@@ -22,6 +22,17 @@ package scala.scalajs.js
  */
 package object special {
 
+  /** Tests whether an object has a given enumerable property in its prototype
+   *  chain.
+   *
+   *  This method is the exact equivalent of `p in o` in JavaScript.
+   *
+   *  The recommended surface syntax to perform `p in o` is to use
+   *  `js.Object.hasProperty(o, p)`.
+   */
+  def in(p: scala.Any, o: scala.Any): Boolean =
+    throw new java.lang.Error("stub")
+
   /** Dynamically tests whether a value is an instance of a JavaScript class.
    *
    *  This method is the exact equivalent of `x instanceof clazz` in

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -245,6 +245,13 @@ class JSSymbolTest {
     iterateIterable(obj)(content += _)
     assertArrayEquals(Array(532), content.result())
   }
+
+  @Test def inOperatorWithSymbols(): Unit = {
+    val obj = mkObject(sym1 -> "foo")
+
+    assertTrue(js.special.in(sym1, obj))
+    assertFalse(js.special.in(sym2, obj))
+  }
 }
 
 object JSSymbolTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -109,25 +109,23 @@ class MiscInteropTest {
   // scala.scalajs.js.Object
 
   @Test def should_provide_an_equivalent_to_p_in_o(): Unit = {
-    import js.Object.{hasProperty => hasProp}
-    val o = js.Dynamic.literal(foo = 5, bar = "foobar").asInstanceOf[js.Object]
-    assertTrue(hasProp(o, "foo"))
-    assertFalse(hasProp(o, "foobar"))
-    assertTrue(hasProp(o, "toString")) // in prototype
+    val o = js.Dynamic.literal(foo = 5, bar = "foobar")
+    assertTrue(js.Object.hasProperty(o, "foo"))
+    assertFalse(js.Object.hasProperty(o, "foobar"))
+    assertTrue(js.Object.hasProperty(o, "toString")) // in prototype
   }
 
   @Test def should_respect_evaluation_order_for_hasProperty(): Unit = {
-    import js.Object.{hasProperty => hasProp}
     var indicator = 3
     def o(): js.Object = {
       indicator += 4
-      js.Dynamic.literal(x = 5).asInstanceOf[js.Object]
+      js.Dynamic.literal(x = 5)
     }
     def p(): String = {
       indicator *= 2
       "x"
     }
-    assertTrue(hasProp(o(), p()))
+    assertTrue(js.Object.hasProperty(o(), p()))
     assertEquals(14, indicator)
   }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
@@ -17,6 +17,15 @@ import org.scalajs.testsuite.utils.AssertThrows._
 class SpecialTest {
   import SpecialTest._
 
+  // scala.scalajs.js.special.in
+
+  @Test def inTest(): Unit = {
+    val o = js.Dynamic.literal(foo = 5, bar = "foobar")
+    assertTrue(js.special.in("foo", o))
+    assertFalse(js.special.in("foobar", o))
+    assertTrue(js.special.in("toString", o)) // in prototype
+  }
+
   // scala.scalajs.js.special.instanceof
 
   @Test def instanceofTest(): Unit = {


### PR DESCRIPTION
The semantics of JS types are governed by the interoperability semantics. According to those semantics, a method call of the form `x.m()` should always correspond to the equivalent JS method call. If `m` is statically declared as a primitive, those semantics are broken.

Therefore, we avoid any primitive in JS types.