### PR TITLE
Remove `abstractMethods` from `LinkedClass`.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
@@ -20,9 +20,8 @@ import ir.Definitions
 /** A ClassDef after linking.
  *
  *  Note that the [[version]] in the LinkedClass does not cover
- *  [[staticMethods]], [[memberMethods]], [[abstractMethods]] and
- *  [[exportedMembers]] as they have their individual versions. (The collections
- *  themselves are not versioned).
+ *  [[staticMethods]], [[memberMethods]] and [[exportedMembers]] as they have
+ *  their individual versions. (The collections themselves are not versioned).
  *
  *  Moreover, the [[version]] is relative to the identity of a LinkedClass.
  *  The definition of identity varies as linked classes progress through the
@@ -44,7 +43,6 @@ final class LinkedClass(
     val fields: List[FieldDef],
     val staticMethods: List[Versioned[MethodDef]],
     val memberMethods: List[Versioned[MethodDef]],
-    val abstractMethods: List[Versioned[MethodDef]],
     val exportedMembers: List[Versioned[MemberDef]],
     val topLevelExports: List[Versioned[TopLevelExportDef]],
     val optimizerHints: OptimizerHints,
@@ -79,7 +77,6 @@ final class LinkedClass(
       fields: List[FieldDef] = this.fields,
       staticMethods: List[Versioned[MethodDef]] = this.staticMethods,
       memberMethods: List[Versioned[MethodDef]] = this.memberMethods,
-      abstractMethods: List[Versioned[MethodDef]] = this.abstractMethods,
       exportedMembers: List[Versioned[MemberDef]] = this.exportedMembers,
       topLevelExports: List[Versioned[TopLevelExportDef]] = this.topLevelExports,
       optimizerHints: OptimizerHints = this.optimizerHints,
@@ -100,7 +97,6 @@ final class LinkedClass(
         fields,
         staticMethods,
         memberMethods,
-        abstractMethods,
         exportedMembers,
         topLevelExports,
         optimizerHints,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -76,7 +76,6 @@ private final class IRChecker(unit: LinkingUnit,
             ClassKind.NativeJSModuleClass =>
           if (classDef.fields.nonEmpty ||
               classDef.memberMethods.nonEmpty ||
-              classDef.abstractMethods.nonEmpty ||
               classDef.exportedMembers.nonEmpty ||
               classDef.topLevelExports.nonEmpty) {
             reportError(s"Raw JS type ${classDef.name} cannot "+
@@ -256,7 +255,7 @@ private final class IRChecker(unit: LinkingUnit,
     }
 
     // Check methods
-    for (method <- classDef.memberMethods ++ classDef.abstractMethods) {
+    for (method <- classDef.memberMethods) {
       val tree = method.value
       implicit val ctx = ErrorContext(tree)
 
@@ -329,10 +328,9 @@ private final class IRChecker(unit: LinkingUnit,
 
     body.fold {
       // Abstract
-      if (static)
-        reportError(s"Static method ${classDef.name.name}.$name cannot be abstract")
-      else if (isConstructor)
-        reportError(s"Constructor ${classDef.name.name}.$name cannot be abstract")
+      reportError(
+          s"The abstract method ${classDef.name.name}.$name survived the " +
+          "Analyzer (this is a bug)")
     } { body =>
       // Concrete
       if (resultType == NoType)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/Refiner.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/Refiner.scala
@@ -87,10 +87,6 @@ final class Refiner(config: CommonPhaseConfig) {
       info.methodInfos(m.value.encodedName).isReachable
     }
 
-    val abstractMethods = classDef.abstractMethods filter { m =>
-      info.methodInfos(m.value.encodedName).isReachable
-    }
-
     val kind =
       if (info.isModuleAccessed) classDef.kind
       else classDef.kind.withoutModuleAccessor
@@ -100,7 +96,6 @@ final class Refiner(config: CommonPhaseConfig) {
         fields = fields,
         staticMethods = staticMethods,
         memberMethods = memberMethods,
-        abstractMethods = abstractMethods,
         hasInstances = info.isAnySubclassInstantiated,
         hasInstanceTests = info.areInstanceTestsUsed,
         hasRuntimeTypeInfo = info.isDataAccessed)
@@ -151,7 +146,6 @@ private object Refiner {
     private var cacheUsed: Boolean = false
     private val staticMethodsInfoCaches = LinkedMembersInfosCache()
     private val memberMethodsInfoCaches = LinkedMembersInfosCache()
-    private val abstractMethodsInfoCaches = LinkedMembersInfosCache()
     private val exportedMembersInfoCaches = LinkedMembersInfosCache()
     private var info: Infos.ClassInfo = _
 
@@ -174,8 +168,6 @@ private object Refiner {
           builder.addMethod(staticMethodsInfoCaches.getInfo(linkedMethod))
         for (linkedMethod <- linkedClass.memberMethods)
           builder.addMethod(memberMethodsInfoCaches.getInfo(linkedMethod))
-        for (linkedMethod <- linkedClass.abstractMethods)
-          builder.addMethod(abstractMethodsInfoCaches.getInfo(linkedMethod))
         for (linkedMember <- linkedClass.exportedMembers)
           builder.addMethod(exportedMembersInfoCaches.getInfo(linkedMember))
 
@@ -202,7 +194,6 @@ private object Refiner {
         // No point in cleaning the inner caches if the whole class disappears
         staticMethodsInfoCaches.cleanAfterRun()
         memberMethodsInfoCaches.cleanAfterRun()
-        abstractMethodsInfoCaches.cleanAfterRun()
         exportedMembersInfoCaches.cleanAfterRun()
       }
       result


### PR DESCRIPTION
That field was "dead code" (it was always an empty list), because the Analyzer never marks as reachable an abstract method. So all code paths that were processing reachable abstract methods were dead code.