### PR TITLE
Fix #3476: Specify that com messages must be valid UTF-16 strings.

### DIFF
--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/ComTests.scala
@@ -103,8 +103,13 @@ private[test] class ComTests(config: JSEnvSuiteConfig) {
 
   @Test
   def largeMessageTest: Unit = {
-    // 1MB data
-    replyTest(new String(Array.tabulate(1024 * 1024)(_.toChar)))
+    /* 1MB data.
+     * (i & 0x7f) limits the input to the ASCII repertoire, which will use
+     * exactly 1 byte per Char in UTF-8. This restriction also ensures that we
+     * do not introduce surrogate characters and therefore no invalid UTF-16
+     * strings.
+     */
+    replyTest(new String(Array.tabulate(1024 * 1024)(i => (i & 0x7f).toChar)))
   }
 
   @Test

--- a/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/JSEnv.scala
@@ -51,6 +51,11 @@ trait JSEnv {
    *  scalajsCom.send("my message");
    *  }}}
    *
+   *  All messages, sent in both directions, must be valid UTF-16 strings,
+   *  i.e., they must not contain any unpaired surrogate character. The
+   *  behavior of a communication channel is unspecified if this requirement is
+   *  not met.
+   *
    *  We describe the expected message delivery guarantees by denoting the
    *  transmitter as `t` and  the receiver as `r`. Both the JVM and the JS end
    *  act once as a transmitter and once as a receiver. These two

--- a/js-envs/src/main/scala/org/scalajs/jsenv/JSRuns.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/JSRuns.scala
@@ -63,6 +63,10 @@ object JSRun {
 trait JSComRun extends JSRun {
   /** Sends a message to the JS end.
    *
+   *  The `msg` must be a valid UTF-16 string, i.e., it must not contain any
+   *  unpaired surrogate character. The behavior of the communication channel
+   *  is unspecified if this requirement is not met.
+   *
    *  Async, nothrow. See [[JSEnv#startWithCom]] for expected message delivery
    *  guarantees.
    */


### PR DESCRIPTION
* Document it in the Scaladoc of `startWithCom`
* Assert that all messages are valid in the `TestKit`
* Fix `ComTests.largeMessageTest` not to use an invalid message