### PR TITLE
Don't fix #3180: Blacklist run/t3877.scala and run/t6272.scala.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/BlacklistedTests.txt
@@ -870,6 +870,10 @@ run/t3493.scala
 # Using Class.forName
 run/private-inline.scala
 
+# Suffers from #3180
+run/t3877.scala
+run/t6272.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.0/WhitelistedTests.txt
@@ -1025,7 +1025,6 @@ run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
 run/runtime-richChar.scala
-run/t6272.scala
 run/t7215.scala
 run/t1939.scala
 run/ReverseSeqView.scala
@@ -1278,7 +1277,6 @@ run/t0042.scala
 run/t3050.scala
 run/t4536.scala
 run/NestedClasses.scala
-run/t3877.scala
 run/seqlike-kmp.scala
 run/t5907.scala
 run/t266.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/BlacklistedTests.txt
@@ -878,6 +878,10 @@ run/t3493.scala
 # Using Class.forName
 run/private-inline.scala
 
+# Suffers from #3180
+run/t3877.scala
+run/t6272.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.1/WhitelistedTests.txt
@@ -1025,7 +1025,6 @@ run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
 run/runtime-richChar.scala
-run/t6272.scala
 run/t7215.scala
 run/t1939.scala
 run/ReverseSeqView.scala
@@ -1278,7 +1277,6 @@ run/t0042.scala
 run/t3050.scala
 run/t4536.scala
 run/NestedClasses.scala
-run/t3877.scala
 run/seqlike-kmp.scala
 run/t5907.scala
 run/t266.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/BlacklistedTests.txt
@@ -988,6 +988,10 @@ run/t3493.scala
 # Using Class.forName
 run/private-inline.scala
 
+# Suffers from #3180
+run/t3877.scala
+run/t6272.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/WhitelistedTests.txt
@@ -1118,7 +1118,6 @@ run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
 run/runtime-richChar.scala
-run/t6272.scala
 run/t7215.scala
 run/t1939.scala
 run/ReverseSeqView.scala
@@ -1368,7 +1367,6 @@ run/t0042.scala
 run/t3050.scala
 run/t4536.scala
 run/NestedClasses.scala
-run/t3877.scala
 run/seqlike-kmp.scala
 run/t5907.scala
 run/t266.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/BlacklistedTests.txt
@@ -892,6 +892,10 @@ run/t3493.scala
 # Using Class.forName
 run/private-inline.scala
 
+# Suffers from #3180
+run/t3877.scala
+run/t6272.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.2/WhitelistedTests.txt
@@ -1025,7 +1025,6 @@ run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
 run/runtime-richChar.scala
-run/t6272.scala
 run/t7215.scala
 run/t1939.scala
 run/ReverseSeqView.scala
@@ -1278,7 +1277,6 @@ run/t0042.scala
 run/t3050.scala
 run/t4536.scala
 run/NestedClasses.scala
-run/t3877.scala
 run/seqlike-kmp.scala
 run/t5907.scala
 run/t266.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/BlacklistedTests.txt
@@ -919,6 +919,10 @@ run/t3493.scala
 # Using Class.forName
 run/private-inline.scala
 
+# Suffers from #3180
+run/t3877.scala
+run/t6272.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.5/WhitelistedTests.txt
@@ -1088,7 +1088,6 @@ run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
 run/runtime-richChar.scala
-run/t6272.scala
 run/t7215.scala
 run/t1939.scala
 run/ReverseSeqView.scala
@@ -1338,7 +1337,6 @@ run/t0042.scala
 run/t3050.scala
 run/t4536.scala
 run/NestedClasses.scala
-run/t3877.scala
 run/seqlike-kmp.scala
 run/t5907.scala
 run/t266.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/BlacklistedTests.txt
@@ -921,6 +921,10 @@ run/t3493.scala
 # Using Class.forName
 run/private-inline.scala
 
+# Suffers from #3180
+run/t3877.scala
+run/t6272.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.6/WhitelistedTests.txt
@@ -1100,7 +1100,6 @@ run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
 run/runtime-richChar.scala
-run/t6272.scala
 run/t7215.scala
 run/t1939.scala
 run/ReverseSeqView.scala
@@ -1350,7 +1349,6 @@ run/t0042.scala
 run/t3050.scala
 run/t4536.scala
 run/NestedClasses.scala
-run/t3877.scala
 run/seqlike-kmp.scala
 run/t5907.scala
 run/t266.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
@@ -949,6 +949,10 @@ run/t3493.scala
 # Using Class.forName
 run/private-inline.scala
 
+# Suffers from #3180
+run/t3877.scala
+run/t6272.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
@@ -1119,7 +1119,6 @@ run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
 run/runtime-richChar.scala
-run/t6272.scala
 run/t7215.scala
 run/t1939.scala
 run/ReverseSeqView.scala
@@ -1369,7 +1368,6 @@ run/t0042.scala
 run/t3050.scala
 run/t4536.scala
 run/NestedClasses.scala
-run/t3877.scala
 run/seqlike-kmp.scala
 run/t5907.scala
 run/t266.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/BlacklistedTests.txt
@@ -966,6 +966,10 @@ run/t3493.scala
 # Using Class.forName
 run/private-inline.scala
 
+# Suffers from #3180
+run/t3877.scala
+run/t6272.scala
+
 ###  Incorrect partests  ###
 # Badly uses constract of Console.print (no flush)
 run/t429.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/WhitelistedTests.txt
@@ -1118,7 +1118,6 @@ run/t6337a.scala
 run/exoticnames.scala
 run/t0936.scala
 run/runtime-richChar.scala
-run/t6272.scala
 run/t7215.scala
 run/t1939.scala
 run/ReverseSeqView.scala
@@ -1368,7 +1367,6 @@ run/t0042.scala
 run/t3050.scala
 run/t4536.scala
 run/NestedClasses.scala
-run/t3877.scala
 run/seqlike-kmp.scala
 run/t5907.scala
 run/t266.scala

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -65,6 +65,7 @@ class MainGenericRunner {
         command.thingToRun, "main", command.arguments))
 
     val linkerConfig = StandardLinker.Config()
+      .withCheckIR(true)
       .withSemantics(semantics)
       .withSourceMap(false)
       .withOptimizer(optMode != NoOpt)


### PR DESCRIPTION
Those partests are affected by #3180, which we decided not to fix, given that the root cause in scalac also affects Scala/JVM and produces invalid bytecode in some cases.