### PR TITLE
[no-master] Fix #3417: Handle Windows file separator in VirtualFile.nameFromPath.

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala
@@ -45,7 +45,10 @@ trait VirtualFile {
 object VirtualFile {
   /** Splits at the last slash and returns remainder */
   def nameFromPath(path: String): String = {
-    val pos = path.lastIndexOf('/')
+    val pos0 = path.lastIndexOf('/')
+    val pos =
+      if (pos0 >= 0) pos0
+      else path.lastIndexOf('\\')
     if (pos == -1) path
     else path.substring(pos + 1)
   }


### PR DESCRIPTION
Fixes issue [3417](https://github.com/scala-js/scala-js/issues/3417) 

See issue link for description.
Fixes a path issue which was not os specific. The issue was happening because of the `jsDependencies` resolution, while materializing js files on windows system, the path was not correct.