### PR TITLE
Do not exclude bridges when looking for JUnit-related methods.

### DIFF
--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -260,7 +260,7 @@ class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
 
       def jUnitAnnotatedMethods(sym: Symbol): List[MethodSymbol] = {
         sym.selfType.members.collect {
-          case m: MethodSymbol if !m.isBridge && hasJUnitMethodAnnotation(m) => m
+          case m: MethodSymbol if hasJUnitMethodAnnotation(m) => m
         }.toList
       }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
@@ -186,7 +186,7 @@ class RuntimeLongTest {
     assertEquals(512144461, lg(-615008378, -976157749).hashCode())
   }
 
-  @Test def toString()(): Unit = {
+  @Test def testToString(): Unit = {
     assertEquals("0", lg(0).toString())
     assertEquals("1", lg(1).toString())
     assertEquals("-1", lg(-1).toString())


### PR DESCRIPTION
It turns out that this was only necessary for one very peculiar test method, which was defined as

    @Test def toString()(): Unit = ...

The double-`()` allowed it not to clash with the `toString()` inherited from `Object`, but then for some reason erasure was generating a bridge (although it shouldn't).

Instead of having the JUnit plugin working around that single method, we rename it.

Not excluding bridges is more regular with respect to how JUnit works on the JVM.