### PR TITLE
Move the default value of some sbt settings to the Global scope.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -22,6 +22,7 @@ import org.scalajs.linker._
 import org.scalajs.linker.irio._
 
 import org.scalajs.jsenv.JSEnv
+import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 object ScalaJSPlugin extends AutoPlugin {
   override def requires: Plugins = plugins.JvmPlugin
@@ -160,6 +161,15 @@ object ScalaJSPlugin extends AutoPlugin {
   override def globalSettings: Seq[Setting[_]] = {
     Seq(
         scalaJSStage := Stage.FastOpt,
+
+        scalaJSLinkerConfig := {
+          StandardLinker.Config()
+            .withParallel(ScalaJSPluginInternal.DefaultParallelLinker)
+        },
+
+        jsEnv := new NodeJSEnv(),
+
+        jsExecutionFiles := Nil,
 
         // Clear the IR cache stats every time a sequence of tasks ends
         onComplete := {

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -19,7 +19,6 @@ import org.scalajs.linker._
 import org.scalajs.linker.irio._
 
 import org.scalajs.jsenv._
-import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 import org.scalajs.ir.Printers.IRTreePrinter
 
@@ -85,7 +84,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
    * which uses Scala 2.12. We should get rid of that workaround at that point
    * for tidiness, though.
    */
-  private val DefaultParallelLinker: Boolean = {
+  val DefaultParallelLinker: Boolean = {
     try {
       scala.util.Properties.isJavaAtLeast("1.8")
       true
@@ -427,17 +426,8 @@ private[sbtplugin] object ScalaJSPluginInternal {
   private val scalaJSProjectBaseSettings = Seq(
       platformDepsCrossVersion := ScalaJSCrossVersion.binary,
 
-      scalaJSLinkerConfig := {
-        StandardLinker.Config()
-          .withParallel(DefaultParallelLinker)
-      },
-
       scalaJSModuleInitializers := Seq(),
       scalaJSUseMainModuleInitializer := false,
-
-      jsEnv := new NodeJSEnv(),
-
-      jsExecutionFiles := Nil,
 
       // you will need the Scala.js compiler plugin
       addCompilerPlugin(


### PR DESCRIPTION
We do this for `scalaJSLinkerConfig`, `jsEnv` and `jsExecutionFiles`. It can be convenient to override those settings at the global level in a build, for example to globally enable or disable batch mode, or switch the JS environment.

The only Scala.js-specific settings left that we initialize in the project scope are `scalaJSModuleInitializers` and `scalaJSUseMainModuleInitialize`. It does not make sense to set those at the global level, since they depend on the specific codebase being linked.