### PR TITLE
Add title prefix on scaladoc

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1050,7 +1050,12 @@ object Build {
       ) ++ (
           scalaJSExternalCompileSettings
       ) ++ inConfig(Compile)(Seq(
-          scalacOptions in doc ++= Seq("-implicits", "-groups"),
+          scalacOptions in doc ++= Seq(
+              "-implicits",
+              "-groups",
+              "-doc-title", "Scala.js",
+              "-doc-version", scalaJSVersion
+          ),
 
           // Filter doc sources to remove implementation details from doc.
           sources in doc := {


### PR DESCRIPTION
Addresses #1701 

This PR adds "Scala.js" and version as title on scaladoc pages, so that developes can recognize pages are for what library and version.

![image](https://user-images.githubusercontent.com/127635/38249204-dc0c0386-3785-11e8-959a-44a0de83b6b7.png)
