### PR TITLE
Fix #3538: Ignore mixin forwarders when looking for export alternatives.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSExports.scala
@@ -308,7 +308,14 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
     }
 
     private def genMemberExport(classSym: Symbol, name: TermName): js.Tree = {
-      val alts = classSym.info.member(name).alternatives
+      /* This used to be `.member(name)`, but it caused #3538, since we were
+       * sometimes selecting mixin forwarders, whose type history does not go
+       * far enough back in time to see varargs. We now explicitly exclude
+       * mixed-in members in addition to bridge methods (the latter are always
+       * excluded by `.member(name)`).
+       */
+      val alts = classSym.info.memberBasedOnName(name,
+          excludedFlags = Flags.BRIDGE | Flags.MIXEDIN).alternatives
 
       assert(!alts.isEmpty,
           s"Ended up with no alternatives for ${classSym.fullName}::$name. " +

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -356,6 +356,35 @@ class ExportsTest {
     assertEquals(4, bar.method(2))
   }
 
+  @Test def should_inherit_exports_from_traits_with_value_classes(): Unit = {
+    trait Foo {
+      @JSExport
+      def x: SomeValueClass = new SomeValueClass(5)
+
+      @JSExport
+      def method(x: SomeValueClass): Int = x.i
+    }
+
+    class Bar extends Foo
+
+    val bar = (new Bar).asInstanceOf[js.Dynamic]
+    assertEquals(new SomeValueClass(5), bar.x)
+    val vc = new SomeValueClass(4)
+    assertEquals(4, bar.method(vc.asInstanceOf[js.Any]))
+  }
+
+  @Test def should_inherit_exports_from_traits_with_varargs_issue_3538(): Unit = {
+    trait Foo {
+      @JSExport
+      def method(args: Int*): Int = args.sum
+    }
+
+    class Bar extends Foo
+
+    val bar = (new Bar).asInstanceOf[js.Dynamic]
+    assertEquals(18, bar.method(5, 6, 7))
+  }
+
   @Test def overloading_with_inherited_exports(): Unit = {
     class A {
       @JSExport


### PR DESCRIPTION
Mixin forwarders are cloned with a type history that does not go far enough back in time to see varargs. By skipping them when looking for the alternatives of an export, we look further in the class hierarchy to the original definition in the trait, which does expose the entire type history that we need.

Inspired by the discussion at https://github.com/scala/scala/pull/7843.
Supersedes https://github.com/scala/scala/pull/7752.