### PR TITLE
Mark all JUnit assertion and assumption methods as `@noinline`.

### DIFF
--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -9,27 +9,34 @@ import org.hamcrest.Matcher
 import org.hamcrest.MatcherAssert
 
 object Assert {
+  @noinline
   def assertTrue(message: String, condition: Boolean): Unit = {
     if (!condition)
       fail(message)
   }
 
+  @noinline
   def assertTrue(condition: Boolean): Unit =
     assertTrue(null, condition)
 
+  @noinline
   def assertFalse(message: String, condition: Boolean): Unit =
     assertTrue(message, !condition)
 
+  @noinline
   def assertFalse(condition: Boolean): Unit =
     assertFalse(null, condition)
 
+  @noinline
   def fail(message: String): Unit =
     if (message eq null) throw new AssertionError()
     else throw new AssertionError(message)
 
+  @noinline
   def fail(): Unit =
     fail(null)
 
+  @noinline
   def assertEquals(message: String, expected: Any, actual: Any): Unit = {
     if (!equalsRegardingNull(expected, actual)) {
       (expected, actual) match {
@@ -52,14 +59,17 @@ object Assert {
   private def isEquals(expected: Any, actual: Any): Boolean =
     expected.equals(actual)
 
+  @noinline
   def assertEquals(expected: Any, actual: Any): Unit =
     assertEquals(null, expected, actual)
 
+  @noinline
   def assertNotEquals(message: String, unexpected: Any, actual: Any): Unit = {
     if (equalsRegardingNull(unexpected, actual))
       failEquals(message, actual)
   }
 
+  @noinline
   def assertNotEquals(unexpected: Any, actual: Any): Unit =
     assertNotEquals(null, unexpected, actual)
 
@@ -71,28 +81,34 @@ object Assert {
     fail(s"$checkedMessage. Actual: $actual")
   }
 
+  @noinline
   def assertNotEquals(message: String, unexpected: Long, actual: Long): Unit = {
     if (unexpected == actual)
       failEquals(message, actual)
   }
 
+  @noinline
   def assertNotEquals(unexpected: Long, actual: Long): Unit =
     assertNotEquals(null, unexpected, actual)
 
+  @noinline
   def assertNotEquals(message: String, unexpected: Double, actual: Double,
       delta: Double): Unit = {
     if (!doubleIsDifferent(unexpected, actual, delta))
       failEquals(message, actual)
   }
 
+  @noinline
   def assertNotEquals(unexpected: Double, actual: Double, delta: Double): Unit =
     assertNotEquals(null, unexpected, actual, delta)
 
+  @noinline
   def assertNotEquals(unexpected: Float, actual: Float, delta: Float): Unit =
     assertNotEquals(null, unexpected, actual, delta)
 
   @deprecated("Use assertEquals(double expected, double actual, double " +
       "epsilon) instead", "")
+  @noinline
   def assertEquals(expected: Double, actual: Double): Unit = {
     fail("Use assertEquals(expected, actual, delta) to compare " +
         "floating-point numbers")
@@ -100,94 +116,115 @@ object Assert {
 
   @deprecated("Use assertEquals(String message, double expected, double " +
       "actual, double epsilon) instead", "")
+  @noinline
   def assertEquals(message: String, expected: Double, actual: Double): Unit = {
     fail("Use assertEquals(expected, actual, delta) to compare " +
         "floating-point numbers")
   }
 
+  @noinline
   def assertEquals(expected: Long, actual: Long): Unit =
     assertEquals(null, expected, actual)
 
+  @noinline
   def assertEquals(message: String, expected: Long, actual: Long): Unit =
     assertEquals(message, expected: Any, actual: Any)
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[AnyRef],
       actuals: Array[AnyRef]): Unit = {
     internalArrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[AnyRef],
       actuals: Array[AnyRef]): Unit = {
     assertArrayEquals(null, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[Boolean],
       actuals: Array[Boolean]): Unit = {
     internalArrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[Boolean],
       actuals: Array[Boolean]): Unit = {
     assertArrayEquals(null, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[Byte],
       actuals: Array[Byte]): Unit = {
     internalArrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[Byte], actuals: Array[Byte]): Unit =
     assertArrayEquals(null, expecteds, actuals)
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[Char],
       actuals: Array[Char]): Unit = {
     internalArrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[Char], actuals: Array[Char]): Unit =
     assertArrayEquals(null, expecteds, actuals)
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[Short],
       actuals: Array[Short]): Unit = {
     internalArrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[Short],
       actuals: Array[Short]): Unit = {
     assertArrayEquals(null, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[Int],
       actuals: Array[Int]): Unit = {
     internalArrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[Int], actuals: Array[Int]): Unit =
     assertArrayEquals(null, expecteds, actuals)
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[Long],
       actuals: Array[Long]): Unit = {
     internalArrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[Long], actuals: Array[Long]): Unit =
     assertArrayEquals(null, expecteds, actuals)
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[Double],
       actuals: Array[Double], delta: Double): Unit = {
     new InexactComparisonCriteria(delta).arrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[Double], actuals: Array[Double],
       delta: Double): Unit = {
     assertArrayEquals(null, expecteds, actuals, delta)
   }
 
+  @noinline
   def assertArrayEquals(message: String, expecteds: Array[Float],
       actuals: Array[Float], delta: Float): Unit = {
     new InexactComparisonCriteria(delta).arrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertArrayEquals(expecteds: Array[Float], actuals: Array[Float],
       delta: Float): Unit = {
     assertArrayEquals(null, expecteds, actuals, delta)
@@ -198,6 +235,7 @@ object Assert {
     new ExactComparisonCriteria().arrayEquals(message, expecteds, actuals)
   }
 
+  @noinline
   def assertEquals(message: String, expected: Double, actual: Double,
       delta: Double): Unit = {
     if (doubleIsDifferent(expected, actual, delta)) {
@@ -205,6 +243,7 @@ object Assert {
     }
   }
 
+  @noinline
   def assertEquals(message: String, expected: Float, actual: Float,
       delta: Float): Unit = {
     if (floatIsDifferent(expected, actual, delta)) {
@@ -212,6 +251,7 @@ object Assert {
     }
   }
 
+  @noinline
   def assertNotEquals(message: String, unexpected: Float, actual: Float,
       delta: Float): Unit = {
     if (!floatIsDifferent(unexpected, actual, delta))
@@ -226,23 +266,29 @@ object Assert {
   private def floatIsDifferent(f1: Float, f2: Float, delta: Float): Boolean =
     java.lang.Float.compare(f1, f2) != 0 && Math.abs(f1 - f2) > delta
 
+  @noinline
   def assertEquals(expected: Double, actual: Double, delta: Double): Unit =
     assertEquals(null, expected, actual, delta)
 
+  @noinline
   def assertEquals(expected: Float, actual: Float, delta: Float): Unit =
     assertEquals(null, expected, actual, delta)
 
+  @noinline
   def assertNotNull(message: String, obj: Any): Unit =
     assertTrue(message, obj != null)
 
+  @noinline
   def assertNotNull(obj: Any): Unit =
     assertNotNull(null, obj)
 
+  @noinline
   def assertNull(message: String, obj: Any): Unit = {
     if (obj != null)
       failNotNull(message, obj)
   }
 
+  @noinline
   def assertNull(obj: Any): Unit =
     assertNull(null, obj)
 
@@ -251,19 +297,23 @@ object Assert {
     fail(s"${formatted}expected null, but was:<$actual}>")
   }
 
+  @noinline
   def assertSame(message: String, expected: Any, actual: Any): Unit = {
     if (expected.asInstanceOf[AnyRef] ne actual.asInstanceOf[AnyRef])
       failNotSame(message, expected, actual)
   }
 
+  @noinline
   def assertSame(expected: Any, actual: Any): Unit =
     assertSame(null, expected, actual)
 
+  @noinline
   def assertNotSame(message: String, unexpected: Any, actual: Any): Unit = {
     if (unexpected.asInstanceOf[AnyRef] eq actual.asInstanceOf[AnyRef])
       failSame(message)
   }
 
+  @noinline
   def assertNotSame(unexpected: Any, actual: Any): Unit =
     assertNotSame(null, unexpected, actual)
 
@@ -303,9 +353,11 @@ object Assert {
     s"$className<$valueString>"
   }
 
+  @noinline
   def assertThat[T](actual: T, matcher: Matcher[T]): Unit =
     assertThat("", actual, matcher)
 
+  @noinline
   def assertThat[T](reason: String, actual: T, matcher: Matcher[T]): Unit =
     MatcherAssert.assertThat(reason, actual, matcher)
 
@@ -313,11 +365,13 @@ object Assert {
   // is being tested in JUnitAssertionTest until 4.13 is released.
 
   /*
+  @noinline
   def assertThrows(expectedThrowable: Class[_ <: Throwable],
       runnable: ThrowingRunnable): Unit = {
     expectThrows(expectedThrowable, runnable)
   }
 
+  @noinline
   def expectThrows[T <: Throwable](expectedThrowable: Class[T], runnable: ThrowingRunnable): T = {
     try {
       runnable.run()

--- a/junit-runtime/src/main/scala/org/junit/Assume.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assume.scala
@@ -10,34 +10,43 @@ import org.hamcrest.Matcher
 
 object Assume {
 
+  @noinline
   def assumeTrue(b: Boolean): Unit =
     assumeThat(b, is(true))
 
+  @noinline
   def assumeFalse(b: Boolean): Unit =
     assumeTrue(!b)
 
+  @noinline
   def assumeTrue(message: String, b: Boolean): Unit =
     if (!b) throw new AssumptionViolatedException(message)
 
+  @noinline
   def assumeFalse(message: String, b: Boolean): Unit =
     assumeTrue(message, !b)
 
+  @noinline
   def assumeNotNull(objects: AnyRef*): Unit =
     objects.foreach(assumeThat(_, notNullValue()))
 
+  @noinline
   def assumeThat[T](actual: T, matcher: Matcher[T]): Unit = {
     if (!matcher.matches(actual.asInstanceOf[AnyRef]))
       throw new AssumptionViolatedException(actual, matcher)
   }
 
+  @noinline
   def assumeThat[T](message: String, actual: T, matcher: Matcher[T]): Unit = {
     if (!matcher.matches(actual.asInstanceOf[AnyRef]))
       throw new AssumptionViolatedException(message, actual, matcher)
   }
 
+  @noinline
   def assumeNoException(e: Throwable): Unit =
     assumeThat(e, nullValue())
 
+  @noinline
   def assumeNoException(message: String, e: Throwable): Unit =
     assumeThat(message, e, nullValue())
 }


### PR DESCRIPTION
This produces much better reports, because the JUnit "renderer" highlights stack trace elements that do not belong to JUnit methods. If the entry points to JUnit are inlined, the detection is flawed.