### PR TITLE
FF ONLY Merge 0.6.x into master, February 7

### DIFF
--- a/scalalib/overrides-2.13/scala/Enumeration.scala
+++ b/scalalib/overrides-2.13/scala/Enumeration.scala
@@ -304,8 +304,6 @@ abstract class Enumeration (initial: Int) extends Serializable {
       super[SortedSet].zip[B](that)
     override def collect[B](pf: PartialFunction[Value, B])(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): SortedIterableCC[B] =
       super[SortedSet].collect[B](pf)
-
-    override protected[this] def writeReplace(): AnyRef = this
   }
 
   /** A factory object for value sets */

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -49,7 +49,8 @@ sealed class NumericRange[T](
   extends AbstractSeq[T]
     with IndexedSeq[T]
     with IndexedSeqOps[T, IndexedSeq, IndexedSeq[T]]
-    with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]] { self =>
+    with StrictOptimizedSeqOps[T, IndexedSeq, IndexedSeq[T]]
+    with Serializable { self =>
 
   override def iterator: Iterator[T] = new NumericRange.NumericRangeIterator(this, num)
 
@@ -231,8 +232,6 @@ sealed class NumericRange[T](
     val stepped = if (step == 1) "" else s" by $step"
     s"${empty}NumericRange $start $preposition $end$stepped"
   }
-
-  override protected[this] def writeReplace(): AnyRef = this
 
   override protected[this] def className = "NumericRange"
 }

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -64,7 +64,8 @@ sealed abstract class Range(
   extends AbstractSeq[Int]
     with IndexedSeq[Int]
     with IndexedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
-    with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]] { range =>
+    with StrictOptimizedSeqOps[Int, IndexedSeq, IndexedSeq[Int]]
+    with Serializable { range =>
 
   final override def iterator: Iterator[Int] = new RangeIterator(start, step, lastElement, isEmpty)
 
@@ -434,8 +435,6 @@ sealed abstract class Range(
     val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
     s"${prefix}Range $start $preposition $end$stepped"
   }
-
-  final override protected[this] def writeReplace(): AnyRef = this
 
   override protected[this] def className = "Range"
 


### PR DESCRIPTION
Motivation: get #3560 in master for the community build.

Trivial -s ours commit + clean merge.
```
$ git checkout -b merge-0.6.x-into-master-february-7
Switched to a new branch 'merge-0.6.x-into-master-february-7'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   dcbc15776 (scalajs/0.6.x) Merge pull request #3560 from sjrd/scala-2.13.x-no-writereplace
|\  
| * d7f07c829 Update overrides of 2.13 to the latest nightly.
|/  
* e2fb6edd4 Merge pull request #3559 from sjrd/adapt-neg-test-for-2.13
* f55569035 [no-master] Adapt a neg test in JSInteropTest for Scala 2.13.x.
```
```
$ git merge -s ours e2fb6edd4
Merge made by the 'ours' strategy.
```
```
$ git show
commit 17e7e73c8510f9134dddd6318aa1813506dc4e83 (HEAD -> merge-0.6.x-into-master-february-7)
Merge: 413e5d6eb e2fb6edd4
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Thu Feb 7 17:05:08 2019 +0100

    Skip the [no-master] commit f555690.

```
```
$ git merge --no-commit scalajs/0.6.x 
Automatic merge went well; stopped before committing as requested
```
```
$ git st
M  scalalib/overrides-2.13/scala/Enumeration.scala
M  scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
M  scalalib/overrides-2.13/scala/collection/immutable/Range.scala
```
```
$ git commit
[merge-0.6.x-into-master-february-7 830e3c612] Merge '0.6.x' into 'master'.
```

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-596c123
> testSuite/test
> compiler/test
```