### PR TITLE
Fix #3257: Several fixes for annotations on bridges with Scala 2.12.5

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -5397,7 +5397,7 @@ abstract class GenJSCode extends plugins.PluginComponent
    *  originally a public or protected member of a Scala.js-defined JS class.
    */
   private def isExposed(sym: Symbol): Boolean =
-    sym.hasAnnotation(ExposedJSMemberAnnot)
+    !sym.isBridge && sym.hasAnnotation(ExposedJSMemberAnnot)
 
   /** Test whether `sym` is the symbol of a raw JS function definition */
   private def isRawJSFunctionDef(sym: Symbol): Boolean =

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -629,6 +629,9 @@ abstract class GenJSCode extends plugins.PluginComponent
         case property: js.PropertyDef =>
           classMembers += property
 
+        case _: js.Skip =>
+          // This can happen in cases of earlier errors. Don't crash.
+
         case tree =>
           abort("Unexpected tree: " + tree)
       }

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -248,7 +248,7 @@ class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
 
       def jUnitAnnotatedMethods(sym: Symbol): List[MethodSymbol] = {
         sym.selfType.members.collect {
-          case m: MethodSymbol if hasJUnitMethodAnnotation(m) => m
+          case m: MethodSymbol if !m.isBridge && hasJUnitMethodAnnotation(m) => m
         }.toList
       }
 

--- a/test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala
+++ b/test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala
@@ -14,6 +14,10 @@ private[scalajs] object FutureUtil {
 
   implicit class RichFuture[T](val __self: Future[T]) extends AnyVal {
     def liftToTry: Future[Try[T]] =
-      __self.map(Success(_)).recover(PartialFunction(Failure(_)))
+      __self.map(Success(_)).recover(pf(Failure(_)))
+  }
+
+  private def pf[A, B](f: A => B): PartialFunction[A, B] = {
+    case x => f(x)
   }
 }


### PR DESCRIPTION
Tested locally with:
```
> clean
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.12.5-bin-707b0f3
> testSuite/test
```