### PR TITLE
Mitigate #3206: Send stderr of Node.js to the `JSConsole`.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -96,13 +96,8 @@ abstract class ExternalJSEnv(
       try { sendVMStdin(out) }
       finally { out.close() }
 
-      // Pipe stdout to console
+      // Pipe stdout (and stderr which is merged into it) to console
       pipeToConsole(vmInst.getInputStream(), console)
-
-      // We are probably done (stdin is closed). Report any errors
-      val errSrc = Source.fromInputStream(vmInst.getErrorStream(), "UTF-8")
-      try { errSrc.getLines.foreach(err => logger.error(err)) }
-      finally { errSrc.close }
     }
 
     /** Wait for the VM to terminate, verify exit code
@@ -125,6 +120,7 @@ abstract class ExternalJSEnv(
 
       val allArgs = executable +: vmArgs
       val pBuilder = new ProcessBuilder(allArgs: _*)
+      pBuilder.redirectErrorStream(true) // merge stderr into stdout
 
       pBuilder.environment().clear()
       for ((name, value) <- vmEnv)


### PR DESCRIPTION
This way, at least all JS environments agree on what they do with `console.error()`, which is to merge it with `console.log()` and send everything to the `console: JSConsole` (which is the standard output by default).

A deeper fix would allow to separately configure stdout and stderr, but that can only be done in Scala.js 1.x in the context of the redesign of `JSEnv`s #3033.