### PR TITLE
FF ONLY Merge 0.6.x into master, March 20

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -39,11 +39,11 @@ trait JSDefinitions {
 
     lazy val BoxedUnitModClass = BoxedUnitModule.moduleClass
 
-    lazy val ScalaJSJSPackage = getPackage(newTermNameCached("scala.scalajs.js")) // compat 2.11
-      lazy val JSPackage_typeOf        = getMemberMethod(ScalaJSJSPackage, newTermName("typeOf"))
-      lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackage, newTermName("constructorOf"))
-      lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackage, newTermName("native"))
-      lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackage, newTermName("undefined"))
+    lazy val ScalaJSJSPackageModule = getPackageObject("scala.scalajs.js")
+      lazy val JSPackage_typeOf        = getMemberMethod(ScalaJSJSPackageModule, newTermName("typeOf"))
+      lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackageModule, newTermName("constructorOf"))
+      lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackageModule, newTermName("native"))
+      lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackageModule, newTermName("undefined"))
 
     lazy val JSNativeAnnotation = getRequiredClass("scala.scalajs.js.native")
 

--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@ -260,7 +260,7 @@ class ScalaJSJUnitPlugin(val global: Global) extends NscPlugin {
         gen.mkAsInstanceOf(Ident(param), clazz.tpe, any = false)
 
       private def annotatedMethods(owner: Symbol, annot: Symbol): Scope =
-        owner.info.members.filter(m => m.isMethod && !m.isBridge && m.hasAnnotation(annot))
+        owner.info.members.filter(m => m.isMethod && m.hasAnnotation(annot))
     }
   }
 }

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -147,14 +147,14 @@ sealed class NumericRange[T](
   //   (Integral <: Ordering). This can happen for custom Integral types.
   // - The Ordering is the default Ordering of a well-known Integral type.
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
-      if (num.signum(step) > 0) head
+      if (num.sign(step) > zero) head
       else last
     } else super.min(ord)
 
   override def max[T1 >: T](implicit ord: Ordering[T1]): T =
   // See comment for fast path in min().
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
-      if (num.signum(step) > 0) last
+      if (num.sign(step) > zero) last
       else head
     } else super.max(ord)
 
@@ -300,10 +300,10 @@ object NumericRange {
         if (num.gt(t, limit)) throw new IllegalArgumentException("More than Int.MaxValue elements.")
         else t
       // If the range crosses zero, it might overflow when subtracted
-      val startside = num.signum(start)
-      val endside = num.signum(end)
+      val startside = num.sign(start)
+      val endside = num.sign(end)
       num.toInt{
-        if (startside*endside >= 0) {
+        if (num.gteq(num.times(startside, endside), zero)) {
           // We're sure we can subtract these numbers.
           // Note that we do not use .rem because of different conventions for Long and BigInt
           val diff = num.minus(end, start)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -374,6 +374,35 @@ class ExportsTest {
     assertEquals(4, bar.method(2))
   }
 
+  @Test def should_inherit_exports_from_traits_with_value_classes(): Unit = {
+    trait Foo {
+      @JSExport
+      def x: SomeValueClass = new SomeValueClass(5)
+
+      @JSExport
+      def method(x: SomeValueClass): Int = x.i
+    }
+
+    class Bar extends Foo
+
+    val bar = (new Bar).asInstanceOf[js.Dynamic]
+    assertEquals(new SomeValueClass(5), bar.x)
+    val vc = new SomeValueClass(4)
+    assertEquals(4, bar.method(vc.asInstanceOf[js.Any]))
+  }
+
+  @Test def should_inherit_exports_from_traits_with_varargs_issue_3538(): Unit = {
+    trait Foo {
+      @JSExport
+      def method(args: Int*): Int = args.sum
+    }
+
+    class Bar extends Foo
+
+    val bar = (new Bar).asInstanceOf[js.Dynamic]
+    assertEquals(18, bar.method(5, 6, 7))
+  }
+
   @Test def overloading_with_inherited_exports(): Unit = {
     class A {
       @JSExport


### PR DESCRIPTION
```
$ git checkout -b merge-0.6.x-into-master-march-20
Switched to a new branch 'merge-0.6.x-into-master-march-20'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   7bbb19aa5 (scalajs/0.6.x) Merge pull request #3591 from sjrd/update-overrides-2.13
|\  
| * b77029017 Update the override of `NumericRange.scala` for 2.13.
* |   3707b4f6a Merge pull request #3590 from sjrd/fix-getpackage-deprecation
|\ \  
| * | f00623221 Use `getPackageObject` instead of `getPackage` to fix a deprecation.
| |/  
* |   7f8e85293 Merge pull request #3582 from sjrd/dont-exclude-bridges-in-junit-plugin
|\ \  
| |/  
|/|   
| * 3ca0aecb0 Do not exclude bridges when looking for JUnit-related methods.
|/  
* 959030a2e Merge pull request #3584 from sjrd/fix-exports-in-traits-with-varargs
* 08a3c1497 Fix #3538: Ignore mixin forwarders when looking for export alternatives.
```
```
$ git merge --no-commit scalajs/0.6.x
CONFLICT (modify/delete): test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala left in tree.
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
Auto-merging junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
CONFLICT (content): Merge conflict in junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
UU junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
M  scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
DU test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
```
```
$ git rm -f test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala
test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala: needs merge
rm 'test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/RuntimeLongTest.scala'
```
```diff
$ git diff | cat
diff --cc compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
index 691c51ab9,8420f475e..000000000
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@@ -249,11 -247,75 +249,18 @@@ trait GenJSExports[G <: Global with Sin
        }
      }
  
 -    /** Tests whether the given def a named exporter def that needs to be
 -     *  generated with `genNamedExporterDef`.
 -     */
 -    def isNamedExporterDef(dd: DefDef): Boolean = {
 -      jsInterop.isExport(dd.symbol) &&
 -      dd.symbol.annotations.exists(_.symbol == JSExportNamedAnnotation)
 -    }
 -
 -    /** Generate the exporter proxy for a named export */
 -    def genNamedExporterDef(dd: DefDef): Option[js.MethodDef] = {
 -      implicit val pos = dd.pos
 -
 -      if (isAbstractMethod(dd)) {
 -        None
 -      } else {
 -        val sym = dd.symbol
 -
 -        val Block(Apply(fun, _) :: Nil, _) = dd.rhs
 -        val trgSym = fun.symbol
 +    private def checkedCast[A: ClassTag](x: js.IRNode): A =
 +      classTag[A].runtimeClass.asInstanceOf[Class[A]].cast(x)
  
 -        val inArg =
 -          js.ParamDef(js.Ident("namedParams"), jstpe.AnyType,
 -              mutable = false, rest = false)
 -        val inArgRef = inArg.ref
 -
 -        val methodIdent = encodeMethodSym(sym)
 -
 -        Some(js.MethodDef(static = false, methodIdent,
 -            List(inArg), toIRType(sym.tpe.resultType),
 -            Some(genNamedExporterBody(trgSym, inArg.ref)))(
 -            OptimizerHints.empty, None))
 -      }
 -    }
 -
 -    private def genNamedExporterBody(trgSym: Symbol, inArg: js.Tree)(
 -        implicit pos: Position) = {
 -
 -      if (hasRepeatedParam(trgSym)) {
 -        reporter.error(pos,
 -            "You may not name-export a method with a *-parameter")
 -      }
 -
 -      val jsArgs = for {
 -        (pSym, index) <- trgSym.info.params.zipWithIndex
 -      } yield {
 -        val rhs = js.JSBracketSelect(inArg,
 -            js.StringLiteral(pSym.name.decoded))
 -        js.VarDef(js.Ident("namedArg$" + index), jstpe.AnyType,
 -            mutable = false, rhs = rhs)
 -      }
 -
 -      val jsArgRefs = jsArgs.map(_.ref)
 -
 -      // Generate JS code to prepare arguments (default getters and unboxes)
 -      val jsArgPrep = genPrepareArgs(jsArgRefs, trgSym)
 -      val jsResult = genResult(trgSym, jsArgPrep.map(_.ref), static = false)
 -
 -      js.Block(jsArgs ++ jsArgPrep :+ jsResult)
 -    }
 -
 -    private def genMemberExport(classSym: Symbol, name: TermName): js.Tree = {
 +    private def genMemberExport(classSym: Symbol, name: TermName): js.MemberDef = {
-       val alts = classSym.info.member(name).alternatives
+       /* This used to be `.member(name)`, but it caused #3538, since we were
+        * sometimes selecting mixin forwarders, whose type history does not go
+        * far enough back in time to see varargs. We now explicitly exclude
+        * mixed-in members in addition to bridge methods (the latter are always
+        * excluded by `.member(name)`).
+        */
+       val alts = classSym.info.memberBasedOnName(name,
+           excludedFlags = Flags.BRIDGE | Flags.MIXEDIN).alternatives
  
        assert(!alts.isEmpty,
            s"Ended up with no alternatives for ${classSym.fullName}::$name. " +
diff --cc compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
index 854595840,90ccafa32..000000000
--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@@ -32,18 -32,11 +32,18 @@@ trait JSDefinitions 
  
    class JSDefinitionsClass {
  
 +    lazy val HackedStringClass = getClassIfDefined("java.lang._String")
 +    lazy val HackedStringModClass = getModuleIfDefined("java.lang._String").moduleClass
 +
 +    lazy val JavaLangVoidClass = getRequiredClass("java.lang.Void")
 +
 +    lazy val BoxedUnitModClass = BoxedUnitModule.moduleClass
 +
-     lazy val ScalaJSJSPackage = getPackage(newTermNameCached("scala.scalajs.js")) // compat 2.11
-       lazy val JSPackage_typeOf        = getMemberMethod(ScalaJSJSPackage, newTermName("typeOf"))
-       lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackage, newTermName("constructorOf"))
-       lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackage, newTermName("native"))
-       lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackage, newTermName("undefined"))
+     lazy val ScalaJSJSPackageModule = getPackageObject("scala.scalajs.js")
+       lazy val JSPackage_typeOf        = getMemberMethod(ScalaJSJSPackageModule, newTermName("typeOf"))
+       lazy val JSPackage_constructorOf = getMemberMethod(ScalaJSJSPackageModule, newTermName("constructorOf"))
+       lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackageModule, newTermName("native"))
+       lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackageModule, newTermName("undefined"))
  
      lazy val JSNativeAnnotation = getRequiredClass("scala.scalajs.js.native")
  
diff --cc junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
index 6f1c81c66,c16e163aa..000000000
--- a/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
+++ b/junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
@@@ -161,106 -258,244 +161,106 @@@ class ScalaJSJUnitPlugin(val global: Gl
          typer.typedDefDef(newDefDef(sym, rhs)())
        }
  
 -      def jUnitAnnotatedMethods(sym: Symbol): List[MethodSymbol] = {
 -        sym.selfType.members.collect {
 -          case m: MethodSymbol if hasJUnitMethodAnnotation(m) => m
 -        }.toList
 -      }
 -
 -      /** This method generates a method that invokes a test method in the module
 -       *  given its name. These methods have no parameters.
 -       *
 -       *  Example:
 -       *  {{{
 -       *  object Foo {
 -       *    @BeforeClass def bar(): Unit
 -       *    @AfterClass def baz(): Unit
 -       *  }
 -       *  object Foo\$scalajs\$junit\$bootstrapper {
 -       *    // This is the method generated by mkInvokeJUnitMethodOnModuleDef
 -       *    def invoke(methodName: String): Unit = {
 -       *      if (methodName == "bar") Foo.bar()
 -       *      else if (methodName == "baz") Foo.baz()
 -       *      else throw new NoSuchMethodException(methodName + " not found")
 -       *    }
 -       *  }
 -       *  }}}
 -       */
 -      def mkInvokeJUnitMethodOnModuleDef(methods: List[MethodSymbol],
 -          bootSym: Symbol, modClassSym: Option[Symbol]): DefDef = {
 -        val invokeJUnitMethodSym = bootSym.newMethod(newTermName("invoke"))
 -
 -        val paramSyms = {
 -          val params = List(("methodName", definitions.StringTpe))
 -          mkParamSymbols(invokeJUnitMethodSym, params)
 -        }
 -
 -        invokeJUnitMethodSym.setInfo(MethodType(paramSyms, definitions.UnitTpe))
 -
 -        def callLocally(methodSymbol: Symbol): Tree = {
 -          val methodSymbolLocal = {
 -            modClassSym.fold(methodSymbol) { sym =>
 -              methodSymbol.cloneSymbol(newOwner = sym)
 -            }
 -          }
 -          gen.mkMethodCall(methodSymbolLocal, Nil)
 -        }
 +      private def genCallOnModule(owner: ClassSymbol, name: TermName, module: Symbol, annot: Symbol): DefDef = {
 +        val sym = owner.newMethodSymbol(name)
 +        sym.setInfoAndEnter(MethodType(Nil, definitions.UnitTpe))
  
 -        val invokeJUnitMethodRhs = mkMethodResolutionAndCall(invokeJUnitMethodSym,
 -            methods, paramSyms.head, callLocally)
 +        val calls = annotatedMethods(module, annot)
 +          .map(gen.mkMethodCall(Ident(module), _, Nil, Nil))
 +          .toList
  
 -        mkMethod(invokeJUnitMethodSym, invokeJUnitMethodRhs, paramSyms)
 +        typer.typedDefDef(newDefDef(sym, Block(calls: _*))())
        }
  
 -      /** This method generates a method that invokes a test method in the class
 -       *  given its name. These methods have no parameters.
 -       *
 -       *  Example:
 -       *  {{{
 -       *  class Foo {
 -       *    @Test def bar(): Unit
 -       *    @Test def baz(): Unit
 -       *  }
 -       *  object Foo\$scalajs\$junit\$bootstrapper {
 -       *    // This is the method generated by mkInvokeJUnitMethodOnInstanceDef
 -       *    def invoke(instance: AnyRef, methodName: String): Unit = {
 -       *      if (methodName == "bar") instance.asInstanceOf[Foo].bar()
 -       *      else if (methodName == "baz") instance.asInstanceOf[Foo].baz()
 -       *      else throw new NoSuchMethodException(methodName + " not found")
 -       *    }
 -       *  }
 -       *  }}}
 -       */
 -      def mkInvokeJUnitMethodOnInstanceDef(methods: List[MethodSymbol],
 -          classSym: Symbol, refClassSym: Symbol): DefDef = {
 -        val invokeJUnitMethodSym = classSym.newMethod(newTermName("invoke"))
 -
 -        val paramSyms = {
 -          val params = List(("instance", definitions.ObjectTpe),
 -            ("methodName", definitions.StringTpe))
 -          mkParamSymbols(invokeJUnitMethodSym, params)
 -        }
 -
 -        val instanceParamSym :: idParamSym :: Nil = paramSyms
 +      private def genCallOnParam(owner: ClassSymbol, name: TermName, testClass: Symbol, annot: Symbol): DefDef = {
 +        val sym = owner.newMethodSymbol(name)
  
 -        invokeJUnitMethodSym.setInfo(MethodType(paramSyms, definitions.UnitTpe))
 +        val instanceParam = sym.newValueParameter(Names.instance).setInfo(ObjectTpe)
  
 -        def callLocally(methodSymbol: Symbol): Tree = {
 -          val instance = gen.mkAttributedIdent(instanceParamSym)
 -          val castedInstance = gen.mkAttributedCast(instance, refClassSym.tpe)
 -          gen.mkMethodCall(castedInstance, methodSymbol, Nil, Nil)
 -        }
 +        sym.setInfoAndEnter(MethodType(List(instanceParam), definitions.UnitTpe))
  
 -        val invokeJUnitMethodRhs = mkMethodResolutionAndCall(invokeJUnitMethodSym,
 -          methods, idParamSym, callLocally)
 +        val instance = castParam(instanceParam, testClass)
 +        val calls = annotatedMethods(testClass, annot)
 +          .map(gen.mkMethodCall(instance, _, Nil, Nil))
 +          .toList
  
 -        mkMethod(invokeJUnitMethodSym, invokeJUnitMethodRhs, paramSyms)
 +        typer.typedDefDef(newDefDef(sym, Block(calls: _*))())
        }
  
 -      def mkGetJUnitMetadataDef(clSym: Symbol,
 -          modSymOption: Option[Symbol]): DefDef = {
 -        val methods = jUnitAnnotatedMethods(clSym)
 -        val modMethods = modSymOption.map(jUnitAnnotatedMethods)
 -
 -        def liftAnnotations(methodSymbol: Symbol): List[Tree] = {
 -          val annotations = methodSymbol.annotations
 -
 -          // Find and report unsupported JUnit annotations
 -          annotations.foreach {
 -            case ann if ann.atp.typeSymbol == TestClass && ann.original.isInstanceOf[Block] =>
 -              reporter.error(ann.pos, "@Test(timeout = ...) is not " +
 -                "supported in Scala.js JUnit Framework")
 -
 -            case ann if ann.atp.typeSymbol == FixMethodOrderClass =>
 -              reporter.error(ann.pos, "@FixMethodOrder(...) is not supported " +
 -                "in Scala.js JUnit Framework")
 -
 -            case _ => // all is well
 -          }
 -
 -          // Collect lifted representations of the JUnit annotations
 -          annotations.collect {
 -            case ann if annotationWhiteList.contains(ann.tpe.typeSymbol) =>
 -              val args = if (ann.args != null) ann.args else Nil
 -              mkNewInstance(TypeTree(ann.tpe), args)
 -          }
 -        }
 -
 -        def defaultMethodMetadata(tpe: TypeTree)(mtdSym: MethodSymbol): Tree = {
 -          val annotations = liftAnnotations(mtdSym)
 -          mkNewInstance(tpe, List(
 -              Literal(Constant(mtdSym.name.toString)),
 -              mkList(annotations)))
 -        }
 +      private def genTests(owner: ClassSymbol, tests: Scope): DefDef = {
 +        val sym = owner.newMethodSymbol(Names.tests)
 +        sym.setInfoAndEnter(MethodType(Nil,
 +            typeRef(NoType, ArrayClass, List(TestMetadataClass.tpe))))
  
 -        def mkList(elems: List[Tree]): Tree = {
 -          val varargsModule =
 -            if (hasNewCollections) definitions.ScalaRunTimeModule
 -            else definitions.PredefModule
 -
 -          val array = ArrayValue(TypeTree(definitions.ObjectTpe), elems)
 -          val wrappedArray = gen.mkMethodCall(
 -              varargsModule,
 -              definitions.wrapVarargsArrayMethodName(definitions.ObjectTpe),
 -              Nil, List(array))
 -          val listApply = typer.typed {
 -            gen.mkMethodCall(definitions.ListModule, nme.apply, Nil, List(wrappedArray))
 -          }
 +        val metadata = for (test <- tests) yield {
 +          val reifiedAnnot = New(
 +              JUnitAnnots.Test, test.getAnnotation(JUnitAnnots.Test).get.args: _*)
  
 -          if (listApply.tpe.typeSymbol.isSubClass(definitions.ListClass))
 -            listApply
 -          else
 -            gen.mkCast(listApply, definitions.ListClass.toTypeConstructor)
 -        }
 +          val name = Literal(Constant(test.name.toString))
 +          val ignored = Literal(Constant(test.hasAnnotation(JUnitAnnots.Ignore)))
  
 -        def mkMethodList(tpe: TypeTree)(testMethods: List[MethodSymbol]): Tree =
 -          mkList(testMethods.map(defaultMethodMetadata(tpe)))
 -
 -        val getJUnitMethodRhs = {
 -          mkNewInstance(
 -              TypeTree(jUnitClassMetadataType),
 -              List(
 -                mkList(liftAnnotations(clSym)),
 -                gen.mkNil,
 -                mkMethodList(jUnitMethodMetadataTypeTree)(methods),
 -                modMethods.fold(gen.mkNil)(mkMethodList(jUnitMethodMetadataTypeTree))
 -          ))
 +          New(TestMetadataClass, name, ignored, reifiedAnnot)
          }
  
 -        val getJUnitMetadataSym = clSym.newMethod(newTermName("metadata"))
 -        getJUnitMetadataSym.setInfo(MethodType(Nil, jUnitClassMetadataType))
 +        val rhs = ArrayValue(TypeTree(TestMetadataClass.tpe), metadata.toList)
  
 -        typer.typedDefDef(newDefDef(getJUnitMetadataSym, getJUnitMethodRhs)())
 +        typer.typedDefDef(newDefDef(sym, rhs)())
        }
  
 -      private def hasJUnitMethodAnnotation(mtd: MethodSymbol): Boolean =
 -        annotationWhiteList.exists(hasAnnotation(mtd, _))
 +      private def genInvokeTest(owner: ClassSymbol, testClass: Symbol, tests: Scope): DefDef = {
 +        val sym = owner.newMethodSymbol(Names.invokeTest)
  
 -      private def hasAnnotation(mtd: MethodSymbol, tpe: TypeSymbol): Boolean =
 -        mtd.annotations.exists(_.atp.typeSymbol == tpe)
 +        val instanceParam = sym.newValueParameter(Names.instance).setInfo(ObjectTpe)
 +        val nameParam = sym.newValueParameter(Names.name).setInfo(StringTpe)
  
 -      private def mkNewInstance[T: TypeTag](params: List[Tree]): Apply =
 -        mkNewInstance(TypeTree(typeOf[T]), params)
 +        sym.setInfo(MethodType(List(instanceParam, nameParam), FutureClass.toTypeConstructor))
  
 -      private def mkNewInstance(tpe: TypeTree, params: List[Tree]): Apply =
 -        Apply(Select(New(tpe), nme.CONSTRUCTOR), params)
 +        val instance = castParam(instanceParam, testClass)
 +        val rhs = tests.foldRight[Tree] {
 +          Throw(New(typeOf[NoSuchMethodException], Ident(nameParam)))
 +        } { (sym, next) =>
 +          val cond = gen.mkMethodCall(Ident(nameParam), Object_equals, Nil,
 +              List(Literal(Constant(sym.name.toString))))
  
 -      /* Generate a method that creates a new instance of the test class, this
 -       * method will be located in the bootstrapper class.
 -       */
 -      private def genNewInstanceDef(classSym: Symbol, bootSymbol: Symbol): DefDef = {
 -        val mkNewInstanceDefRhs =
 -          mkNewInstance(TypeTree(classSym.typeConstructor), Nil)
 -        val mkNewInstanceDefSym = bootSymbol.newMethodSymbol(newTermName("newInstance"))
 -        mkNewInstanceDefSym.setInfo(MethodType(Nil, definitions.ObjectTpe))
 +          val call = genTestInvocation(sym, instance)
  
 -        typer.typedDefDef(newDefDef(mkNewInstanceDefSym, mkNewInstanceDefRhs)())
 -      }
 -
 -      private def mkParamSymbols(method: MethodSymbol,
 -          params: List[(String, Type)]): List[Symbol] = {
 -        params.map {
 -          case (pName, tpe) =>
 -            val sym = method.newValueParameter(newTermName(pName))
 -            sym.setInfo(tpe)
 -            sym
 +          If(cond, call, next)
          }
 -      }
  
 -      private def mkMethod(methodSym: MethodSymbol, methodRhs: Tree,
 -          paramSymbols: List[Symbol]): DefDef = {
 -        val paramValDefs = List(paramSymbols.map(newValDef(_, EmptyTree)()))
 -        typer.typedDefDef(newDefDef(methodSym, methodRhs)(vparamss = paramValDefs))
 +        typer.typedDefDef(newDefDef(sym, rhs)())
        }
  
 -      private def mkMethodResolutionAndCall(methodSym: MethodSymbol,
 -          methods: List[Symbol], idParamSym: Symbol, genCall: Symbol => Tree): Tree = {
 -        val tree = methods.foldRight[Tree](mkMethodNotFound(idParamSym)) { (methodSymbol, acc) =>
 -            val mName = Literal(Constant(methodSymbol.name.toString))
 -            val paramIdent = gen.mkAttributedIdent(idParamSym)
 -            val cond = gen.mkMethodCall(paramIdent, definitions.Object_equals, Nil, List(mName))
 -            val call = genCall(methodSymbol)
 -            If(cond, call, acc)
 +      private def genTestInvocation(sym: Symbol, instance: Tree): Tree = {
 +        sym.tpe.resultType.typeSymbol match {
 +          case UnitClass =>
 +            val boxedUnit = gen.mkAttributedRef(definitions.BoxedUnit_UNIT)
 +            val newSuccess = gen.mkMethodCall(SuccessModule_apply, List(boxedUnit))
 +            Block(
 +                gen.mkMethodCall(instance, sym, Nil, Nil),
 +                gen.mkMethodCall(FutureModule_successful, List(newSuccess))
 +            )
 +
 +          case FutureClass =>
 +            gen.mkMethodCall(instance, sym, Nil, Nil)
 +
 +          case _ =>
 +            // We lie in the error message to not expose that we support async testing.
 +            reporter.error(sym.pos, "JUnit test must have Unit return type")
 +            EmptyTree
          }
 -        atOwner(methodSym)(typer.typed(tree))
        }
  
 -      private def mkMethodNotFound(paramSym: Symbol) = {
 -        val paramIdent = gen.mkAttributedIdent(paramSym)
 -        val msg = gen.mkMethodCall(paramIdent, definitions.String_+, Nil,
 -          List(Literal(Constant(" not found"))))
 -        val exception = mkNewInstance[NoSuchMethodException](List(msg))
 -        Throw(exception)
 +      private def genNewInstance(owner: ClassSymbol, testClass: ClassSymbol): DefDef = {
 +        val sym = owner.newMethodSymbol(Names.newInstance)
 +        sym.setInfoAndEnter(MethodType(Nil, ObjectTpe))
 +        typer.typedDefDef(newDefDef(sym, New(testClass))())
        }
 -    }
  
 -    private lazy val hasNewCollections = {
 -      val v = scala.util.Properties.versionNumberString
 -      !v.startsWith("2.10.") &&
 -      !v.startsWith("2.11.") &&
 -      !v.startsWith("2.12.")
 +      private def castParam(param: Symbol, clazz: Symbol): Tree =
 +        gen.mkAsInstanceOf(Ident(param), clazz.tpe, any = false)
 +
 +      private def annotatedMethods(owner: Symbol, annot: Symbol): Scope =
-         owner.info.members.filter(m => m.isMethod && !m.isBridge && m.hasAnnotation(annot))
++        owner.info.members.filter(m => m.isMethod && m.hasAnnotation(annot))
      }
    }
  }
```
```
$ git add -u
```
```
$ git st
M  compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
M  junit-plugin/src/main/scala/org/scalajs/junit/plugin/ScalaJSJUnitPlugin.scala
M  scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
```
```
$ git commit
[merge-0.6.x-into-master-march-20 fabe8af56] Merge '0.6.x' into 'master'.
```
Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-cb47197
> testSuite/test
> compiler/test
```