### PR TITLE
Support the latest nightly of Scala 2.13.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/EnumerationInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/EnumerationInteropTest.scala
@@ -128,7 +128,7 @@ class EnumerationInteropTest extends DirectTest with TestHelpers {
       protected class Val1 extends Val
       protected class Val2 extends Val(1)
     }
-    """ warns() // no message checking: position differs in 2.10 and 2.11
+    """.warns() // no message checking: position differs in 2.10 and 2.11
 
   }
 
@@ -140,7 +140,7 @@ class EnumerationInteropTest extends DirectTest with TestHelpers {
       protected class Val1 extends Val(null)
       protected class Val2 extends Val(1,null)
     }
-    """ warns() // no message checking: position differs in 2.10 and 2.11
+    """.warns() // no message checking: position differs in 2.10 and 2.11
 
   }
 

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -155,7 +155,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport("value")
       def world = "bar"
     }
-    """ fails() // No error test, Scala version dependent error messages
+    """.fails() // No error test, Scala version dependent error messages
 
     """
     class Confl {
@@ -166,7 +166,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def ub(x: Box[Int]): Int = x.x
     }
-    """ fails() // No error test, Scala version dependent error messages
+    """.fails() // No error test, Scala version dependent error messages
 
     """
     class Confl {
@@ -176,7 +176,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def rtType(x: Double) = x
     }
-    """ fails() // Error message depends on Scala version
+    """.fails() // Error message depends on Scala version
 
     """
     class Confl {
@@ -218,7 +218,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def foo(x: Double, y: String)(z: String*) = x
     }
-    """ fails() // Error message depends on Scala version
+    """.fails() // Error message depends on Scala version
 
     """
     class A {
@@ -228,7 +228,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def a(x: Any) = 2
     }
-    """ fails() // Error message depends on Scala version
+    """.fails() // Error message depends on Scala version
 
   }
 
@@ -904,7 +904,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExport
       def foo(x: scala.scalajs.js.Any) = 2
     }
-    """ fails() // No error test, Scala version dependent error messages
+    """.fails() // No error test, Scala version dependent error messages
 
     // Ctors
     """
@@ -918,7 +918,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExportNamed
       def this(x: Long) = this()
     }
-    """ fails() // No error test, Scala version dependent error messages
+    """.fails() // No error test, Scala version dependent error messages
 
   }
 
@@ -1025,7 +1025,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       def foo(x: String, y: String = "hello") = x
       def foo(x: Int, y: String = "bar") = x
     }
-    """ fails()
+    """.fails()
   }
 
   @Test

--- a/scalalib/overrides-2.13/scala/reflect/Manifest.scala
+++ b/scalalib/overrides-2.13/scala/reflect/Manifest.scala
@@ -65,6 +65,82 @@ trait Manifest[T] extends ClassManifest[T] with Equals {
   override def hashCode = this.runtimeClass.##
 }
 
+/** The object `Manifest` defines factory methods for manifests.
+ *  It is intended for use by the compiler and should not be used in client code.
+ */
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("use scala.reflect.ClassTag (to capture erasures), scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+object Manifest {
+  /* Forward all the public members of ManifestFactory, since this object used
+   * to be a `private val Manifest = ManifestFactory` in the package object. It
+   * was moved here because it needs to be in the same file as `trait Manifest`
+   * defined above.
+   */
+
+  def valueManifests: List[AnyValManifest[_]] =
+    ManifestFactory.valueManifests
+
+  def Byte: ManifestFactory.ByteManifest = ManifestFactory.Byte
+  def Short: ManifestFactory.ShortManifest = ManifestFactory.Short
+  def Char: ManifestFactory.CharManifest = ManifestFactory.Char
+  def Int: ManifestFactory.IntManifest = ManifestFactory.Int
+  def Long: ManifestFactory.LongManifest = ManifestFactory.Long
+  def Float: ManifestFactory.FloatManifest = ManifestFactory.Float
+  def Double: ManifestFactory.DoubleManifest = ManifestFactory.Double
+  def Boolean: ManifestFactory.BooleanManifest = ManifestFactory.Boolean
+  def Unit: ManifestFactory.UnitManifest = ManifestFactory.Unit
+
+  def Any: Manifest[scala.Any] = ManifestFactory.Any
+  def Object: Manifest[java.lang.Object] = ManifestFactory.Object
+  def AnyRef: Manifest[scala.AnyRef] = ManifestFactory.AnyRef
+  def AnyVal: Manifest[scala.AnyVal] = ManifestFactory.AnyVal
+  def Null: Manifest[scala.Null] = ManifestFactory.Null
+  def Nothing: Manifest[scala.Nothing] = ManifestFactory.Nothing
+
+  /** Manifest for the singleton type `value.type`. */
+  def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
+    ManifestFactory.singleType[T](value)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a top-level or static class.
+    * @note This no-prefix, no-arguments case is separate because we
+    *       it's called from ScalaRunTime.boxArray itself. If we
+    *       pass varargs as arrays into this, we get an infinitely recursive call
+    *       to boxArray. (Besides, having a separate case is more efficient)
+    */
+  def classType[T](clazz: Predef.Class[_]): Manifest[T] =
+    ManifestFactory.classType[T](clazz)
+
+  /** Manifest for the class type `clazz`, where `clazz` is
+    * a top-level or static class and args are its type arguments. */
+  def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.classType[T](clazz, arg1, args: _*)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a class with non-package prefix type `prefix` and type arguments `args`.
+    */
+  def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.classType[T](prefix, clazz, args: _*)
+
+  def arrayType[T](arg: Manifest[_]): Manifest[Array[T]] =
+    ManifestFactory.arrayType[T](arg)
+
+  /** Manifest for the abstract type `prefix # name`. `upperBound` is not
+    * strictly necessary as it could be obtained by reflection. It was
+    * added so that erasure can be calculated without reflection. */
+  def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.abstractType[T](prefix, name, upperBound, args: _*)
+
+  /** Manifest for the unknown type `_ >: L <: U` in an existential. */
+  def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
+    ManifestFactory.wildcardType[T](lowerBound, upperBound)
+
+  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  def intersectionType[T](parents: Manifest[_]*): Manifest[T] =
+    ManifestFactory.intersectionType[T](parents: _*)
+
+}
+
 // TODO undeprecated until Scala reflection becomes non-experimental
 // @deprecated("use type tags and manually check the corresponding class or type instead", "2.10.0")
 @SerialVersionUID(1L)


### PR DESCRIPTION
As of commit b9306a2de1b95eb5f8aa30d1d1341c96b467b1f9.

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-b9306a2
> testSuite/test
> compiler/test
```