### PR TITLE
Use a "minilib" for the unit tests of the linker.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -16,6 +16,7 @@ val javalib = Build.javalib
 val scalalib = Build.scalalib
 val libraryAux = Build.libraryAux
 val library = Build.library
+val minilib = Build.minilib
 val stubs = Build.stubs
 val testInterface = Build.testInterface
 val jUnitRuntime = Build.jUnitRuntime

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -442,8 +442,11 @@ object Character {
   @inline private def lowSurrogateOf(codePoint: Int): Char =
     (0xdc00 | (codePoint & 0x3ff)).toChar
 
-  @inline def toString(c: scala.Char): String =
-    js.Dynamic.global.String.fromCharCode(c.toInt).asInstanceOf[String]
+  @inline def toString(c: scala.Char): String = {
+    js.Dynamic.global.String
+      .fromCharCode(c.toInt.asInstanceOf[js.Dynamic])
+      .asInstanceOf[String]
+  }
 
   @inline def compare(x: scala.Char, y: scala.Char): Int =
     x - y

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -136,15 +136,11 @@ object Integer {
     (((t2 + (t2 >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24
   }
 
-  @inline def divideUnsigned(dividend: Int, divisor: Int): Int = {
-    import js.JSNumberOps._
-    asInt(dividend.toUint / divisor.toUint)
-  }
+  @inline def divideUnsigned(dividend: Int, divisor: Int): Int =
+    asInt(asUint(dividend) / asUint(divisor))
 
-  @inline def remainderUnsigned(dividend: Int, divisor: Int): Int = {
-    import js.JSNumberOps._
-    asInt(dividend.toUint % divisor.toUint)
-  }
+  @inline def remainderUnsigned(dividend: Int, divisor: Int): Int =
+    asInt(asUint(dividend) % asUint(divisor))
 
   @inline def highestOneBit(i: Int): Int = {
     /* The natural way of implementing this is:
@@ -234,10 +230,14 @@ object Integer {
   @inline def min(a: Int, b: Int): Int = Math.min(a, b)
 
   @inline private[this] def toStringBase(i: scala.Int, base: scala.Int): String = {
-    import js.JSNumberOps._
-    i.toUint.toString(base)
+    asUint(i).asInstanceOf[js.Dynamic]
+      .applyDynamic("toString")(base.asInstanceOf[js.Dynamic])
+      .asInstanceOf[String]
   }
 
   @inline private def asInt(n: scala.Double): scala.Int =
     (n.asInstanceOf[js.Dynamic] | 0.asInstanceOf[js.Dynamic]).asInstanceOf[Int]
+
+  @inline private def asUint(n: scala.Int): scala.Double =
+    (n.asInstanceOf[js.Dynamic] >>> 0.asInstanceOf[js.Dynamic]).asInstanceOf[scala.Double]
 }

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -111,8 +111,7 @@ object Long {
   }
 
   // Intrinsic
-  @inline def toString(i: scala.Long): String =
-    toStringImpl(i, 10)
+  @inline def toString(i: scala.Long): String = "" + i
 
   @inline def toUnsignedString(i: scala.Long): String =
     toUnsignedStringImpl(i, 10)

--- a/javalanglib/src/main/scala/java/lang/Throwables.scala
+++ b/javalanglib/src/main/scala/java/lang/Throwables.scala
@@ -248,8 +248,15 @@ class VerifyError(s: String) extends LinkageError(s) {
   def this() = this(null)
 }
 
-abstract class VirtualMachineError(s: String) extends Error(s) {
-  def this() = this(null)
+abstract class VirtualMachineError(message: String, cause: Throwable)
+    extends Error(message, cause) {
+
+  def this() = this(null, null)
+
+  def this(message: String) = this(message, null)
+
+  def this(cause: Throwable) =
+    this(if (cause == null) null else cause.toString, cause)
 }
 
 

--- a/javalanglib/src/main/scala/java/lang/_String.scala
+++ b/javalanglib/src/main/scala/java/lang/_String.scala
@@ -33,8 +33,12 @@ final class _String private () // scalastyle:ignore
     this.asInstanceOf[SpecialJSStringOps]
 
   @inline
-  def charAt(index: Int): Char =
-    thisJSString.charCodeAt(index).toChar
+  def charAt(index: Int): Char = {
+    this.asInstanceOf[js.Dynamic]
+      .charCodeAt(index.asInstanceOf[js.Dynamic])
+      .asInstanceOf[Int]
+      .toChar
+  }
 
   def codePointAt(index: Int): Int = {
     val high = charAt(index)
@@ -225,7 +229,7 @@ final class _String private () // scalastyle:ignore
 
   @inline
   def length(): Int =
-    thisJSString.length
+    this.asInstanceOf[js.Dynamic].length.asInstanceOf[Int]
 
   @inline
   def matches(regex: String): scala.Boolean =
@@ -296,8 +300,11 @@ final class _String private () // scalastyle:ignore
     thisString.jsSubstring(beginIndex)
 
   @inline
-  def substring(beginIndex: Int, endIndex: Int): String =
-    thisString.jsSubstring(beginIndex, endIndex)
+  def substring(beginIndex: Int, endIndex: Int): String = {
+    this.asInstanceOf[js.Dynamic]
+      .substring(beginIndex.asInstanceOf[js.Dynamic], endIndex.asInstanceOf[js.Dynamic])
+      .asInstanceOf[String]
+  }
 
   def toCharArray(): Array[Char] = {
     val len = length
@@ -332,9 +339,6 @@ object _String { // scalastyle:ignore
    *  and that we need to implement these very Scala methods.
    */
   private trait SpecialJSStringOps extends js.Any {
-    def length: Int
-    def charCodeAt(index: Int): Int
-
     def toLowerCase(): String
     def toUpperCase(): String
     def trim(): String

--- a/library/src/main/scala/scala/scalajs/runtime/UndefinedBehaviorError.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/UndefinedBehaviorError.scala
@@ -1,7 +1,5 @@
 package scala.scalajs.runtime
 
-import scala.util.control.ControlThrowable
-
 /** Error thrown when an undefined behavior in Fatal mode has been detected.
  *  This error should never be caught. It indicates a severe programming bug.
  *  In Unchecked mode, the program may behave arbitrarily.
@@ -12,14 +10,12 @@ import scala.util.control.ControlThrowable
  *  Note that this will have (potentially major) performance impacts.
  */
 class UndefinedBehaviorError(message: String, cause: Throwable)
-    extends java.lang.Error(message, cause) with ControlThrowable {
+    extends java.lang.VirtualMachineError(message, cause) {
 
   def this(message: String) = this(message, null)
 
   def this(cause: Throwable) =
-    this("An undefined behavior was detected" +
-        (if (cause == null) "" else ": "+cause.getMessage), cause)
+    this(if (cause == null) null else cause.toString, cause)
 
-  override def fillInStackTrace(): Throwable =
-    super[Error].fillInStackTrace()
+  def this() = this(null, null)
 }

--- a/minilib/src/main/scala/java/lang/Class.scala
+++ b/minilib/src/main/scala/java/lang/Class.scala
@@ -1,0 +1,26 @@
+package java.lang
+
+import scala.scalajs.js
+
+/** Stripped down version of `java.lang.Class`, with just the bare minimum to
+ *  support `toString()`.
+ *
+ *  We cannot use the full `java.lang.Class` out of the box because it
+ *  internally uses a static facade type for its `data`, and the minilib cannot
+ *  contain any JS type.
+ */
+final class Class[A] private (private val data: Object) extends Object {
+  override def toString(): String = {
+    (if (isInterface()) "interface " else
+        if (isPrimitive()) "" else "class ") + getName()
+  }
+
+  def isInterface(): scala.Boolean =
+    data.asInstanceOf[js.Dynamic].isInterface.asInstanceOf[scala.Boolean]
+
+  def isPrimitive(): scala.Boolean =
+    data.asInstanceOf[js.Dynamic].isPrimitive.asInstanceOf[scala.Boolean]
+
+  def getName(): String =
+    data.asInstanceOf[js.Dynamic].name.asInstanceOf[String]
+}

--- a/minilib/src/main/scala/java/lang/FloatingPointBits.scala
+++ b/minilib/src/main/scala/java/lang/FloatingPointBits.scala
@@ -1,0 +1,19 @@
+package java.lang
+
+import scala.scalajs.js
+
+/** Stripped down version of `java.lang.FloatingPointBits` with the bare
+ *  minimum to support a correct `numberHashCode()`.
+ *
+ *  We cannot use the full `java.lang.FloatingPointBits` out of the box,
+ *  because it internally uses typed arrays (and static facade types thereof)
+ *  to implement a better `numberHashCode()`.
+ */
+private[lang] object FloatingPointBits {
+  // Simpler version than the original, technically valid but of lesser quality
+  def numberHashCode(value: scala.Double): Int =
+    rawToInt(value)
+
+  @inline private def rawToInt(x: scala.Double): Int =
+    (x.asInstanceOf[js.Dynamic] | 0.asInstanceOf[js.Dynamic]).asInstanceOf[Int]
+}

--- a/minilib/src/main/scala/java/lang/System.scala
+++ b/minilib/src/main/scala/java/lang/System.scala
@@ -1,0 +1,27 @@
+package java.lang
+
+/** Stripped down version of `java.lang.System` with the bare minimum to
+ *  support a correct `numberHashCode()`.
+ *
+ *  We cannot use the full `java.lang.System` out of the box, because its
+ *  constructor initializes `out` and `err`, which require
+ *  `JSConsoleBasedPrintStream` and therefore a large part of `java.io`. We do
+ *  not simply reuse (copy-paste) `identityHashCode` either because it
+ *  internally uses a `WeakMap` typed as `js.Dynamic`.
+ */
+object System {
+  // Simpler than the original, technically valid but of lesser quality
+  def identityHashCode(x: Object): scala.Int = {
+    (x: Any) match {
+      case null => 0
+      case _:scala.Boolean | _:scala.Double | _:String | () =>
+        x.hashCode()
+      case _ =>
+        // See the original System.scala for the rationale of this test
+        if (x.getClass == null)
+          x.hashCode()
+        else
+          42
+    }
+  }
+}

--- a/minilib/src/main/scala/java/lang/Throwable.scala
+++ b/minilib/src/main/scala/java/lang/Throwable.scala
@@ -1,0 +1,28 @@
+package java.lang
+
+/** Stripped down version of `java.lang.Throwable` with the bare minimum to
+ *  support `toString()` and the subclasses.
+ *
+ *  We cannot use the full `java.lang.Throwable` out of the box, because its
+ *  constructor calls `initStackTrace()`, which uses `StackTrace.scala` and
+ *  therefore a bunch of JS stuff inside to recover stack traces. This stripped
+ *  down `Throwable` does not offer any method to access the stack trace so
+ *  that `initStackTrace()` is not necessary.
+ */
+class Throwable(s: String, e: Throwable)
+    extends Object with java.io.Serializable {
+
+  def this() = this(null, null)
+  def this(s: String) = this(s, null)
+  def this(e: Throwable) = this(if (e == null) null else e.toString, e)
+
+  def getMessage(): String = s
+  def getCause(): Throwable = e
+
+  override def toString(): String = {
+    val className = getClass.getName
+    val message = getMessage()
+    if (message eq null) className
+    else className + ": " + message
+  }
+}

--- a/project/MiniLib.scala
+++ b/project/MiniLib.scala
@@ -1,0 +1,75 @@
+package build
+
+object MiniLib {
+  val Whitelist = {
+    val inJavaLang = List(
+        "Object",
+        // "Class" is overridden in minilib/
+        // "System" is overridden in minilib/
+
+        "CharSequence",
+        "Cloneable",
+        "Comparable",
+        "Number",
+
+        "Boolean",
+        "Character",
+        "Byte",
+        "Short",
+        "Integer",
+        "Long",
+        "Float",
+        "Double",
+        "String",
+
+        // "FloatingPointBits" is overridden in minilib/
+
+        // "Throwable" is overridden in minilib/
+        "Error",
+        "VirtualMachineError",
+        "Exception",
+        "RuntimeException",
+        "ArithmeticException",
+        "ArrayIndexOutOfBoundsException",
+        "ArrayStoreException",
+        "ClassCastException",
+        "CloneNotSupportedException",
+        "IndexOutOfBoundsException",
+        "NullPointerException",
+        "StringIndexOutOfBoundsException"
+    ).map("java/lang/" + _)
+
+    val inJavaIO = List(
+        "Serializable"
+    ).map("java/io/" + _)
+
+    /* TODO Unfortunately, when a class extends java.io.Serializable, scalac
+     * forces its companion object to extend scala.Serializable (ugh!), which
+     * means that things like java.lang.Integer$ depend on scala.Serializable.
+     * However, as far as the linker is concerned, it shouldn't need, so it
+     * would be nice to get rid of this dependency.
+     */
+    val inScala = List(
+        "Serializable"
+    ).map("scala/" + _)
+
+    // TODO We should find a way to get rid of this one
+    val inScalaRuntime = List(
+        "BoxedUnit"
+    ).map("scala/runtime/" + _)
+
+    /* TODO Could we put UndefinedBehaviorError in a neutral namespace?
+     * RuntimeLong should probably be part of the linker itself, as a resource.
+     */
+    val inScalaJSRuntime = List(
+        "UndefinedBehaviorError",
+        "RuntimeLong",
+        "RuntimeLong$Utils"
+    ).map("scala/scalajs/runtime/" + _)
+
+    val allBaseNames =
+      inJavaLang ::: inJavaIO ::: inScala ::: inScalaRuntime ::: inScalaJSRuntime
+
+    allBaseNames.flatMap(name => List(name + ".sjsir", name + "$.sjsir")).toSet
+  }
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UndefinedBehaviorErrorTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UndefinedBehaviorErrorTest.scala
@@ -1,0 +1,28 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.library
+
+import scala.util.control.NonFatal
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.scalajs.runtime.UndefinedBehaviorError
+
+class UndefinedBehaviorErrorTest {
+
+  @Test def ubeIsAFatalError(): Unit = {
+    val error: Throwable = new UndefinedBehaviorError("test")
+    assertFalse(NonFatal(error))
+    assertTrue(error match {
+      case NonFatal(_) => false
+      case _           => true
+    })
+  }
+
+}

--- a/tools/shared/src/test/scala/org/scalajs/core/tools/linker/AnalyzerTest.scala
+++ b/tools/shared/src/test/scala/org/scalajs/core/tools/linker/AnalyzerTest.scala
@@ -18,41 +18,15 @@ import org.scalajs.core.tools.linker.standard._
 import Analysis._
 
 import org.scalajs.core.tools.linker.testutils._
+import org.scalajs.core.tools.linker.testutils.TestIRBuilder._
 
 class AnalyzerTest {
   import AnalyzerTest._
 
   private val reqsFactory = SymbolRequirement.factory("unit test")
 
-  private val emptyOptHints: OptimizerHints = OptimizerHints.empty
-
-  implicit private val noPosition: ir.Position = ir.Position.NoPosition
-
   private val fromAnalyzer = FromCore("analyzer")
   private val fromUnitTest = FromCore("unit test")
-
-  private def classDef(
-      encodedName: String,
-      kind: ClassKind = ClassKind.Class,
-      jsClassCaptures: Option[List[ParamDef]] = None,
-      superClass: Option[String] = None,
-      interfaces: List[String] = Nil,
-      jsSuperClass: Option[Tree] = None,
-      jsNativeLoadSpec: Option[JSNativeLoadSpec] = None,
-      memberDefs: List[MemberDef] = Nil,
-      topLevelExportDefs: List[TopLevelExportDef] = Nil): ClassDef = {
-    ClassDef(Ident(encodedName), kind, jsClassCaptures,
-        superClass.map(Ident(_)), interfaces.map(Ident(_)), jsSuperClass,
-        jsNativeLoadSpec, memberDefs, topLevelExportDefs)(
-        emptyOptHints)
-  }
-
-  private def trivialCtor(enclosingClassName: String): MethodDef = {
-    MethodDef(static = false, Ident("init___"), Nil, NoType,
-        Some(ApplyStatically(This()(ClassType(enclosingClassName)),
-            ClassType(ObjectClass), Ident("init___"), Nil)(NoType)))(
-        emptyOptHints, None)
-  }
 
   @Test
   def trivialOK(): Unit = {

--- a/tools/shared/src/test/scala/org/scalajs/core/tools/linker/testutils/TestIRBuilder.scala
+++ b/tools/shared/src/test/scala/org/scalajs/core/tools/linker/testutils/TestIRBuilder.scala
@@ -1,0 +1,44 @@
+package org.scalajs.core.tools.linker.testutils
+
+import org.scalajs.core.ir
+import org.scalajs.core.ir.ClassKind
+import org.scalajs.core.ir.Definitions._
+import org.scalajs.core.ir.Trees._
+import org.scalajs.core.ir.Types._
+
+object TestIRBuilder {
+  implicit val noPosition: ir.Position = ir.Position.NoPosition
+
+  val emptyOptHints: OptimizerHints = OptimizerHints.empty
+
+  def classDef(
+      encodedName: String,
+      kind: ClassKind = ClassKind.Class,
+      jsClassCaptures: Option[List[ParamDef]] = None,
+      superClass: Option[String] = None,
+      interfaces: List[String] = Nil,
+      jsSuperClass: Option[Tree] = None,
+      jsNativeLoadSpec: Option[JSNativeLoadSpec] = None,
+      memberDefs: List[MemberDef] = Nil,
+      topLevelExportDefs: List[TopLevelExportDef] = Nil): ClassDef = {
+    ClassDef(Ident(encodedName), kind, jsClassCaptures,
+        superClass.map(Ident(_)), interfaces.map(Ident(_)), jsSuperClass,
+        jsNativeLoadSpec, memberDefs, topLevelExportDefs)(
+        emptyOptHints)
+  }
+
+  def trivialCtor(enclosingClassName: String): MethodDef = {
+    MethodDef(static = false, Ident("init___"), Nil, NoType,
+        Some(ApplyStatically(This()(ClassType(enclosingClassName)),
+            ClassType(ObjectClass), Ident("init___"), Nil)(NoType)))(
+        emptyOptHints, None)
+  }
+
+  def mainMethodDef(body: Tree): MethodDef = {
+    val stringArrayType = ArrayType(ArrayTypeRef("T", 1))
+    val argsParamDef = ParamDef(Ident("args", Some("args")), stringArrayType,
+        mutable = false, rest = false)
+    MethodDef(static = false, Ident("main__AT__V"), List(argsParamDef),
+        NoType, Some(body))(emptyOptHints, None)
+  }
+}


### PR DESCRIPTION
Instead of using the full `scalajs-library.jar` for the unit tests of the linker, we now use a minimal library. That "minilib" contains things like `Object`, `Integer` and `RuntimeLong`: core classes without which it is not possible to link a hello world.

The minilib does not contain `js.Any` nor any of its subtypes, proving that the linker can live without them. That required to tweak a few core methods not to use niceties from our standard library, such as `JSStringOps` and `JSNumberOps`. Instead, we must be careful to only use `js.Dynamic`, and only inside methods, so that even `js.Dynamic` does not leave any trace in method signatures.