### PR TITLE
Fix the name of jl_CloneNotSupportedException in inlineable init's blacklist.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -97,7 +97,7 @@ private[emitter] final class KnowledgeGuardian(config: CommonPhaseConfig) {
         "jl_ClassCastException",
         "jl_ArrayIndexOutOfBoundsException",
         "sjsr_UndefinedBehaviorError",
-        "js_CloneNotSupportedException"
+        "jl_CloneNotSupportedException"
     )
 
     val scalaClassDefs = linkingUnit.classDefs.filter(_.kind.isClass)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
@@ -15,6 +15,8 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
+import org.scalajs.testsuite.utils.AssertThrows._
+
 import scala.scalajs.js
 
 // scalastyle:off disallow.space.before.token
@@ -29,5 +31,14 @@ class ObjectJSTest {
   @Test def everything_should_cast_to_Object_successfully_including_null(): Unit = {
     (new js.Object: Any).asInstanceOf[Object]
     (js.Array(5)  : Any).asInstanceOf[Object]
+  }
+
+  @Test def cloneOnNonScalaObject(): Unit = {
+    class CloneOnNonScalaObject extends js.Object {
+      def boom(): Any = this.clone()
+    }
+
+    val obj = new CloneOnNonScalaObject()
+    assertThrows(classOf[CloneNotSupportedException], obj.boom())
   }
 }


### PR DESCRIPTION
The test accompanying this change does not actually fails before the fix, but it does fail in a hello world. The bug cannot be reproduced in our test suite: the existence of JUnit indirectly refers to `java.lang.Enum`, which uses the secondary constructor of `CloneNotSupportedException`, which supersedes the blacklist.