### PR TITLE
Introduce a true for-in loop in the IR.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -94,6 +94,7 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val Special_in = getMemberMethod(SpecialPackageModule, newTermName("in"))
       lazy val Special_instanceof = getMemberMethod(SpecialPackageModule, newTermName("instanceof"))
       lazy val Special_delete = getMemberMethod(SpecialPackageModule, newTermName("delete"))
+      lazy val Special_forin = getMemberMethod(SpecialPackageModule, newTermName("forin"))
       lazy val Special_debugger = getMemberMethod(SpecialPackageModule, newTermName("debugger"))
 
     lazy val BooleanReflectiveCallClass = getRequiredClass("scala.scalajs.runtime.BooleanReflectiveCall")
@@ -111,7 +112,6 @@ trait JSDefinitions { self: JSGlobalAddons =>
       lazy val Runtime_createInnerJSClass         = getMemberMethod(RuntimePackageModule, newTermName("createInnerJSClass"))
       lazy val Runtime_createLocalJSClass         = getMemberMethod(RuntimePackageModule, newTermName("createLocalJSClass"))
       lazy val Runtime_withContextualJSClassValue = getMemberMethod(RuntimePackageModule, newTermName("withContextualJSClassValue"))
-      lazy val Runtime_propertiesOf               = getMemberMethod(RuntimePackageModule, newTermName("propertiesOf"))
       lazy val Runtime_linkingInfo                = getMemberMethod(RuntimePackageModule, newTermName("linkingInfo"))
 
     lazy val WrappedArrayClass = getRequiredClass("scala.scalajs.js.WrappedArray")

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
@@ -49,7 +49,8 @@ abstract class JSPrimitives {
   val IN = LINKING_INFO + 1   // js.special.in
   val INSTANCEOF = IN + 1     // js.special.instanceof
   val DELETE = INSTANCEOF + 1 // js.special.delete
-  val DEBUGGER = DELETE + 1   // js.special.debugger
+  val FORIN = DELETE + 1      // js.special.forin
+  val DEBUGGER = FORIN + 1    // js.special.debugger
 
   val LastJSPrimitiveCode = DEBUGGER
 
@@ -90,6 +91,7 @@ abstract class JSPrimitives {
     addPrimitive(Special_in, IN)
     addPrimitive(Special_instanceof, INSTANCEOF)
     addPrimitive(Special_delete, DELETE)
+    addPrimitive(Special_forin, FORIN)
     addPrimitive(Special_debugger, DEBUGGER)
   }
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -141,6 +141,12 @@ object Hashers {
           mixTree(cond)
           mixOptIdent(label)
 
+        case ForIn(obj, keyVar, body) =>
+          mixTag(TagForIn)
+          mixTree(obj)
+          mixIdent(keyVar)
+          mixTree(body)
+
         case TryCatch(block, errVar, handler) =>
           mixTag(TagTryCatch)
           mixTree(block)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -221,6 +221,14 @@ object Printers {
           print(cond)
           print(')')
 
+        case ForIn(obj, keyVar, body) =>
+          print("for (val ")
+          print(keyVar)
+          print(" in ")
+          print(obj)
+          print(") ")
+          printBlock(body)
+
         case TryFinally(TryCatch(block, errVar, handler), finalizer) =>
           print("try ")
           printBlock(block)

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -170,6 +170,10 @@ object Serializers {
           writeByte(TagDoWhile)
           writeTree(body); writeTree(cond); writeOptIdent(label)
 
+        case ForIn(obj, keyVar, body) =>
+          writeByte(TagForIn)
+          writeTree(obj); writeIdent(keyVar); writeTree(body)
+
         case TryCatch(block, errVar, handler) =>
           writeByte(TagTryCatch)
           writeTree(block); writeIdent(errVar); writeTree(handler)
@@ -851,6 +855,7 @@ object Serializers {
         case TagIf      => If(readTree(), readTree(), readTree())(readType())
         case TagWhile   => While(readTree(), readTree(), readOptIdent())
         case TagDoWhile => DoWhile(readTree(), readTree(), readOptIdent())
+        case TagForIn   => ForIn(readTree(), readIdent(), readTree())
 
         case TagTryCatch =>
           TryCatch(readTree(), readIdent(), readTree())(readType())

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -29,7 +29,8 @@ private[ir] object Tags {
   final val TagIf = TagReturn + 1
   final val TagWhile = TagIf + 1
   final val TagDoWhile = TagWhile + 1
-  final val TagTryCatch = TagDoWhile + 1
+  final val TagForIn = TagDoWhile + 1
+  final val TagTryCatch = TagForIn + 1
   final val TagTryFinally = TagTryCatch + 1
   final val TagThrow = TagTryFinally + 1
   final val TagContinue = TagThrow + 1

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -62,6 +62,9 @@ object Transformers {
         case DoWhile(body, cond, label) =>
           DoWhile(transformStat(body), transformExpr(cond), label)
 
+        case ForIn(obj, keyVar, body) =>
+          ForIn(transformExpr(obj), keyVar, transformStat(body))
+
         case TryCatch(block, errVar, handler) =>
           TryCatch(transform(block, isStat), errVar,
               transform(handler, isStat))(tree.tpe)

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -53,6 +53,10 @@ object Traversers {
         traverse(body)
         traverse(cond)
 
+      case ForIn(obj, keyVar, body) =>
+        traverse(obj)
+        traverse(body)
+
       case TryCatch(block, errVar, handler) =>
         traverse(block)
         traverse(handler)

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -199,6 +199,11 @@ object Trees {
     val tpe = NoType // cannot be in expression position
   }
 
+  case class ForIn(obj: Tree, keyVar: Ident, body: Tree)(
+      implicit val pos: Position) extends Tree {
+    val tpe = NoType
+  }
+
   case class TryCatch(block: Tree, errVar: Ident, handler: Tree)(
       val tpe: Type)(implicit val pos: Position) extends Tree
 

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -225,6 +225,16 @@ class PrintersTest {
         DoWhile(i(5), b(true), Some("lab")))
   }
 
+  @Test def printForIn(): Unit = {
+    assertPrintEquals(
+        """
+          |for (val x in o) {
+          |  5
+          |}
+        """,
+        ForIn(ref("o", AnyType), "x", i(5)))
+  }
+
   @Test def printTry(): Unit = {
     assertPrintEquals(
         """

--- a/library/src/main/scala/scala/scalajs/js/special/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/special/package.scala
@@ -92,6 +92,31 @@ package object special {
   def delete(obj: scala.Any, key: scala.Any): Unit =
     throw new java.lang.Error("stub")
 
+  /** Enumerates the keys of an object.
+   *
+   *  This method is the exact equivalent of the `for (a in o) {}` statement of
+   *  JavaScript. A call of the form
+   *  {{{
+   *  forin(obj)(f)
+   *  }}}
+   *  corresponds to the JavaScript statement
+   *  {{{
+   *  const objTemp = obj;
+   *  const fTemp = f;
+   *  for (const x in objTemp) {
+   *    fTemp(x)
+   *  }
+   *  }}}
+   *
+   *  `for..in` loops exhibit performance cliffs in most JavaScript engines,
+   *  which means their performance is very dependent on their surroundings.
+   *  Therefore, it is recommended to avoid this method and use
+   *  [[js.Any.ObjectCompanionOps.properties js.Object.properties]] instead, if
+   *  possible.
+   */
+  def forin(obj: scala.Any)(f: js.Function1[scala.Any, scala.Any]): Unit =
+    throw new java.lang.Error("stub")
+
   /** The value of the global JavaScript `this`.
    *
    *  This returns the value that would be obtained by writing `this` at the

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -84,54 +84,6 @@ package object runtime {
   def withContextualJSClassValue[A](jsclass: AnyRef, inner: A): A =
     throw new Error("stub")
 
-  /** Returns an array of the enumerable properties in an object's prototype
-   *  chain.
-   *
-   *  This is the implementation of [[js.Object.properties]].
-   */
-  def propertiesOf(obj: js.Any): js.Array[String] = {
-    // See http://stackoverflow.com/questions/26445248/
-    if (obj == null || js.isUndefined(obj)) {
-      js.Array()
-    } else {
-      val result = new js.Array[String]
-      val alreadySeen = js.Dictionary.empty[Boolean]
-
-      @tailrec
-      def loop(obj: js.Object): Unit = {
-        if (obj != null) {
-          // Add own enumerable properties that have not been seen yet
-          val enumProps = js.Object.keys(obj)
-          val enumPropsLen = enumProps.length
-          var i = 0
-          while (i < enumPropsLen) {
-            val prop = enumProps(i)
-            if (!alreadySeen.get(prop).isDefined)
-              result.push(prop)
-            i += 1
-          }
-
-          /* Add all own properties to the alreadySeen set, including
-           * non-enumerable ones.
-           */
-          val allProps = js.Object.getOwnPropertyNames(obj)
-          val allPropsLen = allProps.length
-          var j = 0
-          while (j < allPropsLen) {
-            alreadySeen(allProps(j)) = true
-            j += 1
-          }
-
-          // Continue with the next object in the prototype chain
-          loop(js.Object.getPrototypeOf(obj))
-        }
-      }
-      loop(js.Object(obj))
-
-      result
-    }
-  }
-
   /** Information known at link-time, given the output configuration.
    *
    *  See [[LinkingInfo]] for details.

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
@@ -60,6 +60,9 @@ private[closure] class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
           new Node(Token.DO, transformBlock(body), transformExpr(cond))
         new Node(Token.LABEL, transformLabel(label),
             setNodePosition(doNode, pos))
+      case ForIn(lhs, obj, body) =>
+        new Node(Token.FOR, transformStat(lhs), transformExpr(obj),
+            transformBlock(body))
       case TryFinally(TryCatch(block, errVar, handler), finalizer) =>
         val catchPos = handler.pos orElse pos
         val catchNode =

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -523,13 +523,6 @@ function $moduleDefault(m) {
 };
 //!endif
 
-function $propertiesOf(obj) {
-  const result = [];
-  for (const prop in obj)
-    result["push"](prop);
-  return result;
-};
-
 function $systemArraycopy(src, srcPos, dest, destPos, length) {
   const srcu = src.u;
   const destu = dest.u;

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -625,6 +625,17 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             }, newLabel)
           }
 
+        case ForIn(obj, keyVar, body) =>
+          unnest(obj) { (newObj, env0) =>
+            implicit val env = env0
+
+            val lhs = genEmptyImmutableLet(transformLocalVarIdent(keyVar))
+            js.ForIn(lhs, transformExprNoChar(newObj), {
+              transformStat(body, Set.empty)(
+                  env.withDef(keyVar, mutable = false))
+            })
+          }
+
         case Debugger() =>
           js.Debugger()
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -71,12 +71,19 @@ private[emitter] final class JSGen(val semantics: Semantics,
     }
   }
 
-  def genEmptyMutableLet(name: Ident)(implicit pos: Position): LocalDef = {
+  def genEmptyMutableLet(name: Ident)(implicit pos: Position): LocalDef =
+    genEmptyLet(name, mutable = true)
+
+  def genEmptyImmutableLet(name: Ident)(implicit pos: Position): LocalDef =
+    genEmptyLet(name, mutable = false)
+
+  private def genEmptyLet(name: Ident, mutable: Boolean)(
+      implicit pos: Position): LocalDef = {
     outputMode match {
       case OutputMode.ECMAScript51Isolated =>
         VarDef(name, rhs = None)
       case OutputMode.ECMAScript6 =>
-        Let(name, mutable = true, rhs = None)
+        Let(name, mutable, rhs = None)
     }
   }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/javascript/Printers.scala
@@ -223,6 +223,14 @@ object Printers {
           print(cond)
           print(')')
 
+        case ForIn(lhs, obj, body) =>
+          print("for (")
+          print(lhs)
+          print(" in ")
+          print(obj)
+          print(") ")
+          printBlock(body)
+
         case TryFinally(TryCatch(block, errVar, handler), finalizer) =>
           print("try ")
           printBlock(block)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/javascript/Trees.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/javascript/Trees.scala
@@ -120,6 +120,8 @@ object Trees {
 
   case class DoWhile(body: Tree, cond: Tree, label: Option[Ident] = None)(implicit val pos: Position) extends Tree
 
+  case class ForIn(lhs: Tree, obj: Tree, body: Tree)(implicit val pos: Position) extends Tree
+
   case class TryCatch(block: Tree, errVar: Ident, handler: Tree)(implicit val pos: Position) extends Tree
 
   case class TryFinally(block: Tree, finalizer: Tree)(implicit val pos: Position) extends Tree

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -609,6 +609,13 @@ private final class IRChecker(unit: LinkingUnit,
         typecheckExpect(cond, env, BooleanType)
         env
 
+      case ForIn(obj, keyVar, body) =>
+        typecheckExpr(obj, env)
+        val bodyEnv =
+          env.withLocal(LocalDef(keyVar.name, AnyType, false)(keyVar.pos))
+        typecheckStat(body, bodyEnv)
+        env
+
       case TryCatch(block, errVar, handler) =>
         typecheckStat(block, env)
         val handlerEnv =


### PR DESCRIPTION
This commit adds first-class support for the general `for-in` loop. It can be produced with `js.special.forin`, which is now used to implement `js.Object.properties`.

This is important because `js.Object.properties` cannot encode all uses of `for-in` loops. While it can encode most of the semantics applying to ordinary JS objects, it is not enough for exotic objects, notably proxies. Only exposing `js.Object.properties` was therefore a hole in our interoperability features.

In addition, if another language wants to compile to the IR, they should have a way to encode an efficient `for-in` loop, which was previously not possible, as the only efficient `for-in` loop was based on intrinsifying a method from the Scala.js standard library.