### PR TITLE
FF ONLY Merge 0.6.x into master, November 7

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -327,6 +327,13 @@ trait PrepJSExports { this: PrepJSInterop =>
                 "identifier")
           }
 
+          // Warn for namespaced top-level exports
+          if (name.contains('.')) {
+            reporter.warning(annot.pos,
+                "Using a namespaced export (with a '.') in @JSExportTopLevel " +
+                "is deprecated.")
+          }
+
         case ExportDestination.Static =>
           def companionIsNonNativeJSClass: Boolean = {
             val companion = symOwner.companionClass

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -1038,6 +1038,9 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:23: error: The top-level export name must be a valid JavaScript identifier
       |    @JSExportTopLevel("not-a-valid-JS-identifier-6.foo")
       |     ^
+      |newSource1.scala:26: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |    @JSExportTopLevel("foo.not-a-valid-JS-identifier-7") // valid
+      |     ^
       |newSource1.scala:29: error: The top-level export name must be a valid JavaScript identifier
       |    @JSExportTopLevel(".tricky")
       |     ^
@@ -1799,5 +1802,40 @@ class JSExportTest extends DirectTest with TestHelpers {
       var c: Int = 1
     }
     """.succeeds
+  }
+
+  @Test
+  def warnJSExportTopLevelNamespaced: Unit = {
+    """
+    @JSExportTopLevel("namespaced.export1")
+    object A
+    @JSExportTopLevel("namespaced.export2")
+    class B
+    object C {
+      @JSExportTopLevel("namespaced.export3")
+      val a: Int = 1
+      @JSExportTopLevel("namespaced.export4")
+      var b: Int = 1
+      @JSExportTopLevel("namespaced.export5")
+      def c(): Int = 1
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |    @JSExportTopLevel("namespaced.export1")
+      |     ^
+      |newSource1.scala:5: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |    @JSExportTopLevel("namespaced.export2")
+      |     ^
+      |newSource1.scala:8: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |      @JSExportTopLevel("namespaced.export3")
+      |       ^
+      |newSource1.scala:10: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |      @JSExportTopLevel("namespaced.export4")
+      |       ^
+      |newSource1.scala:12: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |      @JSExportTopLevel("namespaced.export5")
+      |       ^
+    """
   }
 }


### PR DESCRIPTION
Motivation: get #3482 in so that we can then make namespaced top-level exports an error, before we move on to porting ES module support #3478 to master.
```
$ git checkout -b merge-0.6.x-into-master-november-7
Switched to a new branch 'merge-0.6.x-into-master-november-7'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   c183c3c90 (scalajs/0.6.x) Merge pull request #3478 from sjrd/es2015-modules
|\  
| * b744d12e0 [no-master] Fix #2175: Add support for ECMAScript 2015 modules.
|/  
* 75423ccdc Merge pull request #3482 from sjrd/deprecate-namespaced-export
* 9404d5982 Deprecate namespaced top-level exports.
```
```
$ git merge --no-commit 75423ccdc
CONFLICT (modify/delete): tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala deleted in HEAD and modified in 75423ccdc. Version 75423ccdc of tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala left in tree.
CONFLICT (modify/delete): tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala deleted in HEAD and modified in 75423ccdc. Version 75423ccdc of tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala left in tree.
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
CONFLICT (modify/delete): compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala deleted in HEAD and modified in 75423ccdc. Version 75423ccdc of compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala left in tree.
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
DU compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala
M  compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
UU project/Build.scala
DU tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
DU tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
```
`QuickLinker` and `TestRunner` do not have an equivalent in 1.x:
```
$ git rm -f tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala
tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala: needs merge
rm 'tools/js/src/test/scala/org/scalajs/core/tools/test/js/QuickLinker.scala'
```
```
$ git rm -f tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala
tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala: needs merge
rm 'tools/js/src/test/scala/org/scalajs/core/tools/test/js/TestRunner.scala'
```
Changes to `JSExportDeprecationsTest` are moved to `JSExportTest`:
```
$ git rm -f compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala
compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala: needs merge
rm 'compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportDeprecationsTest.scala'
```
[...] Edit conflicts and fix things up.
```
$ git st
UU compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
MM compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
UU project/Build.scala
```
```diff
$ git diff | cat
diff --cc compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
index ca7a44678,b9d1710cf..000000000
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@@ -320,15 -413,20 +320,22 @@@ trait PrepJSExports { this: PrepJSInter
                  "Only static objects may export their members to the top level")
            }
  
 +          // The top-level name must be a valid JS identifier
 +          if (!isValidIdentifier(name.split('.').head)) {
 +            reporter.error(annot.pos,
 +                "The top-level export name must be a valid JavaScript " +
 +                "identifier")
 +          }
 +
+           // Warn for namespaced top-level exports
 -          if (name.contains('.') && !scalaJSOpts.suppressExportDeprecations) {
++          if (name.contains('.')) {
+             reporter.warning(annot.pos,
+                 "Using a namespaced export (with a '.') in @JSExportTopLevel " +
 -                "is deprecated." +
 -                SuppressExportDeprecationsMsg)
++                "is deprecated.")
+           }
+ 
          case ExportDestination.Static =>
 -          val symOwner =
 -            if (sym.isClassConstructor) sym.owner.owner
 -            else sym.owner
 -
 -          def companionIsScalaJSDefinedJSClass: Boolean = {
 +          def companionIsNonNativeJSClass: Boolean = {
              val companion = symOwner.companionClass
              companion != NoSymbol &&
              !companion.isTrait &&
diff --cc project/Build.scala
index b265f569d,1b710ce5a..000000000
--- a/project/Build.scala
+++ b/project/Build.scala
diff --git a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
index 44991b8c9..e2c57f245 100644
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -1038,6 +1038,9 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:23: error: The top-level export name must be a valid JavaScript identifier
       |    @JSExportTopLevel("not-a-valid-JS-identifier-6.foo")
       |     ^
+      |newSource1.scala:26: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |    @JSExportTopLevel("foo.not-a-valid-JS-identifier-7") // valid
+      |     ^
       |newSource1.scala:29: error: The top-level export name must be a valid JavaScript identifier
       |    @JSExportTopLevel(".tricky")
       |     ^
@@ -1802,7 +1805,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noWarnJSExportTopLevelNamespacedWhenSuppressed: Unit = {
+  def warnJSExportTopLevelNamespaced: Unit = {
     """
     @JSExportTopLevel("namespaced.export1")
     object A
@@ -1816,6 +1819,23 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExportTopLevel("namespaced.export5")
       def c(): Int = 1
     }
-    """.hasNoWarns
+    """ hasWarns
+    """
+      |newSource1.scala:3: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |    @JSExportTopLevel("namespaced.export1")
+      |     ^
+      |newSource1.scala:5: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |    @JSExportTopLevel("namespaced.export2")
+      |     ^
+      |newSource1.scala:8: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |      @JSExportTopLevel("namespaced.export3")
+      |       ^
+      |newSource1.scala:10: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |      @JSExportTopLevel("namespaced.export4")
+      |       ^
+      |newSource1.scala:12: warning: Using a namespaced export (with a '.') in @JSExportTopLevel is deprecated.
+      |      @JSExportTopLevel("namespaced.export5")
+      |       ^
+    """
   }
 }
```
```
$ git add -u
```
```
$ git st
M  compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
M  compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
```
```
$ git commit
[merge-0.6.x-into-master-november-7 27d644ebc] Merge '0.6.x' into 'master'.
```
I stop here for today. I'm not yet doing a `git merge -s ours` of #3478. I'll do that *after* we've ported the support for ES modules to 1.x, otherwise the history will be a bit weird.