### PR TITLE
More 2.13.x changes

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/Compat210Component.scala
@@ -46,7 +46,7 @@ trait Compat210Component {
     def isTraitOrInterface: Boolean = self.isTrait || self.isInterface
   }
 
-  // enteringPhase/exitingPhase replace beforePhase/afterPhase
+  // Global compat
 
   @inline final def enteringPhase[T](ph: Phase)(op: => T): T = {
     global.enteringPhase(ph)(op)
@@ -55,6 +55,12 @@ trait Compat210Component {
   @inline final def exitingPhase[T](ph: Phase)(op: => T): T = {
     global.exitingPhase(ph)(op)
   }
+
+  @inline final def devWarning(msg: => String): Unit =
+    global.devWarning(msg)
+
+  @inline final def forScaladoc: Boolean =
+    global.forScaladoc
 
   implicit final class GlobalCompat(
       self: Compat210Component.this.global.type) {
@@ -70,6 +76,26 @@ trait Compat210Component {
     def afterPhase[T](ph: Phase)(op: => T): T = infiniteLoop()
 
     def delambdafy: DelambdafyCompat.type = DelambdafyCompat
+
+    def devWarning(msg: => String): Unit = self.debugwarn(msg)
+    def debugwarn(msg: => String): Unit = infiniteLoop()
+
+    def forScaladoc: Boolean =
+      self.isInstanceOf[ScaladocGlobalCompat.ScaladocGlobalCompat]
+  }
+
+  object ScaladocGlobalCompat {
+    object Compat {
+      trait ScaladocGlobal
+    }
+
+    import Compat._
+
+    object Inner {
+      type ScaladocGlobalCompat = ScaladocGlobal
+    }
+
+    type ScaladocGlobalCompat = Inner.ScaladocGlobalCompat
   }
 
   object DelambdafyCompat {

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -2020,8 +2020,7 @@ abstract class GenJSCode extends plugins.PluginComponent
                 val tpeEnteringPosterasure =
                   enteringPhase(currentRun.posterasurePhase)(rhs.tpe)
                 if ((tpeEnteringPosterasure eq null) && genRhs.isInstanceOf[js.Null]) {
-                  // 2.10.x does not yet have `devWarning`, so use `debugwarn` instead.
-                  debugwarn(
+                  devWarning(
                       "Working around https://github.com/scala-js/scala-js/issues/3422 " +
                       s"for ${sym.fullName} at ${sym.pos}")
                   // Fortunately, a literal `null` never needs to be boxed

--- a/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/ScalaJSPlugin.scala
@@ -26,13 +26,15 @@ import org.scalajs.core.ir.Trees
  *
  *  @author Sébastien Doeraene
  */
-class ScalaJSPlugin(val global: Global) extends NscPlugin {
+class ScalaJSPlugin(val global: Global)
+    extends NscPlugin with Compat210Component {
+
   import global._
 
   val name = "scalajs"
   val description = "Compile to JavaScript"
   val components = {
-    if (global.forScaladoc) {
+    if (forScaladoc) {
       List[NscPluginComponent](PrepInteropComponent)
     } else {
       List[NscPluginComponent](PreTyperComponentComponent, PrepInteropComponent,

--- a/scalalib/overrides-2.13/scala/Enumeration.scala
+++ b/scalalib/overrides-2.13/scala/Enumeration.scala
@@ -254,7 +254,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
   }
 
   /** An ordering by id for values of this set */
-  object ValueOrdering extends Ordering[Value] {
+  implicit object ValueOrdering extends Ordering[Value] {
     def compare(x: Value, y: Value): Int = x compare y
   }
 
@@ -284,7 +284,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     def excl (value: Value) = new ValueSet(nnIds - (value.id - bottomId))
     def iterator = nnIds.iterator map (id => thisenum.apply(bottomId + id))
     override def iteratorFrom(start: Value) = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
-    override def className = thisenum + ".ValueSet"
+    override def className = s"$thisenum.ValueSet"
     /** Creates a bit mask for the zero-adjusted ids in this set as a
      *  new array of longs */
     def toBitMask: Array[Long] = nnIds.toBitMask

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -92,7 +92,7 @@ sealed class NumericRange[T](
     else locationAfterN(idx)
   }
 
-  override def foreach[@specialized(Unit) U](f: T => U): Unit = {
+  override def foreach[@specialized(Specializable.Unit) U](f: T => U): Unit = {
     var count = 0
     var current = start
     while (count < length) {

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -171,7 +171,7 @@ sealed abstract class Range(
     else start + (step * idx)
   }
 
-  /*@`inline`*/ final override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
+  /*@`inline`*/ final override def foreach[@specialized(Specializable.Unit) U](f: Int => U): Unit = {
     // Implementation chosen on the basis of favorable microbenchmarks
     // Note--initialization catches step == 0 so we don't need to here
     if (!isEmpty) {

--- a/scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
@@ -34,6 +34,8 @@ sealed abstract class ArrayBuilder[T]
 
   def length: Int = size
 
+  override def knownSize: Int = size
+
   protected[this] final def ensureSize(size: Int): Unit = {
     if (capacity < size || capacity == 0) {
       var newsize = if (capacity == 0) 16 else capacity * 2

--- a/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
@@ -24,6 +24,8 @@ trait Buffer[A]
 
   override def iterableFactory: SeqFactory[Buffer] = Buffer
 
+  override def knownSize: Int = super[Seq].knownSize
+
   //TODO Prepend is a logical choice for a readable name of `+=:` but it conflicts with the renaming of `append` to `add`
   /** Prepends a single element at the front of this $coll.
     *
@@ -166,6 +168,7 @@ trait Buffer[A]
     this
   }
 
+  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "Buffer"
 }
 


### PR DESCRIPTION
Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-ffde2cb
> testSuite/test
> compiler/test
```

The first commit is [no-master] because we already stopped relying on `forScaladoc` and `debugwarn` in 895b833506a750ab34a3dd79a8b61099473a1247.