### PR TITLE
Fix #3219: Correctly recognize exports for `$xyz` in the back-end.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -109,8 +109,7 @@ trait JSGlobalAddons extends JSDefinitions
 
     /** checks if the given symbol is a JSExport */
     def isExport(sym: Symbol): Boolean =
-      sym.unexpandedName.startsWith(exportPrefix) &&
-      !sym.hasFlag(Flags.DEFAULTPARAM)
+      sym.name.startsWith(exportPrefix) && !sym.hasFlag(Flags.DEFAULTPARAM)
 
     /** retrieves the originally assigned jsName of this export and whether it
      *  is a property
@@ -119,7 +118,7 @@ trait JSGlobalAddons extends JSDefinitions
       def dropPrefix(prefix: String) ={
         if (name.startsWith(prefix)) {
           // We can't decode right away due to $ separators
-          val enc = name.encoded.substring(prefix.length)
+          val enc = name.toString.substring(prefix.length)
           Some(NameTransformer.decode(enc))
         } else None
       }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -73,6 +73,30 @@ class ExportsTest {
     assertEquals(42, foo.myMethod())
   }
 
+  @Test def exports_for_methods_whose_encodedName_starts_with_dollar_issue_3219(): Unit = {
+    class ExportsForMethodsWhoseEncodedNameStartsWithDollar {
+      @JSExport("$a")
+      def f(x: Int): Int = x + 1
+
+      @JSExport
+      def +(x: Int): Int = x + 2
+
+      @JSExport("-")
+      def plus(x: Int): Int = x + 3
+
+      @JSExport("plus")
+      def ++(x: Int): Int = x + 4
+    }
+
+    val fns = new ExportsForMethodsWhoseEncodedNameStartsWithDollar()
+      .asInstanceOf[js.Dynamic]
+
+    assertEquals(6, fns.applyDynamic("$a")(5))
+    assertEquals(7, fns.applyDynamic("+")(5))
+    assertEquals(8, fns.applyDynamic("-")(5))
+    assertEquals(9, fns.applyDynamic("plus")(5))
+  }
+
   @Test def exports_for_protected_methods(): Unit = {
     class Foo {
       @JSExport
@@ -144,6 +168,30 @@ class ExportsTest {
     assertEquals("hello get", foo.y)
     foo.y = "world"
     assertEquals("world set get", foo.y)
+  }
+
+  @Test def exports_for_properties_whose_encodedName_starts_with_dollar_issue_3219(): Unit = {
+    class ExportsForPropertiesWhoseEncodedNameStartsWithDollar {
+      @JSExport("$a")
+      def f: Int = 6
+
+      @JSExport
+      def + : Int = 7 // scalastyle:ignore
+
+      @JSExport("-")
+      def plus: Int = 8
+
+      @JSExport("plus")
+      def ++ : Int = 9 // scalastyle:ignore
+    }
+
+    val fns = new ExportsForPropertiesWhoseEncodedNameStartsWithDollar()
+      .asInstanceOf[js.Dynamic]
+
+    assertEquals(6, fns.selectDynamic("$a"))
+    assertEquals(7, fns.selectDynamic("+"))
+    assertEquals(8, fns.selectDynamic("-"))
+    assertEquals(9, fns.selectDynamic("plus"))
   }
 
   @Test def exports_for_protected_properties(): Unit = {


### PR DESCRIPTION
We were erroneously using `sym.unexpandedName` when testing whether a method is an export bridge. However, if the export name happens to start with a `$`, then `unexpandedName` considers the whole thing as an expanded name, and removes the whole prefix as if it were the result of an expansion.

Simply using the `name` for the test fixes the issue. Note that `jsExportInfo` was already using `name`, and not `unexpandedName`.