### PR TITLE
Update overrides of 2.13 to the latest nightly.

### DIFF
--- a/scalalib/overrides-2.13/scala/Enumeration.scala
+++ b/scalalib/overrides-2.13/scala/Enumeration.scala
@@ -304,8 +304,6 @@ abstract class Enumeration (initial: Int) extends Serializable {
       super[SortedSet].zip[B](that)
     override def collect[B](pf: PartialFunction[Value, B])(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): SortedIterableCC[B] =
       super[SortedSet].collect[B](pf)
-
-    override protected[this] def writeReplace(): AnyRef = this
   }
 
   /** A factory object for value sets */

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -49,7 +49,8 @@ sealed class NumericRange[T](
   extends AbstractSeq[T]
     with IndexedSeq[T]
     with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]
-    with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]] { self =>
+    with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]]
+    with Serializable { self =>
 
   override def iterator: Iterator[T] = new NumericRange.NumericRangeIterator(this, num)
 
@@ -231,8 +232,6 @@ sealed class NumericRange[T](
     val stepped = if (step == 1) "" else s" by $step"
     s"${empty}NumericRange $start $preposition $end$stepped"
   }
-
-  override protected[this] def writeReplace(): AnyRef = this
 
   override protected[this] def className = "NumericRange"
 }

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -64,7 +64,8 @@ sealed abstract class Range(
   extends AbstractSeq[Int]
     with IndexedSeq[Int]
     with IndexedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
-    with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]] { range =>
+    with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
+    with Serializable { range =>
 
   final override def iterator: Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 
@@ -434,8 +435,6 @@ sealed abstract class Range(
     val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
     s"${prefix}Range $start $preposition $end$stepped"
   }
-
-  final override protected[this] def writeReplace(): AnyRef = this
 
   override protected[this] def className = "Range"
 


### PR DESCRIPTION
Porting changes from https://github.com/scala/scala/pull/7624.

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-596c123
> testSuite/test
> compiler/test
```