### PR TITLE
Fix #3218: Do not execute `main()` in `Test` twice for `test:run`.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -1017,7 +1017,7 @@ object ScalaJSPluginInternal {
       // without loosing autocompletion.
       definedTestNames := {
         definedTests.map(_.map(_.name).distinct)
-          .storeAs(definedTestNames).triggeredBy(loadedJSEnv).value
+          .storeAs(definedTestNames).triggeredBy(loadedTestFrameworks).value
       }
   )
 


### PR DESCRIPTION
Running `test:run` depends on `loadedJSEnv in Test`, which itself triggered the discovery of tests, resulting in an additional instance of the .js file to be executed. This meant that the `main()` was effectively run twice when doing `test:run`.

We fix this problem by backporting one change from Scala.js 1.x, which is to trigger test discovery only on `loadedTestFrameworks`, but not on `loadedJSEnv`.