### PR TITLE
FF ONLY Merge 0.6.x into master, January 28

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -60,6 +60,37 @@ object Object extends js.Object {
   def apply(): js.Object = js.native
   def apply(value: scala.Any): js.Object = js.native
 
+  /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+   *  The `Object.assign()` method is used to copy the values of all enumerable
+   *  own properties from one or more source objects to a target object. It will
+   *  return the target object.
+   *
+   *  Properties in the target object will be overwritten by properties in the
+   *  sources if they have the same key. Later sources' properties will
+   *  similarly overwrite earlier ones.
+   *
+   *  The `Object.assign()` method only copies enumerable and own properties from
+   *  a source object to a target object. It uses `Get` on the source and `Set`
+   *  on the target, so it will invoke getters and setters. Therefore it
+   *  assigns properties versus just copying or defining new properties. This may
+   *  make it unsuitable for merging new properties into a prototype if the merge
+   *  sources contain getters. For copying property definitions, including their
+   *  enumerability, into prototypes `Object.getOwnPropertyDescriptor()` and
+   *  `Object.defineProperty()` should be used instead.
+   *
+   *  Both `String` and `Symbol` properties are copied.
+   *
+   *  In case of an error, for example if a property is non-writable, a
+   *  `TypeError` will be raised, and the target object can be changed if any
+   *  properties are added before error is raised.
+   *
+   *  Note that `Object.assign()` does not throw on null or undefined source
+   *  values.
+   *
+   *  MDN
+   */
+  def assign(t: js.Object, s: js.Object*): js.Object = js.native
+
   /**
    * The Object.getPrototypeOf() method returns the prototype (i.e. the
    * internal `Prototype`) of the specified object.

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -36,6 +36,21 @@ object ScalaJSPlugin extends AutoPlugin {
     /** The current version of the Scala.js sbt plugin and tool chain. */
     val scalaJSVersion = ScalaJSVersions.current
 
+    /** Declares [[sbt.Tags.Tag Tag]]s which may be used to limit the
+     *  concurrency of build tasks.
+     *
+     *  For example, the following snippet can be used to limit the
+     *  number of linking tasks which are able to run at once:
+     *
+     *  {{{
+     *  Global / concurrentRestrictions += Tags.limit(ScalaJSTags.Link, 2)
+     *  }}}
+     */
+    object ScalaJSTags {
+      /** This tag is applied to the [[fastOptJS]] and [[fullOptJS]] tasks. */
+      val Link = Tags.Tag("scalajs-link")
+    }
+
     // Stage values
     val FastOptStage = Stage.FastOpt
     val FullOptStage = Stage.FullOpt

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -221,7 +221,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
           } (realFiles.toSet)
 
           Attributed.blank(output).put(scalaJSSourceMap, sourceMapFile)
-        }.tag(usesLinkerTag)
+        }.tag(usesLinkerTag, ScalaJSTags.Link)
       }.value
   )
 

--- a/scalalib/overrides-2.13/scala/reflect/Manifest.scala
+++ b/scalalib/overrides-2.13/scala/reflect/Manifest.scala
@@ -65,6 +65,82 @@ trait Manifest[T] extends ClassManifest[T] with Equals {
   override def hashCode = this.runtimeClass.##
 }
 
+/** The object `Manifest` defines factory methods for manifests.
+ *  It is intended for use by the compiler and should not be used in client code.
+ */
+// TODO undeprecated until Scala reflection becomes non-experimental
+// @deprecated("use scala.reflect.ClassTag (to capture erasures), scala.reflect.runtime.universe.TypeTag (to capture types) or both instead", "2.10.0")
+object Manifest {
+  /* Forward all the public members of ManifestFactory, since this object used
+   * to be a `private val Manifest = ManifestFactory` in the package object. It
+   * was moved here because it needs to be in the same file as `trait Manifest`
+   * defined above.
+   */
+
+  def valueManifests: List[AnyValManifest[_]] =
+    ManifestFactory.valueManifests
+
+  def Byte: ManifestFactory.ByteManifest = ManifestFactory.Byte
+  def Short: ManifestFactory.ShortManifest = ManifestFactory.Short
+  def Char: ManifestFactory.CharManifest = ManifestFactory.Char
+  def Int: ManifestFactory.IntManifest = ManifestFactory.Int
+  def Long: ManifestFactory.LongManifest = ManifestFactory.Long
+  def Float: ManifestFactory.FloatManifest = ManifestFactory.Float
+  def Double: ManifestFactory.DoubleManifest = ManifestFactory.Double
+  def Boolean: ManifestFactory.BooleanManifest = ManifestFactory.Boolean
+  def Unit: ManifestFactory.UnitManifest = ManifestFactory.Unit
+
+  def Any: Manifest[scala.Any] = ManifestFactory.Any
+  def Object: Manifest[java.lang.Object] = ManifestFactory.Object
+  def AnyRef: Manifest[scala.AnyRef] = ManifestFactory.AnyRef
+  def AnyVal: Manifest[scala.AnyVal] = ManifestFactory.AnyVal
+  def Null: Manifest[scala.Null] = ManifestFactory.Null
+  def Nothing: Manifest[scala.Nothing] = ManifestFactory.Nothing
+
+  /** Manifest for the singleton type `value.type`. */
+  def singleType[T <: AnyRef](value: AnyRef): Manifest[T] =
+    ManifestFactory.singleType[T](value)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a top-level or static class.
+    * @note This no-prefix, no-arguments case is separate because we
+    *       it's called from ScalaRunTime.boxArray itself. If we
+    *       pass varargs as arrays into this, we get an infinitely recursive call
+    *       to boxArray. (Besides, having a separate case is more efficient)
+    */
+  def classType[T](clazz: Predef.Class[_]): Manifest[T] =
+    ManifestFactory.classType[T](clazz)
+
+  /** Manifest for the class type `clazz`, where `clazz` is
+    * a top-level or static class and args are its type arguments. */
+  def classType[T](clazz: Predef.Class[T], arg1: Manifest[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.classType[T](clazz, arg1, args: _*)
+
+  /** Manifest for the class type `clazz[args]`, where `clazz` is
+    * a class with non-package prefix type `prefix` and type arguments `args`.
+    */
+  def classType[T](prefix: Manifest[_], clazz: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.classType[T](prefix, clazz, args: _*)
+
+  def arrayType[T](arg: Manifest[_]): Manifest[Array[T]] =
+    ManifestFactory.arrayType[T](arg)
+
+  /** Manifest for the abstract type `prefix # name`. `upperBound` is not
+    * strictly necessary as it could be obtained by reflection. It was
+    * added so that erasure can be calculated without reflection. */
+  def abstractType[T](prefix: Manifest[_], name: String, upperBound: Predef.Class[_], args: Manifest[_]*): Manifest[T] =
+    ManifestFactory.abstractType[T](prefix, name, upperBound, args: _*)
+
+  /** Manifest for the unknown type `_ >: L <: U` in an existential. */
+  def wildcardType[T](lowerBound: Manifest[_], upperBound: Manifest[_]): Manifest[T] =
+    ManifestFactory.wildcardType[T](lowerBound, upperBound)
+
+  /** Manifest for the intersection type `parents_0 with ... with parents_n`. */
+  def intersectionType[T](parents: Manifest[_]*): Manifest[T] =
+    ManifestFactory.intersectionType[T](parents: _*)
+
+}
+
 // TODO undeprecated until Scala reflection becomes non-experimental
 // @deprecated("use type tags and manually check the corresponding class or type instead", "2.10.0")
 @SerialVersionUID(1L)


### PR DESCRIPTION
Motivation: hopefully this finally repairs Scala.js in the community build for 2.13.x.
```
$ git checkout -b merge-0.6.x-into-master-january-28
Switched to a new branch 'merge-0.6.x-into-master-january-28'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   edd3c557a (scalajs/0.6.x) Merge pull request #3548 from sjrd/updates-from-scala-2.13
|\  
| * 8ab36894d Support the latest nightly of Scala 2.13.
* |   ef37b0eb6 Merge pull request #3549 from sjrd/fix-nodejs-report-esmodule-error
|\ \  
| |/  
|/|   
| * 12a7988b3 [no-master] Fix #3528: Use `console.error(e)` to report ES module errors.
|/  
*   f294555dc (origin/0.6.x) Merge pull request #3542 from cquiroz/object-assign
|\  
| * 4f30236be Add Object.assign method
|/  
* 3a3340f87 Merge pull request #3541 from DavidGregory084/limit-concurrent-linking
* c9390707e Fix #3539: Enable users to limit concurrent linking tasks in sbt
```
```
$ git merge --no-commit f294555dc
Auto-merging sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
CONFLICT (content): Merge conflict in sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
Auto-merging sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
Auto-merging library/src/main/scala/scala/scalajs/js/Object.scala
CONFLICT (content): Merge conflict in library/src/main/scala/scala/scalajs/js/Object.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU library/src/main/scala/scala/scalajs/js/Object.scala
M  sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
UU sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
```
```diff
$ git diff | cat
diff --cc library/src/main/scala/scala/scalajs/js/Object.scala
index 96b2148fa,efbb5cac8..000000000
--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@@ -54,12 -51,49 +54,43 @@@ class Object extends js.Any 
  }
  
  /** The top-level `Object` JavaScript object. */
 -@native
 +@js.native
  @JSGlobal
 -object Object extends Object {
 -  def apply(): Object = native
 -  def apply(value: Any): Object = native
 +object Object extends js.Object {
 +  def apply(): js.Object = js.native
 +  def apply(value: scala.Any): js.Object = js.native
  
+   /** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+    *  The `Object.assign()` method is used to copy the values of all enumerable
+    *  own properties from one or more source objects to a target object. It will
+    *  return the target object.
+    *
+    *  Properties in the target object will be overwritten by properties in the
+    *  sources if they have the same key. Later sources' properties will
+    *  similarly overwrite earlier ones.
+    *
+    *  The `Object.assign()` method only copies enumerable and own properties from
+    *  a source object to a target object. It uses `Get` on the source and `Set`
+    *  on the target, so it will invoke getters and setters. Therefore it
+    *  assigns properties versus just copying or defining new properties. This may
+    *  make it unsuitable for merging new properties into a prototype if the merge
+    *  sources contain getters. For copying property definitions, including their
+    *  enumerability, into prototypes `Object.getOwnPropertyDescriptor()` and
+    *  `Object.defineProperty()` should be used instead.
+    *
+    *  Both `String` and `Symbol` properties are copied.
+    *
+    *  In case of an error, for example if a property is non-writable, a
+    *  `TypeError` will be raised, and the target object can be changed if any
+    *  properties are added before error is raised.
+    *
+    *  Note that `Object.assign()` does not throw on null or undefined source
+    *  values.
+    *
+    *  MDN
+    */
 -  def assign(t: Object, s: Object*): Object = native
 -
 -  /** Tests whether the object has a property on itself or in its prototype
 -   *  chain. This method is the equivalent of `p in o` in JavaScript.
 -   */
 -  def hasProperty(o: Object, p: String): Boolean =
 -    throw new java.lang.Error("stub")
++  def assign(t: js.Object, s: js.Object*): js.Object = js.native
+ 
    /**
     * The Object.getPrototypeOf() method returns the prototype (i.e. the
     * internal `Prototype`) of the specified object.
diff --cc sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
index 73952b9ed,99cbb4a9f..000000000
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@@ -217,11 -328,23 +217,11 @@@ private[sbtplugin] object ScalaJSPlugin
  
              logIRCacheStats(log)
  
 -            Set(output)
 +            Set(output, sourceMapFile)
            } (realFiles.toSet)
  
 -          val sourceMapFile = FileVirtualJSFile(output).sourceMapFile
            Attributed.blank(output).put(scalaJSSourceMap, sourceMapFile)
-         }.tag(usesLinkerTag)
+         }.tag(usesLinkerTag, ScalaJSTags.Link)
 -      }.value,
 -
 -      key := key.dependsOn(packageJSDependencies, packageScalaJSLauncherInternal).value,
 -
 -      scalaJSLinkedFile in key := new FileVirtualJSFile(key.value.data)
 -  )
 -
 -  private def dispatchSettingKeySettings[T](key: SettingKey[T]) = Seq(
 -      key := Def.settingDyn {
 -        val stageKey = stageKeys(scalaJSStage.value)
 -        Def.setting { (key in stageKey).value }
        }.value
    )
  
$ git add -u
```
```
$ git commit
[merge-0.6.x-into-master-january-28 73e7006a8] Merge '0.6.x' into 'master'.
```
```
$ export mb=$(git merge-base scalajs/0.6.x HEAD)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   edd3c557a (scalajs/0.6.x) Merge pull request #3548 from sjrd/updates-from-scala-2.13
|\  
| * 8ab36894d Support the latest nightly of Scala 2.13.
* ef37b0eb6 Merge pull request #3549 from sjrd/fix-nodejs-report-esmodule-error
* 12a7988b3 [no-master] Fix #3528: Use `console.error(e)` to report ES module errors.
```
```
$ git merge -s ours ef37b0eb6
Merge made by the 'ours' strategy.
```
```
$ git show
commit af0787ab12d60e47b6ccad60b4d8bcf5303884d2 (HEAD -> merge-0.6.x-into-master-january-28)
Merge: 73e7006a8 ef37b0eb6
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Mon Jan 28 10:47:51 2019 +0100

    Skip the [no-master] commit 12a7988.

```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
CONFLICT (content): Merge conflict in compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
Auto-merging compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
CONFLICT (content): Merge conflict in compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
M  scalalib/overrides-2.13/scala/reflect/Manifest.scala
```
```diff
$ git diff | cat
diff --cc compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
index 25bce4177,a278e98d2..000000000
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
diff --cc compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
index 1fe4def54,938d445fd..000000000
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
```
```
$ git add -u
```
```
$ git st
M  scalalib/overrides-2.13/scala/reflect/Manifest.scala
```
```
$ git commit
[merge-0.6.x-into-master-january-28 b6ebb1185] Merge '0.6.x' into 'master'.
```
