### PR TITLE
FF ONLY Merge 0.6.x into master, October 15

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -124,6 +124,7 @@ def Tasks = [
     sbtretry ++$scala testSuite/test:doc library/test compiler/test reversi/fastOptJS reversi/fullOptJS &&
     sbtretry ++$scala compiler/compile:doc library/compile:doc \
         testInterface/compile:doc &&
+    sbtretry ++$scala headerCheck &&
     sbtretry ++$scala partest/fetchScalaSource &&
     sbtretry ++$scala library/mimaReportBinaryIssues testInterface/mimaReportBinaryIssues &&
     sh ci/checksizes.sh $scala &&

--- a/LICENSE
+++ b/LICENSE
@@ -1,27 +1,202 @@
-Copyright (c) 2013-2014 EPFL
 
-All rights reserved.
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Redistribution and use in source and binary forms, with or without modification,
-are permitted provided that the following conditions are met:
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-    * Neither the name of the EPFL nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
+   1. Definitions.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright (c) 2013-2018 EPFL
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,6 +1,26 @@
+Scala.js
+Copyright (c) 2013-2018 EPFL
+
+Scala.js includes software developed at EPFL (https://lamp.epfl.ch/ and
+https://scala.epfl.ch/).
+
+Licensed under the Apache License, Version 2.0 (the "License").
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
 This project contains a translation of JUnit 4.12 to Scala.js in
 junit-runtime/src/main/scala/org/junit/. The original code can be found at
 https://github.com/junit-team/junit4/commit/64155f8a9babcfcf4263cf4d08253a1556e75481
 As a translation, it constitutes a derivative work and is therefore licensed
 under the Eclipse Public License v1.0, whose full text can be found in
 junit-runtime/src/main/scala/org/junit/LICENSE-junit.txt
+
+This project contains a translation of Hamcrest 1.3 to Scala.js in
+junit-runtime/src/main/scala/org/hamcrest/. The original code can be found at
+https://github.com/hamcrest/JavaHamcrest/tree/hamcrest-java-1.3
+As a translation, it constitutes a derivative work and is therefore licensed
+under the BSD License, whose full text can be found in
+junit-runtime/src/main/scala/org/hamcrest/LICENSE-hamcrest.txt

--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ This is the repository for
 ## License
 
 Scala.js is distributed under the
-[Scala License](https://www.scala-lang.org/license.html).
+[Apache License Version 2.0](https://www.apache.org/licenses/LICENSE-2.0).

--- a/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitInnerJS.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitInnerJS.scala
@@ -1,5 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013-2017 LAMP/EPFL
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitLocalJS.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitLocalJS.scala
@@ -1,5 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013-2017 LAMP/EPFL
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSTreeExtractors.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSTreeExtractors.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Tobias Schlatter
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author Nicolas Stucki
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Tobias Schlatter
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author Tobias Schlatter
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSOptions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSOptions.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author Tobias Schlatter
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeKinds.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeKinds.scala
@@ -1,6 +1,13 @@
-/* Scala.js compiler
- * Copyright 2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package org.scalajs.nscplugin

--- a/compiler/src/main/scala/org/scalajs/nscplugin/util/ScopedVar.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/util/ScopedVar.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.util
 
 import language.implicitConversions

--- a/compiler/src/main/scala/org/scalajs/nscplugin/util/VarBox.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/util/VarBox.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.util
 
 import language.implicitConversions

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/DiverseErrorsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/DiverseErrorsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/InternalAnnotationsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/InternalAnnotationsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSDynamicLiteralTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSDynamicLiteralTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportASTTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSGlobalScopeTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSGlobalScopeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSInteropTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSOptionalTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSOptionalTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSSAMTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSSAMTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSUndefinedParamTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSUndefinedParamTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/MatchASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/MatchASTTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/PositionTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/PositionTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import util.JSASTTest

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/ReflectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/ReflectTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test.util
 
 import scala.tools.nsc._

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/JSASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/JSASTTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test.util
 
 import language.implicitConversions

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/TestHelpers.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/TestHelpers.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.nscplugin.test.util
 
 import java.io._

--- a/io/js/src/main/scala/org/scalajs/io/NodeVirtualFiles.scala
+++ b/io/js/src/main/scala/org/scalajs/io/NodeVirtualFiles.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.io
 
 import scala.annotation.tailrec

--- a/io/jvm/src/main/scala/org/scalajs/io/AtomicFileOutputStream.scala
+++ b/io/jvm/src/main/scala/org/scalajs/io/AtomicFileOutputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.io
 
 import scala.util.control.NonFatal

--- a/io/jvm/src/main/scala/org/scalajs/io/AtomicWritableFileVirtualFiles.scala
+++ b/io/jvm/src/main/scala/org/scalajs/io/AtomicWritableFileVirtualFiles.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.io
 
 import java.io._

--- a/io/jvm/src/main/scala/org/scalajs/io/FileVirtualFiles.scala
+++ b/io/jvm/src/main/scala/org/scalajs/io/FileVirtualFiles.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.io
 
 import java.io._

--- a/io/shared/src/main/scala/org/scalajs/io/JSUtils.scala
+++ b/io/shared/src/main/scala/org/scalajs/io/JSUtils.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.io
 

--- a/io/shared/src/main/scala/org/scalajs/io/MemFiles.scala
+++ b/io/shared/src/main/scala/org/scalajs/io/MemFiles.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.io
 

--- a/io/shared/src/main/scala/org/scalajs/io/URIUtils.scala
+++ b/io/shared/src/main/scala/org/scalajs/io/URIUtils.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.io
 

--- a/io/shared/src/main/scala/org/scalajs/io/VirtualFiles.scala
+++ b/io/shared/src/main/scala/org/scalajs/io/VirtualFiles.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.io
 
 import java.io._

--- a/io/shared/src/test/scala/org/scalajs/io/URIUtilsTest.scala
+++ b/io/shared/src/test/scala/org/scalajs/io/URIUtilsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.io
 
 import java.net.URI

--- a/ir/src/main/scala/org/scalajs/ir/ClassKind.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ClassKind.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Definitions.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/EntryPointsInfo.scala
+++ b/ir/src/main/scala/org/scalajs/ir/EntryPointsInfo.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.ir
 
 import java.security.{MessageDigest, DigestOutputStream}

--- a/ir/src/main/scala/org/scalajs/ir/IRVersionNotSupportedException.scala
+++ b/ir/src/main/scala/org/scalajs/ir/IRVersionNotSupportedException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.ir
 
 import java.io.IOException

--- a/ir/src/main/scala/org/scalajs/ir/InvalidIRException.scala
+++ b/ir/src/main/scala/org/scalajs/ir/InvalidIRException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.ir
 
 class InvalidIRException(val tree: Trees.Tree, message: String)

--- a/ir/src/main/scala/org/scalajs/ir/Position.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Position.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.ir
 
 object ScalaJSVersions {

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Tags.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Types.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/main/scala/org/scalajs/ir/Utils.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Utils.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js IR                **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.ir
 

--- a/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.ir
 
 import scala.language.implicitConversions

--- a/javalanglib/src/main/scala/java/lang/Appendable.scala
+++ b/javalanglib/src/main/scala/java/lang/Appendable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 trait Appendable {

--- a/javalanglib/src/main/scala/java/lang/AutoCloseable.scala
+++ b/javalanglib/src/main/scala/java/lang/AutoCloseable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 trait AutoCloseable {

--- a/javalanglib/src/main/scala/java/lang/Boolean.scala
+++ b/javalanglib/src/main/scala/java/lang/Boolean.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Byte.scala
+++ b/javalanglib/src/main/scala/java/lang/Byte.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/CharSequence.scala
+++ b/javalanglib/src/main/scala/java/lang/CharSequence.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 trait CharSequence {

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Class.scala
+++ b/javalanglib/src/main/scala/java/lang/Class.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/ClassLoader.scala
+++ b/javalanglib/src/main/scala/java/lang/ClassLoader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Cloneable.scala
+++ b/javalanglib/src/main/scala/java/lang/Cloneable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 trait Cloneable

--- a/javalanglib/src/main/scala/java/lang/Comparable.scala
+++ b/javalanglib/src/main/scala/java/lang/Comparable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 trait Comparable[A] {

--- a/javalanglib/src/main/scala/java/lang/Double.scala
+++ b/javalanglib/src/main/scala/java/lang/Double.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Enum.scala
+++ b/javalanglib/src/main/scala/java/lang/Enum.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 abstract class Enum[E <: Enum[E]] protected (_name: String, _ordinal: Int)

--- a/javalanglib/src/main/scala/java/lang/EnvironmentInfo.scala
+++ b/javalanglib/src/main/scala/java/lang/EnvironmentInfo.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Float.scala
+++ b/javalanglib/src/main/scala/java/lang/Float.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 /* This is a hijacked class. Its instances are primitive numbers.

--- a/javalanglib/src/main/scala/java/lang/FloatingPointBits.scala
+++ b/javalanglib/src/main/scala/java/lang/FloatingPointBits.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/InheritableThreadLocal.scala
+++ b/javalanglib/src/main/scala/java/lang/InheritableThreadLocal.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 class InheritableThreadLocal[T] extends ThreadLocal[T] {

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Iterable.scala
+++ b/javalanglib/src/main/scala/java/lang/Iterable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import java.util.Iterator

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.annotation.{switch, tailrec}

--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java
 package lang
 

--- a/javalanglib/src/main/scala/java/lang/Number.scala
+++ b/javalanglib/src/main/scala/java/lang/Number.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/ObjectClone.scala
+++ b/javalanglib/src/main/scala/java/lang/ObjectClone.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Readable.scala
+++ b/javalanglib/src/main/scala/java/lang/Readable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import java.nio.CharBuffer

--- a/javalanglib/src/main/scala/java/lang/Runnable.scala
+++ b/javalanglib/src/main/scala/java/lang/Runnable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 trait Runnable {

--- a/javalanglib/src/main/scala/java/lang/Runtime.scala
+++ b/javalanglib/src/main/scala/java/lang/Runtime.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Short.scala
+++ b/javalanglib/src/main/scala/java/lang/Short.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 /* This is a hijacked class. Its instances are primitive numbers.

--- a/javalanglib/src/main/scala/java/lang/StackTrace.scala
+++ b/javalanglib/src/main/scala/java/lang/StackTrace.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.annotation.tailrec

--- a/javalanglib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalanglib/src/main/scala/java/lang/StackTraceElement.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/StringBuffer.scala
+++ b/javalanglib/src/main/scala/java/lang/StringBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 /* Given the rare usefulness of StringBuffer in the context of Scala.js, and

--- a/javalanglib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalanglib/src/main/scala/java/lang/StringBuilder.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 class StringBuilder

--- a/javalanglib/src/main/scala/java/lang/System.scala
+++ b/javalanglib/src/main/scala/java/lang/System.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import java.io._

--- a/javalanglib/src/main/scala/java/lang/Thread.scala
+++ b/javalanglib/src/main/scala/java/lang/Thread.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 /* We need a constructor to create SingleThread in the companion object, but

--- a/javalanglib/src/main/scala/java/lang/ThreadLocal.scala
+++ b/javalanglib/src/main/scala/java/lang/ThreadLocal.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 class ThreadLocal[T] {

--- a/javalanglib/src/main/scala/java/lang/Throwables.scala
+++ b/javalanglib/src/main/scala/java/lang/Throwables.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/javalanglib/src/main/scala/java/lang/Void.scala
+++ b/javalanglib/src/main/scala/java/lang/Void.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 final class Void private ()

--- a/javalanglib/src/main/scala/java/lang/_String.scala
+++ b/javalanglib/src/main/scala/java/lang/_String.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import java.util.Comparator

--- a/javalanglib/src/main/scala/java/lang/annotation/Annotation.scala
+++ b/javalanglib/src/main/scala/java/lang/annotation/Annotation.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang.annotation
 
 trait Annotation {

--- a/javalanglib/src/main/scala/java/lang/ref/PhantomReference.scala
+++ b/javalanglib/src/main/scala/java/lang/ref/PhantomReference.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang.ref
 
 class PhantomReference[T >: Null <: AnyRef](referent: T,

--- a/javalanglib/src/main/scala/java/lang/ref/Reference.scala
+++ b/javalanglib/src/main/scala/java/lang/ref/Reference.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang.ref
 
 abstract class Reference[T >: Null <: AnyRef](private[this] var referent: T) {

--- a/javalanglib/src/main/scala/java/lang/ref/ReferenceQueue.scala
+++ b/javalanglib/src/main/scala/java/lang/ref/ReferenceQueue.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang.ref
 
 class ReferenceQueue[T >: Null <: AnyRef]

--- a/javalanglib/src/main/scala/java/lang/ref/SoftReference.scala
+++ b/javalanglib/src/main/scala/java/lang/ref/SoftReference.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang.ref
 
 class SoftReference[T >: Null <: AnyRef](referent: T,

--- a/javalanglib/src/main/scala/java/lang/ref/WeakReference.scala
+++ b/javalanglib/src/main/scala/java/lang/ref/WeakReference.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang.ref
 
 class WeakReference[T >: Null <: AnyRef](referent: T,

--- a/javalanglib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalanglib/src/main/scala/java/lang/reflect/Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang.reflect
 
 import scala.scalajs.js

--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class BufferedReader(in: Reader, sz: Int) extends Reader {

--- a/javalib/src/main/scala/java/io/ByteArrayInputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayInputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class ByteArrayInputStream(

--- a/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 import scala.scalajs.js

--- a/javalib/src/main/scala/java/io/Closeable.scala
+++ b/javalib/src/main/scala/java/io/Closeable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 trait Closeable extends AutoCloseable {

--- a/javalib/src/main/scala/java/io/DataInput.scala
+++ b/javalib/src/main/scala/java/io/DataInput.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 trait DataInput {

--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/io/DataOutput.scala
+++ b/javalib/src/main/scala/java/io/DataOutput.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 trait DataOutput {

--- a/javalib/src/main/scala/java/io/DataOutputStream.scala
+++ b/javalib/src/main/scala/java/io/DataOutputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class DataOutputStream(out: OutputStream)

--- a/javalib/src/main/scala/java/io/FilterInputStream.scala
+++ b/javalib/src/main/scala/java/io/FilterInputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class FilterInputStream protected (

--- a/javalib/src/main/scala/java/io/FilterOutputStream.scala
+++ b/javalib/src/main/scala/java/io/FilterOutputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class FilterOutputStream(protected val out: OutputStream) extends OutputStream {

--- a/javalib/src/main/scala/java/io/Flushable.scala
+++ b/javalib/src/main/scala/java/io/Flushable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 trait Flushable {

--- a/javalib/src/main/scala/java/io/InputStream.scala
+++ b/javalib/src/main/scala/java/io/InputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 abstract class InputStream extends Closeable {

--- a/javalib/src/main/scala/java/io/InputStreamReader.scala
+++ b/javalib/src/main/scala/java/io/InputStreamReader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/io/OutputStream.scala
+++ b/javalib/src/main/scala/java/io/OutputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 abstract class OutputStream extends Object with Closeable with Flushable {

--- a/javalib/src/main/scala/java/io/OutputStreamWriter.scala
+++ b/javalib/src/main/scala/java/io/OutputStreamWriter.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/io/PrintStream.scala
+++ b/javalib/src/main/scala/java/io/PrintStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 import java.nio.charset.Charset

--- a/javalib/src/main/scala/java/io/PrintWriter.scala
+++ b/javalib/src/main/scala/java/io/PrintWriter.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 import java.util.Formatter

--- a/javalib/src/main/scala/java/io/Reader.scala
+++ b/javalib/src/main/scala/java/io/Reader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 import java.nio.CharBuffer

--- a/javalib/src/main/scala/java/io/Serializable.scala
+++ b/javalib/src/main/scala/java/io/Serializable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 trait Serializable

--- a/javalib/src/main/scala/java/io/StringReader.scala
+++ b/javalib/src/main/scala/java/io/StringReader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class StringReader(s: String) extends Reader {

--- a/javalib/src/main/scala/java/io/StringWriter.scala
+++ b/javalib/src/main/scala/java/io/StringWriter.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class StringWriter extends Writer {

--- a/javalib/src/main/scala/java/io/Throwables.scala
+++ b/javalib/src/main/scala/java/io/Throwables.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class IOException(s: String, e: Throwable) extends Exception(s, e) {

--- a/javalib/src/main/scala/java/io/Writer.scala
+++ b/javalib/src/main/scala/java/io/Writer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 abstract class Writer private[this] (_lock: Option[Object]) extends

--- a/javalib/src/main/scala/java/math/Multiplication.scala
+++ b/javalib/src/main/scala/java/math/Multiplication.scala
@@ -1,6 +1,7 @@
 /*
  * Ported by Alistair Johnson from
  * https://android.googlesource.com/platform/libcore/+/master/luni/src/main/java/java/math/Multiplication.java
+ * Original license copied below:
  */
 
 /*

--- a/javalib/src/main/scala/java/net/Throwables.scala
+++ b/javalib/src/main/scala/java/net/Throwables.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.net
 
 import java.io.IOException

--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.net
 
 import scala.scalajs.js.RegExp

--- a/javalib/src/main/scala/java/net/URLDecoder.scala
+++ b/javalib/src/main/scala/java/net/URLDecoder.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.net
 
 import java.io.UnsupportedEncodingException

--- a/javalib/src/main/scala/java/nio/Buffer.scala
+++ b/javalib/src/main/scala/java/nio/Buffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/BufferOverflowException.scala
+++ b/javalib/src/main/scala/java/nio/BufferOverflowException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 class BufferOverflowException extends RuntimeException

--- a/javalib/src/main/scala/java/nio/BufferUnderflowException.scala
+++ b/javalib/src/main/scala/java/nio/BufferUnderflowException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 class BufferUnderflowException extends RuntimeException

--- a/javalib/src/main/scala/java/nio/ByteArrayBits.scala
+++ b/javalib/src/main/scala/java/nio/ByteArrayBits.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] object ByteArrayBits {

--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/ByteOrder.scala
+++ b/javalib/src/main/scala/java/nio/ByteOrder.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js

--- a/javalib/src/main/scala/java/nio/CharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/CharBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/DataViewCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DataViewCharBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/DataViewDoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DataViewDoubleBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/DataViewFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DataViewFloatBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/DataViewIntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DataViewIntBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/DataViewLongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DataViewLongBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/DataViewShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DataViewShortBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/DoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DoubleBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/FloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/FloatBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/GenBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] object GenBuffer {

--- a/javalib/src/main/scala/java/nio/GenDataViewBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenDataViewBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.Dynamic.{literal => lit}

--- a/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] object GenHeapBuffer {

--- a/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
+++ b/javalib/src/main/scala/java/nio/GenHeapBufferView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] object GenHeapBufferView {

--- a/javalib/src/main/scala/java/nio/GenTypedArrayBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenTypedArrayBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapByteBuffer private (

--- a/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapByteBufferCharView private (

--- a/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapByteBufferDoubleView private (

--- a/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapByteBufferFloatView private (

--- a/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapByteBufferIntView private (

--- a/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapByteBufferLongView private (

--- a/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
+++ b/javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapByteBufferShortView private (

--- a/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapCharBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapCharBuffer private (

--- a/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapDoubleBuffer private (

--- a/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapFloatBuffer private (

--- a/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapIntBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapIntBuffer private (

--- a/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapLongBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapLongBuffer private (

--- a/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/HeapShortBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class HeapShortBuffer private (

--- a/javalib/src/main/scala/java/nio/IntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/IntBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/InvalidMarkException.scala
+++ b/javalib/src/main/scala/java/nio/InvalidMarkException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 class InvalidMarkException extends IllegalStateException

--- a/javalib/src/main/scala/java/nio/LongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/LongBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 object LongBuffer {

--- a/javalib/src/main/scala/java/nio/ReadOnlyBufferException.scala
+++ b/javalib/src/main/scala/java/nio/ReadOnlyBufferException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 class ReadOnlyBufferException extends UnsupportedOperationException

--- a/javalib/src/main/scala/java/nio/ShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ShortBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/StringCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/StringCharBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 private[nio] final class StringCharBuffer private (

--- a/javalib/src/main/scala/java/nio/TypedArrayByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayByteBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/TypedArrayCharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayCharBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/TypedArrayDoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayDoubleBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/TypedArrayFloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayFloatBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/TypedArrayIntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayIntBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/TypedArrayShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/TypedArrayShortBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio
 
 import scala.scalajs.js.typedarray._

--- a/javalib/src/main/scala/java/nio/charset/CharacterCodingException.scala
+++ b/javalib/src/main/scala/java/nio/charset/CharacterCodingException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 class CharacterCodingException extends java.io.IOException

--- a/javalib/src/main/scala/java/nio/charset/Charset.scala
+++ b/javalib/src/main/scala/java/nio/charset/Charset.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 import java.nio.{ByteBuffer, CharBuffer}

--- a/javalib/src/main/scala/java/nio/charset/CharsetDecoder.scala
+++ b/javalib/src/main/scala/java/nio/charset/CharsetDecoder.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 import scala.annotation.{switch, tailrec}

--- a/javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
+++ b/javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 import scala.annotation.{switch, tailrec}

--- a/javalib/src/main/scala/java/nio/charset/CoderMalfunctionError.scala
+++ b/javalib/src/main/scala/java/nio/charset/CoderMalfunctionError.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 class CoderMalfunctionError(cause: Exception) extends Error(cause)

--- a/javalib/src/main/scala/java/nio/charset/CoderResult.scala
+++ b/javalib/src/main/scala/java/nio/charset/CoderResult.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 import scala.annotation.switch

--- a/javalib/src/main/scala/java/nio/charset/CodingErrorAction.scala
+++ b/javalib/src/main/scala/java/nio/charset/CodingErrorAction.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 class CodingErrorAction private (name: String) {

--- a/javalib/src/main/scala/java/nio/charset/ISO_8859_1.scala
+++ b/javalib/src/main/scala/java/nio/charset/ISO_8859_1.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 private[charset] object ISO_8859_1 extends ISO_8859_1_And_US_ASCII_Common(

--- a/javalib/src/main/scala/java/nio/charset/ISO_8859_1_And_US_ASCII_Common.scala
+++ b/javalib/src/main/scala/java/nio/charset/ISO_8859_1_And_US_ASCII_Common.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/nio/charset/MalformedInputException.scala
+++ b/javalib/src/main/scala/java/nio/charset/MalformedInputException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 class MalformedInputException(

--- a/javalib/src/main/scala/java/nio/charset/StandardCharsets.scala
+++ b/javalib/src/main/scala/java/nio/charset/StandardCharsets.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 import java.nio.charset

--- a/javalib/src/main/scala/java/nio/charset/US_ASCII.scala
+++ b/javalib/src/main/scala/java/nio/charset/US_ASCII.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 private[charset] object US_ASCII extends ISO_8859_1_And_US_ASCII_Common(

--- a/javalib/src/main/scala/java/nio/charset/UTF_16.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 private[charset] object UTF_16 extends UTF_16_Common(

--- a/javalib/src/main/scala/java/nio/charset/UTF_16BE.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16BE.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 private[charset] object UTF_16BE extends UTF_16_Common(

--- a/javalib/src/main/scala/java/nio/charset/UTF_16LE.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16LE.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 private[charset] object UTF_16LE extends UTF_16_Common(

--- a/javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/nio/charset/UTF_8.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_8.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 import scala.annotation.{switch, tailrec}

--- a/javalib/src/main/scala/java/nio/charset/UnmappableCharacterException.scala
+++ b/javalib/src/main/scala/java/nio/charset/UnmappableCharacterException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 class UnmappableCharacterException(

--- a/javalib/src/main/scala/java/nio/charset/UnsupportedCharsetException.scala
+++ b/javalib/src/main/scala/java/nio/charset/UnsupportedCharsetException.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.nio.charset
 
 class UnsupportedCharsetException(

--- a/javalib/src/main/scala/java/security/Guard.scala
+++ b/javalib/src/main/scala/java/security/Guard.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.security
 
 trait Guard {

--- a/javalib/src/main/scala/java/security/Permission.scala
+++ b/javalib/src/main/scala/java/security/Permission.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.security
 
 abstract class Permission(name: String) extends Guard with Serializable {

--- a/javalib/src/main/scala/java/security/Throwables.scala
+++ b/javalib/src/main/scala/java/security/Throwables.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.security
 
 import java.lang.SecurityException

--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/util/AbstractQueue.scala
+++ b/javalib/src/main/scala/java/util/AbstractQueue.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 abstract class AbstractQueue[E] protected ()

--- a/javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
+++ b/javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 abstract private[util] class AbstractRandomAccessListIterator[E](private var i: Int,

--- a/javalib/src/main/scala/java/util/AbstractSequentialList.scala
+++ b/javalib/src/main/scala/java/util/AbstractSequentialList.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 abstract class AbstractSequentialList[E] protected ()

--- a/javalib/src/main/scala/java/util/AbstractSet.scala
+++ b/javalib/src/main/scala/java/util/AbstractSet.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/util/ArrayDeque.scala
+++ b/javalib/src/main/scala/java/util/ArrayDeque.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.scalajs.js

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.scalajs._

--- a/javalib/src/main/scala/java/util/Arrays.scala
+++ b/javalib/src/main/scala/java/util/Arrays.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.scalajs.js

--- a/javalib/src/main/scala/java/util/Base64.scala
+++ b/javalib/src/main/scala/java/util/Base64.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/util/Collection.scala
+++ b/javalib/src/main/scala/java/util/Collection.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait Collection[E] extends java.lang.Iterable[E] {

--- a/javalib/src/main/scala/java/util/Collections.scala
+++ b/javalib/src/main/scala/java/util/Collections.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import java.{lang => jl}

--- a/javalib/src/main/scala/java/util/Comparator.scala
+++ b/javalib/src/main/scala/java/util/Comparator.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.scalajs.js.annotation.JavaDefaultMethod

--- a/javalib/src/main/scala/java/util/Compat.scala
+++ b/javalib/src/main/scala/java/util/Compat.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.collection.mutable

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -1,6 +1,13 @@
-/**
- * 2014 Matt Seddon
- * This code is donated in full to the scala-js project.
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package java.util

--- a/javalib/src/main/scala/java/util/Deque.scala
+++ b/javalib/src/main/scala/java/util/Deque.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait Deque[E] extends Queue[E] {

--- a/javalib/src/main/scala/java/util/Dictionary.scala
+++ b/javalib/src/main/scala/java/util/Dictionary.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 abstract class Dictionary[K, V] {

--- a/javalib/src/main/scala/java/util/Enumeration.scala
+++ b/javalib/src/main/scala/java/util/Enumeration.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait Enumeration[E] {

--- a/javalib/src/main/scala/java/util/EventObject.scala
+++ b/javalib/src/main/scala/java/util/EventObject.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 class EventObject(protected var source: AnyRef) {

--- a/javalib/src/main/scala/java/util/Formattable.scala
+++ b/javalib/src/main/scala/java/util/Formattable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait Formattable {

--- a/javalib/src/main/scala/java/util/FormattableFlags.scala
+++ b/javalib/src/main/scala/java/util/FormattableFlags.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 object FormattableFlags {

--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.annotation.switch

--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.collection.mutable

--- a/javalib/src/main/scala/java/util/HashSet.scala
+++ b/javalib/src/main/scala/java/util/HashSet.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.collection.mutable

--- a/javalib/src/main/scala/java/util/Hashtable.scala
+++ b/javalib/src/main/scala/java/util/Hashtable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import java.{util => ju}

--- a/javalib/src/main/scala/java/util/Iterator.scala
+++ b/javalib/src/main/scala/java/util/Iterator.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait Iterator[E] {

--- a/javalib/src/main/scala/java/util/LinkedHashMap.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashMap.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.collection.mutable

--- a/javalib/src/main/scala/java/util/LinkedHashSet.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashSet.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.collection.mutable

--- a/javalib/src/main/scala/java/util/LinkedList.scala
+++ b/javalib/src/main/scala/java/util/LinkedList.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait List[E] extends Collection[E] {

--- a/javalib/src/main/scala/java/util/ListIterator.scala
+++ b/javalib/src/main/scala/java/util/ListIterator.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait ListIterator[E] extends Iterator[E] {

--- a/javalib/src/main/scala/java/util/Map.scala
+++ b/javalib/src/main/scala/java/util/Map.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait Map[K, V] {

--- a/javalib/src/main/scala/java/util/NavigableMap.scala
+++ b/javalib/src/main/scala/java/util/NavigableMap.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait NavigableMap[K, V] extends SortedMap[K, V] {

--- a/javalib/src/main/scala/java/util/NavigableSet.scala
+++ b/javalib/src/main/scala/java/util/NavigableSet.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait NavigableSet[E] extends SortedSet[E] {

--- a/javalib/src/main/scala/java/util/NavigableView.scala
+++ b/javalib/src/main/scala/java/util/NavigableView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.math.Ordering

--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.reflect.ClassTag

--- a/javalib/src/main/scala/java/util/Optional.scala
+++ b/javalib/src/main/scala/java/util/Optional.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 final class Optional[T] private (value: T) {

--- a/javalib/src/main/scala/java/util/PriorityQueue.scala
+++ b/javalib/src/main/scala/java/util/PriorityQueue.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import java.lang.Comparable

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import java.{util => ju}

--- a/javalib/src/main/scala/java/util/Queue.scala
+++ b/javalib/src/main/scala/java/util/Queue.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait Queue[E] extends Collection[E] {

--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.annotation.tailrec

--- a/javalib/src/main/scala/java/util/RandomAccess.scala
+++ b/javalib/src/main/scala/java/util/RandomAccess.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait RandomAccess

--- a/javalib/src/main/scala/java/util/Set.scala
+++ b/javalib/src/main/scala/java/util/Set.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait Set[E] extends Collection[E]

--- a/javalib/src/main/scala/java/util/SizeChangeEvent.scala
+++ b/javalib/src/main/scala/java/util/SizeChangeEvent.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 private[util] trait SizeChangeEvent {

--- a/javalib/src/main/scala/java/util/SortedMap.scala
+++ b/javalib/src/main/scala/java/util/SortedMap.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait SortedMap[K, V] extends Map[K, V] {

--- a/javalib/src/main/scala/java/util/SortedSet.scala
+++ b/javalib/src/main/scala/java/util/SortedSet.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 trait SortedSet[E] extends Set[E] {

--- a/javalib/src/main/scala/java/util/SplittableRandom.scala
+++ b/javalib/src/main/scala/java/util/SplittableRandom.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 /*

--- a/javalib/src/main/scala/java/util/Throwables.scala
+++ b/javalib/src/main/scala/java/util/Throwables.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 class ServiceConfigurationError(s: String, e: Throwable) extends Error(s, e) {

--- a/javalib/src/main/scala/java/util/Timer.scala
+++ b/javalib/src/main/scala/java/util/Timer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.collection._

--- a/javalib/src/main/scala/java/util/TimerTask.scala
+++ b/javalib/src/main/scala/java/util/TimerTask.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import scala.concurrent.duration.FiniteDuration

--- a/javalib/src/main/scala/java/util/TreeSet.scala
+++ b/javalib/src/main/scala/java/util/TreeSet.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import java.lang.Comparable

--- a/javalib/src/main/scala/java/util/UUID.scala
+++ b/javalib/src/main/scala/java/util/UUID.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util
 
 import java.lang.{Long => JLong}

--- a/javalib/src/main/scala/java/util/concurrent/Callable.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Callable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 trait Callable[V] {

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 import java.lang.{reflect => jlr}

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 import java.util._

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentMap.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 import java.util._

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentSkipListSet.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentSkipListSet.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 import java.util._

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 import java.lang.{reflect => jlr}

--- a/javalib/src/main/scala/java/util/concurrent/Executor.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Executor.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 trait Executor {

--- a/javalib/src/main/scala/java/util/concurrent/ThreadFactory.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadFactory.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 trait ThreadFactory {

--- a/javalib/src/main/scala/java/util/concurrent/Throwables.scala
+++ b/javalib/src/main/scala/java/util/concurrent/Throwables.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 class ExecutionException(message: String, cause: Throwable)

--- a/javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
+++ b/javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent
 
 abstract class TimeUnit private (name: String, ordinal: Int)

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent.atomic
 
 class AtomicBoolean(private[this] var value: Boolean) extends Serializable {

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent.atomic
 
 class AtomicInteger(private[this] var value: Int)

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent.atomic
 
 class AtomicLong(private[this] var value: Long) extends Number with Serializable {

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent.atomic
 
 class AtomicLongArray(length: Int) extends Serializable {

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent.atomic
 
 class AtomicReference[T <: AnyRef](

--- a/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent.atomic
 
 class AtomicReferenceArray[E <: AnyRef](

--- a/javalib/src/main/scala/java/util/concurrent/locks/Lock.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/Lock.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent.locks
 
 import java.util.concurrent.TimeUnit

--- a/javalib/src/main/scala/java/util/concurrent/locks/ReentrantLock.scala
+++ b/javalib/src/main/scala/java/util/concurrent/locks/ReentrantLock.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.concurrent.locks
 
 import java.io.Serializable

--- a/javalib/src/main/scala/java/util/package.scala
+++ b/javalib/src/main/scala/java/util/package.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java
 
 package object util {

--- a/javalib/src/main/scala/java/util/regex/GroupStartMap.scala
+++ b/javalib/src/main/scala/java/util/regex/GroupStartMap.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.regex
 
 import scala.annotation.{tailrec, switch}

--- a/javalib/src/main/scala/java/util/regex/MatchResult.scala
+++ b/javalib/src/main/scala/java/util/regex/MatchResult.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.regex
 
 trait MatchResult {

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.regex
 
 import scala.language.implicitConversions
@@ -23,6 +35,9 @@ final class Matcher private[regex] (
   private var lastMatch: js.RegExp.ExecResult = null
   private var lastMatchIsValid = false
   private var canStillFind = true
+
+  // Group count
+  private var lastGroupCount: Option[Int] = None
 
   // Append state (updated by replacement methods)
   private var appendPos: Int = 0
@@ -160,6 +175,7 @@ final class Matcher private[regex] (
     regexp = pattern.newJSRegExp()
     regexp.lastIndex = prevLastIndex
     lastMatch = null
+    lastGroupCount = None
     startOfGroupCache = None
     this
   }
@@ -172,7 +188,21 @@ final class Matcher private[regex] (
     lastMatch
   }
 
-  def groupCount(): Int = ensureLastMatch.length-1
+  def groupCount(): Int = {
+    if (lastMatch != null) {
+      lastMatch.length-1
+    } else {
+      lastGroupCount match {
+        case Some(n) => n
+
+        case None =>
+          val groupCountRegex = new js.RegExp("|" + pattern0.jsPattern)
+          val newGroupCount = groupCountRegex.exec("").length-1
+          lastGroupCount = Some(newGroupCount)
+          newGroupCount
+      }
+    }
+  }
 
   def start(): Int = ensureLastMatch.index
   def end(): Int = start() + group().length
@@ -198,7 +228,7 @@ final class Matcher private[regex] (
 
   // Seal the state
 
-  def toMatchResult(): MatchResult = new SealedResult(inputstr, lastMatch, pattern())
+  def toMatchResult(): MatchResult = new SealedResult(inputstr, lastMatch, pattern(), groupCount())
 
   // Other query state methods
 
@@ -249,10 +279,11 @@ object Matcher {
   }
 
   private final class SealedResult(inputstr: String,
-      lastMatch: js.RegExp.ExecResult, pattern: Pattern)
+      lastMatch: js.RegExp.ExecResult, pattern: Pattern,
+      lastGroupCount: Int)
       extends MatchResult {
 
-    def groupCount(): Int = ensureLastMatch.length-1
+    def groupCount(): Int = lastGroupCount
 
     def start(): Int = ensureLastMatch.index
     def end(): Int = start() + group().length

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.util.regex
 
 import scala.annotation.switch

--- a/javalib/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
+++ b/javalib/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /* !!!!!
  * THIS FILE IS ALMOST COPY-PASTED IN javalib/ AND library/.
@@ -27,7 +30,6 @@
  * (Yes, this is a hack.)
  * !!!!!
  */
-
 
 package scala.scalajs.js.typedarray
 

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test
 
 import org.junit.{Before, Test}

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvSuite.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvSuite.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test
 
 import org.scalajs.jsenv.JSEnv

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvSuiteConfig.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvSuiteConfig.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test
 
 import org.scalajs.jsenv.JSEnv

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/RunTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/RunTests.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test
 
 import org.junit.Assume._

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/TimeoutComTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/TimeoutComTests.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test
 
 import scala.concurrent.duration._

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/TimeoutRunTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/TimeoutRunTests.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test
 
 import scala.concurrent.duration._

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/ComRun.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/ComRun.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test.kit
 
 import scala.concurrent.Await

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/IOReader.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/IOReader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test.kit
 
 import scala.annotation.tailrec

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/MsgHandler.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/MsgHandler.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test.kit
 
 import scala.annotation.tailrec

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/Run.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/Run.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test.kit
 
 import scala.concurrent.Await

--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/TestKit.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/kit/TestKit.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test.kit
 
 import scala.concurrent.ExecutionContext

--- a/js-envs-test-kit/src/test/scala/org/scalajs/jsenv/test/kit/TestEnv.scala
+++ b/js-envs-test-kit/src/test/scala/org/scalajs/jsenv/test/kit/TestEnv.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test.kit
 
 import scala.concurrent.Future

--- a/js-envs-test-kit/src/test/scala/org/scalajs/jsenv/test/kit/TestKitTest.scala
+++ b/js-envs-test-kit/src/test/scala/org/scalajs/jsenv/test/kit/TestKitTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.test.kit
 
 import scala.concurrent.duration._

--- a/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSRun.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSRun.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js JS Envs           **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.jsenv
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js JS Envs           **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.jsenv
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js JS Envs           **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.jsenv
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/JSRuns.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/JSRuns.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js JS Envs           **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.jsenv
 

--- a/js-envs/src/main/scala/org/scalajs/jsenv/RunConfig.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/RunConfig.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js JS Envs           **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.jsenv
 

--- a/js-envs/src/test/scala/org/scalajs/jsenv/RunConfigTest.scala
+++ b/js-envs/src/test/scala/org/scalajs/jsenv/RunConfigTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv
 
 import org.junit.Test

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/CompatComponent.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/CompatComponent.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit.plugin
 
 import scala.reflect.internal.Flags

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit.plugin
 
 import scala.language.reflectiveCalls

--- a/junit-runtime/src/main/scala/com/novocode/junit/Ansi.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/Ansi.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package com.novocode.junit
 
 object Ansi {

--- a/junit-runtime/src/main/scala/com/novocode/junit/JUnitFramework.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/JUnitFramework.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package com.novocode.junit
 
 import org.scalajs.junit.{JUnitMasterRunner, JUnitSlaveRunner}

--- a/junit-runtime/src/main/scala/com/novocode/junit/RichLogger.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/RichLogger.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package com.novocode.junit
 
 import sbt.testing._

--- a/junit-runtime/src/main/scala/com/novocode/junit/RunSettings.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/RunSettings.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package com.novocode.junit
 
 import com.novocode.junit.Ansi._

--- a/junit-runtime/src/main/scala/org/hamcrest/LICENSE-hamcrest.txt
+++ b/junit-runtime/src/main/scala/org/hamcrest/LICENSE-hamcrest.txt
@@ -1,0 +1,27 @@
+BSD License
+
+Copyright (c) 2000-2006, www.hamcrest.org
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer. Redistributions in binary form must reproduce
+the above copyright notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the distribution.
+
+Neither the name of Hamcrest nor the names of its contributors may be used to endorse
+or promote products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY
+WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitBaseRunner.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitBaseRunner.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import com.novocode.junit.RunSettings

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitEvent.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitEvent.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import sbt.testing._

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitExecuteTest.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitExecuteTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import java.io.ByteArrayOutputStream

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitMasterRunner.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitMasterRunner.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import com.novocode.junit.RunSettings

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitSlaveRunner.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitSlaveRunner.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import com.novocode.junit.RunSettings

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTask.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTask.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import com.novocode.junit.{Ansi, RichLogger}

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTestBootstrapper.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitTestBootstrapper.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import java.lang.annotation.Annotation

--- a/junit-test/output-js/src/test/scala/org/scalajs/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-js/src/test/scala/org/scalajs/junit/utils/JUnitTestPlatformImpl.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit.utils
 
 import sbt.testing._

--- a/junit-test/output-jvm/src/test/scala/org/scalajs/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-jvm/src/test/scala/org/scalajs/junit/utils/JUnitTestPlatformImpl.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit.utils
 
 import sbt.testing._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEquals2Test.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEquals2Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assert._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsDoubleTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsDoubleTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assert._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assert._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertFalse2Test.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertFalse2Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assert._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertFalseTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertFalseTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assert._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertStringEqualsTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertStringEqualsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assert._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssertTrueTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssertTrueTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assert._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/AssumeTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/AssumeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assume._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/BeforeAndAfterTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/BeforeAndAfterTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/BeforeAssumeFailTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/BeforeAssumeFailTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assume._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInAfterTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInAfterTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInBeforeTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInBeforeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInConstructorTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInConstructorTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Test

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/IgnoreTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/IgnoreTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/MethodNameDecodeTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/MethodNameDecodeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Test

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/Multi1Test.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/Multi1Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Test

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/Multi2Test.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/Multi2Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Test

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/MultiAssumeFail1Test.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/MultiAssumeFail1Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assume._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/MultiAssumeFail2Test.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/MultiAssumeFail2Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assume._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/MultiBeforeAssumeFailTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/MultiBeforeAssumeFailTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit.Assume._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnore1Test.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnore1Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnore2Test.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnore2Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnoreAllTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnoreAllTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit
 
 import org.junit._

--- a/junit-test/shared/src/test/scala/org/scalajs/junit/utils/JUnitTest.scala
+++ b/junit-test/shared/src/test/scala/org/scalajs/junit/utils/JUnitTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.junit.utils
 
 import sbt.testing._

--- a/library-aux/src/main/scala/scala/runtime/ArrayRuntime.scala
+++ b/library-aux/src/main/scala/scala/runtime/ArrayRuntime.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.runtime
 
 /** Not for public consumption.  Usage by the runtime only.

--- a/library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
+++ b/library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.runtime
 
 /* This is a hijacked class. Its only instance is the value 'undefined'.

--- a/library-aux/src/main/scala/scala/runtime/RefTypes.scala
+++ b/library-aux/src/main/scala/scala/runtime/RefTypes.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.runtime
 
 import java.io.Serializable

--- a/library-aux/src/main/scala/scala/runtime/Statics.scala
+++ b/library-aux/src/main/scala/scala/runtime/Statics.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.runtime
 
 /** Not for public consumption.  Usage by the runtime only.

--- a/library/src/main/scala-m4-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-m4-collections/scala/scalajs/js/Any.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala-m4-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-m4-collections/scala/scalajs/js/ArrayOps.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-m4-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-m4-collections/scala/scalajs/js/JSConverters.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-m4-collections/scala/scalajs/js/WrappedArray.scala
+++ b/library/src/main/scala-m4-collections/scala/scalajs/js/WrappedArray.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-m4-collections/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala-m4-collections/scala/scalajs/js/WrappedDictionary.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-m4-collections/scala/scalajs/runtime/Compat.scala
+++ b/library/src/main/scala-m4-collections/scala/scalajs/runtime/Compat.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.collection.IterableOnce

--- a/library/src/main/scala-m4-collections/scala/scalajs/runtime/WrappedVarArgs.scala
+++ b/library/src/main/scala-m4-collections/scala/scalajs/runtime/WrappedVarArgs.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.collection.immutable

--- a/library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedArray.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedArray.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedDictionary.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-new-collections/scala/scalajs/runtime/Compat.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/runtime/Compat.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.collection.IterableOnce

--- a/library/src/main/scala-new-collections/scala/scalajs/runtime/WrappedVarArgs.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/runtime/WrappedVarArgs.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.collection.immutable

--- a/library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala-old-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/ArrayOps.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedArray.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedArray.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedDictionary.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala-old-collections/scala/scalajs/runtime/Compat.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/runtime/Compat.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.collection.GenTraversableOnce

--- a/library/src/main/scala/scala/scalajs/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/LinkingInfo.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs
 

--- a/library/src/main/scala/scala/scalajs/concurrent/JSExecutionContext.scala
+++ b/library/src/main/scala/scala/scalajs/concurrent/JSExecutionContext.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.concurrent
 
 import scala.concurrent.ExecutionContextExecutor

--- a/library/src/main/scala/scala/scalajs/concurrent/QueueExecutionContext.scala
+++ b/library/src/main/scala/scala/scalajs/concurrent/QueueExecutionContext.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.concurrent
 
 import scala.concurrent.ExecutionContextExecutor

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/ArrayOpsCommon.scala
+++ b/library/src/main/scala/scala/scalajs/js/ArrayOpsCommon.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
+++ b/library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/Date.scala
+++ b/library/src/main/scala/scala/scalajs/js/Date.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/Dictionary.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dictionary.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/Dynamic.scala
+++ b/library/src/main/scala/scala/scalajs/js/Dynamic.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/DynamicImplicits.scala
+++ b/library/src/main/scala/scala/scalajs/js/DynamicImplicits.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/Error.scala
+++ b/library/src/main/scala/scala/scalajs/js/Error.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/Function.nodoc.scala
+++ b/library/src/main/scala/scala/scalajs/js/Function.nodoc.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /* Definitions for js.Function3 to js.Function22 that do not show in doc */
 package scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/Function.scala
+++ b/library/src/main/scala/scala/scalajs/js/Function.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/Iterable.scala
+++ b/library/src/main/scala/scala/scalajs/js/Iterable.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/IterableOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/IterableOps.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/Iterator.scala
+++ b/library/src/main/scala/scala/scalajs/js/Iterator.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/JSArrayOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSArrayOps.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/JSON.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSON.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/JSStringOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSStringOps.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
+++ b/library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/Math.scala
+++ b/library/src/main/scala/scala/scalajs/js/Math.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/Promise.scala
+++ b/library/src/main/scala/scala/scalajs/js/Promise.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/PropertyDescriptor.scala
+++ b/library/src/main/scala/scala/scalajs/js/PropertyDescriptor.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/RegExp.scala
+++ b/library/src/main/scala/scala/scalajs/js/RegExp.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/Symbol.scala
+++ b/library/src/main/scala/scala/scalajs/js/Symbol.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/Thenable.scala
+++ b/library/src/main/scala/scala/scalajs/js/Thenable.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/ThisFunction.nodoc.scala
+++ b/library/src/main/scala/scala/scalajs/js/ThisFunction.nodoc.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /* Definitions for js.ThisFunction3 to js.ThisFunction22 that do not show in doc */
 package scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/ThisFunction.scala
+++ b/library/src/main/scala/scala/scalajs/js/ThisFunction.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/Tuple.nodoc.scala
+++ b/library/src/main/scala/scala/scalajs/js/Tuple.nodoc.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /* Definitions for js.Tuple4 to js.Tuple22 that do not show in doc */
 package scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/Tuple.scala
+++ b/library/src/main/scala/scala/scalajs/js/Tuple.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /**
  * All doc-comments marked as "MDN" are by Mozilla Contributors,

--- a/library/src/main/scala/scala/scalajs/js/URIUtils.scala
+++ b/library/src/main/scala/scala/scalajs/js/URIUtils.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/UnicodeNormalizationForm.scala
+++ b/library/src/main/scala/scala/scalajs/js/UnicodeNormalizationForm.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /* All doc-comments marked as "MDN" are by Mozilla Contributors,
  * distributed under the Creative Commons Attribution-ShareAlike license from

--- a/library/src/main/scala/scala/scalajs/js/Union.scala
+++ b/library/src/main/scala/scala/scalajs/js/Union.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSBracketAccess.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSBracketAccess.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSBracketCall.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSBracketCall.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExport.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExport.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExportAll.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExportAll.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExportStatic.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExportStatic.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExportTopLevel.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExportTopLevel.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSGlobal.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSGlobal.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSGlobalScope.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSGlobalScope.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSImport.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSImport.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSName.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSName.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/JavaDefaultMethod.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JavaDefaultMethod.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/internal/AnonymousJSClass.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/internal/AnonymousJSClass.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.annotation.internal
 
 /** IMPLEMENTATION DETAIL: Marks anonymous non-native JS classes.

--- a/library/src/main/scala/scala/scalajs/js/annotation/internal/ExposedJSMember.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/internal/ExposedJSMember.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation.internal
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/internal/JSOptional.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/internal/JSOptional.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation.internal
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/internal/RawJSType.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/internal/RawJSType.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2003-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.annotation.internal
 

--- a/library/src/main/scala/scala/scalajs/js/annotation/internal/WasPublicBeforeTyper.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/internal/WasPublicBeforeTyper.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.annotation.internal
 
 /** IMPLEMENTATION DETAIL: Marks public members of anonymous classes before typer.

--- a/library/src/main/scala/scala/scalajs/js/defined.scala
+++ b/library/src/main/scala/scala/scalajs/js/defined.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs
 

--- a/library/src/main/scala/scala/scalajs/js/special/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/special/package.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/timers/Handles.scala
+++ b/library/src/main/scala/scala/scalajs/js/timers/Handles.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.timers
 

--- a/library/src/main/scala/scala/scalajs/js/timers/RawTimers.scala
+++ b/library/src/main/scala/scala/scalajs/js/timers/RawTimers.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.timers
 

--- a/library/src/main/scala/scala/scalajs/js/timers/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/timers/package.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js
 

--- a/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBuffer.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBuffer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBufferInputStream.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBufferInputStream.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import java.io.InputStream

--- a/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBufferView.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/ArrayBufferView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/DataView.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/DataView.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/DataViewExt.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/DataViewExt.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.typedarray
 

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBuffer.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBuffer.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.typedarray
 

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 /* !!!!!
  * THIS FILE IS ALMOST COPY-PASTED IN javalib/ AND library/.
@@ -27,7 +30,6 @@
  * (Yes, this is a hack.)
  * !!!!!
  */
-
 
 package scala.scalajs.js.typedarray
 

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferOps.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-lang.org/     **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala.scalajs.js.typedarray
 

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js.typedarray
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/js/typedarray/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/package.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.js
 
 import JSConverters._

--- a/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
+++ b/library/src/main/scala/scala/scalajs/reflect/Reflect.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.reflect
 
 import scala.collection.mutable

--- a/library/src/main/scala/scala/scalajs/reflect/annotation/EnableReflectiveInstantiation.scala
+++ b/library/src/main/scala/scala/scalajs/reflect/annotation/EnableReflectiveInstantiation.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js API               **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.reflect.annotation
 
 /** Enables reflective instantiation for the annotated class, trait or object,

--- a/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.scalajs.js

--- a/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.annotation.tailrec

--- a/library/src/main/scala/scala/scalajs/runtime/SemanticsUtils.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/SemanticsUtils.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 import scala.annotation.switch

--- a/library/src/main/scala/scala/scalajs/runtime/UndefinedBehaviorError.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/UndefinedBehaviorError.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs.runtime
 
 /** Error thrown when an undefined behavior in Fatal mode has been detected.

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.scalajs
 
 import scala.annotation.tailrec

--- a/linker/js/src/main/scala/org/scalajs/linker/StandardLinkerPlatformExtensions.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/StandardLinkerPlatformExtensions.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/js/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatform.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatform.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend
 

--- a/linker/js/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatformExtensions.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatformExtensions.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend
 

--- a/linker/js/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImplPlatform.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImplPlatform.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend
 

--- a/linker/js/src/main/scala/org/scalajs/linker/irio/NodeVirtualIRFiles.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/irio/NodeVirtualIRFiles.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.irio
 

--- a/linker/js/src/test/scala/org/scalajs/linker/testutils/Platform.scala
+++ b/linker/js/src/test/scala/org/scalajs/linker/testutils/Platform.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.testutils
 
 import org.scalajs.linker.irio._

--- a/linker/jvm/src/main/scala/org/scalajs/linker/StandardLinkerPlatformExtensions.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/StandardLinkerPlatformExtensions.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatform.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatform.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatformExtensions.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatformExtensions.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.backend.closure
 
 import scala.annotation.switch

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.closure
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureModuleBuilder.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureModuleBuilder.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.backend.closure
 
 import org.scalajs.ir

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/LoggerErrorManager.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/LoggerErrorManager.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.backend.closure
 
 import com.google.javascript.jscomp.{ BasicErrorManager, CheckLevel, JSError }

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/URIUtil.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/URIUtil.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.backend.closure
 
 import java.net.URI

--- a/linker/jvm/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImplPlatform.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImplPlatform.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/frontend/optimizer/ConcurrencyUtils.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/frontend/optimizer/ConcurrencyUtils.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend.optimizer
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/frontend/optimizer/ParIncOptimizer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/frontend/optimizer/ParIncOptimizer.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend.optimizer
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/irio/FileVirtualIRFiles.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/irio/FileVirtualIRFiles.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.irio
 

--- a/linker/jvm/src/test/scala/org/scalajs/linker/testutils/Platform.scala
+++ b/linker/jvm/src/test/scala/org/scalajs/linker/testutils/Platform.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.testutils
 
 import java.io.File

--- a/linker/shared/src/main/scala/org/scalajs/linker/CheckedBehavior.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/CheckedBehavior.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/ClearableLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/ClearableLinker.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/ESFeatures.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/ESFeatures.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js linker            **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/Linker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/Linker.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/LinkerOutput.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/LinkerOutput.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js linker            **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/LinkingException.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/LinkingException.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/ModuleInitializer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/ModuleInitializer.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/ModuleKind.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/ModuleKind.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/Semantics.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/Semantics.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/StandardLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/StandardLinker.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.analyzer
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.analyzer
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.analyzer
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/LinkerBackendImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/LinkerBackendImpl.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLibs.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLibs.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalRefUtils.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalRefUtils.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/InternalOptions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/InternalOptions.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/WithGlobals.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/WithGlobals.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.emitter
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/JSBuilders.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/JSBuilders.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.javascript
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.javascript
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/SourceMapWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/SourceMapWriter.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.javascript
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2014, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.backend.javascript
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.checker
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImpl.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend.optimizer
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend.optimizer
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.frontend.optimizer
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/irio/IRFileCache.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/irio/IRFileCache.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.irio
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/irio/MemIRFiles.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/irio/MemIRFiles.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.irio
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/irio/VirtualIRFiles.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/irio/VirtualIRFiles.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.irio
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/CommonPhaseConfig.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/CommonPhaseConfig.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/CoreSpec.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/CoreSpec.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerBackend.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js linker            **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerFrontend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerFrontend.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js linker            **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkingUnit.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkingUnit.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.standard
 
 import org.scalajs.linker._

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerBackend.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js linker            **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerFrontend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerFrontend.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js linker            **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerImpl.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/Versioned.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/Versioned.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.linker.standard
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker
 
 import org.junit.Test

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker
 
 import org.junit.Test

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.testutils
 
 import org.scalajs.ir

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.linker.testutils
 
 import scala.collection.mutable

--- a/logging/shared/src/main/scala/org/scalajs/logging/Level.scala
+++ b/logging/shared/src/main/scala/org/scalajs/logging/Level.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.logging
 

--- a/logging/shared/src/main/scala/org/scalajs/logging/Logger.scala
+++ b/logging/shared/src/main/scala/org/scalajs/logging/Logger.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js tools             **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2014, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.logging
 

--- a/logging/shared/src/main/scala/org/scalajs/logging/NullLogger.scala
+++ b/logging/shared/src/main/scala/org/scalajs/logging/NullLogger.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.logging
 
 object NullLogger extends Logger {

--- a/logging/shared/src/main/scala/org/scalajs/logging/ScalaConsoleLogger.scala
+++ b/logging/shared/src/main/scala/org/scalajs/logging/ScalaConsoleLogger.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.logging
 
 class ScalaConsoleLogger(minLevel: Level = Level.Debug) extends Logger {

--- a/minilib/src/main/scala/java/lang/Class.scala
+++ b/minilib/src/main/scala/java/lang/Class.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/minilib/src/main/scala/java/lang/FloatingPointBits.scala
+++ b/minilib/src/main/scala/java/lang/FloatingPointBits.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 import scala.scalajs.js

--- a/minilib/src/main/scala/java/lang/System.scala
+++ b/minilib/src/main/scala/java/lang/System.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 /** Stripped down version of `java.lang.System` with the bare minimum to

--- a/minilib/src/main/scala/java/lang/Throwable.scala
+++ b/minilib/src/main/scala/java/lang/Throwable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.lang
 
 /** Stripped down version of `java.lang.Throwable` with the bare minimum to

--- a/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/ComSupport.scala
+++ b/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/ComSupport.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Node.js env       **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.jsenv.nodejs
 

--- a/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Node.js env       **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.jsenv.nodejs
 

--- a/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/Support.scala
+++ b/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/Support.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Node.js env       **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.jsenv.nodejs
 

--- a/nodejs-env/src/test/scala/org/scalajs/jsenv/nodejs/NodeJSSuite.scala
+++ b/nodejs-env/src/test/scala/org/scalajs/jsenv/nodejs/NodeJSSuite.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.jsenv.nodejs
 
 import org.scalajs.jsenv.test._

--- a/partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -1,6 +1,13 @@
-/* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package scala.tools.partest

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.tools.nsc
 
 /* Super hacky overriding of the MainGenericRunner used by partest */

--- a/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala
+++ b/partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 /* NOTE
  * Most of this file is copy-pasted from
  * https://github.com/scala/scala-partest-interface

--- a/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
+++ b/partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scala.tools.partest.scalajs
 
 class ScalaJSPartestOptions private (

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,3 +1,5 @@
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
 
 addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")

--- a/sbt-plugin/src/main/scala-sbt-0.13/org/scalajs/sbtplugin/SBTCompat.scala
+++ b/sbt-plugin/src/main/scala-sbt-0.13/org/scalajs/sbtplugin/SBTCompat.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.sbtplugin
 
 import sbt._

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Loggers.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Loggers.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.sbtplugin
 
 import org.scalajs.logging._

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Run.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Run.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.sbtplugin
 
 import org.scalajs.jsenv._

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.sbtplugin
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.sbtplugin
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.sbtplugin
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.sbtplugin
 
 import scala.annotation.tailrec

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalajspUtils.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalajspUtils.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.sbtplugin
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Stage.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Stage.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.sbtplugin
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/FrameworkAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/FrameworkAdapter.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testing.adapter
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/HTMLRunnerBuilder.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/HTMLRunnerBuilder.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testing.adapter
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/JSEnvRPC.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/JSEnvRPC.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testing.adapter
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/RunnerAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/RunnerAdapter.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js test adapter      **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testing.adapter
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TaskAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TaskAdapter.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js test adapter      **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testing.adapter
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js test adapter      **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testing.adapter
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapterInitializer.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapterInitializer.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js test adapter      **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2017, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testing.adapter
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/package.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/package.scala
@@ -1,11 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js sbt plugin        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
-
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testing
 

--- a/test-common/src/main/scala/org/scalajs/testing/common/Endpoints.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/Endpoints.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 private[testing] sealed trait Endpoint {

--- a/test-common/src/main/scala/org/scalajs/testing/common/ExecuteRequest.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/ExecuteRequest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 private[testing] final class ExecuteRequest(

--- a/test-common/src/main/scala/org/scalajs/testing/common/FrameworkInfo.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/FrameworkInfo.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import sbt.testing._

--- a/test-common/src/main/scala/org/scalajs/testing/common/FrameworkMessage.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/FrameworkMessage.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 private[testing] final class FrameworkMessage(val slaveId: Long, val msg: String)

--- a/test-common/src/main/scala/org/scalajs/testing/common/FutureUtil.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/FutureUtil.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import scala.util._

--- a/test-common/src/main/scala/org/scalajs/testing/common/IsolatedTestSet.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/IsolatedTestSet.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import sbt.testing.TaskDef

--- a/test-common/src/main/scala/org/scalajs/testing/common/JSEndpoints.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/JSEndpoints.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import sbt.testing.TaskDef

--- a/test-common/src/main/scala/org/scalajs/testing/common/JVMEndpoints.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/JVMEndpoints.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import sbt.testing.Event

--- a/test-common/src/main/scala/org/scalajs/testing/common/LogElement.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/LogElement.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 private[testing] final class LogElement[T](val index: Int, val x: T)

--- a/test-common/src/main/scala/org/scalajs/testing/common/RPCCore.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/RPCCore.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import scala.util.{Try, Failure, Success}
@@ -76,7 +88,28 @@ private[testing] abstract class RPCCore()(implicit ex: ExecutionContext) {
         case _ =>
           endpoints.get(opCode) match {
             case null =>
-              throw new IllegalStateException(s"Unknown opcode: $opCode")
+              /* Quick and dirty way to provide more error detail for certain
+               * known problems.
+               * This is not ideal, but the best we can do, since we do not know
+               * all possible opCodes we could receive (we'd need something like
+               * an opCode "domain").
+               * For now this is good enough; if collisions happen in the
+               * future, we can improve this.
+               */
+              val detail = opCode match {
+                case JSEndpoints.msgSlave.opCode =>
+                  "; " +
+                  "The test adapter could not send a message to a slave, " +
+                  "which probably happens because the slave terminated early, " +
+                  "without waiting for the reply to a call to send(). " +
+                  "This is probably a bug in the testing framework you are " +
+                  "using. See also #3201."
+
+                case _ =>
+                  ""
+              }
+
+              throw new IllegalStateException(s"Unknown opcode: $opCode$detail")
 
             case bep: BoundMsgEndpoint =>
               val ep: bep.endpoint.type = bep.endpoint

--- a/test-common/src/main/scala/org/scalajs/testing/common/RunMux.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/RunMux.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 private[testing] final class RunMux[+T](val runId: RunMux.RunID, val value: T)

--- a/test-common/src/main/scala/org/scalajs/testing/common/RunMuxRPC.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/RunMuxRPC.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import scala.language.higherKinds

--- a/test-common/src/main/scala/org/scalajs/testing/common/RunnerArgs.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/RunnerArgs.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 private[testing] final class RunnerArgs(

--- a/test-common/src/main/scala/org/scalajs/testing/common/Serializer.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/Serializer.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import sbt.testing._

--- a/test-common/src/main/scala/org/scalajs/testing/common/TaskInfo.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/TaskInfo.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import sbt.testing._

--- a/test-common/src/main/scala/org/scalajs/testing/common/TestInterfaceMode.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/TestInterfaceMode.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 /** Mode in which the test interface executes. */

--- a/test-common/src/test/scala/org/scalajs/testing/common/RPCCoreTest.scala
+++ b/test-common/src/test/scala/org/scalajs/testing/common/RPCCoreTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import scala.concurrent._

--- a/test-common/src/test/scala/org/scalajs/testing/common/RunMuxRPCTest.scala
+++ b/test-common/src/test/scala/org/scalajs/testing/common/RunMuxRPCTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import scala.concurrent._

--- a/test-common/src/test/scala/org/scalajs/testing/common/SerializerTest.scala
+++ b/test-common/src/test/scala/org/scalajs/testing/common/SerializerTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.common
 
 import org.junit.Test

--- a/test-interface/src/main/scala/org/scalajs/testing/interface/Bridge.scala
+++ b/test-interface/src/main/scala/org/scalajs/testing/interface/Bridge.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.interface
 
 import scala.scalajs.js

--- a/test-interface/src/main/scala/org/scalajs/testing/interface/FrameworkLoader.scala
+++ b/test-interface/src/main/scala/org/scalajs/testing/interface/FrameworkLoader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.interface
 
 import scala.scalajs.js

--- a/test-interface/src/main/scala/org/scalajs/testing/interface/HTMLRunner.scala
+++ b/test-interface/src/main/scala/org/scalajs/testing/interface/HTMLRunner.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.interface
 
 import scala.scalajs.js

--- a/test-interface/src/main/scala/org/scalajs/testing/interface/JSRPC.scala
+++ b/test-interface/src/main/scala/org/scalajs/testing/interface/JSRPC.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.interface
 
 import scala.scalajs.js

--- a/test-interface/src/main/scala/org/scalajs/testing/interface/ScalaJSClassLoader.scala
+++ b/test-interface/src/main/scala/org/scalajs/testing/interface/ScalaJSClassLoader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.interface
 
 import scala.scalajs.js

--- a/test-interface/src/main/scala/org/scalajs/testing/interface/TaskInfoBuilder.scala
+++ b/test-interface/src/main/scala/org/scalajs/testing/interface/TaskInfoBuilder.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.interface
 
 import sbt.testing._

--- a/test-interface/src/main/scala/org/scalajs/testing/interface/TestAdapterBridge.scala
+++ b/test-interface/src/main/scala/org/scalajs/testing/interface/TestAdapterBridge.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.interface
 
 import scala.concurrent.{Future, Promise}

--- a/test-interface/src/main/scala/org/scalajs/testing/interface/TestLoader.scala
+++ b/test-interface/src/main/scala/org/scalajs/testing/interface/TestLoader.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testing.interface
 
 import java.io._

--- a/test-interface/src/main/scala/sbt/testing/Event.scala
+++ b/test-interface/src/main/scala/sbt/testing/Event.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** An event fired by the test framework during a run. */

--- a/test-interface/src/main/scala/sbt/testing/EventHandler.scala
+++ b/test-interface/src/main/scala/sbt/testing/EventHandler.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** Interface implemented by clients that handle events fired by the test

--- a/test-interface/src/main/scala/sbt/testing/Fingerprints.scala
+++ b/test-interface/src/main/scala/sbt/testing/Fingerprints.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** A way to identify test classes and/or modules that should be discovered

--- a/test-interface/src/main/scala/sbt/testing/Framework.scala
+++ b/test-interface/src/main/scala/sbt/testing/Framework.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 import scala.scalajs.reflect.annotation._

--- a/test-interface/src/main/scala/sbt/testing/Logger.scala
+++ b/test-interface/src/main/scala/sbt/testing/Logger.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** A logger through which to provide feedback to the user about a run.

--- a/test-interface/src/main/scala/sbt/testing/OptionalThrowable.scala
+++ b/test-interface/src/main/scala/sbt/testing/OptionalThrowable.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** An optional <code>Throwable</code>. */

--- a/test-interface/src/main/scala/sbt/testing/Runner.scala
+++ b/test-interface/src/main/scala/sbt/testing/Runner.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** Represents one run of a suite of tests.

--- a/test-interface/src/main/scala/sbt/testing/Selectors.scala
+++ b/test-interface/src/main/scala/sbt/testing/Selectors.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** Information in addition to a test class name that identifies the suite or

--- a/test-interface/src/main/scala/sbt/testing/Status.scala
+++ b/test-interface/src/main/scala/sbt/testing/Status.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** Represents the status of running a test.

--- a/test-interface/src/main/scala/sbt/testing/Task.scala
+++ b/test-interface/src/main/scala/sbt/testing/Task.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 /** A task to execute.

--- a/test-interface/src/main/scala/sbt/testing/TaskDef.scala
+++ b/test-interface/src/main/scala/sbt/testing/TaskDef.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package sbt.testing
 
 import java.util.Arrays

--- a/test-suite-ex/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTestEx.scala
+++ b/test-suite-ex/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTestEx.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import scala.scalajs.js

--- a/test-suite-ex/src/test/scala/org/scalajs/testsuite/jsinterop/GlobalScopeTestEx.scala
+++ b/test-suite-ex/src/test/scala/org/scalajs/testsuite/jsinterop/GlobalScopeTestEx.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import org.junit.Test

--- a/test-suite-ex/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTestEx.scala
+++ b/test-suite-ex/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTestEx.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import org.junit.Test

--- a/test-suite-ex/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/test-suite-ex/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 /** This is a copy of the implementation in the testSuite */

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/Typechecking.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/Typechecking.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite
 
 import scala.language.experimental.macros

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/TypecheckingMacros.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/TypecheckingMacros.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite
 
 import scala.reflect.macros.TypecheckException

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/jsinterop/NonNativeTypeTestSeparateRun.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/jsinterop/NonNativeTypeTestSeparateRun.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/junit/MultiCompilationTest.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/junit/MultiCompilationTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Test

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
+++ b/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/resources/SourceMapTestTemplate.scala
+++ b/test-suite/js/src/test/resources/SourceMapTestTemplate.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Assert._
@@ -62,7 +74,7 @@ class SourceMapTest {
         val topSte = trace2.head
         assertTrue(normFileName(topSte).contains("/SourceMapTest.scala"))
 
-        val throwSte = if (topSte.getLineNumber == 19) {
+        val throwSte = if (topSte.getLineNumber == 31) {
           // line where `case class TestException is written` above
           val throwSte = trace2.tail.head
           assertTrue(normFileName(throwSte).contains("/SourceMapTest.scala"))

--- a/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
+++ b/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
+++ b/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
+++ b/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
+++ b/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
+++ b/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
+++ b/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/BooleanJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/BooleanJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/DefaultMethodsJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/DefaultMethodsJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/IntJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/IntJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import scala.language.implicitConversions

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/LongJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/LongJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import scala.language.implicitConversions

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import java.lang.Cloneable

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/UnitJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/UnitJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamJSTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io.InputStream

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import scala.language.reflectiveCalls

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.scalajs.testsuite.utils.Platform

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowableJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowableJSTest.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013--2018, LAMP/EPFL  **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testsuite.javalib.lang
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang.reflect
 
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/TimerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/TimerTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.language.implicitConversions

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.language.implicitConversions

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.language.implicitConversions

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/IterableTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/IterableTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNativeInPackage.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNativeInPackage.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NestedJSClassTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NestedJSClassTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PrimitivesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PrimitivesTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PromiseMock.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PromiseMock.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SymbolTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThrowAndCatchTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThrowAndCatchTest.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2018, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package org.scalajs.testsuite.jsinterop
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TimeoutMock.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TimeoutMock.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TupleTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TupleTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.language.implicitConversions

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitAbstractClassTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitAbstractClassTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitMixinTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitMixinTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitNamesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitNamesTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitPackageTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitPackageTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitSubClassTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitSubClassTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.scalajs.junit.JUnitTestBootstrapper

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/MultiCompilationSecondUnitTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/junit/MultiCompilationSecondUnitTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/JavaScriptExceptionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/JavaScriptExceptionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UndefinedBehaviorErrorTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UndefinedBehaviorErrorTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.util.control.NonFatal

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.language.implicitConversions

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedArrayTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedDictionaryTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedDictionaryTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.library
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferJSFactories.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferJSFactories.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import scala.scalajs.js.JSConverters._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import org.scalajs.testsuite.niobuffer.BufferFactory.ByteBufferFactory

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferJSTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/SupportsTypedArrays.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/SupportsTypedArrays.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import org.junit.BeforeClass

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeJSTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArrayBufferInputStreamTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArrayBufferInputStreamTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.typedarray
 
 import org.scalajs.testsuite.utils.Requires

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArrayBufferTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArrayBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.typedarray
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArraysTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArraysTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.typedarray
 
 import scala.scalajs.js.typedarray._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.typedarray
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.typedarray
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.typedarray
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/JSAssert.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/JSAssert.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/JSUtils.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/JSUtils.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 import scala.language.implicitConversions

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/PlatformTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/PlatformTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 import org.junit.Test

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/Requires.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/Requires.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 import org.junit.Assume._

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 object Platform {

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/CharacterTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/CharacterTestOnJDK7.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/SystemTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/SystemTestOnJDK7.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.scalajs.testsuite.utils.Platform._

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/ThrowablesTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/ThrowablesTestOnJDK7.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Assert._

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/CollectionsTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/CollectionsTestOnJDK7.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/ObjectsTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/ObjectsTestOnJDK7.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/compiler/DefaultMethodsTest.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/compiler/DefaultMethodsTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/DoubleTestJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/DoubleTestJDK8.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/FloatTestJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/FloatTestJDK8.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/IntegerTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/IntegerTestOnJDK8.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/LongTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/LongTestOnJDK8.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Assume._

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/Base64Test.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/Base64Test.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException}

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/CollectionsOnCopyOnWriteArrayListTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/CollectionsOnCopyOnWriteArrayListTestOnJDK8.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/ComparatorTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/ComparatorTestOnJDK8.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/ObjectsTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/ObjectsTestOnJDK8.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/OptionalTest.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/OptionalTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Assert._

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/SplittableRandom.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/SplittableRandom.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Assert._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/BooleanTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/BooleanTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ByteTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/CharTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/CharTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import scala.annotation.switch

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/OuterClassTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/OuterClassTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/PatMatOuterPointerCheckTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/PatMatOuterPointerCheckTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import language.reflectiveCalls

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import scala.annotation.tailrec

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ShortTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ShortTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/UnitTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/UnitTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.compiler
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/MockByteArrayOutputStream.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/MockByteArrayOutputStream.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintStreamTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintWriterTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import scala.annotation.tailrec

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/SerializableTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/SerializableTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ThrowablesTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import java.lang.{Boolean => JBoolean}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import java.lang.{Byte => JByte}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import java.lang.{Long => JLong}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import java.lang.{Short => JShort}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Assert._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import java.lang.StringBuilder

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import java.nio.charset.Charset

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThreadTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThreadTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/WrappedStringCharSequence.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/WrappedStringCharSequence.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2017, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang
 
 object WrappedStringCharSequence {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ref/ReferenceTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ref/ReferenceTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang.ref
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.lang.reflect
 
 import scala.runtime.BoxedUnit

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalCompareTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalCompareTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.math
 
 import java.math.BigDecimal

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerAddTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerAddTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerAndTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerAndTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerCompareTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerCompareTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConvertTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConvertTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerDivideTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerDivideTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerHashCodeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerHashCodeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerNotTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerNotTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOrTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOrTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerSubtractTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerSubtractTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.math
 
 import java.math.BigInteger

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerToStringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerToStringTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerXorTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerXorTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/RoundingModeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/RoundingModeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 // scalastyle:off line.size.limit
 /*
  * Ported by Alistair Johnson from

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.net
 
 import java.net.{URI, URISyntaxException}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URLDecoderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URLDecoderTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.net
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/security/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/security/ThrowablesTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.security
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractCollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractCollectionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractListTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractMapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.util

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju, lang => jl}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedCollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedCollectionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedMapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCollectionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCollectionsTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.util.Comparator

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{lang => jl, util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnMapsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnMapsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{lang => jl, util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSetFromMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSetFromMapTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{lang => jl, util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSetsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSetsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju, lang => jl}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedCollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedCollectionTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedListTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedMapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.util.Date

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DequeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DequeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/EventObjectTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/EventObjectTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Assert._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashtableTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashtableTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedListTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/NavigableSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/NavigableSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PropertiesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PropertiesTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.util.Properties

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/RandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/RandomTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Assert._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ThrowablesTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Assert._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Assert._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent
 
 import java.util.concurrent.ConcurrentLinkedQueue

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentMapTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent
 
 import java.util.concurrent.ConcurrentSkipListSet

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/CopyOnWriteArrayListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/CopyOnWriteArrayListTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/TimeUnitTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/TimeUnitTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent
 
 import java.util.concurrent.TimeUnit

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/atomic/AtomicTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/atomic/AtomicTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent.atomic
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.concurrent.locks
 
 import java.util.concurrent.locks.ReentrantLock

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/package.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/package.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib
 
 package object util {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.regex
 
 import scala.language.implicitConversions
@@ -102,6 +107,7 @@ class RegexMatcherTest  {
 
   def parseExpect(regex: String, str: String, pos: (Int, Int)*): Unit = {
     val matcher = Pattern.compile(regex).matcher(str)
+    assertEquals(pos.length - 1, matcher.groupCount)
     assertTrue(matcher.find())
     assertEquals(pos.length - 1, matcher.groupCount)
     var i = 0
@@ -159,6 +165,8 @@ class RegexMatcherTest  {
   }
 
   def checkGroups(matcher: Matcher, startEndMatch: (Int, Int, String)*): Unit = {
+    assertEquals(startEndMatch.size - 1, matcher.groupCount)
+
     assertTrue(matcher.find())
 
     assertEquals(startEndMatch(0)._1, matcher.start)
@@ -233,6 +241,13 @@ class RegexMatcherTest  {
     assertTrue(matcher1.matches())
     matcher1.usePattern(patternNoDots)
     assertFalse(matcher1.matches())
+
+    val patternWithOneGroup = Pattern.compile("ab(cd)efg")
+    val patternWithTwoGroups = Pattern.compile("ab(cd)(ef)g")
+    val matcher2 = patternWithOneGroup.matcher("Scala.js")
+    assertEquals(1, matcher2.groupCount())
+    matcher2.usePattern(patternWithTwoGroups)
+    assertEquals(2, matcher2.groupCount())
   }
 
   @Test def lookingAt(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.util.regex
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsParamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsParamTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssumptionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssumptionsTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.junit
 
 import org.hamcrest.CoreMatchers._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio.{ReadOnlyBufferException, BufferUnderflowException, InvalidMarkException, BufferOverflowException}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BufferAdapter.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BufferAdapter.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BufferFactory.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BufferFactory.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferFactories.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferFactories.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niobuffer
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niocharset
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niocharset
 
 import scala.collection.JavaConverters._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niocharset
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niocharset
 
 import java.nio.charset._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niocharset
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.niocharset
 
 import java.nio._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013--2015, LAMP/EPFL  **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013--2018, LAMP/EPFL  **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import scala.language.implicitConversions

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/NameTransformerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/NameTransformerTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2015, LAMP/EPFL   **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import scala.reflect.NameTransformer

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeTest.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
@@ -1,10 +1,15 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
-**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013, LAMP/EPFL        **
-**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
-** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
-**                          |/____/                                     **
-\*                                                                      */
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.scalalib
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 import scala.util.{Failure, Try, Success}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/CollectionsTestBase.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/CollectionsTestBase.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.utils
 
 import java.{lang => jl, util => ju}


### PR DESCRIPTION
Motivation: deal with the license change.
```
$ git checkout -b merge-0.6.x-into-master-october-15
Switched to a new branch 'merge-0.6.x-into-master-october-15'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   de34cee53 (scalajs/0.6.x) Merge pull request #3468 from neVERberleRfellerER/fix-matcher-group-count
|\  
| * e5d3d6b49 Fix #3280: Count capturing groups independently on find.
* |   195c4071c Merge pull request #3467 from sjrd/apache-license-0.6.x
|\ \  
| |/  
|/|   
| * 9dc4d5b36 Fix #3462: Apache License Version 2.0.
|/  
* b1dd33595 Merge pull request #3464 from gzm0/error-detail
* 535d52c98 Fix #3201: Provide more detail on "Unknown opcode: 5".
```
```
$ git merge --no-commit scalajs/0.6.x
[...] // zillions of conflicts and clean merges
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
M  Jenkinsfile
M  LICENSE
M  NOTICE
UU README.md
DU cli/src/main/scala/org/scalajs/cli/Scalajsld.scala
DU cli/src/main/scala/org/scalajs/cli/Scalajsp.scala
DU compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
DU compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
DU compiler/src/main/scala/org/scalajs/core/compiler/JSTreeExtractors.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSOptions.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/TypeKinds.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/util/ScopedVar.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/util/VarBox.scala
DU compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala
DU compiler/src/test/scala/org/scalajs/core/compiler/test/JSNativeByDefaultTest.scala
DU compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala
DU compiler/src/test/scala/org/scalajs/core/compiler/test/MatchASTTest.scala
DU compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsSuppressedTest.scala
DU compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsTest.scala
DU compiler/src/test/scala/org/scalajs/core/compiler/test/RegressionTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/DiverseErrorsTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/InternalAnnotationsTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/JSDynamicLiteralTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportASTTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/JSInteropTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/JSSAMTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/JSUndefinedParamTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/PositionTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/ReflectTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/util/JSASTTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/util/TestHelpers.scala
UU io/jvm/src/main/scala/org/scalajs/io/AtomicFileOutputStream.scala
UU io/shared/src/test/scala/org/scalajs/io/URIUtilsTest.scala
DU ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala
M  ir/src/main/scala/org/scalajs/ir/ClassKind.scala
M  ir/src/main/scala/org/scalajs/ir/Definitions.scala
UU ir/src/main/scala/org/scalajs/ir/Hashers.scala
UU ir/src/main/scala/org/scalajs/ir/IRVersionNotSupportedException.scala
UU ir/src/main/scala/org/scalajs/ir/InvalidIRException.scala
M  ir/src/main/scala/org/scalajs/ir/Position.scala
M  ir/src/main/scala/org/scalajs/ir/Printers.scala
UU ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
M  ir/src/main/scala/org/scalajs/ir/Serializers.scala
M  ir/src/main/scala/org/scalajs/ir/Tags.scala
M  ir/src/main/scala/org/scalajs/ir/Transformers.scala
M  ir/src/main/scala/org/scalajs/ir/Traversers.scala
M  ir/src/main/scala/org/scalajs/ir/Trees.scala
M  ir/src/main/scala/org/scalajs/ir/Types.scala
M  ir/src/main/scala/org/scalajs/ir/Utils.scala
UU ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
M  javalanglib/src/main/scala/java/lang/Appendable.scala
M  javalanglib/src/main/scala/java/lang/Boolean.scala
M  javalanglib/src/main/scala/java/lang/Byte.scala
M  javalanglib/src/main/scala/java/lang/CharSequence.scala
M  javalanglib/src/main/scala/java/lang/Character.scala
M  javalanglib/src/main/scala/java/lang/Class.scala
M  javalanglib/src/main/scala/java/lang/ClassLoader.scala
M  javalanglib/src/main/scala/java/lang/Cloneable.scala
M  javalanglib/src/main/scala/java/lang/Comparable.scala
M  javalanglib/src/main/scala/java/lang/Double.scala
M  javalanglib/src/main/scala/java/lang/Enum.scala
M  javalanglib/src/main/scala/java/lang/Float.scala
UU javalanglib/src/main/scala/java/lang/FloatingPointBits.scala
M  javalanglib/src/main/scala/java/lang/InheritableThreadLocal.scala
M  javalanglib/src/main/scala/java/lang/Integer.scala
M  javalanglib/src/main/scala/java/lang/Iterable.scala
M  javalanglib/src/main/scala/java/lang/Long.scala
M  javalanglib/src/main/scala/java/lang/Math.scala
DU javalanglib/src/main/scala/java/lang/MathJDK8Bridge.scala
M  javalanglib/src/main/scala/java/lang/Number.scala
M  javalanglib/src/main/scala/java/lang/Readable.scala
M  javalanglib/src/main/scala/java/lang/Runnable.scala
M  javalanglib/src/main/scala/java/lang/Runtime.scala
M  javalanglib/src/main/scala/java/lang/Short.scala
UU javalanglib/src/main/scala/java/lang/StackTrace.scala
M  javalanglib/src/main/scala/java/lang/StackTraceElement.scala
M  javalanglib/src/main/scala/java/lang/StringBuffer.scala
M  javalanglib/src/main/scala/java/lang/StringBuilder.scala
M  javalanglib/src/main/scala/java/lang/System.scala
M  javalanglib/src/main/scala/java/lang/Thread.scala
M  javalanglib/src/main/scala/java/lang/ThreadLocal.scala
M  javalanglib/src/main/scala/java/lang/Throwables.scala
M  javalanglib/src/main/scala/java/lang/Void.scala
M  javalanglib/src/main/scala/java/lang/annotation/Annotation.scala
M  javalanglib/src/main/scala/java/lang/ref/PhantomReference.scala
M  javalanglib/src/main/scala/java/lang/ref/Reference.scala
M  javalanglib/src/main/scala/java/lang/ref/ReferenceQueue.scala
M  javalanglib/src/main/scala/java/lang/ref/SoftReference.scala
M  javalanglib/src/main/scala/java/lang/ref/WeakReference.scala
M  javalanglib/src/main/scala/java/lang/reflect/Array.scala
DU javalib-ex-test-suite/src/test/scala/scala/scalajs/testsuite/javalibex/ZipInputStreamTest.scala
DU javalib-ex-test-suite/src/test/scala/scala/scalajs/testsuite/utils/Platform.scala
DU javalib-ex/src/main/scala/java/util/zip/InflaterInputStream.scala
DU javalib-ex/src/main/scala/java/util/zip/ZipEntry.scala
DU javalib-ex/src/main/scala/java/util/zip/ZipInputStream.scala
M  javalib/src/main/scala/java/io/BufferedReader.scala
M  javalib/src/main/scala/java/io/ByteArrayInputStream.scala
M  javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
M  javalib/src/main/scala/java/io/Closeable.scala
M  javalib/src/main/scala/java/io/DataInput.scala
M  javalib/src/main/scala/java/io/DataInputStream.scala
M  javalib/src/main/scala/java/io/DataOutput.scala
M  javalib/src/main/scala/java/io/DataOutputStream.scala
M  javalib/src/main/scala/java/io/FilterInputStream.scala
M  javalib/src/main/scala/java/io/FilterOutputStream.scala
M  javalib/src/main/scala/java/io/Flushable.scala
M  javalib/src/main/scala/java/io/InputStream.scala
M  javalib/src/main/scala/java/io/InputStreamReader.scala
M  javalib/src/main/scala/java/io/OutputStream.scala
M  javalib/src/main/scala/java/io/OutputStreamWriter.scala
M  javalib/src/main/scala/java/io/PrintStream.scala
M  javalib/src/main/scala/java/io/PrintWriter.scala
M  javalib/src/main/scala/java/io/Reader.scala
M  javalib/src/main/scala/java/io/Serializable.scala
M  javalib/src/main/scala/java/io/StringReader.scala
M  javalib/src/main/scala/java/io/StringWriter.scala
M  javalib/src/main/scala/java/io/Throwables.scala
M  javalib/src/main/scala/java/io/Writer.scala
DU javalib/src/main/scala/java/lang/AutoCloseable.scala
DU javalib/src/main/scala/java/lang/MathJDK8Bridge.scala
M  javalib/src/main/scala/java/math/Multiplication.scala
M  javalib/src/main/scala/java/net/Throwables.scala
M  javalib/src/main/scala/java/net/URI.scala
M  javalib/src/main/scala/java/net/URLDecoder.scala
M  javalib/src/main/scala/java/nio/Buffer.scala
M  javalib/src/main/scala/java/nio/BufferOverflowException.scala
M  javalib/src/main/scala/java/nio/BufferUnderflowException.scala
M  javalib/src/main/scala/java/nio/ByteArrayBits.scala
M  javalib/src/main/scala/java/nio/ByteBuffer.scala
M  javalib/src/main/scala/java/nio/ByteOrder.scala
M  javalib/src/main/scala/java/nio/CharBuffer.scala
M  javalib/src/main/scala/java/nio/DataViewCharBuffer.scala
M  javalib/src/main/scala/java/nio/DataViewDoubleBuffer.scala
M  javalib/src/main/scala/java/nio/DataViewFloatBuffer.scala
M  javalib/src/main/scala/java/nio/DataViewIntBuffer.scala
M  javalib/src/main/scala/java/nio/DataViewLongBuffer.scala
M  javalib/src/main/scala/java/nio/DataViewShortBuffer.scala
M  javalib/src/main/scala/java/nio/DoubleBuffer.scala
M  javalib/src/main/scala/java/nio/FloatBuffer.scala
M  javalib/src/main/scala/java/nio/GenBuffer.scala
M  javalib/src/main/scala/java/nio/GenDataViewBuffer.scala
M  javalib/src/main/scala/java/nio/GenHeapBuffer.scala
M  javalib/src/main/scala/java/nio/GenHeapBufferView.scala
M  javalib/src/main/scala/java/nio/GenTypedArrayBuffer.scala
M  javalib/src/main/scala/java/nio/HeapByteBuffer.scala
M  javalib/src/main/scala/java/nio/HeapByteBufferCharView.scala
M  javalib/src/main/scala/java/nio/HeapByteBufferDoubleView.scala
M  javalib/src/main/scala/java/nio/HeapByteBufferFloatView.scala
M  javalib/src/main/scala/java/nio/HeapByteBufferIntView.scala
M  javalib/src/main/scala/java/nio/HeapByteBufferLongView.scala
M  javalib/src/main/scala/java/nio/HeapByteBufferShortView.scala
M  javalib/src/main/scala/java/nio/HeapCharBuffer.scala
M  javalib/src/main/scala/java/nio/HeapDoubleBuffer.scala
M  javalib/src/main/scala/java/nio/HeapFloatBuffer.scala
M  javalib/src/main/scala/java/nio/HeapIntBuffer.scala
M  javalib/src/main/scala/java/nio/HeapLongBuffer.scala
M  javalib/src/main/scala/java/nio/HeapShortBuffer.scala
M  javalib/src/main/scala/java/nio/IntBuffer.scala
M  javalib/src/main/scala/java/nio/InvalidMarkException.scala
M  javalib/src/main/scala/java/nio/LongBuffer.scala
M  javalib/src/main/scala/java/nio/ReadOnlyBufferException.scala
M  javalib/src/main/scala/java/nio/ShortBuffer.scala
M  javalib/src/main/scala/java/nio/StringCharBuffer.scala
M  javalib/src/main/scala/java/nio/TypedArrayByteBuffer.scala
M  javalib/src/main/scala/java/nio/TypedArrayCharBuffer.scala
M  javalib/src/main/scala/java/nio/TypedArrayDoubleBuffer.scala
M  javalib/src/main/scala/java/nio/TypedArrayFloatBuffer.scala
M  javalib/src/main/scala/java/nio/TypedArrayIntBuffer.scala
M  javalib/src/main/scala/java/nio/TypedArrayShortBuffer.scala
M  javalib/src/main/scala/java/nio/charset/CharacterCodingException.scala
M  javalib/src/main/scala/java/nio/charset/Charset.scala
M  javalib/src/main/scala/java/nio/charset/CharsetDecoder.scala
M  javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
M  javalib/src/main/scala/java/nio/charset/CoderMalfunctionError.scala
M  javalib/src/main/scala/java/nio/charset/CoderResult.scala
M  javalib/src/main/scala/java/nio/charset/CodingErrorAction.scala
UU javalib/src/main/scala/java/nio/charset/ISO_8859_1_And_US_ASCII_Common.scala
M  javalib/src/main/scala/java/nio/charset/MalformedInputException.scala
M  javalib/src/main/scala/java/nio/charset/StandardCharsets.scala
UU javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
UU javalib/src/main/scala/java/nio/charset/UTF_8.scala
M  javalib/src/main/scala/java/nio/charset/UnmappableCharacterException.scala
M  javalib/src/main/scala/java/nio/charset/UnsupportedCharsetException.scala
M  javalib/src/main/scala/java/security/Guard.scala
M  javalib/src/main/scala/java/security/Permission.scala
M  javalib/src/main/scala/java/security/Throwables.scala
M  javalib/src/main/scala/java/util/AbstractCollection.scala
M  javalib/src/main/scala/java/util/AbstractList.scala
M  javalib/src/main/scala/java/util/AbstractMap.scala
M  javalib/src/main/scala/java/util/AbstractQueue.scala
M  javalib/src/main/scala/java/util/AbstractRandomAccessListIterator.scala
M  javalib/src/main/scala/java/util/AbstractSequentialList.scala
M  javalib/src/main/scala/java/util/AbstractSet.scala
M  javalib/src/main/scala/java/util/ArrayDeque.scala
M  javalib/src/main/scala/java/util/ArrayList.scala
M  javalib/src/main/scala/java/util/Arrays.scala
M  javalib/src/main/scala/java/util/Base64.scala
M  javalib/src/main/scala/java/util/Collection.scala
M  javalib/src/main/scala/java/util/Collections.scala
M  javalib/src/main/scala/java/util/Comparator.scala
M  javalib/src/main/scala/java/util/Compat.scala
M  javalib/src/main/scala/java/util/Date.scala
M  javalib/src/main/scala/java/util/Deque.scala
M  javalib/src/main/scala/java/util/Dictionary.scala
M  javalib/src/main/scala/java/util/Enumeration.scala
M  javalib/src/main/scala/java/util/EventObject.scala
M  javalib/src/main/scala/java/util/Formattable.scala
M  javalib/src/main/scala/java/util/FormattableFlags.scala
M  javalib/src/main/scala/java/util/Formatter.scala
M  javalib/src/main/scala/java/util/HashMap.scala
M  javalib/src/main/scala/java/util/HashSet.scala
M  javalib/src/main/scala/java/util/Hashtable.scala
M  javalib/src/main/scala/java/util/Iterator.scala
M  javalib/src/main/scala/java/util/LinkedHashMap.scala
M  javalib/src/main/scala/java/util/LinkedHashSet.scala
M  javalib/src/main/scala/java/util/LinkedList.scala
M  javalib/src/main/scala/java/util/List.scala
M  javalib/src/main/scala/java/util/ListIterator.scala
M  javalib/src/main/scala/java/util/Map.scala
M  javalib/src/main/scala/java/util/NavigableMap.scala
M  javalib/src/main/scala/java/util/NavigableSet.scala
M  javalib/src/main/scala/java/util/NavigableView.scala
M  javalib/src/main/scala/java/util/Objects.scala
M  javalib/src/main/scala/java/util/Optional.scala
M  javalib/src/main/scala/java/util/PriorityQueue.scala
M  javalib/src/main/scala/java/util/Properties.scala
M  javalib/src/main/scala/java/util/Queue.scala
M  javalib/src/main/scala/java/util/Random.scala
M  javalib/src/main/scala/java/util/RandomAccess.scala
M  javalib/src/main/scala/java/util/Set.scala
M  javalib/src/main/scala/java/util/SizeChangeEvent.scala
M  javalib/src/main/scala/java/util/SortedMap.scala
M  javalib/src/main/scala/java/util/SortedSet.scala
M  javalib/src/main/scala/java/util/SplittableRandom.scala
M  javalib/src/main/scala/java/util/Throwables.scala
M  javalib/src/main/scala/java/util/Timer.scala
M  javalib/src/main/scala/java/util/TimerTask.scala
M  javalib/src/main/scala/java/util/TreeSet.scala
M  javalib/src/main/scala/java/util/UUID.scala
M  javalib/src/main/scala/java/util/concurrent/Callable.scala
M  javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
M  javalib/src/main/scala/java/util/concurrent/ConcurrentLinkedQueue.scala
M  javalib/src/main/scala/java/util/concurrent/ConcurrentMap.scala
M  javalib/src/main/scala/java/util/concurrent/ConcurrentSkipListSet.scala
M  javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
M  javalib/src/main/scala/java/util/concurrent/Executor.scala
M  javalib/src/main/scala/java/util/concurrent/ThreadFactory.scala
M  javalib/src/main/scala/java/util/concurrent/Throwables.scala
M  javalib/src/main/scala/java/util/concurrent/TimeUnit.scala
M  javalib/src/main/scala/java/util/concurrent/atomic/AtomicBoolean.scala
M  javalib/src/main/scala/java/util/concurrent/atomic/AtomicInteger.scala
M  javalib/src/main/scala/java/util/concurrent/atomic/AtomicLong.scala
M  javalib/src/main/scala/java/util/concurrent/atomic/AtomicLongArray.scala
M  javalib/src/main/scala/java/util/concurrent/atomic/AtomicReference.scala
M  javalib/src/main/scala/java/util/concurrent/atomic/AtomicReferenceArray.scala
M  javalib/src/main/scala/java/util/concurrent/locks/Lock.scala
M  javalib/src/main/scala/java/util/concurrent/locks/ReentrantLock.scala
M  javalib/src/main/scala/java/util/package.scala
M  javalib/src/main/scala/java/util/regex/GroupStartMap.scala
M  javalib/src/main/scala/java/util/regex/MatchResult.scala
M  javalib/src/main/scala/java/util/regex/Matcher.scala
M  javalib/src/main/scala/java/util/regex/Pattern.scala
M  javalib/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
DU js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/AsyncTests.scala
DU js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/BasicJSEnvTests.scala
M  js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
DU js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/CustomInitFilesTest.scala
DU js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvTest.scala
DU js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/StoreJSConsole.scala
DU js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/StoreLogger.scala
M  js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/TimeoutComTests.scala
DU js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/TimeoutTests.scala
DU js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala
DU js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/NodeJSTest.scala
DU js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/NodeJSWithCustomInitFilesTest.scala
DU js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/PhantomJSTest.scala
DU js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/PhantomJSWithCustomInitFilesTest.scala
DU js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala
DU js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RhinoJSEnvTest.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSRunner.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/ComJSRunner.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/ConsoleJSConsole.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala
UU js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/JSInitFiles.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/JSRunner.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitAsyncJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitComJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/NullJSConsole.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/RetryingComJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/Utils.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/VirtualFileMaterializer.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/JettyWebsocketManager.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJettyClassLoader.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/WebsocketListener.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/WebsocketManager.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/rhino/LazyScalaJSScope.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala
DU js-envs/src/main/scala/org/scalajs/jsenv/rhino/package.scala
DU junit-plugin/src/main/scala/org/scalajs/junit/plugin/Compat210Component.scala
M  junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
M  junit-runtime/src/main/scala/com/novocode/junit/Ansi.scala
M  junit-runtime/src/main/scala/com/novocode/junit/JUnitFramework.scala
M  junit-runtime/src/main/scala/com/novocode/junit/RichLogger.scala
M  junit-runtime/src/main/scala/com/novocode/junit/RunSettings.scala
A  junit-runtime/src/main/scala/org/hamcrest/LICENSE-hamcrest.txt
M  junit-runtime/src/main/scala/org/scalajs/junit/JUnitBaseRunner.scala
M  junit-runtime/src/main/scala/org/scalajs/junit/JUnitEvent.scala
M  junit-runtime/src/main/scala/org/scalajs/junit/JUnitExecuteTest.scala
M  junit-runtime/src/main/scala/org/scalajs/junit/JUnitMasterRunner.scala
M  junit-runtime/src/main/scala/org/scalajs/junit/JUnitSlaveRunner.scala
M  junit-runtime/src/main/scala/org/scalajs/junit/JUnitTask.scala
M  junit-runtime/src/main/scala/org/scalajs/junit/JUnitTestBootstrapper.scala
M  junit-test/output-js/src/test/scala/org/scalajs/junit/utils/JUnitTestPlatformImpl.scala
M  junit-test/output-jvm/src/test/scala/org/scalajs/junit/utils/JUnitTestPlatformImpl.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/AssertEquals2Test.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsDoubleTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/AssertEqualsTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/AssertFalse2Test.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/AssertFalseTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/AssertStringEqualsTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/AssertTrueTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/AssumeTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/BeforeAndAfterTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/BeforeAssumeFailTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInAfterTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInBeforeTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionInConstructorTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/ExceptionTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/IgnoreTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/MethodNameDecodeTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/Multi1Test.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/Multi2Test.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/MultiAssumeFail1Test.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/MultiAssumeFail2Test.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/MultiBeforeAssumeFailTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnore1Test.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnore2Test.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/MultiIgnoreAllTest.scala
M  junit-test/shared/src/test/scala/org/scalajs/junit/utils/JUnitTest.scala
M  library-aux/src/main/scala/scala/runtime/ArrayRuntime.scala
M  library-aux/src/main/scala/scala/runtime/BoxedUnit.scala
M  library-aux/src/main/scala/scala/runtime/RefTypes.scala
M  library-aux/src/main/scala/scala/runtime/Statics.scala
M  library/src/main/scala-m4-collections/scala/scalajs/js/Any.scala
M  library/src/main/scala-m4-collections/scala/scalajs/js/ArrayOps.scala
M  library/src/main/scala-m4-collections/scala/scalajs/js/JSConverters.scala
M  library/src/main/scala-m4-collections/scala/scalajs/js/WrappedArray.scala
M  library/src/main/scala-m4-collections/scala/scalajs/js/WrappedDictionary.scala
M  library/src/main/scala-m4-collections/scala/scalajs/runtime/Compat.scala
M  library/src/main/scala-m4-collections/scala/scalajs/runtime/WrappedVarArgs.scala
M  library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
M  library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
M  library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
M  library/src/main/scala-new-collections/scala/scalajs/js/WrappedArray.scala
M  library/src/main/scala-new-collections/scala/scalajs/js/WrappedDictionary.scala
M  library/src/main/scala-new-collections/scala/scalajs/runtime/Compat.scala
M  library/src/main/scala-new-collections/scala/scalajs/runtime/WrappedVarArgs.scala
M  library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
M  library/src/main/scala-old-collections/scala/scalajs/js/ArrayOps.scala
M  library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
M  library/src/main/scala-old-collections/scala/scalajs/js/WrappedArray.scala
M  library/src/main/scala-old-collections/scala/scalajs/js/WrappedDictionary.scala
M  library/src/main/scala-old-collections/scala/scalajs/runtime/Compat.scala
M  library/src/main/scala/scala/scalajs/LinkingInfo.scala
M  library/src/main/scala/scala/scalajs/concurrent/JSExecutionContext.scala
M  library/src/main/scala/scala/scalajs/concurrent/QueueExecutionContext.scala
DU library/src/main/scala/scala/scalajs/concurrent/RunNowExcecutionContext.scala
M  library/src/main/scala/scala/scalajs/js/Array.scala
M  library/src/main/scala/scala/scalajs/js/ArrayOpsCommon.scala
M  library/src/main/scala/scala/scalajs/js/ConstructorTag.scala
M  library/src/main/scala/scala/scalajs/js/Date.scala
M  library/src/main/scala/scala/scalajs/js/Dictionary.scala
M  library/src/main/scala/scala/scalajs/js/Dynamic.scala
M  library/src/main/scala/scala/scalajs/js/DynamicImplicits.scala
M  library/src/main/scala/scala/scalajs/js/Error.scala
M  library/src/main/scala/scala/scalajs/js/Function.nodoc.scala
M  library/src/main/scala/scala/scalajs/js/Function.scala
DU library/src/main/scala/scala/scalajs/js/GlobalScope.scala
M  library/src/main/scala/scala/scalajs/js/Iterable.scala
M  library/src/main/scala/scala/scalajs/js/IterableOps.scala
M  library/src/main/scala/scala/scalajs/js/Iterator.scala
DU library/src/main/scala/scala/scalajs/js/JSApp.scala
M  library/src/main/scala/scala/scalajs/js/JSArrayOps.scala
M  library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
M  library/src/main/scala/scala/scalajs/js/JSON.scala
M  library/src/main/scala/scala/scalajs/js/JSStringOps.scala
M  library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
M  library/src/main/scala/scala/scalajs/js/Math.scala
M  library/src/main/scala/scala/scalajs/js/Object.scala
M  library/src/main/scala/scala/scalajs/js/Promise.scala
M  library/src/main/scala/scala/scalajs/js/PropertyDescriptor.scala
M  library/src/main/scala/scala/scalajs/js/RegExp.scala
M  library/src/main/scala/scala/scalajs/js/Symbol.scala
M  library/src/main/scala/scala/scalajs/js/Thenable.scala
M  library/src/main/scala/scala/scalajs/js/ThisFunction.nodoc.scala
M  library/src/main/scala/scala/scalajs/js/ThisFunction.scala
M  library/src/main/scala/scala/scalajs/js/Tuple.nodoc.scala
M  library/src/main/scala/scala/scalajs/js/Tuple.scala
M  library/src/main/scala/scala/scalajs/js/URIUtils.scala
M  library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
M  library/src/main/scala/scala/scalajs/js/UnicodeNormalizationForm.scala
M  library/src/main/scala/scala/scalajs/js/Union.scala
DU library/src/main/scala/scala/scalajs/js/Using.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSBracketAccess.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSBracketCall.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSExport.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSExportAll.scala
DU library/src/main/scala/scala/scalajs/js/annotation/JSExportDescendentClasses.scala
DU library/src/main/scala/scala/scalajs/js/annotation/JSExportDescendentObjects.scala
DU library/src/main/scala/scala/scalajs/js/annotation/JSExportNamed.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSExportStatic.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSExportTopLevel.scala
DU library/src/main/scala/scala/scalajs/js/annotation/JSFullName.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSGlobal.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSGlobalScope.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSImport.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JSName.scala
M  library/src/main/scala/scala/scalajs/js/annotation/JavaDefaultMethod.scala
DU library/src/main/scala/scala/scalajs/js/annotation/SJSDefinedAnonymousClass.scala
DU library/src/main/scala/scala/scalajs/js/annotation/ScalaJSDefined.scala
M  library/src/main/scala/scala/scalajs/js/annotation/internal/ExposedJSMember.scala
DU library/src/main/scala/scala/scalajs/js/annotation/internal/HasJSNativeLoadSpec.scala
M  library/src/main/scala/scala/scalajs/js/annotation/internal/JSOptional.scala
M  library/src/main/scala/scala/scalajs/js/annotation/internal/RawJSType.scala
UU library/src/main/scala/scala/scalajs/js/annotation/internal/WasPublicBeforeTyper.scala
M  library/src/main/scala/scala/scalajs/js/defined.scala
M  library/src/main/scala/scala/scalajs/js/package.scala
M  library/src/main/scala/scala/scalajs/js/special/package.scala
M  library/src/main/scala/scala/scalajs/js/timers/Handles.scala
M  library/src/main/scala/scala/scalajs/js/timers/RawTimers.scala
M  library/src/main/scala/scala/scalajs/js/timers/package.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/ArrayBuffer.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/ArrayBufferInputStream.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/ArrayBufferView.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/DataView.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/DataViewExt.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBuffer.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferOps.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
M  library/src/main/scala/scala/scalajs/js/typedarray/package.scala
DU library/src/main/scala/scala/scalajs/macroimpls/Compat210.scala
DU library/src/main/scala/scala/scalajs/macroimpls/JSMemberSelection.scala
DU library/src/main/scala/scala/scalajs/macroimpls/JSMembers.scala
DU library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala
DU library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1.scala
DU library/src/main/scala/scala/scalajs/niocharset/StandardCharsets.scala
DU library/src/main/scala/scala/scalajs/niocharset/US_ASCII.scala
DU library/src/main/scala/scala/scalajs/niocharset/UTF_16.scala
DU library/src/main/scala/scala/scalajs/niocharset/UTF_16BE.scala
DU library/src/main/scala/scala/scalajs/niocharset/UTF_16LE.scala
M  library/src/main/scala/scala/scalajs/reflect/Reflect.scala
M  library/src/main/scala/scala/scalajs/reflect/annotation/EnableReflectiveInstantiation.scala
M  library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala
DU library/src/main/scala/scala/scalajs/runtime/BooleanReflectiveCall.scala
DU library/src/main/scala/scala/scalajs/runtime/EnvironmentInfo.scala
DU library/src/main/scala/scala/scalajs/runtime/IntegerReflectiveCall.scala
M  library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
DU library/src/main/scala/scala/scalajs/runtime/LongReflectiveCall.scala
DU library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala
M  library/src/main/scala/scala/scalajs/runtime/RuntimeLong.scala
DU library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala
M  library/src/main/scala/scala/scalajs/runtime/SemanticsUtils.scala
M  library/src/main/scala/scala/scalajs/runtime/UndefinedBehaviorError.scala
M  library/src/main/scala/scala/scalajs/runtime/package.scala
M  linker/js/src/main/scala/org/scalajs/linker/StandardLinkerPlatformExtensions.scala
UU linker/js/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatform.scala
UU linker/js/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImplPlatform.scala
M  linker/jvm/src/main/scala/org/scalajs/linker/StandardLinkerPlatformExtensions.scala
UU linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
M  linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
UU linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/LoggerErrorManager.scala
M  linker/jvm/src/main/scala/org/scalajs/linker/frontend/optimizer/ConcurrencyUtils.scala
M  linker/jvm/src/main/scala/org/scalajs/linker/frontend/optimizer/ParIncOptimizer.scala
M  linker/shared/src/main/scala/org/scalajs/linker/CheckedBehavior.scala
M  linker/shared/src/main/scala/org/scalajs/linker/LinkingException.scala
M  linker/shared/src/main/scala/org/scalajs/linker/ModuleInitializer.scala
M  linker/shared/src/main/scala/org/scalajs/linker/ModuleKind.scala
M  linker/shared/src/main/scala/org/scalajs/linker/Semantics.scala
M  linker/shared/src/main/scala/org/scalajs/linker/StandardLinker.scala
M  linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
M  linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
UU linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLibs.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/InternalOptions.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/SourceMapWriter.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
M  linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
M  linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
M  linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
M  linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
M  linker/shared/src/main/scala/org/scalajs/linker/irio/IRFileCache.scala
M  linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
M  logging/shared/src/main/scala/org/scalajs/logging/Level.scala
M  logging/shared/src/main/scala/org/scalajs/logging/Logger.scala
UU logging/shared/src/main/scala/org/scalajs/logging/NullLogger.scala
UU logging/shared/src/main/scala/org/scalajs/logging/ScalaConsoleLogger.scala
M  partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
M  partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
M  partest/src/main/scala/scala/tools/partest/scalajs/PartestInterface.scala
M  partest/src/main/scala/scala/tools/partest/scalajs/ScalaJSPartestOptions.scala
UU project/Build.scala
UU project/build.sbt
M  sbt-plugin/src/main/scala-sbt-0.13/org/scalajs/sbtplugin/SBTCompat.scala
DU sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/AbstractJSDeps.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/HTMLRunnerTemplate.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Implicits.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LoggerJSConsole.scala
M  sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Loggers.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala
M  sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
M  sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
M  sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
M  sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
M  sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalajspUtils.scala
M  sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Stage.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossClasspathDependency.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossType.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/MacroUtils.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/DependencyBuilders.scala
DU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/internal/ScalaJSGlobalPlugin.scala
DU stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala
DU stubs/src/main/scala/scala/scalajs/js/annotation/ExportAnnotations.scala
DU stubs/src/main/scala/scala/scalajs/reflect/annotation/ReflectAnnotations.scala
DU test-adapter/src/main/scala/org/scalajs/sbttestadapter/ComJSEnvRPC.scala
DU test-adapter/src/main/scala/org/scalajs/sbttestadapter/RemoteException.scala
DU test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala
DU test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala
DU test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSTask.scala
M  test-adapter/src/main/scala/org/scalajs/testing/adapter/FrameworkAdapter.scala
M  test-adapter/src/main/scala/org/scalajs/testing/adapter/RunnerAdapter.scala
M  test-adapter/src/main/scala/org/scalajs/testing/adapter/TaskAdapter.scala
M  test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
UU test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapterInitializer.scala
M  test-adapter/src/main/scala/org/scalajs/testing/adapter/package.scala
DU test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala
UU test-common/src/main/scala/org/scalajs/testing/common/Endpoints.scala
UU test-common/src/main/scala/org/scalajs/testing/common/ExecuteRequest.scala
UU test-common/src/main/scala/org/scalajs/testing/common/FrameworkInfo.scala
UU test-common/src/main/scala/org/scalajs/testing/common/FrameworkMessage.scala
UU test-common/src/main/scala/org/scalajs/testing/common/JSEndpoints.scala
UU test-common/src/main/scala/org/scalajs/testing/common/JVMEndpoints.scala
UU test-common/src/main/scala/org/scalajs/testing/common/LogElement.scala
UU test-common/src/main/scala/org/scalajs/testing/common/RPCCore.scala
UU test-common/src/main/scala/org/scalajs/testing/common/RunMux.scala
UU test-common/src/main/scala/org/scalajs/testing/common/RunMuxRPC.scala
UU test-common/src/main/scala/org/scalajs/testing/common/RunnerArgs.scala
UU test-common/src/main/scala/org/scalajs/testing/common/Serializer.scala
UU test-common/src/main/scala/org/scalajs/testing/common/TaskInfo.scala
UU test-common/src/test/scala/org/scalajs/testing/common/RPCCoreTest.scala
UU test-common/src/test/scala/org/scalajs/testing/common/RunMuxRPCTest.scala
UU test-common/src/test/scala/org/scalajs/testing/common/SerializerTest.scala
UU test-interface/src/main/scala/org/scalajs/testing/interface/HTMLRunner.scala
UU test-interface/src/main/scala/org/scalajs/testing/interface/JSRPC.scala
UU test-interface/src/main/scala/org/scalajs/testing/interface/ScalaJSClassLoader.scala
UU test-interface/src/main/scala/org/scalajs/testing/interface/TaskInfoBuilder.scala
UU test-interface/src/main/scala/org/scalajs/testing/interface/TestAdapterBridge.scala
DU test-interface/src/main/scala/org/scalajs/testinterface/TestDetector.scala
DU test-interface/src/main/scala/org/scalajs/testinterface/TestUtils.scala
DU test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkLoader.scala
M  test-interface/src/main/scala/sbt/testing/Event.scala
M  test-interface/src/main/scala/sbt/testing/EventHandler.scala
M  test-interface/src/main/scala/sbt/testing/Fingerprints.scala
M  test-interface/src/main/scala/sbt/testing/Framework.scala
M  test-interface/src/main/scala/sbt/testing/Logger.scala
M  test-interface/src/main/scala/sbt/testing/OptionalThrowable.scala
M  test-interface/src/main/scala/sbt/testing/Runner.scala
M  test-interface/src/main/scala/sbt/testing/Selectors.scala
M  test-interface/src/main/scala/sbt/testing/Status.scala
M  test-interface/src/main/scala/sbt/testing/Task.scala
M  test-interface/src/main/scala/sbt/testing/TaskDef.scala
M  test-suite-ex/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTestEx.scala
UU test-suite-ex/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTestEx.scala
UU test-suite-ex/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
DU test-suite/js/src/main/scala/org/scalajs/testsuite/Compat210.scala
M  test-suite/js/src/main/scala/org/scalajs/testsuite/Typechecking.scala
M  test-suite/js/src/main/scala/org/scalajs/testsuite/TypecheckingMacros.scala
M  test-suite/js/src/main/scala/org/scalajs/testsuite/jsinterop/NonNativeTypeTestSeparateRun.scala
M  test-suite/js/src/main/scala/org/scalajs/testsuite/junit/MultiCompilationTest.scala
M  test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
M  test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
M  test-suite/js/src/test/resources/SourceMapTestTemplate.scala
M  test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
M  test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
M  test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
M  test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
M  test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
M  test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/BooleanJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/DefaultMethodsJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/IntJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/LongJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/UnitJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/TimerTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/IterableTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNativeInPackage.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSOptionalTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PrimitivesTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PromiseMock.scala
DU test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SymbolTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TimeoutMock.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TupleTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitAbstractClassTest.scala
DU test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitBootstrapTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitMixinTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitNamesTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitPackageTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitSubClassTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitUtil.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/junit/MultiCompilationSecondUnitTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/JavaScriptExceptionTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
UU test-suite/js/src/test/scala/org/scalajs/testsuite/library/UndefinedBehaviorErrorTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
DU test-suite/js/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedArrayTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedDictionaryTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferJSFactories.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/niobuffer/SupportsTypedArrays.scala
DU test-suite/js/src/test/scala/org/scalajs/testsuite/niocharset/CharsetJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeJSTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArrayBufferInputStreamTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArrayBufferTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArraysTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/utils/JSAssert.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/utils/JSUtils.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/utils/PlatformTest.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/utils/Requires.scala
M  test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/CharacterTestOnJDK7.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/SystemTestOnJDK7.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/lang/ThrowablesTestOnJDK7.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/CollectionsTestOnJDK7.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/ObjectsTestOnJDK7.scala
M  test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/compiler/DefaultMethodsTest.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/DoubleTestJDK8.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/FloatTestJDK8.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/IntegerTestOnJDK8.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/LongTestOnJDK8.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/Base64Test.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/CollectionsOnCopyOnWriteArrayListTestOnJDK8.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/ComparatorTestOnJDK8.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/ObjectsTestOnJDK8.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/OptionalTest.scala
M  test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/util/SplittableRandom.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/BooleanTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ByteTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/CharTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/MatchTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/OuterClassTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/PatMatOuterPointerCheckTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ShortTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/UnitTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/MockByteArrayOutputStream.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintStreamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintWriterTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/SerializableTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ThrowablesTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThreadTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/WrappedStringCharSequence.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ref/ReferenceTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalCompareTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerAddTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerAndTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerCompareTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConvertTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerDivideTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerHashCodeTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerNotTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOrTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerSubtractTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerToStringTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerXorTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/RoundingModeTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URLDecoderTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/security/ThrowablesTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractCollectionTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractListTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedCollectionTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCollectionsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnMapsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSetFromMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSetsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedCollectionTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedListTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DequeTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/EventObjectTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashtableTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedListTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/NavigableSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PropertiesTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/RandomTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ThrowablesTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentMapTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/CopyOnWriteArrayListTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/TimeUnitTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/atomic/AtomicTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/package.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsParamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAnnotationsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssumptionsTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BufferAdapter.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BufferFactory.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferFactories.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/CharBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/DoubleBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/FloatBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/IntBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/LongBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ShortBufferTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/NameTransformerTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/CollectionsTestBase.scala
DU tools/js/src/main/scala/org/scalajs/core/tools/io/NodeVirtualFiles.scala
DU tools/js/src/main/scala/org/scalajs/core/tools/json/Impl.scala
DU tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
DU tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
DU tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
DU tools/jvm/src/main/scala/org/scalajs/core/tools/io/AtomicWritableFileVirtualFiles.scala
DU tools/jvm/src/main/scala/org/scalajs/core/tools/io/FileVirtualFiles.scala
DU tools/jvm/src/main/scala/org/scalajs/core/tools/io/IRContainerPlatformExtensions.scala
DU tools/jvm/src/main/scala/org/scalajs/core/tools/json/Impl.scala
DU tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala
DU tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstBuilder.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/io/CacheUtils.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/io/IO.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/io/MemFiles.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/javascript/JSBuilders.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/javascript/package.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ComplianceRequirement.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/DependencyResolver.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/Exceptions.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/FlatJSDependency.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependency.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependencyManifest.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ManifestFilters.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/Origin.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ResolutionInfo.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ResolvedJSDependency.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/json/AbstractJSONImpl.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONDeserializer.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjBuilder.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjExtractor.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONSerializer.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/json/package.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedMember.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/OutputMode.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/KnowledgeGuardian.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/InfoChecker.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontend.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/Refiner.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala
DU tools/shared/src/test/scala/org/scalajs/core/tools/jsdep/ComplianceRequirementTest.scala
DU tools/shared/src/test/scala/org/scalajs/core/tools/jsdep/ManifestFiltersTest.scala
DU tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala
```
For every file that was modified in 0.6.x, but deleted in master, just delete it again:
```
$ git st | grep -e '^DU ' | cut -c4- | xargs git rm -f
cli/src/main/scala/org/scalajs/cli/Scalajsld.scala: needs merge
cli/src/main/scala/org/scalajs/cli/Scalajsp.scala: needs merge
compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala: needs merge
compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala: needs merge
compiler/src/main/scala/org/scalajs/core/compiler/JSTreeExtractors.scala: needs merge
compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala: needs merge
compiler/src/test/scala/org/scalajs/core/compiler/test/JSNativeByDefaultTest.scala: needs merge
compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala: needs merge
compiler/src/test/scala/org/scalajs/core/compiler/test/MatchASTTest.scala: needs merge
compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsSuppressedTest.scala: needs merge
compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsTest.scala: needs merge
compiler/src/test/scala/org/scalajs/core/compiler/test/RegressionTest.scala: needs merge
ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala: needs merge
javalanglib/src/main/scala/java/lang/MathJDK8Bridge.scala: needs merge
javalib-ex-test-suite/src/test/scala/scala/scalajs/testsuite/javalibex/ZipInputStreamTest.scala: needs merge
javalib-ex-test-suite/src/test/scala/scala/scalajs/testsuite/utils/Platform.scala: needs merge
javalib-ex/src/main/scala/java/util/zip/InflaterInputStream.scala: needs merge
javalib-ex/src/main/scala/java/util/zip/ZipEntry.scala: needs merge
javalib-ex/src/main/scala/java/util/zip/ZipInputStream.scala: needs merge
javalib/src/main/scala/java/lang/AutoCloseable.scala: needs merge
javalib/src/main/scala/java/lang/MathJDK8Bridge.scala: needs merge
js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/AsyncTests.scala: needs merge
js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/BasicJSEnvTests.scala: needs merge
js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/CustomInitFilesTest.scala: needs merge
js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvTest.scala: needs merge
js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/StoreJSConsole.scala: needs merge
js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/StoreLogger.scala: needs merge
js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/TimeoutTests.scala: needs merge
js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala: needs merge
js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/NodeJSTest.scala: needs merge
js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/NodeJSWithCustomInitFilesTest.scala: needs merge
js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/PhantomJSTest.scala: needs merge
js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/PhantomJSWithCustomInitFilesTest.scala: needs merge
js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala: needs merge
js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RhinoJSEnvTest.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSRunner.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/ComJSRunner.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/ConsoleJSConsole.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/JSInitFiles.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/JSRunner.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitAsyncJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitComJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/NullJSConsole.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/RetryingComJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/Utils.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/VirtualFileMaterializer.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/JettyWebsocketManager.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJettyClassLoader.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/WebsocketListener.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/WebsocketManager.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/rhino/LazyScalaJSScope.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala: needs merge
js-envs/src/main/scala/org/scalajs/jsenv/rhino/package.scala: needs merge
junit-plugin/src/main/scala/org/scalajs/junit/plugin/Compat210Component.scala: needs merge
library/src/main/scala/scala/scalajs/concurrent/RunNowExcecutionContext.scala: needs merge
library/src/main/scala/scala/scalajs/js/GlobalScope.scala: needs merge
library/src/main/scala/scala/scalajs/js/JSApp.scala: needs merge
library/src/main/scala/scala/scalajs/js/Using.scala: needs merge
library/src/main/scala/scala/scalajs/js/annotation/JSExportDescendentClasses.scala: needs merge
library/src/main/scala/scala/scalajs/js/annotation/JSExportDescendentObjects.scala: needs merge
library/src/main/scala/scala/scalajs/js/annotation/JSExportNamed.scala: needs merge
library/src/main/scala/scala/scalajs/js/annotation/JSFullName.scala: needs merge
library/src/main/scala/scala/scalajs/js/annotation/SJSDefinedAnonymousClass.scala: needs merge
library/src/main/scala/scala/scalajs/js/annotation/ScalaJSDefined.scala: needs merge
library/src/main/scala/scala/scalajs/js/annotation/internal/HasJSNativeLoadSpec.scala: needs merge
library/src/main/scala/scala/scalajs/macroimpls/Compat210.scala: needs merge
library/src/main/scala/scala/scalajs/macroimpls/JSMemberSelection.scala: needs merge
library/src/main/scala/scala/scalajs/macroimpls/JSMembers.scala: needs merge
library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala: needs merge
library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1.scala: needs merge
library/src/main/scala/scala/scalajs/niocharset/StandardCharsets.scala: needs merge
library/src/main/scala/scala/scalajs/niocharset/US_ASCII.scala: needs merge
library/src/main/scala/scala/scalajs/niocharset/UTF_16.scala: needs merge
library/src/main/scala/scala/scalajs/niocharset/UTF_16BE.scala: needs merge
library/src/main/scala/scala/scalajs/niocharset/UTF_16LE.scala: needs merge
library/src/main/scala/scala/scalajs/runtime/BooleanReflectiveCall.scala: needs merge
library/src/main/scala/scala/scalajs/runtime/EnvironmentInfo.scala: needs merge
library/src/main/scala/scala/scalajs/runtime/IntegerReflectiveCall.scala: needs merge
library/src/main/scala/scala/scalajs/runtime/LongReflectiveCall.scala: needs merge
library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala: needs merge
library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/AbstractJSDeps.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/HTMLRunnerTemplate.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Implicits.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LoggerJSConsole.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossClasspathDependency.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossType.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/MacroUtils.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/DependencyBuilders.scala: needs merge
sbt-plugin/src/main/scala/org/scalajs/sbtplugin/internal/ScalaJSGlobalPlugin.scala: needs merge
stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala: needs merge
stubs/src/main/scala/scala/scalajs/js/annotation/ExportAnnotations.scala: needs merge
stubs/src/main/scala/scala/scalajs/reflect/annotation/ReflectAnnotations.scala: needs merge
test-adapter/src/main/scala/org/scalajs/sbttestadapter/ComJSEnvRPC.scala: needs merge
test-adapter/src/main/scala/org/scalajs/sbttestadapter/RemoteException.scala: needs merge
test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala: needs merge
test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala: needs merge
test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSTask.scala: needs merge
test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala: needs merge
test-interface/src/main/scala/org/scalajs/testinterface/TestDetector.scala: needs merge
test-interface/src/main/scala/org/scalajs/testinterface/TestUtils.scala: needs merge
test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkLoader.scala: needs merge
test-suite/js/src/main/scala/org/scalajs/testsuite/Compat210.scala: needs merge
test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala: needs merge
test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitBootstrapTest.scala: needs merge
test-suite/js/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala: needs merge
test-suite/js/src/test/scala/org/scalajs/testsuite/niocharset/CharsetJSTest.scala: needs merge
tools/js/src/main/scala/org/scalajs/core/tools/io/NodeVirtualFiles.scala: needs merge
tools/js/src/main/scala/org/scalajs/core/tools/json/Impl.scala: needs merge
tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala: needs merge
tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala: needs merge
tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala: needs merge
tools/jvm/src/main/scala/org/scalajs/core/tools/io/AtomicWritableFileVirtualFiles.scala: needs merge
tools/jvm/src/main/scala/org/scalajs/core/tools/io/FileVirtualFiles.scala: needs merge
tools/jvm/src/main/scala/org/scalajs/core/tools/io/IRContainerPlatformExtensions.scala: needs merge
tools/jvm/src/main/scala/org/scalajs/core/tools/json/Impl.scala: needs merge
tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala: needs merge
tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstBuilder.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/io/CacheUtils.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/io/IO.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/io/MemFiles.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/javascript/JSBuilders.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/javascript/package.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ComplianceRequirement.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/DependencyResolver.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/Exceptions.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/FlatJSDependency.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependency.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependencyManifest.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ManifestFilters.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/Origin.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ResolutionInfo.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ResolvedJSDependency.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/json/AbstractJSONImpl.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONDeserializer.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjBuilder.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjExtractor.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONSerializer.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/json/package.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedMember.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/OutputMode.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/KnowledgeGuardian.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/InfoChecker.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontend.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/Refiner.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala: needs merge
tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala: needs merge
tools/shared/src/test/scala/org/scalajs/core/tools/jsdep/ComplianceRequirementTest.scala: needs merge
tools/shared/src/test/scala/org/scalajs/core/tools/jsdep/ManifestFiltersTest.scala: needs merge
tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala: needs merge
rm 'cli/src/main/scala/org/scalajs/cli/Scalajsld.scala'
rm 'cli/src/main/scala/org/scalajs/cli/Scalajsp.scala'
rm 'compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala'
rm 'compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala'
rm 'compiler/src/main/scala/org/scalajs/core/compiler/JSTreeExtractors.scala'
rm 'compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala'
rm 'compiler/src/test/scala/org/scalajs/core/compiler/test/JSNativeByDefaultTest.scala'
rm 'compiler/src/test/scala/org/scalajs/core/compiler/test/JSOptionalTest.scala'
rm 'compiler/src/test/scala/org/scalajs/core/compiler/test/MatchASTTest.scala'
rm 'compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsSuppressedTest.scala'
rm 'compiler/src/test/scala/org/scalajs/core/compiler/test/MissingJSGlobalDeprecationsTest.scala'
rm 'compiler/src/test/scala/org/scalajs/core/compiler/test/RegressionTest.scala'
rm 'ir/src/main/scala/org/scalajs/core/ir/InfoSerializers.scala'
rm 'javalanglib/src/main/scala/java/lang/MathJDK8Bridge.scala'
rm 'javalib-ex-test-suite/src/test/scala/scala/scalajs/testsuite/javalibex/ZipInputStreamTest.scala'
rm 'javalib-ex-test-suite/src/test/scala/scala/scalajs/testsuite/utils/Platform.scala'
rm 'javalib-ex/src/main/scala/java/util/zip/InflaterInputStream.scala'
rm 'javalib-ex/src/main/scala/java/util/zip/ZipEntry.scala'
rm 'javalib-ex/src/main/scala/java/util/zip/ZipInputStream.scala'
rm 'javalib/src/main/scala/java/lang/AutoCloseable.scala'
rm 'javalib/src/main/scala/java/lang/MathJDK8Bridge.scala'
rm 'js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/AsyncTests.scala'
rm 'js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/BasicJSEnvTests.scala'
rm 'js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/CustomInitFilesTest.scala'
rm 'js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvTest.scala'
rm 'js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/StoreJSConsole.scala'
rm 'js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/StoreLogger.scala'
rm 'js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/TimeoutTests.scala'
rm 'js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/JSDOMNodeJSEnvTest.scala'
rm 'js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/NodeJSTest.scala'
rm 'js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/NodeJSWithCustomInitFilesTest.scala'
rm 'js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/PhantomJSTest.scala'
rm 'js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/PhantomJSWithCustomInitFilesTest.scala'
rm 'js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RetryingComJSEnvTest.scala'
rm 'js-envs-test-suite/src/test/scala/org/scalajs/jsenv/test/RhinoJSEnvTest.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/AsyncJSRunner.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/ComJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/ComJSRunner.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/ConsoleJSConsole.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/ExternalJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/JSInitFiles.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/JSRunner.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitAsyncJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitComJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/LinkingUnitJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/NullJSConsole.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/RetryingComJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/Utils.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/VirtualFileMaterializer.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/jsdomnodejs/JSDOMNodeJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/JettyWebsocketManager.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/PhantomJettyClassLoader.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/WebsocketListener.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/phantomjs/WebsocketManager.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/rhino/LazyScalaJSScope.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/rhino/RhinoJSEnv.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/rhino/ScalaJSCoreLib.scala'
rm 'js-envs/src/main/scala/org/scalajs/jsenv/rhino/package.scala'
rm 'junit-plugin/src/main/scala/org/scalajs/junit/plugin/Compat210Component.scala'
rm 'library/src/main/scala/scala/scalajs/concurrent/RunNowExcecutionContext.scala'
rm 'library/src/main/scala/scala/scalajs/js/GlobalScope.scala'
rm 'library/src/main/scala/scala/scalajs/js/JSApp.scala'
rm 'library/src/main/scala/scala/scalajs/js/Using.scala'
rm 'library/src/main/scala/scala/scalajs/js/annotation/JSExportDescendentClasses.scala'
rm 'library/src/main/scala/scala/scalajs/js/annotation/JSExportDescendentObjects.scala'
rm 'library/src/main/scala/scala/scalajs/js/annotation/JSExportNamed.scala'
rm 'library/src/main/scala/scala/scalajs/js/annotation/JSFullName.scala'
rm 'library/src/main/scala/scala/scalajs/js/annotation/SJSDefinedAnonymousClass.scala'
rm 'library/src/main/scala/scala/scalajs/js/annotation/ScalaJSDefined.scala'
rm 'library/src/main/scala/scala/scalajs/js/annotation/internal/HasJSNativeLoadSpec.scala'
rm 'library/src/main/scala/scala/scalajs/macroimpls/Compat210.scala'
rm 'library/src/main/scala/scala/scalajs/macroimpls/JSMemberSelection.scala'
rm 'library/src/main/scala/scala/scalajs/macroimpls/JSMembers.scala'
rm 'library/src/main/scala/scala/scalajs/macroimpls/UseAsMacros.scala'
rm 'library/src/main/scala/scala/scalajs/niocharset/ISO_8859_1.scala'
rm 'library/src/main/scala/scala/scalajs/niocharset/StandardCharsets.scala'
rm 'library/src/main/scala/scala/scalajs/niocharset/US_ASCII.scala'
rm 'library/src/main/scala/scala/scalajs/niocharset/UTF_16.scala'
rm 'library/src/main/scala/scala/scalajs/niocharset/UTF_16BE.scala'
rm 'library/src/main/scala/scala/scalajs/niocharset/UTF_16LE.scala'
rm 'library/src/main/scala/scala/scalajs/runtime/BooleanReflectiveCall.scala'
rm 'library/src/main/scala/scala/scalajs/runtime/EnvironmentInfo.scala'
rm 'library/src/main/scala/scala/scalajs/runtime/IntegerReflectiveCall.scala'
rm 'library/src/main/scala/scala/scalajs/runtime/LongReflectiveCall.scala'
rm 'library/src/main/scala/scala/scalajs/runtime/NumberReflectiveCall.scala'
rm 'library/src/main/scala/scala/scalajs/runtime/RuntimeString.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/jsdependencies/sbtplugin/JSDependenciesPlugin.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/AbstractJSDeps.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/FrameworkDetector.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/HTMLRunnerTemplate.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Implicits.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LoggerJSConsole.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/OptimizerOptions.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossClasspathDependency.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossProject.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/CrossType.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/cross/MacroUtils.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/impl/DependencyBuilders.scala'
rm 'sbt-plugin/src/main/scala/org/scalajs/sbtplugin/internal/ScalaJSGlobalPlugin.scala'
rm 'stubs/src/main/scala/org/scalajs/testinterface/TestUtils.scala'
rm 'stubs/src/main/scala/scala/scalajs/js/annotation/ExportAnnotations.scala'
rm 'stubs/src/main/scala/scala/scalajs/reflect/annotation/ReflectAnnotations.scala'
rm 'test-adapter/src/main/scala/org/scalajs/sbttestadapter/ComJSEnvRPC.scala'
rm 'test-adapter/src/main/scala/org/scalajs/sbttestadapter/RemoteException.scala'
rm 'test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSFramework.scala'
rm 'test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSRunner.scala'
rm 'test-adapter/src/main/scala/org/scalajs/sbttestadapter/ScalaJSTask.scala'
rm 'test-common/src/main/scala/org/scalajs/testcommon/FutureUtil.scala'
rm 'test-interface/src/main/scala/org/scalajs/testinterface/TestDetector.scala'
rm 'test-interface/src/main/scala/org/scalajs/testinterface/TestUtils.scala'
rm 'test-interface/src/main/scala/org/scalajs/testinterface/internal/FrameworkLoader.scala'
rm 'test-suite/js/src/main/scala/org/scalajs/testsuite/Compat210.scala'
rm 'test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala'
rm 'test-suite/js/src/test/scala/org/scalajs/testsuite/junit/JUnitBootstrapTest.scala'
rm 'test-suite/js/src/test/scala/org/scalajs/testsuite/library/UseAsTest.scala'
rm 'test-suite/js/src/test/scala/org/scalajs/testsuite/niocharset/CharsetJSTest.scala'
rm 'tools/js/src/main/scala/org/scalajs/core/tools/io/NodeVirtualFiles.scala'
rm 'tools/js/src/main/scala/org/scalajs/core/tools/json/Impl.scala'
rm 'tools/js/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala'
rm 'tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala'
rm 'tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala'
rm 'tools/jvm/src/main/scala/org/scalajs/core/tools/io/AtomicWritableFileVirtualFiles.scala'
rm 'tools/jvm/src/main/scala/org/scalajs/core/tools/io/FileVirtualFiles.scala'
rm 'tools/jvm/src/main/scala/org/scalajs/core/tools/io/IRContainerPlatformExtensions.scala'
rm 'tools/jvm/src/main/scala/org/scalajs/core/tools/json/Impl.scala'
rm 'tools/jvm/src/main/scala/org/scalajs/core/tools/linker/LinkerPlatformExtensions.scala'
rm 'tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstBuilder.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/io/CacheUtils.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/io/IO.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/io/MemFiles.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/io/VirtualFiles.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/javascript/JSBuilders.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/javascript/package.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ComplianceRequirement.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/DependencyResolver.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/Exceptions.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/FlatJSDependency.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependency.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/JSDependencyManifest.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ManifestFilters.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/Origin.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ResolutionInfo.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/jsdep/ResolvedJSDependency.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/json/AbstractJSONImpl.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONDeserializer.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjBuilder.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONObjExtractor.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/json/JSONSerializer.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/json/package.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/ClearableLinker.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/GenLinker.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedClass.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkedMember.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/Linker.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/LinkingUnit.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/BasicLinkerBackend.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/LinkerBackend.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/OutputMode.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/ClassEmitter.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/Emitter.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/KnowledgeGuardian.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/InfoChecker.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/BaseLinker.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/LinkerFrontend.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/Refiner.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/package.scala'
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/standard/package.scala'
rm 'tools/shared/src/test/scala/org/scalajs/core/tools/jsdep/ComplianceRequirementTest.scala'
rm 'tools/shared/src/test/scala/org/scalajs/core/tools/jsdep/ManifestFiltersTest.scala'
rm 'tools/shared/src/test/scala/org/scalajs/core/tools/linker/LinkerTest.scala'
```
For every file that had a conflict only in the header, due to the license change on 0.6.x and a package name change in master, just check it out back from master:
```
$ git checkout HEAD compiler/
$ git checkout HEAD test-common/
$ git checkout HEAD test-interface/
$ git checkout HEAD ir/
$ git checkout HEAD io/
$ git checkout HEAD logging/
$ git checkout HEAD linker/
$ git checkout HEAD js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
$ git checkout HEAD test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapterInitializer.scala
$ git checkout HEAD library/src/main/scala/scala/scalajs/js/annotation/internal/WasPublicBeforeTyper.scala
$ git checkout HEAD test-suite-ex/
$ git checkout HEAD test-suite/js/src/test/scala/org/scalajs/testsuite/library/UndefinedBehaviorErrorTest.scala
$ git checkout HEAD javalanglib/src/main/scala/java/lang/FloatingPointBits.scala
$ git checkout HEAD javalanglib/src/main/scala/java/lang/StackTrace.scala
$ git checkout HEAD javalib/src/main/scala/java/nio/charset/ISO_8859_1_And_US_ASCII_Common.scala
$ git checkout HEAD javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
$ git checkout HEAD javalib/src/main/scala/java/nio/charset/UTF_8.scala
```
Now we we're left with:
```
$ git st | grep -e '^UU'
UU README.md
UU project/Build.scala
UU project/build.sbt
```
Fix conflicts now, then:
```diff
$ git diff -w | cat
diff --cc README.md
index 9de62451e,261cf301b..000000000
--- a/README.md
+++ b/README.md
diff --cc project/Build.scala
index dcfb22408,58c9b9cb9..000000000
--- a/project/Build.scala
+++ b/project/Build.scala
@@@ -4,10 -5,8 +4,11 @@@ import scala.language.implicitConversio
  
  import scala.annotation.tailrec
  
 +import sbt._
 +import Keys._
 +
  import com.typesafe.tools.mima.plugin.MimaPlugin.autoImport._
+ import de.heikoseeberger.sbtheader.HeaderPlugin.autoImport._
  
  import java.io.{
    BufferedOutputStream,
@@@ -524,25 -479,38 +537,38 @@@ object Build 
        name := "Scala.js",
        publishArtifact in Compile := false,
  
-       clean := clean.dependsOn(
-           clean in compiler,
-           clean in irProject, clean in irProjectJS,
-           clean in io, clean in ioJS,
-           clean in logging, clean in loggingJS,
-           clean in linker, clean in linkerJS,
-           clean in jsEnvs, clean in jsEnvsTestKit, clean in nodeJSEnv,
-           clean in testAdapter, clean in plugin,
-           clean in javalanglib, clean in javalib, clean in scalalib,
-           clean in libraryAux, clean in library, clean in minilib,
-           clean in testInterface,
-           clean in jUnitRuntime, clean in jUnitPlugin,
-           clean in jUnitTestOutputsJS, clean in jUnitTestOutputsJVM,
-           clean in examples, clean in helloworld,
-           clean in reversi, clean in testingExample,
-           clean in testSuite, clean in testSuiteJVM,
-           clean in testSuiteEx,
-           clean in partest, clean in partestSuite,
-           clean in scalaTestSuite).value,
+       {
+         val allProjects = Seq(
 -                compiler, irProject, irProjectJS, tools, toolsJS,
 -                jsEnvs, jsEnvsTestKit, jsEnvsTestSuite, testAdapter, plugin,
 -                javalanglib, javalib, scalalib, libraryAux, library, javalibEx,
 -                stubs, cli,
++            compiler, irProject, irProjectJS, io, ioJS, logging, loggingJS,
++            linker, linkerJS,
++            jsEnvs, jsEnvsTestKit, nodeJSEnv, testAdapter, plugin,
++            javalanglib, javalib, scalalib, libraryAux, library, minilib,
+             testInterface, jUnitRuntime, jUnitPlugin,
+             jUnitTestOutputsJS, jUnitTestOutputsJVM,
+             helloworld, reversi, testingExample, testSuite, testSuiteJVM,
 -                noIrCheckTest, javalibExTestSuite,
++            testSuiteEx,
+             partest, partestSuite,
+             scalaTestSuite
+         )
+ 
+         val keys = Seq[TaskKey[_]](
+             clean, headerCreate in Compile, headerCreate in Test,
+             headerCheck in Compile, headerCheck in Test
+         )
+ 
+         for (key <- keys) yield {
+           /* The match is only used to capture the type parameter `a` of
+            * each individual TaskKey.
+            */
+           key match {
+             case key: TaskKey[a] =>
+               key := key.dependsOn(allProjects.map(key in _): _*).value
+           }
+         }
+       },
+ 
+       headerCreate := (headerCreate in Test).dependsOn(headerCreate in Compile).value,
+       headerCheck := (headerCheck in Test).dependsOn(headerCheck in Compile).value,
  
        publish := {},
        publishLocal := {}
@@@ -869,22 -906,28 +895,30 @@@
        name := "Java library for Scala.js",
        publishArtifact in Compile := false,
        delambdafySetting,
 +      ensureSAMSupportSetting,
        noClassFilesSettings,
-       scalaJSExternalCompileSettings
+       scalaJSExternalCompileSettings,
+ 
+       headerSources in Compile ~= { srcs =>
+         srcs.filter { src =>
+           val path = src.getPath.replace('\\', '/')
+           !path.contains("/java/math/") &&
+           !path.endsWith("/java/util/concurrent/ThreadLocalRandom.scala")
+         }
+       }
 -      )
    ).withScalaJSCompiler.dependsOnLibraryNoJar
  
 -  lazy val scalalib: Project = Project(
 -      id = "scalalib",
 -      base = file("scalalib"),
 -      settings = commonSettings ++ Seq(
 +  lazy val scalalib: Project = project.enablePlugins(
 +      MyScalaJSPlugin
 +  ).settings(
 +      commonSettings,
        /* Link source maps to the GitHub sources of the original scalalib
 -           * #2195 This must come *before* the option added by myScalaJSSettings
 +       * #2195 This must come *before* the option added by MyScalaJSPlugin
         * because mapSourceURI works on a first-match basis.
         */
 -          scalacOptions += {
 +      scalacOptions := {
 +        val previousScalacOptions = scalacOptions.value
 +        val sourceMapOption = {
            "-P:scalajs:mapSourceURI:" +
            (artifactPath in fetchScalaSource).value.toURI +
            "->https://raw.githubusercontent.com/scala/scala/v" +
@@@ -1012,14 -1054,35 +1046,17 @@@
          sources.result()
        },
  
+       headerSources in Compile := Nil,
+       headerSources in Test := Nil,
+ 
 -          // Continuation plugin (when using 2.10.x)
 -          autoCompilerPlugins := true,
 -          libraryDependencies ++= {
 -            val ver = scalaVersion.value
 -            if (ver.startsWith("2.10."))
 -              Seq(compilerPlugin("org.scala-lang.plugins" % "continuations" % ver))
 -            else
 -              Nil
 -          },
 -          scalacOptions ++= {
 -            if (scalaVersion.value.startsWith("2.10."))
 -              Seq("-P:continuations:enable")
 -            else
 -              Nil
 -          }
 -      ) ++ (
        scalaJSExternalCompileSettings
 -      )
    ).withScalaJSCompiler.dependsOnLibraryNoJar
  
 -  lazy val libraryAux: Project = Project(
 -      id = "libraryAux",
 -      base = file("library-aux"),
 -      settings = (
 -          commonSettings ++ myScalaJSSettings ++ fatalWarningsSettings
 -      ) ++ Seq(
 +  lazy val libraryAux: Project = (project in file("library-aux")).enablePlugins(
 +      MyScalaJSPlugin
 +  ).settings(
 +      commonSettings,
 +      fatalWarningsSettings,
        name := "Scala.js aux library",
        publishArtifact in Compile := false,
        delambdafySetting,
@@@ -1172,19 -1268,28 +1209,26 @@@
         * stuff and JUnit does not support async tests. Therefore we need to
         * block, so we cannot run on JS.
         */
 -      )
    ).withScalaJSCompiler.dependsOn(library)
  
 -  lazy val jUnitRuntime = Project(
 -    id = "jUnitRuntime",
 -    base = file("junit-runtime"),
 -    settings = (
 -        commonSettings ++ publishSettings ++ myScalaJSSettings ++
 -        fatalWarningsSettings
 -    ) ++ Def.settings(
 +  lazy val jUnitRuntime = (project in file("junit-runtime")).enablePlugins(
 +      MyScalaJSPlugin
 +  ).settings(
 +      commonSettings,
 +      publishSettings,
 +      fatalWarningsSettings,
-       name := "Scala.js JUnit test runtime"
+       name := "Scala.js JUnit test runtime",
+ 
+       headerSources in Compile ~= { srcs =>
+         srcs.filter { src =>
+           val path = src.getPath.replace('\\', '/')
+           !path.contains("/org/junit/") && !path.contains("/org/hamcrest/")
+         }
+       }
 -    )
    ).withScalaJSCompiler.dependsOn(testInterface)
  
 -  val commonJUnitTestOutputsSettings = commonSettings ++ Seq(
 +  val commonJUnitTestOutputsSettings = Def.settings(
 +      commonSettings,
        publishArtifact in Compile := false,
        parallelExecution in Test := false,
        unmanagedSourceDirectories in Test +=
@@@ -1226,34 -1335,48 +1270,37 @@@
  
    // Examples
  
 -  lazy val examples: Project = Project(
 -      id = "examples",
 -      base = file("examples"),
 -      settings = commonSettings ++ Seq(
 +  lazy val examples: Project = project.settings(
 +      commonSettings,
        name := "Scala.js examples"
 -      )
    ).aggregate(helloworld, reversi, testingExample)
  
-   lazy val exampleSettings = commonSettings ++ fatalWarningsSettings
 -  lazy val exampleSettings = commonSettings ++ myScalaJSSettings ++ fatalWarningsSettings ++ Def.settings(
++  lazy val exampleSettings = commonSettings ++ fatalWarningsSettings ++ Def.settings(
+       headerSources in Compile := Nil,
+       headerSources in Test := Nil
+   )
  
 -  lazy val helloworld: Project = Project(
 -      id = "helloworld",
 -      base = file("examples") / "helloworld",
 -      settings = exampleSettings ++ Seq(
 +  lazy val helloworld: Project = (project in (file("examples") / "helloworld")).enablePlugins(
 +      MyScalaJSPlugin
 +  ).settings(
 +      exampleSettings,
        name := "Hello World - Scala.js example",
        moduleName := "helloworld",
 -          scalaJSUseMainModuleInitializer := true,
 -
 -          /* We have to test js.JSApp somewhere, so we avoid the fatal
 -           * deprecation warning here.
 -           */
 -          scalacOptions -= "-Xfatal-warnings"
 -      )
 +      scalaJSUseMainModuleInitializer := true
    ).withScalaJSCompiler.dependsOn(library)
  
 -  lazy val reversi = Project(
 -      id = "reversi",
 -      base = file("examples") / "reversi",
 -      settings = exampleSettings ++ Seq(
 +  lazy val reversi = (project in (file("examples") / "reversi")).enablePlugins(
 +      MyScalaJSPlugin
 +  ).settings(
 +      exampleSettings,
        name := "Reversi - Scala.js example",
        moduleName := "reversi"
 -      )
    ).withScalaJSCompiler.dependsOn(library)
  
 -  lazy val testingExample = Project(
 -      id = "testingExample",
 -      base = file("examples") / "testing",
 -      settings = exampleSettings ++ Seq(
 +  lazy val testingExample = (project in (file("examples") / "testing")).enablePlugins(
 +      MyScalaJSPlugin
 +  ).settings(
 +      exampleSettings,
        name := "Testing - Scala.js example",
        moduleName := "testing",
  
diff --cc project/build.sbt
index eb1be9198,89d6db39a..000000000
--- a/project/build.sbt
+++ b/project/build.sbt
@@@ -1,3 -1,7 +1,5 @@@
+ addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+ 
 -addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")
 -
  addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.1.18")
  
  addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
```
Quick local test, then:
```
$ git add -u
```
(Re-)create the headers for all the new files in master, and those that we `git checkout`'ed back to master:
```
$ sbt headerCreate
```
Other quick test, then:
```
$ git add -u
```
```
$ git commit
[merge-0.6.x-into-master-october-15 1e15e7867] Merge '0.6.x' into 'master'.
```
