### PR TITLE
Do not delete `global.ArrayBuffer` in `NodeJSEnvForcePolyfills`.

### DIFF
--- a/project/NodeJSEnvForcePolyfills.scala
+++ b/project/NodeJSEnvForcePolyfills.scala
@@ -45,7 +45,6 @@ final class NodeJSEnvForcePolyfills(config: NodeJSEnv.Config) extends JSEnv {
         |
         |delete global.Promise;
         |
-        |delete global.ArrayBuffer;
         |delete global.Int8Array;
         |delete global.Int16Array;
         |delete global.Int32Array;


### PR DESCRIPTION
Because Node.js v10.0.0's `readFileSync`, used by the core module loading mechanism, relies on it being there and working.