### PR TITLE
Fix #2175: Add support for ECMAScript 2015 modules.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -112,6 +112,18 @@ def Tasks = [
         'set scalaJSLinkerConfig in helloworld ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         helloworld/run \
         helloworld/clean &&
+    sbtretry ++$scala \
+        'set artifactPath in (helloworld, Compile, fastOptJS) := (crossTarget in helloworld).value / "helloworld-fastopt.mjs"' \
+        'set jsEnv in helloworld := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSLinkerConfig in helloworld ~= (_.withModuleKind(ModuleKind.ESModule))' \
+        helloworld/run &&
+    sbtretry ++$scala \
+        'set artifactPath in (helloworld, Compile, fullOptJS) := (crossTarget in helloworld).value / "helloworld-opt.mjs"' \
+        'set jsEnv in helloworld := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSLinkerConfig in helloworld ~= (_.withModuleKind(ModuleKind.ESModule))' \
+        'set scalaJSStage in Global := FullOptStage' \
+        helloworld/run \
+        helloworld/clean &&
     sbtretry ++$scala testingExample/testHtml &&
     sbtretry 'set scalaJSStage in Global := FullOptStage' \
         ++$scala testingExample/testHtml \
@@ -169,6 +181,18 @@ def Tasks = [
     sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set artifactPath in ($testSuite, Test, fastOptJS) := (crossTarget in $testSuite).value / "testsuite-fastopt.mjs"' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSLinkerConfig in $testSuite ~= (_.withModuleKind(ModuleKind.ESModule))' \
+        'set MyScalaJSPlugin.wantSourceMaps in $testSuite := false' \
+        ++$scala $testSuite/test &&
+    sbtretry 'set artifactPath in ($testSuite, Test, fullOptJS) := (crossTarget in $testSuite).value / "testsuite-opt.mjs"' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSLinkerConfig in $testSuite ~= (_.withModuleKind(ModuleKind.ESModule))' \
+        'set MyScalaJSPlugin.wantSourceMaps in $testSuite := false' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test
   ''',
@@ -242,6 +266,18 @@ def Tasks = [
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
         'set scalaJSLinkerConfig in $testSuite ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala $testSuite/test \
+        $testSuite/clean &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
+        'set artifactPath in ($testSuite, Test, fastOptJS) := (crossTarget in $testSuite).value / "testsuite-fastopt.mjs"' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSLinkerConfig in $testSuite ~= (_.withModuleKind(ModuleKind.ESModule))' \
+        ++$scala $testSuite/test &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite ~= (_.withESFeatures(_.withUseECMAScript2015(true)))' \
+        'set artifactPath in ($testSuite, Test, fullOptJS) := (crossTarget in $testSuite).value / "testsuite-opt.mjs"' \
+        'set jsEnv in $testSuite := new org.scalajs.jsenv.nodejs.NodeJSEnv(org.scalajs.jsenv.nodejs.NodeJSEnv.Config().withArgs(List("--experimental-modules")).withSourceMap(false))' \
+        'set scalaJSLinkerConfig in $testSuite ~= (_.withModuleKind(ModuleKind.ESModule))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite/test
   ''',

--- a/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
@@ -29,6 +29,16 @@ object Input {
   /** All files are to be loaded as scripts into the global scope in the order given. */
   final case class ScriptsToLoad(scripts: List[VirtualBinaryFile]) extends Input
 
+  /** All files are to be loaded as ES modules, in the given order.
+   *
+   *  Some environments may not be able to execute several ES modules in a
+   *  deterministic order. If that is the case, they must reject an
+   *  `ESModulesToLoad` input if the `modules` argument has more than one
+   *  element.
+   */
+  final case class ESModulesToLoad(modules: List[VirtualBinaryFile])
+      extends Input
+
   /** All files are to be loaded as CommonJS modules, in the given order. */
   final case class CommonJSModulesToLoad(modules: List[VirtualBinaryFile])
       extends Input

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -44,12 +44,15 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
   import config.commonConfig.coreSpec._
 
   require(!esFeatures.useECMAScript2015,
-      s"Cannot use features $esFeatures with the Closure Compiler" +
+      s"Cannot use features $esFeatures with the Closure Compiler " +
       "because they contain ECMAScript 2015 features")
 
   require(!esFeatures.allowBigIntsForLongs,
-      s"Cannot use features $esFeatures with the Closure Compiler" +
+      s"Cannot use features $esFeatures with the Closure Compiler " +
       "because they allow to use BigInts")
+
+  require(moduleKind != ModuleKind.ESModule,
+      s"Cannot use module kind $moduleKind with the Closure Compiler")
 
   private[this] val emitter = {
     new Emitter(config.commonConfig)
@@ -59,8 +62,8 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements
 
   private val needsIIFEWrapper = moduleKind match {
-    case ModuleKind.NoModule       => true
-    case ModuleKind.CommonJSModule => false
+    case ModuleKind.NoModule                             => true
+    case ModuleKind.ESModule | ModuleKind.CommonJSModule => false
   }
 
   /** Emit the given [[standard.LinkingUnit LinkingUnit]] to the target output.

--- a/linker/shared/src/main/scala/org/scalajs/linker/ModuleKind.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/ModuleKind.scala
@@ -24,6 +24,7 @@ object ModuleKind {
    */
   val All: List[ModuleKind] = List(
       NoModule,
+      ESModule,
       CommonJSModule)
 
   /** No module structure.
@@ -33,6 +34,13 @@ object ModuleKind {
    *  Imports are not supported.
    */
   case object NoModule extends ModuleKind
+
+  /** An ECMAScript 2015 module.
+   *
+   *  Scala.js imports and exports directly map to `import` and `export`
+   *  clauses in the ES module.
+   */
+  case object ESModule extends ModuleKind
 
   /** A CommonJS module (notably used by Node.js).
    *

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -148,8 +148,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
     require(useClasses)
 
     val className = tree.name.name
-    val classIdent =
-      encodeClassVar(className)(tree.name.pos).asInstanceOf[js.VarRef].ident
+    val classIdent = encodeClassVar(className)(tree.name.pos).ident
 
     val parentVarWithGlobals = for (parentIdent <- tree.superClass) yield {
       implicit val pos = parentIdent.pos
@@ -1102,6 +1101,12 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
       case ModuleKind.NoModule =>
         genAssignToNoModuleExportVar(exportName, exportedValue)
 
+      case ModuleKind.ESModule =>
+        val field = envField("e", exportName)
+        val let = js.Let(field.ident, mutable = true, Some(exportedValue))
+        val export = js.Export((field.ident -> js.ExportName(exportName)) :: Nil)
+        WithGlobals(js.Block(let, export))
+
       case ModuleKind.CommonJSModule =>
         val exportsVarRef = js.VarRef(js.Ident("exports"))
         WithGlobals(js.Assign(
@@ -1136,6 +1141,11 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
          */
         genAssignToNoModuleExportVar(exportName,
             genSelectStatic(cd.encodedName, field))
+
+      case ModuleKind.ESModule =>
+        val staticVarIdent = genSelectStatic(cd.encodedName, field).ident
+        WithGlobals(
+            js.Export((staticVarIdent -> js.ExportName(exportName)) :: Nil))
 
       case ModuleKind.CommonJSModule =>
         // defineProperty method

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -96,7 +96,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
   }
 
   def genSelectStatic(className: String, item: irt.Ident)(
-      implicit pos: Position): Tree = {
+      implicit pos: Position): VarRef = {
     envField("t", className + "__" + item.name)
   }
 
@@ -163,7 +163,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
     Apply(envField(helperName), args.toList)
   }
 
-  def encodeClassVar(className: String)(implicit pos: Position): Tree =
+  def encodeClassVar(className: String)(implicit pos: Position): VarRef =
     envField("c", className)
 
   def genLoadModule(moduleClass: String)(implicit pos: Position): Tree = {
@@ -224,7 +224,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
       case irt.JSNativeLoadSpec.Import(module, path) =>
         val moduleValue = envModuleField(module)
         path match {
-          case DefaultExportName :: rest =>
+          case DefaultExportName :: rest if moduleKind == ModuleKind.CommonJSModule =>
             val defaultField = genCallHelper("moduleDefault", moduleValue)
             WithGlobals(pathSelection(defaultField, rest))
           case _ =>
@@ -235,7 +235,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
         moduleKind match {
           case ModuleKind.NoModule =>
             genLoadJSFromSpec(globalSpec, keepOnlyDangerousVarNames)
-          case ModuleKind.CommonJSModule =>
+          case ModuleKind.ESModule | ModuleKind.CommonJSModule =>
             genLoadJSFromSpec(importSpec, keepOnlyDangerousVarNames)
         }
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -585,6 +585,49 @@ object Printers {
         case Super() =>
           print("super")
 
+        // ECMAScript 6 modules
+
+        case Import(bindings, from) =>
+          print("import { ")
+          var first = true
+          var rest = bindings
+          while (rest.nonEmpty) {
+            val binding = rest.head
+            if (first)
+              first = false
+            else
+              print(", ")
+            print(binding._1)
+            print(" as ")
+            print(binding._2)
+            rest = rest.tail
+          }
+          print(" } from ")
+          print(from: Tree)
+
+        case ImportNamespace(binding, from) =>
+          print("import * as ")
+          print(binding)
+          print(" from ")
+          print(from: Tree)
+
+        case Export(bindings) =>
+          print("export { ")
+          var first = true
+          var rest = bindings
+          while (rest.nonEmpty) {
+            val binding = rest.head
+            if (first)
+              first = false
+            else
+              print(", ")
+            print(binding._1)
+            print(" as ")
+            print(binding._2)
+            rest = rest.tail
+          }
+          print(" }")
+
         case _ =>
           print(s"<error, elem of class ${tree.getClass}>")
       }
@@ -605,6 +648,9 @@ object Printers {
         print(tree)
         print("]")
     }
+
+    protected def print(exportName: ExportName): Unit =
+      printEscapeJS(exportName.name)
 
     protected def print(s: String): Unit =
       out.write(s)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -288,9 +288,13 @@ private[sbtplugin] object ScalaJSPluginInternal {
             ((moduleName in fullOptJS).value + "-opt.js")),
 
       scalaJSLinkerConfig in fullOptJS ~= { prevConfig =>
+        val useClosure = {
+          !prevConfig.esFeatures.useECMAScript2015 &&
+          prevConfig.moduleKind != ModuleKind.ESModule
+        }
         prevConfig
           .withSemantics(_.optimized)
-          .withClosureCompiler(!prevConfig.esFeatures.useECMAScript2015)
+          .withClosureCompiler(useClosure)
       },
 
       scalaJSLinkedFile := Def.settingDyn {
@@ -311,6 +315,8 @@ private[sbtplugin] object ScalaJSPluginInternal {
         scalaJSLinkerConfig.value.moduleKind match {
           case ModuleKind.NoModule =>
             Input.ScriptsToLoad(List(linkedFile))
+          case ModuleKind.ESModule =>
+            Input.ESModulesToLoad(List(linkedFile))
           case ModuleKind.CommonJSModule =>
             Input.CommonJSModulesToLoad(List(linkedFile))
         }

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -60,6 +60,7 @@ object Platform {
   def hasStrictFloats: Boolean = sysProp("strict-floats")
 
   def isNoModule: Boolean = sysProp("modulekind-nomodule")
+  def isESModule: Boolean = sysProp("modulekind-esmodule")
   def isCommonJSModule: Boolean = sysProp("modulekind-commonjs")
 
   private def sysProp(key: String): Boolean =

--- a/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ModulesTest.scala
+++ b/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ModulesTest.scala
@@ -26,7 +26,7 @@ class ModulesTest {
 
   @Test def testImportModuleItself(): Unit = {
     val qs = QueryString
-    assertTrue(qs.isInstanceOf[js.Object])
+    assertEquals("object", js.typeOf(qs))
 
     val dict = js.Dictionary("foo" -> "bar", "baz" -> "qux")
 
@@ -42,7 +42,7 @@ class ModulesTest {
 
   @Test def testImportLegacyModuleItselfAsDefault(): Unit = {
     val qs = QueryStringAsDefault
-    assertTrue(qs.isInstanceOf[js.Object])
+    assertEquals("object", js.typeOf(qs))
 
     val dict = js.Dictionary("foo" -> "bar", "baz" -> "qux")
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -69,6 +69,8 @@ class SystemJSTest {
   @Test def systemProperties(): Unit = {
     def get(key: String): String = java.lang.System.getProperty(key)
 
+    def trueCount(xs: Boolean*): Int = xs.count(identity)
+
     // Defined in System.scala
 
     assertEquals("1.8", get("java.version"))
@@ -133,9 +135,11 @@ class SystemJSTest {
     assertEquals(isInFullOpt, Platform.isInFullOpt)
 
     val isNoModule = get("scalajs.modulekind-nomodule") == "true"
+    val isESModule = get("scalajs.modulekind-esmodule") == "true"
     val isCommonJSModule = get("scalajs.modulekind-commonjs") == "true"
     assertEquals(isNoModule, Platform.isNoModule)
+    assertEquals(isESModule, Platform.isESModule)
     assertEquals(isCommonJSModule, Platform.isCommonJSModule)
-    assertTrue(isNoModule ^ isCommonJSModule)
+    assertEquals(1, trueCount(isNoModule, isESModule, isCommonJSModule))
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ModulesWithGlobalFallbackTest.scala
@@ -33,7 +33,7 @@ class ModulesWithGlobalFallbackTest {
 
   @Test def testImportModuleItself(): Unit = {
     val qs = QueryString
-    assertTrue(qs.isInstanceOf[js.Object])
+    assertEquals("object", js.typeOf(qs))
 
     val dict = js.Dictionary("foo" -> "bar", "baz" -> "qux")
 
@@ -49,7 +49,7 @@ class ModulesWithGlobalFallbackTest {
 
   @Test def testImportLegacyModuleItselfAsDefault(): Unit = {
     val qs = QueryStringAsDefault
-    assertTrue(qs.isInstanceOf[js.Object])
+    assertEquals("object", js.typeOf(qs))
 
     val dict = js.Dictionary("foo" -> "bar", "baz" -> "qux")
 


### PR DESCRIPTION
This is a port of b744d12e0c6d8af74960e0ce5071c8e0011249a5.

This commit adds a third `ModuleKind` for ES modules, namely `ModuleKind.ESModule`. When emitting an ES module, `@JSImport`s and `@JSExportTopLevel`s straightforwardly map to ES `import` and `export` clauses, respectively.

At the moment, imports are always implemented using a namespace import, then selecting fields inside the namespace. This is suboptimal because it can prevent advanced DCE across ES modules. Improving on this is left for future work.

The Node.js-based environment is adapted to interpret files whose name ends with `.mjs` as ES modules rather than scripts. This aligns with how Node.js itself identifies ES modules as of version 10.x, although it is still experimental, so that could change in the future.

This mechanism goes against the API of `Input`, which is supposed to address this concern. This needs to be fixed.

Although setting `scalaJSLinkerConfig.moduleKind` to `ModuleKind.ESModule` is enough for the Scala.js linker to emit a valid ES module, two additional settings are required to *run* or *test* using Node.js:
```scala
    artifactPath in (proj, Compile, fastOptJS) :=
      (crossTarget in (proj, Compile)).value / "somename.mjs"

    jsEnv := {
      new org.scalajs.jsenv.NodeJSEnv(
          org.scalajs.jsenv.NODEJSEnv.Config()
            .withArguments(List("--experimental-modules"))
      )
    }
```
The first setting is necessary to give the `.mjs` extension to the file produced by Scala.js, which in turn is necessary for Node.js to accept it as an ES module.

The second setting will be necessary until Node.js declares its support for ES module as non-experimental.

The version of the Closure Compiler that we use does not support ES modules yet, so we deactivate GCC when emitting an ES module.

At this point, the emission of ES modules can be considered stable, but the support in `NodeJSEnv` is experimental (since the support of ES modules in Node.js is itself experimental).

Running the full test suite with ES modules requires Node.js 10.2.0 or later. It has been tested with v10.12.0.