### PR TITLE
FF ONLY Merge 0.6.x into master, June 29

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -145,7 +145,7 @@ object Build {
     "Whether we should partest the current scala version (and fail if we can't)")
 
   /* MiMa configuration -- irrelevant while in 1.0.0-SNAPSHOT.
-  val previousVersion = "0.6.23"
+  val previousVersion = "0.6.24"
   val previousSJSBinaryVersion =
     ScalaJSCrossVersion.binaryScalaJSVersion(previousVersion)
   val previousBinaryCrossVersion =


### PR DESCRIPTION
Motivation: one last merge before releasing 1.0.0-M4.
```
$ git checkout -b merge-0.6.x-into-master-june-29
Switched to a new branch 'merge-0.6.x-into-master-june-29'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* e913ee60a (scalajs/0.6.x) Towards 0.6.25.
* e82edddf5 (tag: v0.6.24, origin/0.6.x) Version 0.6.24.
* e8dfb73f3 Merge pull request #3394 from sjrd/fail-test-on-top-level-exception
* 25d4057a1 Fix #3393: Correctly report VM crashes as failed futures.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
CONFLICT (modify/delete): js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala left in tree.
Auto-merging ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
UU project/Build.scala
```
master was not affected by #3393 (I just checked), so just delete the conflicting `ExternalJSEnv.scala`:
```
$ git rm -f js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala 
js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala: needs merge
rm 'js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala'
```
[...] Edit conflicting files (the typical version number clash)
```diff
$ git diff | cat
diff --cc ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
index 73a88b396,ab627acfa..000000000
--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
diff --cc project/Build.scala
index dc507b001,2995a6f40..000000000
--- a/project/Build.scala
+++ b/project/Build.scala
@@@ -144,8 -57,7 +144,8 @@@ object Build 
    val shouldPartest = settingKey[Boolean](
      "Whether we should partest the current scala version (and fail if we can't)")
  
 +  /* MiMa configuration -- irrelevant while in 1.0.0-SNAPSHOT.
-   val previousVersion = "0.6.23"
+   val previousVersion = "0.6.24"
    val previousSJSBinaryVersion =
      ScalaJSCrossVersion.binaryScalaJSVersion(previousVersion)
    val previousBinaryCrossVersion =
```
```
$ git add -u
```
```
$ git st
M  project/Build.scala
```
```
$ git commit
[merge-0.6.x-into-master-june-29 641c63d9d] Merge '0.6.x' into 'master'.
```
