### PR TITLE
Make `js.FunctionN`s map to arrow functions in ECMAScript 2015.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -439,8 +439,9 @@ object Hashers {
           mixTag(TagThis)
           mixType(tree.tpe)
 
-        case Closure(captureParams, params, body, captureValues) =>
+        case Closure(arrow, captureParams, params, body, captureValues) =>
           mixTag(TagClosure)
+          mixBoolean(arrow)
           mixParamDefs(captureParams)
           mixParamDefs(params)
           mixTree(body)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -794,8 +794,11 @@ object Printers {
         case This() =>
           print("this")
 
-        case Closure(captureParams, params, body, captureValues) =>
-          print("(lambda<")
+        case Closure(arrow, captureParams, params, body, captureValues) =>
+          if (arrow)
+            print("(arrow-lambda<")
+          else
+            print("(lambda<")
           var first = true
           for ((param, value) <- captureParams.zip(captureValues)) {
             if (first)

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -425,8 +425,9 @@ object Serializers {
           writeByte(TagThis)
           writeType(tree.tpe)
 
-        case Closure(captureParams, params, body, captureValues) =>
+        case Closure(arrow, captureParams, params, body, captureValues) =>
           writeByte(TagClosure)
+          writeBoolean(arrow)
           writeParamDefs(captureParams)
           writeParamDefs(params)
           writeTree(body)
@@ -926,7 +927,8 @@ object Serializers {
         case TagThis =>
           This()(readType())
         case TagClosure =>
-          Closure(readParamDefs(), readParamDefs(), readTree(), readTrees())
+          Closure(readBoolean(), readParamDefs(), readParamDefs(), readTree(),
+              readTrees())
         case TagCreateJSClass =>
           CreateJSClass(readClassRef(), readTrees())
       }

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -194,8 +194,8 @@ object Transformers {
 
         // Atomic expressions
 
-        case Closure(captureParams, params, body, captureValues) =>
-          Closure(captureParams, params, transformExpr(body),
+        case Closure(arrow, captureParams, params, body, captureValues) =>
+          Closure(arrow, captureParams, params, transformExpr(body),
               captureValues.map(transformExpr))
 
         case CreateJSClass(cls, captureValues) =>

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -194,7 +194,7 @@ object Traversers {
 
       // Atomic expressions
 
-      case Closure(captureParams, params, body, captureValues) =>
+      case Closure(arrow, captureParams, params, body, captureValues) =>
         traverse(body)
         captureValues.foreach(traverse)
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -853,10 +853,14 @@ object Trees {
   case class This()(val tpe: Type)(implicit val pos: Position) extends Tree
 
   /** Closure with explicit captures.
-   *  The n captures map to the n first formal arguments.
+   *
+   *  @param arrow
+   *    If `true`, the closure is an Arrow Function (`=>`), which does not have
+   *    an `this` parameter, and cannot be constructed (called with `new`).
+   *    If `false`, it is a regular Function (`function`).
    */
-  case class Closure(captureParams: List[ParamDef], params: List[ParamDef],
-      body: Tree, captureValues: List[Tree])(
+  case class Closure(arrow: Boolean, captureParams: List[ParamDef],
+      params: List[ParamDef], body: Tree, captureValues: List[Tree])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -834,15 +834,16 @@ class PrintersTest {
           |  5
           |})
         """,
-        Closure(Nil, Nil, i(5), Nil))
+        Closure(false, Nil, Nil, i(5), Nil))
 
     assertPrintEquals(
         """
-          |(lambda<x: any = a, y: int = 6>(z: any) = {
+          |(arrow-lambda<x: any = a, y: int = 6>(z: any) = {
           |  z
           |})
         """,
         Closure(
+            true,
             List(
                 ParamDef("x", AnyType, mutable = false, rest = false),
                 ParamDef("y", IntType, mutable = false, rest = false)),

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
@@ -8,8 +8,10 @@
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js
+import scala.scalajs.LinkingInfo.assumingES6
 
 import org.junit.Assert._
+import org.junit.Assume._
 import org.junit.Test
 
 import org.scalajs.testsuite.utils.AssertThrows._
@@ -37,6 +39,30 @@ class FunctionTest {
     assertEquals(42, res("0"))
     assertEquals(true, res("1"))
     assertFalse(res.contains("2"))
+  }
+
+  @Test def functionWithConversionIsAnArrowFunction(): Unit = {
+    assumeTrue("In ES 5.1, arrow functions do not exist", assumingES6)
+
+    val ctor: js.Function = (x: js.Any) => x
+    val ctorDyn = ctor.asInstanceOf[js.Dynamic]
+
+    assertEquals(js.undefined, ctorDyn.prototype)
+
+    assertThrows(classOf[js.JavaScriptException],
+        js.Dynamic.newInstance(ctorDyn)("foo"))
+  }
+
+  @Test def functionWithSAMIsAnArrowFunction(): Unit = {
+    assumeTrue("In ES 5.1, arrow functions do not exist", assumingES6)
+
+    val ctor: js.Function1[js.Any, Any] = (x: js.Any) => x
+    val ctorDyn = ctor.asInstanceOf[js.Dynamic]
+
+    assertEquals(js.undefined, ctorDyn.prototype)
+
+    assertThrows(classOf[js.JavaScriptException],
+        js.Dynamic.newInstance(ctorDyn)("foo"))
   }
 
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
@@ -98,4 +98,36 @@ class ThisFunctionTest {
     assertSame(thisValue, obj.foobar.call(thisValue))
   }
 
+  @Test def thisFunctionWithConversionCanBeConstructed(): Unit = {
+    val ctor: js.ThisFunction = {
+      (thiz: js.Dynamic, x: js.Any) =>
+        thiz.x = x
+        thiz.y = 42
+    }
+    val ctorDyn = ctor.asInstanceOf[js.Dynamic]
+
+    assertEquals("object", js.typeOf(ctorDyn.prototype))
+
+    val obj = js.Dynamic.newInstance(ctorDyn)("foo")
+    assertEquals("foo", obj.x)
+    assertEquals(42, obj.y)
+    assertSame(ctor, obj.constructor)
+  }
+
+  @Test def thisFunctionWithSAMCanBeConstructed(): Unit = {
+    val ctor: js.ThisFunction1[js.Dynamic, js.Any, Any] = {
+      (thiz: js.Dynamic, x: js.Any) =>
+        thiz.x = x
+        thiz.y = 42
+    }
+    val ctorDyn = ctor.asInstanceOf[js.Dynamic]
+
+    assertEquals("object", js.typeOf(ctorDyn.prototype))
+
+    val obj = js.Dynamic.newInstance(ctorDyn)("foo")
+    assertEquals("foo", obj.x)
+    assertEquals(42, obj.y)
+    assertSame(ctor, obj.constructor)
+  }
+
 }

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
@@ -202,7 +202,7 @@ private[closure] class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
       case This() =>
         new Node(Token.THIS)
 
-      case Function(args, body) =>
+      case Function(false, args, body) =>
         genFunction("", args, body)
       case FunctionDef(name, args, body) =>
         genFunction(name.name, args, body)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -233,7 +233,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
       pos: Position): WithGlobals[js.Tree] = {
     for (fun <- desugarToFunction(Nil, expr, resultType)) yield {
       fun match {
-        case js.Function(Nil, js.Return(newExpr)) =>
+        case js.Function(_, Nil, js.Return(newExpr)) =>
           // no need for an IIFE, we can just use `newExpr` directly
           newExpr
         case _ =>
@@ -391,9 +391,10 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
          */
         val thisIdent = js.Ident("$thiz", Some("this"))
         val env = env0.withThisIdent(Some(thisIdent))
-        val js.Function(jsParams, jsBody) =
-          desugarToFunctionInternal(params, body, isStat, env)
-        js.Function(js.ParamDef(thisIdent, rest = false) :: jsParams, jsBody)
+        val js.Function(jsArrow, jsParams, jsBody) =
+          desugarToFunctionInternal(arrow = false, params, body, isStat, env)
+        js.Function(jsArrow, js.ParamDef(thisIdent, rest = false) :: jsParams,
+            jsBody)
       }
     }
 
@@ -403,13 +404,13 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
         params: List[ParamDef], body: Tree, isStat: Boolean, env0: Env)(
         implicit pos: Position): WithGlobals[js.Function] = {
       performOptimisticThenPessimisticRuns {
-        desugarToFunctionInternal(params, body, isStat, env0)
+        desugarToFunctionInternal(arrow = false, params, body, isStat, env0)
       }
     }
 
     /** Desugars parameters and body to a JS function.
      */
-    private def desugarToFunctionInternal(
+    private def desugarToFunctionInternal(arrow: Boolean,
         params: List[ParamDef], body: Tree, isStat: Boolean, env0: Env)(
         implicit pos: Position): js.Function = {
 
@@ -438,7 +439,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
         case other                                        => other
       }
 
-      js.Function(newParams, js.Block(extractRestParam, newBody))
+      js.Function(arrow && useArrowFunctions, newParams,
+          js.Block(extractRestParam, newBody))
     }
 
     private def makeExtractRestParam(params: List[ParamDef])(
@@ -958,8 +960,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                 }
                 JSObjectConstr(newItems)
 
-              case Closure(captureParams, params, body, captureValues) =>
-                Closure(captureParams, params, body, recs(captureValues))
+              case Closure(arrow, captureParams, params, body, captureValues) =>
+                Closure(arrow, captureParams, params, body, recs(captureValues))
 
               case New(cls, constr, args) if noExtractYet =>
                 New(cls, constr, recs(args))
@@ -1148,7 +1150,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
               case _                     => true
             })
           }
-        case Closure(captureParams, params, body, captureValues) =>
+        case Closure(arrow, captureParams, params, body, captureValues) =>
           allowUnpure && (captureValues forall test)
 
         // Scala expressions that can always have side-effects
@@ -1750,9 +1752,10 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
 
         // Closures
 
-        case Closure(captureParams, params, body, captureValues) =>
+        case Closure(arrow, captureParams, params, body, captureValues) =>
           unnest(captureValues) { (newCaptureValues, env) =>
-            redo(Closure(captureParams, params, body, newCaptureValues))(env)
+            redo(Closure(arrow, captureParams, params, body, newCaptureValues))(
+                env)
           }
 
         case CreateJSClass(cls, captureValues) =>
@@ -2406,16 +2409,17 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             js.VarRef(ident)
           }
 
-        case Closure(captureParams, params, body, captureValues) =>
-          val innerFunction =
-            desugarToFunctionInternal(params, body, isStat = false,
+        case Closure(arrow, captureParams, params, body, captureValues) =>
+          val innerFunction = {
+            desugarToFunctionInternal(arrow, params, body, isStat = false,
                 Env.empty(AnyType).withParams(captureParams ++ params))
+          }
 
           if (captureParams.isEmpty) {
             innerFunction
           } else {
             js.Apply(
-                js.Function(captureParams.map(transformParamDef), {
+                genArrowFunction(captureParams.map(transformParamDef), {
                   js.Return(innerFunction)
                 }),
                 captureValues.zip(captureParams).map {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -34,6 +34,13 @@ private[emitter] final class JSGen(val semantics: Semantics,
 
   import JSGen._
 
+  val useArrowFunctions = {
+    outputMode match {
+      case OutputMode.ECMAScript51Isolated => false
+      case OutputMode.ECMAScript6          => true
+    }
+  }
+
   def genZeroOf(tpe: Type)(implicit pos: Position): Tree = {
     tpe match {
       case BooleanType => BooleanLiteral(false)
@@ -354,6 +361,11 @@ private[emitter] final class JSGen(val semantics: Semantics,
       DotSelect(qual, Ident(item))
     else
       BracketSelect(qual, StringLiteral(item))
+  }
+
+  def genArrowFunction(args: List[ParamDef], body: Tree)(
+      implicit pos: Position): Function = {
+    Function(useArrowFunctions, args, body)
   }
 }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/javascript/Printers.scala
@@ -481,11 +481,24 @@ object Printers {
         case This() =>
           print("this")
 
-        case Function(args, body) =>
-          print("(function")
-          printSig(args)
-          printBlock(body)
-          print(')')
+        case Function(arrow, args, body) =>
+          if (arrow) {
+            print('(')
+            printSig(args)
+            print("=> ")
+            body match {
+              case Return(expr) =>
+                print(expr)
+              case _ =>
+                printBlock(body)
+            }
+            print(')')
+          } else {
+            print("(function")
+            printSig(args)
+            printBlock(body)
+            print(')')
+          }
 
         // Named function definition
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/javascript/Trees.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/javascript/Trees.scala
@@ -216,7 +216,8 @@ object Trees {
 
   case class This()(implicit val pos: Position) extends Tree
 
-  case class Function(args: List[ParamDef], body: Tree)(implicit val pos: Position) extends Tree
+  case class Function(arrow: Boolean, args: List[ParamDef], body: Tree)(
+      implicit val pos: Position) extends Tree
 
   // Named function definition
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -1042,7 +1042,7 @@ private final class IRChecker(unit: LinkingUnit,
         if (!isSubtype(env.thisTpe, tree.tpe))
           reportError(s"this of type ${env.thisTpe} typed as ${tree.tpe}")
 
-      case Closure(captureParams, params, body, captureValues) =>
+      case Closure(arrow, captureParams, params, body, captureValues) =>
         /* Check compliance of captureValues wrt. captureParams in the current
          * method state, i.e., outside `withPerMethodState`.
          */
@@ -1068,8 +1068,9 @@ private final class IRChecker(unit: LinkingUnit,
 
           checkJSParamDefs(params)
 
+          val thisType = if (arrow) NoType else AnyType
           val bodyEnv = Env.fromSignature(
-              AnyType, None, captureParams ++ params, AnyType)
+              thisType, None, captureParams ++ params, AnyType)
           typecheckExpect(body, bodyEnv, AnyType)
         }
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -646,8 +646,8 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           pretransformExpr(tree)(finishTransform(isStat))
         }
 
-      case Closure(captureParams, params, body, captureValues) =>
-        transformClosureCommon(captureParams, params, body,
+      case Closure(arrow, captureParams, params, body, captureValues) =>
+        transformClosureCommon(arrow, captureParams, params, body,
             captureValues.map(transformExpr))
 
       case CreateJSClass(cls, captureValues) =>
@@ -669,16 +669,18 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     else result
   }
 
-  private def transformClosureCommon(captureParams: List[ParamDef],
-      params: List[ParamDef], body: Tree, newCaptureValues: List[Tree])(
+  private def transformClosureCommon(arrow: Boolean,
+      captureParams: List[ParamDef], params: List[ParamDef], body: Tree,
+      newCaptureValues: List[Tree])(
       implicit pos: Position): Closure = {
 
+    val thisType = if (arrow) NoType else AnyType
     val (allNewParams, newBody) =
-      transformIsolatedBody(None, AnyType, captureParams ++ params, AnyType, body)
+      transformIsolatedBody(None, thisType, captureParams ++ params, AnyType, body)
     val (newCaptureParams, newParams) =
       allNewParams.splitAt(captureParams.size)
 
-    Closure(newCaptureParams, newParams, newBody, newCaptureValues)
+    Closure(arrow, newCaptureParams, newParams, newBody, newCaptureValues)
   }
 
   private def transformBlock(tree: Block, isStat: Boolean)(
@@ -891,20 +893,23 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           }
         }
 
-      case Closure(captureParams, params, body, captureValues) =>
+      case Closure(arrow, captureParams, params, body, captureValues) =>
         pretransformExprs(captureValues) { tcaptureValues =>
           def default(): TailRec[Tree] = {
-            val newClosure = transformClosureCommon(captureParams, params, body,
-                tcaptureValues.map(finishTransformExpr))
+            val newClosure = transformClosureCommon(arrow, captureParams,
+                params, body, tcaptureValues.map(finishTransformExpr))
             cont(PreTransTree(
                 newClosure,
                 RefinedType(AnyType, isExact = false, isNullable = false)))
           }
 
-          if (params.exists(_.rest)) {
+          if (!arrow && params.exists(_.rest)) {
             /* TentativeClosureReplacement assumes there are no rest
              * parameters, because that would not be inlineable anyway.
-             * So we never try to inline a Closure with a rest parameter.
+             * Likewise, it assumes that there is no binding for `this`, which
+             * is only true for arrow functions.
+             * So we never try to inline non-arrow Closures, nor Closures with
+             * a rest parameter. There are few use cases for either anyway.
              */
             default()
           } else {
@@ -1373,7 +1378,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       Block(lengths.map(keepOnlySideEffects))(stat.pos)
     case Select(qualifier, _) =>
       keepOnlySideEffects(qualifier)
-    case Closure(_, _, _, captureValues) =>
+    case Closure(_, _, _, _, captureValues) =>
       Block(captureValues.map(keepOnlySideEffects))(stat.pos)
     case UnaryOp(_, arg) =>
       keepOnlySideEffects(arg)


### PR DESCRIPTION
Arrow functions have some distinct semantics besides not capturing `this`: they cannot be *constructed* (i.e., called with `new`) and they do not have a `prototype` property. Therefore, they also cannot be used as "parent classes".

As such, we need an interop feature to create true arrow functions when targeting ES 2015+. The existing `js.FunctionN`s are actually a perfect fit for this, since they already do not have access to their `this` parameter.

This is, in theory, a breaking change, as someone could have relied on calling a `js.FunctionN` with `new` (which succeeded before, and now throws). However, without access to the `this` value, there is no non-contrived use case for that, so it is unlikely to be noticeable.