### PR TITLE
Fix #3575: Do not reverse non-equality comparisons between floats.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -48,4 +48,58 @@ class DoubleTest {
     test(-2147483565.123, -2147483565)
     test(-65.67, -65)
   }
+
+  @Test
+  def noReverseComparisons_issue3575(): Unit = {
+    import Double.NaN
+
+    @noinline def test_not_==(x: Double, y: Double): Boolean = !(x == y)
+    @noinline def test_not_!=(x: Double, y: Double): Boolean = !(x != y)
+    @noinline def test_not_<(x: Double, y: Double): Boolean = !(x < y)
+    @noinline def test_not_<=(x: Double, y: Double): Boolean = !(x <= y)
+    @noinline def test_not_>(x: Double, y: Double): Boolean = !(x > y)
+    @noinline def test_not_>=(x: Double, y: Double): Boolean = !(x >= y)
+
+    assertFalse(test_not_==(5, 5))
+    assertTrue(test_not_==(5, 10))
+    assertTrue(test_not_==(10, 5))
+    assertTrue(test_not_==(5, NaN))
+    assertTrue(test_not_==(NaN, NaN))
+    assertFalse(test_not_==(0.0, -0.0))
+
+    assertTrue(test_not_!=(5, 5))
+    assertFalse(test_not_!=(5, 10))
+    assertFalse(test_not_!=(10, 5))
+    assertFalse(test_not_!=(5, NaN))
+    assertFalse(test_not_!=(NaN, NaN))
+    assertTrue(test_not_!=(0.0, -0.0))
+
+    assertTrue(test_not_<(5, 5))
+    assertFalse(test_not_<(5, 10))
+    assertTrue(test_not_<(10, 5))
+    assertTrue(test_not_<(5, NaN))
+    assertTrue(test_not_<(NaN, NaN))
+    assertTrue(test_not_<(0.0, -0.0))
+
+    assertFalse(test_not_<=(5, 5))
+    assertFalse(test_not_<=(5, 10))
+    assertTrue(test_not_<=(10, 5))
+    assertTrue(test_not_<=(5, NaN))
+    assertTrue(test_not_<=(NaN, NaN))
+    assertFalse(test_not_<=(0.0, -0.0))
+
+    assertTrue(test_not_>(5, 5))
+    assertTrue(test_not_>(5, 10))
+    assertFalse(test_not_>(10, 5))
+    assertTrue(test_not_>(5, NaN))
+    assertTrue(test_not_>(NaN, NaN))
+    assertTrue(test_not_>(0.0, -0.0))
+
+    assertFalse(test_not_>=(5, 5))
+    assertTrue(test_not_>=(5, 10))
+    assertFalse(test_not_>=(10, 5))
+    assertTrue(test_not_>=(5, NaN))
+    assertTrue(test_not_>=(NaN, NaN))
+    assertFalse(test_not_>=(0.0, -0.0))
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -47,4 +47,58 @@ class FloatTest {
     test(-2147483500f, -2147483520)
     test(-65.67f, -65)
   }
+
+  @Test
+  def noReverseComparisons_issue3575(): Unit = {
+    import Float.NaN
+
+    @noinline def test_not_==(x: Float, y: Float): Boolean = !(x == y)
+    @noinline def test_not_!=(x: Float, y: Float): Boolean = !(x != y)
+    @noinline def test_not_<(x: Float, y: Float): Boolean = !(x < y)
+    @noinline def test_not_<=(x: Float, y: Float): Boolean = !(x <= y)
+    @noinline def test_not_>(x: Float, y: Float): Boolean = !(x > y)
+    @noinline def test_not_>=(x: Float, y: Float): Boolean = !(x >= y)
+
+    assertFalse(test_not_==(5, 5))
+    assertTrue(test_not_==(5, 10))
+    assertTrue(test_not_==(10, 5))
+    assertTrue(test_not_==(5, NaN))
+    assertTrue(test_not_==(NaN, NaN))
+    assertFalse(test_not_==(0.0f, -0.0f))
+
+    assertTrue(test_not_!=(5, 5))
+    assertFalse(test_not_!=(5, 10))
+    assertFalse(test_not_!=(10, 5))
+    assertFalse(test_not_!=(5, NaN))
+    assertFalse(test_not_!=(NaN, NaN))
+    assertTrue(test_not_!=(0.0f, -0.0f))
+
+    assertTrue(test_not_<(5, 5))
+    assertFalse(test_not_<(5, 10))
+    assertTrue(test_not_<(10, 5))
+    assertTrue(test_not_<(5, NaN))
+    assertTrue(test_not_<(NaN, NaN))
+    assertTrue(test_not_<(0.0f, -0.0f))
+
+    assertFalse(test_not_<=(5, 5))
+    assertFalse(test_not_<=(5, 10))
+    assertTrue(test_not_<=(10, 5))
+    assertTrue(test_not_<=(5, NaN))
+    assertTrue(test_not_<=(NaN, NaN))
+    assertFalse(test_not_<=(0.0f, -0.0f))
+
+    assertTrue(test_not_>(5, 5))
+    assertTrue(test_not_>(5, 10))
+    assertFalse(test_not_>(10, 5))
+    assertTrue(test_not_>(5, NaN))
+    assertTrue(test_not_>(NaN, NaN))
+    assertTrue(test_not_>(0.0f, -0.0f))
+
+    assertFalse(test_not_>=(5, 5))
+    assertTrue(test_not_>=(5, 10))
+    assertFalse(test_not_>=(10, 5))
+    assertTrue(test_not_>=(5, NaN))
+    assertTrue(test_not_>=(NaN, NaN))
+    assertFalse(test_not_>=(0.0f, -0.0f))
+  }
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -2620,10 +2620,6 @@ private[optimizer] abstract class OptimizerCore(
 
               case BinaryOp.Num_== => BinaryOp.Num_!=
               case BinaryOp.Num_!= => BinaryOp.Num_==
-              case BinaryOp.Num_<  => BinaryOp.Num_>=
-              case BinaryOp.Num_<= => BinaryOp.Num_>
-              case BinaryOp.Num_>  => BinaryOp.Num_<=
-              case BinaryOp.Num_>= => BinaryOp.Num_<
 
               case BinaryOp.Long_== => BinaryOp.Long_!=
               case BinaryOp.Long_!= => BinaryOp.Long_==


### PR DESCRIPTION
The reversed operations do not have the same result when one of the operands is `NaN`.

And this is officially the highest ratio of tests versus implementation that we ever had, since it is actually *negative* :stuck_out_tongue_closed_eyes: 