### PR TITLE
FF ONLY Merge 0.6.x into master, October 18

### DIFF
--- a/partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -1,6 +1,13 @@
-/* NSC -- new Scala compiler
- * Copyright 2005-2013 LAMP/EPFL
- * @author  Sébastien Doeraene
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
  */
 
 package scala.tools.partest


### PR DESCRIPTION
Motivation: Fix the nightly build on master so that we can release.

Trivial merge without conflict. No review needed.

```
$ git checkout -b merge-0.6.x-into-master-october-18
Switched to a new branch 'merge-0.6.x-into-master-october-18'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* f8bdcdcde (scalajs/0.6.x) Merge pull request #3472 from sjrd/fix-some-more-license-headers
* 206f6f383 Fix one license header.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
Automatic merge went well; stopped before committing as requested
```
```
$ git st
M  partest/src/main-partest-1.0.13/scala/tools/partest/scalajs/ScalaJSPartest.scala
```
```
$ git commit
[merge-0.6.x-into-master-october-18 a5493fdb6] Merge '0.6.x' into 'master'.
```