### PR TITLE
Fix #3285: Fix multi-param lists with defaults in JS class ctor.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1260,28 +1260,32 @@ abstract class GenJSCode extends plugins.PluginComponent
      */
     private def mkOverloadSelection(jsConstructorBuilder: JSConstructorBuilder,
         overloadIdent: js.Ident, dispatchResolution: js.Tree)(
-        implicit pos: Position): List[js.Tree]= {
-      if (!jsConstructorBuilder.hasSubConstructors) {
-        dispatchResolution match {
-          /* Dispatch to constructor with no arguments.
-           * Contains trivial parameterless call to the constructor.
-           */
-          case js.ApplyStatic(_, mtd, js.This() :: Nil)
-              if ir.Definitions.isConstructorName(mtd.name) =>
-            Nil
+        implicit pos: Position): List[js.Tree] = {
 
-          /* Dispatch to constructor with at least one argument.
-           * Where js.Block's stats.init corresponds to the parameter casts and
-           * js.Block's stats.last contains the call to the constructor.
-           */
-          case js.Block(stats) =>
-            val js.ApplyStatic(_, method, _) = stats.last
-            val refs = jsConstructorBuilder.getParamRefsFor(method.name)
-            val paramCasts = stats.init.map(_.asInstanceOf[js.VarDef])
-            zipMap(refs, paramCasts) { (ref, paramCast) =>
-              js.VarDef(ref.ident, ref.tpe, mutable = false, paramCast.rhs)
-            }
+      def deconstructApplyCtor(body: js.Tree): (List[js.Tree], String, List[js.Tree]) = {
+        val (prepStats, applyCtor) = body match {
+          case applyCtor: js.ApplyStatic =>
+            (Nil, applyCtor)
+          case js.Block(prepStats :+ (applyCtor: js.ApplyStatic)) =>
+            (prepStats, applyCtor)
         }
+        val js.ApplyStatic(_, js.Ident(ctorName, _), js.This() :: ctorArgs) =
+          applyCtor
+        assert(ir.Definitions.isConstructorName(ctorName))
+        (prepStats, ctorName, ctorArgs)
+      }
+
+      if (!jsConstructorBuilder.hasSubConstructors) {
+        val (prepStats, ctorName, ctorArgs) =
+          deconstructApplyCtor(dispatchResolution)
+
+        val refs = jsConstructorBuilder.getParamRefsFor(ctorName)
+        assert(refs.size == ctorArgs.size, currentClassSym.fullName)
+        val assignCtorParams = zipMap(refs, ctorArgs) { (ref, ctorArg) =>
+          js.VarDef(ref.ident, ref.tpe, mutable = false, ctorArg)
+        }
+
+        prepStats ::: assignCtorParams
       } else {
         val overloadRef = js.VarRef(overloadIdent)(jstpe.IntType)
 
@@ -1289,30 +1293,6 @@ abstract class GenJSCode extends plugins.PluginComponent
          * `genJSConstructorExport` and transform it recursively.
          */
         def transformDispatch(tree: js.Tree): js.Tree = tree match {
-          /* Dispatch to constructor with no arguments.
-           * Contains trivial parameterless call to the constructor.
-           */
-          case js.ApplyStatic(_, method, js.This() :: Nil)
-              if ir.Definitions.isConstructorName(method.name) =>
-            js.Assign(overloadRef,
-              js.IntLiteral(jsConstructorBuilder.getOverrideNum(method.name)))
-
-          /* Dispatch to constructor with at least one argument.
-           * Where js.Block's stats.init corresponds to the parameter casts and
-           * js.Block's stats.last contains the call to the constructor.
-           */
-          case js.Block(stats) =>
-            val js.ApplyStatic(_, method, _) = stats.last
-
-            val num = jsConstructorBuilder.getOverrideNum(method.name)
-            val overloadAssign = js.Assign(overloadRef, js.IntLiteral(num))
-
-            val refs = jsConstructorBuilder.getParamRefsFor(method.name)
-            val paramCasts = stats.init.map(_.asInstanceOf[js.VarDef].rhs)
-            val parameterAssigns = zipMap(refs, paramCasts)(js.Assign(_, _))
-
-            js.Block(overloadAssign :: parameterAssigns)
-
           // Parameter count resolution
           case js.Match(selector, cases, default) =>
             val newCases = cases.map {
@@ -1329,6 +1309,19 @@ abstract class GenJSCode extends plugins.PluginComponent
           // Throw(StringLiteral(No matching overload))
           case tree: js.Throw =>
             tree
+
+          // Overload resolution done, apply the constructor
+          case _ =>
+            val (prepStats, ctorName, ctorArgs) = deconstructApplyCtor(tree)
+
+            val num = jsConstructorBuilder.getOverrideNum(ctorName)
+            val overloadAssign = js.Assign(overloadRef, js.IntLiteral(num))
+
+            val refs = jsConstructorBuilder.getParamRefsFor(ctorName)
+            assert(refs.size == ctorArgs.size, currentClassSym.fullName)
+            val assignCtorParams = zipMap(refs, ctorArgs)(js.Assign(_, _))
+
+            js.Block(overloadAssign :: prepStats ::: assignCtorParams)
         }
 
         val newDispatchResolution = transformDispatch(dispatchResolution)

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -665,4 +665,18 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     """
   }
 
+  @Test
+  def noCallOtherConstructorsWithLeftOutDefaultParams: Unit = {
+    """
+    class A(x: Int, y: String = "default") extends js.Object {
+      def this() = this(12)
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: Implementation restriction: in a JS class, a secondary constructor calling another constructor with default parameters must provide the values of all parameters.
+      |    class A(x: Int, y: String = "default") extends js.Object {
+      |          ^
+    """
+  }
+
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -1102,6 +1102,30 @@ class ScalaJSDefinedTest {
     assertEquals("desc", foo2.description)
   }
 
+  @Test def constructors_with_default_parameters_in_multi_param_lists_and_overloading(): Unit = {
+    val foo1 = new ConstructorDefaultParamMultiParamListWithOverloading(5)(
+        "foobar")
+    assertEquals(5, foo1.default)
+    assertEquals("foobar", foo1.title)
+    assertEquals("5", foo1.description)
+
+    val foo2 = new ConstructorDefaultParamMultiParamListWithOverloading(56)(
+        "babar", "desc")
+    assertEquals(56, foo2.default)
+    assertEquals("babar", foo2.title)
+    assertEquals("desc", foo2.description)
+
+    val foo3 = new ConstructorDefaultParamMultiParamListWithOverloading('A')
+    assertEquals(65, foo3.default)
+    assertEquals("char", foo3.title)
+    assertEquals("a char", foo3.description)
+
+    val foo4 = new ConstructorDefaultParamMultiParamListWithOverloading(123, 456)
+    assertEquals(123, foo4.default)
+    assertEquals("456", foo4.title)
+    assertEquals(js.undefined, foo4.description)
+  }
+
   @Test def `call_super_constructor_with_:__*`(): Unit = {
     class CallSuperCtorWithSpread(x: Int, y: Int, z: Int)
         extends NativeParentClassWithVarargs(x, Seq(y, z): _*)
@@ -1746,6 +1770,14 @@ object ScalaJSDefinedTest {
   class ConstructorDefaultParamMultiParamList(val default: Int)(
       val title: String, val description: js.UndefOr[String] = default.toString)
       extends js.Object
+
+  class ConstructorDefaultParamMultiParamListWithOverloading(val default: Int)(
+      val title: String, val description: js.UndefOr[String] = default.toString)
+      extends js.Object {
+    def this(c: Char) = this(c.toInt)("char", "a char")
+
+    def this(x: Int, y: Int) = this(x)(y.toString, js.undefined)
+  }
 
   class OverloadedConstructorParamNumber(val foo: Int) extends js.Object {
     def this(x: Int, y: Int) = this(x + y)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -1090,6 +1090,18 @@ class ScalaJSDefinedTest {
     assertEquals(5, new ConstructorDefaultParamScalaNone(5).foo)
   }
 
+  @Test def constructors_with_default_parameters_in_multi_param_lists(): Unit = {
+    val foo1 = new ConstructorDefaultParamMultiParamList(5)("foobar")
+    assertEquals(5, foo1.default)
+    assertEquals("foobar", foo1.title)
+    assertEquals("5", foo1.description)
+
+    val foo2 = new ConstructorDefaultParamMultiParamList(56)("babar", "desc")
+    assertEquals(56, foo2.default)
+    assertEquals("babar", foo2.title)
+    assertEquals("desc", foo2.description)
+  }
+
   @Test def `call_super_constructor_with_:__*`(): Unit = {
     class CallSuperCtorWithSpread(x: Int, y: Int, z: Int)
         extends NativeParentClassWithVarargs(x, Seq(y, z): _*)
@@ -1730,6 +1742,10 @@ object ScalaJSDefinedTest {
 
   // sanity check
   class ConstructorDefaultParamScalaNone(val foo: Int = -1)
+
+  class ConstructorDefaultParamMultiParamList(val default: Int)(
+      val title: String, val description: js.UndefOr[String] = default.toString)
+      extends js.Object
 
   class OverloadedConstructorParamNumber(val foo: Int) extends js.Object {
     def this(x: Int, y: Int) = this(x + y)


### PR DESCRIPTION
The bug was actually fixed by chance in 645fa78, which we cherry-picked as the parent commit of this commit.

This PR also adds tests for overloaded JS class constructors with default params. In particular, we add an explicit check for an implementation restriction: a secondary constructor calling another one must supply all the parameters, even ones with default values. The cost/benefit of adding support for this case seems too high.