### PR TITLE
Remove useless call to `registerModuleExports` in the JUnit plugin.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
@@ -59,11 +59,13 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
   }
 
   /** Checks and registers module exports on the symbol.
-   *  This bridge allows other plugins (such as ScalaJSJUnitPlugin) to register
-   *  new modules for export between jsinterop and jscode phases. It is meant to
-   *  be accessed using reflection. The calling code still must insert the
-   *  `@JSExport` annotation to the module.
+   *
+   *  This bridge allows other plugins to register new modules for export
+   *  between jsinterop and jscode phases. It is meant to be accessed using
+   *  reflection. The calling code still must insert the `@JSExport` annotation
+   *  to the module.
    */
+  @deprecated("Might be removed at any time, use at your own risk.", "0.6.24")
   def registerModuleExports(sym: Symbol): Unit =
     PrepInteropComponent.registerModuleExports(sym)
 

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -87,20 +87,6 @@ class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
 
   val description: String = "Makes JUnit test classes invokable in Scala.js"
 
-  // `ScalaJSPlugin` instance reference. Only `registerModuleExports` is accessible.
-  private lazy val scalaJSPlugin = {
-    type ScalaJSPlugin = NscPlugin {
-      def registerModuleExports(sym: ScalaJSJUnitPluginComponent.global.Symbol): Unit
-    }
-    global.plugins.collectFirst {
-      case pl if pl.getClass.getName == "org.scalajs.core.compiler.ScalaJSPlugin" =>
-        pl.asInstanceOf[ScalaJSPlugin]
-    }.getOrElse {
-      throw new Exception(
-          "The Scala.js JUnit plugin only works with the Scala.js plugin enabled.")
-    }
-  }
-
   object ScalaJSJUnitPluginComponent
       extends plugins.PluginComponent with transform.Transform with Compat210Component {
 
@@ -238,7 +224,6 @@ class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
           ClassInfoType(newParentsInfo, decls, bootSym.info.typeSymbol)
         }
         bootSym.setInfo(newClazzInfo)
-        scalaJSPlugin.registerModuleExports(bootSym)
         bootClazz.setSymbol(bootSym)
 
         currentRun.symSource(bootSym) = clazz.symbol.sourceFile


### PR DESCRIPTION
The call has been useless since f7e4cf733d3a723437afd848d628ff81d4b98671, when we transitioned from using exports to `@EnableReflectiveInstantiation` for the JUnit bootstrapper objects.

We also deprecate the hook, which, although "documented", was not well-specified and was there only for the JUnit plugin.

/cc @MasseGuillaume 