### PR TITLE
Blacklist LongTest.scala in FullOpt.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1635,6 +1635,20 @@ object Build {
         Seq(outFile)
       }.taskValue,
 
+      /* Blacklist LongTest.scala in FullOpt, because it generates so much
+       * code, through optimizer-based generative programming, that Closure
+       * loses it on that code.
+       */
+      sources in Test := {
+        val prev = (sources in Test).value
+        scalaJSStage.value match {
+          case FastOptStage =>
+            prev
+          case FullOptStage =>
+            prev.filter(!_.getPath.replace('\\', '/').endsWith("compiler/LongTest.scala"))
+        }
+      },
+
       // Module initializers. Duplicated in toolsJS/test
       scalaJSModuleInitializers += {
         ModuleInitializer.mainMethod(


### PR DESCRIPTION
`LongTest.scala` uses optimizer-based generative programming to generate a *lot* of tests. Worse, the way it optimizes `Long`s turns that huge amount of test code into an *insane* amount of .js code within methods. Closure then completely loses it with that much code and all the intra-method optimizations it can do about it.

Blacklisting this test when compiling for `FullOpt` dramatically improves the time it takes to fully optimize the test suite (between 4x and 5x on my machine).