### PR TITLE
Fix #3422: Support nulling-out lazy vals in non-native JS classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -2009,8 +2009,17 @@ abstract class GenJSCode extends plugins.PluginComponent
               val genQual = genExpr(qualifier)
 
               def genBoxedRhs: js.Tree = {
-                ensureBoxed(genRhs,
-                    enteringPhase(currentRun.posterasurePhase)(rhs.tpe))
+                val tpeEnteringPosterasure =
+                  enteringPhase(currentRun.posterasurePhase)(rhs.tpe)
+                if ((tpeEnteringPosterasure eq null) && genRhs.isInstanceOf[js.Null]) {
+                  devWarning(
+                      "Working around https://github.com/scala-js/scala-js/issues/3422 " +
+                      s"for ${sym.fullName} at ${sym.pos}")
+                  // Fortunately, a literal `null` never needs to be boxed
+                  genRhs
+                } else {
+                  ensureBoxed(genRhs, tpeEnteringPosterasure)
+                }
               }
 
               if (isScalaJSDefinedJSClass(sym.owner)) {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -206,6 +206,10 @@ class ScalaJSDefinedTest {
     assertNull(obj.asInstanceOf[js.Dynamic].valueClass)
   }
 
+  @Test def nullingOutLazyValField_issue3422(): Unit = {
+    assertEquals("foo", new NullingOutLazyValFieldBug3422("foo").str)
+  }
+
   @Test def simple_inherited_from_a_native_class(): Unit = {
     val obj = new SimpleInheritedFromNative(3, 5)
     assertEquals(3, obj.x)
@@ -1824,6 +1828,10 @@ object ScalaJSDefinedTest {
     var string: String = _
     var unit: Unit = _
     var valueClass: SomeValueClass = _
+  }
+
+  class NullingOutLazyValFieldBug3422(initStr: String) extends js.Object {
+    lazy val str: String = initStr
   }
 
   class SimpleInheritedFromNative(


### PR DESCRIPTION
We work around the `rhs.tpe eq null` caused by scalac by testing explicitly for this case, when the rhs is a literal `null`. It is decidedly ugly, but it gets the job done.