### PR TITLE
Reduce the code size for toJSArray calls

### DIFF
--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -32,9 +32,13 @@ package object runtime {
       case col: js.ArrayOps[A]     => col.result()
       case col: js.WrappedArray[A] => col.array
       case _ =>
-        val result = new js.Array[A]
-        col.foreach(x => result.push(x))
-        result
+        @noinline
+        def unhappyPath() = {
+          val result = new js.Array[A]
+          col.foreach(x => result.push(x))
+          result
+        }
+        unhappyPath()
     }
   }
 


### PR DESCRIPTION
@kahliburke mentioned this problem at https://gitter.im/ThoughtWorksInc/Binding.scala?at=5a0fa86471ad3f8736fba227 and https://gitter.im/scala-js/scala-js?at=5a0b53da505b630c05e202dc