### PR TITLE
Get rid of `TopLevelConstructorExportDef`s in the IR.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -912,13 +912,6 @@ object Printers {
 
     def print(topLevelExportDef: TopLevelExportDef): Unit = {
       topLevelExportDef match {
-        case TopLevelConstructorExportDef(fullName, args, body) =>
-          print("export top constructor \"")
-          printEscapeJS(fullName, out)
-          print('\"')
-          printSig(args, NoType) // NoType as trick not to display a type
-          printBlock(body)
-
         case TopLevelJSClassExportDef(fullName) =>
           print("export top class \"")
           printEscapeJS(fullName, out)

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -533,10 +533,6 @@ object Serializers {
       import buffer._
       writePosition(topLevelExportDef.pos)
       topLevelExportDef match {
-        case TopLevelConstructorExportDef(fullName, args, body) =>
-          writeByte(TagTopLevelConstructorExportDef)
-          writeString(fullName); writeParamDefs(args); writeTree(body)
-
         case TopLevelJSClassExportDef(fullName) =>
           writeByte(TagTopLevelJSClassExportDef)
           writeString(fullName)
@@ -996,10 +992,6 @@ object Serializers {
       val tag = input.readByte()
 
       (tag: @switch) match {
-        case TagTopLevelConstructorExportDef =>
-          TopLevelConstructorExportDef(readString(), readParamDefs(),
-              readTree())
-
         case TagTopLevelJSClassExportDef => TopLevelJSClassExportDef(readString())
         case TagTopLevelModuleExportDef  => TopLevelModuleExportDef(readString())
         case TagTopLevelMethodExportDef  => TopLevelMethodExportDef(readMemberDef().asInstanceOf[MethodDef])

--- a/ir/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Tags.scala
@@ -105,8 +105,7 @@ private[ir] object Tags {
 
   // Tags for top-level export defs
 
-  final val TagTopLevelConstructorExportDef = 1
-  final val TagTopLevelJSClassExportDef = TagTopLevelConstructorExportDef + 1
+  final val TagTopLevelJSClassExportDef = 1
   final val TagTopLevelModuleExportDef = TagTopLevelJSClassExportDef + 1
   final val TagTopLevelMethodExportDef = TagTopLevelModuleExportDef + 1
   final val TagTopLevelFieldExportDef = TagTopLevelMethodExportDef + 1

--- a/ir/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -250,9 +250,6 @@ object Transformers {
       implicit val pos = exportDef.pos
 
       exportDef match {
-        case TopLevelConstructorExportDef(fullName, args, body) =>
-          TopLevelConstructorExportDef(fullName, args, transformStat(body))
-
         case _:TopLevelJSClassExportDef | _:TopLevelModuleExportDef |
             _:TopLevelFieldExportDef =>
           exportDef

--- a/ir/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -230,9 +230,6 @@ object Traversers {
 
     def traverseTopLevelExportDef(exportDef: TopLevelExportDef): Unit = {
       exportDef match {
-        case TopLevelConstructorExportDef(fullName, args, body) =>
-          traverse(body)
-
         case _:TopLevelJSClassExportDef | _:TopLevelModuleExportDef |
             _:TopLevelFieldExportDef =>
 

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -985,9 +985,8 @@ object Trees {
 
   sealed abstract class TopLevelExportDef extends IRNode {
     final def topLevelExportName: String = this match {
-      case TopLevelConstructorExportDef(name, _, _) => name
-      case TopLevelModuleExportDef(name)            => name
-      case TopLevelJSClassExportDef(name)           => name
+      case TopLevelModuleExportDef(name)  => name
+      case TopLevelJSClassExportDef(name) => name
 
       case TopLevelMethodExportDef(MethodDef(_, propName, _, _, _)) =>
         val StringLiteral(name) = propName
@@ -996,9 +995,6 @@ object Trees {
       case TopLevelFieldExportDef(name, _) => name
     }
   }
-
-  case class TopLevelConstructorExportDef(name: String, args: List[ParamDef],
-      body: Tree)(implicit val pos: Position) extends TopLevelExportDef
 
   case class TopLevelJSClassExportDef(fullName: String)(
       implicit val pos: Position) extends TopLevelExportDef

--- a/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -1183,18 +1183,6 @@ class PrintersTest {
     }
   }
 
-  @Test def printConstructorExportDef(): Unit = {
-    assertPrintEquals(
-        """
-          |export top constructor "pkg.Foo"(x: any) {
-          |  5
-          |}
-        """,
-        TopLevelConstructorExportDef("pkg.Foo",
-            List(ParamDef("x", AnyType, mutable = false, rest = false)),
-            i(5)))
-  }
-
   @Test def printJSClassExportDef(): Unit = {
     assertPrintEquals(
         """export top class "pkg.Foo"""",

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -351,13 +351,10 @@ object Infos {
   def generateTopLevelExportsInfo(enclosingClass: String,
       topLevelExportDefs: List[TopLevelExportDef]): Option[MethodInfo] = {
 
-    var exportedConstructors: List[TopLevelConstructorExportDef] = Nil
     var topLevelMethodExports: List[TopLevelMethodExportDef] = Nil
     var topLevelFieldExports: List[TopLevelFieldExportDef] = Nil
 
     topLevelExportDefs.foreach {
-      case constructorDef: TopLevelConstructorExportDef =>
-        exportedConstructors ::= constructorDef
       case _:TopLevelJSClassExportDef | _:TopLevelModuleExportDef =>
       case topLevelMethodExport: TopLevelMethodExportDef =>
         topLevelMethodExports ::= topLevelMethodExport
@@ -365,10 +362,9 @@ object Infos {
         topLevelFieldExports ::= topLevelFieldExport
     }
 
-    if (exportedConstructors.nonEmpty || topLevelMethodExports.nonEmpty ||
-        topLevelFieldExports.nonEmpty) {
+    if (topLevelMethodExports.nonEmpty || topLevelFieldExports.nonEmpty) {
       Some(new GenInfoTraverser().generateTopLevelExportsInfo(enclosingClass,
-          exportedConstructors, topLevelMethodExports, topLevelFieldExports))
+          topLevelMethodExports, topLevelFieldExports))
     } else {
       None
     }
@@ -416,15 +412,11 @@ object Infos {
     }
 
     def generateTopLevelExportsInfo(enclosingClass: String,
-        topLevelConstructorDefs: List[TopLevelConstructorExportDef],
         topLevelMethodExports: List[TopLevelMethodExportDef],
         topLevelFieldExports: List[TopLevelFieldExportDef]): MethodInfo = {
       builder
         .setEncodedName(TopLevelExportsName)
         .setIsExported(true)
-
-      for (topLevelConstructorDef <- topLevelConstructorDefs)
-        traverse(topLevelConstructorDef.body)
 
       for (topLevelMethodExport <- topLevelMethodExports)
         topLevelMethodExport.methodDef.body.foreach(traverse(_))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -109,9 +109,7 @@ private[emitter] final class KnowledgeGuardian {
       /* We can enable inlined init if all of the following apply:
        * - The class is not blacklisted
        * - It does not have any instantiated subclass
-       * - It has exactly one (regular) constructor
-       * - It does not have any exported constructor (since they are
-       *   effectively secondary constructors)
+       * - It has exactly one constructor
        *
        * By construction, this is always true for module classes.
        */
@@ -119,9 +117,6 @@ private[emitter] final class KnowledgeGuardian {
       !classesWithInstantiatedSubclasses(classDef.encodedName) && {
         classDef.memberMethods.count(
             x => Definitions.isConstructorName(x.value.encodedName)) == 1
-      } && {
-        !classDef.topLevelExports.exists(
-            _.value.isInstanceOf[TopLevelConstructorExportDef])
       }
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -219,9 +219,6 @@ private final class IRChecker(unit: LinkingUnit,
         implicit val ctx = ErrorContext(tree)
 
         tree match {
-          case tree: TopLevelConstructorExportDef =>
-            checkTopLevelConstructorExportDef(tree, classDef)
-
           case tree: TopLevelJSClassExportDef =>
             checkTopLevelJSClassExportDef(tree, classDef)
 
@@ -490,24 +487,6 @@ private final class IRChecker(unit: LinkingUnit,
           reportError("Only JS classes may contain members with computed names")
         typecheckExpect(tree, Env.empty, AnyType)
     }
-  }
-
-  private def checkTopLevelConstructorExportDef(
-      ctorDef: TopLevelConstructorExportDef,
-      classDef: LinkedClass): Unit = withPerMethodState {
-    val TopLevelConstructorExportDef(_, params, body) = ctorDef
-    implicit val ctx = ErrorContext(ctorDef)
-
-    if (!classDef.kind.isClass) {
-      reportError(s"Exported constructor def can only appear in a class")
-      return
-    }
-
-    checkJSParamDefs(params)
-
-    val thisType = ClassType(classDef.name.name)
-    val bodyEnv = Env.fromSignature(thisType, None, params, NoType)
-    typecheckStat(body, bodyEnv)
   }
 
   private def checkTopLevelJSClassExportDef(


### PR DESCRIPTION
Another thing I found while formalizing the IR ...

Exports of Scala constructors can be directly encoded as top-level static *functions* instead, since what they did was creating a new instance inside of the desugared body anyway. Therefore, this commit gets rid of them at the IR level, by moving their desugaring from the `ClassEmitter` all the way back to the compiler.

The only piece of observable semantics we lose by doing so is that a constructor export def did set the `prototype` of the function to `$c_LTheClass.prototype`, indirectly allowing JS code to use `x instanceof ExportedCtor` to perform a Scala instance test. However, this "feature" was never documented, nor tested.