### PR TITLE
Fix #3192: Do not reexecute the constructor in `Object.clone()`.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/ObjectClone.scala
+++ b/javalanglib/src/main/scala/java/lang/ObjectClone.scala
@@ -7,6 +7,76 @@ import scala.scalajs.js
  *  Called by the hard-coded IR of `java.lang.Object`.
  */
 private[lang] object ObjectClone {
+  private val getOwnPropertyDescriptors: js.Function1[js.Object, js.Object] = {
+    import js.Dynamic.{global, literal}
+
+    // The val f = ...; f.asInstanceOf's are necessary for 2.10 not to crash
+
+    // Fetch or polyfill Object.getOwnPropertyDescriptors
+    if (js.typeOf(global.Object.getOwnPropertyDescriptors) == "function") {
+      val f = global.Object.getOwnPropertyDescriptors
+      f.asInstanceOf[js.Function1[js.Object, js.Object]]
+    } else {
+      // Fetch or polyfill Reflect.ownKeys
+      type OwnKeysType = js.Function1[js.Object, js.Array[js.Any]]
+      val ownKeysFun: OwnKeysType = {
+        if (js.typeOf(global.Reflect) != "undefined" &&
+            js.typeOf(global.Reflect.ownKeys) == "function") {
+          val f = global.Reflect.ownKeys
+          f.asInstanceOf[OwnKeysType]
+        } else {
+          // Fetch Object.getOwnPropertyNames
+          val getOwnPropertyNames = {
+            val f = global.Object.getOwnPropertyNames
+            f.asInstanceOf[OwnKeysType]
+          }
+
+          // Fetch or polyfill Object.getOwnPropertySymbols
+          val getOwnPropertySymbols: OwnKeysType = {
+            if (js.typeOf(global.Object.getOwnPropertySymbols) == "function") {
+              val f = global.Object.getOwnPropertySymbols
+              f.asInstanceOf[OwnKeysType]
+            } else {
+              /* Polyfill for Object.getOwnPropertySymbols.
+               * We assume that if that function does not exist, then symbols
+               * do not exist at all. Therefore, the result is always an empty
+               * array.
+               */
+              { (o: js.Object) =>
+                js.Array[js.Any]()
+              }
+            }
+          }
+
+          // Polyfill for Reflect.ownKeys
+          { (o: js.Object) =>
+            getOwnPropertyNames(o) ++ getOwnPropertySymbols(o)
+          }
+        }
+      }
+
+      // Polyfill for Object.getOwnPropertyDescriptors
+      { (o: js.Object) =>
+        val ownKeys = ownKeysFun(o)
+        val descriptors = new js.Object
+        for (key <- ownKeys) {
+          /* Almost equivalent to the JavaScript code
+           *   descriptors[key] = Object.getOwnPropertyDescriptor(descriptors, key);
+           * except that `defineProperty` will by-pass any existing setter for
+           * the property `key` on `descriptors` or in its prototype chain.
+           */
+          global.Object.defineProperty(descriptors, key, literal(
+              configurable = true,
+              enumerable = true,
+              writable = true,
+              value = global.Object.getOwnPropertyDescriptor(o, key)
+          ))
+        }
+        descriptors
+      }
+    }
+  }
+
   /** Returns a new shallow clone of `o`.
    *
    *  This method does not test that `o` is an instance of `Cloneable`. The
@@ -14,12 +84,7 @@ private[lang] object ObjectClone {
    *  rely on that property for correctness.
    */
   def clone(o: Object): Object = {
-    val fromDyn = o.asInstanceOf[js.Dynamic]
-    val result = js.Dynamic.newInstance(fromDyn.constructor)()
-    val fromDict = o.asInstanceOf[js.Dictionary[js.Any]]
-    val resultDict = result.asInstanceOf[js.Dictionary[js.Any]]
-    for (key <- fromDict.keys)
-      resultDict(key) = fromDict(key)
-    result
+    js.Object.create(js.Object.getPrototypeOf(o.asInstanceOf[js.Object]),
+        getOwnPropertyDescriptors(o.asInstanceOf[js.Object]))
   }
 }

--- a/javalanglib/src/main/scala/java/lang/ObjectClone.scala
+++ b/javalanglib/src/main/scala/java/lang/ObjectClone.scala
@@ -1,0 +1,25 @@
+package java.lang
+
+import scala.scalajs.js
+
+/** Implementation of `java.lang.Object.clone()`.
+ *
+ *  Called by the hard-coded IR of `java.lang.Object`.
+ */
+private[lang] object ObjectClone {
+  /** Returns a new shallow clone of `o`.
+   *
+   *  This method does not test that `o` is an instance of `Cloneable`. The
+   *  caller should do that themselves, although this `cloneObject` does not
+   *  rely on that property for correctness.
+   */
+  def clone(o: Object): Object = {
+    val fromDyn = o.asInstanceOf[js.Dynamic]
+    val result = js.Dynamic.newInstance(fromDyn.constructor)()
+    val fromDict = o.asInstanceOf[js.Dictionary[js.Any]]
+    val resultDict = result.asInstanceOf[js.Dictionary[js.Any]]
+    for (key <- fromDict.keys)
+      resultDict(key) = fromDict(key)
+    result
+  }
+}

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -16,16 +16,6 @@ package object runtime {
     case _                         => th
   }
 
-  def cloneObject(from: js.Object): js.Object = {
-    val fromDyn = from.asInstanceOf[js.Dynamic]
-    val result = js.Dynamic.newInstance(fromDyn.constructor)()
-    val fromDict = from.asInstanceOf[js.Dictionary[js.Any]]
-    val resultDict = result.asInstanceOf[js.Dictionary[js.Any]]
-    for (key <- fromDict.keys)
-      resultDict(key) = fromDict(key)
-    result
-  }
-
   @inline final def genTraversableOnce2jsArray[A](
       col: GenTraversableOnce[A]): js.Array[A] = {
     col match {

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -87,8 +87,8 @@ object JavaLangObject {
           AnyType,
           Some {
             If(IsInstanceOf(This()(ThisType), ClassRef("jl_Cloneable")), {
-              Apply(LoadModule(ClassType("sjsr_package$")),
-                  Ident("cloneObject__sjs_js_Object__sjs_js_Object", Some("cloneObject")),
+              Apply(LoadModule(ClassType("jl_ObjectClone$")),
+                  Ident("clone__O__O", Some("clone")),
                   List(This()(ThisType)))(AnyType)
             }, {
               Throw(New(ClassType("jl_CloneNotSupportedException"),

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
@@ -74,4 +74,24 @@ class ObjectTest {
     (Array(Nil)     : Any).asInstanceOf[Object]
     (null           : Any).asInstanceOf[Object]
   }
+
+  @Test def cloneCtorSideEffects_issue_3192(): Unit = {
+    var ctorInvokeCount = 0
+
+    // This class has an inlineable init
+    class CloneCtorSideEffectsBug(val x: Int) extends java.lang.Cloneable {
+      ctorInvokeCount += 1
+
+      override def clone(): CloneCtorSideEffectsBug =
+        super.clone().asInstanceOf[CloneCtorSideEffectsBug]
+    }
+
+    val o = new CloneCtorSideEffectsBug(54)
+    assertEquals(54, o.x)
+    assertEquals(1, ctorInvokeCount)
+
+    val o2 = o.clone()
+    assertEquals(54, o2.x)
+    assertEquals(1, ctorInvokeCount)
+  }
 }


### PR DESCRIPTION
We now use the "official" way to create a shallow copy of a JavaScript object, which uses a combination of `Object.create`, `Object.getPrototypeOf` and `Object.getOwnPropertyDescriptors`.

The latter was introduced in ECMAScript 2017, though, so we need to polyfill it, and along with it two other functions from ECMAScript 2015.

Locally tested with variants that ensured that all code paths were taken and correct. Including `testSuite/testHtml` in Firefox, which already implements `Object.getOwnPropertyDescriptors` itself.