### PR TITLE
Fix reported ambiguous method names and make error pos deterministic

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -173,7 +173,7 @@ class JSExportTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:4: error: Cannot disambiguate overloads for exported method $js$exported$meth$foo with types
+      |newSource1.scala:6: error: Cannot disambiguate overloads for exported method $js$exported$meth$foo with types
       |  (x: Int)Object
       |  (x: Seq)Object
       |      @JSExport

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/ScalaJSDefinedTest.scala
@@ -221,7 +221,7 @@ class ScalaJSDefinedTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:14: error: Cannot disambiguate overloads for method bar with types
+      |newSource1.scala:14: error: Cannot disambiguate overloads for method foo with types
       |  (x: Int)Int
       |  (x: Int)Int
       |    class Bar extends Foo {


### PR DESCRIPTION
- Fix the type test used to determine whether we should use the jsName
  or the name of a symbol.

- Sort positions of alternative ambiguous overloads and pick the last
  one to not rely on the arbitrary order of the hashmap implementation
  used by the underlying compiler.