### PR TITLE
Fix #3406: Use the JS pattern and flags for group detection.

### DIFF
--- a/javalib/src/main/scala/java/util/regex/GroupStartMap.scala
+++ b/javalib/src/main/scala/java/util/regex/GroupStartMap.scala
@@ -388,12 +388,8 @@ private[regex] class GroupStartMap(string: String, start: Int, pattern: Pattern)
   import Pattern.{CASE_INSENSITIVE, MULTILINE}
 
   val mapping: Int => Int = {
-    val node = parseRegex(pattern.pattern())
-    val flags = {
-      "g" +
-      (if ((pattern.flags() & CASE_INSENSITIVE) != 0) "i" else "") +
-      (if ((pattern.flags() & MULTILINE) != 0) "m" else "")
-    }
+    val node = parseRegex(pattern.jsPattern)
+    val flags = pattern.jsFlags
     node.setNewGroup(1)
     val groupNodeMap = node.getGroupNodeMap
     node.transformGroupNumber(groupNodeMap.mapValues(_.newGroup).toMap)

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -12,6 +12,14 @@ final class Pattern private (jsRegExp: js.RegExp, _pattern: String, _flags: Int)
   def pattern(): String = _pattern
   def flags(): Int = _flags
 
+  private[regex] def jsPattern: String = jsRegExp.source
+
+  private[regex] def jsFlags: String = {
+    (if (jsRegExp.global) "g" else "") +
+    (if (jsRegExp.ignoreCase) "i" else "") +
+    (if (jsRegExp.multiline) "m" else "")
+  }
+
   override def toString(): String = pattern
 
   private[regex] def newJSRegExp(): js.RegExp = {
@@ -26,12 +34,7 @@ final class Pattern private (jsRegExp: js.RegExp, _pattern: String, _flags: Int)
        * We therefore reconstruct the pattern and flags used to create
        * jsRegExp and create a new one from there.
        */
-      val jsFlags = {
-        (if (jsRegExp.global) "g" else "") +
-        (if (jsRegExp.ignoreCase) "i" else "") +
-        (if (jsRegExp.multiline) "m" else "")
-      }
-      new js.RegExp(jsRegExp.source, jsFlags)
+      new js.RegExp(jsPattern, jsFlags)
     }
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -85,6 +85,21 @@ class RegexMatcherTest  {
     )
   }
 
+  @Test def start_end_group_and_toMatchResult_with_inline_flags_issue3406(): Unit = {
+    val matcher = Pattern
+      .compile("(?i)(a).*(aa)")
+      .matcher("bBaccAaD")
+    checkGroups(matcher,
+        (2, 7, "accAa"),
+        (2, 3, "a"),
+        (5, 7, "Aa")
+    )
+
+    // Test case from the bug report
+    assertEquals(List("a", "A"),
+        "(?i)(a)".r.findAllMatchIn("aA").map(_.matched).toList)
+  }
+
   def parseExpect(regex: String, str: String, pos: (Int, Int)*): Unit = {
     val matcher = Pattern.compile(regex).matcher(str)
     assertTrue(matcher.find())
@@ -151,9 +166,9 @@ class RegexMatcherTest  {
     assertEquals(startEndMatch(0)._3, matcher.group)
     assertEquals(startEndMatch.size - 1, matcher.groupCount)
     for (((start, end, mtch), i) <- startEndMatch.zipWithIndex) {
-      assertEquals(start, matcher.start(i))
-      assertEquals(end, matcher.end(i))
-      assertEquals(mtch, matcher.group(i))
+      assertEquals("" + i, start, matcher.start(i))
+      assertEquals("" + i, end, matcher.end(i))
+      assertEquals("" + i, mtch, matcher.group(i))
     }
 
     val matchResult = matcher.toMatchResult


### PR DESCRIPTION
`Pattern` preprocesses the `pattern` string to extract some Java-specific features, such as in-line flags, before giving the patched patterns and flags to a `js.RegExp`.

Before this commit, the logic for group recovery in `GroupStartMap` used the original pattern and flags. In this commit, we use the already processed pattern and flags instead, so that this preprocessing carries over to the regexes used for group recovery.

/cc @MikaelMayer, since you authored that file.