### PR TITLE
Use ClassRef instead of ClassType in a bunch of places in IR trees.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -645,7 +645,7 @@ trait GenJSExports extends SubComponent { self: GenJSCode =>
         if (isNestedJSClass(superClassSym)) {
           js.VarRef(js.Ident(JSSuperClassParamName))(jstpe.AnyType)
         } else {
-          js.LoadJSConstructor(jstpe.ClassType(encodeClassFullName(superClassSym)))
+          js.LoadJSConstructor(encodeClassRef(superClassSym))
         }
       }
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -229,6 +229,9 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
     }
   }
 
+  def encodeClassRef(sym: Symbol): jstpe.ClassRef =
+    jstpe.ClassRef(encodeClassFullName(sym))
+
   def encodeClassFullNameIdent(sym: Symbol)(implicit pos: Position): js.Ident = {
     js.Ident(encodeClassFullName(sym), Some(sym.fullName))
   }

--- a/ir/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -189,17 +189,17 @@ object Hashers {
 
         case New(cls, ctor, args) =>
           mixTag(TagNew)
-          mixType(cls)
+          mixClassRef(cls)
           mixIdent(ctor)
           mixTrees(args)
 
         case LoadModule(cls) =>
           mixTag(TagLoadModule)
-          mixType(cls)
+          mixClassRef(cls)
 
         case StoreModule(cls, value) =>
           mixTag(TagStoreModule)
-          mixType(cls)
+          mixClassRef(cls)
           mixTree(value)
 
         case Select(qualifier, item) =>
@@ -210,7 +210,7 @@ object Hashers {
 
         case SelectStatic(cls, item) =>
           mixTag(TagSelectStatic)
-          mixType(cls)
+          mixClassRef(cls)
           mixIdent(item)
           mixType(tree.tpe)
 
@@ -224,14 +224,14 @@ object Hashers {
         case ApplyStatically(receiver, cls, method, args) =>
           mixTag(TagApplyStatically)
           mixTree(receiver)
-          mixType(cls)
+          mixClassRef(cls)
           mixIdent(method)
           mixTrees(args)
           mixType(tree.tpe)
 
         case ApplyStatic(cls, method, args) =>
           mixTag(TagApplyStatic)
-          mixType(cls)
+          mixClassRef(cls)
           mixIdent(method)
           mixTrees(args)
           mixType(tree.tpe)
@@ -247,14 +247,14 @@ object Hashers {
           mixTree(lhs)
           mixTree(rhs)
 
-        case NewArray(tpe, lengths) =>
+        case NewArray(typeRef, lengths) =>
           mixTag(TagNewArray)
-          mixType(tpe)
+          mixArrayTypeRef(typeRef)
           mixTrees(lengths)
 
-        case ArrayValue(tpe, elems) =>
+        case ArrayValue(typeRef, elems) =>
           mixTag(TagArrayValue)
-          mixType(tpe)
+          mixArrayTypeRef(typeRef)
           mixTrees(elems)
 
         case ArrayLength(array) =>
@@ -342,11 +342,11 @@ object Hashers {
 
         case LoadJSConstructor(cls) =>
           mixTag(TagLoadJSConstructor)
-          mixType(cls)
+          mixClassRef(cls)
 
         case LoadJSModule(cls) =>
           mixTag(TagLoadJSModule)
-          mixType(cls)
+          mixClassRef(cls)
 
         case JSDelete(prop) =>
           mixTag(TagJSDelete)
@@ -476,17 +476,21 @@ object Hashers {
     }
 
     def mixTypeRef(typeRef: TypeRef): Unit = typeRef match {
-      case ClassRef(className) =>
+      case typeRef: ClassRef =>
         mixTag(TagClassRef)
-        mixString(className)
-      case ArrayTypeRef(baseClassName, dimensions) =>
+        mixClassRef(typeRef)
+      case typeRef: ArrayTypeRef =>
         mixTag(TagArrayTypeRef)
-        mixString(baseClassName)
-        mixInt(dimensions)
+        mixArrayTypeRef(typeRef)
     }
 
     def mixClassRef(classRef: ClassRef): Unit =
       mixString(classRef.className)
+
+    def mixArrayTypeRef(arrayTypeRef: ArrayTypeRef): Unit = {
+      mixString(arrayTypeRef.baseClassName)
+      mixInt(arrayTypeRef.dimensions)
+    }
 
     def mixType(tpe: Type): Unit = tpe match {
       case AnyType     => mixTag(TagAnyType)

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -451,19 +451,19 @@ object Printers {
           print(rhs)
           print(')')
 
-        case NewArray(tpe, lengths) =>
+        case NewArray(typeRef, lengths) =>
           print("new ")
-          print(tpe.arrayTypeRef.baseClassName)
+          print(typeRef.baseClassName)
           for (length <- lengths) {
             print('[')
             print(length)
             print(']')
           }
-          for (dim <- lengths.size until tpe.arrayTypeRef.dimensions)
+          for (dim <- lengths.size until typeRef.dimensions)
             print("[]")
 
-        case ArrayValue(tpe, elems) =>
-          print(tpe)
+        case ArrayValue(typeRef, elems) =>
+          print(typeRef)
           printArgs(elems)
 
         case ArrayLength(array) =>

--- a/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -514,20 +514,20 @@ class PrintersTest {
   }
 
   @Test def printNewArray(): Unit = {
-    assertPrintEquals("new I[3]", NewArray(arrayType("I", 1), List(i(3))))
-    assertPrintEquals("new I[3][]", NewArray(arrayType("I", 2), List(i(3))))
+    assertPrintEquals("new I[3]", NewArray(ArrayTypeRef("I", 1), List(i(3))))
+    assertPrintEquals("new I[3][]", NewArray(ArrayTypeRef("I", 2), List(i(3))))
     assertPrintEquals("new O[3][4][][]",
-        NewArray(arrayType("O", 4), List(i(3), i(4))))
+        NewArray(ArrayTypeRef("O", 4), List(i(3), i(4))))
   }
 
   @Test def printArrayValue(): Unit = {
     assertPrintEquals("I[]()",
-        ArrayValue(arrayType("I", 1), List()))
+        ArrayValue(ArrayTypeRef("I", 1), List()))
     assertPrintEquals("I[](5, 6)",
-        ArrayValue(arrayType("I", 1), List(i(5), i(6))))
+        ArrayValue(ArrayTypeRef("I", 1), List(i(5), i(6))))
 
     assertPrintEquals("I[][](null)",
-        ArrayValue(arrayType("I", 2), List(Null())))
+        ArrayValue(ArrayTypeRef("I", 2), List(Null())))
   }
 
   @Test def printArrayLength(): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -438,27 +438,27 @@ object Infos {
         /* Do not call super.traverse() so that the field is not also marked as
          * read.
          */
-        case Assign(SelectStatic(ClassType(cls), Ident(field, _)), rhs) =>
+        case Assign(SelectStatic(ClassRef(cls), Ident(field, _)), rhs) =>
           builder.addStaticFieldWritten(cls, field)
           traverse(rhs)
 
         // In all other cases, we'll have to call super.traverse()
         case _ =>
           tree match {
-            case New(ClassType(cls), ctor, _) =>
+            case New(ClassRef(cls), ctor, _) =>
               builder.addInstantiatedClass(cls, ctor.name)
 
-            case SelectStatic(ClassType(cls), Ident(field, _)) =>
+            case SelectStatic(ClassRef(cls), Ident(field, _)) =>
               builder.addStaticFieldRead(cls, field)
 
             case Apply(receiver, Ident(method, _), _) =>
               builder.addMethodCalled(receiver.tpe, method)
-            case ApplyStatically(_, ClassType(cls), method, _) =>
+            case ApplyStatically(_, ClassRef(cls), method, _) =>
               builder.addMethodCalledStatically(cls, method.name)
-            case ApplyStatic(ClassType(cls), method, _) =>
+            case ApplyStatic(ClassRef(cls), method, _) =>
               builder.addStaticMethodCalled(cls, method.name)
 
-            case LoadModule(ClassType(cls)) =>
+            case LoadModule(ClassRef(cls)) =>
               builder.addAccessedModule(cls)
 
             case IsInstanceOf(_, tpe) =>
@@ -466,17 +466,17 @@ object Infos {
             case AsInstanceOf(_, tpe) =>
               builder.addUsedInstanceTest(tpe)
 
-            case NewArray(tpe, _) =>
-              builder.addAccessedClassData(tpe.arrayTypeRef)
-            case ArrayValue(tpe, _) =>
-              builder.addAccessedClassData(tpe.arrayTypeRef)
+            case NewArray(typeRef, _) =>
+              builder.addAccessedClassData(typeRef)
+            case ArrayValue(typeRef, _) =>
+              builder.addAccessedClassData(typeRef)
             case ClassOf(cls) =>
               builder.addAccessedClassData(cls)
 
             case LoadJSConstructor(cls) =>
               builder.addInstantiatedClass(cls.className)
 
-            case LoadJSModule(ClassType(cls)) =>
+            case LoadJSModule(ClassRef(cls)) =>
               builder.addAccessedModule(cls)
 
             case CreateJSClass(cls, _) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -1221,9 +1221,9 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
 
       case ModuleInitializer.MainMethodWithArgs(moduleClassName, mainMethodName,
           args) =>
-        val stringArrayTpe = ArrayType(ArrayTypeRef(BoxedStringClass, 1))
+        val stringArrayTypeRef = ArrayTypeRef(BoxedStringClass, 1)
         js.Apply(genLoadModule(moduleClassName) DOT mainMethodName,
-            genArrayValue(stringArrayTpe, args.map(js.StringLiteral(_))) :: Nil)
+            genArrayValue(stringArrayTypeRef, args.map(js.StringLiteral(_))) :: Nil)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -490,7 +490,7 @@ final class Emitter private (config: CommonPhaseConfig,
 
           val methodName = methodDef.name.asInstanceOf[Ident]
           val newBody = ApplyStatically(This()(ClassType(className)),
-              ClassType(ObjectClass), methodName, methodDef.args.map(_.ref))(
+              ClassRef(ObjectClass), methodName, methodDef.args.map(_.ref))(
               methodDef.resultType)
           val newMethodDef = MethodDef(static = false, methodName,
               methodDef.args, methodDef.resultType, Some(newBody))(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1363,7 +1363,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           val base = js.Assign(transformExpr(lhs, preserveChar = true),
               transformExpr(rhs, lhs.tpe))
           lhs match {
-            case SelectStatic(ClassType(className), Ident(field, _))
+            case SelectStatic(ClassRef(className), Ident(field, _))
                 if moduleKind == ModuleKind.NoModule =>
               val mirrors =
                 globalKnowledge.getStaticFieldMirrors(className, field)
@@ -2394,15 +2394,15 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             case Boolean_& => !(!js.BinaryOp(JSBinaryOp.&, newLhs, newRhs))
           }
 
-        case NewArray(tpe, lengths) =>
+        case NewArray(typeRef, lengths) =>
           genCallHelper("newArrayObject",
-              genClassDataOf(tpe.arrayTypeRef),
+              genClassDataOf(typeRef),
               js.ArrayConstr(lengths.map(transformExprNoChar)))
 
-        case ArrayValue(tpe, elems) =>
-          val ArrayTypeRef(baseClassName, dimensions) = tpe.arrayTypeRef
+        case ArrayValue(typeRef, elems) =>
+          val ArrayTypeRef(baseClassName, dimensions) = typeRef
           val preserveChar = baseClassName == "C" && dimensions == 1
-          genArrayValue(tpe, elems.map(transformExpr(_, preserveChar)))
+          genArrayValue(typeRef, elems.map(transformExpr(_, preserveChar)))
 
         case ArrayLength(array) =>
           genIdentBracketSelect(js.DotSelect(transformExprNoChar(array),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -254,9 +254,9 @@ private[emitter] final class JSGen(val semantics: Semantics,
     }
   }
 
-  def genArrayValue(tpe: ArrayType, elems: List[Tree])(
+  def genArrayValue(arrayTypeRef: ArrayTypeRef, elems: List[Tree])(
       implicit pos: Position): Tree = {
-    genCallHelper("makeNativeArrayWrapper", genClassDataOf(tpe.arrayTypeRef),
+    genCallHelper("makeNativeArrayWrapper", genClassDataOf(arrayTypeRef),
         ArrayConstr(elems))
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -262,7 +262,7 @@ final class BaseLinker(config: CommonPhaseConfig) {
     val currentClassType = ClassType(classInfo.encodedName)
 
     val body = ApplyStatically(
-        This()(currentClassType), ClassType(targetInterface), targetIdent,
+        This()(currentClassType), ClassRef(targetInterface), targetIdent,
         params.map(_.ref))(targetMDef.resultType)
 
     MethodDef(static = false, bridgeIdent, params, targetMDef.resultType, Some(body))(

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -620,14 +620,14 @@ abstract class GenIncOptimizer private[optimizer] (config: CommonPhaseConfig) {
         case Assign(Select(This(), _), rhs) => isTriviallySideEffectFree(rhs)
 
         // Mixin constructor, 2.11
-        case ApplyStatic(ClassType(cls), methodName, List(This())) =>
+        case ApplyStatic(ClassRef(cls), methodName, List(This())) =>
           statics(cls).methods(methodName.name).originalDef.body.exists {
             case Skip() => true
             case _      => false
           }
 
         // Mixin constructor, 2.12+
-        case ApplyStatically(This(), ClassType(cls), methodName, Nil)
+        case ApplyStatically(This(), ClassRef(cls), methodName, Nil)
             if !classes.contains(cls) =>
           // Since cls is not in classes, it must be a default method call.
           defaults(cls).methods.get(methodName.name) exists { methodDef =>
@@ -638,7 +638,7 @@ abstract class GenIncOptimizer private[optimizer] (config: CommonPhaseConfig) {
           }
 
         // Super class constructor.
-        case ApplyStatically(This(), ClassType(cls), methodName, args) =>
+        case ApplyStatically(This(), ClassRef(cls), methodName, args) =>
           Definitions.isConstructorName(methodName.name) &&
           args.forall(isTriviallySideEffectFree) &&
           impl.owner.asInstanceOf[Class].superClass.exists { superCls =>

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -42,7 +42,7 @@ object TestIRBuilder {
   def trivialCtor(enclosingClassName: String): MethodDef = {
     MethodDef(static = false, Ident("init___"), Nil, NoType,
         Some(ApplyStatically(This()(ClassType(enclosingClassName)),
-            ClassType(ObjectClass), Ident("init___"), Nil)(NoType)))(
+            ClassRef(ObjectClass), Ident("init___"), Nil)(NoType)))(
         emptyOptHints, None)
   }
 

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -60,7 +60,7 @@ object JavaLangObject {
           IntType,
           Some {
             Apply(
-              LoadModule(ClassType("jl_System$")),
+              LoadModule(ClassRef("jl_System$")),
               Ident("identityHashCode__O__I", Some("identityHashCode")),
               List(This()(ThisType)))(IntType)
           })(OptimizerHints.empty, None),
@@ -89,11 +89,11 @@ object JavaLangObject {
           AnyType,
           Some {
             If(IsInstanceOf(This()(ThisType), ClassRef("jl_Cloneable")), {
-              Apply(LoadModule(ClassType("jl_ObjectClone$")),
+              Apply(LoadModule(ClassRef("jl_ObjectClone$")),
                   Ident("clone__O__O", Some("clone")),
                   List(This()(ThisType)))(AnyType)
             }, {
-              Throw(New(ClassType("jl_CloneNotSupportedException"),
+              Throw(New(ClassRef("jl_CloneNotSupportedException"),
                 Ident("init___", Some("<init>")), Nil))
             })(AnyType)
           })(OptimizerHints.empty.withInline(true), None),
@@ -117,7 +117,7 @@ object JavaLangObject {
               StringLiteral("@")),
               // +
               Apply(
-                LoadModule(ClassType("jl_Integer$")),
+                LoadModule(ClassRef("jl_Integer$")),
                 Ident("toHexString__I__T"),
                 List(Apply(This()(ThisType), Ident("hashCode__I"), Nil)(IntType)))(
                 ClassType(BoxedStringClass)))


### PR DESCRIPTION
This ensures that `ClassType` is only used when the referenced class is a Scala class, i.e., it actually defines a *type*. For JS classes, their type is `any` so it does not make sense to use `ClassType`.

To be more consistent, we also use `ArrayTypeRef` in a few places instead of `ArrayType`.