### PR TITLE
Fix #3228: Disable reflective instantiation for nested modules.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -952,8 +952,10 @@ abstract class GenJSCode extends plugins.PluginComponent
 
     private def genRegisterReflectiveInstantiation(sym: Symbol)(
         implicit pos: Position): Option[js.Tree] = {
-      if (sym.isModuleClass)
+      if (isStaticModule(sym))
         genRegisterReflectiveInstantiationForModuleClass(sym)
+      else if (sym.isModuleClass)
+        None // #3228
       else
         genRegisterReflectiveInstantiationForNormalClass(sym)
     }

--- a/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
+++ b/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
@@ -94,9 +94,39 @@ object Reflect {
       new InstantiatableClass(runtimeClass, invokableConstructors.toList)
   }
 
+  /** Reflectively looks up a loadable module class.
+   *
+   *  A module class is the technical term referring to the class of a Scala
+   *  `object`. The object or one of its super types (classes or traits) must
+   *  be annotated with
+   *  [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the object must be "static", i.e., declared at the top-level of
+   *  a package or inside a static object.
+   *
+   *  If the module class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was not static, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   */
   def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
     loadableModuleClasses.get(fqcn)
 
+  /** Reflectively looks up an instantiable class.
+   *
+   *  The class or one of its super types (classes or traits) must be annotated
+   *  with
+   *  [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the class must not be abstract.
+   *
+   *  If the class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was abstract, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   */
   def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
     instantiatableClasses.get(fqcn)
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
@@ -55,6 +55,11 @@ class ReflectTest {
   private final val NameTraitDisable =
     Prefix + "TraitDisable"
 
+  private final val NameInnerObject = {
+    Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
+    "InnerObjectWithEnableReflectiveInstantiation"
+  }
+
   @Test def testClassRuntimeClass(): Unit = {
     for {
       name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
@@ -187,6 +192,11 @@ class ReflectTest {
     }
   }
 
+  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228(): Unit = {
+    assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
+    assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
+  }
+
 }
 
 object ReflectTest {
@@ -307,4 +317,11 @@ object ReflectTest {
   }
 
   trait TraitDisable extends Accessors
+
+  // Regression cases
+
+  class ClassWithInnerObjectWithEnableReflectiveInstantiation {
+    @EnableReflectiveInstantiation
+    object InnerObjectWithEnableReflectiveInstantiation
+  }
 }


### PR DESCRIPTION
We were using `sym.isModuleClass` to identify module classes when generating the reflective instantiation code, but that also matches nested objects. Now, nested objects are not compiled as module classes (only static objects are) because there is one instance per enclosing instance. This caused linking errors as soon as the codebase contained a nested object with `@EnableReflectiveInstantiation`.

Since non-static objects are not really *loadable* as per the API of `Reflect` (we would need a reference to the enclosing instance), we fix this issue by not registering non-static objects at all.