### PR TITLE
Added less granular tags to the fastOptJs and fullOptJS tasks

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Stage.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/Stage.scala
@@ -12,9 +12,21 @@
 
 package org.scalajs.sbtplugin
 
-sealed trait Stage
+sealed trait Stage {
+  def tagName: String
+  def fileSuffix: String
+  def name: String
+}
 
 object Stage {
-  case object FullOpt extends Stage
-  case object FastOpt extends Stage
+  case object FullOpt extends Stage {
+    val tagName: String = "fullopt"
+    val fileSuffix: String = "opt"
+    val name: String = "Full"
+  }
+  case object FastOpt extends Stage {
+    val tagName: String = "fastopt"
+    val fileSuffix: String = "fastopt"
+    val name: String = "Fast"
+  }
 }


### PR DESCRIPTION
Fixes #3539.

This would allow users to restrict how many fastOptJS / fullOptJS tasks are running at once in resource-constrained environments.

Some questions:
 
* Is it okay to add new methods to the `Stage` trait? I imagine that is a problem for bincompat. If not are you happy for me to duplicate some pattern matches on the `stage`?
* I would like to add a `Tags` object to the user-facing `ScalaJSPlugin `which contains these tags, is that okay?
* I'd like to use this with 0.6.x, would you accept a PR for that too?
