### PR TITLE
Complete rewrite of java.util.Formatter.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -434,43 +434,43 @@ object Long {
     else         Integer.numberOfTrailingZeros((l >>> 32).toInt) + 32
   }
 
-  def toBinaryString(l: scala.Long): String = {
+  @inline def toBinaryString(l: scala.Long): String =
+    toBinaryString(l.toInt, (l >>> 32).toInt)
+
+  private def toBinaryString(lo: Int, hi: Int): String = {
     val zeros = "00000000000000000000000000000000" // 32 zeros
     @inline def padBinary32(i: Int) = {
       val s = Integer.toBinaryString(i)
       zeros.substring(s.length) + s
     }
 
-    val lo = l.toInt
-    val hi = (l >>> 32).toInt
-
     if (hi != 0) Integer.toBinaryString(hi) + padBinary32(lo)
     else Integer.toBinaryString(lo)
   }
 
-  def toHexString(l: scala.Long): String = {
+  @inline def toHexString(l: scala.Long): String =
+    toHexString(l.toInt, (l >>> 32).toInt)
+
+  private def toHexString(lo: Int, hi: Int): String = {
     val zeros = "00000000" // 8 zeros
     @inline def padBinary8(i: Int) = {
       val s = Integer.toHexString(i)
       zeros.substring(s.length) + s
     }
 
-    val lo = l.toInt
-    val hi = (l >>> 32).toInt
-
     if (hi != 0) Integer.toHexString(hi) + padBinary8(lo)
     else Integer.toHexString(lo)
   }
 
-  def toOctalString(l: scala.Long): String = {
+  @inline def toOctalString(l: scala.Long): String =
+    toOctalString(l.toInt, (l >>> 32).toInt)
+
+  private def toOctalString(lo: Int, hi: Int): String = {
     val zeros = "0000000000" // 10 zeros
     @inline def padOctal10(i: Int) = {
       val s = Integer.toOctalString(i)
       zeros.substring(s.length) + s
     }
-
-    val lo = l.toInt
-    val hi = (l >>> 32).toInt
 
     val lp = lo & 0x3fffffff
     val mp = ((lo >>> 30) + (hi << 2)) & 0x3fffffff

--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -4,285 +4,744 @@ import scala.annotation.switch
 import scala.scalajs.js
 
 import java.io._
-import java.lang._
 
-final class Formatter(private val dest: Appendable) extends Closeable with Flushable {
+final class Formatter(private[this] var dest: Appendable)
+    extends Closeable with Flushable {
+
   import Formatter._
+  import Flags._
 
-  var closed = false
+  /** If `dest == null`, the real content is in `stringOutput`.
+   *
+   *  A real `StringBuilder` may be created lazily if `out()` is called, which
+   *  will then capture the current content of `stringOutput`.
+   *
+   *  This allows to bypass the allocation of the `StringBuilder`, the call
+   *  through `dest.append()` and more importantly the `try..catch`es in the
+   *  common case where the `Formatter` is created without a specific
+   *  destination.
+   */
+  private[this] var stringOutput: String = ""
 
-  def this() = this(new StringBuilder())
+  private[this] var closed: Boolean = false
+  private[this] var lastIOException: IOException = null
+
+  def this() = this(null: Appendable)
+
+  @inline
+  private def trapIOExceptions(body: => Unit): Unit = {
+    try {
+      body
+    } catch {
+      case th: IOException =>
+        lastIOException = th
+    }
+  }
+
+  private def sendToDest(s: String): Unit = {
+    if (dest eq null)
+      stringOutput += s
+    else
+      sendToDestSlowPath(js.Array(s))
+  }
+
+  private def sendToDest(s1: String, s2: String): Unit = {
+    if (dest eq null)
+      stringOutput += s1 + s2
+    else
+      sendToDestSlowPath(js.Array(s1, s2))
+  }
+
+  private def sendToDest(s1: String, s2: String, s3: String): Unit = {
+    if (dest eq null)
+      stringOutput += s1 + s2 + s3
+    else
+      sendToDestSlowPath(js.Array(s1, s2, s3))
+  }
+
+  @noinline
+  private def sendToDestSlowPath(ss: js.Array[String]): Unit = {
+    trapIOExceptions {
+      ss.foreach(dest.append(_))
+    }
+  }
 
   def close(): Unit = {
-    if (!closed) {
+    if (!closed && (dest ne null)) {
       dest match {
-        case cl: Closeable => cl.close()
+        case cl: Closeable =>
+          trapIOExceptions {
+            cl.close()
+          }
         case _ =>
       }
     }
     closed = true
   }
 
-  def flush(): Unit = ifNotClosed {
-    dest match {
-      case fl: Flushable => fl.flush()
-      case _ =>
+  def flush(): Unit = {
+    checkNotClosed()
+    if (dest ne null) {
+      dest match {
+        case fl: Flushable =>
+          trapIOExceptions {
+            fl.flush()
+          }
+        case _ =>
+      }
     }
   }
 
-  // Begin implem of format()
+  def format(format: String, args: Array[AnyRef]): Formatter = {
+    // scalastyle:off return
 
-  def format(format_in: String, args: Array[AnyRef]): Formatter = ifNotClosed {
-    import js.JSNumberOps._
+    checkNotClosed()
 
-    var fmt: String = format_in
-    var lastImplicitIndex: Int = 0
-    var lastIndex: Int = 0 // required for < flag
+    var lastImplicitArgIndex: Int = 0
+    var lastArgIndex: Int = 0 // required for < flag
 
-    while (!fmt.isEmpty) {
-      fmt match {
-        case RegularChunk(matchResult) =>
-          fmt = fmt.substring(matchResult(0).get.length)
-          dest.append(matchResult(0).get)
+    val fmtLength = format.length
+    var fmtIndex: Int = 0
 
-        case DoublePercent(_) =>
-          fmt = fmt.substring(2)
-          dest.append('%')
-
-        case EOLChunk(_) =>
-          fmt = fmt.substring(2)
-          dest.append('\n')
-
-        case FormattedChunk(matchResult) =>
-          fmt = fmt.substring(matchResult(0).get.length)
-
-          val flags = matchResult(2).get
-          def hasFlag(flag: String) = flags.indexOf(flag) >= 0
-
-          val indexStr = matchResult(1).getOrElse("")
-          val index = if (!indexStr.isEmpty) {
-            Integer.parseInt(indexStr)
-          } else if (hasFlag("<")) {
-            lastIndex
-          } else {
-            lastImplicitIndex += 1
-            lastImplicitIndex
-          }
-          lastIndex = index
-          if (index <= 0 || index > args.length)
-            throw new MissingFormatArgumentException(matchResult(5).get)
-          val arg = args(index-1)
-
-          val widthStr = matchResult(3).getOrElse("")
-          val hasWidth = !widthStr.isEmpty
-          val width = {
-            if (hasWidth) Integer.parseInt(widthStr)
-            else if (hasFlag("-")) throw new MissingFormatWidthException(format_in)
-            else 0
-          }
-
-          val precisionStr = matchResult(4).getOrElse("")
-          val hasPrecision = !precisionStr.isEmpty
-          val precision =
-            if (hasPrecision) Integer.parseInt(precisionStr)
-            else 0
-
-          val conversion = matchResult(5).get.charAt(0)
-
-          // Avoid using conversion.isUpper not to depend on the Unicode database
-          @inline def isConversionUpperCase: scala.Boolean =
-            conversion <= 'Z'
-
-          def intArg: Int = (arg: Any) match {
-            case arg: Int  => arg
-            case arg: Char => arg.toInt
-          }
-          def numberArg: scala.Double = (arg: Any) match {
-            case arg: Number => arg.doubleValue()
-            case arg: Char   => arg.toDouble
-          }
-
-          def padCaptureSign(argStr: String, prefix: String) = {
-            val firstChar = argStr.charAt(0)
-            if (firstChar == '+' || firstChar == '-')
-              pad(argStr.substring(1), firstChar.toString + prefix)
-            else
-              pad(argStr, prefix)
-          }
-
-          def strRepeat(s: String, times: Int) = {
-            var result: String = ""
-            var i = times
-            while (i > 0) {
-              result += s
-              i -= 1
-            }
-            result
-          }
-
-          def with_+(s: String, preventZero: scala.Boolean = false) = {
-            if (s.charAt(0) != '-') {
-              if (hasFlag("+"))
-                pad(s, "+", preventZero)
-              else if (hasFlag(" "))
-                pad(s, " ", preventZero)
-              else
-                pad(s, "", preventZero)
-            } else {
-              if (hasFlag("("))
-                pad(s.substring(1) + ")", "(", preventZero)
-              else
-                pad(s.substring(1), "-", preventZero)
-            }
-          }
-
-          def pad(argStr: String, prefix: String = "",
-                  preventZero: Boolean = false) = {
-            val prePadLen = argStr.length + prefix.length
-
-            val padStr = {
-              if (width <= prePadLen) {
-                prefix + argStr
-              } else {
-                val padRight = hasFlag("-")
-                val padZero = hasFlag("0") && !preventZero
-                val padLength = width - prePadLen
-                val padChar: String = if (padZero) "0" else " "
-                val padding = strRepeat(padChar, padLength)
-
-                if (padZero && padRight)
-                  throw new java.util.IllegalFormatFlagsException(flags)
-                else if (padRight) prefix + argStr  + padding
-                else if (padZero)  prefix + padding + argStr
-                else padding + prefix + argStr
-              }
-            }
-
-            val casedStr =
-              if (isConversionUpperCase) padStr.toUpperCase()
-              else padStr
-            dest.append(casedStr)
-          }
-
-          (conversion: @switch) match {
-            case 'b' | 'B' => pad { arg match {
-              case null => "false"
-              case b: Boolean => String.valueOf(b)
-              case _ => "true"
-            } }
-            case 'h' | 'H' => pad {
-              if (arg eq null) "null"
-              else Integer.toHexString(arg.hashCode)
-            }
-            case 's' | 'S' => arg match {
-              case formattable: Formattable =>
-                val flags = {
-                  (if (hasFlag("-")) FormattableFlags.LEFT_JUSTIFY else 0) |
-                  (if (hasFlag("#")) FormattableFlags.ALTERNATE else 0) |
-                  (if (isConversionUpperCase) FormattableFlags.UPPERCASE else 0)
-                }
-                formattable.formatTo(this, flags,
-                    if (hasWidth) width else -1,
-                    if (hasPrecision) precision else -1)
-                None // no further processing
-              case _ =>
-                if (!hasFlag("#"))
-                  pad(String.valueOf(arg))
-                else
-                  throw new FormatFlagsConversionMismatchException("#", 's')
-            }
-            case 'c' | 'C' =>
-              pad(intArg.toChar.toString)
-            case 'd' =>
-              with_+(numberArg.toString())
-            case 'o' =>
-              val str = (arg: Any) match {
-                case arg: scala.Int  => Integer.toOctalString(arg)
-                case arg: scala.Long => Long.toOctalString(arg)
-              }
-              padCaptureSign(str, if (hasFlag("#")) "0" else "")
-            case 'x' | 'X' =>
-              val str = (arg: Any) match {
-                case arg: scala.Int  => Integer.toHexString(arg)
-                case arg: scala.Long => Long.toHexString(arg)
-              }
-              padCaptureSign(str, if (hasFlag("#")) "0x" else "")
-            case 'e' | 'E' =>
-              sciNotation(if (hasPrecision) precision else 6)
-            case 'g' | 'G' =>
-              val m = Math.abs(numberArg)
-              // precision handling according to JavaDoc
-              // precision here means number of significant digits
-              // not digits after decimal point
-              val p =
-                if (!hasPrecision) 6
-                else if (precision == 0) 1
-                else precision
-              // between 1e-4 and 10e(p): display as fixed
-              if (m >= 1e-4 && m < Math.pow(10, p)) {
-                /* First approximation of the smallest power of 10 that is >= m.
-                 * Due to rounding errors in the event of an imprecise `log10`
-                 * function, sig0 could actually be the smallest power of 10
-                 * that is > m.
-                 */
-                val sig0 = Math.ceil(Math.log10(m)).toInt
-                /* Increment sig0 so that it is always the first power of 10
-                 * that is > m.
-                 */
-                val sig = if (Math.pow(10, sig0) <= m) sig0 + 1 else sig0
-                with_+(numberArg.toFixed(Math.max(p - sig, 0)))
-              } else sciNotation(p - 1)
-            case 'f' =>
-              with_+({
-                // JavaDoc: 6 is default precision
-                numberArg.toFixed(if (hasPrecision) precision else 6)
-              }, numberArg.isNaN || numberArg.isInfinite)
-          }
-
-          def sciNotation(precision: Int) = {
-            val exp = numberArg.toExponential(precision)
-            with_+({
-              // check if we need additional 0 padding in exponent
-              // JavaDoc: at least 2 digits
-              if ('e' == exp.charAt(exp.length - 3)) {
-                exp.substring(0, exp.length - 1) + "0" +
-                  exp.charAt(exp.length - 1)
-              } else exp
-            }, numberArg.isNaN || numberArg.isInfinite)
-          }
+    while (fmtIndex != fmtLength) {
+      // Process a portion without '%'
+      val nextPercentIndex = format.indexOf("%", fmtIndex)
+      if (nextPercentIndex < 0) {
+        // No more '%'
+        sendToDest(format.substring(fmtIndex))
+        return this
       }
+      sendToDest(format.substring(fmtIndex, nextPercentIndex))
+
+      // Process one '%'
+
+      val formatSpecifierIndex = nextPercentIndex + 1
+      val re = FormatSpecifier
+      re.lastIndex = formatSpecifierIndex
+      val execResult = re.exec(format)
+
+      if (execResult == null || execResult.index != formatSpecifierIndex) {
+        /* Could not parse a valid format specifier. The reported unknown
+         * conversion is the character directly following the '%', or '%'
+         * itself if this is a trailing '%'. This mimics the behavior of the
+         * JVM.
+         */
+        val conversion =
+          if (formatSpecifierIndex == fmtLength) "%"
+          else format.substring(formatSpecifierIndex, formatSpecifierIndex + 1)
+        throw new UnknownFormatConversionException(conversion)
+      }
+
+      fmtIndex = re.lastIndex // position at the end of the match
+
+      val conversion = format.charAt(fmtIndex - 1)
+      val flags = parseFlags(execResult(2).asInstanceOf[String], conversion)
+      val width = parsePositiveIntSilent(execResult(3), default = -1)
+      val precision = parsePositiveIntSilent(execResult(4), default = -1)
+
+      val arg = if (conversion == '%' || conversion == 'n') {
+        /* No argument. Make sure not to bump `lastImplicitArgIndex` nor to
+         * affect `lastArgIndex`.
+         */
+        null
+      } else {
+        if (flags.leftAlign && width < 0)
+          throw new MissingFormatWidthException("%" + execResult(0))
+
+        val argIndex = if (flags.useLastIndex) {
+          // Explicitly use the last index
+          lastArgIndex
+        } else {
+          val i = parsePositiveIntSilent(execResult(1), default = 0)
+          if (i == 0) {
+            // Either there is no explicit index, or the explicit index is 0
+            lastImplicitArgIndex += 1
+            lastImplicitArgIndex
+          } else if (i < 0) {
+            // Cannot be parsed, same as useLastIndex
+            lastArgIndex
+          } else {
+            // Could be parsed, this is the index
+            i
+          }
+        }
+
+        if (argIndex <= 0 || argIndex > args.length) {
+          val conversionStr = conversion.toString
+          if ("bBhHsHcCdoxXeEgGfn%".indexOf(conversionStr) < 0)
+            throw new UnknownFormatConversionException(conversionStr)
+          else
+            throw new MissingFormatArgumentException("%" + execResult(0))
+        }
+
+        lastArgIndex = argIndex
+        args(argIndex - 1)
+      }
+
+      formatArg(arg, conversion, flags, width, precision)
     }
 
     this
+
+    // scalastyle:on return
   }
 
-  def ioException(): IOException = null
-  def locale(): Locale = ifNotClosed { null }
-  def out(): Appendable = ifNotClosed { dest }
+  /* Should in theory be a method of `object Flags`. See the comment on that
+   * object about why we keep it here.
+   */
+  private def parseFlags(flags: String, conversion: Char): Flags = {
+    var bits = if (conversion <= 'Z') UpperCase else 0
 
-  override def toString(): String = out().toString()
+    val len = flags.length
+    var i = 0
+    while (i != len) {
+      val f = flags.charAt(i)
+      val bit = (f: @switch) match {
+        case '-' => LeftAlign
+        case '#' => AltFormat
+        case '+' => PositivePlus
+        case ' ' => PositiveSpace
+        case '0' => ZeroPad
+        case ',' => UseGroupingSeps
+        case '(' => NegativeParen
+        case '<' => UseLastIndex
+      }
 
-  @inline private def ifNotClosed[T](body: => T): T =
-    if (closed) throwClosedException()
-    else body
+      if ((bits & bit) != 0)
+        throw new DuplicateFormatFlagsException(f.toString)
 
-  private def throwClosedException(): Nothing =
-    throw new FormatterClosedException()
+      bits |= bit
+      i += 1
+    }
+
+    new Flags(bits)
+  }
+
+  private def parsePositiveIntSilent(capture: js.UndefOr[String],
+      default: Int): Int = {
+    capture.fold {
+      default
+    } { s =>
+      val x = js.Dynamic.global.parseInt(s, 10).asInstanceOf[Double]
+      if (x <= Int.MaxValue)
+        x.toInt
+      else
+        -1 // Silently ignore and return -1
+    }
+  }
+
+  private def formatArg(arg: Any, conversion: Char, flags: Flags, width: Int,
+      precision: Int): Unit = {
+
+    @inline def rejectPrecision(): Unit = {
+      if (precision >= 0)
+        throw new IllegalFormatPrecisionException(precision)
+    }
+
+    def formatNullOrThrowIllegalFormatConversion(): Unit = {
+      if (arg == null)
+        formatNonNumericString(flags, width, precision, "null")
+      else
+        throw new IllegalFormatConversionException(conversion, arg.getClass)
+    }
+
+    @inline def precisionWithDefault =
+      if (precision >= 0) precision
+      else 6
+
+    @inline def efgCommon(notation: (Double, Int, Boolean) => String): Unit = {
+      arg match {
+        case arg: Double =>
+          if (arg.isNaN || arg.isInfinite) {
+            formatNaNOrInfinite(flags, width, arg)
+          } else {
+            /* The alternative format # of 'e', 'f' and 'g' is to force a
+             * decimal separator.
+             */
+            val forceDecimalSep = flags.altFormat
+            formatNumericString(flags, width,
+                notation(arg, precisionWithDefault, forceDecimalSep))
+          }
+        case _ =>
+          formatNullOrThrowIllegalFormatConversion()
+      }
+    }
+
+    (conversion: @switch) match {
+      case 'b' | 'B' =>
+        validateFlags(flags, conversion,
+            invalidFlags = NumericOnlyFlags | AltFormat)
+        val str =
+          if ((arg.asInstanceOf[AnyRef] eq false.asInstanceOf[AnyRef]) || arg == null) "false"
+          else "true"
+        formatNonNumericString(flags, width, precision, str)
+
+      case 'h' | 'H' =>
+        validateFlags(flags, conversion,
+            invalidFlags = NumericOnlyFlags | AltFormat)
+        val str =
+          if (arg == null) "null"
+          else Integer.toHexString(arg.hashCode)
+        formatNonNumericString(flags, width, precision, str)
+
+      case 's' | 'S' =>
+        arg match {
+          case formattable: Formattable =>
+            validateFlags(flags, conversion, invalidFlags = NumericOnlyFlags)
+            val formattableFlags = {
+              (if (flags.leftAlign) FormattableFlags.LEFT_JUSTIFY else 0) |
+              (if (flags.altFormat) FormattableFlags.ALTERNATE else 0) |
+              (if (flags.upperCase) FormattableFlags.UPPERCASE else 0)
+            }
+            formattable.formatTo(this, formattableFlags, width, precision)
+
+          case _ =>
+            validateFlags(flags, conversion,
+                invalidFlags = NumericOnlyFlags | AltFormat)
+            val str = String.valueOf(arg)
+            formatNonNumericString(flags, width, precision, str)
+        }
+
+      case 'c' | 'C' =>
+        validateFlags(flags, conversion,
+            invalidFlags = NumericOnlyFlags | AltFormat)
+        rejectPrecision()
+        arg match {
+          case arg: Char =>
+            formatNonNumericString(flags, width, -1, arg.toString)
+          case arg: Int =>
+            if (!Character.isValidCodePoint(arg))
+              throw new IllegalFormatCodePointException(arg)
+            val str = if (arg < Character.MIN_SUPPLEMENTARY_CODE_POINT) {
+              js.Dynamic.global.String.fromCharCode(arg)
+            } else {
+              js.Dynamic.global.String.fromCharCode(
+                  0xd800 | ((arg >> 10) - (0x10000 >> 10)),
+                  0xdc00 | (arg & 0x3ff))
+            }
+            formatNonNumericString(flags, width, -1, str.asInstanceOf[String])
+          case _ =>
+            formatNullOrThrowIllegalFormatConversion()
+        }
+
+      case 'd' =>
+        validateFlags(flags, conversion, invalidFlags = AltFormat)
+        rejectPrecision()
+        arg match {
+          case arg: Int =>
+            formatNumericString(flags, width, arg.toString())
+          case arg: Long =>
+            formatNumericString(flags, width, arg.toString())
+          case _ =>
+            formatNullOrThrowIllegalFormatConversion()
+        }
+
+      case 'o' =>
+        validateFlags(flags, conversion,
+            invalidFlags = InvalidFlagsForOctalAndHex)
+        rejectPrecision()
+        val prefix =
+          if (flags.altFormat) "0"
+          else ""
+        arg match {
+          case arg: Int =>
+            padAndSendToDest(flags, width, prefix,
+                java.lang.Integer.toOctalString(arg))
+          case arg: Long =>
+            padAndSendToDest(flags, width, prefix,
+                java.lang.Long.toOctalString(arg))
+          case _ =>
+            formatNullOrThrowIllegalFormatConversion()
+        }
+
+      case 'x' | 'X' =>
+        validateFlags(flags, conversion,
+            invalidFlags = InvalidFlagsForOctalAndHex)
+        rejectPrecision()
+        val prefix = {
+          if (!flags.altFormat) ""
+          else if (flags.upperCase) "0X"
+          else "0x"
+        }
+        arg match {
+          case arg: Int =>
+            padAndSendToDest(flags, width, prefix,
+                applyUpperCase(flags, java.lang.Integer.toHexString(arg)))
+          case arg: Long =>
+            padAndSendToDest(flags, width, prefix,
+                applyUpperCase(flags, java.lang.Long.toHexString(arg)))
+          case _ =>
+            formatNullOrThrowIllegalFormatConversion()
+        }
+
+      case 'e' | 'E' =>
+        validateFlags(flags, conversion, invalidFlags = UseGroupingSeps)
+        efgCommon(computerizedScientificNotation _)
+
+      case 'g' | 'G' =>
+        validateFlags(flags, conversion, invalidFlags = AltFormat)
+        efgCommon(generalScientificNotation _)
+
+      case 'f' =>
+        validateFlags(flags, conversion, invalidFlags = 0)
+        efgCommon(decimalNotation _)
+
+      case '%' =>
+        validateFlagsForPercentAndNewline(flags, conversion,
+            invalidFlags = AllWrittenFlags & ~LeftAlign)
+        rejectPrecision()
+        if (flags.leftAlign && width < 0)
+          throw new MissingFormatWidthException("%-%")
+        padAndSendToDestNoZeroPad(flags, width, "%")
+
+      case 'n' =>
+        validateFlagsForPercentAndNewline(flags, conversion,
+            invalidFlags = AllWrittenFlags)
+        rejectPrecision()
+        if (width >= 0)
+          throw new IllegalFormatWidthException(width)
+        sendToDest("\n")
+
+      case _ =>
+        throw new UnknownFormatConversionException(conversion.toString)
+    }
+  }
+
+  @inline private def validateFlags(flags: Flags, conversion: Char,
+      invalidFlags: Int): Unit = {
+
+    @noinline def flagsConversionMismatch(): Nothing = {
+      throw new FormatFlagsConversionMismatchException(
+          flagsToString(new Flags(flags.bits & invalidFlags)), conversion)
+    }
+
+    if ((flags.bits & invalidFlags) != 0)
+      flagsConversionMismatch()
+
+    @noinline def illegalFlags(): Nothing =
+      throw new IllegalFormatFlagsException(flagsToString(flags))
+
+    /* The test `(invalidFlags & BadCombo) == 0` is redundant, but is
+     * constant-folded away at called site, and if false it allows to dce the
+     * test after the `&&`. If both tests are eliminated, the entire `if`
+     * disappears.
+     */
+    val BadCombo1 = LeftAlign | ZeroPad
+    val BadCombo2 = PositivePlus | PositiveSpace
+    if (((invalidFlags & BadCombo1) == 0 && (flags.bits & BadCombo1) == BadCombo1) ||
+        ((invalidFlags & BadCombo2) == 0 && (flags.bits & BadCombo2) == BadCombo2)) {
+      illegalFlags()
+    }
+  }
+
+  @inline private def validateFlagsForPercentAndNewline(flags: Flags,
+      conversion: Char, invalidFlags: Int): Unit = {
+
+    @noinline def illegalFlags(): Nothing =
+      throw new IllegalFormatFlagsException(flagsToString(flags))
+
+    if ((flags.bits & invalidFlags) != 0)
+      illegalFlags()
+  }
+
+  /* Should in theory be a method of `Flags`. See the comment on that class
+   * about why we keep it here.
+   */
+  private def flagsToString(flags: Flags): String = {
+    (if (flags.leftAlign) "-" else "") +
+    (if (flags.altFormat) "#" else "") +
+    (if (flags.positivePlus) "+" else "") +
+    (if (flags.positiveSpace) " " else "") +
+    (if (flags.zeroPad) "0" else "") +
+    (if (flags.useGroupingSeps) "," else "") +
+    (if (flags.negativeParen) "(" else "") +
+    (if (flags.useLastIndex) "<" else "")
+  }
+
+  private def computerizedScientificNotation(x: Double, precision: Int,
+      forceDecimalSep: Boolean): String = {
+    import js.JSNumberOps._
+
+    // First use JavaScript's native toExponential conversion
+    val s1 = x.toExponential(precision)
+
+    // -0.0 should have a leading '-'
+    val s2 =
+      if (x == 0.0 && 1 / x < 0) "-" + s1
+      else s1
+
+    // Then make sure the exponent has at least 2 digits for the JDK spec
+    val len = s2.length
+    val s3 =
+      if ('e' != s2.charAt(len - 3)) s2
+      else s2.substring(0, len - 1) + "0" + s2.substring(len - 1)
+
+    // Finally, force the decimal separator, if requested
+    if (!forceDecimalSep || s3.indexOf(".") >= 0) {
+      s3
+    } else {
+      val pos = s3.indexOf("e")
+      s3.substring(0, pos) + "." + s3.substring(pos)
+    }
+  }
+
+  private def generalScientificNotation(x: Double, precision: Int,
+      forceDecimalSep: Boolean): String = {
+    val m = Math.abs(x)
+
+    val p =
+      if (precision == 0) 1
+      else precision
+
+    // between 1e-4 and 10e(p): display as fixed
+    if (m >= 1e-4 && m < Math.pow(10, p)) {
+      /* First approximation of the smallest power of 10 that is >= m.
+       * Due to rounding errors in the event of an imprecise `log10`
+       * function, sig0 could actually be the smallest power of 10
+       * that is > m.
+       */
+      val sig0 = Math.ceil(Math.log10(m)).toInt
+      /* Increment sig0 so that it is always the first power of 10
+       * that is > m.
+       */
+      val sig = if (Math.pow(10, sig0) <= m) sig0 + 1 else sig0
+      decimalNotation(x, Math.max(p - sig, 0), forceDecimalSep)
+    } else {
+      computerizedScientificNotation(x, p - 1, forceDecimalSep)
+    }
+  }
+
+  private def decimalNotation(x: Double, precision: Int,
+      forceDecimalSep: Boolean): String = {
+
+    import js.JSNumberOps._
+
+    // First use JavaScript's native toFixed conversion
+    val s1 = x.toFixed(precision)
+
+    // -0.0 should have a leading '-'
+    val s2 =
+      if (x == 0.0 && 1 / x < 0) "-" + s1
+      else s1
+
+    // Finally, force the decimal separator, if requested
+    if (forceDecimalSep && s2.indexOf(".") < 0)
+      s2 + "."
+    else
+      s2
+  }
+
+  private def formatNonNumericString(flags: Flags, width: Int, precision: Int,
+      str: String): Unit = {
+
+    val truncatedStr =
+      if (precision < 0) str
+      else str.substring(0, precision)
+    padAndSendToDestNoZeroPad(flags, width, applyUpperCase(flags, truncatedStr))
+  }
+
+  private def formatNaNOrInfinite(flags: Flags, width: Int, x: Double): Unit = {
+    val str = if (x.isNaN) {
+      "NaN"
+    } else if (x > 0.0) {
+      if (flags.positivePlus) "+Infinity"
+      else if (flags.positiveSpace) " Infinity"
+      else "Infinity"
+    } else {
+      if (flags.negativeParen) "(Infinity)"
+      else "-Infinity"
+    }
+
+    padAndSendToDestNoZeroPad(flags, width, applyUpperCase(flags, str))
+  }
+
+  private def formatNumericString(flags: Flags, width: Int, str: String): Unit = {
+    /* Flags for which a numeric string needs to be decomposed and transformed,
+     * not just padded and/or uppercased. We can write fast-paths in this
+     * method if none of them are present.
+     */
+    val TransformativeFlags =
+      PositivePlus | PositiveSpace | UseGroupingSeps | NegativeParen
+
+    if (str.length >= width && !flags.hasAnyOf(TransformativeFlags)) {
+      // Super-fast-path
+      sendToDest(applyUpperCase(flags, str))
+    } else if (!flags.hasAnyOf(TransformativeFlags | ZeroPad)) {
+      // Fast-path that does not need to inspect the string
+      formatNonNumericString(flags, width, -1, str)
+    } else {
+      // Extract prefix and rest, based on flags and the presence of a sign
+      val (prefix, rest0) = if (str.charAt(0) != '-') {
+        if (flags.positivePlus)
+          ("+", str)
+        else if (flags.positiveSpace)
+          (" ", str)
+        else
+          ("", str)
+      } else {
+        if (flags.negativeParen)
+          ("(", str.substring(1) + ")")
+        else
+          ("-", str.substring(1))
+      }
+
+      // Insert grouping separators, if required
+      val rest =
+        if (flags.useGroupingSeps) insertGroupingSeps(rest0)
+        else rest0
+
+      // Apply uppercase, pad and send
+      padAndSendToDest(flags, width, prefix, applyUpperCase(flags, rest))
+    }
+  }
+
+  private def insertGroupingSeps(s: String): String = {
+    val len = s.length
+    var index = 0
+    while (index != len && { val c = s.charAt(index); c >= '0' && c <= '9' }) {
+      index += 1
+    }
+
+    index -= 3
+
+    if (index <= 0) {
+      s
+    } else {
+      var result = s.substring(index)
+      while (index > 3) {
+        val next = index - 3
+        result = s.substring(next, index) + "," + result
+        index = next
+      }
+      s.substring(0, index) + "," + result
+    }
+  }
+
+  private def applyUpperCase(flags: Flags, str: String): String =
+    if (flags.upperCase) str.toUpperCase
+    else str
+
+  /** This method ignores `flags.zeroPad` and `flags.upperCase`. */
+  private def padAndSendToDestNoZeroPad(flags: Flags, width: Int,
+      str: String): Unit = {
+
+    val len = str.length
+
+    if (len >= width)
+      sendToDest(str)
+    else if (flags.leftAlign)
+      sendToDest(str, strRepeat(" ", width - len))
+    else
+      sendToDest(strRepeat(" ", width - len), str)
+  }
+
+  /** This method ignores `flags.upperCase`. */
+  private def padAndSendToDest(flags: Flags, width: Int, prefix: String,
+      str: String): Unit = {
+
+    val len = prefix.length + str.length
+
+    if (len >= width)
+      sendToDest(prefix, str)
+    else if (flags.zeroPad)
+      sendToDest(prefix, strRepeat("0", width - len), str)
+    else if (flags.leftAlign)
+      sendToDest(prefix, str, strRepeat(" ", width - len))
+    else
+      sendToDest(strRepeat(" ", width - len), prefix, str)
+  }
+
+  private def strRepeat(s: String, times: Int): String = {
+    var result: String = ""
+    var i = 0
+    while (i != times) {
+      result += s
+      i += 1
+    }
+    result
+  }
+
+  def ioException(): IOException = lastIOException
+
+  def locale(): Locale = {
+    checkNotClosed()
+    null
+  }
+
+  def out(): Appendable = {
+    checkNotClosed()
+    if (dest eq null) {
+      dest = new java.lang.StringBuilder(stringOutput)
+      stringOutput == ""
+    }
+    dest
+  }
+
+  override def toString(): String = {
+    checkNotClosed()
+    if (dest eq null)
+      stringOutput
+    else
+      dest.toString()
+  }
+
+  @inline private def checkNotClosed(): Unit = {
+    if (closed)
+      throw new FormatterClosedException()
+  }
 
 }
 
 object Formatter {
 
-  private class RegExpExtractor(val regexp: js.RegExp) {
-    def unapply(str: String): Option[js.RegExp.ExecResult] = {
-      Option(regexp.exec(str))
-    }
+  private val FormatSpecifier = new js.RegExp(
+      """(?:(\d+)\$)?([-#+ 0,\(<]*)(\d+)?(?:\.(\d+))?[%A-Za-z]""", "g")
+
+  /* This class is never used in a place where it would box, so it will
+   * completely disappear at link-time. Make sure to keep it that way.
+   *
+   * Also note that methods in this class are moved to the companion object, so
+   * also take into account the comment on `object Flags`. In particular, do
+   * not add non-inlineable methods in this class.
+   */
+  private final class Flags(val bits: Int) extends AnyVal {
+    import Flags._
+
+    @inline def leftAlign: Boolean = (bits & LeftAlign) != 0
+    @inline def altFormat: Boolean = (bits & AltFormat) != 0
+    @inline def positivePlus: Boolean = (bits & PositivePlus) != 0
+    @inline def positiveSpace: Boolean = (bits & PositiveSpace) != 0
+    @inline def zeroPad: Boolean = (bits & ZeroPad) != 0
+    @inline def useGroupingSeps: Boolean = (bits & UseGroupingSeps) != 0
+    @inline def negativeParen: Boolean = (bits & NegativeParen) != 0
+    @inline def useLastIndex: Boolean = (bits & UseLastIndex) != 0
+    @inline def upperCase: Boolean = (bits & UpperCase) != 0
+
+    @inline def hasAnyOf(testBits: Int): Boolean = (bits & testBits) != 0
   }
 
-  private val RegularChunk = new RegExpExtractor(new js.RegExp("""^[^\x25]+"""))
-  private val DoublePercent = new RegExpExtractor(new js.RegExp("""^\x25{2}"""))
-  private val EOLChunk = new RegExpExtractor(new js.RegExp("""^\x25n"""))
-  private val FormattedChunk = new RegExpExtractor(new js.RegExp(
-      """^\x25(?:([1-9]\d*)\$)?([-#+ 0,\(<]*)(\d*)(?:\.(\d+))?([A-Za-z])"""))
+  /* This object only contains `final val`s and (synthetic) `@inline`
+   * methods. Therefore, it will completely disappear at link-time. Make sure
+   * to keep it that way. In particular, do not add non-inlineable methods.
+   */
+  private object Flags {
+    final val LeftAlign = 0x001
+    final val AltFormat = 0x002
+    final val PositivePlus = 0x004
+    final val PositiveSpace = 0x008
+    final val ZeroPad = 0x010
+    final val UseGroupingSeps = 0x020
+    final val NegativeParen = 0x040
+    final val UseLastIndex = 0x080
+    final val UpperCase = 0x100
 
+    final val InvalidFlagsForOctalAndHex =
+      PositivePlus | PositiveSpace | UseGroupingSeps | NegativeParen
+
+    final val NumericOnlyFlags =
+      PositivePlus | PositiveSpace | ZeroPad | UseGroupingSeps | NegativeParen
+
+    final val AllWrittenFlags =
+      LeftAlign | AltFormat | NumericOnlyFlags | UseLastIndex
+  }
 }

--- a/javalib/src/main/scala/java/util/Throwables.scala
+++ b/javalib/src/main/scala/java/util/Throwables.scala
@@ -8,28 +8,22 @@ class ConcurrentModificationException(s: String) extends RuntimeException(s) {
   def this() = this(null)
 }
 
-class DuplicateFormatFlagsException private() extends IllegalFormatException {
-  private var flags: String = null
-  def this(f: String) = {
-    this()
-    if (f == null)
-      throw new NullPointerException()
-    flags = f
-  }
-  def getFlags(): String = flags
-  override def getMessage(): String = s"Flags = '$flags'"
+class DuplicateFormatFlagsException(f: String) extends IllegalFormatException {
+  if (f == null)
+    throw new NullPointerException()
+
+  def getFlags(): String = f
+  override def getMessage(): String = "Flags = '" + f + "'"
 }
 
 class EmptyStackException extends RuntimeException
 
-class FormatFlagsConversionMismatchException private(private val c: Char) extends IllegalFormatException {
-  private var f: String = null
-  def this(f: String, c: Char) = {
-    this(c)
-    if (f == null)
-      throw new NullPointerException()
-    this.f = f
-  }
+class FormatFlagsConversionMismatchException(f: String, c: Char)
+    extends IllegalFormatException {
+
+  if (f == null)
+    throw new NullPointerException()
+
   def getFlags(): String = f
   def getConversion(): Char = c
   override def getMessage(): String = "Conversion = " + c + ", Flags = " + f
@@ -37,9 +31,9 @@ class FormatFlagsConversionMismatchException private(private val c: Char) extend
 
 class FormatterClosedException extends IllegalStateException
 
-class IllegalFormatCodePointException(private val c: Int) extends IllegalFormatException {
+class IllegalFormatCodePointException(c: Int) extends IllegalFormatException {
   def getCodePoint(): Int = c
-  override def getMessage(): String = s"Code point = $c"
+  override def getMessage(): String = "Code point = 0x" + Integer.toHexString(c)
 }
 
 class IllegalFormatConversionException(c: Char, arg: Class[_])
@@ -51,29 +45,25 @@ class IllegalFormatConversionException(c: Char, arg: Class[_])
   def getConversion(): Char = c
   def getArgumentClass(): Class[_] = arg
 
-  override def getMessage(): String = s"$c != ${arg.getName()}"
+  override def getMessage(): String = c.toString() + " != " + arg.getName()
 }
 
 class IllegalFormatException private[util] () extends IllegalArgumentException
 
-class IllegalFormatFlagsException private() extends IllegalFormatException {
-  private var flags: String = null
-  def this(f: String) = {
-    this()
-    if (f == null)
-      throw new NullPointerException()
-    this.flags = f
-  }
-  def getFlags(): String = flags
-  override def getMessage(): String = "Flags = '" + flags + "'"
+class IllegalFormatFlagsException(f: String) extends IllegalFormatException {
+  if (f == null)
+    throw new NullPointerException()
+
+  def getFlags(): String = f
+  override def getMessage(): String = "Flags = '" + f + "'"
 }
 
-class IllegalFormatPrecisionException(private val p: Int) extends IllegalFormatException {
+class IllegalFormatPrecisionException(p: Int) extends IllegalFormatException {
   def getPrecision(): Int = p
   override def getMessage(): String = Integer.toString(p)
 }
 
-class IllegalFormatWidthException(private val w: Int) extends IllegalFormatException {
+class IllegalFormatWidthException(w: Int) extends IllegalFormatException {
   def getWidth(): Int = w
   override def getMessage(): String = Integer.toString(w)
 }
@@ -100,26 +90,18 @@ class InvalidPropertiesFormatException(s: String) extends java.io.IOException(s)
   //   throw new java.io.NotSerializableException("Not serializable.")
 }
 
-class MissingFormatArgumentException private() extends IllegalFormatException {
-  private var s: String = null
-  def this(s: String) = {
-    this()
-    if (s == null)
-      throw new NullPointerException()
-    this.s = s
-  }
+class MissingFormatArgumentException(s: String) extends IllegalFormatException {
+  if (s == null)
+    throw new NullPointerException()
+
   def getFormatSpecifier(): String = s
   override def getMessage(): String = "Format specifier '" + s + "'"
 }
 
-class MissingFormatWidthException private() extends IllegalFormatException {
-  private var s: String = null
-  def this(s: String) = {
-    this()
-    if (s == null)
-      throw new NullPointerException()
-    this.s = s
-  }
+class MissingFormatWidthException(s: String) extends IllegalFormatException {
+  if (s == null)
+    throw new NullPointerException()
+
   def getFormatSpecifier(): String = s
   override def getMessage(): String = s
 }
@@ -140,26 +122,20 @@ class TooManyListenersException(s: String) extends Exception(s) {
   def this() = this(null)
 }
 
-class UnknownFormatConversionException private () extends IllegalFormatException {
-  private var s: String = null
-  def this(s: String) = {
-    this()
-    if (s == null)
-      throw new NullPointerException()
-    this.s = s
-  }
+class UnknownFormatConversionException(s: String)
+    extends IllegalFormatException {
+
+  if (s == null)
+    throw new NullPointerException()
+
   def getConversion(): String = s
-  override def getMessage(): String = s"Conversion = '$s'"
+  override def getMessage(): String = "Conversion = '" + s + "'"
 }
 
-class UnknownFormatFlagsException private() extends IllegalFormatException {
-  private var flags: String = null
-  def this(f: String) = {
-    this()
-    if (f == null)
-      throw new NullPointerException()
-    this.flags = f
-  }
-  def getFlags(): String = flags
-  override def getMessage(): String = "Flags = " + flags
+class UnknownFormatFlagsException(f: String) extends IllegalFormatException {
+  if (f == null)
+    throw new NullPointerException()
+
+  def getFlags(): String = f
+  override def getMessage(): String = "Flags = " + f
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
@@ -15,226 +15,418 @@ import org.scalajs.testsuite.utils.Platform._
 
 import java.util._
 
-import java.lang.{
-Double  => JDouble,
-Float   => JFloat,
-Integer => JInteger,
-Long    => JLong,
-Byte    => JByte,
-Short   => JShort,
-Boolean => JBoolean,
-String  => JString
-}
-
 class FormatterTest {
+  import FormatterTest._
 
-  class HelperClass
-  class FormattableClass extends Formattable {
-    var frm: Formatter = _
-    var flags: Int = _
-    var width: Int = _
-    var precision: Int = _
-    var calls = 0
-
-    def formatTo(frm: Formatter, flags: Int, width: Int, precision: Int): Unit = {
-      this.calls += 1
-      this.flags = flags
-      this.width = width
-      this.precision = precision
-      frm.out().append("foobar")
-    }
-
-    def expectCalled(times: Int, flags: Int, width: Int, precision: Int): Unit = {
-      assertEquals(times, this.calls)
-      assertEquals(flags, this.flags)
-      assertEquals(width, this.width)
-      assertEquals(precision, this.precision)
-    }
-
-  }
-
-  def assertF(expected: String, format: String, args: AnyRef*): Unit = {
+  def assertF(expected: String, format: String, args: Any*): Unit = {
     val fmt = new Formatter()
-    val res = fmt.format(format, args:_*).toString()
+    val res = fmt.format(format, args.asInstanceOf[Seq[AnyRef]]: _*).toString()
     fmt.close()
     assertEquals(expected, res)
   }
 
-  def assertFC(expected: String, format: String, flags: Int, width: Int,
-      precision: Int): Unit = {
-    val fc = new FormattableClass
-    assertF(expected, format, fc)
-    fc.expectCalled(1, flags, width, precision)
+  def testWithInfinityAndNaN(conversion: Char,
+      acceptUpperCase: Boolean = true): Unit = {
+
+    import Double.{NaN, PositiveInfinity => PosInf, NegativeInfinity => NegInf}
+
+    assertF("Infinity", "%" + conversion, PosInf)
+    assertF("-Infinity", "%" + conversion, NegInf)
+    assertF("  Infinity", "%010" + conversion, PosInf)
+    assertF(" -Infinity", "%010" + conversion, NegInf)
+    assertF("Infinity  ", "%-10" + conversion, PosInf)
+    assertF("(Infinity)", "%(" + conversion, NegInf)
+    assertF("     (Infinity)", "%(15" + conversion, NegInf)
+    assertF("     (Infinity)", "%(015" + conversion, NegInf)
+    assertF("       NaN", "%10" + conversion, NaN)
+    assertF("       NaN", "%010" + conversion, NaN)
+
+    assertF("+Infinity", "%+" + conversion, PosInf)
+    assertF(" Infinity", "% " + conversion, PosInf)
+    assertF("-Infinity", "%+" + conversion, NegInf)
+    assertF("-Infinity", "% " + conversion, NegInf)
+
+    assertF("+Infinity", "%+(" + conversion, PosInf)
+    assertF(" Infinity", "% (" + conversion, PosInf)
+    assertF("(Infinity)", "%+(" + conversion, NegInf)
+    assertF("(Infinity)", "% (" + conversion, NegInf)
+
+    if (acceptUpperCase) {
+      val upConversion = conversion.toUpper
+      assertF("INFINITY", "%" + upConversion, PosInf)
+      assertF("-INFINITY", "%" + upConversion, NegInf)
+      assertF("NAN", "%" + upConversion, NaN)
+    }
   }
 
   def expectFormatterThrows[T <: Throwable](exeption: Class[T], format: String,
-      args: AnyRef*): Unit = {
+      args: Any*): T = {
     val fmt = new Formatter()
-    assertThrows(exeption, fmt.format(format, args:_*))
+    expectThrows(exeption,
+        fmt.format(format, args.asInstanceOf[Seq[AnyRef]]: _*))
   }
-
-  // Explicitly define these as `var`'s to avoid any compile-time constant folding
-  var IntMax: Int = Int.MaxValue
-  var IntMin: Int = Int.MinValue
-  var ByteMax: Byte = Byte.MaxValue
-  var ByteMin: Byte = Byte.MinValue
-  var ShortMax: Short = Short.MaxValue
-  var ShortMin: Short = Short.MinValue
 
   @Test def `should_provide_b_conversion`(): Unit = {
     assertF("false", "%b", null)
-    assertF(JString.valueOf(true), "%b", true: JBoolean)
-    assertF(JString.valueOf(false), "%b", false: JBoolean)
+    assertF("true", "%b", true)
+    assertF("false", "%b", false)
     assertF("true", "%b", new HelperClass)
+
+    assertF("  false", "%7b", false)
+    assertF("   true", "%7b", true)
+    assertF("false  ", "%-7b", false)
+    assertF("true   ", "%-7b", true)
+
+    assertF("FALSE", "%B", false)
   }
 
   @Test def `should_provide_h_conversion`(): Unit = {
     val x = new HelperClass
-    assertF(Integer.toHexString(x.hashCode()), "%h", x)
-    assertF(Integer.toHexString(x.hashCode()).toUpperCase(), "%H", x)
+    assertF("f1e2a3", "%h", x)
+    assertF("F1E2A3", "%H", x)
+
+    assertF("  f1e2a3", "%8h", x)
+
     assertF("null", "%h", null)
   }
 
-  @Test def `should_provide_s_conversion`(): Unit = {
-    assertFC("foobar", "%s", 0, -1, -1)
-    assertFC("foobar", "%-10s", FormattableFlags.LEFT_JUSTIFY, 10, -1)
-    assertFC("foobar", "%#-10.2s",
-        FormattableFlags.LEFT_JUSTIFY | FormattableFlags.ALTERNATE, 10, 2)
-    assertFC("foobar", "%#10.2S",
-        FormattableFlags.UPPERCASE | FormattableFlags.ALTERNATE, 10, 2)
+  @Test def sConversionWithNonFormattable(): Unit = {
+    assertF("abcdef", "ab%sef", "cd")
+    assertF("true", "%s", true)
+    assertF("12345", "%s", 12345)
+
+    assertF("ABCDEF", "%S", "aBcdeF")
+
     assertF("     hello", "%10s", "hello")
     assertF("hello     ", "%-10s", "hello")
+
+    assertF("null", "%s", null)
+
     if (!executingInJVMOnJDK6)
       expectFormatterThrows(classOf[Exception], "%#s", "hello")
   }
 
-  @Test def `should_fail_s_conversions_without_width`(): Unit = {
-    // Issue #2246
-    expectFormatterThrows(classOf[MissingFormatWidthException], "%-s", "abc")
+  @Test def sConversionWithFormattable(): Unit = {
+    import FormattableFlags._
+
+    class FormattableClass extends Formattable {
+      private var flags: Int = _
+      private var width: Int = _
+      private var precision: Int = _
+      private var calls: Int = 0
+
+      def formatTo(frm: Formatter, flags: Int, width: Int, precision: Int): Unit = {
+        this.calls += 1
+        this.flags = flags
+        this.width = width
+        this.precision = precision
+        frm.out().append("foobar")
+      }
+
+      def expectCalled(times: Int, flags: Int, width: Int, precision: Int): Unit = {
+        assertEquals(times, this.calls)
+        assertEquals(flags, this.flags)
+        assertEquals(width, this.width)
+        assertEquals(precision, this.precision)
+      }
+    }
+
+    def test(format: String, flags: Int, width: Int, precision: Int): Unit = {
+      val fc = new FormattableClass
+      assertF("foobar", format, fc)
+      fc.expectCalled(1, flags, width, precision)
+    }
+
+    test("%s", 0, -1, -1)
+    test("%-10s", LEFT_JUSTIFY, 10, -1)
+    test("%#-10.2s", LEFT_JUSTIFY | ALTERNATE, 10, 2)
+    test("%#10.2S", UPPERCASE | ALTERNATE, 10, 2)
   }
 
   @Test def `should_provide_c_conversion`(): Unit = {
-    assertF("!    ", "%-5c", new Character('!'))
+    assertF("a", "%c", 'a')
+    assertF("A", "%C", 'A')
+    assertF("A", "%c", 65)
+
+    assertF("    !", "%5c", '!')
+    assertF("!    ", "%-5c", '!')
   }
 
   @Test def `should_provide_d_conversion`(): Unit = {
-    assertF("5", "%d", new Integer(5))
-    assertF("00005", "%05d", new Integer(5))
-    assertF("  -10", "%5d", new Integer(-10))
-    assertF("-0010", "%05d", new Integer(-10))
+    assertF("5", "%d", 5)
+    assertF("-5", "%d", -5)
+
+    assertF("00005", "%05d", 5)
+    assertF("  -10", "%5d", -10)
+    assertF("-0010", "%05d", -10)
+
+    assertF("56", "%(d", 56)
+    assertF("(56)", "%(d", -56)
+    assertF("    (56)", "%(8d", -56)
+    assertF("(000056)", "%(08d", -56)
+
+    assertF(" 56", "% d", 56)
+    assertF("-56", "% d", -56)
+    assertF("+56", "%+d", 56)
+    assertF("-56", "%+d", -56)
+
+    assertF(" 00056", "% 0,6d", 56)
+    assertF("-00056", "% 0,6d", -56)
+    assertF(" 00056", "% 0,(6d", 56)
+    assertF("(0056)", "% 0,(6d", -56)
+
+    assertF("56    ", "%-6d", 56)
+    assertF("-56   ", "%-6d", -56)
   }
 
   @Test def `should_provide_o_conversion`(): Unit = {
-    assertF("10", "%o", new JInteger(8))
-    assertF("00020", "%05o", new JInteger(16))
-    assertF("37777777766", "%5o", new JInteger(-10))
-    assertF("37777777766", "%05o", new JInteger(-10))
-    assertF("10", "%o", new JByte(8.toByte))
-    assertF("00020", "%05o", new JByte(16.toByte))
-    assertF("10", "%o", new JShort(8.toShort))
-    assertF("00020", "%05o", new JShort(16.toShort))
-    if (!executingInJVM) {
-      // expected:<   [377777777]66> but was:<   [        3]66>
-      assertF("   37777777766", "%14o", new JByte(-10.toByte))
-      // expected:<[377777777]66> but was:<[003]66>
-      assertF("37777777766", "%05o", new JByte(-10.toByte))
-      // expected:<[377777]77766> but was:<[1]77766>
-      assertF("1777777777777777777773", "%05o", new JLong(-5L))
-      // expected:<0000[377777]77766> but was:<0000[000001]77766>
-      assertF("37777777766", "%5o", new JShort(-10.toShort))
-      // expected:<0000[377777]77766> but was:<0000[000001]77766>
-      assertF("000037777777766", "%015o",new JShort(-10.toShort))
-    }
+    assertF("10", "%o", 8)
+
+    assertF("00020", "%05o", 16)
+    assertF("37777777766", "%5o", -10)
+    assertF("37777777766", "%05o", -10)
+
+    assertF("   21", "%5o", 17)
+    assertF("21   ", "%-5o", 17)
+
+    assertF("10", "%o", 8.toByte)
+    assertF("00020", "%05o", 16.toByte)
+    assertF("10", "%o", 8.toShort)
+    assertF("00020", "%05o", 16.toShort)
+
+    assertF("30071", "%o", 12345L)
+    assertF("1777777777777777747707", "%o", -12345L)
+
+    assertF("     30071", "%10o", 12345L)
+    assertF("1777777777777777747707", "%10o", -12345L)
+    assertF("0000030071", "%010o", 12345L)
+    assertF("1777777777777777747707", "%010o", -12345L)
+
+    assertF("0664", "%#o", 436)
+    assertF("    0664", "%#8o", 436)
+    assertF("00000664", "%#08o", 436)
+
+    /* Negative Bytes and Shorts are formatted as if they were Ints.
+     * This is a consequence of the non-boxing behavior of numbers in Scala.js.
+     */
+    assertF("   37777777766", "%14o", asIntOnJVM(-10.toByte))
+    assertF("37777777766", "%05o", asIntOnJVM(-10.toByte))
+    assertF("37777777766", "%5o", asIntOnJVM(-10.toShort))
+    assertF("000037777777766", "%015o", asIntOnJVM(-10.toShort))
   }
 
   @Test def `should_provide_x_conversion`(): Unit = {
-    assertF("0x005", "%0#5x", new JInteger(5))
-    assertF("  0x5", "%#5x", new JInteger(5))
-    assertF("  0X5", "%#5X", new JInteger(5))
-    assertF("fffffffd", "%x", new JInteger(-3))
-    if (!executingInJVM) {
-      // expected:<f[ffffff]c> but was:<f[]c>
-      assertF("fffffffc", "%x", new JByte(-4.toByte))
-    }
-    assertF("0x005", "%0#5x", new JByte(5.toByte))
-    assertF("  0x5", "%#5x", new JByte(5.toByte))
-    assertF("  0X5", "%#5X", new JByte(5.toByte))
-    if (!executingInJVM) {
-      // expected:<f[ffffff]d> but was:<f[]d>
-      assertF("fffffffd", "%x", new JByte(-3.toByte))
-    }
-    assertF("0x005", "%0#5x", new JShort(5.toShort))
-    assertF("  0x5", "%#5x", new JShort(5.toShort))
-    assertF("  0X5", "%#5X", new JShort(5.toShort))
-    if (!executingInJVM) {
-      // expected:<fff[ffff]d> but was:<fff[]d>
-      assertF("fffffffd", "%x", new JShort(-3.toShort))
-    }
-    assertF("fffffffffffffffb", "%x", new JLong(-5L))
-    assertF("1A", "%X", new JLong(26L))
+    assertF("d431", "%x", 54321)
+    assertF("ffff2bcf", "%x", -54321)
+    assertF("D431", "%X", 54321)
+    assertF("FFFF2BCF", "%X", -54321)
+
+    assertF("0xd431", "%#x", 54321)
+    assertF("0xffff2bcf", "%#x", -54321)
+    assertF("0XD431", "%#X", 54321)
+    assertF("0XFFFF2BCF", "%#X", -54321)
+
+    assertF("         d431", "%13x", 54321)
+    assertF("     ffff2bcf", "%13x", -54321)
+    assertF("         D431", "%13X", 54321)
+    assertF("     FFFF2BCF", "%13X", -54321)
+    assertF("       0xd431", "%#13x", 54321)
+    assertF("   0xffff2bcf", "%#13x", -54321)
+
+    assertF("d431         ", "%-13x", 54321)
+    assertF("ffff2bcf     ", "%-13x", -54321)
+    assertF("0xd431       ", "%-#13x", 54321)
+    assertF("0xffff2bcf   ", "%-#13x", -54321)
+
+    assertF("000000000d431", "%013x", 54321)
+    assertF("00000ffff2bcf", "%013x", -54321)
+    assertF("0x0000000d431", "%0#13x", 54321)
+    assertF("0x000ffff2bcf", "%0#13x", -54321)
+
+    assertF("fffffffc", "%x", asIntOnJVM(-4.toByte))
+    assertF("0x005", "%0#5x", 5.toByte)
+    assertF("  0x5", "%#5x", 5.toByte)
+    assertF("  0X5", "%#5X", 5.toByte)
+    assertF("fffffffd", "%x", asIntOnJVM(-3.toByte))
+
+    assertF("0x005", "%0#5x", 5.toShort)
+    assertF("  0x5", "%#5x", 5.toShort)
+    assertF("  0X5", "%#5X", 5.toShort)
+    assertF("fffffffd", "%x", asIntOnJVM(-3.toShort))
+
+    assertF("ffffffffffff2bcf", "%x", -54321L)
+    assertF("28EEA4CB1", "%X", 10987654321L)
   }
 
   @Test def `should_provide_e_conversion`(): Unit = {
-    assertF("1.000000e+03", "%e", new JDouble(1000))
-    assertF("1e+100", "%.0e", new JDouble(1.2e100))
-    // We use 1.51e100 in this test, since we seem to have a floating
-    // imprecision at exactly 1.5e100 that yields to a rounding error
-    // towards (1e+100 instead of 2e+100)
-    assertF("2e+100", "%.0e", new JDouble(1.51e100))
-    assertF(" 1.20e+100", "%10.2e", new JDouble(1.2e100))
-    assertF("001.2000e-21", "%012.4e", new JFloat(1.2e-21f))
-    assertF("001.2000E-21", "%012.4E", new JFloat(1.2e-21f))
-    assertF("(0001.2000e-21)", "%(015.4e", new JFloat(-1.2e-21f))
+    assertF("1.000000e+03", "%e", 1000.0)
+    assertF("1e+100", "%.0e", 1.2e100)
+    assertF("0.000e+00", "%.3e", 0.0)
 
-    // Tests with infinity and NaN
-    assertF("Infinity", "%e", new JDouble(Double.PositiveInfinity))
-    assertF("-Infinity", "%e", new JDouble(Double.NegativeInfinity))
-    assertF("  Infinity", "%010e", new JDouble(Double.PositiveInfinity))
-    assertF("Infinity  ", "%-10e", new JDouble(Double.PositiveInfinity))
-    assertF("(Infinity)", "%(e", new JDouble(Double.NegativeInfinity))
-    assertF("       NaN", "%010e", new JDouble(Double.NaN))
+    /* We use 1.51e100 in this test, since we seem to have a floating point
+     * imprecision at exactly 1.5e100 that yields to a rounding error towards
+     * 1e+100 instead of 2e+100.
+     */
+    assertF("2e+100", "%.0e", 1.51e100)
+
+    assertF(" 1.20e+100", "%10.2e", 1.2e100)
+
+    // #3202 Corner case of round-half-up (currently non-compliant)
+    if (executingInJVM) {
+      assertF("7.6543215e-20    ", "%-17.7e", 7.65432145e-20)
+      assertF("-7.6543215e-20   ", "%-17.7e", -7.65432145e-20)
+      assertF("7.6543216e-20    ", "%-17.7e", 7.65432155e-20)
+      assertF("-7.6543216e-20   ", "%-17.7e", -7.65432155e-20)
+    } else {
+      assertF("7.6543214e-20    ", "%-17.7e", 7.65432145e-20)
+      assertF("-7.6543214e-20   ", "%-17.7e", -7.65432145e-20)
+      assertF("7.6543215e-20    ", "%-17.7e", 7.65432155e-20)
+      assertF("-7.6543215e-20   ", "%-17.7e", -7.65432155e-20)
+    }
+
+    assertF("001.2000e-21", "%012.4e", 1.2e-21f)
+    assertF("001.2000E-21", "%012.4E", 1.2e-21f)
+    assertF("(0001.2000e-21)", "%(015.4e", -1.2e-21f)
+
+    assertF("+1.234560e+30", "%+e", 1.23456e30)
+    assertF("-1.234560e+30", "%+e", -1.23456e30)
+    assertF(" 1.234560e+30", "% e", 1.23456e30)
+    assertF("-1.234560e+30", "% e", -1.23456e30)
+
+    testWithInfinityAndNaN('e')
   }
 
   @Test def `should_provide_g_conversion`(): Unit = {
-    assertF("5.00000e-05", "%g", new JDouble(.5e-4))
-    assertF("0.000300000", "%g", new JDouble(3e-4))
-    assertF("0.000300", "%.3g", new JDouble(3e-4))
-    assertF("10.0000", "%g", new JDouble(10.0))
-    assertF("10.00", "%.4g", new JDouble(10.0))
-    assertF("0.0010", "%.2g", new JDouble(1e-3))
-    assertF("300000", "%g", new JDouble(3e5))
-    assertF("3.00e+05", "%.3g", new JDouble(3e5))
-    assertF(" NaN", "%04g", new JDouble(Double.NaN))
+    assertF("5.00000e-05", "%g", 0.5e-4)
+    assertF("-5.00000e-05", "%g", -0.5e-4)
+    assertF("0.000300000", "%g", 3e-4)
+    assertF("0.000300", "%.3g", 3e-4)
+    assertF("10.0000", "%g", 10.0)
+    assertF("10.00", "%.4g", 10.0)
+    assertF("0.0010", "%.2g", 1e-3)
+    assertF("300000", "%g", 3e5)
+    assertF("3.00e+05", "%.3g", 3e5)
+
+    assertF("005.00000e-05", "%013g", 0.5e-4)
+    assertF("-05.00000e-05", "%013g", -0.5e-4)
+    assertF("0000000300000", "%013g", 3e5)
+    assertF("-000000300000", "%013g", -3e5)
+
+    assertF("00003.00e+05", "%012.3g", 3e5)
+    assertF("-0003.00e+05", "%012.3g", -3e5)
+
+    assertF("5.00000e-05", "%(g", 0.5e-4)
+    assertF("(5.00000e-05)", "%(g", -0.5e-4)
+    assertF("300000", "%(g", 3e5)
+    assertF("(300000)", "%(g", -3e5)
+
+    assertF("+5.00000e-05", "%(+g", 0.5e-4)
+    assertF("(5.00000e-05)", "%(+g", -0.5e-4)
+    assertF("+300000", "%(+g", 3e5)
+    assertF("(300000)", "%(+g", -3e5)
+
+    assertF(" 5.00000e-05", "% g", 0.5e-4)
+    assertF("-5.00000e-05", "% g", -0.5e-4)
+    assertF(" 300000", "% g", 3e5)
+    assertF("-300000", "% g", -3e5)
+
+    assertF("    5.00000e-05", "%15g", 0.5e-4)
+    assertF("   -5.00000e-05", "%15g", -0.5e-4)
+    assertF("         300000", "%15g", 3e5)
+    assertF("        -300000", "%15g", -3e5)
+
+    assertF("    5.00000e-05", "%(15g", 0.5e-4)
+    assertF("  (5.00000e-05)", "%(15g", -0.5e-4)
+    assertF("         300000", "%(15g", 3e5)
+    assertF("       (300000)", "%(15g", -3e5)
+
+    assertF("5.00000e-05    ", "%-15g", 0.5e-4)
+    assertF("-5.00000e-05   ", "%-15g", -0.5e-4)
+    assertF("300000         ", "%-15g", 3e5)
+    assertF("-300000        ", "%-15g", -3e5)
+
+    testWithInfinityAndNaN('g')
   }
 
   @Test def `should_provide_f_conversion`(): Unit = {
-    assertF("3.300000", "%f", new JDouble(3.3))
-    assertF("(04.6000)", "%0(9.4f", new JDouble(-4.6))
-    assertF("30000001024.000000", "%f", new JFloat(3e10f))
-    assertF("30000000000.000000", "%f", new JDouble(3e10))
-    assertF(" NaN", "%04f", new JDouble(Double.NaN))
+    assertF("3.300000", "%f", 3.3)
+    assertF("(04.6000)", "%0(9.4f", -4.6)
+
+    assertF("30000001024.000000", "%f", 3e10f)
+
+    assertF("30000000000.000000", "%f", 3e10)
+
+    assertF("00000000.000050", "%015f", 0.5e-4)
+    assertF("-0000000.000050", "%015f", -0.5e-4)
+    assertF("00300000.000000", "%015f", 3e5)
+    assertF("-0300000.000000", "%015f", -3e5)
+
+    assertF("00300000.000", "%012.3f", 3e5)
+    assertF("-0300000.000", "%012.3f", -3e5)
+
+    assertF("0.000050", "%(f", 0.5e-4)
+    assertF("(0.000050)", "%(f", -0.5e-4)
+    assertF("300000.000000", "%(f", 3e5)
+    assertF("(300000.000000)", "%(f", -3e5)
+
+    assertF("+0.000050", "%(+f", 0.5e-4)
+    assertF("(0.000050)", "%(+f", -0.5e-4)
+    assertF("+300000.000000", "%(+f", 3e5)
+    assertF("(300000.000000)", "%(+f", -3e5)
+
+    assertF(" 0.000050", "% f", 0.5e-4)
+    assertF("-0.000050", "% f", -0.5e-4)
+    assertF(" 300000.000000", "% f", 3e5)
+    assertF("-300000.000000", "% f", -3e5)
+
+    assertF("       0.000050", "%15f", 0.5e-4)
+    assertF("      -0.000050", "%15f", -0.5e-4)
+    assertF("  300000.000000", "%15f", 3e5)
+    assertF(" -300000.000000", "%15f", -3e5)
+
+    assertF("       0.000050", "%(15f", 0.5e-4)
+    assertF("     (0.000050)", "%(15f", -0.5e-4)
+    assertF("  300000.000000", "%(15f", 3e5)
+    assertF("(300000.000000)", "%(15f", -3e5)
+
+    assertF("0.000050       ", "%-15f", 0.5e-4)
+    assertF("-0.000050      ", "%-15f", -0.5e-4)
+    assertF("300000.000000  ", "%-15f", 3e5)
+    assertF("-300000.000000 ", "%-15f", -3e5)
+
+    // #3202
+    if (executingInJVM) {
+      assertF("66380.78812500000", "%.11f", 66380.788125)
+    } else {
+      assertF("66380.78812500001", "%.11f", 66380.788125)
+    }
+
+    testWithInfinityAndNaN('f', acceptUpperCase = false)
   }
 
   @Test def `should_support_%%`(): Unit = {
-    assertF("1%2", "%d%%%d", new JInteger(1), new JInteger(2))
+    assertF("1%2", "%d%%%d", 1, 2)
   }
 
   @Test def `should_support_%n`(): Unit = {
-    assertF("1\n2", "%d%n%d", new JInteger(1), new JInteger(2))
-  }
-
-  @Test def `should_survive_null`(): Unit = {
-    assertF("null", "%s", null)
-  }
-
-  @Test def `should_allow_f_string_interpolation_to_survive_null`(): Unit = {
-    assertEquals("null", f"${null}%s")
+    assertF("1\n2", "%d%n%d", 1, 2)
   }
 
   @Test def should_allow_positional_arguments(): Unit = {
-    assertF("2 1", "%2$d %1$d", new JInteger(1), new JInteger(2))
-    assertF("2 2 1", "%2$d %2$d %d", new JInteger(1), new JInteger(2))
-    assertF("2 2 1", "%2$d %<d %d", new JInteger(1), new JInteger(2))
+    assertF("2 1", "%2$d %1$d", 1, 2)
+    assertF("2 2 1", "%2$d %2$d %d", 1, 2)
+    assertF("2 2 1", "%2$d %<d %d", 1, 2)
+  }
+
+  @Test def leftAlignWithoutWidthThrows(): Unit = {
+    for (conversion <- "bBhHsHcCdoxXeEgGf") {
+      val fmt = "ab%-" + conversion + "cd"
+      val arg: Any = conversion match {
+        case 'e' | 'E' | 'g' | 'G' | 'f' => 5.5
+        case _                           => 5
+      }
+      expectFormatterThrows(classOf[MissingFormatWidthException], fmt, arg)
+    }
   }
 
   @Test def should_fail_when_called_after_close(): Unit = {
@@ -254,8 +446,26 @@ class FormatterTest {
   @Test def should_fail_with_not_enough_arguments(): Unit = {
     expectFormatterThrows(classOf[MissingFormatArgumentException], "%f")
     expectFormatterThrows(classOf[MissingFormatArgumentException], "%d%d%d",
-      new JInteger(1), new JInteger(1))
-    expectFormatterThrows(classOf[MissingFormatArgumentException], "%10$d",
-      new JInteger(1))
+        1, 1)
+    expectFormatterThrows(classOf[MissingFormatArgumentException], "%10$d", 1)
   }
+}
+
+object FormatterTest {
+
+  def asIntOnJVM(x: Byte): Any =
+    if (executingInJVM) x.toInt
+    else x
+
+  def asIntOnJVM(x: Short): Any =
+    if (executingInJVM) x.toInt
+    else x
+
+  class HelperClass {
+    override def hashCode(): Int = 0xf1e2a3
+
+    // Soothe Scalastyle (equals and hashCode should be declared together)
+    override def equals(that: Any): Boolean = super.equals(that)
+  }
+
 }


### PR DESCRIPTION
This class was written a very long time ago, when quality standards were not as high as they are now. In this commit, we entirely rewrite it while aiming for:

* Readability
* Performance
* Fidelity in a lot of corner cases wrt. the specification on the JVM, in particular in error cases

The corresponding test suite is significantly enhanced.

In the process, this commit fixes #1619 (thousands grouping), as well as many other issues, among which:

* Formatting of astral characters with `%c`.
* Formatting of `null` with all the format specifiers.
* Handling of precision in non-numeric strings (basically `substring`).
* Capturing `IOException`s thrown by the target `Appendable`.

Despite the large number of fixes, the following items are still not addressed:

* #3202 and, more generally, various discrepancies between the formatting of floating point numbers wrt. the specification, with `%f`, `%e` and `%g`.
* Hexadecimal format for floating point numbers with `%a`.
* Formatting of date/times with the `%t.` family.
* Formatting of `BigInteger`s and `BigDecimal`s.