### PR TITLE
Fix #3539: Enable users to limit concurrent linking tasks in sbt

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -58,6 +58,21 @@ object ScalaJSPlugin extends AutoPlugin {
     val scalaJSIsSnapshotVersion = ScalaJSVersions.currentIsSnapshot
     val scalaJSBinaryVersion = ScalaJSCrossVersion.currentBinaryVersion
 
+    /** Declares [[sbt.Tags.Tag Tag]]s which may be used to limit the
+     *  concurrency of build tasks.
+     *
+     *  For example, the following snippet can be used to limit the
+     *  number of linking tasks which are able to run at once:
+     *
+     *  {{{
+     *  Global / concurrentRestrictions += Tags.limit(ScalaJSTags.Link, 2)
+     *  }}}
+     */
+    object ScalaJSTags {
+      /** This tag is applied to the [[fastOptJS]] and [[fullOptJS]] tasks. */
+      val Link = Tags.Tag("scalajs-link")
+    }
+
     // Stage values
     @deprecated("Use FastOptStage instead", "0.6.6")
     val PreLinkStage = Stage.FastOpt

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -333,7 +333,7 @@ object ScalaJSPluginInternal {
 
           val sourceMapFile = FileVirtualJSFile(output).sourceMapFile
           Attributed.blank(output).put(scalaJSSourceMap, sourceMapFile)
-        }.tag(usesLinkerTag)
+        }.tag(usesLinkerTag, ScalaJSTags.Link)
       }.value,
 
       key := key.dependsOn(packageJSDependencies, packageScalaJSLauncherInternal).value,


### PR DESCRIPTION
This is a continuation of #3540. It will enable users to limit how many linking tasks are able to run at once in sbt by using the `concurrentRestrictions` key:

```scala
Global / concurrentRestrictions += Tags.limit(ScalaJSTags.Link, 2)
```