### PR TITLE
[no-master] Fix #3373: Upgrade to org.mozilla's Rhino v1.7.6.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -718,7 +718,7 @@ object Build {
       ) ++ Seq(
           name := "Scala.js JS Envs",
           libraryDependencies ++= Seq(
-              "io.apigee" % "rhino" % "1.7R5pre4",
+              "org.mozilla" % "rhino" % "1.7.6",
               "org.webjars" % "envjs" % "1.2"
           ) ++ ScalaJSPluginInternal.phantomJSJettyModules.map(_ % "provided"),
           previousArtifactSetting,
@@ -1798,7 +1798,7 @@ object Build {
                       "org.scala-lang.modules" %% "scala-partest" % "1.1.4"
                   },
                   "org.scala-js" % "closure-compiler-java-6" % "v20160517",
-                  "io.apigee" % "rhino" % "1.7R5pre4",
+                  "org.mozilla" % "rhino" % "1.7.6",
                   "com.googlecode.json-simple" % "json-simple" % "1.1.1" exclude("junit", "junit")
               ) ++ (
                   parallelCollectionsDependencies(scalaVersion.value)

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 
 libraryDependencies += "org.scala-js" % "closure-compiler-java-6" % "v20160517"
 
-libraryDependencies += "io.apigee" % "rhino" % "1.7R5pre4"
+libraryDependencies += "org.mozilla" % "rhino" % "1.7.6"
 
 libraryDependencies += "org.webjars" % "envjs" % "1.2"
 


### PR DESCRIPTION
This is the last version that does not introduce `Math.imul`. The implementation added in Rhino 1.7.7, and still used in 1.7.9, is faulty. See https://github.com/mozilla/rhino/issues/448.