### PR TITLE
In `NoModule`, use true top-level `var`s for top-level exports.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
@@ -30,7 +30,7 @@ object Input {
   final case class ScriptsToLoad(scripts: List[VirtualBinaryFile]) extends Input
 }
 
-case class UnsupportedInputException(msg: String, cause: Throwable)
+class UnsupportedInputException(msg: String, cause: Throwable)
     extends IllegalArgumentException(msg, cause) {
   def this(msg: String) = this(msg, null)
   def this(input: Input) = this(s"Unsupported input: $input")

--- a/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/Input.scala
@@ -28,6 +28,10 @@ abstract class Input private ()
 object Input {
   /** All files are to be loaded as scripts into the global scope in the order given. */
   final case class ScriptsToLoad(scripts: List[VirtualBinaryFile]) extends Input
+
+  /** All files are to be loaded as CommonJS modules, in the given order. */
+  final case class CommonJSModulesToLoad(modules: List[VirtualBinaryFile])
+      extends Input
 }
 
 class UnsupportedInputException(msg: String, cause: Throwable)

--- a/linker/scalajsenv.js
+++ b/linker/scalajsenv.js
@@ -7,16 +7,6 @@
  * The top-level Scala.js environment *
  * ---------------------------------- */
 
-// Where to send exports
-//!if moduleKind == CommonJSModule
-const $e = exports;
-//!else
-// TODO Do not use global object detection, and rather export with actual `var` declarations
-const $e = (typeof global === "object" && global && global["Object"] === Object) ? global : this;
-// #3036 - convince GCC that $e must not be dce'ed away
-this["__ScalaJSWorkaroundToRetainExportsInGCC"] = $e;
-//!endif
-
 // Linking info - must be in sync with scala.scalajs.runtime.LinkingInfo
 const $linkingInfo = {
   "semantics": {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -40,7 +40,7 @@ final class Emitter private (config: CommonPhaseConfig,
     this(config, InternalOptions())
   }
 
-  private val knowledgeGuardian = new KnowledgeGuardian
+  private val knowledgeGuardian = new KnowledgeGuardian(config)
 
   private val baseCoreJSLib = CoreJSLibs.lib(semantics, esFeatures, moduleKind)
 
@@ -104,6 +104,8 @@ final class Emitter private (config: CommonPhaseConfig,
   def emitAll(unit: LinkingUnit, builder: JSLineBuilder,
       logger: Logger): Unit = {
     emitInternal(unit, builder, logger) {
+      topLevelVarDeclarations(unit).foreach(builder.addLine(_))
+
       if (needsIIFEWrapper)
         builder.addLine("(function(){")
 
@@ -115,13 +117,34 @@ final class Emitter private (config: CommonPhaseConfig,
   }
 
   /** Emits everything but the core JS lib to the builder, and returns the
-   *  core JS lib.
+   *  top-level var declarations.
    *
    *  This is special for the Closure back-end.
    */
   private[backend] def emitForClosure(unit: LinkingUnit, builder: JSBuilder,
-      logger: Logger): Unit = {
+      logger: Logger): Option[String] = {
     emitInternal(unit, builder, logger)(())(())
+    topLevelVarDeclarations(unit)
+  }
+
+  private def topLevelVarDeclarations(unit: LinkingUnit): Option[String] = {
+    moduleKind match {
+      case ModuleKind.NoModule =>
+        val topLevelExportNames = mutable.Set.empty[String]
+        for {
+          classDef <- unit.classDefs
+          export <- classDef.topLevelExports
+        } {
+          topLevelExportNames += export.value.topLevelExportName
+        }
+        if (topLevelExportNames.isEmpty)
+          None
+        else
+          Some(topLevelExportNames.mkString("var ", ", ", ";"))
+
+      case ModuleKind.CommonJSModule =>
+        None
+    }
   }
 
   private def emitInternal(unit: LinkingUnit, builder: JSBuilder,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -137,10 +137,12 @@ final class Emitter private (config: CommonPhaseConfig,
         } {
           topLevelExportNames += export.value.topLevelExportName
         }
-        if (topLevelExportNames.isEmpty)
+        if (topLevelExportNames.isEmpty) {
           None
-        else
-          Some(topLevelExportNames.mkString("var ", ", ", ";"))
+        } else {
+          val kw = if (esFeatures.useECMAScript2015) "let " else "var "
+          Some(topLevelExportNames.mkString(kw, ", ", ";"))
+        }
 
       case ModuleKind.CommonJSModule =>
         None

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -12,7 +12,7 @@
 
 package org.scalajs.linker.backend.emitter
 
-import org.scalajs.ir.Trees.{FieldDef, JSNativeLoadSpec}
+import org.scalajs.ir.Trees.{FieldDef, Ident, JSNativeLoadSpec}
 import org.scalajs.ir.Types.Type
 
 private[emitter] trait GlobalKnowledge {
@@ -70,4 +70,7 @@ private[emitter] trait GlobalKnowledge {
    *  JS class.
    */
   def getJSClassFieldDefs(className: String): List[FieldDef]
+
+  /** The global variables that mirror a given static field. */
+  def getStaticFieldMirrors(className: String, field: String): List[String]
 }

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -24,7 +24,7 @@ import org.scalajs.io._
 import org.scalajs.linker._
 import org.scalajs.linker.irio._
 
-import org.scalajs.jsenv.JSEnv
+import org.scalajs.jsenv.{Input, JSEnv}
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 object ScalaJSPlugin extends AutoPlugin {
@@ -143,9 +143,9 @@ object ScalaJSPlugin extends AutoPlugin {
         "Prints the content of a .sjsir file in human readable form.",
         CTask)
 
-    val jsExecutionFiles = TaskKey[Seq[VirtualBinaryFile]](
-        "jsExecutionFiles",
-        "All the JS files given to JS environments on `run`, `test`, etc.",
+    val jsEnvInput = TaskKey[Input](
+        "jsEnvInput",
+        "The JSEnv.Input to give to the jsEnv for tasks such as `run` and `test`",
         BTask)
 
     val scalaJSSourceFiles = AttributeKey[Seq[File]]("scalaJSSourceFiles",
@@ -175,8 +175,6 @@ object ScalaJSPlugin extends AutoPlugin {
         },
 
         jsEnv := new NodeJSEnv(),
-
-        jsExecutionFiles := Nil,
 
         // Clear the IR cache stats every time a sequence of tasks ends
         onComplete := {

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -307,8 +307,13 @@ private[sbtplugin] object ScalaJSPluginInternal {
 
       // Use the Scala.js linked file as the default Input for the JSEnv
       jsEnvInput := {
-        Input.ScriptsToLoad(List(
-            new FileVirtualBinaryFile(scalaJSLinkedFile.value.data)))
+        val linkedFile = new FileVirtualBinaryFile(scalaJSLinkedFile.value.data)
+        scalaJSLinkerConfig.value.moduleKind match {
+          case ModuleKind.NoModule =>
+            Input.ScriptsToLoad(List(linkedFile))
+          case ModuleKind.CommonJSModule =>
+            Input.CommonJSModulesToLoad(List(linkedFile))
+        }
       },
 
       scalaJSMainModuleInitializer := {

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/HTMLRunnerBuilder.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/HTMLRunnerBuilder.scala
@@ -24,6 +24,8 @@ import sbt.testing.{Framework, TaskDef}
 import org.scalajs.io._
 import org.scalajs.io.JSUtils.escapeJS
 
+import org.scalajs.jsenv.{Input, UnsupportedInputException}
+
 import org.scalajs.testing.common._
 
 /** Template for the HTML runner. */
@@ -48,9 +50,17 @@ object HTMLRunnerBuilder {
     }
   }
 
-  def writeToFile(output: File, title: String, jsFiles: Seq[VirtualBinaryFile],
+  def writeToFile(output: File, title: String, input: Input,
       frameworkImplClassNames: List[List[String]],
       taskDefs: List[TaskDef]): Unit = {
+
+    val jsFiles = input match {
+      case Input.ScriptsToLoad(jsFiles) =>
+        jsFiles
+      case _ =>
+        throw new UnsupportedInputException(
+            s"Unsupported input for the generation of an HTML runner: $input")
+    }
 
     val jsFileURIs = jsFiles.map {
       case file: FileVirtualFile => file.file.toURI

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -1247,6 +1247,8 @@ class ExportsTest {
   }
 
   @Test def top_level_export_write_val_var_causes_typeerror(): Unit = {
+    assumeFalse("Unchecked in Script mode", isNoModule)
+
     assertThrows(classOf[js.JavaScriptException], {
       exportsNamespace.TopLevelExport_basicVal = 54
     })

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -13,7 +13,8 @@
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js
-import js.annotation._
+import scala.scalajs.js.annotation._
+import scala.scalajs.js.Dynamic.global
 
 import org.scalajs.testsuite.utils.AssertThrows._
 import org.scalajs.testsuite.utils.JSAssert._
@@ -42,7 +43,7 @@ class ExportsTest {
    */
   val exportsNamespace: js.Dynamic = {
     if (Platform.isNoModule) {
-      org.scalajs.testsuite.utils.JSUtils.globalObject
+      null // need to use `global` instead
     } else if (Platform.isCommonJSModule) {
       js.Dynamic.global.exports
     } else {
@@ -687,14 +688,18 @@ class ExportsTest {
   }
 
   @Test def toplevel_exports_for_objects(): Unit = {
-    val obj = exportsNamespace.TopLevelExportedObject
+    val obj =
+      if (isNoModule) global.TopLevelExportedObject
+      else exportsNamespace.TopLevelExportedObject
     assertJSNotUndefined(obj)
     assertEquals("object", js.typeOf(obj))
     assertEquals("witness", obj.witness)
   }
 
   @Test def toplevel_exports_for_Scala_js_defined_JS_objects(): Unit = {
-    val obj1 = exportsNamespace.SJSDefinedTopLevelExportedObject
+    val obj1 =
+      if (isNoModule) global.SJSDefinedTopLevelExportedObject
+      else exportsNamespace.SJSDefinedTopLevelExportedObject
     assertJSNotUndefined(obj1)
     assertEquals("object", js.typeOf(obj1))
     assertEquals("witness", obj1.witness)
@@ -703,28 +708,36 @@ class ExportsTest {
   }
 
   @Test def toplevel_exports_for_nested_objects(): Unit = {
-    val obj = exportsNamespace.NestedExportedObject
+    val obj =
+      if (isNoModule) global.NestedExportedObject
+      else exportsNamespace.NestedExportedObject
     assertJSNotUndefined(obj)
     assertEquals("object", js.typeOf(obj))
     assertSame(obj, ExportHolder.ExportedObject)
   }
 
   @Test def exports_for_objects_with_constant_folded_name(): Unit = {
-    val obj = exportsNamespace.ConstantFoldedObjectExport
+    val obj =
+      if (isNoModule) global.ConstantFoldedObjectExport
+      else exportsNamespace.ConstantFoldedObjectExport
     assertJSNotUndefined(obj)
     assertEquals("object", js.typeOf(obj))
     assertEquals("witness", obj.witness)
   }
 
   @Test def exports_for_protected_objects(): Unit = {
-    val obj = exportsNamespace.ProtectedExportedObject
+    val obj =
+      if (isNoModule) global.ProtectedExportedObject
+      else exportsNamespace.ProtectedExportedObject
     assertJSNotUndefined(obj)
     assertEquals("object", js.typeOf(obj))
     assertEquals("witness", obj.witness)
   }
 
   @Test def toplevel_exports_for_classes(): Unit = {
-    val constr = exportsNamespace.TopLevelExportedClass
+    val constr =
+      if (isNoModule) global.TopLevelExportedClass
+      else exportsNamespace.TopLevelExportedClass
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)(5)
@@ -732,7 +745,9 @@ class ExportsTest {
   }
 
   @Test def toplevel_exports_for_Scala_js_defined_JS_classes(): Unit = {
-    val constr = exportsNamespace.SJSDefinedTopLevelExportedClass
+    val constr =
+      if (isNoModule) global.SJSDefinedTopLevelExportedClass
+      else exportsNamespace.SJSDefinedTopLevelExportedClass
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)(5)
@@ -743,7 +758,9 @@ class ExportsTest {
   }
 
   @Test def toplevel_exports_for_nested_classes(): Unit = {
-    val constr = exportsNamespace.NestedExportedClass
+    val constr =
+      if (isNoModule) global.NestedExportedClass
+      else exportsNamespace.NestedExportedClass
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)()
@@ -751,7 +768,9 @@ class ExportsTest {
   }
 
   @Test def toplevel_exports_for_nested_sjs_defined_classes(): Unit = {
-    val constr = exportsNamespace.NestedSJSDefinedExportedClass
+    val constr =
+      if (isNoModule) global.NestedSJSDefinedExportedClass
+      else exportsNamespace.NestedSJSDefinedExportedClass
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)()
@@ -759,7 +778,9 @@ class ExportsTest {
   }
 
   @Test def exports_for_classes_with_constant_folded_name(): Unit = {
-    val constr = exportsNamespace.ConstantFoldedClassExport
+    val constr =
+      if (isNoModule) global.ConstantFoldedClassExport
+      else exportsNamespace.ConstantFoldedClassExport
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)(5)
@@ -767,7 +788,9 @@ class ExportsTest {
   }
 
   @Test def exports_for_protected_classes(): Unit = {
-    val constr = exportsNamespace.ProtectedExportedClass
+    val constr =
+      if (isNoModule) global.ProtectedExportedClass
+      else exportsNamespace.ProtectedExportedClass
     assertJSNotUndefined(constr)
     assertEquals("function", js.typeOf(constr))
     val obj = js.Dynamic.newInstance(constr)(5)
@@ -775,7 +798,9 @@ class ExportsTest {
   }
 
   @Test def export_for_classes_with_repeated_parameters_in_ctor(): Unit = {
-    val constr = exportsNamespace.ExportedVarArgClass
+    val constr =
+      if (isNoModule) global.ExportedVarArgClass
+      else exportsNamespace.ExportedVarArgClass
     assertEquals("", js.Dynamic.newInstance(constr)().result)
     assertEquals("a", js.Dynamic.newInstance(constr)("a").result)
     assertEquals("a|b", js.Dynamic.newInstance(constr)("a", "b").result)
@@ -784,7 +809,9 @@ class ExportsTest {
   }
 
   @Test def export_for_classes_with_default_parameters_in_ctor(): Unit = {
-    val constr = exportsNamespace.ExportedDefaultArgClass
+    val constr =
+      if (isNoModule) global.ExportedDefaultArgClass
+      else exportsNamespace.ExportedDefaultArgClass
     assertEquals(6, js.Dynamic.newInstance(constr)(1,2,3).result)
     assertEquals(106, js.Dynamic.newInstance(constr)(1).result)
     assertEquals(103, js.Dynamic.newInstance(constr)(1,2).result)
@@ -1188,59 +1215,108 @@ class ExportsTest {
   // @JSExportTopLevel
 
   @Test def basic_top_level_export(): Unit = {
-    assertEquals(1, exportsNamespace.TopLevelExport_basic())
+    if (isNoModule) {
+      assertEquals(1, global.TopLevelExport_basic())
+    } else {
+      assertEquals(1, exportsNamespace.TopLevelExport_basic())
+    }
   }
 
   @Test def overloaded_top_level_export(): Unit = {
-    assertEquals("Hello World", exportsNamespace.TopLevelExport_overload("World"))
-    assertEquals(2, exportsNamespace.TopLevelExport_overload(2))
-    assertEquals(9, exportsNamespace.TopLevelExport_overload(2, 7))
-    assertEquals(10, exportsNamespace.TopLevelExport_overload(1, 2, 3, 4))
+    if (isNoModule) {
+      assertEquals("Hello World", global.TopLevelExport_overload("World"))
+      assertEquals(2, global.TopLevelExport_overload(2))
+      assertEquals(9, global.TopLevelExport_overload(2, 7))
+      assertEquals(10, global.TopLevelExport_overload(1, 2, 3, 4))
+    } else {
+      assertEquals("Hello World", exportsNamespace.TopLevelExport_overload("World"))
+      assertEquals(2, exportsNamespace.TopLevelExport_overload(2))
+      assertEquals(9, exportsNamespace.TopLevelExport_overload(2, 7))
+      assertEquals(10, exportsNamespace.TopLevelExport_overload(1, 2, 3, 4))
+    }
   }
 
   @Test def top_level_export_uses_unique_object(): Unit = {
-    exportsNamespace.TopLevelExport_set(3)
-    assertEquals(3, TopLevelExports.myVar)
-    exportsNamespace.TopLevelExport_set(7)
-    assertEquals(7, TopLevelExports.myVar)
+    if (isNoModule) {
+      global.TopLevelExport_set(3)
+      assertEquals(3, TopLevelExports.myVar)
+      global.TopLevelExport_set(7)
+      assertEquals(7, TopLevelExports.myVar)
+    } else {
+      exportsNamespace.TopLevelExport_set(3)
+      assertEquals(3, TopLevelExports.myVar)
+      exportsNamespace.TopLevelExport_set(7)
+      assertEquals(7, TopLevelExports.myVar)
+    }
   }
 
   @Test def top_level_export_from_nested_object(): Unit = {
-    exportsNamespace.TopLevelExport_setNested(28)
+    if (isNoModule)
+      global.TopLevelExport_setNested(28)
+    else
+      exportsNamespace.TopLevelExport_setNested(28)
     assertEquals(28, TopLevelExports.Nested.myVar)
   }
 
   @Test def top_level_export_is_always_reachable(): Unit = {
-    assertEquals("Hello World", exportsNamespace.TopLevelExport_reachability())
+    if (isNoModule) {
+      assertEquals("Hello World", global.TopLevelExport_reachability())
+    } else {
+      assertEquals("Hello World", exportsNamespace.TopLevelExport_reachability())
+    }
   }
 
   // @JSExportTopLevel fields
 
   @Test def top_level_export_basic_field(): Unit = {
-    // Initialization
-    assertEquals(5, exportsNamespace.TopLevelExport_basicVal)
-    assertEquals("hello", exportsNamespace.TopLevelExport_basicVar)
+    if (isNoModule) {
+      // Initialization
+      assertEquals(5, global.TopLevelExport_basicVal)
+      assertEquals("hello", global.TopLevelExport_basicVar)
 
-    // Scala modifies var
-    TopLevelFieldExports.basicVar = "modified"
-    assertEquals("modified", TopLevelFieldExports.basicVar)
-    assertEquals("modified", exportsNamespace.TopLevelExport_basicVar)
+      // Scala modifies var
+      TopLevelFieldExports.basicVar = "modified"
+      assertEquals("modified", TopLevelFieldExports.basicVar)
+      assertEquals("modified", global.TopLevelExport_basicVar)
+    } else {
+      // Initialization
+      assertEquals(5, exportsNamespace.TopLevelExport_basicVal)
+      assertEquals("hello", exportsNamespace.TopLevelExport_basicVar)
+
+      // Scala modifies var
+      TopLevelFieldExports.basicVar = "modified"
+      assertEquals("modified", TopLevelFieldExports.basicVar)
+      assertEquals("modified", exportsNamespace.TopLevelExport_basicVar)
+    }
 
     // Reset var
     TopLevelFieldExports.basicVar = "hello"
   }
 
   @Test def top_level_export_field_twice(): Unit = {
-    // Initialization
-    assertEquals(5, exportsNamespace.TopLevelExport_valExportedTwice1)
-    assertEquals("hello", exportsNamespace.TopLevelExport_varExportedTwice1)
-    assertEquals("hello", exportsNamespace.TopLevelExport_varExportedTwice2)
+    if (isNoModule) {
+      // Initialization
+      assertEquals(5, global.TopLevelExport_valExportedTwice1)
+      assertEquals("hello", global.TopLevelExport_varExportedTwice1)
+      assertEquals("hello", global.TopLevelExport_varExportedTwice2)
 
-    // Scala modifies var
-    TopLevelFieldExports.varExportedTwice = "modified"
-    assertEquals("modified", TopLevelFieldExports.varExportedTwice)
-    assertEquals("modified", exportsNamespace.TopLevelExport_varExportedTwice1)
-    assertEquals("modified", exportsNamespace.TopLevelExport_varExportedTwice2)
+      // Scala modifies var
+      TopLevelFieldExports.varExportedTwice = "modified"
+      assertEquals("modified", TopLevelFieldExports.varExportedTwice)
+      assertEquals("modified", global.TopLevelExport_varExportedTwice1)
+      assertEquals("modified", global.TopLevelExport_varExportedTwice2)
+    } else {
+      // Initialization
+      assertEquals(5, exportsNamespace.TopLevelExport_valExportedTwice1)
+      assertEquals("hello", exportsNamespace.TopLevelExport_varExportedTwice1)
+      assertEquals("hello", exportsNamespace.TopLevelExport_varExportedTwice2)
+
+      // Scala modifies var
+      TopLevelFieldExports.varExportedTwice = "modified"
+      assertEquals("modified", TopLevelFieldExports.varExportedTwice)
+      assertEquals("modified", exportsNamespace.TopLevelExport_varExportedTwice1)
+      assertEquals("modified", exportsNamespace.TopLevelExport_varExportedTwice2)
+    }
 
     // Reset var
     TopLevelFieldExports.varExportedTwice = "hello"
@@ -1260,20 +1336,29 @@ class ExportsTest {
 
   @Test def top_level_export_uninitialized_fields(): Unit = {
     assertEquals(0, TopLevelFieldExports.uninitializedVarInt)
-    assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarInt)
-
     assertEquals(0L, TopLevelFieldExports.uninitializedVarLong)
-    assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarLong)
-
     assertEquals(null, TopLevelFieldExports.uninitializedVarString)
-    assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarString)
-
     assertEquals('\u0000', TopLevelFieldExports.uninitializedVarChar)
-    assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarChar)
+
+    if (isNoModule) {
+      assertEquals(null, global.TopLevelExport_uninitializedVarInt)
+      assertEquals(null, global.TopLevelExport_uninitializedVarLong)
+      assertEquals(null, global.TopLevelExport_uninitializedVarString)
+      assertEquals(null, global.TopLevelExport_uninitializedVarChar)
+    } else {
+      assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarInt)
+      assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarLong)
+      assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarString)
+      assertEquals(null, exportsNamespace.TopLevelExport_uninitializedVarChar)
+    }
   }
 
   @Test def top_level_export_field_is_always_reachable_and_initialized(): Unit = {
-    assertEquals("Hello World", exportsNamespace.TopLevelExport_fieldreachability)
+    if (isNoModule) {
+      assertEquals("Hello World", global.TopLevelExport_fieldreachability)
+    } else {
+      assertEquals("Hello World", exportsNamespace.TopLevelExport_fieldreachability)
+    }
   }
 
 }


### PR DESCRIPTION
Before, we needed to detect the global object at run-time (which is not fool-proof) to add top-level exports as properties of the global object. Now, top-level exports are truly defined as global `var`s.

When using ECMAScript 2015 features, we emit global `let`s instead. This is trivial to implement, but annoying to test. `ExportsTest` now duplicates every interaction with the "exports namespace", since in ES 2015 `NoModule` the only way to access the exports is as `global.TheExport`, which cannot be abstracted away. This results in quite a bit of code duplication in the tests, but it can't be helped.