### PR TITLE
 Do not require `ju.Properties` if we only use `System.{get,set,clear}Property`.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/System.scala
+++ b/javalanglib/src/main/scala/java/lang/System.scala
@@ -243,7 +243,7 @@ object System {
       sysProp.setProperty("java.vm.specification.vendor", "Oracle Corporation")
       sysProp.setProperty("java.vm.specification.name", "Java Virtual Machine Specification")
       sysProp.setProperty("java.vm.name", "Scala.js")
-      linkingInfo.linkerVersion.foreach(v => sysProp.setProperty("java.vm.version", v))
+      sysProp.setProperty("java.vm.version", linkingInfo.linkerVersion)
       sysProp.setProperty("java.specification.version", "1.8")
       sysProp.setProperty("java.specification.vendor", "Oracle Corporation")
       sysProp.setProperty("java.specification.name", "Java Platform API Specification")

--- a/javalanglib/src/main/scala/java/lang/System.scala
+++ b/javalanglib/src/main/scala/java/lang/System.scala
@@ -234,48 +234,73 @@ object System {
   }
 
   private object SystemProperties {
-    var value = loadSystemProperties()
+    var dict: js.Dictionary[String] = loadSystemProperties()
+    var properties: ju.Properties = null
 
-    private[System] def loadSystemProperties(): ju.Properties = {
-      val sysProp = new ju.Properties()
-      sysProp.setProperty("java.version", "1.8")
-      sysProp.setProperty("java.vm.specification.version", "1.8")
-      sysProp.setProperty("java.vm.specification.vendor", "Oracle Corporation")
-      sysProp.setProperty("java.vm.specification.name", "Java Virtual Machine Specification")
-      sysProp.setProperty("java.vm.name", "Scala.js")
-      sysProp.setProperty("java.vm.version", linkingInfo.linkerVersion)
-      sysProp.setProperty("java.specification.version", "1.8")
-      sysProp.setProperty("java.specification.vendor", "Oracle Corporation")
-      sysProp.setProperty("java.specification.name", "Java Platform API Specification")
-      sysProp.setProperty("file.separator", "/")
-      sysProp.setProperty("path.separator", ":")
-      sysProp.setProperty("line.separator", "\n")
-      sysProp
+    private[System] def loadSystemProperties(): js.Dictionary[String] = {
+      js.Dictionary(
+          "java.version" -> "1.8",
+          "java.vm.specification.version" -> "1.8",
+          "java.vm.specification.vendor" -> "Oracle Corporation",
+          "java.vm.specification.name" -> "Java Virtual Machine Specification",
+          "java.vm.name" -> "Scala.js",
+          "java.vm.version" -> linkingInfo.linkerVersion,
+          "java.specification.version" -> "1.8",
+          "java.specification.vendor" -> "Oracle Corporation",
+          "java.specification.name" -> "Java Platform API Specification",
+          "file.separator" -> "/",
+          "path.separator" -> ":",
+          "line.separator" -> "\n"
+      )
+    }
+
+    private[System] def forceProperties(): ju.Properties = {
+      if (properties eq null) {
+        properties = new ju.Properties
+        for ((key, value) <- dict)
+          properties.setProperty(key, value)
+        dict = null
+      }
+      properties
     }
   }
 
   def getProperties(): ju.Properties =
-    SystemProperties.value
+    SystemProperties.forceProperties()
 
   def lineSeparator(): String = "\n"
 
   def setProperties(properties: ju.Properties): Unit = {
-    SystemProperties.value =
-      if (properties != null) properties
-      else SystemProperties.loadSystemProperties()
+    if (properties eq null) {
+      SystemProperties.dict = SystemProperties.loadSystemProperties()
+      SystemProperties.properties = null
+    } else {
+      SystemProperties.dict = null
+      SystemProperties.properties = properties
+    }
   }
 
   def getProperty(key: String): String =
-    SystemProperties.value.getProperty(key)
+    if (SystemProperties.dict ne null) SystemProperties.dict.getOrElse(key, null)
+    else SystemProperties.properties.getProperty(key)
 
   def getProperty(key: String, default: String): String =
-    SystemProperties.value.getProperty(key, default)
+    if (SystemProperties.dict ne null) SystemProperties.dict.getOrElse(key, default)
+    else SystemProperties.properties.getProperty(key, default)
 
   def clearProperty(key: String): String =
-    SystemProperties.value.remove(key).asInstanceOf[String]
+    if (SystemProperties.dict ne null) SystemProperties.dict.remove(key).getOrElse(null)
+    else SystemProperties.properties.remove(key).asInstanceOf[String]
 
-  def setProperty(key: String, value: String): String =
-    SystemProperties.value.setProperty(key, value).asInstanceOf[String]
+  def setProperty(key: String, value: String): String = {
+    if (SystemProperties.dict ne null) {
+      val oldValue = getProperty(key)
+      SystemProperties.dict(key) = value
+      oldValue
+    } else {
+      SystemProperties.properties.setProperty(key, value).asInstanceOf[String]
+    }
+  }
 
   def getenv(): ju.Map[String, String] =
     ju.Collections.emptyMap()

--- a/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
@@ -23,7 +23,7 @@ sealed trait LinkingInfo extends js.Object {
   val assumingES6: Boolean
 
   /** Version of the linker */
-  val linkerVersion: js.UndefOr[String]
+  val linkerVersion: String
 
   /** The value of the global JavaScript `this`. */
   val globalThis: Any

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -115,7 +115,7 @@ object LinkerTest {
       }
     }
 
-    val allIRFiles = TestIRRepo.stdlibIRFiles ++ classDefsFiles
+    val allIRFiles = TestIRRepo.minilib.stdlibIRFiles ++ classDefsFiles
 
     val output = LinkerOutput(new WritableMemVirtualBinaryFile)
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
@@ -20,8 +20,11 @@ import org.scalajs.linker.analyzer.Infos._
 import org.scalajs.linker.irio._
 
 object TestIRRepo {
-  private val stdlibPath = MinilibHolder.minilib
+  val minilib = new TestIRRepo(StdlibHolder.minilib)
+  val fulllib = new TestIRRepo(StdlibHolder.fulllib)
+}
 
+final class TestIRRepo(stdlibPath: String) {
   private val globalIRCache = new IRFileCache
 
   val stdlibIRFiles: Seq[VirtualScalaJSIRFile] =

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -702,8 +702,9 @@ object Build {
       sourceGenerators in Test += Def.task {
         ConstantHolderGenerator.generate(
             (sourceManaged in Test).value,
-            "org.scalajs.linker.testutils.MinilibHolder",
-            "minilib" -> (packageBin in (LocalProject("minilib"), Compile)).value)
+            "org.scalajs.linker.testutils.StdlibHolder",
+            "minilib" -> (packageBin in (LocalProject("minilib"), Compile)).value,
+            "fulllib" -> (packageBin in (LocalProject("library"), Compile)).value)
       }.taskValue,
 
       previousArtifactSetting,

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -81,6 +81,6 @@ class SystemJSTest {
     assertEquals("/", get("file.separator"))
     assertEquals(":", get("path.separator"))
     assertEquals("\n", get("line.separator"))
-    assertEquals(linkingInfo.linkerVersion.getOrElse(null), get("java.vm.version"))
+    assertEquals(linkingInfo.linkerVersion, get("java.vm.version"))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemPropertiesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemPropertiesTest.scala
@@ -1,0 +1,114 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang
+
+import language.implicitConversions
+
+import org.junit.{After, Test}
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform._
+
+class SystemPropertiesTest {
+
+  private final val LineSeparatorPropName = "line.separator"
+  private final val ExistingPropName = "org.scalajs.testsuite.existingprop"
+  private final val TestPropName = "org.scalajs.testsuite.testprop"
+
+  @After def resetSystemPropertiesAfterEachTest(): Unit = {
+    System.setProperties(null)
+  }
+
+  /** Tests scenarios where only `getProperty`, `setProperty` and
+   *  `clearProperty` are used.
+   *
+   *  In those scenarios, the inner `java.util.Properties` is not forced, and
+   *  only the `dict` field of `SystemProperties` is manipulated.
+   */
+  @Test def testScenariosWithoutJavaUtilProperties(): Unit = {
+    // Known property, always \n even on the JVM because our build ensures it
+    assertEquals("\n", System.getProperty(LineSeparatorPropName))
+    assertEquals("\n", System.getProperty(LineSeparatorPropName, "some default"))
+    assertEquals(null, System.getProperty("this.property.does.not.exist"))
+    assertEquals("some default",
+        System.getProperty("this.property.does.not.exist", "some default"))
+
+    assertEquals(null, System.getProperty(TestPropName))
+    assertEquals(null, System.setProperty(TestPropName, "test value"))
+    assertEquals("test value", System.getProperty(TestPropName))
+    assertEquals("test value", System.getProperty(TestPropName, "some default"))
+    assertEquals("test value", System.setProperty(TestPropName, "another value"))
+    assertEquals("another value", System.getProperty(TestPropName))
+    assertEquals("another value", System.clearProperty(TestPropName))
+    assertEquals(null, System.getProperty(TestPropName))
+    assertEquals(null, System.clearProperty(TestPropName))
+  }
+
+  /** Tests scenarios where we call `getProperties()`, forcing the inner
+   *  `java.util.Properties` to be instantiated.
+   *
+   *  Also tests interactions between the existing values in `dict` at the time
+   *  we force the `java.util.Properties`, and further interactions with
+   *  `getProperty`, `setProperty` and `clearProperty`.
+   */
+  @Test def testScenariosWithGetProperties(): Unit = {
+    System.setProperty(ExistingPropName, "existing value")
+
+    val props = System.getProperties()
+    assertNotNull(props)
+
+    assertEquals("\n", props.getProperty(LineSeparatorPropName))
+    assertEquals("\n", props.getProperty(LineSeparatorPropName, "some default"))
+    assertEquals(null, props.getProperty("this.property.does.not.exist"))
+    assertEquals("some default",
+        props.getProperty("this.property.does.not.exist", "some default"))
+
+    // Existing props prior to calling getProperties() are visible
+    assertEquals("existing value", props.getProperty(ExistingPropName))
+
+    // Manipulate props
+    assertEquals(null, props.getProperty(TestPropName))
+    assertEquals(null, props.setProperty(TestPropName, "test value"))
+    assertEquals("test value", props.getProperty(TestPropName))
+    assertEquals("test value", System.getProperty(TestPropName)) // reflects on System
+    assertEquals("test value", props.getProperty(TestPropName, "some default"))
+    assertEquals("test value", props.setProperty(TestPropName, "another value"))
+    assertEquals("another value", props.getProperty(TestPropName))
+    assertEquals("another value", System.setProperty(TestPropName, "third value"))
+    assertEquals("third value", props.getProperty(TestPropName)) // System reflects on props
+    assertEquals("third value", System.clearProperty(TestPropName))
+    assertEquals(null, props.getProperty(TestPropName)) // System.clear also reflects on props
+    assertEquals(null, System.clearProperty(TestPropName))
+
+    // Kill everything
+    props.clear()
+    assertEquals(null, props.getProperty(LineSeparatorPropName))
+    assertEquals(null, System.getProperty(LineSeparatorPropName)) // also kills it for System
+  }
+
+  /** Tests the effects of `setProperties()`, and its interactions with the
+   *  other methods related to system properties.
+   */
+  @Test def testScenariosWithSetProperties(): Unit = {
+    val props = new java.util.Properties()
+    assertEquals(null, props.getProperty(LineSeparatorPropName))
+    assertEquals(null, props.setProperty(TestPropName, "test value"))
+
+    System.setProperties(props)
+    assertSame(props, System.getProperties())
+    assertEquals(null, System.getProperty(LineSeparatorPropName))
+    assertEquals("test value", System.getProperty(TestPropName))
+  }
+}


### PR DESCRIPTION
It is reasonably common to use `System.getProperty` and other related methods, but not to use `System.{get,set}Properties` nor to directly instantiate `ju.Properties`.

This commit uses a few laziness tricks to avoid making `ju.Properties` reachable (along with `ju.Hashtable` and some others) if the codebase only uses `System.{get,set,clear}Property`.