### PR TITLE
Fix #3415: Propagate the being-inlined set inside closures.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,6 +8,9 @@ object BinaryIncompatibilities {
   )
 
   val Tools = Seq(
+      // private[optimizer], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.core.tools.linker.frontend.optimizer.OptimizerCore.transformIsolatedBody")
   )
 
   val JSEnvs = Seq(

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -436,6 +436,36 @@ class OptimizerTest {
 
     assertEquals("hello", escape(a)._1)
   }
+
+  // Bug #3415
+
+  @Test def infinite_recursion_inlining_issue3415_original(): Unit = {
+    assumeTrue("linking only", false)
+    doWhile1("foo")(f => f(true))
+  }
+
+  @inline def doWhile1[Domain2](endDoWhile1: => Domain2)(
+      condition2: (Boolean => Domain2) => Domain2): Domain2 = {
+    condition2 { (conditionValue2) =>
+      if (conditionValue2)
+        doWhile1[Domain2](endDoWhile1)(condition2)
+      else
+        endDoWhile1
+    }
+  }
+
+  @Test def infinite_recursion_inlining_issue3415_minimized(): Unit = {
+    assumeTrue("linking only", false)
+    doWhile(???)
+  }
+
+  @inline def doWhile(
+      condition: js.Function1[js.Function1[Boolean, String], String]): String = {
+    condition { (conditionValue: Boolean) =>
+      doWhile(condition)
+    }
+  }
+
 }
 
 object OptimizerTest {


### PR DESCRIPTION
When optimizing a `Closure` that was not inlined away, we would not propagate the set of methods already being inlined. That means that a lambda calling its enclosing method, if it was not inlined away itself, would cause an infinite recursion in the optimizer.