### PR TITLE
Reintroduce tests for our EMCAScript 2015 polyfills.

### DIFF
--- a/ci/matrix.xml
+++ b/ci/matrix.xml
@@ -83,6 +83,34 @@
         ++$scala $testSuite/test
   ]]></task>
 
+  <task id="test-suite-ecma-script5-force-polyfills"><![CDATA[
+    setJavaVersion $java
+    npm install &&
+    sbtretry 'set jsEnv in $testSuite := new NodeJSEnvForcePolyfills()' \
+        ++$scala $testSuite/test &&
+    sbtretry 'set jsEnv in $testSuite := new NodeJSEnvForcePolyfills()' \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set jsEnv in $testSuite := new NodeJSEnvForcePolyfills()' \
+        'set scalaJSLinkerConfig in $testSuite ~= (_.withOptimizer(false))' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set jsEnv in $testSuite := new NodeJSEnvForcePolyfills()' \
+        'set scalaJSLinkerConfig in $testSuite ~= makeCompliant' \
+        ++$scala $testSuite/test &&
+    sbtretry 'set jsEnv in $testSuite := new NodeJSEnvForcePolyfills()' \
+        'set scalaJSLinkerConfig in $testSuite ~= makeCompliant' \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set jsEnv in $testSuite := new NodeJSEnvForcePolyfills()' \
+        'set scalaJSLinkerConfig in $testSuite ~= makeCompliant' \
+        'set scalaJSLinkerConfig in $testSuite ~= (_.withOptimizer(false))' \
+        ++$scala $testSuite/test \
+        $testSuite/clean
+  ]]></task>
+
   <task id="test-suite-ecma-script6"><![CDATA[
     setJavaVersion $java
     npm install &&
@@ -276,6 +304,13 @@
     </run>
     <run task="test-suite-ecma-script5">
       <v n="scala">2.13.0-M2</v>
+      <v n="java">1.8</v>
+      <v n="testSuite">testSuite</v>
+    </run>
+
+    <!-- Test suite on ECMAScript5 with forced polyfills tasks -->
+    <run task="test-suite-ecma-script5-force-polyfills">
+      <v n="scala">2.12.4</v>
       <v n="java">1.8</v>
       <v n="testSuite">testSuite</v>
     </run>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -57,6 +57,8 @@ object ExposedValues extends AutoPlugin {
         config: StandardLinker.Config): standard.StandardLinkerConfigStandardOps = {
       standard.StandardLinkerConfigStandardOps(config)
     }
+
+    type NodeJSEnvForcePolyfills = build.NodeJSEnvForcePolyfills
   }
 }
 
@@ -1273,8 +1275,8 @@ object Build {
       testOptionTags := {
         def envTagsFor(env: JSEnv): Seq[String] = env match {
           case env: NodeJSEnv =>
-            val baseArgs = Seq("nodejs", "typedarray")
-            if (env.wantSourceMap) {
+            val tags1 = Seq("nodejs")
+            val tags2 = if (env.wantSourceMap) {
               if (!env.hasSourceMapSupport) {
                 throw new MessageOnlyException(
                     "You must install Node.js source map support to " +
@@ -1283,9 +1285,15 @@ object Build {
                     "tests, do: set jsEnv in " + thisProject.value.id +
                     " := NodeJSEnv().value.withSourceMap(false)")
               }
-              baseArgs :+ "source-maps"
+              tags1 :+ "source-maps"
             } else {
-              baseArgs
+              tags1
+            }
+            env match {
+              case env: NodeJSEnvForcePolyfills =>
+                tags1
+              case _ =>
+                tags1 :+ "typedarray"
             }
 
           case _ =>

--- a/project/NodeJSEnvForcePolyfills.scala
+++ b/project/NodeJSEnvForcePolyfills.scala
@@ -1,0 +1,53 @@
+package build
+
+import org.scalajs.jsenv._
+import org.scalajs.jsenv.nodejs._
+
+import org.scalajs.core.tools.io._
+
+class NodeJSEnvForcePolyfills(config: NodeJSEnv.Config)
+    extends NodeJSEnv(config) {
+
+  def this() = this(NodeJSEnv.Config())
+
+  override protected def vmName: String = "Node.js forcing polyfills"
+
+  /** File(s) to force all our ES 2015 polyfills to be used, by deleting the
+   *  native functions.
+   */
+  protected def forcePolyfills(): Seq[VirtualJSFile] = {
+    val f = new MemVirtualJSFile("scalaJSEnvInfo.js").withContent(
+      """
+        |delete Math.fround;
+        |delete Math.imul;
+        |delete Math.clz32;
+        |delete Math.log10;
+        |delete Math.log1p;
+        |delete Math.cbrt;
+        |delete Math.hypot;
+        |delete Math.expm1;
+        |delete Math.sinh;
+        |delete Math.cosh;
+        |delete Math.tanh;
+        |
+        |delete global.Promise;
+        |
+        |delete global.ArrayBuffer;
+        |delete global.Int8Array;
+        |delete global.Int16Array;
+        |delete global.Int32Array;
+        |delete global.Uint8Array;
+        |delete global.Uint16Array;
+        |delete global.Uint32Array;
+        |delete global.Float32Array;
+        |delete global.Float64Array;
+      """.stripMargin
+    )
+    Seq(f)
+  }
+
+  /** Custom initialization scripts. */
+  override protected def customInitFiles(): Seq[VirtualJSFile] =
+    super.customInitFiles() ++ forcePolyfills()
+
+}


### PR DESCRIPTION
When we removed support for Rhino, and moved the support of PhantomJS in a separate repository, we accidently got rid of all the tests in our build checking our polyfills for ES 2015 features. For example, the polyfills for `Math.imul`, or the floating-point bits conversions (including `Double.hashCode`).

This commit restores that by introducing in our build a custom `NodeJSEnvForcePolyfills`, which is like `NodeJSEnv` but forcefully `delete`s all the good stuff from ES 2015.

This ensures that we do not introduce regressions in our polyfills in the future.