### PR TITLE
Unfork our dependency on the Google Closure Compiler.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -600,7 +600,7 @@ object Build {
   lazy val tools: Project = (project in file("tools/jvm")).settings(
       commonToolsSettings,
       libraryDependencies ++= Seq(
-          "org.scala-js" % "closure-compiler-java-6" % "v20160517",
+          "com.google.javascript" % "closure-compiler" % "v20160517",
           "com.novocode" % "junit-interface" % "0.9" % "test"
       ) ++ (
           parallelCollectionsDependencies(scalaVersion.value)

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -6,7 +6,7 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0-M2")
 
-libraryDependencies += "org.scala-js" % "closure-compiler-java-6" % "v20160517"
+libraryDependencies += "com.google.javascript" % "closure-compiler" % "v20160517"
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.2.0.201312181205-r"
 


### PR DESCRIPTION
Now that we do not support JDK 6 anymore, we can go back to using the official artifacts of GCC.

This is will allow us to upgrade it more easily in the future.

Note that this PR does not make the situation better or worse wrt. #3193.