### PR TITLE
[no-master] Do not test the test suite in fullOpt with PhantomJS.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -214,10 +214,6 @@ def Tasks = [
         $testSuite/clean &&
     sbtretry 'set inScope(ThisScope in $testSuite)(jsEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
         'set parallelExecution in ($testSuite, Test) := false' \
-        ++$scala $testSuite/test &&
-    sbtretry 'set inScope(ThisScope in $testSuite)(jsEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
-        'set parallelExecution in ($testSuite, Test) := false' \
-        'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalacOptions in $testSuite += "-Xexperimental"' \


### PR DESCRIPTION
PhantomJS tests spuriously fail too often, and it seems in particular in fullOpt. This commit removes the fullOpt tests of the test suite with PhantomJS, hopefully reducing spurious failures.