### PR TITLE
Deprecate namespaced top-level exports.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSExports.scala
@@ -413,6 +413,14 @@ trait PrepJSExports { this: PrepJSInterop =>
                 "Only static objects may export their members to the top level")
           }
 
+          // Warn for namespaced top-level exports
+          if (name.contains('.') && !scalaJSOpts.suppressExportDeprecations) {
+            reporter.warning(annot.pos,
+                "Using a namespaced export (with a '.') in @JSExportTopLevel " +
+                "is deprecated." +
+                SuppressExportDeprecationsMsg)
+          }
+
         case ExportDestination.Static =>
           val symOwner =
             if (sym.isClassConstructor) sym.owner.owner

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala
@@ -114,4 +114,44 @@ class JSExportDeprecationsTest extends DirectTest with TestHelpers {
     }
   }
 
+  @Test
+  def warnJSExportTopLevelNamespaced: Unit = {
+    """
+    @JSExportTopLevel("namespaced.export1")
+    object A
+    @JSExportTopLevel("namespaced.export2")
+    class B
+    object C {
+      @JSExportTopLevel("namespaced.export3")
+      val a: Int = 1
+      @JSExportTopLevel("namespaced.export4")
+      var b: Int = 1
+      @JSExportTopLevel("namespaced.export5")
+      def c(): Int = 1
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |    @JSExportTopLevel("namespaced.export1")
+      |     ^
+      |newSource1.scala:5: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |    @JSExportTopLevel("namespaced.export2")
+      |     ^
+      |newSource1.scala:8: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |      @JSExportTopLevel("namespaced.export3")
+      |       ^
+      |newSource1.scala:10: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |      @JSExportTopLevel("namespaced.export4")
+      |       ^
+      |newSource1.scala:12: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |  (you can suppress this warning in 0.6.x by passing the option `-P:scalajs:suppressExportDeprecations` to scalac)
+      |      @JSExportTopLevel("namespaced.export5")
+      |       ^
+    """
+  }
+
 }

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -1890,4 +1890,22 @@ class JSExportTest extends DirectTest with TestHelpers {
     }
     """.succeeds
   }
+
+  @Test
+  def noWarnJSExportTopLevelNamespacedWhenSuppressed: Unit = {
+    """
+    @JSExportTopLevel("namespaced.export1")
+    object A
+    @JSExportTopLevel("namespaced.export2")
+    class B
+    object C {
+      @JSExportTopLevel("namespaced.export3")
+      val a: Int = 1
+      @JSExportTopLevel("namespaced.export4")
+      var b: Int = 1
+      @JSExportTopLevel("namespaced.export5")
+      def c(): Int = 1
+    }
+    """.hasNoWarns
+  }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -719,14 +719,14 @@ object Build {
 
           val code = {
             s"""
-            var linker = scalajs.QuickLinker;
+            var linker = ScalaJSQuickLinker;
             var lib = linker.linkTestSuiteNode($irPaths, $mainMethods);
 
             var __ScalaJSEnv = $scalaJSEnv;
 
             eval("(function() { 'use strict'; " +
               lib + ";" +
-              "scalajs.TestRunner.runTests();" +
+              "ScalaJSTestRunner.runTests();" +
             "}).call(this);");
             """
           }
@@ -1263,11 +1263,16 @@ object Build {
           previousArtifactSetting,
           mimaBinaryIssueFilters ++= BinaryIncompatibilities.TestInterface,
           unmanagedSourceDirectories in Compile +=
-            baseDirectory.value.getParentFile / "test-common/src/main/scala"
+            baseDirectory.value.getParentFile / "test-common/src/main/scala",
           /* Note: We cannot add the test-common tests, since they test async
            * stuff and JUnit does not support async tests. Therefore we need to
            * block, so we cannot run on JS.
            */
+
+          /* The test bridge uses namespaced top-level exports that we cannot
+           * get rid of in 0.6.x.
+           */
+          scalacOptions += "-P:scalajs:suppressExportDeprecations"
       )
   ).withScalaJSCompiler.dependsOn(library)
 

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
@@ -20,7 +20,7 @@ import org.scalajs.core.tools.logging._
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
-@JSExportTopLevel("scalajs.QuickLinker")
+@JSExportTopLevel("ScalaJSQuickLinker")
 object QuickLinker {
 
   /** Link a Scala.js application on Node.js */

--- a/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
+++ b/tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
@@ -19,7 +19,7 @@ import org.scalajs.testinterface.{ScalaJSClassLoader, TestDetector}
 
 import sbt.testing._
 
-@JSExportTopLevel("scalajs.TestRunner")
+@JSExportTopLevel("ScalaJSTestRunner")
 object TestRunner {
 
   @JSExport


### PR DESCRIPTION
`@JSExportTopLevel` with namespaces (containing a `.`) do not have any appropriate equivalent in ECMAScript modules. This commit deprecates them.

As with other exports-related deprecations, the warnings can be suppressed in 0.6.x with `-P:scalajs:suppressExportDeprecations`.

See also #3478 for additional context.