### PR TITLE
Remove the `ScalaJSGroupID` binary compatibility hack.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/ScalaJSGroupID.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/ScalaJSGroupID.scala
@@ -1,7 +1,0 @@
-package org.scalajs.sbtplugin.impl
-
-/** Exclusively for binary compatibility with sbt-scalajs-crossproject. */
-@deprecated(
-    "Exclusively for binary compatibility with sbt-scalajs-crossproject.",
-    "forever")
-private[impl] class ScalaJSGroupID


### PR DESCRIPTION
It was kept there for binary compatibility with sbt-crossproject, but since version 0.5.0, sbt-crossproject does not need it anymore. See [commit e7b769a95a24df24d777d7a03eb1f3659a9fcc25 in the sbt-crossproject history](https://github.com/portable-scala/sbt-crossproject/commit/e7b769a95a24df24d777d7a03eb1f3659a9fcc25).