### PR TITLE
Introduce the new API of ESFeatures instead of OutputMode.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -237,46 +237,46 @@ def Tasks = [
 
   "test-suite-ecma-script6": '''
     setJavaVersion $java
-    sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in noIrCheckTest := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in noIrCheckTest := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         ++$scala noIrCheckTest/test \
         noIrCheckTest/clean &&
-    sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
-    sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         ++$scala $testSuite/test &&
-    sbtretry 'set scalaJSOutputMode in $testSuite := org.scalajs.core.tools.linker.backend.OutputMode.ECMAScript6' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         'set scalaJSStage in Global := FullOptStage' \

--- a/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
+++ b/cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
@@ -26,6 +26,11 @@ import java.net.URI
 
 object Scalajsld {
 
+  private val AllOutputModes = List(
+      OutputMode.ECMAScript51Isolated,
+      OutputMode.ECMAScript6,
+      OutputMode.ECMAScript51Global)
+
   private case class Options(
     cp: Seq[File] = Seq.empty,
     moduleInitializers: Seq[ModuleInitializer] = Seq.empty,
@@ -58,7 +63,7 @@ object Scalajsld {
   private implicit object OutputModeRead extends scopt.Read[OutputMode] {
     val arity = 1
     val reads = { (s: String) =>
-      OutputMode.All.find(_.toString() == s).getOrElse(
+      AllOutputModes.find(_.toString() == s).getOrElse(
           throw new IllegalArgumentException(s"$s is not a valid output mode"))
     }
   }
@@ -117,7 +122,7 @@ object Scalajsld {
         .text("Use compliant asInstanceOfs")
       opt[OutputMode]('m', "outputMode")
         .action { (mode, c) => c.copy(outputMode = mode) }
-        .text("Output mode " + OutputMode.All.mkString("(", ", ", ")"))
+        .text("Output mode " + AllOutputModes.mkString("(", ", ", ")"))
       opt[ModuleKind]('k', "moduleKind")
         .action { (kind, c) => c.copy(moduleKind = kind) }
         .text("Module kind " + ModuleKind.All.mkString("(", ", ", ")"))
@@ -189,7 +194,7 @@ object Scalajsld {
       val config = StandardLinker.Config()
         .withSemantics(semantics)
         .withModuleKind(options.moduleKind)
-        .withOutputMode(options.outputMode)
+        .withESFeatures(options.outputMode)
         .withBypassLinkingErrorsInternal(options.bypassLinkingErrors)
         .withCheckIR(options.checkIR)
         .withOptimizer(!options.noOpt)

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,6 +8,11 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private[linker], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.StandardLinker#Config.outputMode"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.StandardLinker#Config.withOutputMode")
   )
 
   val JSEnvs = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -32,7 +32,6 @@ import org.scalajs.core.tools.sem._
 import org.scalajs.core.tools.jsdep.ResolvedJSDependency
 import org.scalajs.core.tools.json._
 import org.scalajs.core.tools.linker.ModuleInitializer
-import org.scalajs.core.tools.linker.backend.OutputMode
 
 import sbtassembly.AssemblyPlugin.autoImport._
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -223,7 +223,7 @@ object ScalaJSPluginInternal {
         StandardLinker.Config()
           .withSemantics(semantics)
           .withModuleKind(moduleKind)
-          .withOutputMode(outputMode)
+          .withESFeatures(outputMode)
           .withBypassLinkingErrorsInternal(opts.bypassLinkingErrors)
           .withCheckIR(opts.checkScalaJSIR)
           .withOptimizer(!opts.disableOptimizer)
@@ -1183,7 +1183,7 @@ object ScalaJSPluginInternal {
       jsManifestFilter := identity,
 
       scalaJSSemantics := scalaJSLinkerConfig.value.semantics,
-      scalaJSOutputMode := scalaJSLinkerConfig.value.outputMode,
+      scalaJSOutputMode := scalaJSLinkerConfig.value.esFeatures,
       scalaJSModuleKind := scalaJSLinkerConfig.value.moduleKind,
       checkScalaJSSemantics := true,
 

--- a/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -41,7 +41,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
   @deprecated("Use StandardLinker.apply() instead.", "0.6.13")
   def apply(
       semantics: Semantics = Semantics.Defaults,
-      outputMode: OutputMode = OutputMode.Default,
+      outputMode: OutputMode = OutputMode.Defaults,
       withSourceMap: Boolean = true,
       disableOptimizer: Boolean = false,
       frontendConfig: LinkerFrontend.Config = LinkerFrontend.Config(),

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
@@ -52,7 +52,7 @@ trait LinkerPlatformExtensions { this: Linker.type =>
   @deprecated("Use StandardLinker.apply() instead.", "0.6.13")
   def apply(
       semantics: Semantics = Semantics.Defaults,
-      outputMode: OutputMode = OutputMode.Default,
+      outputMode: OutputMode = OutputMode.Defaults,
       withSourceMap: Boolean = true,
       disableOptimizer: Boolean = false,
       parallel: Boolean = true,

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/OutputMode.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/OutputMode.scala
@@ -11,23 +11,57 @@ package org.scalajs.core.tools.linker.backend
 
 import org.scalajs.core.tools.javascript.ESLevel
 
-/** JavaScript output mode. */
+/** JavaScript output mode.
+ *
+ *  For forward source compatibility with Scala.js 1.x, use the alias
+ *  [[org.scalajs.core.tools.linker.ESFeatures]] instead.
+ */
 sealed abstract class OutputMode {
+  import OutputMode._
+
   def esLevel: ESLevel
+
+  /** Whether to use ECMAScript 2015 features, such as classes and arrow
+   *  functions.
+   */
+  def useECMAScript2015: Boolean = this match {
+    case ECMAScript51Global   => false
+    case ECMAScript51Isolated => false
+    case ECMAScript6          => true
+  }
+
+  def withUseECMAScript2015(useECMAScript2015: Boolean): OutputMode =
+    if (useECMAScript2015) ECMAScript6
+    else ECMAScript51Isolated
 }
 
+/** Factory for `OutputMode`s.
+ *
+ *  For forward source compatibility with Scala.js 1.x, use the alias
+ *  [[org.scalajs.core.tools.linker.ESFeatures]] instead.
+ */
 object OutputMode {
   /** All the available output modes.
    *  There are listed in decreasing order of "importance", as judged by
    *  whoever maintains the back-ends.
    */
+  @deprecated(
+      "The notion that there is a list of existing output modes is going away.",
+      "0.6.23")
   val All = List(
       ECMAScript51Isolated,
       ECMAScript6,
       ECMAScript51Global)
 
-  /** The default output mode. This is always the first element of [[All]] */
-  val Default = All.head
+  /** Default configuration of the output mode.
+   *
+   *  - `useECMAScript2015`: false
+   */
+  val Defaults: OutputMode = ECMAScript51Isolated
+
+  /** Default configuration of the output mode. */
+  @deprecated("Use Defaults instead.", "0.6.23")
+  val Default = Defaults
 
   /** Legacy output mode where everything is stored in a global ScalaJS variable.
    *  This is suited to the special Rhino interpreter.
@@ -39,7 +73,9 @@ object OutputMode {
   /** Output mode compliant with ECMAScript 5.1 (deprecated alias).
    *
    *  This value is not annotated with `@deprecated` for technical reasons, but
-   *  it should be considered as such. Use [[ECMAScript51]] instead.
+   *  it should be considered as such.
+   *
+   *  Use `Defaults` instead.
    */
   case object ECMAScript51Isolated extends OutputMode {
     val esLevel: ESLevel = ESLevel.ES5
@@ -50,12 +86,15 @@ object OutputMode {
    *  This is the default output mode. It assumes that the target platform
    *  supports ECMAScript 5.1, ideally with correct handling of strict mode.
    */
+  @deprecated("Use Defaults instead.", "0.6.23")
   val ECMAScript51: ECMAScript51Isolated.type = ECMAScript51Isolated
 
   /** Output mode compliant with ECMAScript 2015 (deprecated alias).
    *
    *  This value is not annotated with `@deprecated` for technical reasons, but
-   *  it should be considered as such. Use [[ECMAScript2015]] instead.
+   *  it should be considered as such.
+   *
+   *  Use `Defaults.withUseECMAScript2015(true)` instead.
    */
   case object ECMAScript6 extends OutputMode {
     val esLevel: ESLevel = ESLevel.ES6
@@ -66,6 +105,7 @@ object OutputMode {
    *  This output mode assumes that the target platform supports ECMAScript
    *  2015 (aka ES 6).
    */
+  @deprecated("Use `Defaults.withUseECMAScript2015(true)` instead.", "0.6.23")
   val ECMAScript2015: ECMAScript6.type = ECMAScript6
 
   // Not binary compatible, but source compatible with deprecation

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
@@ -23,4 +23,9 @@ package object linker {
 
   val ModuleKind: org.scalajs.core.tools.linker.backend.ModuleKind.type =
     org.scalajs.core.tools.linker.backend.ModuleKind
+
+  type ESFeatures = org.scalajs.core.tools.linker.backend.OutputMode
+
+  val ESFeatures: org.scalajs.core.tools.linker.backend.OutputMode.type =
+    org.scalajs.core.tools.linker.backend.OutputMode
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
@@ -20,9 +20,11 @@ package object standard {
     import StandardLinker.Config
 
     /** Standard output mode. */
-    def outputMode: OutputMode = __self.outputMode
+    @deprecated("Use esFeatures instead.", "0.6.23")
+    def outputMode: OutputMode = __self.esFeatures
 
+    @deprecated("Use withESFeatures instead.", "0.6.23")
     def withOutputMode(outputMode: OutputMode): Config =
-      __self.withOutputMode(outputMode)
+      __self.withESFeatures(outputMode)
   }
 }


### PR DESCRIPTION
This is done in a backward source and binary compatible way, so `OutputMode` remains as the "source of truth" while `ESFeatures` builds on top of it to provide the new API.

Whereas `OutputMode` was a sealed abstract class with case objects, `ESFeatures` is an option bag of individual ECMAScript features.

Unlike the `OutputMode` API, it will be possible to evolve the new API in backward compatible ways, which allows to lift it to the stable API in `linker`, instead of `linker.standard`.