### PR TITLE
FF ONLY Merge 0.6.x into master, January 19

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/CompatComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/CompatComponent.scala
@@ -59,7 +59,8 @@ trait CompatComponent {
   // SAMFunction was introduced in 2.12.0-M4 for LMF-capable SAM types
 
   object SAMFunctionAttachCompatDef {
-    case class SAMFunction(samTp: Type, sam: Symbol) extends PlainAttachment
+    case class SAMFunction(samTp: Type, sam: Symbol, synthCls: Symbol)
+        extends PlainAttachment
   }
 
   object SAMFunctionAttachCompat {
@@ -75,6 +76,11 @@ trait CompatComponent {
 
   type SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
   lazy val SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
+
+  implicit final class SAMFunctionCompatOps(self: SAMFunctionCompat) {
+    // Introduced in 2.12.5 to synthesize bridges in LMF classes
+    def synthCls: Symbol = NoSymbol
+  }
 
   /* global.genBCode.bTypes.initializeCoreBTypes()
    *

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1003,8 +1003,10 @@ abstract class GenJSCode extends plugins.PluginComponent
 
     private def genRegisterReflectiveInstantiation(sym: Symbol)(
         implicit pos: Position): Option[js.Tree] = {
-      if (sym.isModuleClass)
+      if (isStaticModule(sym))
         genRegisterReflectiveInstantiationForModuleClass(sym)
+      else if (sym.isModuleClass)
+        None // #3228
       else
         genRegisterReflectiveInstantiationForNormalClass(sym)
     }
@@ -5112,10 +5114,8 @@ abstract class GenJSCode extends plugins.PluginComponent
          * We have to synthesize a class like LambdaMetaFactory would do on
          * the JVM.
          */
-        val sam = originalFunction.attachments.get[SAMFunctionCompat].fold[Symbol] {
+        val sam = originalFunction.attachments.get[SAMFunctionCompat].getOrElse {
           abort(s"Cannot find the SAMFunction attachment on $originalFunction at $pos")
-        } {
-          _.sam
         }
 
         val samWrapperClassName = synthesizeSAMWrapper(funSym, sam)
@@ -5124,7 +5124,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       }
     }
 
-    private def synthesizeSAMWrapper(funSym: Symbol, sam: Symbol)(
+    private def synthesizeSAMWrapper(funSym: Symbol, samInfo: SAMFunctionCompat)(
         implicit pos: Position): String = {
       val intfName = encodeClassFullName(funSym)
 
@@ -5159,8 +5159,38 @@ abstract class GenJSCode extends plugins.PluginComponent
             js.OptimizerHints.empty, None)
       }
 
+      // Compute the set of method symbols that we need to implement
+      val sams = {
+        val samsBuilder = List.newBuilder[Symbol]
+        val seenEncodedNames = mutable.Set.empty[String]
+
+        /* scala/bug#10512: any methods which `samInfo.sam` overrides need
+         * bridges made for them.
+         * On Scala < 2.12.5, `synthCls` is polyfilled to `NoSymbol` and hence
+         * `samBridges` will always be empty. This causes our compiler to be
+         * bug-compatible on these versions.
+         */
+        val synthCls = samInfo.synthCls
+        val samBridges = if (synthCls == NoSymbol) {
+          Nil
+        } else {
+          import scala.reflect.internal.Flags.BRIDGE
+          synthCls.info.findMembers(excludedFlags = 0L, requiredFlags = BRIDGE).toList
+        }
+
+        for (sam <- samInfo.sam :: samBridges) {
+          /* Remove duplicates, e.g., if we override the same method declared
+           * in two super traits.
+           */
+          if (seenEncodedNames.add(encodeMethodSym(sam).name))
+            samsBuilder += sam
+        }
+
+        samsBuilder.result()
+      }
+
       // def samMethod(...params): resultType = this.f$f(...params)
-      val samMethodDef = {
+      val samMethodDefs = for (sam <- sams) yield {
         val jsParams = for (param <- sam.tpe.params) yield {
           js.ParamDef(encodeLocalSym(param), toIRType(param.tpe),
               mutable = false, rest = false)
@@ -5194,7 +5224,7 @@ abstract class GenJSCode extends plugins.PluginComponent
           List(js.Ident(intfName)),
           None,
           None,
-          List(fFieldDef, ctorDef, samMethodDef),
+          fFieldDef :: ctorDef :: samMethodDefs,
           Nil)(
           js.OptimizerHints.empty.withInline(true))
 
@@ -5519,7 +5549,7 @@ abstract class GenJSCode extends plugins.PluginComponent
    *  originally a public or protected member of a non-native JS class.
    */
   private def isExposed(sym: Symbol): Boolean =
-    sym.hasAnnotation(ExposedJSMemberAnnot)
+    !sym.isBridge && sym.hasAnnotation(ExposedJSMemberAnnot)
 
   /** Test whether `sym` is the symbol of a raw JS function definition */
   private def isRawJSFunctionDef(sym: Symbol): Boolean =

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -249,7 +249,7 @@ class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
 
       def jUnitAnnotatedMethods(sym: Symbol): List[MethodSymbol] = {
         sym.selfType.members.collect {
-          case m: MethodSymbol if hasJUnitMethodAnnotation(m) => m
+          case m: MethodSymbol if !m.isBridge && hasJUnitMethodAnnotation(m) => m
         }.toList
       }
 

--- a/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
+++ b/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
@@ -94,9 +94,39 @@ object Reflect {
       new InstantiatableClass(runtimeClass, invokableConstructors.toList)
   }
 
+  /** Reflectively looks up a loadable module class.
+   *
+   *  A module class is the technical term referring to the class of a Scala
+   *  `object`. The object or one of its super types (classes or traits) must
+   *  be annotated with
+   *  [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the object must be "static", i.e., declared at the top-level of
+   *  a package or inside a static object.
+   *
+   *  If the module class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was not static, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the module class, including its trailing `$`
+   */
   def lookupLoadableModuleClass(fqcn: String): Option[LoadableModuleClass] =
     loadableModuleClasses.get(fqcn)
 
+  /** Reflectively looks up an instantiable class.
+   *
+   *  The class or one of its super types (classes or traits) must be annotated
+   *  with
+   *  [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
+   *  Moreover, the class must not be abstract.
+   *
+   *  If the class cannot be found, either because it does not exist,
+   *  was not `@EnableReflectiveInstantiation` or was abstract, this method
+   *  returns `None`.
+   *
+   *  @param fqcn
+   *    Fully-qualified name of the class
+   */
   def lookupInstantiatableClass(fqcn: String): Option[InstantiatableClass] =
     instantiatableClasses.get(fqcn)
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1441,6 +1441,8 @@ object Build {
           case _      => true
         }
 
+        val scalaV = scalaVersion.value
+
         /* Can't add require-sam as unmanagedSourceDirectories because of the
          * use of scalacOptions. Hence sources are added individually.
          * Note that a testSuite/test will not trigger a compile when sources
@@ -1451,8 +1453,18 @@ object Build {
           val sharedTestDir =
             testDir.getParentFile.getParentFile.getParentFile / "shared/src/test"
 
-          ((sharedTestDir / "require-sam") ** "*.scala").get ++
-          (if (isJSTest) ((testDir / "require-sam") ** "*.scala").get else Nil)
+          val allSAMSources = {
+            ((sharedTestDir / "require-sam") ** "*.scala").get ++
+            (if (isJSTest) ((testDir / "require-sam") ** "*.scala").get else Nil)
+          }
+
+          val hasBugWithOverriddenMethods =
+            Set("2.12.0", "2.12.1", "2.12.2", "2.12.3", "2.12.4", "2.13.0-M2").contains(scalaV)
+
+          if (hasBugWithOverriddenMethods)
+            allSAMSources.filter(_.getName != "SAMWithOverridingBridgesTest.scala")
+          else
+            allSAMSources
         } else {
           Nil
         }

--- a/test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala
+++ b/test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala
@@ -14,6 +14,10 @@ private[scalajs] object FutureUtil {
 
   implicit class RichFuture[T](val __self: Future[T]) extends AnyVal {
     def liftToTry: Future[Try[T]] =
-      __self.map(Success(_)).recover(PartialFunction(Failure(_)))
+      __self.map(Success(_)).recover(pf(Failure(_)))
+  }
+
+  private def pf[A, B](f: A => B): PartialFunction[A, B] = {
+    case x => f(x)
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
@@ -55,6 +55,11 @@ class ReflectTest {
   private final val NameTraitDisable =
     Prefix + "TraitDisable"
 
+  private final val NameInnerObject = {
+    Prefix + "ClassWithInnerObjectWithEnableReflectiveInstantiation$" +
+    "InnerObjectWithEnableReflectiveInstantiation"
+  }
+
   @Test def testClassRuntimeClass(): Unit = {
     for {
       name <- Seq(NameClassEnableDirect, NameClassEnableDirectNoZeroArgCtor,
@@ -187,6 +192,11 @@ class ReflectTest {
     }
   }
 
+  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228(): Unit = {
+    assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
+    assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
+  }
+
 }
 
 object ReflectTest {
@@ -307,4 +317,11 @@ object ReflectTest {
   }
 
   trait TraitDisable extends Accessors
+
+  // Regression cases
+
+  class ClassWithInnerObjectWithEnableReflectiveInstantiation {
+    @EnableReflectiveInstantiation
+    object InnerObjectWithEnableReflectiveInstantiation
+  }
 }

--- a/test-suite/shared/src/test/require-sam/org/scalajs/testsuite/compiler/SAMWithOverridingBridgesTest.scala
+++ b/test-suite/shared/src/test/require-sam/org/scalajs/testsuite/compiler/SAMWithOverridingBridgesTest.scala
@@ -1,0 +1,132 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.testsuite.compiler
+
+import org.junit.Test
+import org.junit.Assert._
+
+/* Issue: https://github.com/scala/bug/issues/10512
+ * Test cases taken from: https://github.com/scala/scala/pull/6087
+ */
+class SAMWithOverridingBridgesTest {
+  import SAMWithOverridingBridgesTest._
+
+  @Test def testVariantA(): Unit = {
+    import VariantA._
+    import JsonEncoderInstances._
+
+    implicitly[JsonEncoder[List[String]]].encode("" :: Nil)
+  }
+
+  @Test def testVariantB(): Unit = {
+    import VariantB._
+
+    val s1: SAM_A = () => it
+    val s2: SAM_A1 = () => it
+    val s3: SAM_B = () => it
+    val s4: SAM_B1 = () => it
+    val s5: SAM_B2 = () => it
+    val s6: SAM_C = () => it
+    val s7: SAM_F = () => it
+    val s8: SAM_F1 = () => it
+
+    (s1(): A)
+
+    (s2(): A)
+
+    (s3(): B)
+    (s3(): A)
+
+    (s4(): B)
+    (s4(): A)
+
+    (s5(): B)
+    (s5(): A)
+
+    (s6(): C)
+    (s6(): B)
+    (s6(): A)
+
+    (s7(): C)
+    (s7(): B)
+    (s7(): A)
+
+    (s8(): C)
+    (s8(): B)
+    (s8(): A)
+  }
+}
+
+object SAMWithOverridingBridgesTest {
+  object VariantA {
+    trait JsonValue
+    class JsonObject extends JsonValue
+    class JsonString extends JsonValue
+
+    trait JsonEncoder[A] {
+      def encode(value: A): JsonValue
+    }
+
+    trait JsonObjectEncoder[A] extends JsonEncoder[A] {
+      def encode(value: A): JsonObject
+    }
+
+    object JsonEncoderInstances {
+      implicit val stringEncoder: JsonEncoder[String] = {
+        s => new JsonString
+        // new JsonEncoder[String] {
+        //   def encode(value: String): JsonString = new JsonString
+        // }
+      }
+
+      implicit def listEncoder[A](
+          implicit encoder: JsonEncoder[A]): JsonObjectEncoder[List[A]] = {
+        l => new JsonObject
+        // new JsonObjectEncoder[List[A]] {
+        //   def encode(value: List[A]): JsonObject = new JsonObject
+        // }
+      }
+    }
+  }
+
+  object VariantB {
+    trait A
+    trait B extends A
+    trait C extends B
+    object it extends C
+
+    /* try as many weird diamondy things as I can think of */
+
+    trait SAM_A {
+      def apply(): A
+    }
+
+    trait SAM_A1 extends SAM_A {
+      def apply(): A
+    }
+
+    trait SAM_B extends SAM_A1 {
+      def apply(): B
+    }
+
+    trait SAM_B1 extends SAM_A1 {
+      def apply(): B
+    }
+
+    trait SAM_B2 extends SAM_B with SAM_B1
+
+    trait SAM_C extends SAM_B2 {
+      def apply(): C
+    }
+
+    trait SAM_F extends (() => A) with SAM_C
+
+    trait SAM_F1 extends (() => C) with SAM_F
+  }
+}


### PR DESCRIPTION
Motivation: get #3258 onto master to unblock the community build.

Uneventful:
```
$ git checkout -b merge-0.6.x-into-master-january-19
Switched to a new branch 'merge-0.6.x-into-master-january-19'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   211d486 (scalajs/0.6.x, 0.6.x) Merge pull request #3260 from sjrd/fix-sams-with-overriding-bridges
|\  
| * b6be908 (origin/fix-sams-with-overriding-bridges, fix-sams-with-overriding-bridges) Fix #3259: Generate overriding bridges in synthesized SAM wrappers.
|/  
*   c9d237f Merge pull request #3258 from sjrd/fixes-for-annotations-on-bridges-2.12.5
|\  
| * dfb2a2c (origin/fixes-for-annotations-on-bridges-2.12.5, fixes-for-annotations-on-bridges-2.12.5) Do not consider bridges as exposed.
| * 7b5296f Do not crash the compiler after "Conflicting properties and methods".
| * f2746b6 Ignore bridges when computing JUnit-annotated methods.
| * 563e309 Avoid `PartialFunction.apply` because it is deprecated in 2.12.5.
|/  
* e668446 (origin/0.6.x) Merge pull request #3239 from sjrd/no-reflective-instantiation-for-nested-object
* e28ff5e Fix #3228: Disable reflective instantiation for nested modules.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
Auto-merging compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
CONFLICT (modify/delete): compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala left in tree.
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
DU compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
UU compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
M  junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
M  library/src/main/scala/scala/scalajs/reflect/Reflect.scala
UU project/Build.scala
M  test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
A  test-suite/shared/src/test/require-sam/org/scalajs/testsuite/compiler/SAMWithOverridingBridgesTest.scala
```
[...] Edit conflicting files, port changes made in `Compat210Component` to `CompatComponent`
```
$ git rm -f compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala 
compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala: needs merge
```
```diff
$ git diff -w | cat
diff --cc compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
index a3286a9,6a980d7..0000000
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@@ -5193,9 -5215,7 +5223,9 @@@ abstract class GenJSCode extends plugin
            Some(js.Ident(ir.Definitions.ObjectClass)),
            List(js.Ident(intfName)),
            None,
 -          fFieldDef :: ctorDef :: samMethodDefs)(
 +          None,
-           List(fFieldDef, ctorDef, samMethodDef),
++          fFieldDef :: ctorDef :: samMethodDefs,
 +          Nil)(
            js.OptimizerHints.empty.withInline(true))
  
        generatedClasses += ((currentClassSym.get, Some(suffix), classDef))
@@@ -5516,10 -5422,10 +5546,10 @@@
    }
  
    /** Tests whether the given member is exposed, i.e., whether it was
 -   *  originally a public or protected member of a Scala.js-defined JS class.
 +   *  originally a public or protected member of a non-native JS class.
     */
    private def isExposed(sym: Symbol): Boolean =
-     sym.hasAnnotation(ExposedJSMemberAnnot)
+     !sym.isBridge && sym.hasAnnotation(ExposedJSMemberAnnot)
  
    /** Test whether `sym` is the symbol of a raw JS function definition */
    private def isRawJSFunctionDef(sym: Symbol): Boolean =
diff --cc project/Build.scala
index d7244f5,25cfbf4..0000000
--- a/project/Build.scala
+++ b/project/Build.scala
@@@ -1441,10 -1437,12 +1441,12 @@@ object Build 
            case _      => true
          }
  
+         val scalaV = scalaVersion.value
+ 
 -      /* Can't add require-sam as unmanagedSourceDirectories because of the use
 -       * of scalacOptions. Hence sources are added individually.
 -       * Note that a testSuite/test will not trigger a compile when sources are
 -       * modified in require-sam
 +        /* Can't add require-sam as unmanagedSourceDirectories because of the
 +         * use of scalacOptions. Hence sources are added individually.
 +         * Note that a testSuite/test will not trigger a compile when sources
 +         * are modified in require-sam
           */
          if (supportsSAM) {
            val testDir = (sourceDirectory in Test).value
diff --git a/compiler/src/main/scala/org/scalajs/core/compiler/CompatComponent.scala b/compiler/src/main/scala/org/scalajs/core/compiler/CompatComponent.scala
index 02aa2bc..bb91228 100644
--- a/compiler/src/main/scala/org/scalajs/core/compiler/CompatComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/CompatComponent.scala
@@ -59,7 +59,8 @@ trait CompatComponent {
   // SAMFunction was introduced in 2.12.0-M4 for LMF-capable SAM types
 
   object SAMFunctionAttachCompatDef {
-    case class SAMFunction(samTp: Type, sam: Symbol) extends PlainAttachment
+    case class SAMFunction(samTp: Type, sam: Symbol, synthCls: Symbol)
+        extends PlainAttachment
   }
 
   object SAMFunctionAttachCompat {
@@ -76,6 +77,11 @@ trait CompatComponent {
   type SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
   lazy val SAMFunctionCompat = SAMFunctionAttachCompat.Inner.SAMFunctionAlias
 
+  implicit final class SAMFunctionCompatOps(self: SAMFunctionCompat) {
+    // Introduced in 2.12.5 to synthesize bridges in LMF classes
+    def synthCls: Symbol = NoSymbol
+  }
+
   /* global.genBCode.bTypes.initializeCoreBTypes()
    *
    * This one has a very particular history:
```
```
$ git st
 M compiler/src/main/scala/org/scalajs/core/compiler/CompatComponent.scala
UU compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
M  junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
M  library/src/main/scala/scala/scalajs/reflect/Reflect.scala
UU project/Build.scala
M  test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
A  test-suite/shared/src/test/require-sam/org/scalajs/testsuite/compiler/SAMWithOverridingBridgesTest.scala
$ git add -u
```
```
$ git commit
[merge-0.6.x-into-master-january-19 048a377] Merge '0.6.x' into 'master'.
```