### PR TITLE
[no-master] Fix #3439: Also look for `@ExposedJSMember` on the lazy def.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -5605,10 +5605,14 @@ abstract class GenJSCode extends plugins.PluginComponent
    */
   private def isExposed(sym: Symbol): Boolean = {
     !sym.isBridge && {
-      if (sym.isLazy)
-        sym.isAccessor && sym.accessed.hasAnnotation(ExposedJSMemberAnnot)
-      else
+      if (sym.isLazy) {
+        sym.isAccessor && {
+          sym.accessed.hasAnnotation(ExposedJSMemberAnnot) ||
+          sym.hasAnnotation(ExposedJSMemberAnnot) // for 2.12.0, see #3439
+        }
+      } else {
         sym.hasAnnotation(ExposedJSMemberAnnot)
+      }
     }
   }
 


### PR DESCRIPTION
Scala 2.12.0 does not correctly transfer annotations from the lazy def to the backing field, which confuses the definition of `isExposed` for lazy defs. We now also look for the annotation on the lazy def as a workaround.

Locally tested with `testSuite/test` on 2.12.0, obviously.