### PR TITLE
Consolidate the notion of transient node in the IR.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -285,12 +285,6 @@ object Hashers {
           mixTag(TagGetClass)
           mixTree(expr)
 
-        case CallHelper(helper, args) =>
-          mixTag(TagCallHelper)
-          mixString(helper)
-          mixTrees(args)
-          mixType(tree.tpe)
-
         case JSNew(ctor, args) =>
           mixTag(TagJSNew)
           mixTree(ctor)
@@ -384,15 +378,6 @@ object Hashers {
         case Undefined() =>
           mixTag(TagUndefined)
 
-        case UndefinedParam() =>
-          /* UndefinedParam is a "transient" IR node, and cannot be hashed.
-           * TODO At the moment, this is quite ad hoc to support dangling
-           * UndefinedParam detection in the compiler back-end. This should be
-           * generalized for custom transient nodes.
-           */
-          throw new InvalidIRException(tree,
-              "Cannot hash a transient IR node of type UndefinedParam")
-
         case Null() =>
           mixTag(TagNull)
 
@@ -457,6 +442,11 @@ object Hashers {
           mixTag(TagCreateJSClass)
           mixClassRef(cls)
           mixTrees(captureValues)
+
+        case Transient(value) =>
+          throw new InvalidIRException(tree,
+              "Cannot hash a transient IR node (its value is of class " +
+              s"${value.getClass})")
 
         case _ =>
           throw new IllegalArgumentException(

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -527,10 +527,6 @@ object Printers {
           print(expr)
           print(".getClass()")
 
-        case CallHelper(helper, args) =>
-          print(helper)
-          printArgs(args)
-
         // JavaScript expressions
 
         case JSNew(ctor, args) =>
@@ -789,11 +785,6 @@ object Printers {
           print(typeRef)
           print(']')
 
-        // Specials
-
-        case UndefinedParam() =>
-          print("<undefined param>")
-
         // Atomic expressions
 
         case VarRef(ident) =>
@@ -825,6 +816,11 @@ object Printers {
           print("createjsclass[")
           print(cls)
           printRow(captureValues, "](", ", ", ")")
+
+        // Transient
+
+        case Transient(value) =>
+          value.printIR(this)
       }
     }
 
@@ -1012,10 +1008,10 @@ object Printers {
         print(')')
     }
 
-    protected def print(ident: Ident): Unit =
+    def print(ident: Ident): Unit =
       printEscapeJS(ident.name, out)
 
-    private final def print(propName: PropertyName): Unit = propName match {
+    def print(propName: PropertyName): Unit = propName match {
       case lit: StringLiteral => print(lit: Tree)
       case ident: Ident       => print(ident)
 
@@ -1027,7 +1023,7 @@ object Printers {
         print(")")
     }
 
-    private def print(spec: JSNativeLoadSpec): Unit = {
+    def print(spec: JSNativeLoadSpec): Unit = {
       def printPath(path: List[String]): Unit = {
         for (propName <- path) {
           print("[\"")
@@ -1055,13 +1051,13 @@ object Printers {
       }
     }
 
-    protected def print(s: String): Unit =
+    def print(s: String): Unit =
       out.write(s)
 
-    protected def print(c: Int): Unit =
+    def print(c: Int): Unit =
       out.write(c)
 
-    protected def print(optimizerHints: OptimizerHints)(
+    def print(optimizerHints: OptimizerHints)(
         implicit dummy: DummyImplicit): Unit = {
       if (optimizerHints != OptimizerHints.empty) {
         print("@hints(")

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -56,9 +56,8 @@ private[ir] object Tags {
   final val TagAsInstanceOf = TagIsInstanceOf + 1
   final val TagUnbox = TagAsInstanceOf + 1
   final val TagGetClass = TagUnbox + 1
-  final val TagCallHelper = TagGetClass + 1
 
-  final val TagJSNew = TagCallHelper + 1
+  final val TagJSNew = TagGetClass + 1
   final val TagJSDotSelect = TagJSNew + 1
   final val TagJSBracketSelect = TagJSDotSelect + 1
   final val TagJSFunctionApply = TagJSBracketSelect + 1
@@ -94,6 +93,10 @@ private[ir] object Tags {
   final val TagThis = TagVarRef + 1
   final val TagClosure = TagThis + 1
   final val TagCreateJSClass = TagClosure + 1
+
+  /* Note that there is no TagTransient, since transient nodes are never
+   * serialized nor hashed.
+   */
 
   // Tags for member defs
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -135,9 +135,6 @@ object Transformers {
         case GetClass(expr) =>
           GetClass(transformExpr(expr))
 
-        case CallHelper(helper, args) =>
-          CallHelper(helper, args map transformExpr)(tree.tpe)
-
         // JavaScript expressions
 
         case JSNew(ctor, args) =>
@@ -208,7 +205,7 @@ object Transformers {
 
         case _:Skip | _:Continue | _:Debugger | _:LoadModule | _:SelectStatic |
             _:LoadJSConstructor | _:LoadJSModule  | _:JSLinkingInfo |
-            _:Literal | _:UndefinedParam | _:VarRef | _:This | _:JSGlobalRef  =>
+            _:Literal | _:VarRef | _:This | _:JSGlobalRef | _:Transient  =>
           tree
       }
     }

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -130,9 +130,6 @@ object Traversers {
       case GetClass(expr) =>
         traverse(expr)
 
-      case CallHelper(helper, args) =>
-        args foreach traverse
-
       // JavaScript expressions
 
       case JSNew(ctor, args) =>
@@ -209,7 +206,7 @@ object Traversers {
 
       case _:Skip | _:Continue | _:Debugger | _:LoadModule | _:SelectStatic |
           _:LoadJSConstructor | _:LoadJSModule | _:JSLinkingInfo | _:Literal |
-          _:UndefinedParam | _:VarRef | _:This | _:JSGlobalRef =>
+          _:VarRef | _:This | _:JSGlobalRef | _:Transient =>
     }
 
     def traverseClassDef(tree: ClassDef): Unit = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -474,16 +474,6 @@ object Trees {
     val tpe = ClassType(Definitions.ClassClass)
   }
 
-  case class CallHelper(helper: String, args: List[Tree])(val tpe: Type)(
-      implicit val pos: Position) extends Tree
-
-  object CallHelper {
-    def apply(helper: String, args: Tree*)(tpe: Type)(
-        implicit pos: Position): CallHelper = {
-      CallHelper(helper, args.toList)(tpe)
-    }
-  }
-
   // JavaScript expressions
 
   case class JSNew(ctor: Tree, args: List[TreeOrJSSpread])(
@@ -845,11 +835,6 @@ object Trees {
     val tpe = ClassType(Definitions.ClassClass)
   }
 
-  // Specials
-
-  case class UndefinedParam()(val tpe: Type)(
-      implicit val pos: Position) extends Tree
-
   // Atomic expressions
 
   case class VarRef(ident: Ident)(val tpe: Type)(
@@ -884,6 +869,37 @@ object Trees {
       implicit val pos: Position)
       extends Tree {
     val tpe = AnyType
+  }
+
+  // Transient, a special one
+
+  /** A transient node for custom purposes.
+   *
+   *  A transient node is never a valid input to the [[Serializers]] nor to the
+   *  linker, but can be used in a transient state for internal purposes.
+   *
+   *  @param value
+   *    The payload of the transient node, without any specified meaning.
+   */
+  case class Transient(value: Transient.Value)(val tpe: Type)(
+      implicit val pos: Position)
+      extends Tree
+
+  object Transient {
+    /** Common interface for the values that can be stored in [[Transient]]
+     *  nodes.
+     */
+    trait Value {
+      /** Prints the IR representation of this transient node.
+       *  This method is called by the IR printers when encountering a
+       *  [[Transient]] node.
+       *
+       *  @param out
+       *    The [[Printers.IRTreePrinter]] to which the transient node must be
+       *    printed. It can be used to print raw strings or nested IR nodes.
+       */
+      def printIR(out: Printers.IRTreePrinter): Unit
+    }
   }
 
   // Classes

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -576,11 +576,6 @@ class PrintersTest {
     assertPrintEquals("x.getClass()", GetClass(ref("x", AnyType)))
   }
 
-  @Test def printCallHelper(): Unit = {
-    assertPrintEquals("help(x, y)",
-        CallHelper("help", List(ref("x", AnyType), ref("y", AnyType)))(IntType))
-  }
-
   @Test def printJSNew(): Unit = {
     assertPrintEquals("new C()", JSNew(ref("C", AnyType), Nil))
     assertPrintEquals("new C(4, 5)", JSNew(ref("C", AnyType), List(i(4), i(5))))
@@ -825,10 +820,6 @@ class PrintersTest {
     assertPrintEquals("classOf[LTest]", ClassOf("LTest"))
   }
 
-  @Test def printUndefinedParam(): Unit = {
-    assertPrintEquals("<undefined param>", UndefinedParam()(IntType))
-  }
-
   @Test def printVarRef(): Unit = {
     assertPrintEquals("x", VarRef("x")(IntType))
   }
@@ -868,6 +859,19 @@ class PrintersTest {
           |createjsclass[LFoo](x, y)
         """,
         CreateJSClass("LFoo", List(ref("x", IntType), ref("y", AnyType))))
+  }
+
+  @Test def printTransient(): Unit = {
+    class MyTransient(expr: Tree) extends Transient.Value {
+      def printIR(out: Printers.IRTreePrinter): Unit = {
+        out.print("mytransient(")
+        out.print(expr)
+        out.print(")")
+      }
+    }
+
+    assertPrintEquals("mytransient(5)",
+        Transient(new MyTransient(i(5)))(AnyType))
   }
 
   @Test def printClassDefKinds(): Unit = {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Infos.scala
@@ -18,6 +18,7 @@ import org.scalajs.core.ir.Trees._
 import org.scalajs.core.ir.Types._
 
 import org.scalajs.core.tools.linker.LinkedClass
+import org.scalajs.core.tools.linker.backend.emitter.Transients._
 
 object Infos {
 
@@ -486,6 +487,10 @@ object Infos {
 
             case CreateJSClass(cls, _) =>
               builder.addInstantiatedClass(cls.className)
+
+            case Transient(CallHelper(_, args)) =>
+              // This should only happen when called from the Refiner
+              args.foreach(traverse)
 
             case _ =>
           }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Transients.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Transients.scala
@@ -1,0 +1,30 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js tools             **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.core.tools.linker.backend.emitter
+
+import org.scalajs.core.ir.Trees._
+import org.scalajs.core.ir.Printers._
+
+object Transients {
+
+  final case class CallHelper(helper: String, args: List[Tree])
+      extends Transient.Value {
+
+    def printIR(out: IRTreePrinter): Unit = {
+      out.print("$callHelper(")
+      out.print(helper)
+      for (arg <- args) {
+        out.print(", ")
+        out.print(arg)
+      }
+      out.print(")")
+    }
+  }
+
+}


### PR DESCRIPTION
Previously, we had two kinds of nodes in the IR used for internal purposes: `UndefinedParam` and `CallHelper`. Those nodes should not be part of the public IR definition.

We get rid of that public display by introducing a unique, generic `Transient` node, which can be used by internal phases for custom purposes. The scalac plugin uses it for `UndefinedParam`, and the optimizer+emitter use it for `CallHelper`. Transient nodes could be used by any other phase, including user-defined tools manipulating IR trees.