### PR TITLE
Fix #3281: Backport the new `genConversion` from 1.x.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -748,6 +748,16 @@ class RegressionTest {
     assertEquals(107, new ParserWithHelpers().rec(3))
   }
 
+  @Test def adaptedIntToLongInMatch_issue_3281(): Unit = {
+    import Bug3281._
+
+    val l: Any = 0 :: Nil
+    val r = overloaded(l match {
+      case x :: xs => 5
+    })
+    assertEquals(5L, r)
+  }
+
 }
 
 object RegressionTest {
@@ -797,5 +807,13 @@ object RegressionTest {
         def t3: String = B.this.f
       }
     }
+  }
+
+  object Bug3281 {
+    def overloaded(x: Long): Any =
+      x
+
+    def overloaded(x: Any): Unit =
+      fail("Bug3281.overloaded(x: Any) was called")
   }
 }


### PR DESCRIPTION
Starting with Scala 2.13.0-M3, if the typer needs to *adapt* an `Int` to a `Long` inside a `match`, typically after overload resolution has taken place, we end up with a tree of the form `(x: Int).$asInstanceOf[Long]` in the back-end. This kind of node is handled by the `genConversion` method, which was previously buggy for the `Int`-to-`Long` conversion (among others).

This commit backports the implementation of `genConversion` from master, which was rewritten in
9890ee7. We needed to adapt the code to rely on `TypeKind`s instead of `jstpe.Type`s, because in 0.6.x the latter do not know the difference between the various sub-`Int` types.

Will need to rebased on top of #3315 when it is merged. Only the last commit belongs to this PR.

The commit is not marked `[no-master]`, because the test should be merged forward. The conflict resolution in `GenJSCode.scala` will be to drop the code coming from 0.6.x and keep the code already in master.