### PR TITLE
Handle cancellation correctly in 1.x's `ComRun`

### DIFF
--- a/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/ComSupport.scala
+++ b/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/ComSupport.scala
@@ -119,16 +119,21 @@ private final class ComRun(run: JSRun, handleMessage: String => Unit,
 
   def close(): Unit = synchronized {
     val oldState = state
+    if (oldState == Closing) () // Do nothing if old state is already closing
+    else {
+      // Close the underlying run
+      run.close()
 
-    // Signal receiver thread that it is OK if socket read fails.
-    state = Closing
+      // Signal receiver thread that it is OK if socket read fails.
+      state = Closing
 
-    oldState match {
-      case c: Connected =>
-        // Interrupts the receiver thread and signals the VM to terminate.
-        closeAll(c)
+      oldState match {
+        case c: Connected =>
+          // Interrupts the receiver thread and signals the VM to terminate.
+          closeAll(c)
 
-      case Closing | _:AwaitingConnection =>
+        case Closing | _: AwaitingConnection =>
+      }
     }
   }
 


### PR DESCRIPTION
In 0.6.x, calling `close` on the test adapter always kills the
underlying processes that are instantiated by the js environments.

Unlike 0.6.x, the latest 1.x test module doesn't kill the underlying
processes. This causes a resource leak that is fatal in Windows
environments (where the underlying process keeps a reference to the
output JS file indefinitely and prevents other tasks in the build tool
from linking again).

This pull request does the following:

1. Invokes `run.close()` in `ComRun`'s' close method.
2. Only runs `close` once, as `ComRun.close` can be called several times.

We're testing cancellation in Bloop for both Scala.js 0.6.x and 1.x and,
after these changes, all tests pass.