### PR TITLE
Run tests with `withAllowBigIntsForLongs(true)`.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -152,6 +152,14 @@ def Tasks = [
         'set scalaJSLinkerConfig in $testSuite ~= (_.withOptimizer(false))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withAllowBigIntsForLongs(true)))' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--harmony-bigint")))' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withAllowBigIntsForLongs(true)).withOptimizer(false))' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--harmony-bigint")))' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
     sbtretry 'set scalacOptions in $testSuite += "-Xexperimental"' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalacOptions in $testSuite += "-Xexperimental"' \
@@ -218,6 +226,14 @@ def Tasks = [
     sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSLinkerConfig in $testSuite ~= (_.withOptimizer(false))' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true).withAllowBigIntsForLongs(true)))' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--harmony-bigint")))' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true).withAllowBigIntsForLongs(true)).withOptimizer(false))' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--harmony-bigint")))' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2073,7 +2073,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
               case AnyType =>
                 genDispatchApply()
 
-              case LongType | ClassType(BoxedLongClass) =>
+              case LongType | ClassType(BoxedLongClass) if !useBigIntForLongs =>
                 // All methods of java.lang.Long are also in RuntimeLong
                 genNormalApply()
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -2818,7 +2818,8 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
    *  `===` comparison, since they all upcast as primitive numbers.
    *
    *  Chars and Longs, however, never compare as `===`, since they are boxed
-   *  chars and instances of `RuntimeLong`, respectively.
+   *  chars and instances of `RuntimeLong`, respectively---unless we are using
+   *  `BigInt`s for `Long`s, in which case those can be `===`.
    */
   private def literal_===(lhs: Literal, rhs: Literal): Boolean = {
     object AnyNumLiteral {
@@ -2837,6 +2838,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case (StringLiteral(l), StringLiteral(r))   => l == r
       case (ClassOf(l), ClassOf(r))               => l == r
       case (AnyNumLiteral(l), AnyNumLiteral(r))   => l == r
+      case (LongLiteral(l), LongLiteral(r))       => l == r && !useRuntimeLong
       case (Undefined(), Undefined())             => true
       case (Null(), Null())                       => true
       case _                                      => false

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -177,11 +177,16 @@ class OptimizerTest {
     test(false, 5.toByte, 5L)
     test(false, 5, 5L)
     test(false, 5L, 6L)
-    test(false, 5L, 5L) // they're instances of RuntimeLong, so not ===
     test(false, false, 0)
     test(false, 65, 'A')
     test(false, classOf[String], classOf[Boolean])
     test(false, "hello", "world")
+
+    /* When using BigInts for Longs, equal Longs will be ===, but not when
+     * using RuntimeLongs since the instances will be different.
+     */
+    val usingBigIntForLongs = js.typeOf(5L) == "bigint"
+    test(usingBigIntForLongs, 5L, 5L)
   }
 
   @Test def constant_folding_==(): Unit = {


### PR DESCRIPTION
Now that Node.js v10.0.0 has been released, with a version of v8 that supports BigInts under the flag `--harmony-bigint`, we can actually test that feature on the CI.