### PR TITLE
(Don't) fix #3454: Remove `regex.Matcher.hitEnd()`.

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -232,10 +232,11 @@ final class Matcher private[regex] (
 
   // Other query state methods
 
-  def hitEnd(): Boolean =
-    lastMatchIsValid && (lastMatch == null || end() == inputstr.length)
+  // Cannot be implemented (see #3454)
+  //def hitEnd(): Boolean
 
-  //def requireEnd(): Boolean // I don't understand the spec
+  // Similar difficulties as with hitEnd()
+  //def requireEnd(): Boolean
 
   // Stub methods for region management
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -264,25 +264,6 @@ class RegexMatcherTest  {
     assertTrue(matcher3.lookingAt())
   }
 
-  @Test def hitEnd(): Unit = {
-    val matcher0 = Pattern.compile("S[a-z]*").matcher("Scala.js")
-    assertTrue(matcher0.find())
-    assertFalse(matcher0.hitEnd)
-    assertFalse(matcher0.find())
-    assertTrue(matcher0.hitEnd)
-
-    val matcher1 = Pattern.compile("[A-Za-z]+").matcher("Scala.js")
-    assertTrue(matcher1.find())
-    assertFalse(matcher1.hitEnd)
-    assertEquals("Scala", matcher1.group)
-    assertTrue(matcher1.find())
-    assertTrue(matcher1.hitEnd)
-    assertEquals("js", matcher1.group)
-    assertTrue(matcher1.lookingAt())
-    assertEquals("Scala", matcher1.group)
-    assertFalse(matcher1.hitEnd)
-  }
-
   @Test def region(): Unit = {
     val matcher0 = Pattern.compile("S[a-z]+").matcher("A Scalable Solution")
 


### PR DESCRIPTION
The implementation of `hitEnd()` was not even remotely correct, and a correct version cannot be implemented on top of JavaScript regular expressions. Therefore, this commit removes the method altogether, signaling with a linking error that it is not supported.