### PR TITLE
Make the constructors and underlying vals of AnyVals private.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -1413,7 +1413,9 @@ abstract class PrepJSInterop extends plugins.PluginComponent
 }
 
 object PrepJSInterop {
-  private final class OwnerKind(val baseKinds: Int) extends AnyVal {
+  private final class OwnerKind private (private val baseKinds: Int)
+      extends AnyVal {
+
     import OwnerKind._
 
     @inline def isBaseKind: Boolean =

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -22,7 +22,7 @@ object Hashers {
       hasher.mixParamDefs(args)
       hasher.mixType(resultType)
       body.foreach(hasher.mixTree)
-      hasher.mixInt(methodDef.optimizerHints.bits)
+      hasher.mixInt(OptimizerHints.toBits(methodDef.optimizerHints))
 
       val hash = hasher.finalizeHash()
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -1052,7 +1052,7 @@ object Printers {
         implicit dummy: DummyImplicit): Unit = {
       if (optimizerHints != OptimizerHints.empty) {
         print("@hints(")
-        print(optimizerHints.bits.toString)
+        print(OptimizerHints.toBits(optimizerHints).toString)
         print(") ")
       }
     }

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -474,7 +474,7 @@ object Serializers {
       writeJSNativeLoadSpec(jsNativeLoadSpec)
       writeMemberDefs(memberDefs)
       writeTopLevelExportDefs(topLevelExportDefs)
-      writeInt(optimizerHints.bits)
+      writeInt(OptimizerHints.toBits(optimizerHints))
     }
 
     def writeMemberDef(memberDef: MemberDef): Unit = {
@@ -501,7 +501,7 @@ object Serializers {
           // Write out method def
           writeBoolean(static); writePropertyName(name)
           writeParamDefs(args); writeType(resultType); writeOptTree(body)
-          writeInt(methodDef.optimizerHints.bits)
+          writeInt(OptimizerHints.toBits(methodDef.optimizerHints))
 
           // Jump back and write true length
           val length = bufferUnderlying.jumpBack()
@@ -934,7 +934,7 @@ object Serializers {
       val jsNativeLoadSpec = readJSNativeLoadSpec()
       val memberDefs = readMemberDefs()
       val topLevelExportDefs = readTopLevelExportDefs()
-      val optimizerHints = new OptimizerHints(readInt())
+      val optimizerHints = OptimizerHints.fromBits(readInt())
       ClassDef(name, kind, jsClassCaptures, superClass, parents, jsSuperClass,
           jsNativeLoadSpec, memberDefs, topLevelExportDefs)(
           optimizerHints)
@@ -957,7 +957,7 @@ object Serializers {
           assert(len >= 0)
           MethodDef(readBoolean(), readPropertyName(),
               readParamDefs(), readType(), readOptTree())(
-              new OptimizerHints(readInt()), optHash)
+              OptimizerHints.fromBits(readInt()), optHash)
 
         case TagPropertyDef =>
           val static = readBoolean()

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -994,8 +994,10 @@ object Trees {
 
   // Miscellaneous
 
-  final class OptimizerHints(val bits: Int) extends AnyVal {
+  final class OptimizerHints private (val __private_bits: Int) extends AnyVal {
     import OptimizerHints._
+
+    @inline private def bits: Int = __private_bits
 
     def inline: Boolean = (bits & InlineMask) != 0
     def noinline: Boolean = (bits & NoinlineMask) != 0
@@ -1013,14 +1015,20 @@ object Trees {
   }
 
   object OptimizerHints {
-    final val InlineShift = 0
-    final val InlineMask = 1 << InlineShift
+    private final val InlineShift = 0
+    private final val InlineMask = 1 << InlineShift
 
-    final val NoinlineShift = 1
-    final val NoinlineMask = 1 << NoinlineShift
+    private final val NoinlineShift = 1
+    private final val NoinlineMask = 1 << NoinlineShift
 
     final val empty: OptimizerHints =
       new OptimizerHints(0)
+
+    private[ir] def fromBits(bits: Int): OptimizerHints =
+      new OptimizerHints(bits)
+
+    private[ir] def toBits(hints: OptimizerHints): Int =
+      hints.bits
   }
 
   /** Loading specification for a native JS class or object. */

--- a/javalanglib/src/main/scala/java/lang/StackTrace.scala
+++ b/javalanglib/src/main/scala/java/lang/StackTrace.scala
@@ -278,7 +278,7 @@ private[lang] object StackTrace {
     }
   }
 
-  private implicit class StringRE(val s: String) extends AnyVal {
+  private implicit class StringRE(private val s: String) extends AnyVal {
     def re: js.RegExp = new js.RegExp(s)
     def re(mods: String): js.RegExp = new js.RegExp(s, mods)
   }

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -281,7 +281,7 @@ object BigDecimal {
     insertString(s, pos, s2.substring(s2Start, s2Start + s2Len))
   }
 
-  private implicit class StringOps(val s: String) extends AnyVal {
+  private implicit class StringOps(private val s: String) extends AnyVal {
     @inline
     def insert(pos: Int, s2: String): String = insertString(s, pos, s2)
 

--- a/javalib/src/main/scala/java/nio/GenBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenBuffer.scala
@@ -5,7 +5,13 @@ private[nio] object GenBuffer {
     new GenBuffer(self)
 }
 
-private[nio] final class GenBuffer[B <: Buffer](val self: B) extends AnyVal {
+/* The underlying `val self` is intentionally public because
+ * `self.ElementType` and `self.BufferType` appear in signatures.
+ * It's tolerable because the class is `private[nio]` anyway.
+ */
+private[nio] final class GenBuffer[B <: Buffer] private (val self: B)
+    extends AnyVal {
+
   import self._
 
   @inline

--- a/javalib/src/main/scala/java/nio/GenDataViewBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenDataViewBuffer.scala
@@ -44,7 +44,13 @@ private[nio] object GenDataViewBuffer {
   }
 }
 
-private[nio] final class GenDataViewBuffer[B <: Buffer](val self: B) extends AnyVal {
+/* The underlying `val self` is intentionally public because
+ * `self.BufferType` appears in signatures.
+ * It's tolerable because the class is `private[nio]` anyway.
+ */
+private[nio] final class GenDataViewBuffer[B <: Buffer] private (val self: B)
+    extends AnyVal {
+
   import self._
 
   import GenDataViewBuffer.newDataView

--- a/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
@@ -24,7 +24,13 @@ private[nio] object GenHeapBuffer {
   }
 }
 
-private[nio] final class GenHeapBuffer[B <: Buffer](val self: B) extends AnyVal {
+/* The underlying `val self` is intentionally public because
+ * `self.ElementType` and `self.BufferType` appear in signatures.
+ * It's tolerable because the class is `private[nio]` anyway.
+ */
+private[nio] final class GenHeapBuffer[B <: Buffer] private (val self: B)
+    extends AnyVal {
+
   import self._
 
   type NewThisHeapBuffer = GenHeapBuffer.NewHeapBuffer[BufferType, ElementType]

--- a/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
@@ -25,7 +25,12 @@ private[nio] object GenHeapBufferView {
   }
 }
 
-private[nio] final class GenHeapBufferView[B <: Buffer](val self: B) extends AnyVal {
+/* The underlying `val self` is intentionally public because
+ * `self.BufferType` appears in signatures.
+ * It's tolerable because the class is `private[nio]` anyway.
+ */
+private[nio] final class GenHeapBufferView[B <: Buffer] private (val self: B)
+    extends AnyVal {
   import self._
 
   type NewThisHeapBufferView = GenHeapBufferView.NewHeapBufferView[BufferType]

--- a/javalib/src/main/scala/java/nio/GenTypedArrayBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenTypedArrayBuffer.scala
@@ -32,8 +32,13 @@ private[nio] object GenTypedArrayBuffer {
   }
 }
 
-private[nio] final class GenTypedArrayBuffer[B <: Buffer](
-    val self: B) extends AnyVal {
+/* The underlying `val self` is intentionally public because
+ * `self.BufferType` appears in signatures.
+ * It's tolerable because the class is `private[nio]` anyway.
+ */
+private[nio] final class GenTypedArrayBuffer[B <: Buffer] private (val self: B)
+    extends AnyVal {
+
   import self._
 
   type NewThisTypedArrayBuffer =

--- a/javalib/src/main/scala/java/util/package.scala
+++ b/javalib/src/main/scala/java/util/package.scala
@@ -2,7 +2,9 @@ package java
 
 package object util {
 
-  implicit private[util] class CompareNullablesOps(val self: Any) extends AnyVal {
+  implicit private[util] class CompareNullablesOps(private val self: Any)
+      extends AnyVal {
+
     @inline
     def ===(that: Any): Boolean =
       if (self.asInstanceOf[AnyRef] eq null) that.asInstanceOf[AnyRef] eq null

--- a/js-envs/src/main/scala/org/scalajs/jsenv/Utils.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/Utils.scala
@@ -13,7 +13,11 @@ import scala.concurrent.duration._
 
 private[jsenv] object Utils {
   final class OptDeadline private (
-      val deadline: Deadline /* nullable */) extends AnyVal { // scalastyle:ignore
+      val __private_deadline: Deadline /* nullable */) // scalastyle:ignore
+      extends AnyVal {
+
+    @inline private def deadline: Deadline = __private_deadline
+
     def millisLeft: Long =
       if (deadline == null) 0
       else (deadline.timeLeft.toMillis max 1L)

--- a/library/src/main/scala/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala/scala/scalajs/js/Any.scala
@@ -178,7 +178,10 @@ object Any extends js.LowPrioAnyImplicits {
   @inline implicit def fromJDouble(value: java.lang.Double): js.Any =
     value.asInstanceOf[js.Any]
 
-  implicit class ObjectCompanionOps(val __self: js.Object.type) extends AnyVal {
+  implicit class ObjectCompanionOps private[Any] (
+      private val self: js.Object.type)
+      extends AnyVal {
+
     /** Tests whether the specified object `o` has a property `p` on itself or
      *  in its prototype chain.
      *

--- a/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
+++ b/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
@@ -20,7 +20,7 @@ import scala.scalajs.js
  *  type argument to `js.constructorOf`.
  */
 final class ConstructorTag[T <: js.Any] private[scalajs] (
-    val constructor: js.Dynamic)
+    val constructor: js.Dynamic) // intentionally public
     extends AnyVal {
 
   /** Instantiates the class `T` with the specified arguments.

--- a/library/src/main/scala/scala/scalajs/js/Iterator.scala
+++ b/library/src/main/scala/scala/scalajs/js/Iterator.scala
@@ -45,8 +45,11 @@ object Iterator {
     }
   }
 
-  final implicit class IteratorOps[A](val __self: js.Iterator[A]) extends AnyVal {
+  final implicit class IteratorOps[A] private[Iterator] (
+      private val self: js.Iterator[A])
+      extends AnyVal {
+
     @inline
-    def toIterator: scala.collection.Iterator[A] = new WrappedIterator(__self)
+    def toIterator: scala.collection.Iterator[A] = new WrappedIterator(self)
   }
 }

--- a/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
@@ -82,7 +82,9 @@ object JSNumberOps {
   implicit def enableJSNumberExtOps(x: Double): ExtOps =
     new ExtOps(x.asInstanceOf[js.Dynamic])
 
-  final class ExtOps(val self: js.Dynamic) extends AnyVal {
+  final class ExtOps private[JSNumberOps] (private val self: js.Dynamic)
+      extends AnyVal {
+
     @inline def toUint: Double =
       (self >>> 0.asInstanceOf[js.Dynamic]).asInstanceOf[Double]
   }

--- a/library/src/main/scala/scala/scalajs/js/Thenable.scala
+++ b/library/src/main/scala/scala/scalajs/js/Thenable.scala
@@ -38,7 +38,10 @@ trait Thenable[+A] extends js.Object {
 }
 
 object Thenable {
-  implicit class ThenableOps[+A](val p: js.Thenable[A]) extends AnyVal {
+  implicit class ThenableOps[+A] private[Thenable] (
+      private val p: js.Thenable[A])
+      extends AnyVal {
+
     /** Converts the [[Thenable]] into a Scala [[scala.concurrent.Future Future]].
      *
      *  Unlike when calling the `then` methods of [[Thenable]], the resulting

--- a/library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
@@ -17,7 +17,9 @@ import scala.scalajs.js.|.Evidence
 /** @define option [[js.UndefOr]]
  *  @define none [[js.undefined]]
  */
-final class UndefOrOps[A](val self: js.UndefOr[A]) extends AnyVal {
+final class UndefOrOps[A] private[js] (private val self: js.UndefOr[A])
+    extends AnyVal {
+
   import UndefOrOps._
 
   /** Returns true if the option is `undefined`, false otherwise.

--- a/library/src/main/scala/scala/scalajs/js/Union.scala
+++ b/library/src/main/scala/scala/scalajs/js/Union.scala
@@ -89,7 +89,9 @@ object | { // scalastyle:ignore
     a.asInstanceOf[F[B]]
 
   /** Operations on union types. */
-  implicit class UnionOps[A <: _ | _](val self: A) extends AnyVal {
+  implicit class UnionOps[A <: _ | _] private[|] (private val self: A)
+      extends AnyVal {
+
     /** Explicitly merge a union type to a supertype (which might not be a
      *  union type itself).
      *

--- a/library/src/main/scala/scala/scalajs/js/typedarray/DataViewExt.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/DataViewExt.scala
@@ -11,7 +11,10 @@ package scala.scalajs.js.typedarray
 
 /** Extensions for [[DataView]]. */
 object DataViewExt {
-  implicit class DataViewExtOps(val dataView: DataView) extends AnyVal {
+  implicit class DataViewExtOps private[DataViewExt] (
+      private val dataView: DataView)
+      extends AnyVal {
+
     /** Reads a 2's complement signed 64-bit integers from the data view.
      *  @param index        Starting index
      *  @param littleEndian Whether the number is stored in little endian

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferOps.scala
@@ -21,8 +21,10 @@ import java.nio._
  *  elements in the buffer.
  */
 final class TypedArrayBufferOps[ // scalastyle:ignore
-    TypedArrayType <: TypedArray[_, TypedArrayType]](
-    val buffer: Buffer) extends AnyVal {
+    TypedArrayType <: TypedArray[_, TypedArrayType]] private (
+    private val buffer: Buffer)
+    extends AnyVal {
+
   /** Tests whether this buffer has a valid associated [[ArrayBuffer]].
    *
    *  This is true iff the buffer is direct and not read-only.

--- a/library/src/main/scala/scala/scalajs/js/typedarray/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/package.scala
@@ -14,42 +14,60 @@ package object typedarray {
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toTypedArray` conversion to an `Array[Byte]`
    */
-  implicit class AB2TA(val array: scala.Array[Byte]) extends AnyVal {
+  implicit class AB2TA private[typedarray] (
+      private val array: scala.Array[Byte])
+      extends AnyVal {
+
     def toTypedArray: Int8Array = byteArray2Int8Array(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toTypedArray` conversion to an `Array[Short]`
    */
-  implicit class AS2TA(val array: scala.Array[Short]) extends AnyVal {
+  implicit class AS2TA private[typedarray] (
+      private val array: scala.Array[Short])
+      extends AnyVal {
+
     def toTypedArray: Int16Array = shortArray2Int16Array(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toTypedArray` conversion to an `Array[Char]`
    */
-  implicit class AC2TA(val array: scala.Array[Char]) extends AnyVal {
+  implicit class AC2TA private[typedarray] (
+      private val array: scala.Array[Char])
+      extends AnyVal {
+
     def toTypedArray: Uint16Array = charArray2Uint16Array(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toTypedArray` conversion to an `Array[Int]`
    */
-  implicit class AI2TA(val array: scala.Array[Int]) extends AnyVal {
+  implicit class AI2TA private[typedarray] (
+      private val array: scala.Array[Int])
+      extends AnyVal {
+
     def toTypedArray: Int32Array = intArray2Int32Array(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toTypedArray` conversion to an `Array[Float]`
    */
-  implicit class AF2TA(val array: scala.Array[Float]) extends AnyVal {
+  implicit class AF2TA private[typedarray] (
+      private val array: scala.Array[Float])
+      extends AnyVal {
+
     def toTypedArray: Float32Array = floatArray2Float32Array(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toTypedArray` conversion to an `Array[Double]`
    */
-  implicit class AD2TA(val array: scala.Array[Double]) extends AnyVal {
+  implicit class AD2TA private[typedarray] (
+      private val array: scala.Array[Double])
+      extends AnyVal {
+
     def toTypedArray: Float64Array = doubleArray2Float64Array(array)
   }
 
@@ -58,42 +76,54 @@ package object typedarray {
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toArray` conversion to a [[Int8Array]]
    */
-  implicit class TA2AB(val array: Int8Array) extends AnyVal {
+  implicit class TA2AB private[typedarray] (private val array: Int8Array)
+      extends AnyVal {
+
     def toArray: scala.Array[Byte] = int8Array2ByteArray(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toArray` conversion to a [[Int16Array]]
    */
-  implicit class TA2AS(val array: Int16Array) extends AnyVal {
+  implicit class TA2AS private[typedarray] (private val array: Int16Array)
+      extends AnyVal {
+
     def toArray: scala.Array[Short] = int16Array2ShortArray(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toArray` conversion to a [[Uint16Array]]
    */
-  implicit class TA2AC(val array: Uint16Array) extends AnyVal {
+  implicit class TA2AC private[typedarray] (private val array: Uint16Array)
+      extends AnyVal {
+
     def toArray: scala.Array[Char] = uint16Array2CharArray(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toArray` conversion to a [[Int32Array]]
    */
-  implicit class TA2AI(val array: Int32Array) extends AnyVal {
+  implicit class TA2AI private[typedarray] (private val array: Int32Array)
+      extends AnyVal {
+
     def toArray: scala.Array[Int] = int32Array2IntArray(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toArray` conversion to a [[Float32Array]]
    */
-  implicit class TA2AF(val array: Float32Array) extends AnyVal {
+  implicit class TA2AF private[typedarray] (private val array: Float32Array)
+      extends AnyVal {
+
     def toArray: scala.Array[Float] = float32Array2FloatArray(array)
   }
 
   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
    *  Adds `toArray` conversion to a [[Float64Array]]
    */
-  implicit class TA2AD(val array: Float64Array) extends AnyVal {
+  implicit class TA2AD private[typedarray] (private val array: Float64Array)
+      extends AnyVal {
+
     def toArray: scala.Array[Double] = float64Array2DoubleArray(array)
   }
 

--- a/test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
+++ b/test-interface/src/main/scala/org/scalajs/testinterface/HTMLRunner.scala
@@ -473,7 +473,9 @@ protected[testinterface] object HTMLRunner {
       var search: String = js.native
     }
 
-    implicit class RichElement(val element: Element) extends AnyVal {
+    implicit class RichElement private[dom] (private val element: Element)
+        extends AnyVal {
+
       def newElement(clss: String = "", text: String = "",
           tpe: String = "div"): dom.Element = {
         val el = document.createElement(tpe)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
@@ -91,7 +91,7 @@ class ArrayTest {
 
 object ArrayTest {
 
-  private class VC(val x: Int) extends AnyVal {
+  private class VC(private val x: Int) extends AnyVal {
     override def toString(): String = s"VC($x)"
   }
 

--- a/test-suite/shared/src/test/require-sam/org/scalajs/testsuite/compiler/SAMTest.scala
+++ b/test-suite/shared/src/test/require-sam/org/scalajs/testsuite/compiler/SAMTest.scala
@@ -110,7 +110,10 @@ object SAMTest {
     def apply(x: Int): String
   }
 
-  implicit class ComparatorCompat[A](val c: Comparator[A]) extends AnyVal {
+  implicit class ComparatorCompat[A] private[SAMTest] (
+      private val c: Comparator[A])
+      extends AnyVal {
+
     def reversed(): Comparator[A] = {
       assumeTrue("Comparator.reversed() is not available on this JDK", false)
       ???

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
@@ -95,7 +95,7 @@ object MatchTest {
     def f(): T
   }
 
-  class ValueClass(val x: Int) extends AnyVal with ValueClassBase[Int] {
+  class ValueClass(private val x: Int) extends AnyVal with ValueClassBase[Int] {
     def f(): Int = x * 2
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
@@ -463,7 +463,7 @@ class ReflectiveCallTest {
 }
 
 object ReflectiveCallTest {
-  class AnyValWithAnyRefPrimitiveMethods(val x: Int) extends AnyVal {
+  class AnyValWithAnyRefPrimitiveMethods(private val x: Int) extends AnyVal {
     def eq(that: AnyRef): Boolean = (x + 1) == that
     def ne(that: AnyRef): Boolean = (x + 1) != that
     def synchronized[T](f: T): Any = f + "there"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
@@ -479,7 +479,10 @@ class BigDecimalConstructorsTest {
 
 object BigDecimalConstructorsTest {
   // Helper for comparing values within a certain +/- delta
-  implicit class BigDecimalOps(val actual: BigDecimal) extends AnyVal {
+  implicit class BigDecimalOps private[BigDecimalConstructorsTest] (
+      private val actual: BigDecimal)
+      extends AnyVal {
+
     def minus(expected: BigDecimal): Double = {
       val actualDeltaDecimal:BigDecimal = actual.subtract(expected)
       val actualDelta = actualDeltaDecimal.abs().doubleValue()

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/package.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/package.scala
@@ -9,7 +9,9 @@ package org.scalajs.testsuite.javalib
 
 package object util {
 
-  implicit private[util] class CompareNullablesOps(val self: Any) extends AnyVal {
+  implicit private[util] class CompareNullablesOps(private val self: Any)
+      extends AnyVal {
+
     @inline
     def ===(that: Any): Boolean =
       if (self.asInstanceOf[AnyRef] eq null) that.asInstanceOf[AnyRef] eq null

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
@@ -203,7 +203,10 @@ object BaseCharsetTest {
       BufferPart(buf)
   }
 
-  implicit class Interpolators(val sc: StringContext) extends AnyVal {
+  implicit class Interpolators private[BaseCharsetTest] (
+      private val sc: StringContext)
+      extends AnyVal {
+
     def bb(args: Any*): ByteBuffer = {
       val strings = sc.parts.iterator
       val expressions = args.iterator

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
@@ -11,7 +11,9 @@ package org.scalajs.core.tools.linker
 object StandardLinkerPlatformExtensions {
   import StandardLinker.Config
 
-  final class ConfigExt(val config: Config) extends AnyVal {
+  final class ConfigExt private[linker] (private val self: Config)
+      extends AnyVal {
+
     /** Whether to actually use the Google Closure Compiler pass.
      *
      *  On the JavaScript platform, this always returns `false`, as GCC is not

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackendPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackendPlatformExtensions.scala
@@ -11,7 +11,9 @@ package org.scalajs.core.tools.linker.backend
 object LinkerBackendPlatformExtensions {
   import LinkerBackend.Config
 
-  final class ConfigExt(val config: Config) extends AnyVal {
+  final class ConfigExt private[backend] (private val self: Config)
+      extends AnyVal {
+
     /** Whether to actually use the Google Closure Compiler pass.
      *
      *  On the JavaScript platform, this always returns `false`, as GCC is not

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/StandardLinkerPlatformExtensions.scala
@@ -11,11 +11,15 @@ package org.scalajs.core.tools.linker
 object StandardLinkerPlatformExtensions {
   import StandardLinker.Config
 
-  final class ConfigExt(val config: Config) extends AnyVal {
+  final class ConfigExt private[linker] (val __private_self: Config)
+      extends AnyVal {
+
+    @inline private def self: Config = __private_self
+
     /** Whether to actually use the Google Closure Compiler pass. */
-    def closureCompiler: Boolean = config.closureCompilerIfAvailable
+    def closureCompiler: Boolean = self.closureCompilerIfAvailable
 
     def withClosureCompiler(closureCompiler: Boolean): Config =
-      config.withClosureCompilerIfAvailable(closureCompiler)
+      self.withClosureCompilerIfAvailable(closureCompiler)
   }
 }

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackendPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackendPlatformExtensions.scala
@@ -13,11 +13,15 @@ import org.scalajs.core.tools.linker.backend.closure.ClosureLinkerBackend
 object LinkerBackendPlatformExtensions {
   import LinkerBackend.Config
 
-  final class ConfigExt(val config: Config) extends AnyVal {
+  final class ConfigExt private[backend] (val __private_self: Config)
+      extends AnyVal {
+
+    @inline private def self: Config = __private_self
+
     /** Whether to actually use the Google Closure Compiler pass. */
-    def closureCompiler: Boolean = config.closureCompilerIfAvailable
+    def closureCompiler: Boolean = self.closureCompilerIfAvailable
 
     def withClosureCompiler(closureCompiler: Boolean): Config =
-      config.withClosureCompilerIfAvailable(closureCompiler)
+      self.withClosureCompilerIfAvailable(closureCompiler)
   }
 }

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/ConcurrencyUtils.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/ConcurrencyUtils.scala
@@ -28,14 +28,19 @@ private[optimizer] object ConcurrencyUtils {
       new AtomicReference(l)
   }
 
-  implicit class AtomicAccOps[T](val acc: AtomicAcc[T]) extends AnyVal {
-    @inline final def size: Int = acc.get.size
+  implicit class AtomicAccOps[T] private[ConcurrencyUtils] (
+      val __private_self: AtomicAcc[T])
+      extends AnyVal {
+
+    @inline private def self: AtomicAcc[T] = __private_self
+
+    @inline final def size: Int = self.get.size
 
     @inline
-    final def +=(x: T): Unit = AtomicAccOps.append(acc, x)
+    final def +=(x: T): Unit = AtomicAccOps.append(self, x)
 
     @inline
-    final def removeAll(): List[T] = AtomicAccOps.removeAll(acc)
+    final def removeAll(): List[T] = AtomicAccOps.removeAll(self)
   }
 
   object AtomicAccOps {
@@ -54,19 +59,29 @@ private[optimizer] object ConcurrencyUtils {
 
   type TrieSet[T] = TrieMap[T, Null]
 
-  implicit class TrieSetOps[T](val set: TrieSet[T]) extends AnyVal {
-    @inline final def +=(x: T): Unit = set.put(x, null)
+  implicit class TrieSetOps[T] private[ConcurrencyUtils] (
+      val __private_self: TrieSet[T])
+      extends AnyVal {
+
+    @inline private def self: TrieSet[T] = __private_self
+
+    @inline final def +=(x: T): Unit = self.put(x, null)
   }
 
   object TrieSet {
     @inline final def empty[T]: TrieSet[T] = TrieMap.empty
   }
 
-  implicit class TrieMapOps[K,V](val map: TrieMap[K,V]) extends AnyVal {
+  implicit class TrieMapOps[K, V] private[ConcurrencyUtils] (
+      val __private_self: TrieMap[K, V])
+      extends AnyVal {
+
+    @inline private def self: TrieMap[K, V] = __private_self
+
     @inline final def getOrPut(k: K, default: => V): V = {
-      map.get(k).getOrElse {
+      self.get(k).getOrElse {
         val v = default
-        map.putIfAbsent(k, v).getOrElse(v)
+        self.putIfAbsent(k, v).getOrElse(v)
       }
     }
   }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/TreeDSL.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/TreeDSL.scala
@@ -17,7 +17,11 @@ import org.scalajs.core.ir.Position
 import org.scalajs.core.tools.linker.backend.javascript.Trees._
 
 private[emitter] object TreeDSL {
-  implicit class TreeOps(val self: Tree) extends AnyVal {
+  implicit class TreeOps private[TreeDSL] (val __private_self: Tree)
+      extends AnyVal {
+
+    @inline private def self: Tree = __private_self
+
     /** Select a member */
     def DOT(field: Ident)(implicit pos: Position): DotSelect =
       DotSelect(self, field)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -1394,8 +1394,11 @@ object IRChecker {
    *  IR is invalid, so all bets are off and we can be slow and allocate stuff;
    *  we don't care.
    */
-  private final class ErrorContext private (val nodeOrLinkedClass: Any)
+  private final class ErrorContext private (
+      val __private_nodeOrLinkedClass: Any)
       extends AnyVal {
+
+    @inline private def nodeOrLinkedClass: Any = __private_nodeOrLinkedClass
 
     override def toString(): String = {
       val (pos, name) = nodeOrLinkedClass match {
@@ -1421,8 +1424,11 @@ object IRChecker {
       val pos: Position)
 
   /** Enable the right-biased API of Either from 2.12 in earlier versions. */
-  private implicit class RightBiasedEither[A, B](val self: Either[A, B])
+  private implicit class RightBiasedEither[A, B](
+      val __private_self: Either[A, B])
       extends AnyVal {
+
+    @inline private def self: Either[A, B] = __private_self
 
     def foreach[U](f: B => U): Unit = self match {
       case Left(_)  =>

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/Refiner.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/Refiner.scala
@@ -209,7 +209,7 @@ private object Refiner {
     }
   }
 
-  private final class LinkedMembersInfosCache(
+  private final class LinkedMembersInfosCache private (
       val caches: mutable.Map[(Boolean, String), LinkedMemberInfoCache])
       extends AnyVal {
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -4803,15 +4803,20 @@ private[optimizer] object OptimizerCore {
     }
   }
 
-  private implicit class OptimizerTreeOps(val selfTree: Tree) extends AnyVal {
+  private implicit class OptimizerTreeOps private[OptimizerCore] (
+      val __private_self: Tree)
+      extends AnyVal {
+
+    @inline private def self: Tree = __private_self
+
     def toPreTransform: PreTransform = {
-      selfTree match {
+      self match {
         case UnaryOp(op, lhs) =>
-          PreTransUnaryOp(op, lhs.toPreTransform)(selfTree.pos)
+          PreTransUnaryOp(op, lhs.toPreTransform)(self.pos)
         case BinaryOp(op, lhs, rhs) =>
-          PreTransBinaryOp(op, lhs.toPreTransform, rhs.toPreTransform)(selfTree.pos)
+          PreTransBinaryOp(op, lhs.toPreTransform, rhs.toPreTransform)(self.pos)
         case _ =>
-          PreTransTree(selfTree)
+          PreTransTree(self)
       }
     }
   }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
@@ -9,15 +9,17 @@
 package org.scalajs.core.tools.linker
 
 package object standard {
-  implicit class StandardLinkerConfigStandardOps(
-      val __self: StandardLinker.Config) extends AnyVal {
+  implicit class StandardLinkerConfigStandardOps private[standard] (
+      val __private_self: StandardLinker.Config) extends AnyVal {
 
     import StandardLinker.Config
 
+    @inline private def self: Config = __private_self
+
     /** Standard output mode. */
-    def outputMode: OutputMode = __self.outputMode
+    def outputMode: OutputMode = self.outputMode
 
     def withOutputMode(outputMode: OutputMode): Config =
-      __self.withOutputMode(outputMode)
+      self.withOutputMode(outputMode)
   }
 }


### PR DESCRIPTION
Now that our JS artifacts do not need to be compiled with 2.10 anymore, we can truly make the underlying `val`s of `AnyVal`s private. In the process, we also ensure that their constructors are private.

For implicit classes, the constructor must be `private[Enclosing]` because it is accessed by the automatically generated `implicit def` that comes with them.

For our artifacts that still support 2.10, we also standardize on a `val __private_foo` to make it clear that they are not part of the API, even if the language prevents us from marking them as actually private.