### PR TITLE
Fix #3264: Reset generatedSAMWrapperCount to 0 for nested classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -166,7 +166,7 @@ abstract class GenJSCode extends plugins.PluginComponent
       withScopedVars(
           currentClassSym := clsSym,
           unexpectedMutatedFields := mutable.Set.empty,
-          generatedSAMWrapperCount := null,
+          generatedSAMWrapperCount := new VarBox(0),
           currentMethodSym := null,
           thisLocalVarInfo := null,
           fakeTailJumpParamRepl := null,

--- a/test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/SAMJSTest.scala
+++ b/test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/SAMJSTest.scala
@@ -1,0 +1,43 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.JSAssert._
+
+class SAMJSTest {
+
+  import SAMJSTest._
+
+  @Test def samNestedInAnonJSClass_issue3264(): Unit = {
+    val outer = new SAMInAnonJSClass_ParentJSClass {
+      def foo(x: Int): Int = {
+        val innerSAM: SAMInAnonJSClass_MySAM = _ * 2
+        innerSAM.bar(x + 3)
+      }
+    }
+
+    assertEquals(16, outer.foo(5))
+  }
+
+}
+
+object SAMJSTest {
+  abstract class SAMInAnonJSClass_ParentJSClass extends js.Object {
+    def foo(x: Int): Int
+  }
+
+  trait SAMInAnonJSClass_MySAM {
+    def bar(x: Int): Int
+  }
+}


### PR DESCRIPTION
When generating nested classes through `nestedGenerateClass`, the scoped var `generatedSAMWrapperCount` was reset to `null`, whereas it is set to `new VarBox(0)` for top-level classes. This could cause NPEs in `synthesizeSAMWrapper` if an LMF-capable SAM function was nested in the body of an anonymous JS class.

This commit fixes the issue by resetting `generatedSAMWrapperCount` to `new VarBox(0)`.