### PR TITLE
Remove the `js.Dynamic.x` workaround.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Dynamic.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dynamic.scala
@@ -67,10 +67,6 @@ sealed trait Dynamic extends js.Any with scala.Dynamic {
 
   def &&(that: js.Dynamic): js.Dynamic = js.native
   def ||(that: js.Dynamic): js.Dynamic = js.native
-
-  // Work around the annoying implicits in Predef in Scala 2.10.
-  def x: js.Dynamic = js.native
-  def x_=(value: js.Any): Unit = js.native
 }
 
 /** Factory for dynamically typed JavaScript values. */

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
@@ -1095,7 +1095,17 @@ class NonNativeJSTypeTest {
     assertJSArrayEquals(js.Array(8, 23), foo.args)
 
     val dyn = foo.asInstanceOf[js.Dynamic]
-    assertEquals(4, dyn.x)
+    /* Dark magic is at play here: everywhere else in this compilation unit,
+     * it's fine to do `assertEquals(4, dyn.x)` (for example, in the test
+     * `override_native_method` below), but right here, it causes scalac to die
+     * with a completely nonsensical compile error:
+     *
+     * > applyDynamic does not support passing a vararg parameter
+     *
+     * Extracting it in a separate `val` works around it.
+     */
+    val dynx = dyn.x
+    assertEquals(4, dynx)
     val args = dyn.args.asInstanceOf[js.Array[Int]]
     assertJSArrayEquals(js.Array(8, 23), args)
   }


### PR DESCRIPTION
The explicit presence of `x` in `js.Dynamic` was a workaround for the implicits in `Predef` that were accidentally providing `x` on `Any`.

Since those implicits were removed in 2.11, and we do not support 2.10 anymore, we can remove the workaround.

This surfaces a spectacular scalac bug in one of our tests, which I have not been able to minimize. The problem was already visible with `y` or any other field not named `x`, so the explicit `js.Dynamic.x` was hiding another bug.