### PR TITLE
Get rid of the `Continue` IR node, as well as labels on loops.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -129,17 +129,15 @@ object Hashers {
           mixTree(elsep)
           mixType(tree.tpe)
 
-        case While(cond, body, label) =>
+        case While(cond, body) =>
           mixTag(TagWhile)
           mixTree(cond)
           mixTree(body)
-          mixOptIdent(label)
 
-        case DoWhile(body, cond, label) =>
+        case DoWhile(body, cond) =>
           mixTag(TagDoWhile)
           mixTree(body)
           mixTree(cond)
-          mixOptIdent(label)
 
         case ForIn(obj, keyVar, body) =>
           mixTag(TagForIn)
@@ -163,10 +161,6 @@ object Hashers {
         case Throw(expr) =>
           mixTag(TagThrow)
           mixTree(expr)
-
-        case Continue(label) =>
-          mixTag(TagContinue)
-          mixOptIdent(label)
 
         case Match(selector, cases, default) =>
           mixTag(TagMatch)

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -200,21 +200,13 @@ object Printers {
               printBlock(elsep)
           }
 
-        case While(cond, body, label) =>
-          if (label.isDefined) {
-            print(label.get)
-            print(": ")
-          }
+        case While(cond, body) =>
           print("while (")
           print(cond)
           print(") ")
           printBlock(body)
 
-        case DoWhile(body, cond, label) =>
-          if (label.isDefined) {
-            print(label.get)
-            print(": ")
-          }
+        case DoWhile(body, cond) =>
           print("do ")
           printBlock(body)
           print(" while (")
@@ -256,13 +248,6 @@ object Printers {
         case Throw(expr) =>
           print("throw ")
           print(expr)
-
-        case Continue(label) =>
-          print("continue")
-          if (label.isDefined) {
-            print(' ')
-            print(label.get)
-          }
 
         case Match(selector, cases, default) =>
           print("match (")

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -162,13 +162,13 @@ object Serializers {
           writeTree(cond); writeTree(thenp); writeTree(elsep)
           writeType(tree.tpe)
 
-        case While(cond, body, label) =>
+        case While(cond, body) =>
           writeByte(TagWhile)
-          writeTree(cond); writeTree(body); writeOptIdent(label)
+          writeTree(cond); writeTree(body)
 
-        case DoWhile(body, cond, label) =>
+        case DoWhile(body, cond) =>
           writeByte(TagDoWhile)
-          writeTree(body); writeTree(cond); writeOptIdent(label)
+          writeTree(body); writeTree(cond)
 
         case ForIn(obj, keyVar, body) =>
           writeByte(TagForIn)
@@ -186,10 +186,6 @@ object Serializers {
         case Throw(expr) =>
           writeByte(TagThrow)
           writeTree(expr)
-
-        case Continue(label) =>
-          writeByte(TagContinue)
-          writeOptIdent(label)
 
         case Match(selector, cases, default) =>
           writeByte(TagMatch)
@@ -845,8 +841,8 @@ object Serializers {
         case TagAssign  => Assign(readTree(), readTree())
         case TagReturn  => Return(readTree(), readOptIdent())
         case TagIf      => If(readTree(), readTree(), readTree())(readType())
-        case TagWhile   => While(readTree(), readTree(), readOptIdent())
-        case TagDoWhile => DoWhile(readTree(), readTree(), readOptIdent())
+        case TagWhile   => While(readTree(), readTree())
+        case TagDoWhile => DoWhile(readTree(), readTree())
         case TagForIn   => ForIn(readTree(), readIdent(), readTree())
 
         case TagTryCatch =>
@@ -856,7 +852,6 @@ object Serializers {
           TryFinally(readTree(), readTree())
 
         case TagThrow    => Throw(readTree())
-        case TagContinue => Continue(readOptIdent())
         case TagMatch    =>
           Match(readTree(), List.fill(readInt()) {
             (readTrees().map(_.asInstanceOf[Literal]), readTree())

--- a/ir/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Tags.scala
@@ -33,8 +33,7 @@ private[ir] object Tags {
   final val TagTryCatch = TagForIn + 1
   final val TagTryFinally = TagTryCatch + 1
   final val TagThrow = TagTryFinally + 1
-  final val TagContinue = TagThrow + 1
-  final val TagMatch = TagContinue + 1
+  final val TagMatch = TagThrow + 1
   final val TagDebugger = TagMatch + 1
 
   final val TagNew = TagDebugger + 1

--- a/ir/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -56,11 +56,11 @@ object Transformers {
           If(transformExpr(cond), transform(thenp, isStat),
               transform(elsep, isStat))(tree.tpe)
 
-        case While(cond, body, label) =>
-          While(transformExpr(cond), transformStat(body), label)
+        case While(cond, body) =>
+          While(transformExpr(cond), transformStat(body))
 
-        case DoWhile(body, cond, label) =>
-          DoWhile(transformStat(body), transformExpr(cond), label)
+        case DoWhile(body, cond) =>
+          DoWhile(transformStat(body), transformExpr(cond))
 
         case ForIn(obj, keyVar, body) =>
           ForIn(transformExpr(obj), keyVar, transformStat(body))
@@ -203,7 +203,7 @@ object Transformers {
 
         // Trees that need not be transformed
 
-        case _:Skip | _:Continue | _:Debugger | _:LoadModule | _:SelectStatic |
+        case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic |
             _:LoadJSConstructor | _:LoadJSModule  | _:JSLinkingInfo |
             _:Literal | _:VarRef | _:This | _:JSGlobalRef | _:Transient  =>
           tree

--- a/ir/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -45,11 +45,11 @@ object Traversers {
         traverse(thenp)
         traverse(elsep)
 
-      case While(cond, body, label) =>
+      case While(cond, body) =>
         traverse(cond)
         traverse(body)
 
-      case DoWhile(body, cond, label) =>
+      case DoWhile(body, cond) =>
         traverse(body)
         traverse(cond)
 
@@ -204,7 +204,7 @@ object Traversers {
 
       // Trees that need not be traversed
 
-      case _:Skip | _:Continue | _:Debugger | _:LoadModule | _:SelectStatic |
+      case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic |
           _:LoadJSConstructor | _:LoadJSModule | _:JSLinkingInfo | _:Literal |
           _:VarRef | _:This | _:JSGlobalRef | _:Transient =>
     }

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -177,7 +177,7 @@ object Trees {
     val tpe = NoType // cannot be in expression position
   }
 
-  case class Return(expr: Tree, label: Option[Ident] = None)(
+  case class Return(expr: Tree, label: Option[Ident])(
       implicit val pos: Position) extends Tree {
     val tpe = NothingType
   }
@@ -185,7 +185,7 @@ object Trees {
   case class If(cond: Tree, thenp: Tree, elsep: Tree)(val tpe: Type)(
       implicit val pos: Position) extends Tree
 
-  case class While(cond: Tree, body: Tree, label: Option[Ident] = None)(
+  case class While(cond: Tree, body: Tree)(
       implicit val pos: Position) extends Tree {
     // cannot be in expression position, unless it is infinite
     val tpe = cond match {
@@ -194,7 +194,7 @@ object Trees {
     }
   }
 
-  case class DoWhile(body: Tree, cond: Tree, label: Option[Ident] = None)(
+  case class DoWhile(body: Tree, cond: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType // cannot be in expression position
   }
@@ -213,11 +213,6 @@ object Trees {
   }
 
   case class Throw(expr: Tree)(implicit val pos: Position) extends Tree {
-    val tpe = NothingType
-  }
-
-  case class Continue(label: Option[Ident] = None)(
-      implicit val pos: Position) extends Tree {
     val tpe = NothingType
   }
 

--- a/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -147,7 +147,7 @@ class PrintersTest {
   }
 
   @Test def printReturn(): Unit = {
-    assertPrintEquals("return 5", Return(i(5)))
+    assertPrintEquals("return 5", Return(i(5), None))
     assertPrintEquals("return(lab) 5", Return(i(5), Some("lab")))
   }
 
@@ -197,14 +197,6 @@ class PrintersTest {
           |}
         """,
         While(b(true), i(5)))
-
-    assertPrintEquals(
-        """
-          |lab: while (true) {
-          |  5
-          |}
-        """,
-        While(b(true), i(5), Some("lab")))
   }
 
   @Test def printDoWhile(): Unit = {
@@ -215,14 +207,6 @@ class PrintersTest {
           |} while (true)
         """,
         DoWhile(i(5), b(true)))
-
-    assertPrintEquals(
-        """
-          |lab: do {
-          |  5
-          |} while (true)
-        """,
-        DoWhile(i(5), b(true), Some("lab")))
   }
 
   @Test def printForIn(): Unit = {
@@ -271,11 +255,6 @@ class PrintersTest {
 
   @Test def printThrow(): Unit = {
     assertPrintEquals("throw null", Throw(Null()))
-  }
-
-  @Test def printContinue(): Unit = {
-    assertPrintEquals("continue", Continue())
-    assertPrintEquals("continue lab", Continue(Some("lab")))
   }
 
   @Test def printMatch(): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -598,14 +598,12 @@ private final class IRChecker(unit: LinkingUnit,
         typecheckStat(elsep, env)
         env
 
-      case While(cond, body, label) =>
-        label.foreach(checkDeclareLabel)
+      case While(cond, body) =>
         typecheckExpect(cond, env, BooleanType)
         typecheckStat(body, env)
         env
 
-      case DoWhile(body, cond, label) =>
-        label.foreach(checkDeclareLabel)
+      case DoWhile(body, cond) =>
         typecheckStat(body, env)
         typecheckExpect(cond, env, BooleanType)
         env
@@ -725,8 +723,7 @@ private final class IRChecker(unit: LinkingUnit,
         typecheckExpect(thenp, env, tpe)
         typecheckExpect(elsep, env, tpe)
 
-      case While(BooleanLiteral(true), body, label) if tree.tpe == NothingType =>
-        label.foreach(checkDeclareLabel)
+      case While(BooleanLiteral(true), body) if tree.tpe == NothingType =>
         typecheckStat(body, env)
 
       case TryCatch(block, errVar, handler) =>
@@ -743,13 +740,6 @@ private final class IRChecker(unit: LinkingUnit,
 
       case Throw(expr) =>
         typecheckExpr(expr, env)
-
-      case Continue(label) =>
-        /* Here we could check that it is indeed legal to break to the
-         * specified label. However, if we do anything illegal here, it will
-         * result in a SyntaxError in JavaScript anyway, so we do not really
-         * care.
-         */
 
       case Match(selector, cases, default) =>
         val tpe = tree.tpe


### PR DESCRIPTION
Where we previously used `continue` statements in the IR, as in:
```javascript
lab: while (cond) {
  ...
  if (c)
    continue lab;
  ...
}
```
We now use a labeled block inside the loop, as well as a return off that labeled block, instead:
```javascript
while (cond) {
  lab[void]: {
    ...
    if (c)
      return(lab) undefined;
    ...
  }
}
```
This allows two important simplifications in the IR:

* We do not have the `Continue` IR node anymore.
* `While` and `DoWhile` loops do not have labels anymore.

With those changes, labels are only used by `Labeled` blocks and their corresponding `Return` statements.

To prevent some regressions in the quality of the generated .js code, we recover JS `continue` statements out of the above structure in the `FunctionEmitter`. We also received some *improvements* for free, because the `tailPosLabels` can kick in for those labels.

Full diff of the `testsuite-test-fastopt.js`: https://gist.github.com/sjrd/3d3f427d4b94072d4811b295c4c0a762