### PR TITLE
FF ONLY Merge 0.6.x into master, February 18

### DIFF
--- a/scalalib/overrides-2.13/scala/Enumeration.scala
+++ b/scalalib/overrides-2.13/scala/Enumeration.scala
@@ -254,7 +254,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
   }
 
   /** An ordering by id for values of this set */
-  object ValueOrdering extends Ordering[Value] {
+  implicit object ValueOrdering extends Ordering[Value] {
     def compare(x: Value, y: Value): Int = x compare y
   }
 
@@ -284,7 +284,7 @@ abstract class Enumeration (initial: Int) extends Serializable {
     def excl (value: Value) = new ValueSet(nnIds - (value.id - bottomId))
     def iterator = nnIds.iterator map (id => thisenum.apply(bottomId + id))
     override def iteratorFrom(start: Value) = nnIds iteratorFrom start.id  map (id => thisenum.apply(bottomId + id))
-    override def className = thisenum + ".ValueSet"
+    override def className = s"$thisenum.ValueSet"
     /** Creates a bit mask for the zero-adjusted ids in this set as a
      *  new array of longs */
     def toBitMask: Array[Long] = nnIds.toBitMask

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -92,7 +92,7 @@ sealed class NumericRange[T](
     else locationAfterN(idx)
   }
 
-  override def foreach[@specialized(Unit) U](f: T => U): Unit = {
+  override def foreach[@specialized(Specializable.Unit) U](f: T => U): Unit = {
     var count = 0
     var current = start
     while (count < length) {

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -171,7 +171,7 @@ sealed abstract class Range(
     else start + (step * idx)
   }
 
-  /*@`inline`*/ final override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
+  /*@`inline`*/ final override def foreach[@specialized(Specializable.Unit) U](f: Int => U): Unit = {
     // Implementation chosen on the basis of favorable microbenchmarks
     // Note--initialization catches step == 0 so we don't need to here
     if (!isEmpty) {

--- a/scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
@@ -34,6 +34,8 @@ sealed abstract class ArrayBuilder[T]
 
   def length: Int = size
 
+  override def knownSize: Int = size
+
   protected[this] final def ensureSize(size: Int): Unit = {
     if (capacity < size || capacity == 0) {
       var newsize = if (capacity == 0) 16 else capacity * 2

--- a/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
+++ b/scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
@@ -24,6 +24,8 @@ trait Buffer[A]
 
   override def iterableFactory: SeqFactory[Buffer] = Buffer
 
+  override def knownSize: Int = super[Seq].knownSize
+
   //TODO Prepend is a logical choice for a readable name of `+=:` but it conflicts with the renaming of `append` to `add`
   /** Prepends a single element at the front of this $coll.
     *
@@ -166,6 +168,7 @@ trait Buffer[A]
     this
   }
 
+  @deprecatedOverriding("Compatibility override", since="2.13.0")
   override protected[this] def stringPrefix = "Buffer"
 }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -179,17 +179,32 @@ class LongTest {
   }
 
   @Test def `should_have_correct_hash_in_case_classes`(): Unit = {
-    assertEquals(-1669410282, HashTestBox(0L).##)
-    assertEquals(-1561146018, HashTestBox(55L).##)
-    assertEquals(-1266055417, HashTestBox(-12L).##)
-    assertEquals(-1383472436, HashTestBox(10006548L).##)
-    assertEquals(1748124846, HashTestBox(-1098748L).##)
+    if (scalaVersion.startsWith("2.10.") || scalaVersion.startsWith("2.11.") ||
+        scalaVersion.startsWith("2.12.") || scalaVersion == "2.13.0-M5") {
+      assertEquals(-1669410282, HashTestBox(0L).##)
+      assertEquals(-1561146018, HashTestBox(55L).##)
+      assertEquals(-1266055417, HashTestBox(-12L).##)
+      assertEquals(-1383472436, HashTestBox(10006548L).##)
+      assertEquals(1748124846, HashTestBox(-1098748L).##)
 
-    assertEquals(1291324266, HashTestBox(9863155567412L).##)
-    assertEquals(-450677189, HashTestBox(3632147899696541255L).##)
+      assertEquals(1291324266, HashTestBox(9863155567412L).##)
+      assertEquals(-450677189, HashTestBox(3632147899696541255L).##)
 
-    assertEquals(259268522, HashTestBox(1461126709984L).##)
-    assertEquals(818387364, HashTestBox(1L).##)
+      assertEquals(259268522, HashTestBox(1461126709984L).##)
+      assertEquals(818387364, HashTestBox(1L).##)
+    } else {
+      assertEquals(1445817443, HashTestBox(0L).##)
+      assertEquals(536512430, HashTestBox(55L).##)
+      assertEquals(2131034006, HashTestBox(-12L).##)
+      assertEquals(713468002, HashTestBox(10006548L).##)
+      assertEquals(-1926941956, HashTestBox(-1098748L).##)
+
+      assertEquals(1150870245, HashTestBox(9863155567412L).##)
+      assertEquals(-1713893803, HashTestBox(3632147899696541255L).##)
+
+      assertEquals(-1901418683, HashTestBox(1461126709984L).##)
+      assertEquals(-491089524, HashTestBox(1L).##)
+    }
   }
 
   @Test def `should_correctly_concat_to_string`(): Unit = {


### PR DESCRIPTION
```
$ git checkout -b merge-0.6.x-into-master-february-18
Switched to a new branch 'merge-0.6.x-into-master-february-18'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   469729499 (scalajs/0.6.x) Merge pull request #3564 from sjrd/more-2.13.x-changes
|\  
| * 2fb0f24e0 Bring overrides up-to-date with the latest Scala 2.13.x nightly.
| * 2ad1e2cee [no-master] Do not rely on `forScaladoc` and `debugwarn`.
|/  
* cb1ab3ab9 Merge pull request #3562 from sjrd/adapt-hashcode-test-2.13.x
* 1302d4444 Adapt some hash code tests to the new case class hash codes of 2.13.x.
```
```
$ git merge --no-commit cb1ab3ab9
Auto-merging test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
CONFLICT (content): Merge conflict in test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
```
```diff
$ git diff | cat
diff --cc test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
index 53fc3a998,c193332b6..000000000
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
```
```
$ git add -u
```
```
$ git st
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
```
```
$ git commit
[merge-0.6.x-into-master-february-18 153592a89] Merge '0.6.x' into 'master'.
```
```
$ git merge -s ours 2ad1e2cee
Merge made by the 'ours' strategy.
```
```
$ git show
commit c18e6182fb7d6c98237be5c945ade5eab9231234 (HEAD -> merge-0.6.x-into-master-february-18)
Merge: 153592a89 2ad1e2cee
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Mon Feb 18 17:15:42 2019 +0100

    Skip the [no-master] commit 2ad1e2cee.

```
```
$ git merge --no-commit scalajs/0.6.x 
Automatic merge went well; stopped before committing as requested
```
```
$ git st
M  scalalib/overrides-2.13/scala/Enumeration.scala
M  scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
M  scalalib/overrides-2.13/scala/collection/immutable/Range.scala
M  scalalib/overrides-2.13/scala/collection/mutable/ArrayBuilder.scala
M  scalalib/overrides-2.13/scala/collection/mutable/Buffer.scala
```
```
$ git commit
[merge-0.6.x-into-master-february-18 aff2fc274] Merge '0.6.x' into 'master'.
```

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-ffde2cb
> testSuite/test
> compiler/test
```