### PR TITLE
Make the ir/ subproject compilable with Dotty.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -441,10 +441,6 @@ object Hashers {
           throw new InvalidIRException(tree,
               "Cannot hash a transient IR node (its value is of class " +
               s"${value.getClass})")
-
-        case _ =>
-          throw new IllegalArgumentException(
-              s"Unable to hash tree of class ${tree.getClass}")
       }
     }
 

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -247,20 +247,20 @@ object Printers {
         case Match(selector, cases, default) =>
           print("match (")
           print(selector)
-          print(") {"); indent
+          print(") {"); indent()
           for ((values, body) <- cases) {
             println()
-            printRow(values, "case ", " | ", ":"); indent; println()
+            printRow(values, "case ", " | ", ":"); indent(); println()
             print(body)
             print(";")
-            undent
+            undent()
           }
           println()
-          print("default:"); indent; println()
+          print("default:"); indent(); println()
           print(default)
           print(";")
-          undent
-          undent; println(); print('}')
+          undent()
+          undent(); println(); print('}')
 
         case Debugger() =>
           print("debugger")
@@ -657,7 +657,7 @@ object Printers {
           print("{}")
 
         case JSObjectConstr(fields) =>
-          print('{'); indent; println()
+          print('{'); indent(); println()
           var rest = fields
           while (rest.nonEmpty) {
             print(rest.head._1)
@@ -669,7 +669,7 @@ object Printers {
               println()
             }
           }
-          undent; println(); print('}')
+          undent(); println(); print('}')
 
         case JSGlobalRef(ident) =>
           print("global:")

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -822,7 +822,7 @@ object Serializers {
     }
 
     def readTreeOrJSSpreads(): List[TreeOrJSSpread] =
-      List.fill(input.readInt())(readTreeOrJSSpread)
+      List.fill(input.readInt())(readTreeOrJSSpread())
 
     private def readTreeFromTag(tag: Byte)(implicit pos: Position): Tree = {
       import input._

--- a/ir/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -40,8 +40,8 @@ object Transformers {
 
         // Control flow constructs
 
-        case Block(stats :+ expr) =>
-          Block(stats.map(transformStat) :+ transform(expr, isStat))
+        case Block(stats) =>
+          Block(stats.init.map(transformStat) :+ transform(stats.last, isStat))
 
         case Labeled(label, tpe, body) =>
           Labeled(label, tpe, transform(body, isStat))


### PR DESCRIPTION
This will be necessary for Dotty to compile to sjsir, as it will need to bring the sources of scalajs-ir in the dotty compiler, which needs to be compilable by itself.

Changes are due to:

* Dotty requires call sites to use `foo()` rather than `foo` if the method `foo` was declared with `()`.
* Improved reachability analysis in the pattern matcher discovers more stuff.