### PR TITLE
Replace FrameworkDetector test with JSEnv test

### DIFF
--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
@@ -108,4 +108,26 @@ private[test] class ComTests(config: JSEnvSuiteConfig) {
         .closeRun()
     }
   }
+
+  @Test
+  def separateComStdoutTest: Unit = {
+    // Make sure that com and stdout do not interfere with each other.
+    kit.withComRun("""
+      scalajsCom.init(function (msg) {
+        console.log("got: " + msg)
+      });
+      console.log("a");
+      scalajsCom.send("b");
+      scalajsCom.send("c");
+      console.log("d");
+    """) {
+      _.expectOut("a\n")
+        .expectMsg("b")
+        .expectMsg("c")
+        .expectOut("d\n")
+        .send("foo")
+        .expectOut("got: foo\n")
+        .closeRun()
+    }
+  }
 }

--- a/sbt-plugin-test/build.sbt
+++ b/sbt-plugin-test/build.sbt
@@ -125,13 +125,6 @@ lazy val multiTestJS = project.in(file("multiTest/js")).
   settings(
     name := "Multi test framework test JS",
 
-    // Make FrameworkDetector resilient to other output - #1572
-    jsExecutionFiles in Test := {
-      val consoleWriter = new FileVirtualBinaryFile(
-          (resourceDirectory in Test).value / "consoleWriter.js")
-      consoleWriter +: (jsExecutionFiles in Test).value
-    },
-
     // Test platformDepsCrossVersion (as a setting, it's evaluated when loading the build)
     platformDepsCrossVersion ~= { value =>
       assert(value eq ScalaJSCrossVersion.binary,

--- a/sbt-plugin-test/multiTest/js/src/test/resources/consoleWriter.js
+++ b/sbt-plugin-test/multiTest/js/src/test/resources/consoleWriter.js
@@ -1,2 +1,0 @@
-// Make FrameworkDetector resilient to other output - #1572
-console.log("Breaking message")


### PR DESCRIPTION
This test was originally designed to make sure FrameworkDetector
doesn't fail with other `console.log` statements. However, since
22a8d7dc52669c537154f21519752a8b6680a174 FrameworkDetector does
not exist anymore.

We replace the specific test with a more generalized test that ensures
that stdout and the scalajsCom do not interact for JSEnvs in general.