### PR TITLE
Make division by 0 compliant (always).

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -154,10 +154,12 @@ object Integer {
   }
 
   @inline def divideUnsigned(dividend: Int, divisor: Int): Int =
-    asInt(asUint(dividend) / asUint(divisor))
+    if (divisor == 0) 0 / 0
+    else asInt(asUint(dividend) / asUint(divisor))
 
   @inline def remainderUnsigned(dividend: Int, divisor: Int): Int =
-    asInt(asUint(dividend) % asUint(divisor))
+    if (divisor == 0) 0 % 0
+    else asInt(asUint(dividend) % asUint(divisor))
 
   @inline def highestOneBit(i: Int): Int = {
     /* The natural way of implementing this is:

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -466,6 +466,27 @@ object Infos {
             case AsInstanceOf(_, tpe) =>
               builder.addUsedInstanceTest(tpe)
 
+            case BinaryOp(op, _, rhs) =>
+              import BinaryOp._
+
+              def addArithmeticException(): Unit =
+                builder.addInstantiatedClass("jl_ArithmeticException", "init___T")
+
+              op match {
+                case Int_/ | Int_% =>
+                  rhs match {
+                    case IntLiteral(r) if r != 0 =>
+                    case _                       => addArithmeticException()
+                  }
+                case Long_/ | Long_% =>
+                  rhs match {
+                    case LongLiteral(r) if r != 0L =>
+                    case _                         => addArithmeticException()
+                  }
+                case _ =>
+                  // do nothing
+              }
+
             case NewArray(typeRef, _) =>
               builder.addAccessedClassData(typeRef)
             case ArrayValue(typeRef, _) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -94,6 +94,7 @@ private[emitter] final class KnowledgeGuardian(config: CommonPhaseConfig) {
      * has an inlineable init.
      */
     val blackList = Set(
+        "jl_ArithmeticException",
         "jl_ClassCastException",
         "jl_ArrayIndexOutOfBoundsException",
         "sjsr_UndefinedBehaviorError",

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/IntegerTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/IntegerTestOnJDK8.scala
@@ -106,6 +106,8 @@ class IntegerTestOnJDK8 {
     test(0xFFFFFFFF, 7, 613566756)
     test(0xFFFFFFFF, 0xEE6B2800, 1)
     test(0xEE6B2800, 2, 2000000000)
+
+    assertThrows(classOf[ArithmeticException], Integer.divideUnsigned(5, 0))
   }
 
   @Test def should_provide_remainderUnsigned(): Unit = {
@@ -118,6 +120,8 @@ class IntegerTestOnJDK8 {
     test(0xFFFFFFFF, 7, 3)
     test(0xFFFFFFFF, 0xEE6B2800, 294967295)
     test(0xEE6B2800, 2, 0)
+
+    assertThrows(classOf[ArithmeticException], Integer.remainderUnsigned(5, 0))
   }
 
   @Test def should_provide_toUnsignedString_without_radix(): Unit = {

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/LongTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/LongTestOnJDK8.scala
@@ -332,6 +332,8 @@ class LongTestOnJDK8 {
     test(89731974104L, 1173247030L, 76L)
     test(385847542338318L, 7846L, 49177611819L)
     test(-9223372026066135207L, 480301980L, 19203277170L)
+
+    assertThrows(classOf[ArithmeticException], JLong.divideUnsigned(5L, 0L))
   }
 
   @Test def remainderUnsigned(): Unit = {
@@ -395,6 +397,8 @@ class LongTestOnJDK8 {
     test(-9223372036846154797L, 11L, 0L)
     test(-9212519596031121696L, 1L, 0L)
     test(0L, 2L, 0L)
+
+    assertThrows(classOf[ArithmeticException], JLong.remainderUnsigned(5L, 0L))
   }
 
   @Test def toUnsignedString(): Unit = {

--- a/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
+++ b/test-suite/shared/src/test/require-jdk8/org/scalajs/testsuite/javalib/lang/MathTestOnJDK8.scala
@@ -248,6 +248,8 @@ class MathTestOnJDK8 {
     assertEquals(Int.MinValue, Math.floorDiv(Int.MinValue, 1))
     assertEquals(Int.MinValue, Math.floorDiv(Int.MinValue, -1))
 
+    assertThrows(classOf[ArithmeticException], Math.floorDiv(5, 0))
+
     assertEquals(0L, Math.floorDiv(0L, 1L))
     assertEquals(0L, Math.floorDiv(0L, -1L))
     assertEquals(1L, Math.floorDiv(1L, 1L))
@@ -264,6 +266,8 @@ class MathTestOnJDK8 {
     assertEquals(-Long.MaxValue, Math.floorDiv(Long.MaxValue, -1))
     assertEquals(Long.MinValue, Math.floorDiv(Long.MinValue, 1))
     assertEquals(Long.MinValue, Math.floorDiv(Long.MinValue, -1))
+
+    assertThrows(classOf[ArithmeticException], Math.floorDiv(5L, 0L))
   }
 
   @Test def floorMod(): Unit = {
@@ -284,6 +288,8 @@ class MathTestOnJDK8 {
     assertEquals(0, Math.floorMod(Int.MinValue, 1))
     assertEquals(0, Math.floorMod(Int.MinValue, -1))
 
+    assertThrows(classOf[ArithmeticException], Math.floorMod(5, 0))
+
     assertEquals(0L, Math.floorMod(0L, 1L))
     assertEquals(0L, Math.floorMod(0L, -1L))
     assertEquals(0L, Math.floorMod(1L, 1L))
@@ -300,6 +306,8 @@ class MathTestOnJDK8 {
     assertEquals(0L, Math.floorMod(Long.MaxValue, -1L))
     assertEquals(0L, Math.floorMod(Long.MinValue, 1L))
     assertEquals(0L, Math.floorMod(Long.MinValue, -1L))
+
+    assertThrows(classOf[ArithmeticException], Math.floorMod(5L, 0L))
   }
 
   @Test def nextDown_for_Double(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
@@ -17,6 +17,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.Platform
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /* General note on the way these tests are written:
  * We leverage the constant folding applied by the Scala compiler to write
@@ -286,6 +287,46 @@ class IntTest {
     test(AlmostMaxVal, -14, AlmostMaxVal / -14)
     test(AlmostMinVal, 100, AlmostMinVal / 100)
     test(AlmostMaxVal, -123, AlmostMaxVal / -123)
+  }
+
+  @Test def divisionByZero(): Unit = {
+    @noinline def divNoInline(x: Int, y: Int): Int = x / y
+
+    @inline def divInline(x: Int, y: Int): Int = x / y
+
+    @inline def test(x: Int): Unit = {
+      assertThrows(classOf[ArithmeticException], x / 0)
+      assertThrows(classOf[ArithmeticException], divNoInline(x, 0))
+      assertThrows(classOf[ArithmeticException], divInline(x, 0))
+    }
+
+    test(0)
+    test(1)
+    test(43)
+    test(-3)
+
+    // Eligible for constant-folding by scalac itself
+    assertThrows(classOf[ArithmeticException], 5 / 0)
+  }
+
+  @Test def moduloByZero(): Unit = {
+    @noinline def modNoInline(x: Int, y: Int): Int = x % y
+
+    @inline def modInline(x: Int, y: Int): Int = x % y
+
+    @inline def test(x: Int): Unit = {
+      assertThrows(classOf[ArithmeticException], x % 0)
+      assertThrows(classOf[ArithmeticException], modNoInline(x, 0))
+      assertThrows(classOf[ArithmeticException], modInline(x, 0))
+    }
+
+    test(0)
+    test(1)
+    test(43)
+    test(-3)
+
+    // Eligible for constant-folding by scalac itself
+    assertThrows(classOf[ArithmeticException], 5 % 0)
   }
 
   @Test def `percent_should_never_produce_a_negative_0_#1984`(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -16,6 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class LongTest {
@@ -2029,6 +2030,26 @@ class LongTest {
     test(lg(8, 0), lg(1810734914, 124115952), lg(1149563530, 15197570))
   }
 
+  @Test def divisionByZero(): Unit = {
+    @noinline def divNoInline(x: Long, y: Long): Long = x / y
+
+    @inline def divInline(x: Long, y: Long): Long = x / y
+
+    @inline def test(x: Long): Unit = {
+      assertThrows(classOf[ArithmeticException], x / 0L)
+      assertThrows(classOf[ArithmeticException], divNoInline(x, 0L))
+      assertThrows(classOf[ArithmeticException], divInline(x, 0L))
+    }
+
+    test(0L)
+    test(1L)
+    test(43L)
+    test(-3L)
+
+    // Eligible for constant-folded by scalac itself
+    assertThrows(classOf[ArithmeticException], 5L / 0L)
+  }
+
   @Test def modulo_%(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x % y)
@@ -2518,6 +2539,26 @@ class LongTest {
     test(lg(2056903464, -4954201), lg(-425905039, -180148939), lg(-1397064581, -15926795))
     test(lg(-2055992988, 596420), lg(-920215872, 219325473), lg(1357686103, 54682263))
     test(lg(1279110660, -10784541), lg(1279110660, -10784541), lg(278869448, 758126792))
+  }
+
+  @Test def moduloByZero(): Unit = {
+    @noinline def modNoInline(x: Long, y: Long): Long = x % y
+
+    @inline def modInline(x: Long, y: Long): Long = x % y
+
+    @inline def test(x: Long): Unit = {
+      assertThrows(classOf[ArithmeticException], x % 0L)
+      assertThrows(classOf[ArithmeticException], modNoInline(x, 0L))
+      assertThrows(classOf[ArithmeticException], modInline(x, 0L))
+    }
+
+    test(0L)
+    test(1L)
+    test(43L)
+    test(-3L)
+
+    // Eligible for constant-folded by scalac itself
+    assertThrows(classOf[ArithmeticException], 5L % 0L)
   }
 }
 


### PR DESCRIPTION
So far, division by 0 has been an unchecked undefined behavior. Contrary to the other undefined behaviors we have, this one has always been problematic, because Scala as a language and a type system do nothing to guard against it.

This commit makes division by 0 compliant, i.e., throwing an `ArithmeticException`, in all cases. Some optimizations are thrown in to avoid the additional checks when the rhs is a non-zero constant.