### PR TITLE
Fix #3228: Correctly identify module classes for refl. instantiation.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -941,7 +941,7 @@ abstract class GenJSCode extends plugins.PluginComponent
 
     private def genRegisterReflectiveInstantiation(sym: Symbol)(
         implicit pos: Position): Option[js.Tree] = {
-      if (sym.isModuleClass)
+      if (isStaticModule(sym))
         genRegisterReflectiveInstantiationForModuleClass(sym)
       else
         genRegisterReflectiveInstantiationForNormalClass(sym)


### PR DESCRIPTION
We were using `sym.isModuleClass` to identify module classes when generating the reflective instantiation code, but that also matches nested objects. The appropriate predicate is `isStaticModule(sym)`.