### PR TITLE
Tighten `Match` nodes to only accept selectors of type `IntType`.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -850,7 +850,7 @@ object Serializers {
         case TagThrow    => Throw(readTree())
         case TagMatch    =>
           Match(readTree(), List.fill(readInt()) {
-            (readTrees().map(_.asInstanceOf[Literal]), readTree())
+            (readTrees().map(_.asInstanceOf[IntLiteral]), readTree())
           }, readTree())(readType())
         case TagDebugger => Debugger()
 

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -218,12 +218,12 @@ object Trees {
 
   /** A break-free switch (without fallthrough behavior).
    *  Unlike a JavaScript switch, it can be used in expression position.
-   *  It supports alternatives explicitly (hence the List[Tree] in cases),
-   *  whereas in a switch one would use the fallthrough behavior to
+   *  It supports alternatives explicitly (hence the `List[IntLiteral]` in
+   *  cases), whereas in a switch one would use the fallthrough behavior to
    *  implement alternatives.
    *  (This is not a pattern matching construct like in Scala.)
    */
-  case class Match(selector: Tree, cases: List[(List[Literal], Tree)],
+  case class Match(selector: Tree, cases: List[(List[IntLiteral], Tree)],
       default: Tree)(val tpe: Type)(implicit val pos: Position) extends Tree
 
   case class Debugger()(implicit val pos: Position) extends Tree {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1557,7 +1557,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
               val newCases = {
                 for {
                   (values, body) <- cases
-                  newValues = values.map(transformExpr(_, preserveChar = true))
+                  newValues = values.map(v => js.IntLiteral(v.value)(v.pos))
                   // add the break statement
                   newBody = js.Block(
                       pushLhsInto(newLhs, body, tailPosLabels)(branchesEnv),

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -607,11 +607,10 @@ private final class IRChecker(unit: LinkingUnit,
         env
 
       case Match(selector, cases, default) =>
-        typecheckExpr(selector, env)
-        for ((alts, body) <- cases) {
-          alts.foreach(typecheckExpr(_, env))
+        typecheckExpect(selector, env, IntType)
+        // The alternatives are IntLiterals, no point typechecking them
+        for ((_, body) <- cases)
           typecheckStat(body, env)
-        }
         typecheckStat(default, env)
         env
 
@@ -722,11 +721,10 @@ private final class IRChecker(unit: LinkingUnit,
 
       case Match(selector, cases, default) =>
         val tpe = tree.tpe
-        typecheckExpr(selector, env)
-        for ((alts, body) <- cases) {
-          alts.foreach(typecheckExpr(_, env))
+        typecheckExpect(selector, env, IntType)
+        // The alternatives are IntLiterals, no point typechecking them
+        for ((_, body) <- cases)
           typecheckExpect(body, env, tpe)
-        }
         typecheckExpect(default, env, tpe)
 
       // Scala expressions

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -430,10 +430,10 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case Match(selector, cases, default) =>
         val newSelector = transformExpr(selector)
         newSelector match {
-          case newSelector: Literal =>
-            val body = cases collectFirst {
-              case (alts, body) if alts.exists(literal_===(_, newSelector)) => body
-            } getOrElse default
+          case IntLiteral(selectorValue) =>
+            val body = cases.collectFirst {
+              case (alts, body) if alts.exists(_.value == selectorValue) => body
+            }.getOrElse(default)
             transform(body, isStat)
           case _ =>
             Match(newSelector,
@@ -783,10 +783,10 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case Match(selector, cases, default) =>
         val newSelector = transformExpr(selector)
         newSelector match {
-          case newSelector: Literal =>
-            val body = cases collectFirst {
-              case (alts, body) if alts.exists(literal_===(_, newSelector)) => body
-            } getOrElse default
+          case IntLiteral(selectorValue) =>
+            val body = cases.collectFirst {
+              case (alts, body) if alts.exists(_.value == selectorValue) => body
+            }.getOrElse(default)
             pretransformExpr(body)(cont)
           case _ =>
             cont(Match(newSelector,


### PR DESCRIPTION
This corresponds to how switch tables work on the JVM, and hence to how `GenBCode` works in Scala/JVM anyway.

This tightening fixes by construction some loopholes that were present with looser `Match`s. For example, `Long`s could not be reliably used anyway, because their `===` compares the *references* to `RuntimeLong` instances rather than the underlying values.