### PR TITLE
Fix #3351: Use Buffer.alloc and Buffer.from instead of new Buffer().

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
@@ -172,7 +172,7 @@ abstract class AbstractNodeJSEnv(
              |  var recvCallback = null;
              |
              |  // Buffers received data
-             |  var inBuffer = new Buffer(0);
+             |  var inBuffer = Buffer.alloc(0);
              |
              |  function onData(data) {
              |    inBuffer = Buffer.concat([inBuffer, data]);
@@ -227,7 +227,7 @@ abstract class AbstractNodeJSEnv(
              |      if (socket === null) throw new Error("Com not open");
              |
              |      var len = msg.length;
-             |      var buf = new Buffer(4 + len * 2);
+             |      var buf = Buffer.allocUnsafe(4 + len * 2);
              |      buf.writeInt32BE(len, 0);
              |      for (var i = 0; i < len; ++i)
              |        buf.writeUInt16BE(msg.charCodeAt(i), 4 + i * 2);

--- a/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ModulesTest.scala
+++ b/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ModulesTest.scala
@@ -62,7 +62,7 @@ class ModulesTest {
   }
 
   @Test def testImportClassInModule(): Unit = {
-    val b = new Buffer(5)
+    val b = Buffer.alloc(5)
     for (i <- 0 until 5)
       b(i) = (i * i).toShort
 
@@ -71,8 +71,8 @@ class ModulesTest {
   }
 
   @Test def testImportIntegrated(): Unit = {
-    val b = new Buffer(js.Array[Short](0xe3, 0x81, 0x93, 0xe3, 0x82, 0x93, 0xe3,
-        0x81, 0xab, 0xe3, 0x81, 0xa1, 0xe3, 0x81, 0xaf))
+    val b = Buffer.from(js.Array[Short](0xe3, 0x81, 0x93, 0xe3, 0x82, 0x93,
+        0xe3, 0x81, 0xab, 0xe3, 0x81, 0xa1, 0xe3, 0x81, 0xaf))
     val decoder = new StringDecoder()
     assertTrue(Buffer.isBuffer(b))
     assertFalse(Buffer.isBuffer(decoder))
@@ -105,19 +105,17 @@ object ModulesTest {
     def end(): String = js.native
   }
 
-  /* To stay compatible with Node.js 4.2.1, we describe and use deprecated
-   * APIs.
-   */
   @js.native
   @JSImport("buffer", "Buffer")
-  class Buffer private[this] () extends js.typedarray.Uint8Array(0) {
-    def this(size: Int) = this()
-    def this(array: js.Array[Short]) = this()
-  }
+  class Buffer private[this] () extends js.typedarray.Uint8Array(0)
 
+  // This API requires Node.js >= v5.10.0
   @js.native
   @JSImport("buffer", "Buffer")
   object Buffer extends js.Object {
+    def alloc(size: Int): Buffer = js.native
+    def from(array: js.Array[Short]): Buffer = js.native
+
     def isBuffer(x: Any): Boolean = js.native
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
@@ -64,7 +64,7 @@ class ModulesWithGlobalFallbackTest {
   }
 
   @Test def testImportClassInModule(): Unit = {
-    val b = new Buffer(5)
+    val b = Buffer.alloc(5)
     for (i <- 0 until 5)
       b(i) = (i * i).toShort
 
@@ -73,8 +73,8 @@ class ModulesWithGlobalFallbackTest {
   }
 
   @Test def testImportIntegrated(): Unit = {
-    val b = new Buffer(js.Array[Short](0xe3, 0x81, 0x93, 0xe3, 0x82, 0x93, 0xe3,
-        0x81, 0xab, 0xe3, 0x81, 0xa1, 0xe3, 0x81, 0xaf))
+    val b = Buffer.from(js.Array[Short](0xe3, 0x81, 0x93, 0xe3, 0x82, 0x93,
+        0xe3, 0x81, 0xab, 0xe3, 0x81, 0xa1, 0xe3, 0x81, 0xaf))
     val decoder = new StringDecoder()
     assertTrue(Buffer.isBuffer(b))
     assertFalse(Buffer.isBuffer(decoder))
@@ -139,6 +139,9 @@ object ModulesWithGlobalFallbackTest {
   }
 
   object BufferStaticFallbackImpl extends js.Object {
+    def alloc(size: Int): Any = new Uint8Array(size)
+    def from(array: js.Array[Short]): Any = new Uint8Array(array)
+
     def isBuffer(x: Any): Boolean = x.isInstanceOf[Uint8Array]
   }
 
@@ -184,21 +187,19 @@ object ModulesWithGlobalFallbackTest {
     def end(): String = js.native
   }
 
-  /* To stay compatible with Node.js 4.2.1, we describe and use deprecated
-   * APIs.
-   */
   @js.native
   @JSImport("buffer", "Buffer",
       globalFallback = "ModulesWithGlobalFallbackTest_Buffer")
-  class Buffer private[this] () extends js.typedarray.Uint8Array(0) {
-    def this(size: Int) = this()
-    def this(array: js.Array[Short]) = this()
-  }
+  class Buffer private[this] () extends js.typedarray.Uint8Array(0)
 
+  // This API requires Node.js >= v5.10.0
   @js.native
   @JSImport("buffer", "Buffer",
       globalFallback = "ModulesWithGlobalFallbackTest_BufferStatic")
   object Buffer extends js.Object {
+    def alloc(size: Int): Buffer = js.native
+    def from(array: js.Array[Short]): Buffer = js.native
+
     def isBuffer(x: Any): Boolean = js.native
   }
 }


### PR DESCRIPTION
The latter was deprecated a long time ago, and has started printing noisy warnings to the console in Node.js v10.

There is still one deprecation inside jszip, but there is nothing we can do about that one.