### PR TITLE
A number of changes for the upcoming Scala 2.13.0-M5.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -20,8 +20,7 @@ import org.scalajs.core.ir
 import ir.{Trees => js, Types => jstpe, ClassKind, Hashers}
 import ir.Trees.OptimizerHints
 
-import util.ScopedVar
-import util.VarBox
+import org.scalajs.core.compiler.util.{ScopedVar, VarBox}
 import ScopedVar.withScopedVars
 
 /** Generate JavaScript code and output it to disk

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -15,7 +15,7 @@ import org.scalajs.core.ir
 import ir.{Trees => js, Types => jstpe}
 import ir.Trees.OptimizerHints
 
-import util.ScopedVar
+import org.scalajs.core.compiler.util.ScopedVar
 import ScopedVar.withScopedVars
 
 /** Generation of exports for JavaScript

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -12,7 +12,7 @@ import scala.tools.nsc._
 import org.scalajs.core.ir
 import ir.{Trees => js, Types => jstpe}
 
-import util.ScopedVar
+import org.scalajs.core.compiler.util.ScopedVar
 import ScopedVar.withScopedVars
 
 /** Encoding of symbol names for JavaScript

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -45,11 +45,11 @@ class Character(private val value: scala.Char)
   protected def +(x: String): String = value + x
 
   protected def <<(x: scala.Int): scala.Int = value << x
-  protected def <<(x: scala.Long): scala.Int = value << x
+  protected def <<(x: scala.Long): scala.Int = value << x.toInt
   protected def >>>(x: scala.Int): scala.Int = value >>> x
-  protected def >>>(x: scala.Long): scala.Int = value >>> x
+  protected def >>>(x: scala.Long): scala.Int = value >>> x.toInt
   protected def >>(x: scala.Int): scala.Int = value >> x
-  protected def >>(x: scala.Long): scala.Int = value >> x
+  protected def >>(x: scala.Long): scala.Int = value >> x.toInt
 
   protected def ==(x: scala.Byte): scala.Boolean = value == x
   protected def ==(x: scala.Short): scala.Boolean = value == x

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -42,7 +42,7 @@ class Character(private val value: scala.Char)
   protected def unary_- : scala.Int = -value
   // scalastyle:on disallow.space.before.token
 
-  protected def +(x: String): String = value + x
+  protected def +(x: String): String = "" + value + x
 
   protected def <<(x: scala.Int): scala.Int = value << x
   protected def <<(x: scala.Long): scala.Int = value << x.toInt

--- a/javalanglib/src/main/scala/java/lang/Class.scala
+++ b/javalanglib/src/main/scala/java/lang/Class.scala
@@ -84,7 +84,7 @@ final class Class[A] private (data: ScalaJSClassData[A]) extends Object {
     scala.scalajs.runtime.SemanticsUtils.asInstanceOfCheck(
         (this eq classOf[Nothing]) ||
         (obj != null && !isRawJSType && !isInstance(obj)),
-        new ClassCastException(obj + " is not an instance of " + getName))
+        new ClassCastException("" + obj + " is not an instance of " + getName))
     obj.asInstanceOf[A]
   }
 

--- a/javalib/src/main/scala/java/math/Conversion.scala
+++ b/javalib/src/main/scala/java/math/Conversion.scala
@@ -100,7 +100,7 @@ private[math] object Conversion {
           @tailrec
           def innerLoop(): Unit = {
             currentChar -= 1
-            result = Character.forDigit(resDigit % radix, radix) + result
+            result = Character.forDigit(resDigit % radix, radix).toString + result
             resDigit /= radix
             if(resDigit != 0 && currentChar != 0)
               innerLoop()
@@ -111,7 +111,7 @@ private[math] object Conversion {
           var i: Int = 0
           while (i < delta && currentChar > 0) {
             currentChar -= 1
-            result = '0' + result
+            result = "0" + result
             i += 1
           }
           i = tempLen - 1
@@ -130,14 +130,14 @@ private[math] object Conversion {
           while (j < 8 && currentChar > 0) {
             resDigit = digits(i) >> (j << 2) & 0xf
             currentChar -= 1
-            result = java.lang.Character.forDigit(resDigit, 16) + result
+            result = resDigit.toHexString + result
             j += 1
           }
         }
       }
       // strip leading zero's
       result = result.dropWhile(_ == '0')
-      if (sign == -1) '-' + result
+      if (sign == -1) "-" + result
       else result
     }
   }
@@ -192,7 +192,7 @@ private[math] object Conversion {
 
       result = dropLeadingZeros(result)
 
-      if (sign < 0) '-' + result
+      if (sign < 0) "-" + result
       else result
     }
   }
@@ -241,7 +241,7 @@ private[math] object Conversion {
         val prev = v
         v /= 10
         currentChar -= 1
-        result = (48 + (prev - v * 10)).toChar + result
+        result = (prev - v * 10).toInt.toString + result
       } while (v != 0)
 
       val exponent = resLengthInChars - currentChar - scale - 1
@@ -254,24 +254,24 @@ private[math] object Conversion {
         } else {
           // special case 2
           for (j <- 0 until -index) {
-            result = '0' + result
+            result = "0" + result
           }
           result = "0." + result
         }
       } else if (scale !=0) {
         var result1 =  exponent.toString
         if (exponent > 0)
-          result1 = '+' + result1
-        result1 = 'E' + result1
+          result1 = "+" + result1
+        result1 = "E" + result1
 
         result =
           if (resLengthInChars - currentChar > 1)
-            result(0) + "." + result.substring(1) + result1
+            result.substring(0, 1) + "." + result.substring(1) + result1
           else
             result + result1
       }
 
-      if (negNumber) '-' + result
+      if (negNumber) "-" + result
       else result
     }
   }

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -48,7 +48,7 @@ object AbstractMap {
       entryHashCode(this)
 
     override def toString(): String =
-      getKey + "=" + getValue
+      "" + getKey + "=" + getValue
   }
 
   class SimpleImmutableEntry[K, V](key: K, value: V)
@@ -71,7 +71,7 @@ object AbstractMap {
       entryHashCode(this)
 
     override def toString(): String =
-      getKey + "=" + getValue
+      "" + getKey + "=" + getValue
   }
 }
 

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -593,7 +593,7 @@ object Arrays {
   @inline private def checkIndicesForCopyOfRange(
       len: Int, start: Int, end: Int): Unit = {
     if (start > end)
-      throw new IllegalArgumentException(start + " > " + end)
+      throw new IllegalArgumentException("" + start + " > " + end)
     SemanticsUtils.arrayIndexOutOfBoundsCheck(start < 0 || start > len,
         new ArrayIndexOutOfBoundsException)
   }

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -18,6 +18,16 @@ object Arrays {
     }
   }
 
+  // Impose the total ordering of java.lang.Float.compare in Arrays
+  private implicit object FloatTotalOrdering extends Ordering[Float] {
+    def compare(x: Float, y: Float): Int = java.lang.Float.compare(x, y)
+  }
+
+  // Impose the total ordering of java.lang.Double.compare in Arrays
+  private implicit object DoubleTotalOrdering extends Ordering[Double] {
+    def compare(x: Double, y: Double): Int = java.lang.Double.compare(x, y)
+  }
+
   @noinline def sort(a: Array[Int]): Unit =
     sortImpl(a)
 

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -98,7 +98,7 @@ class Date private (private val date: js.Date) extends Object
 
   @Deprecated
   def toGMTString(): String = {
-    date.getUTCDate() + " " + Months(date.getUTCMonth()) + " " +
+    "" + date.getUTCDate() + " " + Months(date.getUTCMonth()) + " " +
       date.getUTCFullYear() + " " + pad0(date.getUTCHours()) + ":" +
       pad0(date.getUTCMinutes()) + ":" +
       pad0(date.getUTCSeconds()) +" GMT"
@@ -106,7 +106,7 @@ class Date private (private val date: js.Date) extends Object
 
   @Deprecated
   def toLocaleString(): String = {
-    date.getDate() + "-" + Months(date.getMonth()) + "-" +
+    "" + date.getDate() + "-" + Months(date.getMonth()) + "-" +
       date.getFullYear() + "-" + pad0(date.getHours()) + ":" +
       pad0(date.getMinutes()) + ":" + pad0(date.getSeconds())
   }

--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -105,7 +105,7 @@ final class Formatter(private val dest: Appendable) extends Closeable with Flush
           def padCaptureSign(argStr: String, prefix: String) = {
             val firstChar = argStr.charAt(0)
             if (firstChar == '+' || firstChar == '-')
-              pad(argStr.substring(1), firstChar+prefix)
+              pad(argStr.substring(1), firstChar.toString + prefix)
             else
               pad(argStr, prefix)
           }

--- a/javalib/src/main/scala/java/util/Hashtable.scala
+++ b/javalib/src/main/scala/java/util/Hashtable.scala
@@ -72,7 +72,7 @@ class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
     new ju.Hashtable[K, V](this)
 
   override def toString(): String =
-    inner.iterator.map(kv => kv._1.inner + "=" + kv._2).mkString("{", ", ", "}")
+    inner.iterator.map(kv => "" + kv._1.inner + "=" + kv._2).mkString("{", ", ", "}")
 
   def keySet(): ju.Set[K] =
     inner.keySet.map(_.inner.asInstanceOf[K]).asJava

--- a/javalib/src/main/scala/java/util/regex/GroupStartMap.scala
+++ b/javalib/src/main/scala/java/util/regex/GroupStartMap.scala
@@ -486,7 +486,7 @@ private[regex] class GroupStartMap(string: String, start: Int, pattern: Pattern)
 
         def default = {
           val e = pattern(pIndex)
-          addSiblings(Node(e + ""), pIndex + 1, nextGroupIndex)
+          addSiblings(Node("" + e), pIndex + 1, nextGroupIndex)
         }
 
         (pattern(pIndex): @switch) match {

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -388,7 +388,14 @@ class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
               varargsModule,
               definitions.wrapVarargsArrayMethodName(definitions.ObjectTpe),
               Nil, List(array))
-          gen.mkMethodCall(definitions.List_apply, List(wrappedArray))
+          val listApply = typer.typed {
+            gen.mkMethodCall(definitions.ListModule, nme.apply, Nil, List(wrappedArray))
+          }
+
+          if (listApply.tpe.typeSymbol.isSubClass(definitions.ListClass))
+            listApply
+          else
+            gen.mkCast(listApply, definitions.ListClass.toTypeConstructor)
         }
 
         def mkMethodList(tpe: TypeTree)(testMethods: List[MethodSymbol]): Tree =

--- a/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
@@ -65,29 +65,31 @@ object JSConverters extends JSConvertersLowPrioImplicits {
 
   implicit class JSRichIterable[T](
       val __self: scala.collection.Iterable[T]) extends AnyVal {
-    @inline final def toJSIterable: Iterable[T] = new IterableAdapter(__self)
+    @inline final def toJSIterable: js.Iterable[T] = new IterableAdapter(__self)
   }
 
   implicit class JSRichIterator[T](
       val __self: scala.collection.Iterator[T]) extends AnyVal {
-    @inline final def toJSIterator: Iterator[T] = new IteratorAdapter(__self)
+    @inline final def toJSIterator: js.Iterator[T] = new IteratorAdapter(__self)
   }
 
-  private class IterableAdapter[+T](col: collection.Iterable[T]) extends Iterable[T] {
+  private class IterableAdapter[+T](col: collection.Iterable[T])
+      extends js.Iterable[T] {
+
     @JSName(Symbol.iterator)
-    final def jsIterator(): Iterator[T] = col.iterator.toJSIterator
+    final def jsIterator(): js.Iterator[T] = col.iterator.toJSIterator
   }
 
   private class IteratorAdapter[+T](
-      it: scala.collection.Iterator[T]) extends Iterator[T] {
-    final def next(): Iterator.Entry[T] = {
+      it: scala.collection.Iterator[T]) extends js.Iterator[T] {
+    final def next(): js.Iterator.Entry[T] = {
       if (it.hasNext) {
-        new Iterator.Entry[T] {
+        new js.Iterator.Entry[T] {
           val done: Boolean = false
           val value: T = it.next()
         }
       } else {
-        new Iterator.Entry[T] {
+        new js.Iterator.Entry[T] {
           val done: Boolean = true
           // Evil cast to work around typing. By specification, reading `value`
           // is undefined behavior, so this is ok.

--- a/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
@@ -65,29 +65,31 @@ object JSConverters extends JSConvertersLowPrioImplicits {
 
   implicit class JSRichGenIterable[T](
       val __self: GenIterable[T]) extends AnyVal {
-    @inline final def toJSIterable: Iterable[T] = new IterableAdapter(__self)
+    @inline final def toJSIterable: js.Iterable[T] = new IterableAdapter(__self)
   }
 
   implicit class JSRichIterator[T](
       val __self: scala.collection.Iterator[T]) extends AnyVal {
-    @inline final def toJSIterator: Iterator[T] = new IteratorAdapter(__self)
+    @inline final def toJSIterator: js.Iterator[T] = new IteratorAdapter(__self)
   }
 
-  private class IterableAdapter[+T](col: GenIterable[T]) extends Iterable[T] {
+  private class IterableAdapter[+T](col: GenIterable[T])
+      extends js.Iterable[T] {
+
     @JSName(Symbol.iterator)
-    final def jsIterator(): Iterator[T] = col.iterator.toJSIterator
+    final def jsIterator(): js.Iterator[T] = col.iterator.toJSIterator
   }
 
   private class IteratorAdapter[+T](
-      it: scala.collection.Iterator[T]) extends Iterator[T] {
-    final def next(): Iterator.Entry[T] = {
+      it: scala.collection.Iterator[T]) extends js.Iterator[T] {
+    final def next(): js.Iterator.Entry[T] = {
       if (it.hasNext) {
-        new Iterator.Entry[T] {
+        new js.Iterator.Entry[T] {
           val done: Boolean = false
           val value: T = it.next()
         }
       } else {
-        new Iterator.Entry[T] {
+        new js.Iterator.Entry[T] {
           val done: Boolean = true
           // Evil cast to work around typing. By specification, reading `value`
           // is undefined behavior, so this is ok.

--- a/library/src/main/scala/scala/scalajs/runtime/IntegerReflectiveCall.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/IntegerReflectiveCall.scala
@@ -64,11 +64,11 @@ class IntegerReflectiveCall(value: Int) {
   // scalastyle:on disallow.space.before.token
 
   def <<(x: scala.Int): scala.Int = value << x
-  def <<(x: scala.Long): scala.Int = value << x
+  def <<(x: scala.Long): scala.Int = value << x.toInt
   def >>>(x: scala.Int): scala.Int = value >>> x
-  def >>>(x: scala.Long): scala.Int = value >>> x
+  def >>>(x: scala.Long): scala.Int = value >>> x.toInt
   def >>(x: scala.Int): scala.Int = value >> x
-  def >>(x: scala.Long): scala.Int = value >> x
+  def >>(x: scala.Long): scala.Int = value >> x.toInt
 
   def |(x: scala.Byte): scala.Int = value | x
   def |(x: scala.Short): scala.Int = value | x

--- a/library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala
@@ -42,7 +42,7 @@ class NumberReflectiveCall(value: Double) {
   def unary_- : scala.Double = -value
   // scalastyle:on disallow.space.before.token
 
-  def +(x: String): String = value + x
+  def +(x: String): String = "" + value + x
 
   def ==(x: scala.Byte): scala.Boolean = value == x
   def ==(x: scala.Short): scala.Boolean = value == x

--- a/library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala
@@ -139,11 +139,11 @@ class NumberReflectiveCall(value: Double) {
   // scalastyle:on disallow.space.before.token
 
   def <<(x: scala.Int): scala.Int = value.toInt << x
-  def <<(x: scala.Long): scala.Int = value.toInt << x
+  def <<(x: scala.Long): scala.Int = value.toInt << x.toInt
   def >>>(x: scala.Int): scala.Int = value.toInt >>> x
-  def >>>(x: scala.Long): scala.Int = value.toInt >>> x
+  def >>>(x: scala.Long): scala.Int = value.toInt >>> x.toInt
   def >>(x: scala.Int): scala.Int = value.toInt >> x
-  def >>(x: scala.Long): scala.Int = value.toInt >> x
+  def >>(x: scala.Long): scala.Int = value.toInt >> x.toInt
 
   def |(x: scala.Byte): scala.Int = value.toInt | x
   def |(x: scala.Short): scala.Int = value.toInt | x

--- a/scalalib/overrides-2.13.0-M4/scala/Enumeration.scala
+++ b/scalalib/overrides-2.13.0-M4/scala/Enumeration.scala
@@ -1,0 +1,302 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+
+import scala.collection.{ mutable, immutable, StrictOptimizedIterableOps, SpecificIterableFactory, View }
+import java.lang.reflect.{ Method => JMethod, Field => JField }
+import scala.reflect.NameTransformer._
+import scala.util.matching.Regex
+
+/** Defines a finite set of values specific to the enumeration. Typically
+ *  these values enumerate all possible forms something can take and provide
+ *  a lightweight alternative to case classes.
+ *
+ *  Each call to a `Value` method adds a new unique value to the enumeration.
+ *  To be accessible, these values are usually defined as `val` members of
+ *  the enumeration.
+ *
+ *  All values in an enumeration share a common, unique type defined as the
+ *  `Value` type member of the enumeration (`Value` selected on the stable
+ *  identifier path of the enumeration instance).
+ *
+ * @example {{{
+ * // Define a new enumeration with a type alias and work with the full set of enumerated values
+ * object WeekDay extends Enumeration {
+ *   type WeekDay = Value
+ *   val Mon, Tue, Wed, Thu, Fri, Sat, Sun = Value
+ * }
+ * import WeekDay._
+ *
+ * def isWorkingDay(d: WeekDay) = ! (d == Sat || d == Sun)
+ *
+ * WeekDay.values filter isWorkingDay foreach println
+ * // output:
+ * // Mon
+ * // Tue
+ * // Wed
+ * // Thu
+ * // Fri
+ * }}}
+ *
+ * @example {{{
+ * // Example of adding attributes to an enumeration by extending the Enumeration.Val class
+ * object Planet extends Enumeration {
+ *   protected case class Val(mass: Double, radius: Double) extends super.Val {
+ *     def surfaceGravity: Double = Planet.G * mass / (radius * radius)
+ *     def surfaceWeight(otherMass: Double): Double = otherMass * surfaceGravity
+ *   }
+ *   implicit def valueToPlanetVal(x: Value): Val = x.asInstanceOf[Val]
+ *
+ *   val G: Double = 6.67300E-11
+ *   val Mercury = Val(3.303e+23, 2.4397e6)
+ *   val Venus   = Val(4.869e+24, 6.0518e6)
+ *   val Earth   = Val(5.976e+24, 6.37814e6)
+ *   val Mars    = Val(6.421e+23, 3.3972e6)
+ *   val Jupiter = Val(1.9e+27, 7.1492e7)
+ *   val Saturn  = Val(5.688e+26, 6.0268e7)
+ *   val Uranus  = Val(8.686e+25, 2.5559e7)
+ *   val Neptune = Val(1.024e+26, 2.4746e7)
+ * }
+ *
+ * println(Planet.values.filter(_.radius > 7.0e6))
+ * // output:
+ * // Planet.ValueSet(Jupiter, Saturn, Uranus, Neptune)
+ * }}}
+ *
+ *  @param initial The initial value from which to count the integers that
+ *                 identifies values at run-time.
+ *  @author  Matthias Zenger
+ */
+@SerialVersionUID(8476000850333817230L)
+abstract class Enumeration (initial: Int) extends Serializable {
+  thisenum =>
+
+  def this() = this(0)
+
+  /* Note that `readResolve` cannot be private, since otherwise
+     the JVM does not invoke it when deserializing subclasses. */
+  protected def readResolve(): AnyRef = ???
+
+  /** The name of this enumeration.
+   */
+  override def toString =
+    (getClass.getName.stripSuffix("$").split('.')).last.split('$').last
+
+  /** The mapping from the integer used to identify values to the actual
+    * values. */
+  private val vmap: mutable.Map[Int, Value] = new mutable.HashMap
+
+  /** The cache listing all values of this enumeration. */
+  @transient private var vset: ValueSet = null
+  @transient @volatile private var vsetDefined = false
+
+  /** The mapping from the integer used to identify values to their
+    * names. */
+  private val nmap: mutable.Map[Int, String] = new mutable.HashMap
+
+  /** The values of this enumeration as a set.
+   */
+  def values: ValueSet = {
+    if (!vsetDefined) {
+      vset = (ValueSet.newBuilder ++= vmap.values).result()
+      vsetDefined = true
+    }
+    vset
+  }
+
+  /** The integer to use to identify the next created value. */
+  protected var nextId: Int = initial
+
+  /** The string to use to name the next created value. */
+  protected var nextName: Iterator[String] = _
+
+  private def nextNameOrNull =
+    if (nextName != null && nextName.hasNext) nextName.next() else null
+
+  /** The highest integer amongst those used to identify values in this
+    * enumeration. */
+  private var topId = initial
+
+  /** The lowest integer amongst those used to identify values in this
+    * enumeration, but no higher than 0. */
+  private var bottomId = if(initial < 0) initial else 0
+
+  /** The one higher than the highest integer amongst those used to identify
+    *  values in this enumeration. */
+  final def maxId = topId
+
+  /** The value of this enumeration with given id `x`
+   */
+  final def apply(x: Int): Value = vmap(x)
+
+  /** Return a `Value` from this `Enumeration` whose name matches
+   *  the argument `s`.  The names are determined automatically via reflection.
+   *
+   * @param  s an `Enumeration` name
+   * @return   the `Value` of this `Enumeration` if its name matches `s`
+   * @throws   NoSuchElementException if no `Value` with a matching
+   *           name is in this `Enumeration`
+   */
+  final def withName(s: String): Value = {
+    val (unnamed, named) = values partition {
+      _.toString().startsWith("<Unknown name for enum field ")
+    }
+
+    named.find(_.toString == s) match {
+      case Some(v) => v
+      // If we have unnamed values, we issue a detailed error message
+      case None if unnamed.nonEmpty =>
+        throw new NoSuchElementException(
+          s"""Couldn't find enum field with name $s.
+             |However, there were the following unnamed fields:
+             |${unnamed.mkString("  ","\n  ","")}""".stripMargin)
+      // Normal case (no unnamed Values)
+      case _ => None.get
+    }
+  }
+
+  /** Creates a fresh value, part of this enumeration. */
+  protected final def Value: Value = Value(nextId)
+
+  /** Creates a fresh value, part of this enumeration, identified by the
+   *  integer `i`.
+   *
+   *  @param i An integer that identifies this value at run-time. It must be
+   *           unique amongst all values of the enumeration.
+   *  @return  Fresh value identified by `i`.
+   */
+  protected final def Value(i: Int): Value = Value(i, nextNameOrNull)
+
+  /** Creates a fresh value, part of this enumeration, called `name`.
+   *
+   *  @param name A human-readable name for that value.
+   *  @return  Fresh value called `name`.
+   */
+  protected final def Value(name: String): Value = Value(nextId, name)
+
+  /** Creates a fresh value, part of this enumeration, called `name`
+   *  and identified by the integer `i`.
+   *
+   * @param i    An integer that identifies this value at run-time. It must be
+   *             unique amongst all values of the enumeration.
+   * @param name A human-readable name for that value.
+   * @return     Fresh value with the provided identifier `i` and name `name`.
+   */
+  protected final def Value(i: Int, name: String): Value = new Val(i, name)
+
+  /** The type of the enumerated values. */
+  @SerialVersionUID(7091335633555234129L)
+  abstract class Value extends Ordered[Value] with Serializable {
+    /** the id and bit location of this enumeration value */
+    def id: Int
+    /** a marker so we can tell whose values belong to whom come reflective-naming time */
+    private[Enumeration] val outerEnum = thisenum
+
+    override def compare(that: Value): Int =
+      if (this.id < that.id) -1
+      else if (this.id == that.id) 0
+      else 1
+    override def equals(other: Any) = other match {
+      case that: Enumeration#Value  => (outerEnum eq that.outerEnum) && (id == that.id)
+      case _                        => false
+    }
+    override def hashCode: Int = id.##
+
+    /** Create a ValueSet which contains this value and another one */
+    def + (v: Value) = ValueSet(this, v)
+  }
+
+  /** A class implementing the [[scala.Enumeration.Value]] type. This class
+   *  can be overridden to change the enumeration's naming and integer
+   *  identification behaviour.
+   */
+  @SerialVersionUID(0 - 3501153230598116017L)
+  protected class Val(i: Int, name: String) extends Value with Serializable {
+    def this(i: Int)       = this(i, nextNameOrNull)
+    def this(name: String) = this(nextId, name)
+    def this()             = this(nextId)
+
+    assert(!vmap.isDefinedAt(i), "Duplicate id: " + i)
+    vmap(i) = this
+    vsetDefined = false
+    nextId = i + 1
+    if (nextId > topId) topId = nextId
+    if (i < bottomId) bottomId = i
+    def id = i
+    override def toString() =
+      if (name != null) name
+      // Scala.js specific
+      else s"<Unknown name for enum field #$i of class ${getClass}>"
+
+    protected def readResolve(): AnyRef = {
+      val enum = thisenum.readResolve().asInstanceOf[Enumeration]
+      if (enum.vmap == null) this
+      else enum.vmap(i)
+    }
+  }
+
+  /** An ordering by id for values of this set */
+  object ValueOrdering extends Ordering[Value] {
+    def compare(x: Value, y: Value): Int = x compare y
+  }
+
+  /** A class for sets of values.
+   *  Iterating through this set will yield values in increasing order of their ids.
+   *
+   *  @param nnIds The set of ids of values (adjusted so that the lowest value does
+   *    not fall below zero), organized as a `BitSet`.
+   *  @define Coll `collection.immutable.SortedSet`
+   */
+  class ValueSet private[ValueSet] (private[this] var nnIds: immutable.BitSet)
+    extends immutable.AbstractSet[Value]
+      with immutable.SortedSet[Value]
+      with immutable.SetOps[Value, immutable.Set, ValueSet]
+      with StrictOptimizedIterableOps[Value, immutable.Set, ValueSet]
+      with Serializable {
+
+    implicit def ordering: Ordering[Value] = ValueOrdering
+    def rangeImpl(from: Option[Value], until: Option[Value]): ValueSet =
+      new ValueSet(nnIds.rangeImpl(from.map(_.id - bottomId), until.map(_.id - bottomId)))
+
+    override def empty = ValueSet.empty
+    def contains(v: Value) = nnIds contains (v.id - bottomId)
+    def incl (value: Value) = new ValueSet(nnIds + (value.id - bottomId))
+    def excl (value: Value) = new ValueSet(nnIds - (value.id - bottomId))
+    def iterator = nnIds.iterator map (id => thisenum.apply(bottomId + id))
+    override def iteratorFrom(start: Value) = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
+    override def className = thisenum + ".ValueSet"
+    /** Creates a bit mask for the zero-adjusted ids in this set as a
+     *  new array of longs */
+    def toBitMask: Array[Long] = nnIds.toBitMask
+
+    override protected def fromSpecificIterable(coll: Iterable[Value]) = ValueSet.fromSpecific(coll)
+    override protected def newSpecificBuilder = ValueSet.newBuilder
+
+    def map(f: Value => Value): ValueSet = fromSpecificIterable(new View.Map(toIterable, f))
+    def flatMap(f: Value => IterableOnce[Value]): ValueSet = fromSpecificIterable(new View.FlatMap(toIterable, f))
+  }
+
+  /** A factory object for value sets */
+  object ValueSet extends SpecificIterableFactory[Value, ValueSet] {
+    /** The empty value set */
+    val empty = new ValueSet(immutable.BitSet.empty)
+    /** A value set containing all the values for the zero-adjusted ids
+     *  corresponding to the bits in an array */
+    def fromBitMask(elems: Array[Long]): ValueSet = new ValueSet(immutable.BitSet.fromBitMask(elems))
+    /** A builder object for value sets */
+    def newBuilder: mutable.Builder[Value, ValueSet] = new mutable.Builder[Value, ValueSet] {
+      private[this] val b = new mutable.BitSet
+      def addOne (x: Value) = { b += (x.id - bottomId); this }
+      def clear() = b.clear()
+      def result() = new ValueSet(b.toImmutable)
+    }
+    def fromSpecific(it: IterableOnce[Value]): ValueSet =
+      newBuilder.addAll(it).result()
+  }
+}

--- a/scalalib/overrides-2.13.0-M4/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13.0-M4/scala/collection/immutable/NumericRange.scala
@@ -1,0 +1,409 @@
+package scala.collection.immutable
+
+import scala.collection.{SeqFactory, IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps}
+
+import java.lang.String
+
+import scala.collection.mutable.Builder
+
+/** `NumericRange` is a more generic version of the
+  *  `Range` class which works with arbitrary types.
+  *  It must be supplied with an `Integral` implementation of the
+  *  range type.
+  *
+  *  Factories for likely types include `Range.BigInt`, `Range.Long`,
+  *  and `Range.BigDecimal`.  `Range.Int` exists for completeness, but
+  *  the `Int`-based `scala.Range` should be more performant.
+  *
+  *  {{{
+  *     val r1 = new Range(0, 100, 1)
+  *     val veryBig = Int.MaxValue.toLong + 1
+  *     val r2 = Range.Long(veryBig, veryBig + 100, 1)
+  *     assert(r1 sameElements r2.map(_ - veryBig))
+  *  }}}
+  *
+  *  @define Coll `NumericRange`
+  *  @define coll numeric range
+  *  @define mayNotTerminateInf
+  *  @define willNotTerminateInf
+  */
+@SerialVersionUID(3L)
+sealed class NumericRange[T](
+  val start: T,
+  val end: T,
+  val step: T,
+  val isInclusive: Boolean
+)(implicit
+  num: Integral[T]
+)
+  extends AbstractSeq[T]
+    with IndexedSeq[T]
+    with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]
+    with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]]
+    with Serializable { self =>
+
+  override def iterator() = new Iterator[T] {
+    import num.mkNumericOps
+
+    private var _hasNext = !self.isEmpty
+    private var _next: T = start
+    private val lastElement: T = if (_hasNext) last else start
+    override def knownSize: Int = if (_hasNext) num.toInt((lastElement - _next) / step) + 1 else 0
+    def hasNext: Boolean = _hasNext
+    def next(): T = {
+      if (!_hasNext) Iterator.empty.next()
+      val value = _next
+      _hasNext = value != lastElement
+      _next = num.plus(value, step)
+      value
+    }
+  }
+
+  /** Note that NumericRange must be invariant so that constructs
+    *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
+    */
+  import num._
+
+  // See comment in Range for why this must be lazy.
+  override lazy val length: Int = NumericRange.count(start, end, step, isInclusive)
+  override def isEmpty = length == 0
+  override def last: T =
+    if (length == 0) Nil.head
+    else locationAfterN(length - 1)
+  override def init: NumericRange[T] =
+    if (isEmpty) Nil.init
+    else new NumericRange(start, end - step, step, isInclusive)
+
+  override def head: T = if (isEmpty) Nil.head else start
+  override def tail: NumericRange[T] =
+    if (isEmpty) Nil.tail
+    else if(isInclusive) new NumericRange.Inclusive(start + step, end, step)
+    else new NumericRange.Exclusive(start + step, end, step)
+
+  /** Create a new range with the start and end values of this range and
+    *  a new `step`.
+    */
+  def by(newStep: T): NumericRange[T] = copy(start, end, newStep)
+
+
+  /** Create a copy of this range.
+    */
+  def copy(start: T, end: T, step: T): NumericRange[T] =
+    new NumericRange(start, end, step, isInclusive)
+
+  @throws[IndexOutOfBoundsException]
+  def apply(idx: Int): T = {
+    if (idx < 0 || idx >= length) throw new IndexOutOfBoundsException(idx.toString)
+    else locationAfterN(idx)
+  }
+
+  override def foreach[@specialized(Unit) U](f: T => U): Unit = {
+    var count = 0
+    var current = start
+    while (count < length) {
+      f(current)
+      current += step
+      count += 1
+    }
+  }
+
+  // TODO: these private methods are straight copies from Range, duplicated
+  // to guard against any (most likely illusory) performance drop.  They should
+  // be eliminated one way or another.
+
+  // Tests whether a number is within the endpoints, without testing
+  // whether it is a member of the sequence (i.e. when step > 1.)
+  private def isWithinBoundaries(elem: T) = !isEmpty && (
+    (step > zero && start <= elem && elem <= last ) ||
+      (step < zero &&  last <= elem && elem <= start)
+    )
+  // Methods like apply throw exceptions on invalid n, but methods like take/drop
+  // are forgiving: therefore the checks are with the methods.
+  private def locationAfterN(n: Int): T = start + (step * fromInt(n))
+
+  // When one drops everything.  Can't ever have unchecked operations
+  // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
+  // will overflow.  This creates an exclusive range where start == end
+  // based on the given value.
+  private def newEmptyRange(value: T) = NumericRange(value, value, step)
+
+  override def take(n: Int): NumericRange[T] = {
+    if (n <= 0 || length == 0) newEmptyRange(start)
+    else if (n >= length) this
+    else new NumericRange.Inclusive(start, locationAfterN(n - 1), step)
+  }
+
+  override def drop(n: Int): NumericRange[T] = {
+    if (n <= 0 || length == 0) this
+    else if (n >= length) newEmptyRange(end)
+    else copy(locationAfterN(n), end, step)
+  }
+
+  override def splitAt(n: Int): (NumericRange[T], NumericRange[T]) = (take(n), drop(n))
+
+  override def reverse: NumericRange[T] =
+    if (isEmpty) this else new NumericRange.Inclusive(last, start, -step)
+
+  import NumericRange.defaultOrdering
+
+  override def min[T1 >: T](implicit ord: Ordering[T1]): T =
+  // We can take the fast path:
+  // - If the Integral of this NumericRange is also the requested Ordering
+  //   (Integral <: Ordering). This can happen for custom Integral types.
+  // - The Ordering is the default Ordering of a well-known Integral type.
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
+      if (num.signum(step) > 0) head
+      else last
+    } else super.min(ord)
+
+  override def max[T1 >: T](implicit ord: Ordering[T1]): T =
+  // See comment for fast path in min().
+    if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
+      if (num.signum(step) > 0) last
+      else head
+    } else super.max(ord)
+
+  // Motivated by the desire for Double ranges with BigDecimal precision,
+  // we need some way to map a Range and get another Range.  This can't be
+  // done in any fully general way because Ranges are not arbitrary
+  // sequences but step-valued, so we have a custom method only we can call
+  // which we promise to use responsibly.
+  //
+  // The point of it all is that
+  //
+  //   0.0 to 1.0 by 0.1
+  //
+  // should result in
+  //
+  //   NumericRange[Double](0.0, 0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0)
+  //
+  // and not
+  //
+  //   NumericRange[Double](0.0, 0.1, 0.2, 0.30000000000000004, 0.4, 0.5, 0.6000000000000001, 0.7000000000000001, 0.8, 0.9)
+  //
+  // or perhaps more importantly,
+  //
+  //   (0.1 to 0.3 by 0.1 contains 0.3) == true
+  //
+  private[immutable] def mapRange[A](fm: T => A)(implicit unum: Integral[A]): NumericRange[A] = {
+    val self = this
+
+    // XXX This may be incomplete.
+    new NumericRange[A](fm(start), fm(end), fm(step), isInclusive) {
+
+      private lazy val underlyingRange: NumericRange[T] = self
+      override def foreach[@specialized(Unit) U](f: A => U): Unit = { underlyingRange foreach (x => f(fm(x))) }
+      override def isEmpty = underlyingRange.isEmpty
+      override def apply(idx: Int): A = fm(underlyingRange(idx))
+      override def containsTyped(el: A) = underlyingRange exists (x => fm(x) == el)
+
+      override def toString = {
+        def simpleOf(x: Any): String = x.getClass.getName.split("\\.").last
+        val stepped = simpleOf(underlyingRange.step)
+        s"${super.toString} (using $underlyingRange of $stepped)"
+      }
+    }
+  }
+
+  // a well-typed contains method.
+  def containsTyped(x: T): Boolean =
+    isWithinBoundaries(x) && (((x - start) % step) == zero)
+
+  override def contains[A1 >: T](x: A1): Boolean =
+    try containsTyped(x.asInstanceOf[T])
+    catch { case _: ClassCastException => false }
+
+  override def sum[B >: T](implicit num: Numeric[B]): B = {
+    if (isEmpty) num.zero
+    else if (size == 1) head
+    else {
+      // If there is no overflow, use arithmetic series formula
+      //   a + ... (n terms total) ... + b = n*(a+b)/2
+      if ((num eq scala.math.Numeric.IntIsIntegral)||
+        (num eq scala.math.Numeric.ShortIsIntegral)||
+        (num eq scala.math.Numeric.ByteIsIntegral)||
+        (num eq scala.math.Numeric.CharIsIntegral)) {
+        // We can do math with no overflow in a Long--easy
+        val exact = (size * ((num toLong head) + (num toInt last))) / 2
+        num fromInt exact.toInt
+      }
+      else if (num eq scala.math.Numeric.LongIsIntegral) {
+        // Uh-oh, might be overflow, so we have to divide before we overflow.
+        // Either numRangeElements or (head + last) must be even, so divide the even one before multiplying
+        val a = head.toLong
+        val b = last.toLong
+        val ans =
+          if ((size & 1) == 0) (size / 2) * (a + b)
+          else size * {
+            // Sum is even, but we might overflow it, so divide in pieces and add back remainder
+            val ha = a/2
+            val hb = b/2
+            ha + hb + ((a - 2*ha) + (b - 2*hb)) / 2
+          }
+        ans.asInstanceOf[B]
+      }
+      else {
+        // User provided custom Numeric, so we cannot rely on arithmetic series formula (e.g. won't work on something like Z_6)
+        if (isEmpty) num.zero
+        else {
+          var acc = num.zero
+          var i = head
+          var idx = 0
+          while(idx < length) {
+            acc = num.plus(acc, i)
+            i = i + step
+            idx = idx + 1
+          }
+          acc
+        }
+      }
+    }
+  }
+
+  override lazy val hashCode: Int = super.hashCode()
+  override def equals(other: Any): Boolean = other match {
+    case x: NumericRange[_] =>
+      (x canEqual this) && (length == x.length) && (
+        (length == 0) ||                      // all empty sequences are equal
+          (start == x.start && last == x.last)  // same length and same endpoints implies equality
+        )
+    case _ =>
+      super.equals(other)
+  }
+
+  override def toString: String = {
+    val empty = if (isEmpty) "empty " else ""
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    s"${empty}NumericRange $start $preposition $end$stepped"
+  }
+}
+
+/** A companion object for numeric ranges.
+  *  @define Coll `NumericRange`
+  *  @define coll numeric range
+  */
+object NumericRange {
+
+  /** Calculates the number of elements in a range given start, end, step, and
+    *  whether or not it is inclusive.  Throws an exception if step == 0 or
+    *  the number of elements exceeds the maximum Int.
+    */
+  def count[T](start: T, end: T, step: T, isInclusive: Boolean)(implicit num: Integral[T]): Int = {
+    val zero    = num.zero
+    val upward  = num.lt(start, end)
+    val posStep = num.gt(step, zero)
+
+    if (step == zero) throw new IllegalArgumentException("step cannot be 0.")
+    else if (start == end) if (isInclusive) 1 else 0
+    else if (upward != posStep) 0
+    else {
+      /* We have to be frightfully paranoid about running out of range.
+       * We also can't assume that the numbers will fit in a Long.
+       * We will assume that if a > 0, -a can be represented, and if
+       * a < 0, -a+1 can be represented.  We also assume that if we
+       * can't fit in Int, we can represent 2*Int.MaxValue+3 (at least).
+       * And we assume that numbers wrap rather than cap when they overflow.
+       */
+      // Check whether we can short-circuit by deferring to Int range.
+      val startint = num.toInt(start)
+      if (start == num.fromInt(startint)) {
+        val endint = num.toInt(end)
+        if (end == num.fromInt(endint)) {
+          val stepint = num.toInt(step)
+          if (step == num.fromInt(stepint)) {
+            return {
+              if (isInclusive) Range.inclusive(startint, endint, stepint).length
+              else             Range          (startint, endint, stepint).length
+            }
+          }
+        }
+      }
+      // If we reach this point, deferring to Int failed.
+      // Numbers may be big.
+      val one = num.one
+      val limit = num.fromInt(Int.MaxValue)
+      def check(t: T): T =
+        if (num.gt(t, limit)) throw new IllegalArgumentException("More than Int.MaxValue elements.")
+        else t
+      // If the range crosses zero, it might overflow when subtracted
+      val startside = num.signum(start)
+      val endside = num.signum(end)
+      num.toInt{
+        if (startside*endside >= 0) {
+          // We're sure we can subtract these numbers.
+          // Note that we do not use .rem because of different conventions for Long and BigInt
+          val diff = num.minus(end, start)
+          val quotient = check(num.quot(diff, step))
+          val remainder = num.minus(diff, num.times(quotient, step))
+          if (!isInclusive && zero == remainder) quotient else check(num.plus(quotient, one))
+        }
+        else {
+          // We might not even be able to subtract these numbers.
+          // Jump in three pieces:
+          //   * start to -1 or 1, whichever is closer (waypointA)
+          //   * one step, which will take us at least to 0 (ends at waypointB)
+          //   * there to the end
+          val negone = num.fromInt(-1)
+          val startlim  = if (posStep) negone else one
+          val startdiff = num.minus(startlim, start)
+          val startq    = check(num.quot(startdiff, step))
+          val waypointA = if (startq == zero) start else num.plus(start, num.times(startq, step))
+          val waypointB = num.plus(waypointA, step)
+          check {
+            if (num.lt(waypointB, end) != upward) {
+              // No last piece
+              if (isInclusive && waypointB == end) num.plus(startq, num.fromInt(2))
+              else num.plus(startq, one)
+            }
+            else {
+              // There is a last piece
+              val enddiff = num.minus(end,waypointB)
+              val endq    = check(num.quot(enddiff, step))
+              val last    = if (endq == zero) waypointB else num.plus(waypointB, num.times(endq, step))
+              // Now we have to tally up all the pieces
+              //   1 for the initial value
+              //   startq steps to waypointA
+              //   1 step to waypointB
+              //   endq steps to the end (one less if !isInclusive and last==end)
+              num.plus(startq, num.plus(endq, if (!isInclusive && last==end) one else num.fromInt(2)))
+            }
+          }
+        }
+      }
+    }
+  }
+
+  @SerialVersionUID(3L)
+  class Inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
+    extends NumericRange(start, end, step, true) {
+    override def copy(start: T, end: T, step: T): Inclusive[T] =
+      NumericRange.inclusive(start, end, step)
+
+    def exclusive: Exclusive[T] = NumericRange(start, end, step)
+  }
+
+  @SerialVersionUID(3L)
+  class Exclusive[T](start: T, end: T, step: T)(implicit num: Integral[T])
+    extends NumericRange(start, end, step, false) {
+    override def copy(start: T, end: T, step: T): Exclusive[T] =
+      NumericRange(start, end, step)
+
+    def inclusive: Inclusive[T] = NumericRange.inclusive(start, end, step)
+  }
+
+  def apply[T](start: T, end: T, step: T)(implicit num: Integral[T]): Exclusive[T] =
+    new Exclusive(start, end, step)
+  def inclusive[T](start: T, end: T, step: T)(implicit num: Integral[T]): Inclusive[T] =
+    new Inclusive(start, end, step)
+
+  private[collection] val defaultOrdering = Map[Numeric[_], Ordering[_]](
+    Numeric.IntIsIntegral -> Ordering.Int,
+    Numeric.ShortIsIntegral -> Ordering.Short,
+    Numeric.ByteIsIntegral -> Ordering.Byte,
+    Numeric.CharIsIntegral -> Ordering.Char,
+    Numeric.LongIsIntegral -> Ordering.Long
+  )
+
+}
+

--- a/scalalib/overrides-2.13.0-M4/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13.0-M4/scala/collection/immutable/Range.scala
@@ -1,0 +1,547 @@
+package scala
+package collection.immutable
+
+import collection.{Iterator, SeqFactory}
+
+import java.lang.String
+
+import scala.collection.mutable.Builder
+
+/** The `Range` class represents integer values in range
+  *  ''[start;end)'' with non-zero step value `step`.
+  *  It's a special case of an indexed sequence.
+  *  For example:
+  *
+  *  {{{
+  *     val r1 = 0 until 10
+  *     val r2 = r1.start until r1.end by r1.step + 1
+  *     println(r2.length) // = 5
+  *  }}}
+  *
+  *  Ranges that contain more than `Int.MaxValue` elements can be created, but
+  *  these overfull ranges have only limited capabilities. Any method that
+  *  could require a collection of over `Int.MaxValue` length to be created, or
+  *  could be asked to index beyond `Int.MaxValue` elements will throw an
+  *  exception. Overfull ranges can safely be reduced in size by changing
+  *  the step size (e.g. `by 3`) or taking/dropping elements. `contains`,
+  *  `equals`, and access to the ends of the range (`head`, `last`, `tail`,
+  *  `init`) are also permitted on overfull ranges.
+  *
+  *  @param start       the start of this range.
+  *  @param end         the end of the range.  For exclusive ranges, e.g.
+  *                     `Range(0,3)` or `(0 until 3)`, this is one
+  *                     step past the last one in the range.  For inclusive
+  *                     ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
+  *                     it may be in the range if it is not skipped by the step size.
+  *                     To find the last element inside a non-empty range,
+  *                     use `last` instead.
+  *  @param step        the step for the range.
+  *
+  *  @define coll range
+  *  @define mayNotTerminateInf
+  *  @define willNotTerminateInf
+  *  @define doesNotUseBuilders
+  *    '''Note:''' this method does not use builders to construct a new range,
+  *         and its complexity is O(1).
+  */
+@SerialVersionUID(3L)
+sealed abstract class Range(
+  val start: Int,
+  val end: Int,
+  val step: Int
+)
+  extends AbstractSeq[Int]
+    with IndexedSeq[Int]
+    with IndexedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
+    with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
+    with Serializable { range =>
+
+  override def iterator(): Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
+
+  private def gap           = end.toLong - start.toLong
+  private def isExact       = gap % step == 0
+  private def hasStub       = isInclusive || !isExact
+  private def longLength    = gap / step + ( if (hasStub) 1 else 0 )
+
+  def isInclusive: Boolean
+
+  override val isEmpty: Boolean = (
+    (start > end && step > 0)
+      || (start < end && step < 0)
+      || (start == end && !isInclusive)
+    )
+
+  private val numRangeElements: Int = {
+    if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
+    else if (isEmpty) 0
+    else {
+      val len = longLength
+      if (len > scala.Int.MaxValue) -1
+      else len.toInt
+    }
+  }
+
+  def length = if (numRangeElements < 0) fail() else numRangeElements
+
+  // This field has a sensible value only for non-empty ranges
+  private val lastElement = step match {
+    case 1  => if (isInclusive) end else end-1
+    case -1 => if (isInclusive) end else end+1
+    case _  =>
+      val remainder = (gap % step).toInt
+      if (remainder != 0) end - remainder
+      else if (isInclusive) end
+      else end - step
+  }
+
+  /** The last element of this range.  This method will return the correct value
+    *  even if there are too many elements to iterate over.
+    */
+  override def last: Int = if (isEmpty) Nil.head else lastElement
+  override def head: Int = if (isEmpty) Nil.head else start
+
+  /** Creates a new range containing all the elements of this range except the last one.
+    *
+    *  $doesNotUseBuilders
+    *
+    *  @return  a new range consisting of all the elements of this range except the last one.
+    */
+  override def init: Range = {
+    if (isEmpty)
+      Nil.init
+
+    dropRight(1)
+  }
+
+  /** Creates a new range containing all the elements of this range except the first one.
+    *
+    *  $doesNotUseBuilders
+    *
+    *  @return  a new range consisting of all the elements of this range except the first one.
+    */
+  override def tail: Range = {
+    if (isEmpty)
+      Nil.tail
+    if (numRangeElements == 1) newEmptyRange(end)
+    else if(isInclusive) new Range.Inclusive(start + step, end, step)
+    else new Range.Exclusive(start + step, end, step)
+  }
+
+  protected def copy(start: Int = start, end: Int = end, step: Int = step, isInclusive: Boolean = isInclusive): Range =
+    if(isInclusive) new Range.Inclusive(start, end, step) else new Range.Exclusive(start, end, step)
+
+  /** Create a new range with the `start` and `end` values of this range and
+    *  a new `step`.
+    *
+    *  @return a new range with a different step
+    */
+  def by(step: Int): Range = copy(start, end, step)
+
+  // Check cannot be evaluated eagerly because we have a pattern where
+  // ranges are constructed like: "x to y by z" The "x to y" piece
+  // should not trigger an exception. So the calculation is delayed,
+  // which means it will not fail fast for those cases where failing was
+  // correct.
+  private def validateMaxLength(): Unit = {
+    if (numRangeElements < 0)
+      fail()
+  }
+  private def fail() = Range.fail(start, end, step, isInclusive)
+
+  @throws[IndexOutOfBoundsException]
+  def apply(idx: Int): Int = {
+    validateMaxLength()
+    if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(idx.toString)
+    else start + (step * idx)
+  }
+
+  /*@`inline`*/ override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
+    // Implementation chosen on the basis of favorable microbenchmarks
+    // Note--initialization catches step == 0 so we don't need to here
+    if (!isEmpty) {
+      var i = start
+      while (true) {
+        f(i)
+        if (i == lastElement) return
+        i += step
+      }
+    }
+  }
+
+  /** Creates a new range containing the first `n` elements of this range.
+    *
+    *  @param n  the number of elements to take.
+    *  @return   a new range consisting of `n` first elements.
+    */
+  override def take(n: Int): Range =
+    if (n <= 0 || isEmpty) newEmptyRange(start)
+    else if (n >= numRangeElements && numRangeElements >= 0) this
+    else {
+      // May have more than Int.MaxValue elements in range (numRangeElements < 0)
+      // but the logic is the same either way: take the first n
+      new Range.Inclusive(start, locationAfterN(n - 1), step)
+    }
+
+  /** Creates a new range containing all the elements of this range except the first `n` elements.
+    *
+    *  @param n  the number of elements to drop.
+    *  @return   a new range consisting of all the elements of this range except `n` first elements.
+    */
+  override def drop(n: Int): Range =
+    if (n <= 0 || isEmpty) this
+    else if (n >= numRangeElements && numRangeElements >= 0) newEmptyRange(end)
+    else {
+      // May have more than Int.MaxValue elements (numRangeElements < 0)
+      // but the logic is the same either way: go forwards n steps, keep the rest
+      copy(locationAfterN(n), end, step)
+    }
+
+  /** Creates a new range consisting of the last `n` elements of the range.
+    *
+    *  $doesNotUseBuilders
+    */
+  override def takeRight(n: Int): Range = {
+    if (n <= 0) newEmptyRange(start)
+    else if (numRangeElements >= 0) drop(numRangeElements - n)
+    else {
+      // Need to handle over-full range separately
+      val y = last
+      val x = y - step.toLong*(n-1)
+      if ((step > 0 && x < start) || (step < 0 && x > start)) this
+      else Range.inclusive(x.toInt, y, step)
+    }
+  }
+
+  /** Creates a new range consisting of the initial `length - n` elements of the range.
+    *
+    *  $doesNotUseBuilders
+    */
+  override def dropRight(n: Int): Range = {
+    if (n <= 0) this
+    else if (numRangeElements >= 0) take(numRangeElements - n)
+    else {
+      // Need to handle over-full range separately
+      val y = last - step.toInt*n
+      if ((step > 0 && y < start) || (step < 0 && y > start)) newEmptyRange(start)
+      else Range.inclusive(start, y.toInt, step)
+    }
+  }
+
+  // Advance from the start while we meet the given test
+  private def argTakeWhile(p: Int => Boolean): Long = {
+    if (isEmpty) start
+    else {
+      var current = start
+      val stop = last
+      while (current != stop && p(current)) current += step
+      if (current != stop || !p(current)) current
+      else current.toLong + step
+    }
+  }
+
+  override def takeWhile(p: Int => Boolean): Range = {
+    val stop = argTakeWhile(p)
+    if (stop==start) newEmptyRange(start)
+    else {
+      val x = (stop - step).toInt
+      if (x == last) this
+      else Range.inclusive(start, x, step)
+    }
+  }
+
+  override def dropWhile(p: Int => Boolean): Range = {
+    val stop = argTakeWhile(p)
+    if (stop == start) this
+    else {
+      val x = (stop - step).toInt
+      if (x == last) newEmptyRange(last)
+      else Range.inclusive(x + step, last, step)
+    }
+  }
+
+  override def span(p: Int => Boolean): (Range, Range) = {
+    val border = argTakeWhile(p)
+    if (border == start) (newEmptyRange(start), this)
+    else {
+      val x = (border - step).toInt
+      if (x == last) (this, newEmptyRange(last))
+      else (Range.inclusive(start, x, step), Range.inclusive(x+step, last, step))
+    }
+  }
+
+  /** Creates a new range containing the elements starting at `from` up to but not including `until`.
+    *
+    *  $doesNotUseBuilders
+    *
+    *  @param from  the element at which to start
+    *  @param until  the element at which to end (not included in the range)
+    *  @return   a new range consisting of a contiguous interval of values in the old range
+    */
+  override def slice(from: Int, until: Int): Range =
+    if (from <= 0) take(until)
+    else if (until >= numRangeElements && numRangeElements >= 0) drop(from)
+    else {
+      val fromValue = locationAfterN(from)
+      if (from >= until) newEmptyRange(fromValue)
+      else Range.inclusive(fromValue, locationAfterN(until-1), step)
+    }
+
+  // Overridden only to refine the return type
+  override def splitAt(n: Int): (Range, Range) = (take(n), drop(n))
+
+  // Methods like apply throw exceptions on invalid n, but methods like take/drop
+  // are forgiving: therefore the checks are with the methods.
+  private def locationAfterN(n: Int) = start + (step * n)
+
+  // When one drops everything.  Can't ever have unchecked operations
+  // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
+  // will overflow.  This creates an exclusive range where start == end
+  // based on the given value.
+  private def newEmptyRange(value: Int) = new Range.Exclusive(value, value, step)
+
+  /** Returns the reverse of this range.
+    */
+  override def reverse: Range =
+    if (isEmpty) this
+    else new Range.Inclusive(last, start, -step)
+
+  /** Make range inclusive.
+    */
+  def inclusive: Range =
+    if (isInclusive) this
+    else new Range.Inclusive(start, end, step)
+
+  def contains(x: Int) = {
+    if (x == end && !isInclusive) false
+    else if (step > 0) {
+      if (x < start || x > end) false
+      else (step == 1) || (((x - start) % step) == 0)
+    }
+    else {
+      if (x < end || x > start) false
+      else (step == -1) || (((x - start) % step) == 0)
+    }
+  }
+
+  override def sum[B >: Int](implicit num: Numeric[B]): Int = {
+    if (num eq scala.math.Numeric.IntIsIntegral) {
+      // this is normal integer range with usual addition. arithmetic series formula can be used
+      if (isEmpty) 0
+      else if (size == 1) head
+      else ((size * (head.toLong + last)) / 2).toInt
+    } else {
+      // user provided custom Numeric, we cannot rely on arithmetic series formula
+      if (isEmpty) num.toInt(num.zero)
+      else {
+        var acc = num.zero
+        var i = head
+        while (true) {
+          acc = num.plus(acc, i)
+          if (i == lastElement) return num.toInt(acc)
+          i = i + step
+        }
+        0 // Never hit this--just to satisfy compiler since it doesn't know while(true) has type Nothing
+      }
+    }
+  }
+
+  override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
+    if (ord eq Ordering.Int) {
+      if (step > 0) head
+      else last
+    } else super.min(ord)
+
+  override def max[A1 >: Int](implicit ord: Ordering[A1]): Int =
+    if (ord eq Ordering.Int) {
+      if (step > 0) last
+      else head
+    } else super.max(ord)
+
+
+  override def equals(other: Any) = other match {
+    case x: Range =>
+      // Note: this must succeed for overfull ranges (length > Int.MaxValue)
+      if (isEmpty) x.isEmpty                  // empty sequences are equal
+      else                                    // this is non-empty...
+        x.nonEmpty && start == x.start && {   // ...so other must contain something and have same start
+          val l0 = last
+          (l0 == x.last && (                    // And same end
+            start == l0 || step == x.step       // And either the same step, or not take any steps
+          ))
+        }
+    case _ =>
+      super.equals(other)
+  }
+
+  /* Note: hashCode can't be overridden without breaking Seq's equals contract. */
+
+  override def toString: String = {
+    val preposition = if (isInclusive) "to" else "until"
+    val stepped = if (step == 1) "" else s" by $step"
+    val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
+    s"${prefix}Range $start $preposition $end$stepped"
+  }
+
+}
+
+/**
+  * Companion object for ranges.
+  *  @define Coll `Range`
+  *  @define coll range
+  */
+object Range {
+
+  private def description(start: Int, end: Int, step: Int, isInclusive: Boolean) =
+    start + (if (isInclusive) " to " else " until ") + end + " by " + step
+
+  private def fail(start: Int, end: Int, step: Int, isInclusive: Boolean) =
+    throw new IllegalArgumentException(description(start, end, step, isInclusive) +
+        ": seqs cannot contain more than Int.MaxValue elements.")
+
+  /** Counts the number of range elements.
+    *  precondition:  step != 0
+    *  If the size of the range exceeds Int.MaxValue, the
+    *  result will be negative.
+    */
+  def count(start: Int, end: Int, step: Int, isInclusive: Boolean): Int = {
+    if (step == 0)
+      throw new IllegalArgumentException("step cannot be 0.")
+
+    val isEmpty =
+      if (start == end) !isInclusive
+      else if (start < end) step < 0
+      else step > 0
+
+    if (isEmpty) 0
+    else {
+      // Counts with Longs so we can recognize too-large ranges.
+      val gap: Long    = end.toLong - start.toLong
+      val jumps: Long  = gap / step
+      // Whether the size of this range is one larger than the
+      // number of full-sized jumps.
+      val hasStub      = isInclusive || (gap % step != 0)
+      val result: Long = jumps + ( if (hasStub) 1 else 0 )
+
+      if (result > scala.Int.MaxValue) -1
+      else result.toInt
+    }
+  }
+  def count(start: Int, end: Int, step: Int): Int =
+    count(start, end, step, isInclusive = false)
+
+  /** Make a range from `start` until `end` (exclusive) with given step value.
+    * @note step != 0
+    */
+  def apply(start: Int, end: Int, step: Int): Range.Exclusive = new Range.Exclusive(start, end, step)
+
+  /** Make a range from `start` until `end` (exclusive) with step value 1.
+    */
+  def apply(start: Int, end: Int): Range.Exclusive = new Range.Exclusive(start, end, 1)
+
+  /** Make an inclusive range from `start` to `end` with given step value.
+    * @note step != 0
+    */
+  def inclusive(start: Int, end: Int, step: Int): Range.Inclusive = new Range.Inclusive(start, end, step)
+
+  /** Make an inclusive range from `start` to `end` with step value 1.
+    */
+  def inclusive(start: Int, end: Int): Range.Inclusive = new Range.Inclusive(start, end, 1)
+
+  @SerialVersionUID(3L)
+  @inline
+  final class Inclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
+    def isInclusive = true
+  }
+
+  @SerialVersionUID(3L)
+  @inline
+  final class Exclusive(start: Int, end: Int, step: Int) extends Range(start, end, step) {
+    def isInclusive = false
+  }
+
+  // BigInt and Long are straightforward generic ranges.
+  object BigInt {
+    def apply(start: BigInt, end: BigInt, step: BigInt) = NumericRange(start, end, step)
+    def inclusive(start: BigInt, end: BigInt, step: BigInt) = NumericRange.inclusive(start, end, step)
+  }
+
+  object Long {
+    def apply(start: Long, end: Long, step: Long) = NumericRange(start, end, step)
+    def inclusive(start: Long, end: Long, step: Long) = NumericRange.inclusive(start, end, step)
+  }
+
+  // BigDecimal uses an alternative implementation of Numeric in which
+  // it pretends to be Integral[T] instead of Fractional[T].  See Numeric for
+  // details.  The intention is for it to throw an exception anytime
+  // imprecision or surprises might result from anything, although this may
+  // not yet be fully implemented.
+  object BigDecimal {
+    implicit val bigDecAsIntegral: Numeric.BigDecimalAsIfIntegral = Numeric.BigDecimalAsIfIntegral
+
+    def apply(start: BigDecimal, end: BigDecimal, step: BigDecimal) =
+      NumericRange(start, end, step)
+    def inclusive(start: BigDecimal, end: BigDecimal, step: BigDecimal) =
+      NumericRange.inclusive(start, end, step)
+  }
+
+  // Double works by using a BigDecimal under the hood for precise
+  // stepping, but mapping the sequence values back to doubles with
+  // .doubleValue.  This constructs the BigDecimals by way of the
+  // String constructor (valueOf) instead of the Double one, which
+  // is necessary to keep 0.3d at 0.3 as opposed to
+  // 0.299999999999999988897769753748434595763683319091796875 or so.
+  object Double {
+    implicit val bigDecAsIntegral: Numeric.BigDecimalAsIfIntegral = Numeric.BigDecimalAsIfIntegral
+    implicit val doubleAsIntegral: Numeric.DoubleAsIfIntegral = Numeric.DoubleAsIfIntegral
+    def toBD(x: Double): BigDecimal = scala.math.BigDecimal valueOf x
+
+    @deprecated("use Range.BigDecimal instead", "2.12.6")
+    def apply(start: Double, end: Double, step: Double) =
+      BigDecimal(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
+
+    @deprecated("use Range.BigDecimal.inclusive instead", "2.12.6")
+    def inclusive(start: Double, end: Double, step: Double) =
+      BigDecimal.inclusive(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
+  }
+
+  // As there is no appealing default step size for not-really-integral ranges,
+  // we offer a partially constructed object.
+  class Partial[T, U](private val f: T => U) extends AnyVal {
+    def by(x: T): U = f(x)
+    override def toString = "Range requires step"
+  }
+
+  // Illustrating genericity with Int Range, which should have the same behavior
+  // as the original Range class.  However we leave the original Range
+  // indefinitely, for performance and because the compiler seems to bootstrap
+  // off it and won't do so with our parameterized version without modifications.
+  object Int {
+    def apply(start: Int, end: Int, step: Int) = NumericRange(start, end, step)
+    def inclusive(start: Int, end: Int, step: Int) = NumericRange.inclusive(start, end, step)
+  }
+
+}
+
+/**
+  * @param lastElement The last element included in the Range
+  * @param initiallyEmpty Whether the Range was initially empty or not
+  */
+private class RangeIterator(
+  start: Int,
+  step: Int,
+  lastElement: Int,
+  initiallyEmpty: Boolean
+) extends Iterator[Int] {
+  private var _hasNext: Boolean = !initiallyEmpty
+  private var _next: Int = start
+  override def knownSize: Int = if (_hasNext) (lastElement - _next) / step + 1 else 0
+  def hasNext: Boolean = _hasNext
+  @throws[NoSuchElementException]
+  def next(): Int = {
+    if (!_hasNext) Iterator.empty.next()
+    val value = _next
+    _hasNext = value != lastElement
+    _next = value + step
+    value
+  }
+}

--- a/scalalib/overrides-2.13.0-M4/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.13.0-M4/scala/runtime/ScalaRunTime.scala
@@ -1,0 +1,282 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___     Scala API                            **
+**    / __/ __// _ | / /  / _ |    (c) 2002-2013, LAMP/EPFL             **
+**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
+** /____/\___/_/ |_/____/_/ | |                                         **
+**                          |/                                          **
+\*                                                                      */
+
+package scala
+package runtime
+
+import scala.collection.{ AbstractIterator, AnyConstr, SortedOps, StrictOptimizedIterableOps, StringOps, StringView, View }
+import scala.collection.generic.IsIterableLike
+import scala.collection.immutable.{ NumericRange, ArraySeq }
+import scala.collection.mutable.StringBuilder
+import scala.reflect.{ ClassTag, classTag }
+import java.lang.{ Class => jClass }
+
+import java.lang.reflect.{ Method => JMethod }
+
+/** The object ScalaRunTime provides support methods required by
+ *  the scala runtime.  All these methods should be considered
+ *  outside the API and subject to change or removal without notice.
+ */
+object ScalaRunTime {
+  def isArray(x: Any, atLevel: Int = 1): Boolean =
+    x != null && isArrayClass(x.getClass, atLevel)
+
+  private def isArrayClass(clazz: jClass[_], atLevel: Int): Boolean =
+    clazz != null && clazz.isArray && (atLevel == 1 || isArrayClass(clazz.getComponentType, atLevel - 1))
+
+  // A helper method to make my life in the pattern matcher a lot easier.
+  def drop[Repr](coll: Repr, num: Int)(implicit iterable: IsIterableLike[Repr]): Repr =
+    iterable conversion coll drop num
+
+  /** Return the class object representing an array with element class `clazz`.
+   */
+  def arrayClass(clazz: jClass[_]): jClass[_] = {
+    // newInstance throws an exception if the erasure is Void.TYPE. see scala/bug#5680
+    if (clazz == java.lang.Void.TYPE) classOf[Array[Unit]]
+    else java.lang.reflect.Array.newInstance(clazz, 0).getClass
+  }
+
+  /** Return the class object representing an unboxed value type,
+   *  e.g., classOf[int], not classOf[java.lang.Integer].  The compiler
+   *  rewrites expressions like 5.getClass to come here.
+   */
+  def anyValClass[T <: AnyVal : ClassTag](value: T): jClass[T] =
+    classTag[T].runtimeClass.asInstanceOf[jClass[T]]
+
+  /** Retrieve generic array element */
+  def array_apply(xs: AnyRef, idx: Int): Any = {
+    xs match {
+      case x: Array[AnyRef]  => x(idx).asInstanceOf[Any]
+      case x: Array[Int]     => x(idx).asInstanceOf[Any]
+      case x: Array[Double]  => x(idx).asInstanceOf[Any]
+      case x: Array[Long]    => x(idx).asInstanceOf[Any]
+      case x: Array[Float]   => x(idx).asInstanceOf[Any]
+      case x: Array[Char]    => x(idx).asInstanceOf[Any]
+      case x: Array[Byte]    => x(idx).asInstanceOf[Any]
+      case x: Array[Short]   => x(idx).asInstanceOf[Any]
+      case x: Array[Boolean] => x(idx).asInstanceOf[Any]
+      case x: Array[Unit]    => x(idx).asInstanceOf[Any]
+      case null => throw new NullPointerException
+    }
+  }
+
+  /** update generic array element */
+  def array_update(xs: AnyRef, idx: Int, value: Any): Unit = {
+    xs match {
+      case x: Array[AnyRef]  => x(idx) = value.asInstanceOf[AnyRef]
+      case x: Array[Int]     => x(idx) = value.asInstanceOf[Int]
+      case x: Array[Double]  => x(idx) = value.asInstanceOf[Double]
+      case x: Array[Long]    => x(idx) = value.asInstanceOf[Long]
+      case x: Array[Float]   => x(idx) = value.asInstanceOf[Float]
+      case x: Array[Char]    => x(idx) = value.asInstanceOf[Char]
+      case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
+      case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
+      case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
+      case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
+      case null => throw new NullPointerException
+    }
+  }
+
+  /** Get generic array length */
+  def array_length(xs: AnyRef): Int = xs match {
+    case x: Array[AnyRef]  => x.length
+    case x: Array[Int]     => x.length
+    case x: Array[Double]  => x.length
+    case x: Array[Long]    => x.length
+    case x: Array[Float]   => x.length
+    case x: Array[Char]    => x.length
+    case x: Array[Byte]    => x.length
+    case x: Array[Short]   => x.length
+    case x: Array[Boolean] => x.length
+    case x: Array[Unit]    => x.length
+    case null => throw new NullPointerException
+  }
+
+  def array_clone(xs: AnyRef): AnyRef = xs match {
+    case x: Array[AnyRef]  => x.clone()
+    case x: Array[Int]     => x.clone()
+    case x: Array[Double]  => x.clone()
+    case x: Array[Long]    => x.clone()
+    case x: Array[Float]   => x.clone()
+    case x: Array[Char]    => x.clone()
+    case x: Array[Byte]    => x.clone()
+    case x: Array[Short]   => x.clone()
+    case x: Array[Boolean] => x.clone()
+    case x: Array[Unit]    => x
+    case null => throw new NullPointerException
+  }
+
+  /** Convert an array to an object array.
+   *  Needed to deal with vararg arguments of primitive types that are passed
+   *  to a generic Java vararg parameter T ...
+   */
+  def toObjectArray(src: AnyRef): Array[Object] = src match {
+    case x: Array[AnyRef] => x
+    case _ =>
+      val length = array_length(src)
+      val dest = new Array[Object](length)
+      for (i <- 0 until length)
+        array_update(dest, i, array_apply(src, i))
+      dest
+  }
+
+  def toArray[T](xs: scala.collection.Seq[T]) = {
+    val arr = new Array[AnyRef](xs.length)
+    var i = 0
+    for (x <- xs) {
+      arr(i) = x.asInstanceOf[AnyRef]
+      i += 1
+    }
+    arr
+  }
+
+  // Java bug: https://bugs.java.com/view_bug.do?bug_id=4071957
+  // More background at ticket #2318.
+  def ensureAccessible(m: JMethod): JMethod = scala.reflect.ensureAccessible(m)
+
+  def _toString(x: Product): String =
+    x.productIterator.mkString(x.productPrefix + "(", ",", ")")
+
+  def _hashCode(x: Product): Int = scala.util.hashing.MurmurHash3.productHash(x)
+
+  /** A helper for case classes. */
+  def typedProductIterator[T](x: Product): Iterator[T] = {
+    new AbstractIterator[T] {
+      private var c: Int = 0
+      private val cmax = x.productArity
+      def hasNext = c < cmax
+      def next() = {
+        val result = x.productElement(c)
+        c += 1
+        result.asInstanceOf[T]
+      }
+    }
+  }
+
+  /** Given any Scala value, convert it to a String.
+   *
+   * The primary motivation for this method is to provide a means for
+   * correctly obtaining a String representation of a value, while
+   * avoiding the pitfalls of naively calling toString on said value.
+   * In particular, it addresses the fact that (a) toString cannot be
+   * called on null and (b) depending on the apparent type of an
+   * array, toString may or may not print it in a human-readable form.
+   *
+   * @param   arg   the value to stringify
+   * @return        a string representation of arg.
+   */
+  def stringOf(arg: Any): String = stringOf(arg, scala.Int.MaxValue)
+  def stringOf(arg: Any, maxElements: Int): String = {
+    def packageOf(x: AnyRef) = x.getClass.getPackage match {
+      case null   => ""
+      case p      => p.getName
+    }
+    def isScalaClass(x: AnyRef)         = packageOf(x) startsWith "scala."
+    def isScalaCompilerClass(x: AnyRef) = packageOf(x) startsWith "scala.tools.nsc."
+
+    // includes specialized subclasses and future proofed against hypothetical TupleN (for N > 22)
+    def isTuple(x: Any) = x != null && x.getClass.getName.startsWith("scala.Tuple")
+
+    // We use reflection because the scala.xml package might not be available
+    def isSubClassOf(potentialSubClass: Class[_], ofClass: String) =
+      try {
+        val classLoader = potentialSubClass.getClassLoader
+        val clazz = Class.forName(ofClass, /*initialize =*/ false, classLoader)
+        clazz.isAssignableFrom(potentialSubClass)
+      } catch {
+        case cnfe: ClassNotFoundException => false
+      }
+    def isXmlNode(potentialSubClass: Class[_])     = isSubClassOf(potentialSubClass, "scala.xml.Node")
+    def isXmlMetaData(potentialSubClass: Class[_]) = isSubClassOf(potentialSubClass, "scala.xml.MetaData")
+
+    // When doing our own iteration is dangerous
+    def useOwnToString(x: Any) = x match {
+      // Range/NumericRange have a custom toString to avoid walking a gazillion elements
+      case _: Range | _: NumericRange[_] => true
+      // Sorted collections to the wrong thing (for us) on iteration - ticket #3493
+      case _: SortedOps[_, _]  => true
+      // StringBuilder(a, b, c) and similar not so attractive
+      case _: StringView | _: StringOps | _: StringBuilder => true
+      // Don't want to evaluate any elements in a view
+      case _: View[_] => true
+      // Node extends NodeSeq extends Seq[Node] and MetaData extends Iterable[MetaData]
+      // -> catch those by isXmlNode and isXmlMetaData.
+      // Don't want to a) traverse infinity or b) be overly helpful with peoples' custom
+      // collections which may have useful toString methods - ticket #3710
+      // or c) print AbstractFiles which are somehow also Iterable[AbstractFile]s.
+      case x: Iterable[_] => (!x.isInstanceOf[StrictOptimizedIterableOps[_, AnyConstr, _]]) || !isScalaClass(x) || isScalaCompilerClass(x) || isXmlNode(x.getClass) || isXmlMetaData(x.getClass)
+      // Otherwise, nothing could possibly go wrong
+      case _ => false
+    }
+
+    // A variation on inner for maps so they print -> instead of bare tuples
+    def mapInner(arg: Any): String = arg match {
+      case (k, v)   => inner(k) + " -> " + inner(v)
+      case _        => inner(arg)
+    }
+
+    // Special casing Unit arrays, the value class which uses a reference array type.
+    def arrayToString(x: AnyRef) = {
+      if (x.getClass.getComponentType == classOf[BoxedUnit])
+        0 until (array_length(x) min maxElements) map (_ => "()") mkString ("Array(", ", ", ")")
+      else
+        x.asInstanceOf[Array[_]].iterator.take(maxElements).map(inner).mkString("Array(", ", ", ")")
+    }
+
+    // The recursively applied attempt to prettify Array printing.
+    // Note that iterator is used if possible and foreach is used as a
+    // last resort, because the parallel collections "foreach" in a
+    // random order even on sequences.
+    def inner(arg: Any): String = arg match {
+      case null                         => "null"
+      case ""                           => "\"\""
+      case x: String                    => if (x.head.isWhitespace || x.last.isWhitespace) "\"" + x + "\"" else x
+      case x if useOwnToString(x)       => x.toString
+      case x: AnyRef if isArray(x)      => arrayToString(x)
+      case x: scala.collection.Map[_, _] => x.iterator take maxElements map mapInner mkString (x.className + "(", ", ", ")")
+      case x: Iterable[_]               => x.iterator take maxElements map inner mkString (x.className + "(", ", ", ")")
+      case x: Product1[_] if isTuple(x) => "(" + inner(x._1) + ",)" // that special trailing comma
+      case x: Product if isTuple(x)     => x.productIterator map inner mkString ("(", ",", ")")
+      case x                            => x.toString
+    }
+
+    // The try/catch is defense against iterables which aren't actually designed
+    // to be iterated, such as some scala.tools.nsc.io.AbstractFile derived classes.
+    try inner(arg)
+    catch {
+      case _: UnsupportedOperationException | _: AssertionError => "" + arg
+    }
+  }
+
+  /** stringOf formatted for use in a repl result. */
+  def replStringOf(arg: Any, maxElements: Int): String = {
+    val s  = stringOf(arg, maxElements)
+    val nl = if (s contains "\n") "\n" else ""
+
+    nl + s + "\n"
+  }
+
+  // Convert arrays to immutable.ArraySeq for use with Java varargs:
+  def genericWrapArray[T](xs: Array[T]): ArraySeq[T] =
+    if (xs eq null) null
+    else ArraySeq.unsafeWrapArray(xs)
+  def wrapRefArray[T <: AnyRef](xs: Array[T]): ArraySeq[T] = {
+    if (xs eq null) null
+    else if (xs.length == 0) ArraySeq.empty[AnyRef].asInstanceOf[ArraySeq[T]]
+    else new ArraySeq.ofRef[T](xs)
+  }
+  def wrapIntArray(xs: Array[Int]): ArraySeq[Int] = if (xs ne null) new ArraySeq.ofInt(xs) else null
+  def wrapDoubleArray(xs: Array[Double]): ArraySeq[Double] = if (xs ne null) new ArraySeq.ofDouble(xs) else null
+  def wrapLongArray(xs: Array[Long]): ArraySeq[Long] = if (xs ne null) new ArraySeq.ofLong(xs) else null
+  def wrapFloatArray(xs: Array[Float]): ArraySeq[Float] = if (xs ne null) new ArraySeq.ofFloat(xs) else null
+  def wrapCharArray(xs: Array[Char]): ArraySeq[Char] = if (xs ne null) new ArraySeq.ofChar(xs) else null
+  def wrapByteArray(xs: Array[Byte]): ArraySeq[Byte] = if (xs ne null) new ArraySeq.ofByte(xs) else null
+  def wrapShortArray(xs: Array[Short]): ArraySeq[Short] = if (xs ne null) new ArraySeq.ofShort(xs) else null
+  def wrapBooleanArray(xs: Array[Boolean]): ArraySeq[Boolean] = if (xs ne null) new ArraySeq.ofBoolean(xs) else null
+  def wrapUnitArray(xs: Array[Unit]): ArraySeq[Unit] = if (xs ne null) new ArraySeq.ofUnit(xs) else null
+}

--- a/scalalib/overrides-2.13/scala/Console.scala
+++ b/scalalib/overrides-2.13/scala/Console.scala
@@ -20,9 +20,9 @@ import scala.util.DynamicVariable
  *  @version 1.0, 03/09/2003
  */
 object Console extends DeprecatedConsole with AnsiColor {
-  private val outVar = new DynamicVariable[PrintStream](java.lang.System.out)
-  private val errVar = new DynamicVariable[PrintStream](java.lang.System.err)
-  private val inVar  = new DynamicVariable[BufferedReader](null)
+  private[this] val outVar = new DynamicVariable[PrintStream](java.lang.System.out)
+  private[this] val errVar = new DynamicVariable[PrintStream](java.lang.System.err)
+  private[this] val inVar  = new DynamicVariable[BufferedReader](null)
     //new BufferedReader(new InputStreamReader(java.lang.System.in)))
 
   protected def setOutDirect(out: PrintStream): Unit  = outVar.value = out

--- a/scalalib/overrides-2.13/scala/Enumeration.scala
+++ b/scalalib/overrides-2.13/scala/Enumeration.scala
@@ -256,7 +256,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
   class ValueSet private[ValueSet] (private[this] var nnIds: immutable.BitSet)
     extends immutable.AbstractSet[Value]
       with immutable.SortedSet[Value]
-      with immutable.SetOps[Value, immutable.Set, ValueSet]
+      with immutable.SortedSetOps[Value, immutable.SortedSet, ValueSet]
       with StrictOptimizedIterableOps[Value, immutable.Set, ValueSet]
       with Serializable {
 

--- a/scalalib/overrides-2.13/scala/Enumeration.scala
+++ b/scalalib/overrides-2.13/scala/Enumeration.scala
@@ -98,7 +98,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
 
   /** The mapping from the integer used to identify values to their
     * names. */
-  private val nmap: mutable.Map[Int, String] = new mutable.HashMap
+  private[this] val nmap: mutable.Map[Int, String] = new mutable.HashMap
 
   /** The values of this enumeration as a set.
    */
@@ -121,11 +121,11 @@ abstract class Enumeration (initial: Int) extends Serializable {
 
   /** The highest integer amongst those used to identify values in this
     * enumeration. */
-  private var topId = initial
+  private[this] var topId = initial
 
   /** The lowest integer amongst those used to identify values in this
     * enumeration, but no higher than 0. */
-  private var bottomId = if(initial < 0) initial else 0
+  private[this] var bottomId = if(initial < 0) initial else 0
 
   /** The one higher than the highest integer amongst those used to identify
     *  values in this enumeration. */

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -42,7 +42,7 @@ sealed class NumericRange[T](
     with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]]
     with Serializable { self =>
 
-  override def iterator() = new Iterator[T] {
+  override def iterator = new Iterator[T] {
     import num.mkNumericOps
 
     private var _hasNext = !self.isEmpty

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -175,7 +175,7 @@ sealed class NumericRange[T](
     // XXX This may be incomplete.
     new NumericRange[A](fm(start), fm(end), fm(step), isInclusive) {
 
-      private lazy val underlyingRange: NumericRange[T] = self
+      private[this] lazy val underlyingRange: NumericRange[T] = self
       override def foreach[@specialized(Unit) U](f: A => U): Unit = { underlyingRange foreach (x => f(fm(x))) }
       override def isEmpty = underlyingRange.isEmpty
       override def apply(idx: Int): A = fm(underlyingRange(idx))
@@ -395,9 +395,9 @@ object NumericRange {
   private final class NumericRangeIterator[T](self: NumericRange[T], num: Integral[T]) extends AbstractIterator[T] with Serializable {
     import num.mkNumericOps
 
-    private var _hasNext = !self.isEmpty
-    private var _next: T = self.start
-    private val lastElement: T = if (_hasNext) self.last else self.start
+    private[this] var _hasNext = !self.isEmpty
+    private[this] var _next: T = self.start
+    private[this] val lastElement: T = if (_hasNext) self.last else self.start
     override def knownSize: Int = if (_hasNext) num.toInt((lastElement - _next) / self.step) + 1 else 0
     def hasNext: Boolean = _hasNext
     def next(): T = {

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -39,25 +39,9 @@ sealed class NumericRange[T](
   extends AbstractSeq[T]
     with IndexedSeq[T]
     with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]
-    with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]]
-    with Serializable { self =>
+    with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]] { self =>
 
-  override def iterator: Iterator[T] = new AbstractIterator[T] {
-    import num.mkNumericOps
-
-    private var _hasNext = !self.isEmpty
-    private var _next: T = start
-    private val lastElement: T = if (_hasNext) last else start
-    override def knownSize: Int = if (_hasNext) num.toInt((lastElement - _next) / step) + 1 else 0
-    def hasNext: Boolean = _hasNext
-    def next(): T = {
-      if (!_hasNext) Iterator.empty.next()
-      val value = _next
-      _hasNext = value != lastElement
-      _next = num.plus(value, step)
-      value
-    }
-  }
+  override def iterator: Iterator[T] = new NumericRange.NumericRangeIterator(this, num)
 
   /** Note that NumericRange must be invariant so that constructs
     *  such as "1L to 10 by 5" do not infer the range type as AnyVal.
@@ -277,6 +261,8 @@ sealed class NumericRange[T](
     val stepped = if (step == 1) "" else s" by $step"
     s"${empty}NumericRange $start $preposition $end$stepped"
   }
+
+  override protected[this] def writeReplace(): AnyRef = this
 }
 
 /** A companion object for numeric ranges.
@@ -405,5 +391,21 @@ object NumericRange {
     Numeric.LongIsIntegral -> Ordering.Long
   )
 
-}
+  @SerialVersionUID(3L)
+  private final class NumericRangeIterator[T](self: NumericRange[T], num: Integral[T]) extends AbstractIterator[T] with Serializable {
+    import num.mkNumericOps
 
+    private var _hasNext = !self.isEmpty
+    private var _next: T = self.start
+    private val lastElement: T = if (_hasNext) self.last else self.start
+    override def knownSize: Int = if (_hasNext) num.toInt((lastElement - _next) / self.step) + 1 else 0
+    def hasNext: Boolean = _hasNext
+    def next(): T = {
+      if (!_hasNext) Iterator.empty.next()
+      val value = _next
+      _hasNext = value != lastElement
+      _next = num.plus(value, self.step)
+      value
+    }
+  }
+}

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -1,6 +1,6 @@
 package scala.collection.immutable
 
-import scala.collection.{SeqFactory, IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps}
+import scala.collection.{AbstractIterator, SeqFactory, IterableFactory, IterableOnce, Iterator, StrictOptimizedIterableOps}
 
 import java.lang.String
 
@@ -42,7 +42,7 @@ sealed class NumericRange[T](
     with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]]
     with Serializable { self =>
 
-  override def iterator = new Iterator[T] {
+  override def iterator: Iterator[T] = new AbstractIterator[T] {
     import num.mkNumericOps
 
     private var _hasNext = !self.isEmpty

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -56,7 +56,7 @@ sealed abstract class Range(
     with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
     with Serializable { range =>
 
-  override def iterator(): Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
+  override def iterator: Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 
   private def gap           = end.toLong - start.toLong
   private def isExact       = gap % step == 0

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -512,8 +512,8 @@ private class RangeIterator(
   lastElement: Int,
   initiallyEmpty: Boolean
 ) extends AbstractIterator[Int] with Serializable {
-  private var _hasNext: Boolean = !initiallyEmpty
-  private var _next: Int = start
+  private[this] var _hasNext: Boolean = !initiallyEmpty
+  private[this] var _next: Int = start
   override def knownSize: Int = if (_hasNext) (lastElement - _next) / step + 1 else 0
   def hasNext: Boolean = _hasNext
   @throws[NoSuchElementException]

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -1,8 +1,7 @@
 package scala
 package collection.immutable
 
-import collection.{Iterator, SeqFactory}
-
+import collection.{AbstractIterator, Iterator, SeqFactory}
 import java.lang.String
 
 import scala.collection.mutable.Builder
@@ -53,8 +52,7 @@ sealed abstract class Range(
   extends AbstractSeq[Int]
     with IndexedSeq[Int]
     with IndexedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
-    with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
-    with Serializable { range =>
+    with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]] { range =>
 
   override def iterator: Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 
@@ -382,6 +380,7 @@ sealed abstract class Range(
     s"${prefix}Range $start $preposition $end$stepped"
   }
 
+  override protected[this] def writeReplace(): AnyRef = this
 }
 
 /**
@@ -506,12 +505,13 @@ object Range {
   * @param lastElement The last element included in the Range
   * @param initiallyEmpty Whether the Range was initially empty or not
   */
+@SerialVersionUID(3L)
 private class RangeIterator(
   start: Int,
   step: Int,
   lastElement: Int,
   initiallyEmpty: Boolean
-) extends Iterator[Int] {
+) extends AbstractIterator[Int] with Serializable {
   private var _hasNext: Boolean = !initiallyEmpty
   private var _next: Int = start
   override def knownSize: Int = if (_hasNext) (lastElement - _next) / step + 1 else 0

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -484,26 +484,6 @@ object Range {
       NumericRange.inclusive(start, end, step)
   }
 
-  // Double works by using a BigDecimal under the hood for precise
-  // stepping, but mapping the sequence values back to doubles with
-  // .doubleValue.  This constructs the BigDecimals by way of the
-  // String constructor (valueOf) instead of the Double one, which
-  // is necessary to keep 0.3d at 0.3 as opposed to
-  // 0.299999999999999988897769753748434595763683319091796875 or so.
-  object Double {
-    implicit val bigDecAsIntegral: Numeric.BigDecimalAsIfIntegral = Numeric.BigDecimalAsIfIntegral
-    implicit val doubleAsIntegral: Numeric.DoubleAsIfIntegral = Numeric.DoubleAsIfIntegral
-    def toBD(x: Double): BigDecimal = scala.math.BigDecimal valueOf x
-
-    @deprecated("use Range.BigDecimal instead", "2.12.6")
-    def apply(start: Double, end: Double, step: Double) =
-      BigDecimal(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
-
-    @deprecated("use Range.BigDecimal.inclusive instead", "2.12.6")
-    def inclusive(start: Double, end: Double, step: Double) =
-      BigDecimal.inclusive(toBD(start), toBD(end), toBD(step)) mapRange (_.doubleValue)
-  }
-
   // As there is no appealing default step size for not-really-integral ranges,
   // we offer a partially constructed object.
   class Partial[T, U](private val f: T => U) extends AnyVal {

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -54,22 +54,22 @@ sealed abstract class Range(
     with IndexedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
     with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]] { range =>
 
-  override def iterator: Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
+  final override def iterator: Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 
-  private def gap           = end.toLong - start.toLong
-  private def isExact       = gap % step == 0
-  private def hasStub       = isInclusive || !isExact
-  private def longLength    = gap / step + ( if (hasStub) 1 else 0 )
+  private[this] def gap           = end.toLong - start.toLong
+  private[this] def isExact       = gap % step == 0
+  private[this] def hasStub       = isInclusive || !isExact
+  private[this] def longLength    = gap / step + ( if (hasStub) 1 else 0 )
 
   def isInclusive: Boolean
 
-  override val isEmpty: Boolean = (
+  final override val isEmpty: Boolean = (
     (start > end && step > 0)
       || (start < end && step < 0)
       || (start == end && !isInclusive)
     )
 
-  private val numRangeElements: Int = {
+  private[this] val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
     else if (isEmpty) 0
     else {
@@ -79,10 +79,10 @@ sealed abstract class Range(
     }
   }
 
-  def length = if (numRangeElements < 0) fail() else numRangeElements
+  final def length = if (numRangeElements < 0) fail() else numRangeElements
 
   // This field has a sensible value only for non-empty ranges
-  private val lastElement = step match {
+  private[this] val lastElement = step match {
     case 1  => if (isInclusive) end else end-1
     case -1 => if (isInclusive) end else end+1
     case _  =>
@@ -95,8 +95,8 @@ sealed abstract class Range(
   /** The last element of this range.  This method will return the correct value
     *  even if there are too many elements to iterate over.
     */
-  override def last: Int = if (isEmpty) Nil.head else lastElement
-  override def head: Int = if (isEmpty) Nil.head else start
+  final override def last: Int = if (isEmpty) Nil.head else lastElement
+  final override def head: Int = if (isEmpty) Nil.head else start
 
   /** Creates a new range containing all the elements of this range except the last one.
     *
@@ -104,7 +104,7 @@ sealed abstract class Range(
     *
     *  @return  a new range consisting of all the elements of this range except the last one.
     */
-  override def init: Range = {
+  final override def init: Range = {
     if (isEmpty)
       Nil.init
 
@@ -117,7 +117,7 @@ sealed abstract class Range(
     *
     *  @return  a new range consisting of all the elements of this range except the first one.
     */
-  override def tail: Range = {
+  final override def tail: Range = {
     if (isEmpty)
       Nil.tail
     if (numRangeElements == 1) newEmptyRange(end)
@@ -125,7 +125,7 @@ sealed abstract class Range(
     else new Range.Exclusive(start + step, end, step)
   }
 
-  protected def copy(start: Int = start, end: Int = end, step: Int = step, isInclusive: Boolean = isInclusive): Range =
+  final protected def copy(start: Int = start, end: Int = end, step: Int = step, isInclusive: Boolean = isInclusive): Range =
     if(isInclusive) new Range.Inclusive(start, end, step) else new Range.Exclusive(start, end, step)
 
   /** Create a new range with the `start` and `end` values of this range and
@@ -133,27 +133,27 @@ sealed abstract class Range(
     *
     *  @return a new range with a different step
     */
-  def by(step: Int): Range = copy(start, end, step)
+  final def by(step: Int): Range = copy(start, end, step)
 
   // Check cannot be evaluated eagerly because we have a pattern where
   // ranges are constructed like: "x to y by z" The "x to y" piece
   // should not trigger an exception. So the calculation is delayed,
   // which means it will not fail fast for those cases where failing was
   // correct.
-  private def validateMaxLength(): Unit = {
+  private[this] def validateMaxLength(): Unit = {
     if (numRangeElements < 0)
       fail()
   }
-  private def fail() = Range.fail(start, end, step, isInclusive)
+  private[this] def fail() = Range.fail(start, end, step, isInclusive)
 
   @throws[IndexOutOfBoundsException]
-  def apply(idx: Int): Int = {
+  final def apply(idx: Int): Int = {
     validateMaxLength()
     if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(idx.toString)
     else start + (step * idx)
   }
 
-  /*@`inline`*/ override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
+  /*@`inline`*/ final override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
     // Implementation chosen on the basis of favorable microbenchmarks
     // Note--initialization catches step == 0 so we don't need to here
     if (!isEmpty) {
@@ -171,7 +171,7 @@ sealed abstract class Range(
     *  @param n  the number of elements to take.
     *  @return   a new range consisting of `n` first elements.
     */
-  override def take(n: Int): Range =
+  final override def take(n: Int): Range =
     if (n <= 0 || isEmpty) newEmptyRange(start)
     else if (n >= numRangeElements && numRangeElements >= 0) this
     else {
@@ -185,7 +185,7 @@ sealed abstract class Range(
     *  @param n  the number of elements to drop.
     *  @return   a new range consisting of all the elements of this range except `n` first elements.
     */
-  override def drop(n: Int): Range =
+  final override def drop(n: Int): Range =
     if (n <= 0 || isEmpty) this
     else if (n >= numRangeElements && numRangeElements >= 0) newEmptyRange(end)
     else {
@@ -198,7 +198,7 @@ sealed abstract class Range(
     *
     *  $doesNotUseBuilders
     */
-  override def takeRight(n: Int): Range = {
+  final override def takeRight(n: Int): Range = {
     if (n <= 0) newEmptyRange(start)
     else if (numRangeElements >= 0) drop(numRangeElements - n)
     else {
@@ -214,7 +214,7 @@ sealed abstract class Range(
     *
     *  $doesNotUseBuilders
     */
-  override def dropRight(n: Int): Range = {
+  final override def dropRight(n: Int): Range = {
     if (n <= 0) this
     else if (numRangeElements >= 0) take(numRangeElements - n)
     else {
@@ -226,7 +226,7 @@ sealed abstract class Range(
   }
 
   // Advance from the start while we meet the given test
-  private def argTakeWhile(p: Int => Boolean): Long = {
+  private[this] def argTakeWhile(p: Int => Boolean): Long = {
     if (isEmpty) start
     else {
       var current = start
@@ -237,7 +237,7 @@ sealed abstract class Range(
     }
   }
 
-  override def takeWhile(p: Int => Boolean): Range = {
+  final override def takeWhile(p: Int => Boolean): Range = {
     val stop = argTakeWhile(p)
     if (stop==start) newEmptyRange(start)
     else {
@@ -247,7 +247,7 @@ sealed abstract class Range(
     }
   }
 
-  override def dropWhile(p: Int => Boolean): Range = {
+  final override def dropWhile(p: Int => Boolean): Range = {
     val stop = argTakeWhile(p)
     if (stop == start) this
     else {
@@ -257,7 +257,7 @@ sealed abstract class Range(
     }
   }
 
-  override def span(p: Int => Boolean): (Range, Range) = {
+  final override def span(p: Int => Boolean): (Range, Range) = {
     val border = argTakeWhile(p)
     if (border == start) (newEmptyRange(start), this)
     else {
@@ -275,7 +275,7 @@ sealed abstract class Range(
     *  @param until  the element at which to end (not included in the range)
     *  @return   a new range consisting of a contiguous interval of values in the old range
     */
-  override def slice(from: Int, until: Int): Range =
+  final override def slice(from: Int, until: Int): Range =
     if (from <= 0) take(until)
     else if (until >= numRangeElements && numRangeElements >= 0) drop(from)
     else {
@@ -285,31 +285,31 @@ sealed abstract class Range(
     }
 
   // Overridden only to refine the return type
-  override def splitAt(n: Int): (Range, Range) = (take(n), drop(n))
+  final override def splitAt(n: Int): (Range, Range) = (take(n), drop(n))
 
   // Methods like apply throw exceptions on invalid n, but methods like take/drop
   // are forgiving: therefore the checks are with the methods.
-  private def locationAfterN(n: Int) = start + (step * n)
+  private[this] def locationAfterN(n: Int) = start + (step * n)
 
   // When one drops everything.  Can't ever have unchecked operations
   // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
   // will overflow.  This creates an exclusive range where start == end
   // based on the given value.
-  private def newEmptyRange(value: Int) = new Range.Exclusive(value, value, step)
+  private[this] def newEmptyRange(value: Int) = new Range.Exclusive(value, value, step)
 
   /** Returns the reverse of this range.
     */
-  override def reverse: Range =
+  final override def reverse: Range =
     if (isEmpty) this
     else new Range.Inclusive(last, start, -step)
 
   /** Make range inclusive.
     */
-  def inclusive: Range =
+  final def inclusive: Range =
     if (isInclusive) this
     else new Range.Inclusive(start, end, step)
 
-  def contains(x: Int) = {
+  final def contains(x: Int) = {
     if (x == end && !isInclusive) false
     else if (step > 0) {
       if (x < start || x > end) false
@@ -321,7 +321,7 @@ sealed abstract class Range(
     }
   }
 
-  override def sum[B >: Int](implicit num: Numeric[B]): Int = {
+  final override def sum[B >: Int](implicit num: Numeric[B]): Int = {
     if (num eq scala.math.Numeric.IntIsIntegral) {
       // this is normal integer range with usual addition. arithmetic series formula can be used
       if (isEmpty) 0
@@ -343,20 +343,20 @@ sealed abstract class Range(
     }
   }
 
-  override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
+  final override def min[A1 >: Int](implicit ord: Ordering[A1]): Int =
     if (ord eq Ordering.Int) {
       if (step > 0) head
       else last
     } else super.min(ord)
 
-  override def max[A1 >: Int](implicit ord: Ordering[A1]): Int =
+  final override def max[A1 >: Int](implicit ord: Ordering[A1]): Int =
     if (ord eq Ordering.Int) {
       if (step > 0) last
       else head
     } else super.max(ord)
 
 
-  override def equals(other: Any) = other match {
+  final override def equals(other: Any) = other match {
     case x: Range =>
       // Note: this must succeed for overfull ranges (length > Int.MaxValue)
       if (isEmpty) x.isEmpty                  // empty sequences are equal
@@ -373,14 +373,14 @@ sealed abstract class Range(
 
   /* Note: hashCode can't be overridden without breaking Seq's equals contract. */
 
-  override def toString: String = {
+  final override def toString: String = {
     val preposition = if (isInclusive) "to" else "until"
     val stepped = if (step == 1) "" else s" by $step"
     val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
     s"${prefix}Range $start $preposition $end$stepped"
   }
 
-  override protected[this] def writeReplace(): AnyRef = this
+  final override protected[this] def writeReplace(): AnyRef = this
 }
 
 /**

--- a/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
@@ -172,4 +172,5 @@ trait IndexedOptimizedBuffer[A] extends IndexedOptimizedSeq[A] with Buffer[A] {
 object Buffer extends SeqFactory.Delegate[Buffer](js.WrappedArray)
 
 /** Explicit instantiation of the `Buffer` trait to reduce class file size in subclasses. */
+@SerialVersionUID(3L)
 abstract class AbstractBuffer[A] extends AbstractSeq[A] with Buffer[A]

--- a/scalalib/overrides-2.13/scala/reflect/Manifest.scala
+++ b/scalalib/overrides-2.13/scala/reflect/Manifest.scala
@@ -289,12 +289,14 @@ object ManifestFactory {
   def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
     new WildcardManifest[T](lowerBound, upperBound)
 
-  private class IntersectionTypeManifest[T](parents: Seq[Manifest[_]]) extends Manifest[T] {
-    def runtimeClass = parents.head.runtimeClass
+  private class IntersectionTypeManifest[T](parents: Array[Manifest[_]]) extends Manifest[T] {
+    // We use an `Array` instead of a `Seq` for `parents` to avoid cyclic dependencies during deserialization
+    // which can cause serialization proxies to leak and cause a ClassCastException.
+    def runtimeClass = parents(0).runtimeClass
     override def toString = parents.mkString(" with ")
   }
 
   /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
   def intersectionType[T](parents: Manifest[_]*): Manifest[T] =
-    new IntersectionTypeManifest[T](parents)
+    new IntersectionTypeManifest[T](parents.toArray)
 }

--- a/scalalib/overrides-2.13/scala/reflect/NameTransformer.scala
+++ b/scalalib/overrides-2.13/scala/reflect/NameTransformer.scala
@@ -22,13 +22,13 @@ object NameTransformer {
   val SETTER_SUFFIX_STRING          = "_$eq"
   val TRAIT_SETTER_SEPARATOR_STRING = "$_setter_$"
 
-  private val nops = 128
-  private val ncodes = 26 * 26
+  private[this] val nops = 128
+  private[this] val ncodes = 26 * 26
 
   private class OpCodes(val op: Char, val code: String, val next: OpCodes)
 
-  private val op2code = new Array[String](nops)
-  private val code2op = new Array[OpCodes](ncodes)
+  private[this] val op2code = new Array[String](nops)
+  private[this] val code2op = new Array[OpCodes](ncodes)
   private def enterOp(op: Char, code: String) = {
     op2code(op.toInt) = code
     val c = (code.charAt(1) - 'a') * 26 + code.charAt(2) - 'a'

--- a/scalalib/overrides-2.13/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.13/scala/runtime/ScalaRunTime.scala
@@ -147,8 +147,8 @@ object ScalaRunTime {
   /** A helper for case classes. */
   def typedProductIterator[T](x: Product): Iterator[T] = {
     new AbstractIterator[T] {
-      private var c: Int = 0
-      private val cmax = x.productArity
+      private[this] var c: Int = 0
+      private[this] val cmax = x.productArity
       def hasNext = c < cmax
       def next() = {
         val result = x.productElement(c)

--- a/scalalib/overrides-2.13/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.13/scala/runtime/ScalaRunTime.scala
@@ -238,8 +238,8 @@ object ScalaRunTime {
       case x: String                    => if (x.head.isWhitespace || x.last.isWhitespace) "\"" + x + "\"" else x
       case x if useOwnToString(x)       => x.toString
       case x: AnyRef if isArray(x)      => arrayToString(x)
-      case x: scala.collection.Map[_, _] => x.iterator take maxElements map mapInner mkString (x.className + "(", ", ", ")")
-      case x: Iterable[_]               => x.iterator take maxElements map inner mkString (x.className + "(", ", ", ")")
+      case x: scala.collection.Map[_, _] => x.iterator take maxElements map mapInner mkString (x.collectionClassName + "(", ", ", ")")
+      case x: Iterable[_]               => x.iterator take maxElements map inner mkString (x.collectionClassName + "(", ", ", ")")
       case x: Product1[_] if isTuple(x) => "(" + inner(x._1) + ",)" // that special trailing comma
       case x: Product if isTuple(x)     => x.productIterator map inner mkString ("(", ",", ")")
       case x                            => x.toString

--- a/scalalib/overrides/scala/App.scala
+++ b/scalalib/overrides/scala/App.scala
@@ -47,9 +47,9 @@ trait App extends DelayedInit {
    */
   protected def args: Array[String] = _args
 
-  private var _args: Array[String] = _
+  private[this] var _args: Array[String] = _
 
-  private val initCode = new ListBuffer[() => Unit]
+  private[this] val initCode = new ListBuffer[() => Unit]
 
   /** The init hook. This saves all initialization code for execution within `main`.
    *  This method is normally never called directly from user code.

--- a/scalalib/overrides/scala/Symbol.scala
+++ b/scalalib/overrides/scala/Symbol.scala
@@ -63,10 +63,10 @@ private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
   import java.util.WeakHashMap
   import java.util.concurrent.locks.ReentrantReadWriteLock
 
-  private val rwl = new ReentrantReadWriteLock()
-  private val rlock = rwl.readLock
-  private val wlock = rwl.writeLock
-  private val map = new WeakHashMap[K, WeakReference[V]]
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
 
   protected def valueFromKey(k: K): V
   protected def keyFromValue(v: V): Option[K]

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
@@ -12,6 +12,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import scala.collection.immutable.NumericRange
+import scala.math.BigDecimal
 
 import org.scalajs.testsuite.utils.Platform._
 
@@ -24,21 +25,6 @@ class RangesTest {
   @Test def Iterable_range_and_simple_range_should_be_equal(): Unit = {
     // Mostly to exercise more methods of ranges for dce warnings
     assertEquals((0 until 10).toList, Iterable.range(0, 10).toList)
-  }
-
-  @Test def Iterable_range_bug_on_floating_points_issue_1974(): Unit = {
-    val range = 0.0 to 6.283 by 1.0
-
-    assertEquals(0.0, range.start, 0.0)
-    assertEquals(6.283, range.end, 0.0)
-    assertEquals(1.0, range.step, 0.0)
-    assertTrue(range.isInclusive)
-
-    assertEquals(0.0, range.head, 0.0)
-    assertEquals(6.0, range.last, 0.0)
-    assertEquals(7, range.length)
-
-    assertEquals(List(0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0), range.toList)
   }
 
   @Test def NumericRange_overflow_issue_2407(): Unit = {
@@ -67,41 +53,29 @@ class RangesTest {
     if (scalaVersion.startsWith("2.10.") || scalaVersion.startsWith("2.11.")) {
       assertEquals("Range(1, 3, 5, 7, 9)", (1 to 10 by 2).toString)
       assertEquals("Range()", (1 until 1 by 2).toString)
-      assertTrue((0.0 to 1.0).toString.startsWith("scala.collection.immutable.Range$Partial"))
+      assertTrue(
+          (BigDecimal(0.0) to BigDecimal(1.0)).toString.startsWith("scala.collection.immutable.Range$Partial"))
       assertEquals("Range(0, 1)", (0 to 1).toString)
     } else {
       assertEquals("inexact Range 1 to 10 by 2", (1 to 10 by 2).toString)
       assertEquals("empty Range 1 until 1 by 2", (1 until 1 by 2).toString)
-      assertEquals("Range requires step", (0.0 to 1.0).toString)
+      assertEquals("Range requires step", (BigDecimal(0.0) to BigDecimal(1.0)).toString)
       assertEquals("Range 0 to 1", (0 to 1).toString)
     }
   }
 
   @Test def NumericRange_toString_issue_2412(): Unit = {
     if (scalaVersion.startsWith("2.10.") || scalaVersion.startsWith("2.11.")) {
-      assertEquals("NumericRange(0.1, 0.2, 0.30000000000000004, 0.4, 0.5, 0.6, 0.7, " +
-          "0.7999999999999999, 0.8999999999999999, 0.9999999999999999)",
-          (0.1 to 1.0 by 0.1).toString())
-      assertEquals(
-          "NumericRange(0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9)",
-          Range.Double(0.1, 1.0, 0.1).toString)
+      assertEquals("NumericRange(0, 2, 4, 6, 8, 10)",
+          NumericRange.inclusive(0, 10, 2).toString())
+      assertEquals("NumericRange(0, 2, 4, 6, 8)",
+          NumericRange(0, 10, 2).toString)
     } else {
-      assertEquals(s"NumericRange 0.1 to ${1.0} by 0.1",
-          (0.1 to 1.0 by 0.1).toString())
-      assertEquals(
-          s"NumericRange 0.1 until ${1.0} by 0.1 (using NumericRange 0.1 until ${1.0} by 0.1 of BigDecimal)",
-          Range.Double(0.1, 1.0, 0.1).toString)
+      assertEquals("NumericRange 0 to 10 by 2",
+          NumericRange.inclusive(0, 10, 2).toString())
+      assertEquals("NumericRange 0 until 10 by 2",
+          NumericRange(0, 10, 2).toString)
     }
-  }
-
-  @Test def NumericRange_min_issue_2655(): Unit = {
-    val y = 1.0 to 10.0 by 1.0
-    assertEquals(1.0, y.min, 0.0)
-  }
-
-  @Test def NumericRange_max_issue_2655(): Unit = {
-    val y = 1.0 to 10.0 by 1.0
-    assertEquals(10.0, y.max, 0.0)
   }
 
   @Test def NumericRange_with_arbitrary_integral(): Unit = {


### PR DESCRIPTION
The changes in this PR allow `testSuite/test` to pass with today's tip of the `2.13.x` branch in scala/scala, i.e., commit https://github.com/scala/scala/commit/1ef688a914f2052ef558596e3beef6403054dc9a.

I have also locally tested that `testSuite/test` still passes with `++2.13.0-M4`.