### PR TITLE
Fix #3324: Construct a proper URI for ScalaJSEnvHolder.sourceMapPath.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+version: '{build}'
+image: Visual Studio 2015
+environment:
+  global:
+    NODEJS_VERSION: "8"
+    JAVA_HOME: C:\Program Files\Java\jdk1.8.0
+    SCALA_VERSION: 2.12.4
+install:
+  - ps: Install-Product node $env:NODEJS_VERSION
+  - npm install
+  - cmd: choco install sbt --version 1.0.2 -ia "INSTALLDIR=""C:\sbt"""
+  - cmd: SET PATH=C:\sbt\bin;%JAVA_HOME%\bin;%PATH%
+  - cmd: SET SBT_OPTS=-Xmx4g
+build: off
+test_script:
+  # Very far from testing everything, but at least it is a good sanity check
+  - cmd: sbt ";clean;++%SCALA_VERSION%;testSuite/test"
+cache:
+  - C:\sbt
+  - C:\Users\appveyor\.ivy2\cache
+  - C:\Users\appveyor\.sbt

--- a/project/project/ScalaJSEnvGenerator.scala
+++ b/project/project/ScalaJSEnvGenerator.scala
@@ -20,7 +20,7 @@ object ScalaJSEnvGenerator {
       if (!ScalaJSVersions.currentIsSnapshot)
         s"https://raw.githubusercontent.com/scala-js/scala-js/v${ScalaJSVersions.current}/$relPath"
       else
-        env.getAbsolutePath
+        env.getAbsoluteFile.toURI.toASCIIString
     }
 
     if (!trg.exists() || trg.lastModified() < env.lastModified()) {
@@ -34,7 +34,7 @@ object ScalaJSEnvGenerator {
 
         private[emitter] object ScalaJSEnvHolder {
           final val scalajsenv = raw\"\"\"$scalajsenv\"\"\"
-          final val sourceMapPath = new URI("$sourceMapPath")
+          final val sourceMapPath = new URI(raw\"\"\"$sourceMapPath\"\"\")
         }
         """
 


### PR DESCRIPTION
In addition, we fully escape it in the Scala string literal.