### PR TITLE
Blacklist the partest neg/inlineMaxSize.scala.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/BlacklistedTests.txt
@@ -32,6 +32,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.11/WhitelistedTests.txt
@@ -1058,7 +1058,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.12/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.12/BlacklistedTests.txt
@@ -32,6 +32,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.12/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.12/WhitelistedTests.txt
@@ -1058,7 +1058,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/BlacklistedTests.txt
@@ -32,6 +32,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.7/WhitelistedTests.txt
@@ -1059,7 +1059,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/BlacklistedTests.txt
@@ -32,6 +32,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.11.8/WhitelistedTests.txt
@@ -1058,7 +1058,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/BlacklistedTests.txt
@@ -27,6 +27,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.0/WhitelistedTests.txt
@@ -1045,7 +1045,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/BlacklistedTests.txt
@@ -30,6 +30,7 @@ neg/t7014
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.1/WhitelistedTests.txt
@@ -1043,7 +1043,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/BlacklistedTests.txt
@@ -27,6 +27,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.2/WhitelistedTests.txt
@@ -1043,7 +1043,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.3/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.3/BlacklistedTests.txt
@@ -27,6 +27,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.3/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.3/WhitelistedTests.txt
@@ -1042,7 +1042,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.4/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.4/BlacklistedTests.txt
@@ -27,6 +27,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.4/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.4/WhitelistedTests.txt
@@ -1042,7 +1042,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.0-M2/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.0-M2/BlacklistedTests.txt
@@ -27,6 +27,7 @@ neg/t7622-cyclic-dependency
 neg/macro-incompatible-macro-engine-c.scala
 
 # Spurious failures
+neg/inlineMaxSize.scala
 neg/patmatexhaust-huge.scala
 
 # Uses .java files

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.0-M2/WhitelistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.0-M2/WhitelistedTests.txt
@@ -1041,7 +1041,6 @@ neg/t9127.scala
 neg/t9286c.scala
 neg/t9286a.scala
 neg/virtpatmat_exhaust_big.scala
-neg/inlineMaxSize.scala
 
 run/t7249.scala
 run/t3563.scala


### PR DESCRIPTION
It often spuriously fails on one of our CI machines, with out-of-memory errors.

It started failing when executed on lampscalatst5, our new shiny CI machine which replaces the dead lamppc51.