### PR TITLE
FF ONLY Merge 0.6.x into master, November 26

### DIFF
--- a/test-adapter/src/main/scala/org/scalajs/testadapter/ComJSEnvRPC.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testadapter/ComJSEnvRPC.scala
@@ -9,7 +9,7 @@
 
 package org.scalajs.testadapter
 
-import scala.concurrent.TimeoutException
+import scala.concurrent.{ExecutionContext, TimeoutException}
 
 import org.scalajs.jsenv.{ComJSEnv, ComJSRunner}
 import org.scalajs.testcommon._
@@ -18,11 +18,8 @@ import org.scalajs.testcommon._
  *
  *  @note You may only create one instance of this per [[ComJSRunner]]
  */
-private[testadapter] final class ComJSEnvRPC(
-    val runner: ComJSRunner) extends RPCCore {
-
-  @volatile
-  private[this] var closed = false
+private[testadapter] final class ComJSEnvRPC(val runner: ComJSRunner)(
+    implicit executionContext: ExecutionContext) extends RPCCore {
 
   private val receiverThread = new Thread {
     setName("ComJSEnvRPC receiver")
@@ -37,11 +34,29 @@ private[testadapter] final class ComJSEnvRPC(
           }
         }
       } catch {
-        case _: ComJSEnv.ComClosedException =>
-        case _: InterruptedException        =>
-        case _: Exception if closed         =>
-          // Some JSEnvs might throw something else if they got closed.
-          // We are graceful in the 0.6.x branch.
+        case e: Exception =>
+          /* We got terminated. This might be due to an interruption from a call
+           * to `close` or due to the JSEnv crashing.
+           *
+           * Ensure all still pending calls are failing.
+           * This can be necessary, if the JSEnv terminates unexpectedly.
+           * Note: We do not need to give a grace time here, since the reply
+           * dispatch happens synchronously in `handleMessage`.
+           * In other words, at this point we'll only see pending calls that
+           * would require another call to `handleMessage` in order to complete
+           * successfully. But this is not going to happen since this thread is
+           * the only one that calls `handleMessage` and it's about to terminate.
+           */
+          ComJSEnvRPC.super.close(e)
+
+        case t: Throwable =>
+          /* Same here, but this is probably a serious VM error condition we
+           * should propagate. We do not use NonFatal, since it does not catch
+           * InterruptedException and ControlThrowables which we do not want to
+           * propagate.
+           */
+          ComJSEnvRPC.super.close(t)
+          throw t
       }
     }
   }
@@ -49,16 +64,14 @@ private[testadapter] final class ComJSEnvRPC(
   receiverThread.start()
 
   override protected def send(msg: String): Unit = synchronized {
-    if (!closed)
-      runner.send(msg)
+    runner.send(msg)
   }
 
-  override def close(): Unit = synchronized {
-    closed = true
+  override def close(cause: Throwable): Unit = synchronized {
+    // First close the RPC layer, so we propagate the right cause.
+    super.close(cause)
 
-    super.close()
-
-    // Close the com first so the receiver thread terminates.
+    // Close the runner so the receiver thread terminates.
     runner.close()
 
     receiverThread.interrupt()

--- a/test-adapter/src/main/scala/org/scalajs/testadapter/RunnerAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testadapter/RunnerAdapter.scala
@@ -12,7 +12,6 @@ package org.scalajs.testadapter
 import scala.collection.concurrent.TrieMap
 
 import scala.concurrent._
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.concurrent.duration._
 
 import scala.util._

--- a/test-adapter/src/main/scala/org/scalajs/testadapter/TestAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testadapter/TestAdapter.scala
@@ -11,10 +11,7 @@ package org.scalajs.testadapter
 
 import scala.concurrent._
 import scala.concurrent.duration._
-import scala.concurrent.ExecutionContext.Implicits.global
 import scala.collection.concurrent.TrieMap
-
-import java.util.concurrent.atomic.{AtomicInteger, AtomicBoolean}
 
 import org.scalajs.core.ir.Utils.escapeJS
 import org.scalajs.core.tools.io._
@@ -34,10 +31,16 @@ final class TestAdapter(jsEnv: ComJSEnv, jsFiles: Seq[VirtualJSFile],
   /** Map of ThreadId -> ManagedRunner */
   private[this] val runners = TrieMap.empty[Long, ManagedRunner]
 
-  private[this] val closing = new AtomicBoolean(false)
+  /** State management. May only be accessed under synchronization. */
+  private[this] var closed = false
+  private[this] var nextRunID = 0
+  private[this] var runs = Set.empty[RunMux.RunID]
 
-  private[this] val nextRunID = new AtomicInteger(0)
-  private[this] val runs = TrieMap.empty[RunMux.RunID, Unit]
+  /** A custom execution context that delegates to the global one for execution,
+   *  but handles failures internally.
+   */
+  private implicit val executionContext =
+    ExecutionContext.fromExecutor(ExecutionContext.global, reportFailure)
 
   /** Creates an `sbt.testing.Framework` for each framework that can be found.
    *
@@ -51,49 +54,71 @@ final class TestAdapter(jsEnv: ComJSEnv, jsFiles: Seq[VirtualJSFile],
       .call(JSEndpoints.detectFrameworks)(frameworkNames)
       .map(_.map(_.map(info => new FrameworkAdapter(info, this))))
 
-    // If there is no testing framework loaded, nothing will reply.
-    val fallback: Future[List[Option[Framework]]] =
-      runner.runner.future.map(_ => frameworkNames.map(_ => None))
+    val recovered = frameworks.recoverWith {
+      // If there is no testing framework loaded, nothing will reply.
+      case _: RPCCore.ClosedException =>
+        // We reply with no framework at all.
+        runner.runner.future.map(_ => frameworkNames.map(_ => None))
+    }
 
-    Future.firstCompletedOf(List(frameworks, fallback)).await()
+    recovered.await()
   }
 
   /** Releases all resources. All associated runs must be done. */
-  def close(): Unit = {
-    if (!closing.getAndSet(true)) {
-      // Snapshot runs.
-      val seenRuns = runs.keySet
+  def close(): Unit = synchronized {
+    val runInfo =
+      if (runs.isEmpty) "All runs have completed."
+      else s"Incomplete runs: $runs"
 
-      runners.values.foreach(_.com.close())
+    val msg = "TestAdapter.close() was called. " + runInfo
+
+    if (runs.nonEmpty)
+      config.logger.warn(msg)
+
+    /* This is the exception callers will see if they are still pending.
+     * That's why it is an IllegalStateException.
+     */
+    val cause = new IllegalStateException(msg)
+    stopEverything(cause)
+  }
+
+  /** Called when a throwable bubbles up the execution stack.
+   *
+   *  We terminate everyting if this happens to make sure nothing hangs waiting
+   *  on an async operation to complete.
+   */
+  private def reportFailure(cause: Throwable): Unit = {
+    val msg = "Failure in async execution. Aborting all test runs."
+    val error = new AssertionError(msg, cause)
+    config.logger.error(msg)
+    config.logger.trace(error)
+    stopEverything(error)
+  }
+
+  private def stopEverything(cause: Throwable): Unit = synchronized {
+    if (!closed) {
+      closed = true
+      runners.values.foreach(_.com.close(cause))
       runners.values.foreach(_.runner.stop())
       runners.clear()
-
-      runs.clear()
-      if (seenRuns.nonEmpty) {
-        throw new IllegalStateException(
-            s"close() called with incomplete runs: $seenRuns")
-      }
     }
   }
 
-  private[testadapter] def runStarting(): RunMux.RunID = {
-    require(!closing.get(), "We are closing. Cannot create new run.")
-    val runID = nextRunID.getAndIncrement()
-    runs.put(runID, ())
+  private[testadapter] def runStarting(): RunMux.RunID = synchronized {
+    require(!closed, "We are closed. Cannot create new run.")
+    val runID = nextRunID
+    nextRunID += 1
+    runs += runID
     runID
   }
 
   /** Called by [[RunnerAdapter]] when the run is completed. */
-  private[testadapter] def runDone(runID: RunMux.RunID): Unit = {
-    val old = runs.remove(runID)
-    require(old.nonEmpty, s"Tried to remove nonexistent run $runID")
+  private[testadapter] def runDone(runID: RunMux.RunID): Unit = synchronized {
+    require(runs.contains(runID), s"Tried to remove nonexistent run $runID")
+    runs -= runID
   }
 
   private[testadapter] def getRunnerForThread(): ManagedRunner = {
-    // Prevent runners from being started after closing started.
-    // Otherwise we might leak runners.
-    require(!closing.get(), "We are closing. Cannot create new runner.")
-
     val threadId = Thread.currentThread().getId()
 
     // Note that this is thread safe, since each thread can only operate on
@@ -101,7 +126,11 @@ final class TestAdapter(jsEnv: ComJSEnv, jsFiles: Seq[VirtualJSFile],
     runners.getOrElseUpdate(threadId, startManagedRunner(threadId))
   }
 
-  private def startManagedRunner(threadId: Long): ManagedRunner = {
+  private def startManagedRunner(threadId: Long): ManagedRunner = synchronized {
+    // Prevent runners from being started after we are closed.
+    // Otherwise we might leak runners.
+    require(!closed, "We are closed. Cannot create new runner.")
+
     // !!! DUPLICATE code with ScalaJSPlugin.makeExportsNamespaceExpr
     val orgExpr = config.moduleKind match {
       case ModuleKind.NoModule =>
@@ -136,8 +165,12 @@ final class TestAdapter(jsEnv: ComJSEnv, jsFiles: Seq[VirtualJSFile],
 
     val launcher = new MemVirtualJSFile("startTestBridge.js").withContent(code)
     val runner = jsEnv.comRunner(jsFiles :+ launcher)
+    val com = new ComJSEnvRPC(runner)
+    val mux = new RunMuxRPC(com)
+
     runner.start(config.logger, config.console)
-    new ManagedRunner(threadId, runner)
+
+    new ManagedRunner(threadId, runner, com, mux)
   }
 }
 
@@ -185,8 +218,9 @@ object TestAdapter {
   }
 
   private[testadapter] final class ManagedRunner(
-      val id: Long, val runner: ComJSRunner) {
-    val com = new ComJSEnvRPC(runner)
-    val mux = new RunMuxRPC(com)
-  }
+      val id: Long,
+      val runner: ComJSRunner,
+      val com: RPCCore,
+      val mux: RunMuxRPC
+  )
 }

--- a/test-common/src/test/scala/org/scalajs/testcommon/RPCCoreTest.scala
+++ b/test-common/src/test/scala/org/scalajs/testcommon/RPCCoreTest.scala
@@ -149,14 +149,15 @@ class RPCCoreTest {
 
     val future = y.call(eps.number)(())
 
-    y.close()
+    val cause = new Throwable("blah")
+    y.close(cause)
 
     try {
       Await.result(future, atMost = 1.second)
       fail("Expected exception")
     } catch {
-      case e: java.io.IOException =>
-        assertEquals("Channel got closed", e.getMessage())
+      case e: RPCCore.ClosedException =>
+        assertSame(cause, e.getCause())
     }
   }
 }

--- a/test-interface/src/main/scala/org/scalajs/testinterface/internal/JSRPC.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/internal/JSRPC.scala
@@ -4,6 +4,7 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
 import scala.concurrent.duration._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import org.scalajs.testcommon.RPCCore
 
@@ -13,16 +14,12 @@ private[internal] final object JSRPC extends RPCCore {
 
   override protected def send(msg: String): Unit = Com.send(msg)
 
-  override def close(): Unit = {
-    super.close()
-    Com.close()
-  }
-
   @js.native
   @JSGlobal("scalajsCom")
   private object Com extends js.Object {
     def init(onReceive: js.Function1[String, Unit]): Unit = js.native
     def send(msg: String): Unit = js.native
-    def close(): Unit = js.native
+    // We support close, but do not use it. The JS side just terminates.
+    // def close(): Unit = js.native
   }
 }


### PR DESCRIPTION
Motivation: Bring in test adapter fixes (#3194) for #3033.

```
$ git checkout -b merge-0.6.x-into-master-november-26
Switched to a new branch 'merge-0.6.x-into-master-november-26'
```

```
$ export mb=$(git merge-base scala-js/0.6.x scala-js/master)
```

```
$ git log --graph --oneline --decorate $mb..scala-js/0.6.x | cat
* e952f9ce5 (sjrd/0.6.x, scala-js/0.6.x, 0.6.x) Merge pull request #3194 from gzm0/fail-well
* fbe0421ac (origin/fail-well) Fix #3175: Propagate failures in TestAdapter
```

```
$ git merge --no-commit scala-js/0.6.x
Auto-merging test-adapter/src/main/scala/org/scalajs/testadapter/TestAdapter.scala
CONFLICT (content): Merge conflict in test-adapter/src/main/scala/org/scalajs/testadapter/TestAdapter.scala
Auto-merging test-adapter/src/main/scala/org/scalajs/testadapter/RunnerAdapter.scala
Auto-merging test-adapter/src/main/scala/org/scalajs/testadapter/ComJSEnvRPC.scala
Auto-merging project/BinaryIncompatibilities.scala
CONFLICT (content): Merge conflict in project/BinaryIncompatibilities.scala
Automatic merge failed; fix conflicts and then commit the result.
```

```
$ git status
On branch merge-0.6.x-into-master-november-26
You have unmerged paths.
  (fix conflicts and run "git commit")
  (use "git merge --abort" to abort the merge)

Changes to be committed:

	modified:   test-adapter/src/main/scala/org/scalajs/testadapter/ComJSEnvRPC.scala
	modified:   test-adapter/src/main/scala/org/scalajs/testadapter/RunnerAdapter.scala
	modified:   test-common/src/main/scala/org/scalajs/testcommon/RPCCore.scala
	modified:   test-common/src/test/scala/org/scalajs/testcommon/RPCCoreTest.scala
	modified:   test-interface/src/main/scala/org/scalajs/testinterface/internal/JSRPC.scala

Unmerged paths:
  (use "git add <file>..." to mark resolution)

	both modified:   project/BinaryIncompatibilities.scala
	both modified:   test-adapter/src/main/scala/org/scalajs/testadapter/TestAdapter.scala
```

```
$ git checkout scala-js/master project/BinaryIncompatibilities.scala
```

Fix trivial conflict in `TestAdapter.scala`.


```diff
$ git diff -w
diff --cc test-adapter/src/main/scala/org/scalajs/testadapter/TestAdapter.scala
index 62860c501,1bf13c96d..000000000
--- a/test-adapter/src/main/scala/org/scalajs/testadapter/TestAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testadapter/TestAdapter.scala
@@@ -135,9 -163,13 +164,13 @@@ final class TestAdapter(jsEnv: ComJSEnv
      """
  
      val launcher = new MemVirtualJSFile("startTestBridge.js").withContent(code)
 -    val runner = jsEnv.comRunner(launcher)
 +    val runner = jsEnv.comRunner(jsFiles :+ launcher)
+     val com = new ComJSEnvRPC(runner)
+     val mux = new RunMuxRPC(com)
+ 
      runner.start(config.logger, config.console)
-     new ManagedRunner(threadId, runner)
+ 
+     new ManagedRunner(threadId, runner, com, mux)
    }
  }
```

```
$ git add -u
$ git commit
[merge-0.6.x-into-master-november-26 5a65bb4b5] Merge remote-tracking branch 'scala-js/0.6.x' into merge-0.6.x-into-master-november-26
```