### PR TITLE
Fix #3433: Report underflow for incomplete multibyte UTF-8 chars.

### DIFF
--- a/library/src/main/scala/scala/scalajs/niocharset/UTF_8.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/UTF_8.scala
@@ -117,15 +117,33 @@ private[niocharset] object UTF_8 extends Charset("UTF-8", Array(
               finalize(CoderResult.malformedForLength(1))
             } else {
               val decoded = {
-                @inline
-                def inArrayOr0(offset: Int): Int =
-                  if (inPos + offset < inEnd) inArray(inPos + offset)
-                  else 0 // 0 is not a valid next byte
-
-                val b2 = inArrayOr0(1)
-                if (length == 2) decode2(leading, b2)
-                else if (length == 3) decode3(leading, b2, inArrayOr0(2))
-                else decode4(leading, b2, inArrayOr0(2), inArrayOr0(3))
+                if (inPos + 1 >= inEnd) {
+                  DecodedMultiByte(CoderResult.UNDERFLOW)
+                } else {
+                  val b2 = inArray(inPos + 1)
+                  if (isInvalidNextByte(b2)) {
+                    DecodedMultiByte(CoderResult.malformedForLength(1))
+                  } else if (length == 2) {
+                    decode2(leading, b2)
+                  } else if (inPos + 2 >= inEnd) {
+                    DecodedMultiByte(CoderResult.UNDERFLOW)
+                  } else {
+                    val b3 = inArray(inPos + 2)
+                    if (isInvalidNextByte(b3)) {
+                      DecodedMultiByte(CoderResult.malformedForLength(2))
+                    } else if (length == 3) {
+                      decode3(leading, b2, b3)
+                    } else if (inPos + 3 >= inEnd) {
+                      DecodedMultiByte(CoderResult.UNDERFLOW)
+                    } else {
+                      val b4 = inArray(inPos + 3)
+                      if (isInvalidNextByte(b4))
+                        DecodedMultiByte(CoderResult.malformedForLength(3))
+                      else
+                        decode4(leading, b2, b3, b4)
+                    }
+                  }
+                }
               }
 
               if (decoded.failure != null) {
@@ -160,9 +178,12 @@ private[niocharset] object UTF_8 extends Charset("UTF-8", Array(
       @inline
       @tailrec
       def loop(): CoderResult = {
+        // Mark the input position so that we can reset on multi-byte failure
+        val startPosition = in.position()
+
         @inline
-        def finalize(read: Int, result: CoderResult): CoderResult = {
-          in.position(in.position() - read)
+        def fail(result: CoderResult): CoderResult = {
+          in.position(startPosition)
           result
         }
 
@@ -173,7 +194,7 @@ private[niocharset] object UTF_8 extends Charset("UTF-8", Array(
           if (leading >= 0) {
             // US-ASCII repertoire
             if (!out.hasRemaining) {
-              finalize(1, CoderResult.OVERFLOW)
+              fail(CoderResult.OVERFLOW)
             } else {
               out.put(leading.toChar)
               loop()
@@ -182,27 +203,44 @@ private[niocharset] object UTF_8 extends Charset("UTF-8", Array(
             // Multi-byte
             val length = lengthByLeading(leading & 0x7f)
             if (length == -1) {
-              finalize(1, CoderResult.malformedForLength(1))
+              fail(CoderResult.malformedForLength(1))
             } else {
-              var bytesRead: Int = 1
-
               val decoded = {
-                @inline
-                def getOr0(): Int =
-                  if (in.hasRemaining) { bytesRead += 1; in.get() }
-                  else 0 // 0 is not a valid next byte
-
-                if (length == 2) decode2(leading, getOr0())
-                else if (length == 3) decode3(leading, getOr0(), getOr0())
-                else decode4(leading, getOr0(), getOr0(), getOr0())
+                if (in.hasRemaining) {
+                  val b2 = in.get()
+                  if (isInvalidNextByte(b2)) {
+                    DecodedMultiByte(CoderResult.malformedForLength(1))
+                  } else if (length == 2) {
+                    decode2(leading, b2)
+                  } else if (in.hasRemaining) {
+                    val b3 = in.get()
+                    if (isInvalidNextByte(b3)) {
+                      DecodedMultiByte(CoderResult.malformedForLength(2))
+                    } else if (length == 3) {
+                      decode3(leading, b2, b3)
+                    } else if (in.hasRemaining) {
+                      val b4 = in.get()
+                      if (isInvalidNextByte(b4))
+                        DecodedMultiByte(CoderResult.malformedForLength(3))
+                      else
+                        decode4(leading, b2, b3, b4)
+                    } else {
+                      DecodedMultiByte(CoderResult.UNDERFLOW)
+                    }
+                  } else {
+                    DecodedMultiByte(CoderResult.UNDERFLOW)
+                  }
+                } else {
+                  DecodedMultiByte(CoderResult.UNDERFLOW)
+                }
               }
 
               if (decoded.failure != null) {
-                finalize(bytesRead, decoded.failure)
+                fail(decoded.failure)
               } else if (decoded.low == 0) {
                 // not a surrogate pair
                 if (!out.hasRemaining)
-                  finalize(bytesRead, CoderResult.OVERFLOW)
+                  fail(CoderResult.OVERFLOW)
                 else {
                   out.put(decoded.high)
                   loop()
@@ -210,7 +248,7 @@ private[niocharset] object UTF_8 extends Charset("UTF-8", Array(
               } else {
                 // a surrogate pair
                 if (out.remaining < 2)
-                  finalize(bytesRead, CoderResult.OVERFLOW)
+                  fail(CoderResult.OVERFLOW)
                 else {
                   out.put(decoded.high)
                   out.put(decoded.low)
@@ -228,64 +266,49 @@ private[niocharset] object UTF_8 extends Charset("UTF-8", Array(
     @inline private def isInvalidNextByte(b: Int): Boolean =
       (b & 0xc0) != 0x80
 
+    /** Requires the input bytes to be a valid byte sequence. */
     @inline private def decode2(b1: Int, b2: Int): DecodedMultiByte = {
-      if (isInvalidNextByte(b2))
+      val codePoint = (((b1 & 0x1f) << 6) | (b2 & 0x3f))
+      // By construction, 0 <= codePoint <= 0x7ff < MIN_SURROGATE
+      if (codePoint < 0x80) {
+        // Should have been encoded with only 1 byte
         DecodedMultiByte(CoderResult.malformedForLength(1))
-      else {
-        val codePoint = (((b1 & 0x1f) << 6) | (b2 & 0x3f))
-        // By construction, 0 <= codePoint <= 0x7ff < MIN_SURROGATE
-        if (codePoint < 0x80) {
-          // Should have been encoded with only 1 byte
-          DecodedMultiByte(CoderResult.malformedForLength(1))
-        } else {
-          DecodedMultiByte(codePoint.toChar)
-        }
+      } else {
+        DecodedMultiByte(codePoint.toChar)
       }
     }
 
+    /** Requires the input bytes to be a valid byte sequence. */
     @inline private def decode3(b1: Int, b2: Int, b3: Int): DecodedMultiByte = {
-      if (isInvalidNextByte(b2))
+      val codePoint = (((b1 & 0xf) << 12) | ((b2 & 0x3f) << 6) | (b3 & 0x3f))
+      // By construction, 0 <= codePoint <= 0xffff < MIN_SUPPLEMENTARY_CODE_POINT
+      if (codePoint < 0x800) {
+        // Should have been encoded with only 1 or 2 bytes
         DecodedMultiByte(CoderResult.malformedForLength(1))
-      else if (isInvalidNextByte(b3))
-        DecodedMultiByte(CoderResult.malformedForLength(2))
-      else {
-        val codePoint = (((b1 & 0xf) << 12) | ((b2 & 0x3f) << 6) | (b3 & 0x3f))
-        // By construction, 0 <= codePoint <= 0xffff < MIN_SUPPLEMENTARY_CODE_POINT
-        if (codePoint < 0x800) {
-          // Should have been encoded with only 1 or 2 bytes
-          DecodedMultiByte(CoderResult.malformedForLength(1))
-        } else if (codePoint >= MIN_SURROGATE && codePoint <= MAX_SURROGATE) {
-          // It is a surrogate, which is not a valid code point
-          DecodedMultiByte(CoderResult.malformedForLength(3))
-        } else {
-          DecodedMultiByte(codePoint.toChar)
-        }
+      } else if (codePoint >= MIN_SURROGATE && codePoint <= MAX_SURROGATE) {
+        // It is a surrogate, which is not a valid code point
+        DecodedMultiByte(CoderResult.malformedForLength(3))
+      } else {
+        DecodedMultiByte(codePoint.toChar)
       }
     }
 
+    /** Requires the input bytes to be a valid byte sequence. */
     @inline private def decode4(b1: Int, b2: Int, b3: Int, b4: Int): DecodedMultiByte = {
-      if (isInvalidNextByte(b2))
+      val codePoint = (((b1 & 0x7) << 18) | ((b2 & 0x3f) << 12) |
+          ((b3 & 0x3f) << 6) | (b4 & 0x3f))
+      // By construction, 0 <= codePoint <= 0x1fffff
+      if (codePoint < 0x10000 || codePoint > MAX_CODE_POINT) {
+        // It should have been encoded with 1, 2, or 3 bytes
+        // or it is not a valid code point
         DecodedMultiByte(CoderResult.malformedForLength(1))
-      else if (isInvalidNextByte(b3))
-        DecodedMultiByte(CoderResult.malformedForLength(2))
-      else if (isInvalidNextByte(b4))
-        DecodedMultiByte(CoderResult.malformedForLength(3))
-      else {
-        val codePoint = (((b1 & 0x7) << 18) | ((b2 & 0x3f) << 12) |
-            ((b3 & 0x3f) << 6) | (b4 & 0x3f))
-        // By construction, 0 <= codePoint <= 0x1fffff
-        if (codePoint < 0x10000 || codePoint > MAX_CODE_POINT) {
-          // It should have been encoded with 1, 2, or 3 bytes
-          // or it is not a valid code point
-          DecodedMultiByte(CoderResult.malformedForLength(1))
-        } else {
-          // Here, we need to encode the code point as a surrogate pair.
-          // http://en.wikipedia.org/wiki/UTF-16
-          val offsetCodePoint = codePoint - 0x10000
-          DecodedMultiByte(
-              ((offsetCodePoint >> 10) | 0xd800).toChar,
-              ((offsetCodePoint & 0x3ff) | 0xdc00).toChar)
-        }
+      } else {
+        // Here, we need to encode the code point as a surrogate pair.
+        // http://en.wikipedia.org/wiki/UTF-16
+        val offsetCodePoint = codePoint - 0x10000
+        DecodedMultiByte(
+            ((offsetCodePoint >> 10) | 0xd800).toChar,
+            ((offsetCodePoint & 0x3ff) | 0xdc00).toChar)
       }
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
@@ -30,18 +30,88 @@ class BaseCharsetTest(val charset: Charset) {
   protected def testDecode(in: ByteBuffer)(
       outParts: OutPart[CharBuffer]*): Unit = {
 
+    def newDecoder(malformedAction: CodingErrorAction,
+        unmappableAction: CodingErrorAction): CharsetDecoder = {
+      val decoder = charset.newDecoder
+      decoder.onMalformedInput(malformedAction)
+      decoder.onUnmappableCharacter(unmappableAction)
+      decoder
+    }
+
+    def prepareInputBuffer(readOnly: Boolean): ByteBuffer = {
+      val buf =
+        if (readOnly) in.asReadOnlyBuffer()
+        else in.duplicate()
+      assert(buf.isReadOnly == readOnly)
+      assert(buf.hasArray != readOnly)
+      buf
+    }
+
+    def testDecodeVsSteppedDecode(malformedAction: CodingErrorAction,
+        unmappableAction: CodingErrorAction, readOnly: Boolean): Unit = {
+
+      /* This test compares the decode result of a single decoder.decode(buffer)
+       * call vs repeated decode(input, output, done) calls, with a buffer that
+       * increments its limit each step. This will catch mishandled broken up
+       * multi-byte sequences.
+       */
+
+      val decoder = newDecoder(malformedAction, unmappableAction)
+
+      val directResult = Try {
+        decoder.decode(prepareInputBuffer(readOnly)).toString()
+      }
+
+      val inputForIncremental = prepareInputBuffer(readOnly)
+      inputForIncremental.limit(inputForIncremental.position())
+
+      val outputBuffer = CharBuffer.allocate(in.capacity() * 2)
+      decoder.reset()
+
+      def increaseBuffer(bb: ByteBuffer): Boolean =
+        (bb.limit() < bb.capacity()) && (bb.limit(bb.limit() + 1) != null)
+
+      val incrementalResult = Try {
+        var result: CoderResult = CoderResult.UNDERFLOW
+        while (increaseBuffer(inputForIncremental) && result.isUnderflow) {
+          result = decoder.decode(inputForIncremental, outputBuffer, false)
+        }
+        if (result.isError)
+          result.throwException()
+        result = decoder.decode(inputForIncremental, outputBuffer, true)
+        if (result.isError)
+          result.throwException()
+        result = decoder.flush(outputBuffer)
+        if (result.isError)
+          result.throwException()
+        outputBuffer.flip()
+        outputBuffer.toString()
+      }
+
+      (directResult, incrementalResult) match {
+        case (Success(directString), Success(incrementalString)) =>
+          assertEquals(incrementalString, directString)
+
+        case (Failure(directEx: UnmappableCharacterException),
+            Failure(incrementalEx: UnmappableCharacterException)) =>
+          assertEquals(incrementalEx.getInputLength, directEx.getInputLength)
+
+        case (Failure(directEx: MalformedInputException),
+            Failure(incrementalEx: MalformedInputException)) =>
+          assertEquals(incrementalEx.getInputLength, directEx.getInputLength)
+
+        case _ =>
+          // Assert false, but display an informational failure message
+          assertSame(directResult, incrementalResult)
+      }
+    }
+
     def testOneConfig(malformedAction: CodingErrorAction,
         unmappableAction: CodingErrorAction, readOnly: Boolean): Unit = {
 
-      val decoder = charset.newDecoder()
-      decoder.onMalformedInput(malformedAction)
-      decoder.onUnmappableCharacter(unmappableAction)
+      val decoder = newDecoder(malformedAction, unmappableAction)
 
-      val inBuf =
-        if (readOnly) in.asReadOnlyBuffer()
-        else in.duplicate()
-      assert(inBuf.isReadOnly == readOnly)
-      assert(inBuf.hasArray != readOnly)
+      val inBuf = prepareInputBuffer(readOnly)
 
       val actualTry = Try {
         val buf = decoder.decode(inBuf)
@@ -105,6 +175,7 @@ class BaseCharsetTest(val charset: Charset) {
       unmappableAction <- if (hasAnyUnmappable) AllErrorActions else ReportActions
       readOnly         <- List(false, true)
     } {
+      testDecodeVsSteppedDecode(malformedAction, unmappableAction, readOnly)
       testOneConfig(malformedAction, unmappableAction, readOnly)
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
@@ -16,27 +16,32 @@ import org.junit.Assert._
 import BaseCharsetTest._
 
 class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
-  @Test def decode(): Unit = {
-    def OutSeq(elems: OutPart[CharBuffer]*): Seq[OutPart[CharBuffer]] =
-      Seq[OutPart[CharBuffer]](elems: _*)
-
+  @Test def decode1byte(): Unit = {
     // 1-byte characters
     testDecode(bb"42 6f 6e 6a 6f 75 72")(cb"Bonjour")
+  }
 
+  @Test def decode2Byte(): Unit = {
     // 2-byte characters
     testDecode(bb"47 72 c3 bc c3 9f 20 47 6f 74 74")(cb"Grüß Gott")
     testDecode(bb"ce 9a ce b1 ce bb ce b7 ce bc ce ad cf 81 ce b1")(cb"Καλημέρα")
     testDecode(bb"d8 b5 d8 a8 d8 a7 d8 ad 20 d8 a7 d9 84 d8 ae d9 8a d8 b1")(cb"صباح الخير")
+  }
 
+  @Test def decode3Byte(): Unit = {
     // 3-byte characters
     testDecode(bb"e3 81 93 e3 82 93 e3 81 ab e3 81 a1 e3 81 af")(cb"こんにちは")
     testDecode(bb"d0 94 d0 be d0 b1 d1 80 d1 8b d0 b9 20 d0 b4 d0 b5 d0 bd d1 8c")(cb"Добрый день")
     testDecode(bb"e4 bd a0 e5 a5 bd")(cb"你好")
+  }
 
+  @Test def decode4Byte(): Unit = {
     // 4-byte characters
     testDecode(bb"f0 9d 93 97 f0 9d 93 ae f0 9d 93 b5 f0 9d 93 b5 f0 9d 93 b8")(
         cb"\ud835\udcd7\ud835\udcee\ud835\udcf5\ud835\udcf5\ud835\udcf8")
+  }
 
+  @Test def decodeBoundaryConditions(): Unit = {
     testDecode(bb"")(cb"")
 
     // First sequence of a certain length
@@ -55,13 +60,15 @@ class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
     testDecode(bb"ed 9f bf")(cb"\ud7ff")
     testDecode(bb"ee 80 80")(cb"\ue000")
     testDecode(bb"ef bf bd")(cb"\ufffd")
+  }
 
-    // Here begin the sequences with at least one error
-
+  @Test def decodeOversizedCodepoint(): Unit = {
     // Code point too big
     testDecode(bb"f4 90 80 80")(Malformed(1), Malformed(1), Malformed(1), Malformed(1))
     testDecode(bb"41 f4 90 80 80 42")(cb"A", Malformed(1), Malformed(1), Malformed(1), Malformed(1), cb"B")
+  }
 
+  @Test def decodeUnexpectedContinuationBytes(): Unit = {
     // Unexpected continuation bytes (each is reported separately)
     testDecode(bb"80")(Malformed(1))
     testDecode(bb"bf")(Malformed(1))
@@ -70,11 +77,15 @@ class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
     testDecode(bb"80 80 80 80")(Malformed(1), Malformed(1), Malformed(1), Malformed(1))
     testDecode(bb"80 80 80 80 80")(Malformed(1), Malformed(1), Malformed(1), Malformed(1), Malformed(1))
     testDecode(bb"41 80 80 42 80 43")(cb"A", Malformed(1), Malformed(1), cb"B", Malformed(1), cb"C")
+  }
 
+  @Test def decodeLonelyStartCharacters(): Unit = {
     // Lonely start characters, separated by spaces
-    testDecode(bb"${(0xc0 to 0xf4).flatMap(c => Seq(c, 32))}")(
-        (0xc0 to 0xf4).flatMap(i => OutSeq(Malformed(1), cb" ")): _*)
+    val vc = (0xc0 to 0xf4).flatMap(_ => List[OutPart[CharBuffer]](Malformed(1), cb" "))
+    testDecode(bb"${(0xc0 to 0xf4).flatMap(c => Seq(c, 32))}")(vc: _*)
+  }
 
+  @Test def decodeMissingContinuationBytes(): Unit = {
     // Sequences with some continuation bytes missing
     testDecode(bb"c2")(Malformed(1))
     testDecode(bb"e0")(Malformed(1))
@@ -82,17 +93,25 @@ class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
     testDecode(bb"f0")(Malformed(1))
     testDecode(bb"f0 90")(Malformed(2))
     testDecode(bb"f0 90 80")(Malformed(3))
+  }
+
+  @Test def decodeNoContinuationAtBufferEnd(): Unit = {
     // at the end of the buffer - #1537
     testDecode(bb"c0")(Malformed(1))
     testDecode(bb"e1 41")(Malformed(1), cb"A")
     testDecode(bb"e1 80 42")(Malformed(2), cb"B")
+  }
+
+  @Test def decodeMalformedCombined(): Unit = {
     // and all of them concatenated
-    testDecode(bb"c2  e0  e0 a0  f0  f0 90  f0 90 80")(
+    testDecode(bb"c2 e0 e0 a0 f0 f0 90 f0 90 80")(
         Seq(1, 1, 2, 1, 2, 3).map(Malformed(_)): _*)
     // and with normal sequences interspersed
     testDecode(bb"c2 41 e0 41 e0 a0 41 f0 41 f0 90 41 f0 90 80 41")(
         Seq(1, 1, 2, 1, 2, 3).flatMap(l => Seq[OutPart[CharBuffer]](Malformed(l), cb"A")): _*)
+  }
 
+  @Test def decodeImpossibleBytes(): Unit = {
     // Impossible bytes
     testDecode(bb"fe")(Malformed(1))
     testDecode(bb"ff")(Malformed(1))
@@ -103,7 +122,9 @@ class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
         Malformed(1), Malformed(1), Malformed(1), Malformed(1), Malformed(1))
     testDecode(bb"fc 80 80 80 80 af")(
         Malformed(1), Malformed(1), Malformed(1), Malformed(1), Malformed(1), Malformed(1))
+  }
 
+  @Test def decodeOverlong(): Unit = {
     // Overlong sequences (encoded with more bytes than necessary)
     // Overlong '/'
     testDecode(bb"c0 af")(Malformed(1), Malformed(1))
@@ -117,7 +138,9 @@ class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
     testDecode(bb"c0 80")(Malformed(1), Malformed(1))
     testDecode(bb"e0 80 80")(Malformed(1), Malformed(1), Malformed(1))
     testDecode(bb"f0 80 80 80")(Malformed(1), Malformed(1), Malformed(1), Malformed(1))
+  }
 
+  @Test def decodeSingleUTF16Surrogates(): Unit = {
     // Single UTF-16 surrogates
     testDecode(bb"ed a0 80")(Malformed(3))
     testDecode(bb"ed ad bf")(Malformed(3))
@@ -126,7 +149,9 @@ class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
     testDecode(bb"ed b0 80")(Malformed(3))
     testDecode(bb"ed be 80")(Malformed(3))
     testDecode(bb"ed bf bf")(Malformed(3))
+  }
 
+  @Test def decodePairedUTF16Surrogates(): Unit = {
     // Paired UTF-16 surrogates
     testDecode(bb"ed a0 80 ed b0 80")(Malformed(3), Malformed(3))
     testDecode(bb"ed a0 80 ed bf bf")(Malformed(3), Malformed(3))


### PR DESCRIPTION
make it return underflow instead of coding error, since there may
still be more input