### PR TITLE
Support Charset.aliases() method

### DIFF
--- a/javalib/src/main/scala/java/nio/charset/Charset.scala
+++ b/javalib/src/main/scala/java/nio/charset/Charset.scala
@@ -1,12 +1,19 @@
 package java.nio.charset
 
 import java.nio.{ByteBuffer, CharBuffer}
+import java.util.{Collections, HashSet, Arrays}
 
 import scala.scalajs.js
 
 abstract class Charset protected (canonicalName: String,
-    aliases: Array[String]) extends AnyRef with Comparable[Charset] {
+    _aliases: Array[String]) extends AnyRef with Comparable[Charset] {
+
+  private lazy val aliasesSet =
+    Collections.unmodifiableSet(new HashSet(Arrays.asList(_aliases)))
+
   final def name(): String = canonicalName
+
+  final def aliases(): java.util.Set[String] = aliasesSet
 
   override final def equals(that: Any): Boolean = that match {
     case that: Charset => this.name == that.name

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
@@ -7,6 +7,8 @@
 \*                                                                      */
 package org.scalajs.testsuite.niocharset
 
+import scala.collection.JavaConverters._
+
 import java.nio.charset._
 
 import org.junit.Test
@@ -16,6 +18,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class CharsetTest {
+  def javaSet[A](elems: A*): java.util.Set[A] = Set(elems: _*).asJava
 
   @Test def defaultCharset(): Unit = {
     assertSame("UTF-8", Charset.defaultCharset().name())
@@ -66,5 +69,25 @@ class CharsetTest {
     assertTrue(Charset.isSupported("unicode"))
 
     assertFalse(Charset.isSupported("this-charset-does-not-exist"))
+  }
+
+  @Test def aliases(): Unit = {
+    assertEquals(Charset.forName("UTF-8").aliases(),
+        javaSet("UTF8", "unicode-1-1-utf-8"))
+    assertEquals(Charset.forName("UTF-16").aliases(),
+        javaSet("UTF_16", "unicode", "utf16", "UnicodeBig"))
+    assertEquals(Charset.forName("UTF-16BE").aliases(),
+        javaSet("X-UTF-16BE", "UTF_16BE", "ISO-10646-UCS-2",
+            "UnicodeBigUnmarked"))
+    assertEquals(Charset.forName("UTF-16LE").aliases(),
+        javaSet("UnicodeLittleUnmarked", "UTF_16LE", "X-UTF-16LE"))
+    assertEquals(Charset.forName("US-ASCII").aliases(),
+        javaSet("ANSI_X3.4-1968", "cp367", "csASCII", "iso-ir-6", "ASCII",
+            "iso_646.irv:1983", "ANSI_X3.4-1986", "ascii7", "default",
+            "ISO_646.irv:1991", "ISO646-US", "IBM367", "646", "us"))
+    assertEquals(Charset.forName("ISO-8859-1").aliases(),
+        javaSet("819", "ISO8859-1", "l1", "ISO_8859-1:1987", "ISO_8859-1", "8859_1",
+            "iso-ir-100", "latin1", "cp819", "ISO8859_1", "IBM819", "ISO_8859_1",
+            "IBM-819", "csISOLatin1"))
   }
 }


### PR DESCRIPTION
This is a small addition to `Charset` to support the method `aliases()` basically exposing the `aliases` field in the right format.

This is the method in particular:
https://docs.oracle.com/javase/7/docs/api/java/nio/charset/Charset.html#aliases()