### PR TITLE
Update overrides for the latest 2.13 nightly.

### DIFF
--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -241,6 +241,19 @@ sealed class NumericRange[T](
   *  @define coll numeric range
   */
 object NumericRange {
+  private def bigDecimalCheckUnderflow[T](start: T, end: T, step: T)(implicit num: Integral[T]): Unit = {
+    def FAIL(boundary: T, step: T): Unit = {
+      val msg = boundary match {
+        case bd: BigDecimal => s"Precision ${bd.mc.getPrecision}"
+        case _              => "Precision"
+      }
+      throw new IllegalArgumentException(
+        s"$msg inadequate to represent steps of size $step near $boundary"
+      )
+    }
+    if (num.minus(num.plus(start, step), start) != step) FAIL(start, step)
+    if (num.minus(end, num.minus(end, step))    != step) FAIL(end,   step)
+  }
 
   /** Calculates the number of elements in a range given start, end, step, and
     *  whether or not it is inclusive.  Throws an exception if step == 0 or
@@ -278,6 +291,9 @@ object NumericRange {
       }
       // If we reach this point, deferring to Int failed.
       // Numbers may be big.
+      if (num.isInstanceOf[Numeric.BigDecimalAsIfIntegral]) {
+        bigDecimalCheckUnderflow(start, end, step)  // Throw exception if math is inaccurate (including no progress at all)
+      }
       val one = num.one
       val limit = num.fromInt(Int.MaxValue)
       def check(t: T): T =

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -14,8 +14,6 @@ package scala
 package collection.immutable
 
 import collection.{AbstractIterator, Iterator}
-import java.lang.String
-
 import scala.util.hashing.MurmurHash3
 
 /** The `Range` class represents integer values in range
@@ -108,8 +106,10 @@ sealed abstract class Range(
   /** The last element of this range.  This method will return the correct value
     *  even if there are too many elements to iterate over.
     */
-  final override def last: Int = if (isEmpty) Nil.head else lastElement
-  final override def head: Int = if (isEmpty) Nil.head else start
+  final override def last: Int =
+    if (isEmpty) throw Range.emptyRangeError("last") else lastElement
+  final override def head: Int =
+    if (isEmpty) throw Range.emptyRangeError("head") else start
 
   /** Creates a new range containing all the elements of this range except the last one.
     *
@@ -117,12 +117,8 @@ sealed abstract class Range(
     *
     *  @return  a new range consisting of all the elements of this range except the last one.
     */
-  final override def init: Range = {
-    if (isEmpty)
-      Nil.init
-
-    dropRight(1)
-  }
+  final override def init: Range =
+    if (isEmpty) throw Range.emptyRangeError("init") else dropRight(1)
 
   /** Creates a new range containing all the elements of this range except the first one.
     *
@@ -131,8 +127,7 @@ sealed abstract class Range(
     *  @return  a new range consisting of all the elements of this range except the first one.
     */
   final override def tail: Range = {
-    if (isEmpty)
-      Nil.tail
+    if (isEmpty) throw Range.emptyRangeError("tail")
     if (numRangeElements == 1) newEmptyRange(end)
     else if(isInclusive) new Range.Inclusive(start + step, end, step)
     else new Range.Exclusive(start + step, end, step)
@@ -171,7 +166,7 @@ sealed abstract class Range(
     else start + (step * idx)
   }
 
-  /*@`inline`*/ final override def foreach[@specialized(Specializable.Unit) U](f: Int => U): Unit = {
+  /*@`inline`*/ final override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
     // Implementation chosen on the basis of favorable microbenchmarks
     // Note--initialization catches step == 0 so we don't need to here
     if (!isEmpty) {
@@ -182,6 +177,38 @@ sealed abstract class Range(
         i += step
       }
     }
+  }
+
+  override final def indexOf[@specialized(Int) B >: Int](elem: B, from: Int = 0): Int =
+    elem match {
+      case i: Int =>
+        val pos = posOf(i)
+        if (pos >= from) pos else -1
+      case _ => super.indexOf(elem, from)
+    }
+
+  override final def lastIndexOf[@specialized(Int) B >: Int](elem: B, end: Int = length - 1): Int =
+    elem match {
+      case i: Int =>
+        val pos = posOf(i)
+        if (pos <= end) pos else -1
+      case _ => super.lastIndexOf(elem, end)
+    }
+
+  private[this] def posOf(i: Int): Int =
+    if (contains(i)) (i - start) / step else -1
+
+  override def sameElements[B >: Int](that: IterableOnce[B]): Boolean = that match {
+    case other: Range =>
+      (this.length : @annotation.switch) match {
+        case 0 => other.isEmpty
+        case 1 => other.length == 1 && this.start == other.start
+        case n => other.length == n && (
+          (this.start == other.start)
+            && (this.step == other.step)
+        )
+      }
+    case _ => super.sameElements(that)
   }
 
   /** Creates a new range containing the first `n` elements of this range.
@@ -337,6 +364,11 @@ sealed abstract class Range(
       if (x < end || x > start) false
       else (step == -1) || (((x - start) % step) == 0)
     }
+  }
+  /* Seq#contains has a type parameter so the optimised contains above doesn't override it */
+  override final def contains[B >: Int](elem: B): Boolean = elem match {
+    case i: Int => this.contains(i)
+    case _      => super.contains(elem)
   }
 
   final override def sum[B >: Int](implicit num: Numeric[B]): Int = {
@@ -589,6 +621,8 @@ object Range {
     def inclusive(start: Int, end: Int, step: Int) = NumericRange.inclusive(start, end, step)
   }
 
+  private def emptyRangeError(what: String): Throwable =
+    new NoSuchElementException(what + " on empty Range")
 }
 
 /**


### PR DESCRIPTION
Changes from:

* https://github.com/scala/scala/pull/7784
* https://github.com/scala/scala/pull/7062
* https://github.com/scala/scala/pull/7670

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-8b510ca
> testSuite/test
> compiler/test
```