### PR TITLE
Fix #3393: Correctly report VM crashes as failed futures.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
@@ -183,8 +183,11 @@ abstract class ExternalJSEnv(
           case e => ioThreadEx = e
         }
 
-        // Chain Try's the other way: We want VM failure first, then IO failure
-        promise.complete(pipeResult orElse vmComplete)
+        /* We want the VM failure to take precedence if there was one,
+         * otherwise the IO failure if there is one. We complete with a
+         * successful () only when both vmComplete and pipeResult were successful.
+         */
+        promise.complete(vmComplete.flatMap(_ => pipeResult))
       }
     }
 


### PR DESCRIPTION
The line in this commit was supposed to complete the future with a failure if either `vmComplete` or `pipeResult` was failed, giving precedence to `vmComplete`. However that line was bogus, and would complete with a success if `pipeResult` was a success, even if `vmComplete` was a failure.

This caused the `TestAdapter` to erroneously interpret a VM failure as a normal exit without spawning the testing interface bridge.