### PR TITLE
Optimize switch-matches that have 0 or 1 case.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/MatchASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/MatchASTTest.scala
@@ -37,4 +37,33 @@ class MatchASTTest extends JSASTTest {
     }
   }
 
+  @Test
+  def matchWithZeroAlternativeInSwitch: Unit = {
+    """
+    object A {
+      def foo(x: Int): Int = (x: @scala.annotation.switch) match {
+        case n if n > 5  => n
+        case n if n >= 0 => 0
+        case n           => -n
+      }
+    }
+    """.hasNot("any match") {
+      case js.Match(_, _, _) =>
+    }
+  }
+
+  @Test
+  def matchWithOneAlternativeInSwitch: Unit = {
+    """
+    object A {
+      def foo(x: Int): Int = (x: @scala.annotation.switch) match {
+        case -1 => 10
+        case n  => n
+      }
+    }
+    """.hasNot("any match") {
+      case js.Match(_, _, _) =>
+    }
+  }
+
 }


### PR DESCRIPTION
They come up in reasonable source code that use `match`es as a convenience for a sequence of `if`s, or with patterns such as
```scala
someComputation() match {
  case -1 => doOneThing()
  case n  => doAnotherThing(n)
}
```
The simplification is done in the compiler rather than the optimizer, because it helps the optimizer to directly receive the `If`s or `Block`s. Moreover, there is no optimization that the optimizer could do that would turn a non-optimizable match into an optimizable one, so we're not losing any optimization opportunity by doing it only once in the compiler.