### PR TITLE
More IR cleanups

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -1023,7 +1023,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
           case REFERENCE(cls) =>
             cls match {
               case BoxedUnitClass => HijackedTypeTest(Defs.BoxedUnitClass, 0)
-              case StringClass    => HijackedTypeTest(Defs.StringClass, 9)
+              case StringClass    => HijackedTypeTest(Defs.BoxedStringClass, 9)
               case ObjectClass    => NoTypeTest
               case _              =>
                 if (isJSType(cls)) NoTypeTest

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -226,7 +226,7 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
 
   def encodeClassFullName(sym: Symbol): String = {
     if (sym == jsDefinitions.HackedStringClass) {
-      ir.Definitions.StringClass
+      ir.Definitions.BoxedStringClass
     } else if (sym == jsDefinitions.HackedStringModClass) {
       "jl_String$"
     } else {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -225,6 +225,8 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
   }
 
   def encodeClassFullName(sym: Symbol): String = {
+    assert(!sym.isPrimitiveValueClass,
+        s"Illegal encodeClassFullName(${sym.fullName}")
     if (sym == jsDefinitions.HackedStringClass) {
       ir.Definitions.BoxedStringClass
     } else if (sym == jsDefinitions.HackedStringModClass) {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -280,10 +280,19 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
   private def internalName(kind: TypeKind): String = kind match {
     case VOID                => "V"
     case kind: ValueTypeKind => kind.primitiveCharCode.toString()
-    case NOTHING             => ir.Definitions.RuntimeNothingClass
-    case NULL                => ir.Definitions.RuntimeNullClass
+    case NOTHING             => ir.Definitions.NothingClass
+    case NULL                => ir.Definitions.NullClass
     case REFERENCE(cls)      => encodeClassFullName(cls)
-    case ARRAY(elem)         => "A"+internalName(elem)
+    case ARRAY(elem)         => "A" + internalArrayElemName(elem)
+  }
+
+  private def internalArrayElemName(kind: TypeKind): String = kind match {
+    case VOID                => "V"
+    case kind: ValueTypeKind => kind.primitiveCharCode.toString()
+    case NOTHING             => encodeClassFullName(definitions.RuntimeNothingClass)
+    case NULL                => encodeClassFullName(definitions.RuntimeNullClass)
+    case REFERENCE(cls)      => encodeClassFullName(cls)
+    case ARRAY(elem)         => "A" + internalArrayElemName(elem)
   }
 
   /** mangles names that are illegal in JavaScript by prepending a $

--- a/compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala
@@ -63,14 +63,16 @@ trait TypeKinds extends SubComponent { this: GenJSCode =>
   sealed abstract class TypeKindButArray extends TypeKind {
     protected def typeSymbol: Symbol
 
-    override def toTypeRef: Types.ClassRef =
-      Types.ClassRef(encodeClassFullName(typeSymbol))
+    def toTypeRef: Types.ClassRef
   }
 
   /** The void, for trees that can only appear in statement position. */
   case object VOID extends TypeKindButArray {
     protected def typeSymbol: Symbol = UnitClass
     def toIRType: Types.NoType.type = Types.NoType
+
+    val toTypeRef: Types.ClassRef =
+      Types.ClassRef(ir.Definitions.VoidClass)
   }
 
   sealed abstract class ValueTypeKind extends TypeKindButArray {
@@ -87,6 +89,9 @@ trait TypeKinds extends SubComponent { this: GenJSCode =>
       case DoubleClass   => 'D'
       case x => abort("Unknown primitive type: " + x.fullName)
     }
+
+    val toTypeRef: Types.ClassRef =
+      Types.ClassRef(primitiveCharCode.toString)
   }
 
   /** Integer number (Byte, Short, Char or Int). */
@@ -123,7 +128,7 @@ trait TypeKinds extends SubComponent { this: GenJSCode =>
   case object NOTHING extends TypeKindButArray {
     protected def typeSymbol: Symbol = definitions.NothingClass
     def toIRType: Types.NothingType.type = Types.NothingType
-    override def toTypeRef: Types.ClassRef =
+    def toTypeRef: Types.ClassRef =
       Types.ClassRef(Definitions.RuntimeNothingClass)
   }
 
@@ -131,7 +136,7 @@ trait TypeKinds extends SubComponent { this: GenJSCode =>
   case object NULL extends TypeKindButArray {
     protected def typeSymbol: Symbol = definitions.NullClass
     def toIRType: Types.NullType.type = Types.NullType
-    override def toTypeRef: Types.ClassRef =
+    def toTypeRef: Types.ClassRef =
       Types.ClassRef(Definitions.RuntimeNullClass)
   }
 
@@ -141,6 +146,9 @@ trait TypeKinds extends SubComponent { this: GenJSCode =>
     override def isReferenceType: Boolean = true
 
     def toIRType: Types.Type = encodeClassType(typeSymbol)
+
+    def toTypeRef: Types.ClassRef =
+      Types.ClassRef(encodeClassFullName(typeSymbol))
   }
 
   /** An array */

--- a/compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala
@@ -128,16 +128,18 @@ trait TypeKinds extends SubComponent { this: GenJSCode =>
   case object NOTHING extends TypeKindButArray {
     protected def typeSymbol: Symbol = definitions.NothingClass
     def toIRType: Types.NothingType.type = Types.NothingType
+
     def toTypeRef: Types.ClassRef =
-      Types.ClassRef(Definitions.RuntimeNothingClass)
+      Types.ClassRef(encodeClassFullName(definitions.RuntimeNothingClass))
   }
 
   /** Null */
   case object NULL extends TypeKindButArray {
     protected def typeSymbol: Symbol = definitions.NullClass
     def toIRType: Types.NullType.type = Types.NullType
+
     def toTypeRef: Types.ClassRef =
-      Types.ClassRef(Definitions.RuntimeNullClass)
+      Types.ClassRef(encodeClassFullName(definitions.RuntimeNullClass))
   }
 
   /** An object */

--- a/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
@@ -25,6 +25,8 @@ object Definitions {
   val LongClass = "J"
   val FloatClass = "F"
   val DoubleClass = "D"
+  val NullClass = "N"
+  val NothingClass = "E" // think "the Empty type", or "throws an Exception"
 
   /** The set of all primitive classes. */
   val PrimitiveClasses: Set[String] = Set(
@@ -36,7 +38,9 @@ object Definitions {
       IntClass,
       LongClass,
       FloatClass,
-      DoubleClass
+      DoubleClass,
+      NullClass,
+      NothingClass
   )
 
   // Hijacked classes
@@ -64,14 +68,6 @@ object Definitions {
       BoxedDoubleClass,
       BoxedStringClass
   )
-
-  // TODO Null and Nothing should have the same status as primitives, I think
-
-  /** The class corresponding to `NullType`. */
-  val RuntimeNullClass = "sr_Null$"
-
-  /** The class corresponding to `NothingType`. */
-  val RuntimeNothingClass = "sr_Nothing$"
 
   /** The class of things returned by `ClassOf` and `GetClass`. */
   val ClassClass = "jl_Class"

--- a/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
@@ -49,7 +49,7 @@ object Definitions {
   val BoxedLongClass = "jl_Long"
   val BoxedFloatClass = "jl_Float"
   val BoxedDoubleClass = "jl_Double"
-  val StringClass = "T" // TODO This should probably be called BoxedStringClass
+  val BoxedStringClass = "T"
 
   /** The set of all hijacked classes. */
   val HijackedClasses: Set[String] = Set(
@@ -62,7 +62,7 @@ object Definitions {
       BoxedLongClass,
       BoxedFloatClass,
       BoxedDoubleClass,
-      StringClass
+      BoxedStringClass
   )
 
   // TODO Null and Nothing should have the same status as primitives, I think

--- a/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
@@ -82,35 +82,28 @@ object Definitions {
   /** Encodes a class name. */
   def encodeClassName(fullName: String): String = {
     val base = fullName.replace("_", "$und").replace(".", "_")
-    val encoded = compressedClasses.getOrElse(base, {
-      compressedPrefixes collectFirst {
+    compressedClasses.getOrElse(base, {
+      compressedPrefixes.collectFirst {
         case (prefix, compressed) if base.startsWith(prefix) =>
           compressed + base.substring(prefix.length)
       } getOrElse {
-        "L"+base
+        "L" + base
       }
     })
-    if (Trees.isKeyword(encoded) || encoded.charAt(0).isDigit ||
-        encoded.charAt(0) == '$') {
-      "$" + encoded
-    } else encoded
   }
 
   // !!! Duplicate logic: this code must be in sync with runtime.StackTrace
 
   /** Decodes a class name encoded with [[encodeClassName]]. */
   def decodeClassName(encodedName: String): String = {
-    val encoded =
-      if (encodedName.charAt(0) == '$') encodedName.substring(1)
-      else encodedName
-    val base = decompressedClasses.getOrElse(encoded, {
-      decompressedPrefixes collectFirst {
-        case (prefix, decompressed) if encoded.startsWith(prefix) =>
-          decompressed + encoded.substring(prefix.length)
+    val base = decompressedClasses.getOrElse(encodedName, {
+      decompressedPrefixes.collectFirst {
+        case (prefix, decompressed) if encodedName.startsWith(prefix) =>
+          decompressed + encodedName.substring(prefix.length)
       } getOrElse {
-        assert(!encoded.isEmpty && encoded.charAt(0) == 'L',
+        assert(!encodedName.isEmpty && encodedName.charAt(0) == 'L',
             s"Cannot decode invalid encoded name '$encodedName'")
-        encoded.substring(1)
+        encodedName.substring(1)
       }
     })
     base.replace("_", ".").replace("$und", "_")

--- a/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
@@ -12,68 +12,72 @@ package org.scalajs.core.ir
 import Types._
 
 object Definitions {
+  /** `java.lang.Object`, the root of the class hierarchy. */
   val ObjectClass = "O"
-  val ClassClass  = "jl_Class"
 
-  val StringClass = "T"
+  // Primitive "classes"
+  val VoidClass = "V"
+  val BooleanClass = "Z"
+  val CharClass = "C"
+  val ByteClass = "B"
+  val ShortClass = "S"
+  val IntClass = "I"
+  val LongClass = "J"
+  val FloatClass = "F"
+  val DoubleClass = "D"
 
-  val PrimitiveClasses = Set("V", "Z", "C", "B", "S", "I", "J", "F", "D")
+  /** The set of all primitive classes. */
+  val PrimitiveClasses: Set[String] = Set(
+      VoidClass,
+      BooleanClass,
+      CharClass,
+      ByteClass,
+      ShortClass,
+      IntClass,
+      LongClass,
+      FloatClass,
+      DoubleClass
+  )
 
-  def isPrimitiveClass(encodedName: String): Boolean =
-    PrimitiveClasses.contains(encodedName)
-
-  val BoxedUnitClass      = "sr_BoxedUnit"
-  val BoxedBooleanClass   = "jl_Boolean"
+  // Hijacked classes
+  val BoxedUnitClass = "sr_BoxedUnit"
+  val BoxedBooleanClass = "jl_Boolean"
   val BoxedCharacterClass = "jl_Character"
-  val BoxedByteClass      = "jl_Byte"
-  val BoxedShortClass     = "jl_Short"
-  val BoxedIntegerClass   = "jl_Integer"
-  val BoxedLongClass      = "jl_Long"
-  val BoxedFloatClass     = "jl_Float"
-  val BoxedDoubleClass    = "jl_Double"
+  val BoxedByteClass = "jl_Byte"
+  val BoxedShortClass = "jl_Short"
+  val BoxedIntegerClass = "jl_Integer"
+  val BoxedLongClass = "jl_Long"
+  val BoxedFloatClass = "jl_Float"
+  val BoxedDoubleClass = "jl_Double"
+  val StringClass = "T" // TODO This should probably be called BoxedStringClass
 
-  val CharSequenceClass = "jl_CharSequence"
-  val SerializableClass = "Ljava_io_Serializable"
-  val CloneableClass    = "jl_Cloneable"
-  val ComparableClass   = "jl_Comparable"
-  val NumberClass       = "jl_Number"
+  /** The set of all hijacked classes. */
+  val HijackedClasses: Set[String] = Set(
+      BoxedUnitClass,
+      BoxedBooleanClass,
+      BoxedCharacterClass,
+      BoxedByteClass,
+      BoxedShortClass,
+      BoxedIntegerClass,
+      BoxedLongClass,
+      BoxedFloatClass,
+      BoxedDoubleClass,
+      StringClass
+  )
 
-  val HijackedBoxedClasses = Set(
-      BoxedUnitClass, BoxedBooleanClass, BoxedCharacterClass, BoxedByteClass,
-      BoxedShortClass, BoxedIntegerClass, BoxedLongClass, BoxedFloatClass,
-      BoxedDoubleClass)
-  val HijackedClasses =
-    HijackedBoxedClasses + StringClass
+  // TODO Null and Nothing should have the same status as primitives, I think
 
-  val AncestorsOfStringClass = Set(
-      CharSequenceClass, ComparableClass, SerializableClass)
-  val AncestorsOfBoxedCharacterClass = Set(
-      ComparableClass, SerializableClass)
-  val AncestorsOfHijackedNumberClasses = Set(
-      NumberClass, ComparableClass, SerializableClass)
-  val AncestorsOfBoxedBooleanClass = Set(
-      ComparableClass, SerializableClass)
-  val AncestorsOfBoxedUnitClass = Set(
-      SerializableClass)
-
-  val AncestorsOfHijackedClasses =
-    AncestorsOfStringClass ++ AncestorsOfHijackedNumberClasses ++
-    AncestorsOfBoxedBooleanClass ++ AncestorsOfBoxedUnitClass
-
+  /** The class corresponding to `NullType`. */
   val RuntimeNullClass = "sr_Null$"
+
+  /** The class corresponding to `NothingType`. */
   val RuntimeNothingClass = "sr_Nothing$"
 
-  val ThrowableClass = "jl_Throwable"
-
-  val PseudoArrayClass = "s_Array"
-  val AncestorsOfPseudoArrayClass = Set(
-      ObjectClass, SerializableClass, CloneableClass)
+  /** The class of things returned by `ClassOf` and `GetClass`. */
+  val ClassClass = "jl_Class"
 
   /** Name of the static initializer method. */
   final val StaticInitializerName = "clinit___"
-
-  /** Name used for infos of top-level exports. */
-  val TopLevelExportsName = "__topLevelExports"
 
   /** Encodes a class name. */
   def encodeClassName(fullName: String): String = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Definitions.scala
@@ -111,16 +111,7 @@ object Definitions {
 
   private val compressedClasses: Map[String, String] = Map(
       "java_lang_Object" -> "O",
-      "java_lang_String" -> "T",
-      "scala_Unit" -> "V",
-      "scala_Boolean" -> "Z",
-      "scala_Char" -> "C",
-      "scala_Byte" -> "B",
-      "scala_Short" -> "S",
-      "scala_Int" -> "I",
-      "scala_Long" -> "J",
-      "scala_Float" -> "F",
-      "scala_Double" -> "D"
+      "java_lang_String" -> "T"
   ) ++ (
       for (index <- 2 to 22)
         yield s"scala_Tuple$index" -> ("T"+index)

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -440,10 +440,8 @@ object Trees {
   case class AsInstanceOf(expr: Tree, typeRef: TypeRef)(
       implicit val pos: Position) extends Tree {
     val tpe = typeRef match {
-      case ClassRef(Definitions.RuntimeNullClass)    => NullType
-      case ClassRef(Definitions.RuntimeNothingClass) => NothingType
-      case ClassRef(className)                       => ClassType(className)
-      case typeRef: ArrayTypeRef                     => ArrayType(typeRef)
+      case ClassRef(className)   => ClassType(className)
+      case typeRef: ArrayTypeRef => ArrayType(typeRef)
     }
   }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Types.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Types.scala
@@ -230,7 +230,7 @@ object Types {
         case (DoubleType, ClassType(cls)) =>
           isSubclass(BoxedDoubleClass, cls)
         case (StringType, ClassType(cls)) =>
-          isSubclass(StringClass, cls)
+          isSubclass(BoxedStringClass, cls)
 
         case (ArrayType(ArrayTypeRef(lhsBase, lhsDims)),
             ArrayType(ArrayTypeRef(rhsBase, rhsDims))) =>

--- a/ir/src/main/scala/org/scalajs/core/ir/Types.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Types.scala
@@ -15,6 +15,9 @@ import Trees._
 
 object Types {
 
+  private val AncestorsOfPseudoArrayClass =
+    Set(Definitions.ObjectClass, "Ljava_io_Serializable", "jl_Cloneable")
+
   /** Type of a term (expression or statement) in the IR.
    *
    *  There is a many-to-one relationship from [[TypeRef]]s to `Type`s,
@@ -237,7 +240,7 @@ object Types {
             rhsBase == ObjectClass // because Array[Array[A]] <: Array[Object]
           } else { // lhsDims == rhsDims
             // lhsBase must be <: rhsBase
-            if (isPrimitiveClass(lhsBase) || isPrimitiveClass(rhsBase)) {
+            if (PrimitiveClasses(lhsBase) || PrimitiveClasses(rhsBase)) {
               lhsBase == rhsBase
             } else {
               /* All things must be considered subclasses of Object for this

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -550,12 +550,12 @@ class PrintersTest {
 
   @Test def printIsInstanceOf(): Unit = {
     assertPrintEquals("x.isInstanceOf[T]",
-        IsInstanceOf(ref("x", AnyType), StringClass))
+        IsInstanceOf(ref("x", AnyType), BoxedStringClass))
   }
 
   @Test def printAsInstanceOf(): Unit = {
     assertPrintEquals("x.asInstanceOf[T]",
-        AsInstanceOf(ref("x", AnyType), StringClass))
+        AsInstanceOf(ref("x", AnyType), BoxedStringClass))
   }
 
   @Test def printUnbox(): Unit = {

--- a/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
@@ -213,24 +213,21 @@ object StackTrace {
   // !!! Duplicate logic: this code must be in sync with ir.Definitions
 
   private def decodeClassName(encodedName: String): String = {
-    val encoded =
-      if (encodedName.charAt(0) == '$') encodedName.substring(1)
-      else encodedName
-    val base = if (decompressedClasses.contains(encoded)) {
-      decompressedClasses(encoded)
+    val base = if (decompressedClasses.contains(encodedName)) {
+      decompressedClasses(encodedName)
     } else {
       @tailrec
       def loop(i: Int): String = {
         if (i < compressedPrefixes.length) {
           val prefix = compressedPrefixes(i)
-          if (encoded.startsWith(prefix))
-            decompressedPrefixes(prefix) + encoded.substring(prefix.length)
+          if (encodedName.startsWith(prefix))
+            decompressedPrefixes(prefix) + encodedName.substring(prefix.length)
           else
             loop(i+1)
         } else {
           // no prefix matches
-          if (encoded.startsWith("L")) encoded.substring(1)
-          else encoded // just in case
+          if (encodedName.startsWith("L")) encodedName.substring(1)
+          else encodedName // just in case
         }
       }
       loop(0)

--- a/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/StackTrace.scala
@@ -238,16 +238,7 @@ object StackTrace {
   private lazy val decompressedClasses: js.Dictionary[String] = {
     val dict = js.Dynamic.literal(
         O = "java_lang_Object",
-        T = "java_lang_String",
-        V = "scala_Unit",
-        Z = "scala_Boolean",
-        C = "scala_Char",
-        B = "scala_Byte",
-        S = "scala_Short",
-        I = "scala_Int",
-        J = "scala_Long",
-        F = "scala_Float",
-        D = "scala_Double"
+        T = "java_lang_String"
     ).asInstanceOf[js.Dictionary[String]]
 
     var index = 0

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -105,14 +105,14 @@ object JavaLangObject {
           static = false,
           Ident("toString__T", Some("toString__T")),
           Nil,
-          ClassType(StringClass),
+          ClassType(BoxedStringClass),
           Some {
             BinaryOp(BinaryOp.String_+, BinaryOp(BinaryOp.String_+,
               Apply(
                 Apply(This()(ThisType),
                   Ident("getClass__jl_Class", Some("getClass__jl_Class")), Nil)(
                   ClassType(ClassClass)),
-                Ident("getName__T"), Nil)(ClassType(StringClass)),
+                Ident("getName__T"), Nil)(ClassType(BoxedStringClass)),
               // +
               StringLiteral("@")),
               // +
@@ -120,7 +120,7 @@ object JavaLangObject {
                 LoadModule(ClassType("jl_Integer$")),
                 Ident("toHexString__I__T"),
                 List(Apply(This()(ThisType), Ident("hashCode__I"), Nil)(IntType)))(
-                ClassType(StringClass)))
+                ClassType(BoxedStringClass)))
           })(OptimizerHints.empty, None),
 
         /* Since wait() is not supported in any way, a correct implementation
@@ -162,7 +162,7 @@ object JavaLangObject {
           Some {
             Apply(This()(ThisType),
                 Ident("toString__T", Some("toString__T")),
-                Nil)(ClassType(StringClass))
+                Nil)(ClassType(BoxedStringClass))
           })(OptimizerHints.empty, None)
       ),
       Nil)(OptimizerHints.empty)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -17,6 +17,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
+import org.scalajs.testsuite.utils.AssertThrows._
 import org.scalajs.testsuite.utils.Platform._
 
 import scala.util.{ Try, Failure }
@@ -40,17 +41,10 @@ class RuntimeTypesTest {
 
   @Test def scala_Nothing_casts_to_scala_Nothing_should_fail(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
-    def test(x: Any): Unit = {
-      try {
-        x.asInstanceOf[Nothing]
-        fail("casting " + x + " to Nothing did not fail")
-      } catch {
-        case th: Throwable =>
-          assertTrue(th.isInstanceOf[ClassCastException])
-          assertEquals(x + " is not an instance of scala.runtime.Nothing$",
-              th.getMessage)
-      }
-    }
+
+    def test(x: Any): Unit =
+      assertThrows(classOf[ClassCastException], x.asInstanceOf[Nothing])
+
     test("a")
     test(null)
   }
@@ -86,11 +80,7 @@ class RuntimeTypesTest {
 
   @Test def scala_Null_casts_to_scala_Null_should_fail_for_everything_else_but_null(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
-    val msg = Try("a".asInstanceOf[Null]) match {
-      case Failure(thr: ClassCastException) => thr.getMessage
-      case _ => "not failed"
-    }
-    assertEquals("a is not an instance of scala.runtime.Null$", msg)
+    assertThrows(classOf[ClassCastException], "a".asInstanceOf[Null])
   }
 
   @Test def scala_Null_classTag_of_scala_Null_should_contain_proper_Class_issue_297(): Unit = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analysis.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analysis.scala
@@ -43,7 +43,9 @@ object Analysis {
       "I" -> "int",
       "J" -> "long",
       "F" -> "float",
-      "D" -> "double"
+      "D" -> "double",
+      "N" -> "null",
+      "E" -> "nothing"
   )
 
   /** Class node in a reachability graph produced by the [[Analyzer]].

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analysis.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analysis.scala
@@ -34,6 +34,18 @@ trait Analysis {
 
 object Analysis {
 
+  private val PrimitiveClassesDisplayNames: Map[String, String] = Map(
+      "V" -> "void",
+      "Z" -> "boolean",
+      "C" -> "char",
+      "B" -> "byte",
+      "S" -> "short",
+      "I" -> "int",
+      "J" -> "long",
+      "F" -> "float",
+      "D" -> "double"
+  )
+
   /** Class node in a reachability graph produced by the [[Analyzer]].
    *
    *  Warning: this trait is not meant to be extended by third-party libraries
@@ -89,9 +101,12 @@ object Analysis {
       } else {
         import ir.Types._
 
+        def classDisplayName(cls: String): String =
+          PrimitiveClassesDisplayNames.getOrElse(cls, decodeClassName(cls))
+
         def typeDisplayName(tpe: TypeRef): String = tpe match {
-          case ClassRef(encodedName)          => decodeClassName(encodedName)
-          case ArrayTypeRef(base, dimensions) => "[" * dimensions + decodeClassName(base)
+          case ClassRef(encodedName)          => classDisplayName(encodedName)
+          case ArrayTypeRef(base, dimensions) => "[" * dimensions + classDisplayName(base)
         }
 
         val (simpleName, paramTypes, resultType) =

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
@@ -946,7 +946,7 @@ private final class Analyzer(config: CommonPhaseConfig,
       val methodsCalledIterator = data.methodsCalled.iterator
       while (methodsCalledIterator.hasNext) {
         val (className, methods) = methodsCalledIterator.next()
-        if (className == Definitions.PseudoArrayClass) {
+        if (className == Infos.PseudoArrayClass) {
           /* The pseudo Array class is not reified in our analyzer/analysis,
            * so we need to cheat here.
            * In the Array[T] class family, only clone__O is defined and

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
@@ -946,26 +946,9 @@ private final class Analyzer(config: CommonPhaseConfig,
       val methodsCalledIterator = data.methodsCalled.iterator
       while (methodsCalledIterator.hasNext) {
         val (className, methods) = methodsCalledIterator.next()
-        if (className == Infos.PseudoArrayClass) {
-          /* The pseudo Array class is not reified in our analyzer/analysis,
-           * so we need to cheat here.
-           * In the Array[T] class family, only clone__O is defined and
-           * overrides j.l.Object.clone__O. Since this method is implemented
-           * in scalajsenv.js and always kept, we can ignore it.
-           * All other methods resolve to their definition in Object, so we
-           * can model their reachability by calling them statically in the
-           * Object class.
-           */
-          val objectClass = lookupClass(Definitions.ObjectClass)
-          for (methodName <- methods) {
-            if (methodName != "clone__O")
-              objectClass.callMethodStatically(methodName)
-          }
-        } else {
-          val classInfo = lookupClass(className)
-          for (methodName <- methods)
-            classInfo.callMethod(methodName)
-        }
+        val classInfo = lookupClass(className)
+        for (methodName <- methods)
+          classInfo.callMethod(methodName)
       }
 
       val methodsCalledStaticallyIterator = data.methodsCalledStatically.iterator

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
@@ -21,6 +21,12 @@ import org.scalajs.core.tools.linker.LinkedClass
 
 object Infos {
 
+  /** A pseudo class to reify arrays in Infos. */
+  val PseudoArrayClass = "s_Array"
+
+  /** Name used for infos of top-level exports. */
+  private val TopLevelExportsName = "__topLevelExports"
+
   final class ClassInfo private (
       val encodedName: String,
       val isExported: Boolean,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
@@ -204,7 +204,7 @@ object Infos {
         case LongType       => addMethodCalled(BoxedLongClass, method)
         case FloatType      => addMethodCalled(BoxedFloatClass, method)
         case DoubleType     => addMethodCalled(BoxedDoubleClass, method)
-        case StringType     => addMethodCalled(StringClass, method)
+        case StringType     => addMethodCalled(BoxedStringClass, method)
 
         case ArrayType(_) =>
           /* The pseudo Array class is not reified in our analyzer/analysis,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
@@ -708,10 +708,6 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
             case Definitions.BoxedStringClass =>
               js.UnaryOp(JSUnaryOp.typeof, obj) === js.StringLiteral("string")
 
-            case Definitions.RuntimeNothingClass =>
-              // Even null is not an instance of Nothing
-              js.BooleanLiteral(false)
-
             case _ =>
               var test = {
                 genIsScalaJSObject(obj) &&
@@ -746,21 +742,13 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
               obj
 
             case _ =>
-              val throwError = {
+              js.If(js.Apply(envField("is", className), List(obj)) ||
+                  (obj === js.Null()), {
+                obj
+              }, {
                 genCallHelper("throwClassCastException",
                     obj, js.StringLiteral(displayName))
-              }
-              if (className == RuntimeNothingClass) {
-                // Always throw for .asInstanceOf[Nothing], even for null
-                throwError
-              } else {
-                js.If(js.Apply(envField("is", className), List(obj)) ||
-                    (obj === js.Null()), {
-                  obj
-                }, {
-                  throwError
-                })
-              }
+              })
         })))
       }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
@@ -681,7 +681,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
     implicit val pos = tree.pos
 
     if (tree.kind.isClass || tree.kind == ClassKind.Interface ||
-        tree.name.name == Definitions.StringClass) {
+        tree.name.name == Definitions.BoxedStringClass) {
       val className = tree.name.name
       val displayName = decodeClassName(className)
 
@@ -705,7 +705,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
             case Definitions.ObjectClass =>
               js.BinaryOp(JSBinaryOp.!==, obj, js.Null())
 
-            case Definitions.StringClass =>
+            case Definitions.BoxedStringClass =>
               js.UnaryOp(JSUnaryOp.typeof, obj) === js.StringLiteral("string")
 
             case Definitions.RuntimeNothingClass =>
@@ -892,7 +892,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
         tree.ancestors.map(ancestor => (js.Ident(ancestor), js.IntLiteral(1))))
 
     val isInstanceFunWithGlobals: WithGlobals[js.Tree] = {
-      if (isAncestorOfHijackedClass || className == StringClass) {
+      if (isAncestorOfHijackedClass || className == BoxedStringClass) {
         /* java.lang.String and ancestors of hijacked classes, including
          * java.lang.Object, have a normal $is_pack_Class test but with a
          * non-standard behavior.
@@ -1284,6 +1284,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
   /** Gen JS code for an [[ModuleInitializer]]. */
   def genModuleInitializer(moduleInitializer: ModuleInitializer): js.Tree = {
     import TreeDSL._
+    import Definitions.BoxedStringClass
 
     implicit val pos = Position.NoPosition
 
@@ -1293,7 +1294,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
 
       case ModuleInitializer.MainMethodWithArgs(moduleClassName, mainMethodName,
           args) =>
-        val stringArrayTpe = ArrayType(ArrayTypeRef("T", 1))
+        val stringArrayTpe = ArrayType(ArrayTypeRef(BoxedStringClass, 1))
         js.Apply(genLoadModule(moduleClassName) DOT mainMethodName,
             genArrayValue(stringArrayTpe, args.map(js.StringLiteral(_))) :: Nil)
     }
@@ -1329,5 +1330,5 @@ private object ClassEmitter {
   )
 
   private val ClassesWhoseDataReferToTheirInstanceTests =
-    AncestorsOfHijackedClasses + Definitions.StringClass
+    AncestorsOfHijackedClasses + Definitions.BoxedStringClass
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -2003,7 +2003,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                  * implementing them, which prevents that form of inlining from
                  * happening.
                  */
-                genHijackedMethodApply(StringClass)
+                genHijackedMethodApply(BoxedStringClass)
 
               case ClassType(cls) if !HijackedClasses.contains(cls) =>
                 /* This is a strict ancestor of a hijacked class. We need to
@@ -2455,7 +2455,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
       case LongType       => Definitions.BoxedLongClass
       case FloatType      => Definitions.BoxedFloatClass
       case DoubleType     => Definitions.BoxedDoubleClass
-      case StringType     => Definitions.StringClass
+      case StringType     => Definitions.BoxedStringClass
     }
 
     /* Ideally, we should dynamically figure out this set. We should test

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -1983,7 +1983,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                  */
                 genDispatchApply()
 
-              case ClassType(CharSequenceClass)
+              case ClassType("jl_CharSequence")
                   if !hijackedMethodsOfStringWithDispatcher.contains(methodName) =>
                 /* This case is required as a hack around a peculiar behavior
                  * of the optimizer. In theory, it should never happen, because
@@ -2435,8 +2435,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
 
     def isMaybeHijackedClass(tpe: Type): Boolean = tpe match {
       case ClassType(cls) =>
-        Definitions.HijackedClasses.contains(cls) ||
-        Definitions.AncestorsOfHijackedClasses.contains(cls)
+        MaybeHijackedClasses.contains(cls)
       case AnyType | UndefType | BooleanType | CharType | ByteType | ShortType |
           IntType | LongType | FloatType | DoubleType | StringType =>
         true
@@ -2553,6 +2552,11 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
 }
 
 private object FunctionEmitter {
+  private val MaybeHijackedClasses = {
+    (Definitions.HijackedClasses ++ ClassEmitter.AncestorsOfHijackedClasses) -
+    Definitions.ObjectClass
+  }
+
   /** A left hand side that can be pushed into a right hand side tree. */
   sealed abstract class Lhs {
     def hasNothingType: Boolean = false

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -104,7 +104,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
           if (className0 == BoxedLongClass) LongImpl.RuntimeLongClass
           else className0
 
-        if (HijackedClasses.contains(className) && className != StringClass) {
+        if (HijackedClasses.contains(className) && className != BoxedStringClass) {
           if (test) {
             className match {
               case BoxedUnitClass      => expr === Undefined()

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -104,7 +104,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
           if (className0 == BoxedLongClass) LongImpl.RuntimeLongClass
           else className0
 
-        if (HijackedBoxedClasses.contains(className)) {
+        if (HijackedClasses.contains(className) && className != StringClass) {
           if (test) {
             className match {
               case BoxedUnitClass      => expr === Undefined()

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -1177,7 +1177,7 @@ private final class IRChecker(unit: LinkingUnit,
         case 'F' => FloatType
         case 'D' => DoubleType
         case 'O' => AnyType
-        case 'T' => ClassType(StringClass) // NOT StringType
+        case 'T' => ClassType(BoxedStringClass) // NOT StringType
       }
     } else if (encodedName == "sr_Nothing$") {
       NothingType

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -483,7 +483,7 @@ private final class IRChecker(unit: LinkingUnit,
         throw new AssertionError("Exported method may not have Ident as name")
 
       case StringLiteral(name) =>
-        if (name.contains("__") && name != Definitions.TopLevelExportsName)
+        if (name.contains("__"))
           reportError("Exported method def name cannot contain __")
 
       case ComputedName(tree, _) =>
@@ -1324,9 +1324,6 @@ private final class IRChecker(unit: LinkingUnit,
           if (classDef.kind.isJSClass) Nil
           else classDef.fields.map(CheckedClass.checkedField))
     }
-
-    def isAncestorOfHijackedClass: Boolean =
-      AncestorsOfHijackedClasses.contains(name)
 
     def lookupField(name: String): Option[CheckedField] =
       fields.get(name).orElse(superClass.flatMap(_.lookupField(name)))

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -1120,7 +1120,7 @@ private final class IRChecker(unit: LinkingUnit,
       implicit ctx: ErrorContext): Unit = {
     typeRef match {
       case ClassRef(encodedName) =>
-        if (Definitions.isPrimitiveClass(encodedName)) {
+        if (Definitions.PrimitiveClasses.contains(encodedName)) {
           reportError(
               s"Primitive type $encodedName is not a valid target type for " +
               "Is/AsInstanceOf")

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -1517,7 +1517,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     case LongType     => LongImpl.RuntimeLongClass
     case FloatType    => Definitions.BoxedFloatClass
     case DoubleType   => Definitions.BoxedDoubleClass
-    case StringType   => Definitions.StringClass
+    case StringType   => Definitions.BoxedStringClass
     case ArrayType(_) => Definitions.ObjectClass
   }
 
@@ -1932,7 +1932,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
     @inline def contTree(result: Tree) = cont(result.toPreTransform)
 
-    @inline def StringClassType = ClassType(Definitions.StringClass)
+    @inline def StringClassType = ClassType(Definitions.BoxedStringClass)
 
     def defaultApply(methodName: String, resultType: Type): TailRec[Tree] =
       contTree(Apply(newReceiver, Ident(methodName), newArgs)(resultType))


### PR DESCRIPTION
This PR contains a series of changes that started with #3195, and turned into decoupling the IR specification from Scala as a source language, as much as possible.

After these changes, there remains only one Scala-specific thing in the IR specification per se: `scala.runtime.BoxedUnit`. I am not sure how to get rid of that dependency, short of introducing a class `java.lang.Unit` in our `javalanglib/`. It would not be accessible as user-level code because there would be no .class file for it, but our back-end would translate `s.r.BoxedUnit` into `j.l.Unit` on the fly to make things work. Other languages like Kotlin could then translate their boxed unit type into `j.l.Unit` too (currently, the Kotlin compiler would have to translate it `scala.runtime.BoxedUnit` ... meh).

There is another catch: besides the IR specification, we also have the `Emitter`'s requirements. And currently it still requires a few Scala-specific things. Some are accidental, but at least one is a language-definition-level thing: the dependency on `scala.scalajs.runtime.UndefinedBehaviorError`. That's another story, though ...