### PR TITLE
FF ONLY Merge 0.6.x into master, March 1

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitInnerJS.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitInnerJS.scala
@@ -54,7 +54,7 @@ import scala.collection.mutable
  *  the future", with `exitingPhase(ExplicitInnerJS)`. This design is similar
  *  to how `explicitouter` works.
  */
-abstract class ExplicitInnerJS
+abstract class ExplicitInnerJS[G <: Global with Singleton](val global: G)
     extends plugins.PluginComponent with InfoTransform with TypingTransformers
     with CompatComponent {
 
@@ -124,7 +124,8 @@ abstract class ExplicitInnerJS
             }
           }
 
-          val accessorName = innerJSClass.name.append("$jsclass").toTermName
+          val accessorName: TermName =
+            innerJSClass.name.append("$jsclass").toTermName
           val accessorFlags =
             Flags.SYNTHETIC | Flags.ARTIFACT | Flags.STABLE | Flags.ACCESSOR
           val accessor =

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitLocalJS.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitLocalJS.scala
@@ -117,7 +117,7 @@ import scala.collection.mutable
  *  basically define something very similar to an `object`, although without
  *  its own JS class.
  */
-abstract class ExplicitLocalJS
+abstract class ExplicitLocalJS[G <: Global with Singleton](val global: G)
     extends plugins.PluginComponent with Transform with TypingTransformers
     with CompatComponent {
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
@@ -24,7 +24,9 @@ import org.scalajs.ir
  *
  *  @author Sébastien Doeraene
  */
-trait GenJSFiles extends SubComponent { self: GenJSCode =>
+trait GenJSFiles[G <: Global with Singleton] extends SubComponent {
+  self: GenJSCode[G] =>
+
   import global._
   import jsAddons._
 
@@ -47,7 +49,7 @@ trait GenJSFiles extends SubComponent { self: GenJSCode =>
     }
 
     val pathParts = fullName.split("[./]")
-    val dir = (baseDir /: pathParts.init)(_.subdirectoryNamed(_))
+    val dir = pathParts.init.foldLeft(baseDir)(_.subdirectoryNamed(_))
 
     var filename = pathParts.last
     if (sym.isModuleClass && !isImplClass(sym))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -18,7 +18,9 @@ import scala.tools.nsc._
  *
  *  @author Sébastien Doeraene
  */
-trait JSDefinitions { self: JSGlobalAddons =>
+trait JSDefinitions {
+  val global: Global
+
   import global._
 
   // scalastyle:off line.size.limit

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -31,7 +31,9 @@ import ScopedVar.withScopedVars
  *
  *  @author Sébastien Doeraene
  */
-trait JSEncoding extends SubComponent { self: GenJSCode =>
+trait JSEncoding[G <: Global with Singleton] extends SubComponent {
+  self: GenJSCode[G] =>
+
   import global._
   import jsAddons._
 
@@ -260,7 +262,7 @@ trait JSEncoding extends SubComponent { self: GenJSCode =>
     sym.isModuleClass && !foreignIsImplClass(sym)
 
   def encodeComputedNameIdentity(sym: Symbol): String = {
-    assert(sym.owner.isModuleClass)
+    assert(sym.owner.isModuleClass, sym)
     encodeClassFullName(sym.owner) + "__" + encodeMemberNameInternal(sym)
   }
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
@@ -67,7 +67,8 @@ import nsc._
  *
  *  @author Nicolas Stucki
  */
-abstract class PreTyperComponent extends plugins.PluginComponent
+abstract class PreTyperComponent(val global: Global)
+    extends plugins.PluginComponent
     with transform.Transform with CompatComponent {
 
   import global._

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -14,6 +14,8 @@ package org.scalajs.nscplugin
 
 import scala.collection.mutable
 
+import scala.tools.nsc.Global
+
 import org.scalajs.ir.Trees.isValidIdentifier
 
 /**
@@ -21,7 +23,7 @@ import org.scalajs.ir.Trees.isValidIdentifier
  *
  *  Helpers for transformation of @JSExport annotations
  */
-trait PrepJSExports { this: PrepJSInterop =>
+trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
 
   import global._
   import jsAddons._
@@ -86,7 +88,8 @@ trait PrepJSExports { this: PrepJSInterop =>
 
       Nil
     } else {
-      assert(!baseSym.isBridge)
+      assert(!baseSym.isBridge,
+          s"genExportMember called for bridge symbol $baseSym")
 
       // Reset interface flag: Any trait will contain non-empty methods
       clsSym.resetFlag(Flags.INTERFACE)
@@ -478,7 +481,8 @@ trait PrepJSExports { this: PrepJSInterop =>
     val trgGetter =
       clsSym.tpe.member(nme.defaultGetterName(trgMethod.name, paramPos))
 
-    assert(trgGetter.exists)
+    assert(trgGetter.exists,
+        s"Cannot find default getter for param $paramPos of $trgMethod")
 
     // Although the following must be true in a correct program, we cannot
     // assert, since a graceful failure message is only generated later

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -32,16 +32,18 @@ import org.scalajs.ir.Trees.{isValidIdentifier, JSNativeLoadSpec}
  *
  * @author Tobias Schlatter
  */
-abstract class PrepJSInterop extends plugins.PluginComponent
-                                with PrepJSExports
-                                with transform.Transform
-                                with CompatComponent {
+abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
+    extends plugins.PluginComponent with PrepJSExports[G]
+    with transform.Transform with CompatComponent {
+
   import PrepJSInterop._
 
+  /** Not for use in the constructor body: only initialized afterwards. */
   val jsAddons: JSGlobalAddons {
     val global: PrepJSInterop.this.global.type
   }
 
+  /** Not for use in the constructor body: only initialized afterwards. */
   val scalaJSOpts: ScalaJSOptions
 
   import global._
@@ -592,7 +594,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
           for (loadSpec <- optLoadSpec)
             jsInterop.storeJSNativeLoadSpec(sym, loadSpec)
         } else {
-          assert(sym.isTrait) // just tested in the previous `if`
+          assert(sym.isTrait, sym) // just tested in the previous `if`
           for (annot <- sym.annotations) {
             val annotSym = annot.symbol
             if (JSNativeLoadingSpecAnnots.contains(annotSym) ||
@@ -1219,21 +1221,19 @@ abstract class PrepJSInterop extends plugins.PluginComponent
     }
   }
 
-  private trait ScalaEnumFctExtractors {
-    protected val methSym: Symbol
-
-    protected def resolve(ptpes: Symbol*) = {
+  private abstract class ScalaEnumFctExtractors(methSym: Symbol) {
+    private def resolve(ptpes: Symbol*) = {
       val res = methSym suchThat {
         _.tpe.params.map(_.tpe.typeSymbol) == ptpes.toList
       }
-      assert(res != NoSymbol)
+      assert(res != NoSymbol, s"no overload of $methSym for param types $ptpes")
       res
     }
 
-    protected val noArg    = resolve()
-    protected val nameArg  = resolve(StringClass)
-    protected val intArg   = resolve(IntClass)
-    protected val fullMeth = resolve(IntClass, StringClass)
+    private val noArg = resolve()
+    private val nameArg = resolve(StringClass)
+    private val intArg = resolve(IntClass)
+    private val fullMeth = resolve(IntClass, StringClass)
 
     /**
      * Extractor object for calls to the targeted symbol that do not have an
@@ -1266,16 +1266,11 @@ abstract class PrepJSInterop extends plugins.PluginComponent
 
   }
 
-  private object ScalaEnumValue extends {
-    protected val methSym = getMemberMethod(ScalaEnumClass, jsnme.Value)
-  } with ScalaEnumFctExtractors
+  private object ScalaEnumValue
+      extends ScalaEnumFctExtractors(getMemberMethod(ScalaEnumClass, jsnme.Value))
 
-  private object ScalaEnumVal extends {
-    protected val methSym = {
-      val valSym = getMemberClass(ScalaEnumClass, jsnme.Val)
-      valSym.tpe.member(nme.CONSTRUCTOR)
-    }
-  } with ScalaEnumFctExtractors
+  private object ScalaEnumVal
+      extends ScalaEnumFctExtractors(getMemberClass(ScalaEnumClass, jsnme.Val).tpe.member(nme.CONSTRUCTOR))
 
   /**
    * Construct a call to Enumeration.Value
@@ -1368,7 +1363,7 @@ abstract class PrepJSInterop extends plugins.PluginComponent
     }
 
   private def shouldModuleBeExposed(sym: Symbol) = {
-    assert(sym.isModuleOrModuleClass)
+    assert(sym.isModuleOrModuleClass, sym)
     !sym.isLocalToBlock && !sym.isSynthetic && !isPrivateMaybeWithin(sym)
   }
 
@@ -1405,8 +1400,9 @@ abstract class PrepJSInterop extends plugins.PluginComponent
     if (tree.isInstanceOf[MemberDef]) {
       for (annotation <- tree.symbol.annotations) {
         if (isCompilerAnnotation(annotation)) {
-          reporter.error(annotation.pos, annotation +
-              " is for compiler internal use only. Do not use it yourself.")
+          reporter.error(annotation.pos,
+              s"$annotation is for compiler internal use only. " +
+              "Do not use it yourself.")
         }
       }
     }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
@@ -18,7 +18,9 @@ import org.scalajs.ir
 import ir.{Definitions, Types}
 
 /** Conversions from scalac `Type`s to the IR `Type`s and `TypeRef`s. */
-trait TypeConversions extends SubComponent { this: GenJSCode =>
+trait TypeConversions[G <: Global with Singleton] extends SubComponent {
+  this: GenJSCode[G] =>
+
   import global._
   import definitions._
 

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
@@ -14,8 +14,9 @@ package org.scalajs.nscplugin.test.util
 
 import scala.tools.nsc._
 import scala.tools.nsc.plugins.Plugin
-import reporters.{Reporter, ConsoleReporter}
-import scala.reflect.internal.util.{ SourceFile, BatchSourceFile }
+import scala.tools.nsc.reporters.ConsoleReporter
+
+import scala.reflect.internal.util.{SourceFile, BatchSourceFile}
 
 import org.scalajs.nscplugin.ScalaJSPlugin
 
@@ -71,7 +72,8 @@ abstract class DirectTest {
   def newScalaJSPlugin(global: Global): ScalaJSPlugin =
     new ScalaJSPlugin(global)
 
-  def newReporter(settings: Settings): Reporter = new ConsoleReporter(settings)
+  def newReporter(settings: Settings): ConsoleReporter =
+    new ConsoleReporter(settings)
 
   private def newSources(codes: String*) = codes.toList.zipWithIndex map {
     case (src, idx) => new BatchSourceFile(s"newSource${idx + 1}.scala", src)

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/TestHelpers.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/TestHelpers.scala
@@ -13,19 +13,17 @@
 package org.scalajs.nscplugin.test.util
 
 import java.io._
-import scala.tools.nsc._
 
-import reporters.{Reporter, ConsoleReporter}
+import scala.tools.nsc._
+import scala.tools.nsc.reporters.ConsoleReporter
 
 import org.junit.Assert._
-
-import scala.util.matching.Regex
 
 trait TestHelpers extends DirectTest {
 
   private[this] val errBuffer = new CharArrayWriter
 
-  override def newReporter(settings: Settings): Reporter = {
+  override def newReporter(settings: Settings): ConsoleReporter = {
     val in = new BufferedReader(new StringReader(""))
     val out = new PrintWriter(errBuffer)
     new ConsoleReporter(settings, in, out)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -2694,10 +2694,6 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
               case BinaryOp.Double_== => BinaryOp.Double_!=
               case BinaryOp.Double_!= => BinaryOp.Double_==
-              case BinaryOp.Double_<  => BinaryOp.Double_>=
-              case BinaryOp.Double_<= => BinaryOp.Double_>
-              case BinaryOp.Double_>  => BinaryOp.Double_<=
-              case BinaryOp.Double_>= => BinaryOp.Double_<
 
               case BinaryOp.Boolean_== => BinaryOp.Boolean_!=
               case BinaryOp.Boolean_!= => BinaryOp.Boolean_==

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -580,14 +580,6 @@ object Build {
       commonSettings,
       publishSettings,
       fatalWarningsSettings,
-      scalacOptions := {
-        val prev = scalacOptions.value
-        val scalaV = scalaVersion.value
-        if (!scalaV.startsWith("2.11.") && !scalaV.startsWith("2.12."))
-          prev.filter(_ != "-Xfatal-warnings") // do not error for early initializers
-        else
-          prev
-      },
       name := "Scala.js compiler",
       crossVersion := CrossVersion.full, // because compiler api is not binary compatible
       libraryDependencies ++= Seq(

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -48,4 +48,58 @@ class DoubleTest {
     test(-2147483565.123, -2147483565)
     test(-65.67, -65)
   }
+
+  @Test
+  def noReverseComparisons_issue3575(): Unit = {
+    import Double.NaN
+
+    @noinline def test_not_==(x: Double, y: Double): Boolean = !(x == y)
+    @noinline def test_not_!=(x: Double, y: Double): Boolean = !(x != y)
+    @noinline def test_not_<(x: Double, y: Double): Boolean = !(x < y)
+    @noinline def test_not_<=(x: Double, y: Double): Boolean = !(x <= y)
+    @noinline def test_not_>(x: Double, y: Double): Boolean = !(x > y)
+    @noinline def test_not_>=(x: Double, y: Double): Boolean = !(x >= y)
+
+    assertFalse(test_not_==(5, 5))
+    assertTrue(test_not_==(5, 10))
+    assertTrue(test_not_==(10, 5))
+    assertTrue(test_not_==(5, NaN))
+    assertTrue(test_not_==(NaN, NaN))
+    assertFalse(test_not_==(0.0, -0.0))
+
+    assertTrue(test_not_!=(5, 5))
+    assertFalse(test_not_!=(5, 10))
+    assertFalse(test_not_!=(10, 5))
+    assertFalse(test_not_!=(5, NaN))
+    assertFalse(test_not_!=(NaN, NaN))
+    assertTrue(test_not_!=(0.0, -0.0))
+
+    assertTrue(test_not_<(5, 5))
+    assertFalse(test_not_<(5, 10))
+    assertTrue(test_not_<(10, 5))
+    assertTrue(test_not_<(5, NaN))
+    assertTrue(test_not_<(NaN, NaN))
+    assertTrue(test_not_<(0.0, -0.0))
+
+    assertFalse(test_not_<=(5, 5))
+    assertFalse(test_not_<=(5, 10))
+    assertTrue(test_not_<=(10, 5))
+    assertTrue(test_not_<=(5, NaN))
+    assertTrue(test_not_<=(NaN, NaN))
+    assertFalse(test_not_<=(0.0, -0.0))
+
+    assertTrue(test_not_>(5, 5))
+    assertTrue(test_not_>(5, 10))
+    assertFalse(test_not_>(10, 5))
+    assertTrue(test_not_>(5, NaN))
+    assertTrue(test_not_>(NaN, NaN))
+    assertTrue(test_not_>(0.0, -0.0))
+
+    assertFalse(test_not_>=(5, 5))
+    assertTrue(test_not_>=(5, 10))
+    assertFalse(test_not_>=(10, 5))
+    assertTrue(test_not_>=(5, NaN))
+    assertTrue(test_not_>=(NaN, NaN))
+    assertFalse(test_not_>=(0.0, -0.0))
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -47,4 +47,58 @@ class FloatTest {
     test(-2147483500f, -2147483520)
     test(-65.67f, -65)
   }
+
+  @Test
+  def noReverseComparisons_issue3575(): Unit = {
+    import Float.NaN
+
+    @noinline def test_not_==(x: Float, y: Float): Boolean = !(x == y)
+    @noinline def test_not_!=(x: Float, y: Float): Boolean = !(x != y)
+    @noinline def test_not_<(x: Float, y: Float): Boolean = !(x < y)
+    @noinline def test_not_<=(x: Float, y: Float): Boolean = !(x <= y)
+    @noinline def test_not_>(x: Float, y: Float): Boolean = !(x > y)
+    @noinline def test_not_>=(x: Float, y: Float): Boolean = !(x >= y)
+
+    assertFalse(test_not_==(5, 5))
+    assertTrue(test_not_==(5, 10))
+    assertTrue(test_not_==(10, 5))
+    assertTrue(test_not_==(5, NaN))
+    assertTrue(test_not_==(NaN, NaN))
+    assertFalse(test_not_==(0.0f, -0.0f))
+
+    assertTrue(test_not_!=(5, 5))
+    assertFalse(test_not_!=(5, 10))
+    assertFalse(test_not_!=(10, 5))
+    assertFalse(test_not_!=(5, NaN))
+    assertFalse(test_not_!=(NaN, NaN))
+    assertTrue(test_not_!=(0.0f, -0.0f))
+
+    assertTrue(test_not_<(5, 5))
+    assertFalse(test_not_<(5, 10))
+    assertTrue(test_not_<(10, 5))
+    assertTrue(test_not_<(5, NaN))
+    assertTrue(test_not_<(NaN, NaN))
+    assertTrue(test_not_<(0.0f, -0.0f))
+
+    assertFalse(test_not_<=(5, 5))
+    assertFalse(test_not_<=(5, 10))
+    assertTrue(test_not_<=(10, 5))
+    assertTrue(test_not_<=(5, NaN))
+    assertTrue(test_not_<=(NaN, NaN))
+    assertFalse(test_not_<=(0.0f, -0.0f))
+
+    assertTrue(test_not_>(5, 5))
+    assertTrue(test_not_>(5, 10))
+    assertFalse(test_not_>(10, 5))
+    assertTrue(test_not_>(5, NaN))
+    assertTrue(test_not_>(NaN, NaN))
+    assertTrue(test_not_>(0.0f, -0.0f))
+
+    assertFalse(test_not_>=(5, 5))
+    assertTrue(test_not_>=(5, 10))
+    assertFalse(test_not_>=(10, 5))
+    assertTrue(test_not_>=(5, NaN))
+    assertTrue(test_not_>=(NaN, NaN))
+    assertFalse(test_not_>=(0.0f, -0.0f))
+  }
 }


### PR DESCRIPTION
```
$ git checkout -b merge-0.6.x-into-master-march-1
Switched to a new branch 'merge-0.6.x-into-master-march-1'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   f524bbeff (scalajs/0.6.x) Merge pull request #3576 from sjrd/fix-double-comparison-opt
|\  
| * 5de468a09 Fix #3575: Do not reverse non-equality comparisons between floats.
|/  
* 080063a57 (origin/0.6.x) Merge pull request #3567 from sjrd/address-2.13.x-compiler-warnings
* 05e8ab54b Avoid early initializers in the compiler.
* e4b4a77b0 Avoid deprecated APIs of the 2.13 collections in the compiler.
* 6a56eaaa0 Always use a message in assert/require in the compiler.
* d639ea556 [no-master] Confine warnings in the compiler to Compat210Component.
```
```
$ git merge -s ours d639ea556
Merge made by the 'ours' strategy.
```
```
$ git show
commit e856204a3c5502d0a3038198e1e863a32d0e2865 (HEAD -> merge-0.6.x-into-master-march-1)
Merge: aad159155 d639ea556
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Fri Mar 1 11:35:05 2019 +0100

    Skip the [no-master] commit d639ea556.

```
```
$ git merge --no-commit scalajs/0.6.x 
Auto-merging linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
CONFLICT (content): Merge conflict in linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
CONFLICT (modify/delete): compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala left in tree.
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
DU compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
UU linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
```
```
$ git rm -f compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala
compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala: needs merge
rm 'compiler/src/main/scala/org/scalajs/core/compiler/TypeKinds.scala'
```
```
$ rm -rf project/project/target/ project/target/scala-2.10/
```
[...] Resolve conflicts, fix a few more 2.13 warnings only in master, and enable fatal-warnings in 2.13
```
$ git st
 M compiler/src/main/scala/org/scalajs/nscplugin/ExplicitInnerJS.scala
 M compiler/src/main/scala/org/scalajs/nscplugin/ExplicitLocalJS.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSFiles.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/PreTyperComponent.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
 M compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
UU linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
 M project/Build.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
```
```
$ git diff > resolved-conflicts.scala.diff
```
[resolved-conflicts.scala.diff](https://gist.github.com/sjrd/b645fbdfcc749e159f3a16ec25a67a5a)
```
$ git add -u
```
```
$ git commit
[merge-0.6.x-into-master-march-1 3217d7a8f] Merge '0.6.x' into 'master'.
```
Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-c742cff
> testSuite/test
> compiler/test
```
With this merge, the compiler plugin is completely warning-free on 2.13, in addition to 2.11 and 2.12.