### PR TITLE
[no-master] Fix #2175: Add support for ECMAScript 2015 modules.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -129,6 +129,18 @@ def Tasks = [
         helloworld/run \
         helloworld/clean &&
     sbtretry ++$scala \
+        'set artifactPath in (helloworld, Compile, fastOptJS) := (crossTarget in helloworld).value / "helloworld-fastopt.mjs"' \
+        'set jsEnv in helloworld := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSModuleKind in helloworld := ModuleKind.ESModule' \
+        helloworld/run &&
+    sbtretry ++$scala \
+        'set artifactPath in (helloworld, Compile, fullOptJS) := (crossTarget in helloworld).value / "helloworld-opt.mjs"' \
+        'set jsEnv in helloworld := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSModuleKind in helloworld := ModuleKind.ESModule' \
+        'set scalaJSStage in Global := FullOptStage' \
+        helloworld/run \
+        helloworld/clean &&
+    sbtretry ++$scala \
         'set Seq(scalaJSUseMainModuleInitializer in helloworld := false, persistLauncher in helloworld := true)' \
         'set scalaJSUseRhino in Global := true' \
         helloworld/run &&
@@ -231,6 +243,16 @@ def Tasks = [
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
         'set scalaJSStage in Global := FullOptStage' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set artifactPath in ($testSuite, Test, fastOptJS) := (crossTarget in $testSuite).value / "testsuite-fastopt.mjs"' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSModuleKind in $testSuite := ModuleKind.ESModule' \
+        ++$scala $testSuite/test &&
+    sbtretry 'set artifactPath in ($testSuite, Test, fullOptJS) := (crossTarget in $testSuite).value / "testsuite-opt.mjs"' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSModuleKind in $testSuite := ModuleKind.ESModule' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test
   ''',
 
@@ -279,6 +301,18 @@ def Tasks = [
     sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withSourceMap(false))' \
         'set scalaJSModuleKind in $testSuite := ModuleKind.CommonJSModule' \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
+        'set artifactPath in ($testSuite, Test, fastOptJS) := (crossTarget in $testSuite).value / "testsuite-fastopt.mjs"' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSModuleKind in $testSuite := ModuleKind.ESModule' \
+        ++$scala $testSuite/test &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
+        'set artifactPath in ($testSuite, Test, fullOptJS) := (crossTarget in $testSuite).value / "testsuite-opt.mjs"' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSModuleKind in $testSuite := ModuleKind.ESModule' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test
   ''',

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -62,6 +62,7 @@ object Platform {
   def hasStrictFloats: Boolean = sysProp("strict-floats")
 
   def isNoModule: Boolean = sysProp("modulekind-nomodule")
+  def isESModule: Boolean = sysProp("modulekind-esmodule")
   def isCommonJSModule: Boolean = sysProp("modulekind-commonjs")
 
   private def sysProp(key: String): Boolean =

--- a/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ModulesTest.scala
+++ b/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ModulesTest.scala
@@ -26,7 +26,7 @@ class ModulesTest {
 
   @Test def testImportModuleItself(): Unit = {
     val qs = QueryString
-    assertTrue(qs.isInstanceOf[js.Object])
+    assertEquals("object", js.typeOf(qs))
 
     val dict = js.Dictionary("foo" -> "bar", "baz" -> "qux")
 
@@ -42,7 +42,7 @@ class ModulesTest {
 
   @Test def testImportLegacyModuleItselfAsDefault(): Unit = {
     val qs = QueryStringAsDefault
-    assertTrue(qs.isInstanceOf[js.Object])
+    assertEquals("object", js.typeOf(qs))
 
     val dict = js.Dictionary("foo" -> "bar", "baz" -> "qux")
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -69,6 +69,8 @@ class SystemJSTest {
   @Test def systemProperties(): Unit = {
     def get(key: String): String = java.lang.System.getProperty(key)
 
+    def trueCount(xs: Boolean*): Int = xs.count(identity)
+
     // Defined in System.scala
 
     assertEquals("1.8", get("java.version"))
@@ -148,9 +150,11 @@ class SystemJSTest {
     assertEquals(isInFullOpt, Platform.isInFullOpt)
 
     val isNoModule = get("scalajs.modulekind-nomodule") == "true"
+    val isESModule = get("scalajs.modulekind-esmodule") == "true"
     val isCommonJSModule = get("scalajs.modulekind-commonjs") == "true"
     assertEquals(isNoModule, Platform.isNoModule)
+    assertEquals(isESModule, Platform.isESModule)
     assertEquals(isCommonJSModule, Platform.isCommonJSModule)
-    assertTrue(isNoModule ^ isCommonJSModule)
+    assertEquals(1, trueCount(isNoModule, isESModule, isCommonJSModule))
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -28,10 +28,30 @@ import org.junit.Test
 import org.scalajs.testsuite.utils.{JSUtils, Platform}
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
+object ExportsTest {
+  /* When using ES modules, there is no way to get hold of our own exports
+   * namespace from within. The build instead sets up a small script that will
+   * import our module and call `setExportsNamespaceForExportsTest` with our
+   * module namespace.
+   */
+
+  private[this] var explicitlySetExportsNamespace: Option[js.Dynamic] = None
+
+  @JSExportTopLevel("setExportsNamespaceForExportsTest")
+  def setExportsNamespaceForExportsTest(value: js.Dynamic): Unit =
+    explicitlySetExportsNamespace = Some(value)
+
+  def exportsNameSpace: js.Dynamic = {
+    explicitlySetExportsNamespace.getOrElse {
+      scala.scalajs.runtime.environmentInfo.exportsNamespace
+    }
+  }
+}
+
 class ExportsTest {
 
   /** The namespace in which top-level exports are stored. */
-  val exportsNamespace = scala.scalajs.runtime.environmentInfo.exportsNamespace
+  val exportsNamespace = ExportsTest.exportsNameSpace
 
   /** This package in the JS (export) namespace */
   val jsPackage = exportsNamespace.org.scalajs.testsuite.jsinterop

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
@@ -33,7 +33,7 @@ class ModulesWithGlobalFallbackTest {
 
   @Test def testImportModuleItself(): Unit = {
     val qs = QueryString
-    assertTrue(qs.isInstanceOf[js.Object])
+    assertEquals("object", js.typeOf(qs))
 
     val dict = js.Dictionary("foo" -> "bar", "baz" -> "qux")
 
@@ -49,7 +49,7 @@ class ModulesWithGlobalFallbackTest {
 
   @Test def testImportLegacyModuleItselfAsDefault(): Unit = {
     val qs = QueryStringAsDefault
-    assertTrue(qs.isInstanceOf[js.Object])
+    assertEquals("object", js.typeOf(qs))
 
     val dict = js.Dictionary("foo" -> "bar", "baz" -> "qux")
 

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/io/FileVirtualFiles.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/io/FileVirtualFiles.scala
@@ -137,7 +137,7 @@ class FileVirtualJSFile(f: File) extends FileVirtualTextFile(f)
   import FileVirtualFile._
   import FileVirtualTextFile._
 
-  val sourceMapFile: File = withExtension(file, ".js", ".js.map")
+  val sourceMapFile: File = withName(file, file.getName + ".map")
 
   override def sourceMap: Option[String] = {
     if (sourceMapFile.exists) Some(readFileToString(sourceMapFile))

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureLinkerBackend.scala
@@ -58,8 +58,8 @@ final class ClosureLinkerBackend(
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements
 
   private val needsIIFEWrapper = moduleKind match {
-    case ModuleKind.NoModule       => true
-    case ModuleKind.CommonJSModule => false
+    case ModuleKind.NoModule                             => true
+    case ModuleKind.ESModule | ModuleKind.CommonJSModule => false
   }
 
   private def toClosureSource(file: VirtualJSFile) =

--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -21,6 +21,9 @@ ScalaJS.g =
     : ((typeof global === "object" && global && global["Object"] === Object) ? global : this);
 ScalaJS.env["global"] = ScalaJS.g;
 
+//!if moduleKind == ESModule
+ScalaJS.env["exportsNamespace"] = void 0;
+//!else
 // Where to send exports
 //!if moduleKind == CommonJSModule
 ScalaJS.e = exports;
@@ -30,6 +33,7 @@ ScalaJS.e =
     ? ScalaJS.env["exportsNamespace"] : ScalaJS.g;
 //!endif
 ScalaJS.env["exportsNamespace"] = ScalaJS.e;
+//!endif
 
 // Freeze the environment info
 ScalaJS.g["Object"]["freeze"](ScalaJS.env);

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
@@ -552,6 +552,49 @@ object Printers {
         case Super() =>
           print("super")
 
+        // ECMAScript 6 modules
+
+        case Import(bindings, from) =>
+          print("import { ")
+          var first = true
+          var rest = bindings
+          while (rest.nonEmpty) {
+            val binding = rest.head
+            if (first)
+              first = false
+            else
+              print(", ")
+            print(binding._1)
+            print(" as ")
+            print(binding._2)
+            rest = rest.tail
+          }
+          print(" } from ")
+          print(from: Tree)
+
+        case ImportNamespace(binding, from) =>
+          print("import * as ")
+          print(binding)
+          print(" from ")
+          print(from: Tree)
+
+        case Export(bindings) =>
+          print("export { ")
+          var first = true
+          var rest = bindings
+          while (rest.nonEmpty) {
+            val binding = rest.head
+            if (first)
+              first = false
+            else
+              print(", ")
+            print(binding._1)
+            print(" as ")
+            print(binding._2)
+            rest = rest.tail
+          }
+          print(" }")
+
         case _ =>
           print(s"<error, elem of class ${tree.getClass}>")
       }
@@ -572,6 +615,9 @@ object Printers {
         print(tree)
         print("]")
     }
+
+    protected def print(exportName: ExportName): Unit =
+      printEscapeJS(exportName.name)
 
     protected def print(s: String): Unit =
       out.write(s)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
@@ -241,4 +241,112 @@ object Trees {
       body: Tree)(implicit val pos: Position) extends Tree
 
   case class Super()(implicit val pos: Position) extends Tree
+
+  // ECMAScript 6 modules
+
+  /** The name of an ES module export.
+   *
+   *  It must be a valid `IdentifierName`, as tested by
+   *  [[ExportName.isValidExportName]].
+   */
+  case class ExportName(name: String)(implicit val pos: Position) {
+    require(ExportName.isValidExportName(name),
+        s"'$name' is not a valid export name")
+  }
+
+  object ExportName {
+    /** Tests whether a string is a valid export name.
+     *
+     *  A string is a valid export name if and only if it is a valid ECMAScript
+     *  `IdentifierName`, which is defined in
+     *  [[http://www.ecma-international.org/ecma-262/6.0/#sec-names-and-keywords
+     *  Section 11.6 of the ECMAScript 2015 specification]].
+     *
+     *  Currently, this implementation is buggy in some corner cases, as it does
+     *  not accept code points with the Unicode properties `Other_ID_Start` and
+     *  `Other_ID_Continue`. For example,
+     *  `isValidIdentifierName(0x2118.toChar.toString)` will return `false`
+     *  instead of `true`.
+     *
+     *  In theory, it does not really account for code points with the Unicode
+     *  properties `Pattern_Syntax` and `Pattern_White_Space`, which should be
+     *  rejected. However, with the current version of Unicode (9.0.0), there
+     *  seems to be no such character that would be accepted by this method.
+     */
+    final def isValidExportName(name: String): Boolean = {
+      // scalastyle:off return
+      import java.lang.Character._
+
+      def isJSIdentifierStart(cp: Int): Boolean =
+        isUnicodeIdentifierStart(cp) || cp == '$' || cp == '_'
+
+      def isJSIdentifierPart(cp: Int): Boolean = {
+        val ZWNJ = 0x200c
+        val ZWJ = 0x200d
+        isUnicodeIdentifierPart(cp) || cp == '$' || cp == '_' || cp == ZWNJ || cp == ZWJ
+      }
+
+      if (name.isEmpty)
+        return false
+
+      val firstCP = name.codePointAt(0)
+      if (!isJSIdentifierStart(firstCP))
+        return false
+
+      var i = charCount(firstCP)
+      while (i < name.length) {
+        val cp = name.codePointAt(i)
+        if (!isJSIdentifierPart(cp))
+          return false
+        i += charCount(cp)
+      }
+
+      true
+      // scalastyle:on return
+    }
+  }
+
+  /** `import` statement, except namespace import.
+   *
+   *  This corresponds to the following syntax:
+   *  {{{
+   *  import { <binding1_1> as <binding1_2>, ..., <bindingN_1> as <bindingN_2> } from <from>
+   *  }}}
+   *  The `_1` parts of bindings are therefore the identifier names that are
+   *  imported, as specified in `export` clauses of the module. The `_2` parts
+   *  are the names under which they are imported in the current module.
+   *
+   *  Special cases:
+   *  - When `_1.name == _2.name`, there is shorter syntax in ES, i.e.,
+   *    `import { binding } from 'from'`.
+   *  - When `_1.name == "default"`, it is equivalent to a default import.
+   */
+  case class Import(bindings: List[(ExportName, Ident)], from: StringLiteral)(
+      implicit val pos: Position)
+      extends Tree
+
+  /** Namespace `import` statement.
+   *
+   *  This corresponds to the following syntax:
+   *  {{{
+   *  import * as <binding> from <from>
+   *  }}}
+   */
+  case class ImportNamespace(binding: Ident, from: StringLiteral)(
+      implicit val pos: Position)
+      extends Tree
+
+  /** `export` statement.
+   *
+   *  This corresponds to the following syntax:
+   *  {{{
+   *  export { <binding1_1> as <binding1_2>, ..., <bindingN_1> as <bindingN_2> }
+   *  }}}
+   *  The `_1` parts of bindings are therefore the identifiers from the current
+   *  module that are exported. The `_2` parts are the names under which they
+   *  are exported to other modules.
+   */
+  case class Export(bindings: List[(Ident, ExportName)])(
+      implicit val pos: Position)
+      extends Tree
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/ModuleKind.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/ModuleKind.scala
@@ -24,6 +24,7 @@ object ModuleKind {
    */
   val All: List[ModuleKind] = List(
       NoModule,
+      ESModule,
       CommonJSModule)
 
   /** No module structure.
@@ -35,6 +36,13 @@ object ModuleKind {
    *  Imports are not supported.
    */
   case object NoModule extends ModuleKind
+
+  /** An ECMAScript 2015 module.
+   *
+   *  Scala.js imports and exports directly map to `import` and `export`
+   *  clauses in the ES module.
+   */
+  case object ESModule extends ModuleKind
 
   /** A CommonJS module (notably used by Node.js).
    *

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/JSGen.scala
@@ -188,7 +188,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
       case irt.JSNativeLoadSpec.Import(module, path) =>
         val moduleValue = envModuleField(module)
         path match {
-          case DefaultExportName :: rest =>
+          case DefaultExportName :: rest if moduleKind == ModuleKind.CommonJSModule =>
             val defaultField = genCallHelper("moduleDefault", moduleValue)
             pathSelection(defaultField, rest)
           case _ =>
@@ -199,7 +199,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
         moduleKind match {
           case ModuleKind.NoModule =>
             genLoadJSFromSpec(globalSpec)
-          case ModuleKind.CommonJSModule =>
+          case ModuleKind.ESModule | ModuleKind.CommonJSModule =>
             genLoadJSFromSpec(importSpec)
         }
     }


### PR DESCRIPTION
This commit adds a third `ModuleKind` for ES modules, namely `ModuleKind.ESModule`. When emitting an ES module, `@JSImport`s and `@JSExportTopLevel`s straightforwardly map to ES `import` and `export` clauses, respectively.

At the moment, imports are always implemented using a namespace import, then selecting fields inside the namespace. This is suboptimal because it can prevent advanced DCE across ES modules. Improving on this is left for future work.

The Node.js-based environment is adapted to interpret files whose name ends with `.mjs` as ES modules rather than scripts. This aligns with how Node.js itself identifies ES modules as of version 10.x, although it is still experimental, so that could change in the future.

For the 0.6.x branch, the `TestAdapter` assumes that it can force the `JSEnv` to interpret its launcher as an ES module by giving it the `.mjs` extension as well. This is wrong in general, but there does not seem to be a good way to deal with this issue. In 1.x, this will be a non-issue since the `TestAdapter` does not require any launcher.

Although setting `scalaJSLinkerConfig.moduleKind` to `ModuleKind.ESModule` is enough for the Scala.js linker to emit a valid ES module, two additional settings are required to *run* or *test* using Node.js:
```scala
artifactPath in (proj, Compile, fastOptJS) :=
  (crossTarget in (proj, Compile)).value / "somename.mjs"

jsEnv := {
  new org.scalajs.jsenv.NodeJSEnv(
      org.scalajs.jsenv.NODEJSEnv.Config()
        .withArguments(List("--experimental-modules"))
  )
}
```
The first setting is necessary to give the `.mjs` extension to the file produced by Scala.js, which in turn is necessary for Node.js to accept it as an ES module.

The second setting will be necessary until Node.js declares its support for ES module as non-experimental.

ES modules are incompatible with a few features, which are all gone in Scala.js 1.x:

* `EnvironmentInfo.exportsNamespace`: an ES module cannot read its   own exports namespace, short of importing itself (which requires   it to know its file name). The value of `exportsNamespace` is `undefined` in an ES module.
* Generation of a `main` launcher script by the sbt plugin. Attempting to use one will throw an exception in the build.

Moreover, the version of the Closure Compiler that we use does not support ES modules yet, so we deactivate GCC when emitting an ES module.

At this point, the emission of ES modules can be considered stable, but the support in `NodeJSEnv` is experimental (since the support of ES modules in Node.js is itself experimental).

Running the full test suite with ES modules requires Node.js 10.2.0 or later. It has been tested with v10.12.0.