### PR TITLE
Stricter typing for `JSSpread`s in the IR.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -641,9 +641,9 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
         assert(allArgs.isEmpty)
         js.JSSuperBracketSelect(superClass, receiver, nameString)
       } else if (jsInterop.isJSSetter(sym)) {
-        assert(allArgs.size == 1 && !allArgs.head.isInstanceOf[js.JSSpread])
+        assert(allArgs.size == 1 && allArgs.head.isInstanceOf[js.Tree])
         js.Assign(js.JSSuperBracketSelect(superClass, receiver, nameString),
-            allArgs.head)
+            allArgs.head.asInstanceOf[js.Tree])
       } else {
         js.JSSuperBracketCall(superClass, receiver, nameString, allArgs)
       }

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -288,7 +288,7 @@ object Hashers {
         case JSNew(ctor, args) =>
           mixTag(TagJSNew)
           mixTree(ctor)
-          mixTrees(args)
+          mixTreeOrJSSpreads(args)
 
         case JSDotSelect(qualifier, item) =>
           mixTag(TagJSDotSelect)
@@ -303,19 +303,19 @@ object Hashers {
         case JSFunctionApply(fun, args) =>
           mixTag(TagJSFunctionApply)
           mixTree(fun)
-          mixTrees(args)
+          mixTreeOrJSSpreads(args)
 
         case JSDotMethodApply(receiver, method, args) =>
           mixTag(TagJSDotMethodApply)
           mixTree(receiver)
           mixIdent(method)
-          mixTrees(args)
+          mixTreeOrJSSpreads(args)
 
         case JSBracketMethodApply(receiver, method, args) =>
           mixTag(TagJSBracketMethodApply)
           mixTree(receiver)
           mixTree(method)
-          mixTrees(args)
+          mixTreeOrJSSpreads(args)
 
         case JSSuperBracketSelect(superClass, qualifier, item) =>
           mixTag(TagJSSuperBracketSelect)
@@ -328,11 +328,11 @@ object Hashers {
           mixTree(superClass)
           mixTree(receiver)
           mixTree(method)
-          mixTrees(args)
+          mixTreeOrJSSpreads(args)
 
         case JSSuperConstructorCall(args) =>
           mixTag(TagJSSuperConstructorCall)
-          mixTrees(args)
+          mixTreeOrJSSpreads(args)
 
         case LoadJSConstructor(cls) =>
           mixTag(TagLoadJSConstructor)
@@ -341,10 +341,6 @@ object Hashers {
         case LoadJSModule(cls) =>
           mixTag(TagLoadJSModule)
           mixType(cls)
-
-        case JSSpread(items) =>
-          mixTag(TagJSSpread)
-          mixTree(items)
 
         case JSDelete(prop) =>
           mixTag(TagJSDelete)
@@ -363,7 +359,7 @@ object Hashers {
 
         case JSArrayConstr(items) =>
           mixTag(TagJSArrayConstr)
-          mixTrees(items)
+          mixTreeOrJSSpreads(items)
 
         case JSObjectConstr(fields) =>
           mixTag(TagJSObjectConstr)
@@ -466,6 +462,19 @@ object Hashers {
 
     def mixTrees(trees: List[Tree]): Unit =
       trees.foreach(mixTree)
+
+    def mixTreeOrJSSpreads(trees: List[TreeOrJSSpread]): Unit =
+      trees.foreach(mixTreeOrJSSpread)
+
+    def mixTreeOrJSSpread(tree: TreeOrJSSpread): Unit = {
+      tree match {
+        case JSSpread(items) =>
+          mixTag(TagJSSpread)
+          mixTree(items)
+        case tree: Tree =>
+          mixTree(tree)
+      }
+    }
 
     def mixTypeRef(typeRef: TypeRef): Unit = typeRef match {
       case ClassRef(className) =>

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -96,7 +96,7 @@ object Printers {
       }
     }
 
-    protected def printArgs(args: List[Tree]): Unit = {
+    protected def printArgs(args: List[TreeOrJSSpread]): Unit = {
       printRow(args, "(", ", ", ")")
     }
 
@@ -106,6 +106,7 @@ object Printers {
         case node: ComputedName      => print(node)
         case node: ParamDef          => print(node)
         case node: Tree              => print(node)
+        case node: JSSpread          => print(node)
         case node: ClassDef          => print(node)
         case node: MemberDef         => print(node)
         case node: TopLevelExportDef => print(node)
@@ -610,10 +611,6 @@ object Printers {
           print("mod:")
           print(cls)
 
-        case JSSpread(items) =>
-          print("...")
-          print(items)
-
         case JSDelete(prop) =>
           print("delete ")
           print(prop)
@@ -818,6 +815,11 @@ object Printers {
           print(cls)
           printRow(captureValues, "](", ", ", ")")
       }
+    }
+
+    def print(spread: JSSpread): Unit = {
+      print("...")
+      print(spread.items)
     }
 
     def print(classDef: ClassDef): Unit = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -17,7 +17,9 @@ private[ir] object Tags {
   /** Use to denote optional trees. */
   final val TagEmptyTree = 1
 
-  final val TagVarDef = TagEmptyTree + 1
+  final val TagJSSpread = TagEmptyTree + 1
+
+  final val TagVarDef = TagJSSpread + 1
 
   final val TagSkip = TagVarDef + 1
   final val TagBlock = TagSkip + 1
@@ -66,8 +68,7 @@ private[ir] object Tags {
   final val TagJSSuperConstructorCall = TagJSSuperBracketCall + 1
   final val TagLoadJSConstructor = TagJSSuperConstructorCall + 1
   final val TagLoadJSModule = TagLoadJSConstructor + 1
-  final val TagJSSpread = TagLoadJSModule + 1
-  final val TagJSDelete = TagJSSpread + 1
+  final val TagJSDelete = TagLoadJSModule + 1
   final val TagJSUnaryOp = TagJSDelete + 1
   final val TagJSBinaryOp = TagJSUnaryOp + 1
   final val TagJSArrayConstr = TagJSBinaryOp + 1

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -14,6 +14,11 @@ import Trees._
 object Traversers {
 
   class Traverser {
+    def traverseTreeOrJSSpread(tree: TreeOrJSSpread): Unit = tree match {
+      case JSSpread(items) => traverse(items)
+      case tree: Tree      => traverse(tree)
+    }
+
     def traverse(tree: Tree): Unit = tree match {
       // Definitions
 
@@ -128,7 +133,7 @@ object Traversers {
 
       case JSNew(ctor, args) =>
         traverse(ctor)
-        args foreach traverse
+        args.foreach(traverseTreeOrJSSpread)
 
       case JSDotSelect(qualifier, item) =>
         traverse(qualifier)
@@ -139,16 +144,16 @@ object Traversers {
 
       case JSFunctionApply(fun, args) =>
         traverse(fun)
-        args foreach traverse
+        args.foreach(traverseTreeOrJSSpread)
 
       case JSDotMethodApply(receiver, method, args) =>
         traverse(receiver)
-        args foreach traverse
+        args.foreach(traverseTreeOrJSSpread)
 
       case JSBracketMethodApply(receiver, method, args) =>
         traverse(receiver)
         traverse(method)
-        args foreach traverse
+        args.foreach(traverseTreeOrJSSpread)
 
       case JSSuperBracketSelect(superClass, qualifier, item) =>
         traverse(superClass)
@@ -159,13 +164,10 @@ object Traversers {
         traverse(superClass)
         traverse(receiver)
         traverse(method)
-        args foreach traverse
+        args.foreach(traverseTreeOrJSSpread)
 
       case JSSuperConstructorCall(args) =>
-        args foreach traverse
-
-      case JSSpread(items) =>
-        traverse(items)
+        args.foreach(traverseTreeOrJSSpread)
 
       case JSDelete(prop) =>
         traverse(prop)
@@ -178,7 +180,7 @@ object Traversers {
         traverse(rhs)
 
       case JSArrayConstr(items) =>
-        items foreach traverse
+        items.foreach(traverseTreeOrJSSpread)
 
       case JSObjectConstr(fields) =>
         for ((key, value) <- fields) {

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -30,8 +30,14 @@ object Trees {
     }
   }
 
+  /** Either a `Tree` or a `JSSpread`.
+   *
+   *  This is the type of actual arguments to JS applications.
+   */
+  sealed trait TreeOrJSSpread extends IRNode
+
   /** Node for a statement or expression in the IR. */
-  abstract sealed class Tree extends IRNode {
+  abstract sealed class Tree extends IRNode with TreeOrJSSpread {
     val tpe: Type
   }
 
@@ -475,7 +481,7 @@ object Trees {
 
   // JavaScript expressions
 
-  case class JSNew(ctor: Tree, args: List[Tree])(
+  case class JSNew(ctor: Tree, args: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
@@ -490,18 +496,18 @@ object Trees {
     val tpe = AnyType
   }
 
-  case class JSFunctionApply(fun: Tree, args: List[Tree])(
+  case class JSFunctionApply(fun: Tree, args: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
   case class JSDotMethodApply(receiver: Tree, method: Ident,
-      args: List[Tree])(implicit val pos: Position) extends Tree {
+      args: List[TreeOrJSSpread])(implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
   case class JSBracketMethodApply(receiver: Tree, method: Tree,
-      args: List[Tree])(implicit val pos: Position) extends Tree {
+      args: List[TreeOrJSSpread])(implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
@@ -585,7 +591,7 @@ object Trees {
    *  }}}
    */
   case class JSSuperBracketCall(superClass: Tree, receiver: Tree, method: Tree,
-      args: List[Tree])(implicit val pos: Position) extends Tree {
+      args: List[TreeOrJSSpread])(implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
@@ -626,7 +632,7 @@ object Trees {
    *  }
    *  }}}
    */
-  case class JSSuperConstructorCall(args: List[Tree])(
+  case class JSSuperConstructorCall(args: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
     val tpe = NoType
   }
@@ -675,9 +681,8 @@ object Trees {
    *
    *  @param items An Array whose items will be spread (not an arbitrary iterable)
    */
-  case class JSSpread(items: Tree)(implicit val pos: Position) extends Tree {
-    val tpe = NoType // there is no reasonable type for this tree
-  }
+  case class JSSpread(items: Tree)(implicit val pos: Position)
+      extends IRNode with TreeOrJSSpread
 
   case class JSDelete(prop: Tree)(implicit val pos: Position) extends Tree {
     require(prop match {
@@ -752,7 +757,7 @@ object Trees {
     final val instanceof = 21
   }
 
-  case class JSArrayConstr(items: List[Tree])(
+  case class JSArrayConstr(items: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -663,12 +663,11 @@ private final class IRChecker(unit: LinkingUnit,
     typecheck(tree, env)
   }
 
-  private def typecheckExprOrSpread(tree: Tree, env: Env): Type = {
+  private def typecheckExprOrSpread(tree: TreeOrJSSpread, env: Env): Unit = {
     tree match {
       case JSSpread(items) =>
         typecheckExpr(items, env)
-        AnyType
-      case _ =>
+      case tree: Tree =>
         typecheckExpr(tree, env)
     }
   }


### PR DESCRIPTION
Previously, `JSSpread` extended `Tree` That was nonsense because `Tree`s are supposed to be valid anywhere in statement/expression position (provided they typecheck), although `JSSpread`s are only valid in very specific positions, structurally speaking.

We reify those restrictions in the types of the IR nodes, by introducing `TreeOrJSSpread` as a common super type for `Tree` and `JSSpread`.