### PR TITLE
FF ONLY Merge 0.6.x into master, March 14

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,7 +58,7 @@ LOC_SBT_BASE="$LOCAL_HOME/scala-js-sbt-homes"
 LOC_SBT_BOOT="$LOC_SBT_BASE/sbt-boot"
 LOC_SBT_HOME="$LOC_SBT_BASE/sbt-home"
 
-export SBT_OPTS="-J-Xmx4G -J-XX:MaxPermSize=512M -Dsbt.boot.directory=$LOC_SBT_BOOT -Dsbt.ivy.home=$LOC_SBT_HOME -Divy.home=$LOC_SBT_HOME -Dsbt.global.base=$LOC_SBT_BASE"
+export SBT_OPTS="-J-Xmx5G -J-XX:MaxPermSize=512M -Dsbt.boot.directory=$LOC_SBT_BOOT -Dsbt.ivy.home=$LOC_SBT_HOME -Divy.home=$LOC_SBT_HOME -Dsbt.global.base=$LOC_SBT_BASE"
 
 export NODE_PATH="$HOME/node_modules/"
 
@@ -420,9 +420,7 @@ mainScalaVersions.each { scalaVersion ->
 otherScalaVersions.each { scalaVersion ->
   // Partest does not compile on Scala 2.11.4 (see #1215).
   if (scalaVersion != "2.11.4") {
-    fullMatrix.add([task: "partest-noopt", scala: scalaVersion, java: mainJavaVersion])
     fullMatrix.add([task: "partest-fastopt", scala: scalaVersion, java: mainJavaVersion])
-    fullMatrix.add([task: "partest-fullopt", scala: scalaVersion, java: mainJavaVersion])
   }
 }
 


### PR DESCRIPTION
Motivation: bring in the CI tweaks of #3299.

```
$ git checkout -b merge-0.6.x-into-master-march-14
Switched to a new branch 'merge-0.6.x-into-master-march-14'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* c70fdce (scalajs/0.6.x) Merge pull request #3299 from sjrd/a-few-ci-tweaks
* 7b101b0 Give one more GB of memory to sbt on the CI.
* b78d588 Only run partest in fastOpt mode for "other" Scala versions.
* 6149bfd Fix typo: in cron syntax, 6 means Saturday, not Sunday.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging Jenkinsfile
CONFLICT (content): Merge conflict in Jenkinsfile
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU Jenkinsfile
```
[...] Resolve the conflicts
```diff
$ git diff -w | cat
diff --cc Jenkinsfile
index 369b002,a03d0f5..0000000
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@@ -417,12 -456,13 +417,10 @@@ mainScalaVersions.each { scalaVersion -
    fullMatrix.add([task: "partest-noopt", scala: scalaVersion, java: mainJavaVersion])
    fullMatrix.add([task: "partest-fullopt", scala: scalaVersion, java: mainJavaVersion])
  }
 -}
  otherScalaVersions.each { scalaVersion ->
    // Partest does not compile on Scala 2.11.4 (see #1215).
 -  if (!scalaVersion.startsWith("2.10.") && scalaVersion != "2.11.4") {
 +  if (scalaVersion != "2.11.4") {
-     fullMatrix.add([task: "partest-noopt", scala: scalaVersion, java: mainJavaVersion])
      fullMatrix.add([task: "partest-fastopt", scala: scalaVersion, java: mainJavaVersion])
-     fullMatrix.add([task: "partest-fullopt", scala: scalaVersion, java: mainJavaVersion])
    }
  }
  
```
```
$ git add -u
```
```
$ git st
M  Jenkinsfile
```
```
$ git commit
[merge-0.6.x-into-master-march-14 80a631f] Merge '0.6.x' into 'master'.
```