### PR TITLE
Do not inline `.toJSArray` to prevent code size blowing up.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSConverters.scala
@@ -39,7 +39,28 @@ object JSConverters extends JSConvertersLowPrioImplicits {
 
   implicit class JSRichGenTraversableOnce[T](
       val col: GenTraversableOnce[T]) extends AnyVal {
-    @inline final def toJSArray: Array[T] = genTraversableOnce2jsArray(col)
+    final def toJSArray: Array[T] = {
+      /* This is basically a duplicate of `runtime.genTraversableOnce2jsArray`,
+       * except it is not marked `@inline`. We do not want to inline this
+       * method every time someone does `.toJSArray`, for code size reasons
+       * (unlike `genTraversableOnce2jsArray`, which is used by the codegen for
+       * transferring Scala varargs to JS varargs).
+       *
+       * One would think that we could still delegate to
+       * `genTraversableOnce2jsArray` and mark `toJSArray` with `@noinline`
+       * instead, but that would prevent `toJSArray` to be inlined even when
+       * `col` is stack-allocated (and we do want that to happen as in that
+       * case the entire match disappears and `col` can stay stack-allocated).
+       */
+      col match {
+        case col: js.ArrayOps[T]     => col.repr
+        case col: js.WrappedArray[T] => col.array
+        case _ =>
+          val result = new js.Array[T]
+          col.foreach(x => result.push(x))
+          result
+      }
+    }
   }
 
   implicit class JSRichGenIterable[T](


### PR DESCRIPTION
For an explicit `.toJSArray`, it is typically not advantageous to inline the method unless the exact type of collection is known. And in most of those cases, the collection would be stack-allocated, which would force inline anyway.

In this commit, we directly implement `.toJSArray` (instead of depending on a method of `runtime`) and mark it as non-inlined.

The method `runtime.genTraversableOnce2jsArray`, used by the code gen for JS varargs, is unchanged.