### PR TITLE
[no-master] Fix #3528: Use `console.error(e)` to report ES module errors.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/AbstractNodeJSEnv.scala
@@ -141,11 +141,8 @@ abstract class AbstractNodeJSEnv(
         importerFile.content = {
           s"""
             |import("${escapeJS(uri)}").catch(e => {
-            |  /* Make sure to fail the process, but give time to Node.js to
-            |   * display a good stack trace before that.
-            |   */
-            |  setTimeout(() => process.exit(1), 100);
-            |  throw e;
+            |  console.error(e);
+            |  process.exit(1);
             |});
           """.stripMargin
         }


### PR DESCRIPTION
Backported from master.