### PR TITLE
FF ONLY Merge 0.6.x into master, December 26

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
@@ -152,8 +152,7 @@ trait JSGlobalAddons extends JSDefinitions
 
     /** checks if the given symbol is a JSExport */
     def isExport(sym: Symbol): Boolean =
-      sym.unexpandedName.startsWith(exportPrefix) &&
-      !sym.hasFlag(Flags.DEFAULTPARAM)
+      sym.name.startsWith(exportPrefix) && !sym.hasFlag(Flags.DEFAULTPARAM)
 
     /** retrieves the originally assigned jsName of this export and whether it
      *  is a property
@@ -162,7 +161,7 @@ trait JSGlobalAddons extends JSDefinitions
       def dropPrefix(prefix: String) ={
         if (name.startsWith(prefix)) {
           // We can't decode right away due to $ separators
-          val enc = name.encoded.substring(prefix.length)
+          val enc = name.toString.substring(prefix.length)
           Some(NameTransformer.decode(enc))
         } else None
       }

--- a/javalib/src/main/scala/java/nio/charset/Charset.scala
+++ b/javalib/src/main/scala/java/nio/charset/Charset.scala
@@ -1,12 +1,19 @@
 package java.nio.charset
 
 import java.nio.{ByteBuffer, CharBuffer}
+import java.util.{Collections, HashSet, Arrays}
 
 import scala.scalajs.js
 
 abstract class Charset protected (canonicalName: String,
-    aliases: Array[String]) extends AnyRef with Comparable[Charset] {
+    _aliases: Array[String]) extends AnyRef with Comparable[Charset] {
+
+  private lazy val aliasesSet =
+    Collections.unmodifiableSet(new HashSet(Arrays.asList(_aliases)))
+
   final def name(): String = canonicalName
+
+  final def aliases(): java.util.Set[String] = aliasesSet
 
   override final def equals(that: Any): Boolean = that match {
     case that: Charset => this.name == that.name

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -93,13 +93,8 @@ abstract class ExternalJSEnv extends AsyncJSEnv {
       try { sendVMStdin(out) }
       finally { out.close() }
 
-      // Pipe stdout to console
+      // Pipe stdout (and stderr which is merged into it) to console
       pipeToConsole(vmInst.getInputStream(), console)
-
-      // We are probably done (stdin is closed). Report any errors
-      val errSrc = Source.fromInputStream(vmInst.getErrorStream(), "UTF-8")
-      try { errSrc.getLines.foreach(err => logger.error(err)) }
-      finally { errSrc.close }
     }
 
     /** Wait for the VM to terminate, verify exit code
@@ -122,6 +117,7 @@ abstract class ExternalJSEnv extends AsyncJSEnv {
 
       val allArgs = executable +: vmArgs
       val pBuilder = new ProcessBuilder(allArgs: _*)
+      pBuilder.redirectErrorStream(true) // merge stderr into stdout
 
       pBuilder.environment().clear()
       for ((name, value) <- vmEnv)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
@@ -63,6 +63,16 @@ class RegressionJSTest {
     assertEquals("B", c.t3())
   }
 
+  @Test def emit_anon_JS_function_class_data_with_2_11_Xexperimental_issue_3222(): Unit = {
+    val initSourceMapper: Option[js.Function1[Int, Int]] = None
+    val sourceMapper: js.Function1[Int, Int] = {
+      initSourceMapper.getOrElse {
+        (s: Int) => s
+      }
+    }
+    assertEquals(4, sourceMapper(4))
+  }
+
 }
 
 object RegressionJSTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -92,6 +92,30 @@ class ExportsTest {
     assertEquals(42, foo.myMethod())
   }
 
+  @Test def exports_for_methods_whose_encodedName_starts_with_dollar_issue_3219(): Unit = {
+    class ExportsForMethodsWhoseEncodedNameStartsWithDollar {
+      @JSExport("$a")
+      def f(x: Int): Int = x + 1
+
+      @JSExport
+      def +(x: Int): Int = x + 2
+
+      @JSExport("-")
+      def plus(x: Int): Int = x + 3
+
+      @JSExport("plus")
+      def ++(x: Int): Int = x + 4
+    }
+
+    val fns = new ExportsForMethodsWhoseEncodedNameStartsWithDollar()
+      .asInstanceOf[js.Dynamic]
+
+    assertEquals(6, fns.applyDynamic("$a")(5))
+    assertEquals(7, fns.applyDynamic("+")(5))
+    assertEquals(8, fns.applyDynamic("-")(5))
+    assertEquals(9, fns.applyDynamic("plus")(5))
+  }
+
   @Test def exports_for_protected_methods(): Unit = {
     class Foo {
       @JSExport
@@ -163,6 +187,30 @@ class ExportsTest {
     assertEquals("hello get", foo.y)
     foo.y = "world"
     assertEquals("world set get", foo.y)
+  }
+
+  @Test def exports_for_properties_whose_encodedName_starts_with_dollar_issue_3219(): Unit = {
+    class ExportsForPropertiesWhoseEncodedNameStartsWithDollar {
+      @JSExport("$a")
+      def f: Int = 6
+
+      @JSExport
+      def + : Int = 7 // scalastyle:ignore
+
+      @JSExport("-")
+      def plus: Int = 8
+
+      @JSExport("plus")
+      def ++ : Int = 9 // scalastyle:ignore
+    }
+
+    val fns = new ExportsForPropertiesWhoseEncodedNameStartsWithDollar()
+      .asInstanceOf[js.Dynamic]
+
+    assertEquals(6, fns.selectDynamic("$a"))
+    assertEquals(7, fns.selectDynamic("+"))
+    assertEquals(8, fns.selectDynamic("-"))
+    assertEquals(9, fns.selectDynamic("plus"))
   }
 
   @Test def exports_for_protected_properties(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
@@ -7,6 +7,8 @@
 \*                                                                      */
 package org.scalajs.testsuite.niocharset
 
+import scala.collection.JavaConverters._
+
 import java.nio.charset._
 
 import org.junit.Test
@@ -16,6 +18,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class CharsetTest {
+  def javaSet[A](elems: A*): java.util.Set[A] = Set(elems: _*).asJava
 
   @Test def defaultCharset(): Unit = {
     assertSame("UTF-8", Charset.defaultCharset().name())
@@ -66,5 +69,25 @@ class CharsetTest {
     assertTrue(Charset.isSupported("unicode"))
 
     assertFalse(Charset.isSupported("this-charset-does-not-exist"))
+  }
+
+  @Test def aliases(): Unit = {
+    assertEquals(Charset.forName("UTF-8").aliases(),
+        javaSet("UTF8", "unicode-1-1-utf-8"))
+    assertEquals(Charset.forName("UTF-16").aliases(),
+        javaSet("UTF_16", "unicode", "utf16", "UnicodeBig"))
+    assertEquals(Charset.forName("UTF-16BE").aliases(),
+        javaSet("X-UTF-16BE", "UTF_16BE", "ISO-10646-UCS-2",
+            "UnicodeBigUnmarked"))
+    assertEquals(Charset.forName("UTF-16LE").aliases(),
+        javaSet("UnicodeLittleUnmarked", "UTF_16LE", "X-UTF-16LE"))
+    assertEquals(Charset.forName("US-ASCII").aliases(),
+        javaSet("ANSI_X3.4-1968", "cp367", "csASCII", "iso-ir-6", "ASCII",
+            "iso_646.irv:1983", "ANSI_X3.4-1986", "ascii7", "default",
+            "ISO_646.irv:1991", "ISO646-US", "IBM367", "646", "us"))
+    assertEquals(Charset.forName("ISO-8859-1").aliases(),
+        javaSet("819", "ISO8859-1", "l1", "ISO_8859-1:1987", "ISO_8859-1", "8859_1",
+            "iso-ir-100", "latin1", "cp819", "ISO8859_1", "IBM819", "ISO_8859_1",
+            "IBM-819", "csISOLatin1"))
   }
 }


### PR DESCRIPTION
Motivation: I need #3223 to be in master to proceed with one of my master plans :)
```
$ git checkout -b merge-0.6.x-into-master-december-26
Switched to a new branch 'merge-0.6.x-into-master-december-26'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   6b1fa94 (scalajs/0.6.x) Merge pull request #3224 from sjrd/fix-exports-with-encoded-name-starting-with-dollar
|\
| * 3ccfd02 Fix #3219: Correctly recognize exports for `$xyz` in the back-end.
* |   ac6c8e3 Merge pull request #3223 from sjrd/fix-ir-checking-error-with-2.11-experimental
|\ \
| * | ca86e39 Fix #3222: Emit a .sjsir for anon JS functions in 2.11/-Xexperimental.
| |/
* |   6705b3c Merge pull request #3226 from cquiroz/charset_aliases
|\ \
| * | 273b250 Support Charset.aliases() method
|/ /
* |   30a254f Merge pull request #3225 from sjrd/no-run-test-main-twice
|\ \
| |/
|/|
| * ce4004e Fix #3218: Do not execute `main()` in `Test` twice for `test:run`.
|/
*   53aeff2 Merge pull request #3214 from sjrd/send-stderr-of-nodejs-to-jsconsole
|\
| * bb9c6cb Mitigate #3206: Send stderr of Node.js to the `JSConsole`.
* |   f6b1d71 Merge pull request #3213 from sjrd/no-compiler-crash-for-refl-call-of-charsequence-default-methods
|\ \
| |/
|/|
| * 7abedec [no-master] Turn the compiler crash of #3211 into a linking error.
|/
*   8e9ae3b Merge pull request #3198 from sjrd/reduce-code-size-for-tojsarray
|\
| * 303b992 Do not inline `.toJSArray` to prevent code size blowing up.
|/
* 37e37a6 Merge pull request #3203 from sjrd/fix-build-bincompat
* e40c92c Fix the build: bincompat check fails on JDK 6, Scala 2.10.7.
```
```
$ git merge --no-commit  8e9ae3b
Auto-merging project/BinaryIncompatibilities.scala
CONFLICT (content): Merge conflict in project/BinaryIncompatibilities.scala
Auto-merging library/src/main/scala/scala/scalajs/js/JSConverters.scala
CONFLICT (content): Merge conflict in library/src/main/scala/scala/scalajs/js/JSConverters.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU library/src/main/scala/scala/scalajs/js/JSConverters.scala
UU project/BinaryIncompatibilities.scala
```
```
$ git checkout -f HEAD project/BinaryIncompatibilities.scala
```
```
$ git st
UU library/src/main/scala/scala/scalajs/js/JSConverters.scala
```
[...] Edit conflicting files
```diff
$ git diff | cat
diff --cc library/src/main/scala/scala/scalajs/js/JSConverters.scala
index f29a087,4dd745e..0000000
--- a/library/src/main/scala/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSConverters.scala
@@@ -40,7 -39,28 +40,28 @@@ object JSConverters extends js.JSConver

    implicit class JSRichGenTraversableOnce[T](
        val col: GenTraversableOnce[T]) extends AnyVal {
-     @inline final def toJSArray: js.Array[T] = genTraversableOnce2jsArray(col)
 -    final def toJSArray: Array[T] = {
++    final def toJSArray: js.Array[T] = {
+       /* This is basically a duplicate of `runtime.genTraversableOnce2jsArray`,
+        * except it is not marked `@inline`. We do not want to inline this
+        * method every time someone does `.toJSArray`, for code size reasons
+        * (unlike `genTraversableOnce2jsArray`, which is used by the codegen for
+        * transferring Scala varargs to JS varargs).
+        *
+        * One would think that we could still delegate to
+        * `genTraversableOnce2jsArray` and mark `toJSArray` with `@noinline`
+        * instead, but that would prevent `toJSArray` to be inlined even when
+        * `col` is stack-allocated (and we do want that to happen as in that
+        * case the entire match disappears and `col` can stay stack-allocated).
+        */
+       col match {
+         case col: js.ArrayOps[T]     => col.repr
+         case col: js.WrappedArray[T] => col.array
+         case _ =>
+           val result = new js.Array[T]
+           col.foreach(x => result.push(x))
+           result
+       }
+     }
    }

    implicit class JSRichGenIterable[T](
```
```
$ git add -u
```
```
$ git st
M  library/src/main/scala/scala/scalajs/js/JSConverters.scala
```
```
$ git commit
[merge-0.6.x-into-master-december-26 2eccb10] Merge '0.6.x' into 'master'.
```
```
$ export mb=$(git merge-base scalajs/0.6.x HEAD)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   6b1fa94 (scalajs/0.6.x) Merge pull request #3224 from sjrd/fix-exports-with-encoded-name-starting-with-dollar
|\
| * 3ccfd02 Fix #3219: Correctly recognize exports for `$xyz` in the back-end.
* |   ac6c8e3 Merge pull request #3223 from sjrd/fix-ir-checking-error-with-2.11-experimental
|\ \
| * | ca86e39 Fix #3222: Emit a .sjsir for anon JS functions in 2.11/-Xexperimental.
| |/
* |   6705b3c Merge pull request #3226 from cquiroz/charset_aliases
|\ \
| * | 273b250 Support Charset.aliases() method
|/ /
* |   30a254f Merge pull request #3225 from sjrd/no-run-test-main-twice
|\ \
| |/
|/|
| * ce4004e Fix #3218: Do not execute `main()` in `Test` twice for `test:run`.
|/
*   53aeff2 Merge pull request #3214 from sjrd/send-stderr-of-nodejs-to-jsconsole
|\
| * bb9c6cb Mitigate #3206: Send stderr of Node.js to the `JSConsole`.
* f6b1d71 Merge pull request #3213 from sjrd/no-compiler-crash-for-refl-call-of-charsequence-default-methods
* 7abedec [no-master] Turn the compiler crash of #3211 into a linking error.
```
```
$ git merge -s ours f6b1d71
Merge made by the 'ours' strategy.
```
```
$ git show --stat
commit bae79ea07eabe6cb042be78608c69f7522c77a5a
Merge: 2eccb10 f6b1d71
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Tue Dec 26 11:59:40 2017 +0100

    Skip the [no-master] commit 7abedec.

```
```
$ export mb=$(git merge-base scalajs/0.6.x HEAD)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   6b1fa94 (scalajs/0.6.x) Merge pull request #3224 from sjrd/fix-exports-with-encoded-name-starting-with-dollar
|\
| * 3ccfd02 Fix #3219: Correctly recognize exports for `$xyz` in the back-end.
* |   ac6c8e3 Merge pull request #3223 from sjrd/fix-ir-checking-error-with-2.11-experimental
|\ \
| * | ca86e39 Fix #3222: Emit a .sjsir for anon JS functions in 2.11/-Xexperimental.
| |/
* |   6705b3c Merge pull request #3226 from cquiroz/charset_aliases
|\ \
| * | 273b250 Support Charset.aliases() method
|/ /
* |   30a254f Merge pull request #3225 from sjrd/no-run-test-main-twice
|\ \
| |/
|/|
| * ce4004e Fix #3218: Do not execute `main()` in `Test` twice for `test:run`.
|/
* 53aeff2 Merge pull request #3214 from sjrd/send-stderr-of-nodejs-to-jsconsole
* bb9c6cb Mitigate #3206: Send stderr of Node.js to the `JSConsole`.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
Auto-merging js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
M  compiler/src/main/scala/org/scalajs/core/compiler/JSGlobalAddons.scala
M  javalib/src/main/scala/java/nio/charset/Charset.scala
M  js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
```
[...] Edit conflicting files
```diff
$ git diff -w | cat
diff --cc compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
index 017fe10,93565f4..0000000
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@@ -278,10 -264,10 +278,10 @@@ abstract class GenJSCode extends plugin
           * Since for all these, we don't know how they inter-depend, we just
           * store them in a map at this point.
           */
-         val (lazyAnons, fullClassDefs) = allClassDefs.partition { cd =>
+         val (lazyAnons, fullClassDefs0) = allClassDefs.partition { cd =>
            val sym = cd.symbol
            isRawJSFunctionDef(sym) || sym.isAnonymousFunction ||
 -          isScalaJSDefinedAnonJSClass(sym)
 +          isAnonJSClass(sym)
          }

          lazilyGeneratedAnonClasses ++= lazyAnons.map(cd => cd.symbol -> cd)
@@@ -301,14 -297,13 +311,14 @@@
                  unexpectedMutatedFields  := mutable.Set.empty,
                  generatedSAMWrapperCount := new VarBox(0)
              ) {
 -              val tree = if (isRawJSType(sym.tpe)) {
 -                if (!sym.isTraitOrInterface && isScalaJSDefinedJSClass(sym) &&
 +              try {
 +                val tree = if (isJSType(sym)) {
-                   assert(!isRawJSFunctionDef(sym),
-                       s"Raw JS function def should have been recorded: $cd")
-                   if (!sym.isTraitOrInterface && isNonNativeJSClass(sym))
++                  if (!sym.isTraitOrInterface && isNonNativeJSClass(sym) &&
+                       !isRawJSFunctionDef(sym)) {
 -                  genScalaJSDefinedJSClass(cd)
 +                    genNonNativeJSClass(cd)
-                   else
+                   } else {
                      genRawJSClassData(cd)
+                   }
                  } else if (sym.isTraitOrInterface) {
                    genInterface(cd)
                  } else if (sym.isImplClass) {
```
```
$ git add -u
```
```
$ git commit
[merge-0.6.x-into-master-december-26 7b3a851] Merge '0.6.x' into 'master'.
```
