### PR TITLE
Use `getPackageObject` instead of `getPackage` to fix a deprecation.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -32,11 +32,11 @@ trait JSDefinitions {
 
   class JSDefinitionsClass {
 
-    lazy val ScalaJSJSPackage = getPackage(newTermNameCached("scala.scalajs.js")) // compat 2.10/2.11
-      lazy val JSPackage_typeOf        = getMemberMethod(ScalaJSJSPackage, newTermName("typeOf"))
-      lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackage, newTermName("constructorOf"))
-      lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackage, newTermName("native"))
-      lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackage, newTermName("undefined"))
+    lazy val ScalaJSJSPackageModule = getPackageObject("scala.scalajs.js")
+      lazy val JSPackage_typeOf        = getMemberMethod(ScalaJSJSPackageModule, newTermName("typeOf"))
+      lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackageModule, newTermName("constructorOf"))
+      lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackageModule, newTermName("native"))
+      lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackageModule, newTermName("undefined"))
 
     lazy val JSNativeAnnotation = getRequiredClass("scala.scalajs.js.native")
 


### PR DESCRIPTION
`getPackage(TermName)` was deprecated upstream in https://github.com/scala/scala/commit/6bcf47d364b77da340fe347893f1a8e13d457589 in favor of a new `getPackage(String)`. We cannot use the new method because it is not available in older versions.

However we can use `getPackageObject`, which is more appropriate anyway, and which we already used to get other package objects like `runtime` and `special`.