### PR TITLE
Fix #3227: Disable reflective instantiation for local classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
@@ -31,6 +31,9 @@ trait Compat210Component {
     def isPrivateThis: Boolean = self.hasAllFlags(PRIVATE | LOCAL)
     def isLocalToBlock: Boolean = self.isLocal
 
+    def originalOwner: Symbol =
+      global.originalOwner.getOrElse(self, self.rawowner)
+
     def implClass: Symbol = NoSymbol
 
     def isTraitOrInterface: Boolean = self.isTrait || self.isInterface
@@ -48,6 +51,10 @@ trait Compat210Component {
 
   implicit final class GlobalCompat(
       self: Compat210Component.this.global.type) {
+
+    object originalOwner {
+      def getOrElse(sym: Symbol, orElse: => Symbol): Symbol = infiniteLoop()
+    }
 
     def enteringPhase[T](ph: Phase)(op: => T): T = self.beforePhase(ph)(op)
     def beforePhase[T](ph: Phase)(op: => T): T = infiniteLoop()

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -959,6 +959,8 @@ abstract class GenJSCode extends plugins.PluginComponent
         genRegisterReflectiveInstantiationForModuleClass(sym)
       else if (sym.isModuleClass)
         None // #3228
+      else if (sym.isLifted && !sym.originalOwner.isClass)
+        None // #3227
       else
         genRegisterReflectiveInstantiationForNormalClass(sym)
     }

--- a/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
+++ b/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
@@ -118,11 +118,13 @@ object Reflect {
    *  The class or one of its super types (classes or traits) must be annotated
    *  with
    *  [[scala.scalajs.reflect.annotation.EnableReflectiveInstantiation @EnableReflectiveInstantiation]].
-   *  Moreover, the class must not be abstract.
+   *  Moreover, the class must not be abstract, nor be a local class (i.e., a
+   *  class defined inside a `def`). Inner classes (defined inside another
+   *  class) are supported.
    *
    *  If the class cannot be found, either because it does not exist,
-   *  was not `@EnableReflectiveInstantiation` or was abstract, this method
-   *  returns `None`.
+   *  was not `@EnableReflectiveInstantiation` or was abstract or local, this
+   *  method returns `None`.
    *
    *  @param fqcn
    *    Fully-qualified name of the class


### PR DESCRIPTION
We make sure that reflective instantiation for inner classes is supported, though. Only local classes (inside `def`s) are excluded from the reflective instantiation support.