### PR TITLE
Abstract IRFileCache#Cache into a trait in the companion object.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -41,7 +41,7 @@ object ScalaJSPlugin extends AutoPlugin {
 
     // All our public-facing keys
 
-    val scalaJSIRCache = SettingKey[IRFileCache#Cache](
+    val scalaJSIRCache = SettingKey[IRFileCache.Cache](
         "scalaJSIRCache",
         "Scala.js internal: Task to access a cache.", KeyRanks.Invisible)
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -49,14 +49,14 @@ private[sbtplugin] object ScalaJSPluginInternal {
   }
 
   private val allocatedIRCaches =
-    new AtomicReference[List[globalIRCache.Cache]](Nil)
+    new AtomicReference[List[IRFileCache.Cache]](Nil)
 
   /** Allocates a new IR cache linked to the [[globalIRCache]].
    *
    *  The allocated IR cache will automatically be freed when the build is
    *  unloaded.
    */
-  private def newIRCache: globalIRCache.Cache =
+  private def newIRCache: IRFileCache.Cache =
     registerResource(allocatedIRCaches, globalIRCache.newCache)
 
   private[sbtplugin] def freeAllIRCaches(): Unit =


### PR DESCRIPTION
This both removes the public view that it is a class, and removes the need for `#` projections.