### PR TITLE
Turn the compiler crash of #3211 into a linking error.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -156,7 +156,6 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
   def encodeRTStringMethodSym(sym: Symbol)(
       implicit pos: Position): (Symbol, js.Ident) = {
     require(sym.isMethod, "encodeMethodSym called with non-method symbol: " + sym)
-    require(sym.owner == definitions.StringClass)
     require(!sym.isClassConstructor && !sym.isPrivate)
 
     val (encodedName, paramsString) =

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/RegressionTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/RegressionTest.scala
@@ -1,0 +1,35 @@
+package org.scalajs.core.compiler.test
+
+import org.scalajs.core.compiler.test.util._
+import org.junit.Test
+import org.junit.Assume._
+
+// scalastyle:off line.size.limit
+
+class RegressionTest extends DirectTest with TestHelpers {
+
+  @Test
+  def noCrashWhenCallingDefaultMethodsOfCharSequence_issue3211: Unit = {
+    val javaVersion = System.getProperty("java.specification.version")
+    assumeTrue(javaVersion.startsWith("1.8") || !javaVersion.startsWith("1."))
+
+    """
+    object LexerUtil {
+      def reflectiveLongest(data: String): Unit = {
+        println(data.chars())
+      }
+    }
+    """.succeeds()
+
+    """
+    import scala.language.reflectiveCalls
+
+    object LexerUtil {
+      def reflectiveLongest(data: Any { def chars: String }): Unit = {
+        println(data.chars)
+      }
+    }
+    """.succeeds()
+  }
+
+}


### PR DESCRIPTION
At the very least, the compiler should not crash on any valid Scala code, so this commit makes the situation a bit less bad than it was before.

It does not really *solve* the issue, though, as there is still a linking error. That, however, seems difficult if not impossible to properly fix, as explained in #3211, so we do not attempt to address it now.