### PR TITLE
Read entryPoints asynchronously

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -105,9 +105,8 @@ private final class Analyzer(config: CommonPhaseConfig,
     reachSymbolRequirement(symbolRequirements)
 
     // Entry points (top-level exports and static initializers)
-    workQueue.enqueue(inputProvider.classesWithEntryPoints()(executionContext)) { names =>
-      names.foreach(n => lookupClass(n)(_.reachEntryPoints()))
-    }
+    for (className <- inputProvider.classesWithEntryPoints())
+      lookupClass(className)(_.reachEntryPoints())
   }
 
   private def postLoad(): Unit = {
@@ -1127,7 +1126,7 @@ object Analyzer {
   }
 
   trait InputProvider {
-    def classesWithEntryPoints()(implicit ex: ExecutionContext): Future[TraversableOnce[String]]
+    def classesWithEntryPoints(): TraversableOnce[String]
 
     def loadInfo(encodedName: String)(implicit ex: ExecutionContext): Option[Future[Infos.ClassInfo]]
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -129,7 +129,7 @@ private object Refiner {
       this.linkedClassesByName = linkedClassesByName
     }
 
-    def classesWithEntryPoints()(implicit ex: ExecutionContext): Future[TraversableOnce[String]] = Future {
+    def classesWithEntryPoints(): TraversableOnce[String] = {
       for {
         linkedClass <- linkedClassesByName.valuesIterator
         if linkedClass.hasEntryPoint

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -455,15 +455,13 @@ class AnalyzerTest {
       classDefs.map(c => c.name.name -> Infos.generateClassInfo(c)).toMap
 
     val inputProvider = new Analyzer.InputProvider {
-      /* Note: We could use Future.successful here to complete the future
-       * immediately. However, in order to exercise as much asynchronizity as
-       * possible, we don't.
-       */
-
-      def classesWithEntryPoints()(implicit ex: ExecutionContext): Future[TraversableOnce[String]] =
-        Future(classesWithEntryPoints0)(ex)
+      def classesWithEntryPoints(): TraversableOnce[String] = classesWithEntryPoints0
 
       def loadInfo(encodedName: String)(implicit ex: ExecutionContext): Option[Future[Infos.ClassInfo]] = {
+        /* Note: We could use Future.successful here to complete the future
+         * immediately. However, in order to exercise as much asynchronizity as
+         * possible, we don't.
+         */
         val own = encodedNameToInfo.get(encodedName)
         own.orElse(stdlib.flatMap(_.loadInfo(encodedName))).map(Future(_)(ex))
       }


### PR DESCRIPTION
Apart from "simulating" an asynchronous interface better, this also
reads entryPoints only once per linker pass.