### PR TITLE
Reduce acceptTimeout

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
@@ -51,7 +51,7 @@ abstract class AbstractNodeJSEnv(
   }
 
   /** Retry-timeout to wait for the JS VM to connect */
-  protected val acceptTimeout = 5000
+  protected val acceptTimeout = 500
 
   protected trait AbstractNodeRunner extends AbstractExtRunner with JSInitFiles {
 


### PR DESCRIPTION
I noticed that my tests were very slow to start running. While running
with sbt | ts '%H:%M:%.S', I found that there was almost always exactly
a 5 second delay between starting the process and the first output being
printed. I grepped for 5000 and found this line. Changing this parameter
eliminated the delay for me. The parameter seems to only be used in the
awaitConnection method, which just loops until serverSocket.accept
succeeds (with failure being a socket timeout). This makes me fairly
confident that this change won't break anything. I also would expect any
additional overhead of the extra thread wake ups to be negligible.