### PR TITLE
Harden neg tests with specific error messages.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSDynamicLiteralTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSDynamicLiteralTest.scala
@@ -17,7 +17,14 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
     // selectDynamic (with any name)
     expr"""
     lit.helloWorld
-    """.fails() // Scala error, no string checking due to versions
+    """ hasErrors
+    """
+      |newSource1.scala:3: error: value selectDynamic is not a member of object scalajs.js.Dynamic.literal
+      |error after rewriting to scala.scalajs.js.Dynamic.literal.<selectDynamic: error>("helloWorld")
+      |possible cause: maybe a wrong Dynamic method signature?
+      |    lit.helloWorld
+      |    ^
+    """
 
     // applyDynamicNamed with wrong method name
     expr"""
@@ -50,7 +57,14 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
       val x = new Object()
       def foo = lit("a" -> x)
     }
-    """.fails()
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: type mismatch;
+      | found   : Object
+      | required: scala.scalajs.js.Any
+      |      def foo = lit("a" -> x)
+      |                           ^
+    """
 
     // Bad key type (applyDynamic)
     """
@@ -58,7 +72,14 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
       val x = Seq()
       def foo = lit(x -> "a")
     }
-    """.fails()
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: type mismatch;
+      | found   : (Seq[Nothing], String)
+      | required: (String, scala.scalajs.js.Any)
+      |      def foo = lit(x -> "a")
+      |                      ^
+    """
 
     // Bad value type (applyDynamicNamed)
     """
@@ -66,7 +87,16 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
       val x = new Object()
       def foo = lit(a = x)
     }
-    """.fails()
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: type mismatch;
+      | found   : Object
+      | required: scala.scalajs.js.Any
+      |error after rewriting to scala.scalajs.js.Dynamic.literal.applyDynamicNamed("apply")(scala.Tuple2("a", x))
+      |possible cause: maybe a wrong Dynamic method signature?
+      |      def foo = lit(a = x)
+      |                        ^
+    """
 
   }
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -98,7 +98,15 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport("value")
       def world = "bar"
     }
-    """ fails() // No error test, Scala version dependent error messages
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: double definition:
+      |def $js$exported$prop$value: Any at line 4 and
+      |def $js$exported$prop$value: Any at line 7
+      |have same type
+      |      @JSExport("value")
+      |       ^
+    """
 
     """
     class Confl {
@@ -109,17 +117,32 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def ub(x: Box[Int]): Int = x.x
     }
-    """ fails() // No error test, Scala version dependent error messages
+    """ hasErrors
+    """
+      |newSource1.scala:8: error: double definition:
+      |def $js$exported$meth$ub(x: Confl.this.Box[String]): Any at line 6 and
+      |def $js$exported$meth$ub(x: Confl.this.Box[Int]): Any at line 8
+      |have same type after erasure: (x: Confl#Box)Object
+      |      @JSExport
+      |       ^
+    """
 
     """
     class Confl {
       @JSExport
-      def rtType(x: scala.scalajs.js.prim.Number) = x
+      def rtType(x: js.Any) = x
 
       @JSExport
-      def rtType(x: Double) = x
+      def rtType(x: js.Dynamic) = x
     }
-    """ fails() // Error message depends on Scala version
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: Cannot disambiguate overloads for exported method $js$exported$meth$rtType with types
+      |  (x: scala.scalajs.js.Dynamic)Object
+      |  (x: scala.scalajs.js.Any)Object
+      |      @JSExport
+      |       ^
+    """
 
     """
     class Confl {
@@ -157,11 +180,18 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
     class Confl {
       @JSExport
-      def foo(x: scala.scalajs.js.prim.Number, y: String)(z: Int = 1) = x
+      def foo(x: Double, y: String)(z: Int = 1) = x
       @JSExport
       def foo(x: Double, y: String)(z: String*) = x
     }
-    """ fails() // Error message depends on Scala version
+    """ hasErrors
+    """
+      |newSource1.scala:4: error: Cannot disambiguate overloads for exported method $js$exported$meth$foo with types
+      |  (x: Double, y: String, z: Int)Object
+      |  (x: Double, y: String, z: Seq)Object
+      |      @JSExport
+      |       ^
+    """
 
     """
     class A {
@@ -171,7 +201,14 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def a(x: Any) = 2
     }
-    """ fails() // Error message depends on Scala version
+    """ hasErrors
+    """
+      |newSource1.scala:7: error: Cannot disambiguate overloads for exported method $js$exported$meth$a with types
+      |  (x: Object)Object
+      |  (x: scala.scalajs.js.Any)Object
+      |      @JSExport
+      |       ^
+    """
 
   }
 
@@ -785,7 +822,12 @@ class JSExportTest extends DirectTest with TestHelpers {
       def foo(x: String, y: String = "hello") = x
       def foo(x: Int, y: String = "bar") = x
     }
-    """ fails()
+    """ hasErrors
+    """
+      |newSource1.scala:3: error: in class A, multiple overloaded alternatives of method foo define default arguments.
+      |    class A {
+      |          ^
+    """
   }
 
   @Test


### PR DESCRIPTION
Most neg tests that were not testing a specific error message did so because of Scala 2.10. Now that 2.10 is gone, we can harden those tests.