### PR TITLE
Fix the way the bootstrap test prepares `testSuite/test:fastOptJS`.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -506,6 +506,7 @@ object Build {
           clean in compiler,
           clean in irProject, clean in irProjectJS,
           clean in io, clean in ioJS,
+          clean in logging, clean in loggingJS,
           clean in linker, clean in linkerJS,
           clean in jsEnvs, clean in jsEnvsTestKit, clean in nodeJSEnv,
           clean in testAdapter, clean in plugin,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1654,6 +1654,27 @@ object Build {
         }
       },
 
+      /* Because of the above tweak of `sources` depending on the value of
+       * `scalaJSStage`, it is ill-advised to invoke a linking task that does
+       * not correspond to the current `scalaJSStage`.
+       */
+      for ((key, stage) <- Seq(fastOptJS -> FastOptStage, fullOptJS -> FullOptStage)) yield {
+        key in Test := {
+          /* Note that due to the way dependencies between tasks work, the
+           * actual linking *will* be computed anyway, but it's not too late to
+           * prevent the user from doing anything meaningful with it
+           * afterwards.
+           */
+          val actual = (key in Test).value
+          if (scalaJSStage.value != stage) {
+            throw new MessageOnlyException(
+                s"testSuite/test:${key.key} can only be invoked when " +
+                s"(scalaJSStage in testSuite).value is $stage")
+          }
+          actual
+        }
+      },
+
       // Module initializers. Duplicated in toolsJS/test
       scalaJSModuleInitializers += {
         ModuleInitializer.mainMethod(


### PR DESCRIPTION
Since b9ec4ee, it is basically invalid to call `testSuite/test:fastOptJS` if `scalaJSStage in testSuite` is `FullOptStage`, and conversely. It didn't cause any hard failure, but was ill-advised since the blacklisting would not be applied appropriately.

The bootstrap test was erroneously doing just that. This commit fixes that test, and adds a check in the test suite settings to make sure no one tries to do that anymore.