### PR TITLE
Disallow namespaced top-level exports.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -321,7 +321,7 @@ trait PrepJSExports { this: PrepJSInterop =>
           }
 
           // The top-level name must be a valid JS identifier
-          if (!isValidIdentifier(name.split('.').head)) {
+          if (!isValidIdentifier(name)) {
             reporter.error(annot.pos,
                 "The top-level export name must be a valid JavaScript " +
                 "identifier")

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -1006,15 +1006,6 @@ class JSExportTest extends DirectTest with TestHelpers {
 
     @JSExportTopLevel("")
     object D
-
-    @JSExportTopLevel("not-a-valid-JS-identifier-6.foo")
-    object E
-
-    @JSExportTopLevel("foo.not-a-valid-JS-identifier-7") // valid
-    object F
-
-    @JSExportTopLevel(".tricky")
-    object G
     """ hasErrors
     """
       |newSource1.scala:3: error: The top-level export name must be a valid JavaScript identifier
@@ -1035,12 +1026,41 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:20: error: The top-level export name must be a valid JavaScript identifier
       |    @JSExportTopLevel("")
       |     ^
-      |newSource1.scala:23: error: The top-level export name must be a valid JavaScript identifier
-      |    @JSExportTopLevel("not-a-valid-JS-identifier-6.foo")
+    """
+  }
+
+  @Test
+  def noExportTopLevelNamespaced: Unit = {
+    """
+    @JSExportTopLevel("namespaced.export1")
+    object A
+    @JSExportTopLevel("namespaced.export2")
+    class B
+    object C {
+      @JSExportTopLevel("namespaced.export3")
+      val a: Int = 1
+      @JSExportTopLevel("namespaced.export4")
+      var b: Int = 1
+      @JSExportTopLevel("namespaced.export5")
+      def c(): Int = 1
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:3: error: The top-level export name must be a valid JavaScript identifier
+      |    @JSExportTopLevel("namespaced.export1")
       |     ^
-      |newSource1.scala:29: error: The top-level export name must be a valid JavaScript identifier
-      |    @JSExportTopLevel(".tricky")
+      |newSource1.scala:5: error: The top-level export name must be a valid JavaScript identifier
+      |    @JSExportTopLevel("namespaced.export2")
       |     ^
+      |newSource1.scala:8: error: The top-level export name must be a valid JavaScript identifier
+      |      @JSExportTopLevel("namespaced.export3")
+      |       ^
+      |newSource1.scala:10: error: The top-level export name must be a valid JavaScript identifier
+      |      @JSExportTopLevel("namespaced.export4")
+      |       ^
+      |newSource1.scala:12: error: The top-level export name must be a valid JavaScript identifier
+      |      @JSExportTopLevel("namespaced.export5")
+      |       ^
     """
   }
 

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -915,25 +915,25 @@ object Printers {
 
     def print(topLevelExportDef: TopLevelExportDef): Unit = {
       topLevelExportDef match {
-        case TopLevelJSClassExportDef(fullName) =>
+        case TopLevelJSClassExportDef(exportName) =>
           print("export top class \"")
-          printEscapeJS(fullName, out)
+          printEscapeJS(exportName, out)
           print('\"')
 
-        case TopLevelModuleExportDef(fullName) =>
+        case TopLevelModuleExportDef(exportName) =>
           print("export top module \"")
-          printEscapeJS(fullName, out)
+          printEscapeJS(exportName, out)
           print('\"')
 
         case TopLevelMethodExportDef(methodDef) =>
           print("export top ")
           print(methodDef)
 
-        case TopLevelFieldExportDef(fullName, field) =>
+        case TopLevelFieldExportDef(exportName, field) =>
           print("export top static field ")
           print(field)
           print(" as \"")
-          printEscapeJS(fullName, out)
+          printEscapeJS(exportName, out)
           print('\"')
       }
     }

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -536,21 +536,21 @@ object Serializers {
       import buffer._
       writePosition(topLevelExportDef.pos)
       topLevelExportDef match {
-        case TopLevelJSClassExportDef(fullName) =>
+        case TopLevelJSClassExportDef(exportName) =>
           writeByte(TagTopLevelJSClassExportDef)
-          writeString(fullName)
+          writeString(exportName)
 
-        case TopLevelModuleExportDef(fullName) =>
+        case TopLevelModuleExportDef(exportName) =>
           writeByte(TagTopLevelModuleExportDef)
-          writeString(fullName)
+          writeString(exportName)
 
         case TopLevelMethodExportDef(methodDef) =>
           writeByte(TagTopLevelMethodExportDef)
           writeMemberDef(methodDef)
 
-        case TopLevelFieldExportDef(fullName, field) =>
+        case TopLevelFieldExportDef(exportName, field) =>
           writeByte(TagTopLevelFieldExportDef)
-          writeString(fullName); writeIdent(field)
+          writeString(exportName); writeIdent(field)
       }
     }
 

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -999,7 +999,7 @@ object Trees {
     }
   }
 
-  case class TopLevelJSClassExportDef(fullName: String)(
+  case class TopLevelJSClassExportDef(exportName: String)(
       implicit val pos: Position) extends TopLevelExportDef
 
   /** Export for a top-level object.
@@ -1007,13 +1007,13 @@ object Trees {
    *  This exports the singleton instance of the containing module class.
    *  The instance is initialized during ES module instantiation.
    */
-  case class TopLevelModuleExportDef(fullName: String)(
+  case class TopLevelModuleExportDef(exportName: String)(
       implicit val pos: Position) extends TopLevelExportDef
 
   case class TopLevelMethodExportDef(methodDef: MethodDef)(
       implicit val pos: Position) extends TopLevelExportDef
 
-  case class TopLevelFieldExportDef(fullName: String, field: Ident)(
+  case class TopLevelFieldExportDef(exportName: String, field: Ident)(
       implicit val pos: Position) extends TopLevelExportDef
 
   // Miscellaneous

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -231,7 +231,7 @@ private final class IRChecker(unit: LinkingUnit,
           case TopLevelMethodExportDef(methodDef) =>
             checkExportedMethodDef(methodDef, classDef, isTopLevel = true)
 
-          case TopLevelFieldExportDef(fullName, field) =>
+          case TopLevelFieldExportDef(_, field) =>
             lookupClass(classDef.name.name).lookupStaticField(field.name).fold {
               reportError(s"Cannot export non-existent static field '$field'")
             } { checkedField =>

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -52,9 +52,6 @@ class ExportsTest {
     }
   }
 
-  /** This package in the JS (export) namespace */
-  val jsPackage = exportsNamespace.org.scalajs.testsuite.jsinterop
-
   // @JSExport
 
   @Test def exports_for_methods_with_implicit_name(): Unit = {
@@ -705,15 +702,8 @@ class ExportsTest {
     assertSame(obj1, SJSDefinedExportedObject)
   }
 
-  @Test def toplevel_exports_for_objects_with_qualified_name(): Unit = {
-    val obj = exportsNamespace.qualified.testobject.TopLevelExportedObject
-    assertJSNotUndefined(obj)
-    assertEquals("object", js.typeOf(obj))
-    assertEquals("witness", obj.witness)
-  }
-
   @Test def toplevel_exports_for_nested_objects(): Unit = {
-    val obj = exportsNamespace.qualified.nested.ExportedObject
+    val obj = exportsNamespace.NestedExportedObject
     assertJSNotUndefined(obj)
     assertEquals("object", js.typeOf(obj))
     assertSame(obj, ExportHolder.ExportedObject)
@@ -752,46 +742,20 @@ class ExportsTest {
     assertSame(constr, js.constructorOf[SJSDefinedTopLevelExportedClass])
   }
 
-  @Test def toplevel_exports_for_classes_with_qualified_name(): Unit = {
-    val constr = exportsNamespace.qualified.testclass.TopLevelExportedClass
-    assertJSNotUndefined(constr)
-    assertEquals("function", js.typeOf(constr))
-    val obj = js.Dynamic.newInstance(constr)(5)
-    assertEquals(5, obj.x)
-  }
-
   @Test def toplevel_exports_for_nested_classes(): Unit = {
-    val constr = exportsNamespace.qualified.nested.ExportedClass
+    val constr = exportsNamespace.NestedExportedClass
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)()
     assertTrue((obj: Any).isInstanceOf[ExportHolder.ExportedClass])
   }
 
-  @Test def toplevel_exports_for_classes_with_qualified_name_SJSDefinedExportedClass(): Unit = {
-    val constr = exportsNamespace.qualified.testclass.SJSDefinedTopLevelExportedClass
-    assertJSNotUndefined(constr)
-    assertEquals("function", js.typeOf(constr))
-    val obj = js.Dynamic.newInstance(constr)(5)
-    assertTrue((obj: Any).isInstanceOf[SJSDefinedTopLevelExportedClass])
-    assertEquals(5, obj.x)
-  }
-
   @Test def toplevel_exports_for_nested_sjs_defined_classes(): Unit = {
-    val constr = exportsNamespace.qualified.nested.SJSDefinedExportedClass
+    val constr = exportsNamespace.NestedSJSDefinedExportedClass
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)()
     assertTrue((obj: Any).isInstanceOf[ExportHolder.SJSDefinedExportedClass])
-  }
-
-  @Test def toplevel_exports_under_nested_invalid_js_identifier(): Unit = {
-    val constr = exportsNamespace.qualified.selectDynamic("not-a-JS-identifier")
-    assertJSNotUndefined(constr)
-    assertEquals("function", js.typeOf(constr))
-    val obj = js.Dynamic.newInstance(constr)()
-    assertTrue(
-        (obj: Any).isInstanceOf[ExportHolder.ClassExportedUnderNestedInvalidJSIdentifier])
   }
 
   @Test def exports_for_classes_with_constant_folded_name(): Unit = {
@@ -973,11 +937,6 @@ class ExportsTest {
     val foo = (new Foo).asInstanceOf[js.Dynamic]
 
     assertEquals(1, foo.b)
-  }
-
-  @Test def exporting_under_org_namespace_issue_364(): Unit = {
-    val obj = exportsNamespace.org.ExportedUnderOrgObject
-    assertSame(ExportedUnderOrgObject.asInstanceOf[js.Any], obj)
   }
 
   @Test def null_for_arguments_of_primitive_value_type_issue_1719(): Unit = {
@@ -1229,48 +1188,43 @@ class ExportsTest {
   // @JSExportTopLevel
 
   @Test def basic_top_level_export(): Unit = {
-    assertEquals(1, jsPackage.toplevel.basic())
+    assertEquals(1, exportsNamespace.TopLevelExport_basic())
   }
 
   @Test def overloaded_top_level_export(): Unit = {
-    assertEquals("Hello World", jsPackage.toplevel.overload("World"))
-    assertEquals(2, jsPackage.toplevel.overload(2))
-    assertEquals(9, jsPackage.toplevel.overload(2, 7))
-    assertEquals(10, jsPackage.toplevel.overload(1, 2, 3, 4))
-  }
-
-  @Test def method_top_level_export_under_invalid_js_identifier(): Unit = {
-    assertEquals("not an identifier",
-        jsPackage.toplevel.applyDynamic("not-a-JS-identifier")())
+    assertEquals("Hello World", exportsNamespace.TopLevelExport_overload("World"))
+    assertEquals(2, exportsNamespace.TopLevelExport_overload(2))
+    assertEquals(9, exportsNamespace.TopLevelExport_overload(2, 7))
+    assertEquals(10, exportsNamespace.TopLevelExport_overload(1, 2, 3, 4))
   }
 
   @Test def top_level_export_uses_unique_object(): Unit = {
-    jsPackage.toplevel.set(3)
+    exportsNamespace.TopLevelExport_set(3)
     assertEquals(3, TopLevelExports.myVar)
-    jsPackage.toplevel.set(7)
+    exportsNamespace.TopLevelExport_set(7)
     assertEquals(7, TopLevelExports.myVar)
   }
 
   @Test def top_level_export_from_nested_object(): Unit = {
-    jsPackage.toplevel.setNested(28)
+    exportsNamespace.TopLevelExport_setNested(28)
     assertEquals(28, TopLevelExports.Nested.myVar)
   }
 
   @Test def top_level_export_is_always_reachable(): Unit = {
-    assertEquals("Hello World", jsPackage.toplevel.reachability())
+    assertEquals("Hello World", exportsNamespace.TopLevelExport_reachability())
   }
 
   // @JSExportTopLevel fields
 
   @Test def top_level_export_basic_field(): Unit = {
     // Initialization
-    assertEquals(5, jsPackage.toplevel.basicVal)
-    assertEquals("hello", jsPackage.toplevel.basicVar)
+    assertEquals(5, exportsNamespace.TopLevelExport_basicVal)
+    assertEquals("hello", exportsNamespace.TopLevelExport_basicVar)
 
     // Scala modifies var
     TopLevelFieldExports.basicVar = "modified"
     assertEquals("modified", TopLevelFieldExports.basicVar)
-    assertEquals("modified", jsPackage.toplevel.basicVar)
+    assertEquals("modified", exportsNamespace.TopLevelExport_basicVar)
 
     // Reset var
     TopLevelFieldExports.basicVar = "hello"
@@ -1278,15 +1232,15 @@ class ExportsTest {
 
   @Test def top_level_export_field_twice(): Unit = {
     // Initialization
-    assertEquals(5, jsPackage.toplevel.valExportedTwice1)
-    assertEquals("hello", jsPackage.toplevel.varExportedTwice1)
-    assertEquals("hello", jsPackage.toplevel.varExportedTwice2)
+    assertEquals(5, exportsNamespace.TopLevelExport_valExportedTwice1)
+    assertEquals("hello", exportsNamespace.TopLevelExport_varExportedTwice1)
+    assertEquals("hello", exportsNamespace.TopLevelExport_varExportedTwice2)
 
     // Scala modifies var
     TopLevelFieldExports.varExportedTwice = "modified"
     assertEquals("modified", TopLevelFieldExports.varExportedTwice)
-    assertEquals("modified", jsPackage.toplevel.varExportedTwice1)
-    assertEquals("modified", jsPackage.toplevel.varExportedTwice2)
+    assertEquals("modified", exportsNamespace.TopLevelExport_varExportedTwice1)
+    assertEquals("modified", exportsNamespace.TopLevelExport_varExportedTwice2)
 
     // Reset var
     TopLevelFieldExports.varExportedTwice = "hello"
@@ -1294,30 +1248,30 @@ class ExportsTest {
 
   @Test def top_level_export_write_val_var_causes_typeerror(): Unit = {
     assertThrows(classOf[js.JavaScriptException], {
-      jsPackage.toplevel.basicVal = 54
+      exportsNamespace.TopLevelExport_basicVal = 54
     })
 
     assertThrows(classOf[js.JavaScriptException], {
-      jsPackage.toplevel.basicVar = 54
+      exportsNamespace.TopLevelExport_basicVar = 54
     })
   }
 
   @Test def top_level_export_uninitialized_fields(): Unit = {
     assertEquals(0, TopLevelFieldExports.uninitializedVarInt)
-    assertEquals(null, jsPackage.toplevel.uninitializedVarInt)
+    assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarInt)
 
     assertEquals(0L, TopLevelFieldExports.uninitializedVarLong)
-    assertEquals(null, jsPackage.toplevel.uninitializedVarLong)
+    assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarLong)
 
     assertEquals(null, TopLevelFieldExports.uninitializedVarString)
-    assertEquals(null, jsPackage.toplevel.uninitializedVarString)
+    assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarString)
 
     assertEquals('\u0000', TopLevelFieldExports.uninitializedVarChar)
-    assertEquals(null, jsPackage.toplevel.uninitializedVarChar)
+    assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarChar)
   }
 
   @Test def top_level_export_field_is_always_reachable_and_initialized(): Unit = {
-    assertEquals("Hello World", jsPackage.toplevel.fieldreachability)
+    assertEquals("Hello World", exportsNamespace.TopLevelExport_fieldreachability)
   }
 
 }
@@ -1329,7 +1283,6 @@ object ExportNameHolder {
 }
 
 @JSExportTopLevel("TopLevelExportedObject")
-@JSExportTopLevel("qualified.testobject.TopLevelExportedObject")
 @JSExportTopLevel(ExportNameHolder.objectName)
 object TopLevelExportedObject {
   @JSExport
@@ -1337,7 +1290,6 @@ object TopLevelExportedObject {
 }
 
 @JSExportTopLevel("SJSDefinedTopLevelExportedObject")
-@JSExportTopLevel("qualified.testobject.SJSDefinedTopLevelExportedObject")
 object SJSDefinedExportedObject extends js.Object {
   val witness: String = "witness"
 }
@@ -1349,7 +1301,6 @@ protected object ProtectedExportedObject {
 }
 
 @JSExportTopLevel("TopLevelExportedClass")
-@JSExportTopLevel("qualified.testclass.TopLevelExportedClass")
 @JSExportTopLevel(ExportNameHolder.className)
 class TopLevelExportedClass(_x: Int) {
   @JSExport
@@ -1357,7 +1308,6 @@ class TopLevelExportedClass(_x: Int) {
 }
 
 @JSExportTopLevel("SJSDefinedTopLevelExportedClass")
-@JSExportTopLevel("qualified.testclass.SJSDefinedTopLevelExportedClass")
 class SJSDefinedTopLevelExportedClass(val x: Int) extends js.Object
 
 @JSExportTopLevel("ProtectedExportedClass")
@@ -1386,47 +1336,38 @@ class ExportedDefaultArgClass(x: Int, y: Int, z: Int) {
   def result: Int = x + y + z
 }
 
-@JSExportTopLevel("org.ExportedUnderOrgObject")
-object ExportedUnderOrgObject
-
 class SomeValueClass(val i: Int) extends AnyVal
 
 object ExportHolder {
-  @JSExportTopLevel("qualified.nested.ExportedClass")
+  @JSExportTopLevel("NestedExportedClass")
   class ExportedClass
 
-  @JSExportTopLevel("qualified.nested.ExportedObject")
+  @JSExportTopLevel("NestedExportedObject")
   object ExportedObject
 
-  @JSExportTopLevel("qualified.nested.SJSDefinedExportedClass")
+  @JSExportTopLevel("NestedSJSDefinedExportedClass")
   class SJSDefinedExportedClass extends js.Object
-
-  @JSExportTopLevel("qualified.not-a-JS-identifier")
-  class ClassExportedUnderNestedInvalidJSIdentifier
 }
 
 object TopLevelExports {
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.basic")
+  @JSExportTopLevel("TopLevelExport_basic")
   def basic(): Int = 1
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.overload")
+  @JSExportTopLevel("TopLevelExport_overload")
   def overload(x: String): String = "Hello " + x
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.overload")
+  @JSExportTopLevel("TopLevelExport_overload")
   def overload(x: Int, y: Int*): Int = x + y.sum
-
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.not-a-JS-identifier")
-  def methodExportedUnderNestedInvalidJSIdentifier(): String = "not an identifier"
 
   var myVar: Int = _
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.set")
+  @JSExportTopLevel("TopLevelExport_set")
   def setMyVar(x: Int): Unit = myVar = x
 
   object Nested {
     var myVar: Int = _
 
-    @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.setNested")
+    @JSExportTopLevel("TopLevelExport_setNested")
     def setMyVar(x: Int): Unit = myVar = x
   }
 }
@@ -1437,35 +1378,35 @@ object TopLevelExports {
 object TopLevelExportsReachability {
   private val name = "World"
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.reachability")
+  @JSExportTopLevel("TopLevelExport_reachability")
   def basic(): String = "Hello " + name
 }
 
 object TopLevelFieldExports {
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.basicVal")
+  @JSExportTopLevel("TopLevelExport_basicVal")
   val basicVal: Int = 5
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.basicVar")
+  @JSExportTopLevel("TopLevelExport_basicVar")
   var basicVar: String = "hello"
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.valExportedTwice1")
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.valExportedTwice2")
+  @JSExportTopLevel("TopLevelExport_valExportedTwice1")
+  @JSExportTopLevel("TopLevelExport_valExportedTwice2")
   val valExportedTwice: Int = 5
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.varExportedTwice1")
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.varExportedTwice2")
+  @JSExportTopLevel("TopLevelExport_varExportedTwice1")
+  @JSExportTopLevel("TopLevelExport_varExportedTwice2")
   var varExportedTwice: String = "hello"
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.uninitializedVarInt")
+  @JSExportTopLevel("TopLevelExport_uninitializedVarInt")
   var uninitializedVarInt: Int = _
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.uninitializedVarLong")
+  @JSExportTopLevel("TopLevelExport_uninitializedVarLong")
   var uninitializedVarLong: Long = _
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.uninitializedVarString")
+  @JSExportTopLevel("TopLevelExport_uninitializedVarString")
   var uninitializedVarString: String = _
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.uninitializedVarChar")
+  @JSExportTopLevel("TopLevelExport_uninitializedVarChar")
   var uninitializedVarChar: Char = _
 }
 
@@ -1476,6 +1417,6 @@ object TopLevelFieldExports {
 object TopLevelFieldExportsReachability {
   private val name = "World"
 
-  @JSExportTopLevel("org.scalajs.testsuite.jsinterop.toplevel.fieldreachability")
+  @JSExportTopLevel("TopLevelExport_fieldreachability")
   val greeting = "Hello " + name
 }


### PR DESCRIPTION
`@JSExportTopLevel` with namespaces (containing a `.`) were deprecated in 9404d59827747bd36bb64e09b494bbaa4b423203 because they do not have any appropriate equivalent in ECMAScript modules. This commit disallows them.

Afterwards, the definition of the IR is implicitly simplified, and we rename the field `fullName` to `exportName` now that it cannot contain namespaces anymore.

We simplify the `ClassEmitter` as we remove all the handling of namespaces in top-level exports.