### PR TITLE
[no-master] Adapt a neg test in JSInteropTest for Scala 2.13.x.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
@@ -41,7 +41,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
     s"""
     package object jspackage extends js.Object
-    """ hasWarns
+    """ containsWarns
     s"""
       |newSource1.scala:5: warning: Package objects inheriting from js.Any are deprecated. Use a normal object instead.
       |    package object jspackage extends js.Object


### PR DESCRIPTION
Scala 2.13 deprecates package objects with an `extends` clause, which causes this test to report an additional warning.

`master` is not affected because it is an error there, and the error comes in an earlier phase than scalac's warning, so the latter doesn't get a chance to be displayed.

Follow up to https://github.com/scala/scala/pull/7662