### PR TITLE
FF ONLY Merge 0.6.x into master, January 29

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -25,7 +25,10 @@ object BinaryIncompatibilities {
   val SbtPlugin = Seq(
   )
 
-  val TestAdapter = Seq(
+  val TestCommon = Seq(
+  )
+
+  val TestAdapter = TestCommon ++ Seq(
   )
 
   val CLI = Seq(
@@ -34,6 +37,6 @@ object BinaryIncompatibilities {
   val Library = Seq(
   )
 
-  val TestInterface = Seq(
+  val TestInterface = TestCommon ++ Seq(
   )
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -110,7 +110,7 @@ object Build {
     "Whether we should partest the current scala version (and fail if we can't)")
 
   /* MiMa configuration -- irrelevant while in 1.0.0-SNAPSHOT.
-  val previousVersion = "0.6.21"
+  val previousVersion = "0.6.22"
   val previousSJSBinaryVersion =
     ScalaJSCrossVersion.binaryScalaJSVersion(previousVersion)
   val previousBinaryCrossVersion =

--- a/test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/SAMJSTest.scala
+++ b/test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/SAMJSTest.scala
@@ -1,0 +1,43 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.JSAssert._
+
+class SAMJSTest {
+
+  import SAMJSTest._
+
+  @Test def samNestedInAnonJSClass_issue3264(): Unit = {
+    val outer = new SAMInAnonJSClass_ParentJSClass {
+      def foo(x: Int): Int = {
+        val innerSAM: SAMInAnonJSClass_MySAM = _ * 2
+        innerSAM.bar(x + 3)
+      }
+    }
+
+    assertEquals(16, outer.foo(5))
+  }
+
+}
+
+object SAMJSTest {
+  abstract class SAMInAnonJSClass_ParentJSClass extends js.Object {
+    def foo(x: Int): Int
+  }
+
+  trait SAMInAnonJSClass_MySAM {
+    def bar(x: Int): Int
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -691,6 +691,56 @@ class RegressionTest {
     assertEquals(15, new Child().bar(1, 0))
   }
 
+  @Test def tailrec_in_trait_with_self_type_scala_2_12_issue_3267(): Unit = {
+    class Parser {
+      def c(): Int = 65
+    }
+
+    trait Helpers { this: Parser =>
+      @tailrec
+      final def rec(i: Int): Int = {
+        if (i == 0) b() + c()
+        else rec(i - 1)
+      }
+
+      def b(): Int = 42
+    }
+
+    class ParserWithoutHelpers extends Parser {
+      def foo(): Int = 5
+    }
+
+    class ParserWithHelpers extends Parser with Helpers
+
+    assertEquals(5, new ParserWithoutHelpers().foo())
+    assertEquals(107, new ParserWithHelpers().rec(3))
+  }
+
+  @Test def tailrec_in_class_with_self_type_scala_2_12_issue_3267(): Unit = {
+    trait Parser {
+      def c(): Int = 65
+    }
+
+    class Helpers { this: Parser =>
+      @tailrec
+      final def rec(i: Int): Int = {
+        if (i == 0) b() + c()
+        else rec(i - 1)
+      }
+
+      def b(): Int = 42
+    }
+
+    class ParserWithoutHelpers extends Parser {
+      def foo(): Int = 5
+    }
+
+    class ParserWithHelpers extends Helpers with Parser
+
+    assertEquals(5, new ParserWithoutHelpers().foo())
+    assertEquals(107, new ParserWithHelpers().rec(3))
+  }
+
 }
 
 object RegressionTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
@@ -47,9 +47,9 @@ trait CollectionsCheckedListTest
   @Test def testCheckedList(): Unit = {
     superList().add(0, new C)
     assertTrue(superList().addAll(0, Seq(new C)))
-    testOnFirstPositionOfIterator[ju.ListIterator[A]](superList().listIterator,
+    testOnFirstPositionOfIterator[ju.ListIterator[A]](superList().listIterator _,
         _.add(new C), None)
-    testOnFirstPositionOfIterator[ju.ListIterator[A]](superList().listIterator,
+    testOnFirstPositionOfIterator[ju.ListIterator[A]](superList().listIterator _,
         _.set(new C), None)
   }
 
@@ -60,10 +60,10 @@ trait CollectionsCheckedListTest
     expectThrows(classOf[ClassCastException],
         superList().addAll(0, Seq(new A)))
     testOnFirstPositionOfIterator[ju.ListIterator[A]](
-        superList().listIterator,
+        superList().listIterator _,
         _.add(new A), Some(classOf[ClassCastException]))
     testOnFirstPositionOfIterator[ju.ListIterator[A]](
-        superList().listIterator,
+        superList().listIterator _,
         _.set(new A), Some(classOf[ClassCastException]))
   }
 


### PR DESCRIPTION
Motivation: get #3270 into master to unblock the 2.13.x community build.

Uneventful:
```
$ git checkout -b merge-0.6.x-into-master-january-29
Switched to a new branch 'merge-0.6.x-into-master-january-29'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   43a7c39 (scalajs/0.6.x) Merge pull request #3272 from sjrd/fix-tailrec-default-method-this-again
|\  
| * a0802f4 Fix #3267: Always use the enclosing class type for this local vars.
| * 3600312 Explain why the special-case for Ident in `genMethodDef()` is needed.
|/  
*   6dd3524 (origin/0.6.x, 0.6.x) Merge pull request #3270 from SethTisue/eta-expansion-2.13-compat
|\  
| * 1a634f0 eta-expand explicitly, for compatibility with Scala 2.13
|/  
* 6cea4c4 Towards 0.6.23.
* 7258a8b (tag: v0.6.22) Version 0.6.22.
* e10b08a Merge pull request #3266 from sjrd/fix-npe-in-synthesize-sam-wrapper
* b5e6e62 Fix #3264: Reset generatedSAMWrapperCount to 0 for nested classes.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging project/BinaryIncompatibilities.scala
CONFLICT (content): Merge conflict in project/BinaryIncompatibilities.scala
Auto-merging ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
M  compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
UU ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
UU project/BinaryIncompatibilities.scala
UU project/Build.scala
A  test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/SAMJSTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
```
[...] Edit conflicting files.
```diff
$ git diff -w | cat
diff --cc ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
index 73a88b3,c17b235..0000000
--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
diff --cc project/BinaryIncompatibilities.scala
index 1d71b14,553c491..0000000
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
diff --cc project/Build.scala
index 34e0627,c7c9f93..0000000
--- a/project/Build.scala
+++ b/project/Build.scala
@@@ -109,8 -58,7 +109,8 @@@ object Build 
    val shouldPartest = settingKey[Boolean](
      "Whether we should partest the current scala version (and fail if we can't)")
  
 +  /* MiMa configuration -- irrelevant while in 1.0.0-SNAPSHOT.
-   val previousVersion = "0.6.21"
+   val previousVersion = "0.6.22"
    val previousSJSBinaryVersion =
      ScalaJSCrossVersion.binaryScalaJSVersion(previousVersion)
    val previousBinaryCrossVersion =
```
```
$ git add -u
```
```
$ git commit
[merge-0.6.x-into-master-january-29 262fdb8] Merge '0.6.x' into 'master'.
```