### PR TITLE
Fix one license header.

### DIFF
--- a/partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -1,6 +1,13 @@
-/* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package scala.tools.partest


### PR DESCRIPTION
It is only relevant in 2.11.{0-2}, so it was only caught by the nightly build.