### PR TITLE
Fix #2801: Enable regression test on JVM 2.12.5+ and 2.13.0-M4+.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -162,8 +162,16 @@ class RegressionTest {
   }
 
   @Test def should_support_class_literals_for_existential_value_types_issue_218(): Unit = {
-    assumeFalse("Not bug-compatible with the JVM, issue #2801",
-        Platform.executingInJVM)
+    import Platform.scalaVersion
+
+    assumeFalse("Affected by https://github.com/scala/bug/issues/10551",
+        Platform.executingInJVM && {
+          scalaVersion.startsWith("2.10.") ||
+          scalaVersion.startsWith("2.11.") ||
+          scalaVersion == "2.12.0" || scalaVersion == "2.12.1" ||
+          scalaVersion == "2.12.2" || scalaVersion == "2.12.3" ||
+          scalaVersion == "2.12.4" || scalaVersion == "2.13.0-M3"
+        })
 
     assertEquals("org.scalajs.testsuite.compiler.RegressionTest$Bug218Foo",
         scala.reflect.classTag[Bug218Foo[_]].toString)


### PR DESCRIPTION
The bug that we were not bug-compatible with was fixed upstream in https://github.com/scala/scala/pull/6131, which is available in 2.12.5+ and 2.13.0-M4+.

Tested locally with ++2.12.5, ++2.12.6 and ++2.13.0-M4.