### PR TITLE
Fix #2751: Fix the definition of `js.Date` for invalid dates.

### DIFF
--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -32,7 +32,14 @@ class Date private (private val date: js.Date) extends Object
   def this(date: Long) = this(new js.Date(date))
 
   @Deprecated
-  def this(date: String) = this(new js.Date(date))
+  def this(date: String) = {
+    this({
+      val jsDate = new js.Date(date)
+      if (jsDate.getTime().isNaN)
+        throw new IllegalArgumentException
+      jsDate
+    })
+  }
 
   def after(when: Date): Boolean = date.getTime() > when.date.getTime()
 
@@ -51,30 +58,30 @@ class Date private (private val date: js.Date) extends Object
   override def hashCode(): Int = date.getTime().hashCode()
 
   @Deprecated
-  def getDate(): Int = date.getDate()
+  def getDate(): Int = date.getDate().toInt
 
   @Deprecated
-  def getDay(): Int = date.getDay()
+  def getDay(): Int = date.getDay().toInt
 
   @Deprecated
-  def getHours(): Int = date.getHours()
+  def getHours(): Int = date.getHours().toInt
 
   @Deprecated
-  def getMinutes(): Int = date.getMinutes()
+  def getMinutes(): Int = date.getMinutes().toInt
 
   @Deprecated
-  def getMonth(): Int = date.getMonth()
+  def getMonth(): Int = date.getMonth().toInt
 
   @Deprecated
-  def getSeconds(): Int = date.getSeconds()
+  def getSeconds(): Int = date.getSeconds().toInt
 
   def getTime(): Long = date.getTime().toLong
 
   @Deprecated
-  def getTimezoneOffset(): Int = date.getTimezoneOffset()
+  def getTimezoneOffset(): Int = date.getTimezoneOffset().toInt
 
   @Deprecated
-  def getYear(): Int = date.getFullYear() - 1900
+  def getYear(): Int = date.getFullYear().toInt - 1900
 
   @Deprecated
   def setDate(date: Int): Unit = this.date.setDate(date)
@@ -98,28 +105,28 @@ class Date private (private val date: js.Date) extends Object
 
   @Deprecated
   def toGMTString(): String = {
-    date.getUTCDate() + " " + Months(date.getUTCMonth()) + " " +
-      date.getUTCFullYear() + " " + pad0(date.getUTCHours()) + ":" +
-      pad0(date.getUTCMinutes()) + ":" +
-      pad0(date.getUTCSeconds()) +" GMT"
+    date.getUTCDate().toInt + " " + Months(date.getUTCMonth().toInt) + " " +
+      date.getUTCFullYear().toInt + " " + pad0(date.getUTCHours().toInt) + ":" +
+      pad0(date.getUTCMinutes().toInt) + ":" +
+      pad0(date.getUTCSeconds().toInt) +" GMT"
   }
 
   @Deprecated
   def toLocaleString(): String = {
-    date.getDate() + "-" + Months(date.getMonth()) + "-" +
-      date.getFullYear() + "-" + pad0(date.getHours()) + ":" +
-      pad0(date.getMinutes()) + ":" + pad0(date.getSeconds())
+    date.getDate().toInt + "-" + Months(date.getMonth().toInt) + "-" +
+      date.getFullYear().toInt + "-" + pad0(date.getHours().toInt) + ":" +
+      pad0(date.getMinutes().toInt) + ":" + pad0(date.getSeconds().toInt)
   }
 
   override def toString(): String = {
-    val offset = -date.getTimezoneOffset()
+    val offset = -date.getTimezoneOffset().toInt
     val sign = if (offset < 0) "-" else "+"
     val hours = pad0(Math.abs(offset) / 60)
     val mins = pad0(Math.abs(offset) % 60)
-    Days(date.getDay()) + " "+ Months(date.getMonth()) + " " +
-      pad0(date.getDate()) + " " + pad0(date.getHours()) + ":" +
-      pad0(date.getMinutes()) + ":" + pad0(date.getSeconds()) + " GMT" + " " +
-      date.getFullYear()
+    Days(date.getDay().toInt) + " "+ Months(date.getMonth().toInt) + " " +
+      pad0(date.getDate().toInt) + " " + pad0(date.getHours().toInt) + ":" +
+      pad0(date.getMinutes().toInt) + ":" + pad0(date.getSeconds().toInt) +
+      " GMT" + " " + date.getFullYear().toInt
   }
 }
 
@@ -142,6 +149,10 @@ object Date {
     js.Date.UTC(year + 1900, month, date, hrs, min, sec).toLong
 
   @Deprecated
-  def parse(string: String): Long =
-    new Date(new js.Date(string)).getTime.toLong
+  def parse(string: String): Long = {
+    val time = new js.Date(string).getTime()
+    if (time.isNaN)
+      throw new IllegalArgumentException
+    time.toLong
+  }
 }

--- a/library/src/main/scala/scala/scalajs/js/Date.scala
+++ b/library/src/main/scala/scala/scalajs/js/Date.scala
@@ -23,6 +23,12 @@ import scala.scalajs.js.annotation._
  * since 1 January, 1970 UTC.
  *
  * MDN
+ *
+ * @note
+ *   `js.Date` objects can represent an *invalid date*, for example, if they
+ *   are constructed from a `String` that cannot be parsed as a date. Most
+ *   methods of such a `js.Date` will return `NaN` (for those returning a
+ *   `Double`) or other invalid values.
  */
 @js.native
 @JSGlobal
@@ -48,141 +54,144 @@ class Date extends js.Object {
    *
    * MDN
    */
-  def getFullYear(): Int = js.native
+  def getFullYear(): Double = js.native
 
   /**
    * Returns the year (4 digits for 4-digit years) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCFullYear(): Int = js.native
+  def getUTCFullYear(): Double = js.native
 
   /**
    * Returns the month (0-11) in the specified date according to local time.
    *
    * MDN
    */
-  def getMonth(): Int = js.native
+  def getMonth(): Double = js.native
 
   /**
    * Returns the month (0-11) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCMonth(): Int = js.native
+  def getUTCMonth(): Double = js.native
 
   /**
    * Returns the day of the month (1-31) for the specified date according to local time.
    *
    * MDN
    */
-  def getDate(): Int = js.native
+  def getDate(): Double = js.native
 
   /**
    * Returns the day (date) of the month (1-31) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCDate(): Int = js.native
+  def getUTCDate(): Double = js.native
 
   /**
    * Returns the day of the week (0-6) for the specified date according to local time.
    *
    * MDN
    */
-  def getDay(): Int = js.native
+  def getDay(): Double = js.native
 
   /**
    * Returns the day of the week (0-6) in the specified date according to universal time.
    * MDN
    */
-  def getUTCDay(): Int = js.native
+  def getUTCDay(): Double = js.native
 
   /**
    * Returns the hour (0-23) in the specified date according to local time.
    *
    * MDN
    */
-  def getHours(): Int = js.native
+  def getHours(): Double = js.native
 
   /**
    * Returns the hours (0-23) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCHours(): Int = js.native
+  def getUTCHours(): Double = js.native
 
   /**
    * Returns the minutes (0-59) in the specified date according to local time.
    *
    * MDN
    */
-  def getMinutes(): Int = js.native
+  def getMinutes(): Double = js.native
 
   /**
    * Returns the minutes (0-59) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCMinutes(): Int = js.native
+  def getUTCMinutes(): Double = js.native
 
   /**
    * Returns the seconds (0-59) in the specified date according to local time.
    *
    * MDN
    */
-  def getSeconds(): Int = js.native
+  def getSeconds(): Double = js.native
 
   /**
    * Returns the seconds (0-59) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCSeconds(): Int = js.native
+  def getUTCSeconds(): Double = js.native
 
   /**
    * Returns the milliseconds (0-999) in the specified date according to local time.
    *
    * MDN
    */
-  def getMilliseconds(): Int = js.native
+  def getMilliseconds(): Double = js.native
 
   /**
    * Returns the milliseconds (0-999) in the specified date according to universal time.
    *
    * MDN
    */
-  def getUTCMilliseconds(): Int = js.native
+  def getUTCMilliseconds(): Double = js.native
 
   /**
    * Returns the time-zone offset in minutes for the current locale.
    *
    * MDN
    */
-  def getTimezoneOffset(): Int = js.native
+  def getTimezoneOffset(): Double = js.native
 
   def setTime(time: Double): Unit = js.native
-  def setMilliseconds(ms: Int): Unit = js.native
-  def setUTCMilliseconds(ms: Int): Unit = js.native
-  def setSeconds(sec: Int, ms: Int = getMilliseconds()): Unit = js.native
-  def setUTCSeconds(sec: Int, ms: Int = getMilliseconds()): Unit = js.native
-  def setMinutes(min: Int, sec: Int = getSeconds(),
-      ms: Int = getMilliseconds()): Unit = js.native
-  def setUTCMinutes(min: Int, sec: Int = getSeconds(),
-      ms: Int = getMilliseconds()): Unit = js.native
-  def setHours(hours: Int, min: Int = getMinutes(),
-      sec: Int = getSeconds(), ms: Int = getMilliseconds()): Unit = js.native
-  def setUTCHours(hours: Int, min: Int = getMinutes(),
-      sec: Int = getSeconds(), ms: Int = getMilliseconds()): Unit = js.native
+  def setMilliseconds(ms: Double): Unit = js.native
+  def setUTCMilliseconds(ms: Double): Unit = js.native
+  def setSeconds(sec: Double, ms: Double = getMilliseconds()): Unit = js.native
+  def setUTCSeconds(sec: Double,
+      ms: Double = getMilliseconds()): Unit = js.native
+  def setMinutes(min: Double, sec: Double = getSeconds(),
+      ms: Double = getMilliseconds()): Unit = js.native
+  def setUTCMinutes(min: Double, sec: Double = getSeconds(),
+      ms: Double = getMilliseconds()): Unit = js.native
+  def setHours(hours: Double, min: Double = getMinutes(),
+      sec: Double = getSeconds(),
+      ms: Double = getMilliseconds()): Unit = js.native
+  def setUTCHours(hours: Double, min: Double = getMinutes(),
+      sec: Double = getSeconds(),
+      ms: Double = getMilliseconds()): Unit = js.native
 
-  def setDate(date: Int): Unit = js.native
-  def setUTCDate(date: Int): Unit = js.native
-  def setMonth(month: Int, date: Int = getDate()): Unit = js.native
-  def setUTCMonth(month: Int, date: Int = getDate()): Unit = js.native
-  def setFullYear(year: Int, month: Int = getMonth(),
-      date: Int = getDate()): Unit = js.native
-  def setUTCFullYear(year: Int, month: Int = getMonth(),
-      date: Int = getDate()): Unit = js.native
+  def setDate(date: Double): Unit = js.native
+  def setUTCDate(date: Double): Unit = js.native
+  def setMonth(month: Double, date: Double = getDate()): Unit = js.native
+  def setUTCMonth(month: Double, date: Double = getDate()): Unit = js.native
+  def setFullYear(year: Double, month: Double = getMonth(),
+      date: Double = getDate()): Unit = js.native
+  def setUTCFullYear(year: Double, month: Double = getMonth(),
+      date: Double = getDate()): Unit = js.native
 
   def toUTCString(): String = js.native
   def toISOString(): String = js.native

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -12,6 +12,8 @@ import java.util.Date
 import org.junit.Assert._
 import org.junit.Test
 
+import org.scalajs.testsuite.utils.AssertThrows._
+
 /**
   * tests the implementation of the java standard library Date
   */
@@ -41,12 +43,17 @@ class DateTest {
   }
 
   @Test def parseStrings(): Unit = {
-    def test(s: String, v: Date): Unit =
+    def test(s: String, v: Date): Unit = {
       assertEquals(0, new Date(s).compareTo(v))
+      assertEquals(0, Date.parse(s).compareTo(v.getTime))
+    }
 
     test("Nov 5 1997 5:23:27 GMT", new Date(Date.UTC(97, 10, 5, 5, 23, 27)))
-    test("Nov 1 1997 GMT", new Date(Date.UTC(97,10,1, 0, 0, 0)))
-    test("Jan 1 1970 18:11:01 GMT", new Date(Date.UTC(70,0,1,18,11,1)))
+    test("Nov 1 1997 GMT", new Date(Date.UTC(97, 10, 1, 0, 0, 0)))
+    test("Jan 1 1970 18:11:01 GMT", new Date(Date.UTC(70, 0, 1, 18, 11, 1)))
+
+    assertThrows(classOf[IllegalArgumentException], new Date("not a date"))
+    assertThrows(classOf[IllegalArgumentException], Date.parse("not a date"))
   }
 
   @Test def after(): Unit = {


### PR DESCRIPTION
For invalid dates, created from a string that cannot be parsed, the methods of `js.Date` return `NaN`. Therefore, they must be typed as `Double`s. By extension, this covers up for Firefox returning -0 for some valid date as well, instead of +0 like everyone else.

In the process, we fix the behavior of `j.u.Date.parse` for invalid inputs.