### PR TITLE
Various ports to js.ArrayOps from upstream changes in ArrayOps.

### DIFF
--- a/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
@@ -15,7 +15,7 @@ package scala.scalajs.js
 import scala.annotation.tailrec
 
 import scala.collection.{immutable, mutable}
-import scala.collection.{AbstractIterator, IndexedSeqView, IterableOnce}
+import scala.collection.{AbstractIndexedSeqView, AbstractIterator, IndexedSeqView, IterableOnce}
 
 import scala.reflect.ClassTag
 
@@ -1799,7 +1799,7 @@ final class ArrayOps[A](private val xs: js.Array[A]) extends AnyVal {
 }
 
 object ArrayOps {
-  private class ArrayView[A](xs: js.Array[A]) extends IndexedSeqView[A] {
+  private class ArrayView[A](xs: js.Array[A]) extends AbstractIndexedSeqView[A] {
     @inline def length: Int = xs.length
 
     @inline def apply(n: Int): A = xs(n)

--- a/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
@@ -284,6 +284,44 @@ final class ArrayOps[A](private val xs: js.Array[A]) extends AnyVal {
     (res1, res2)
   }
 
+  /** Applies a function `f` to each element of the array and returns a pair of
+   *  arrays: the first one made of those values returned by `f` that were
+   *  wrapped in [[scala.util.Left]], and the second one made of those wrapped
+   *  in [[scala.util.Right]].
+   *
+   *  Example:
+   *  {{{
+   *  val xs = js.Array(1, "one", 2, "two", 3, "three").partitionMap {
+   *    case i: Int    => Left(i)
+   *    case s: String => Right(s)
+   *  }
+   *  // xs == (js.Array(1, 2, 3),
+   *  //        js.Array("one", "two", "three"))
+   *  }}}
+   *
+   *  @tparam A1
+   *    the element type of the first resulting collection
+   *  @tparam A2
+   *    the element type of the second resulting collection
+   *  @param f
+   *    the 'split function' mapping the elements of this array to an [[scala.util.Either]]
+   *  @return
+   *    a pair of arrays: the first one made of those values returned by `f`
+   *    that were wrapped in [[scala.util.Left]],  and the second one made of
+   *    those wrapped in [[scala.util.Right]].
+   */
+  def partitionMap[A1, A2](f: A => Either[A1, A2]): (Array[A1], Array[A2]) = {
+    val res1 = js.Array[A1]()
+    val res2 = js.Array[A2]()
+    for (x <- xs) {
+      f(x) match {
+        case Left(y)  => res1 += y
+        case Right(y) => res2 += y
+      }
+    }
+    (res1, res2)
+  }
+
   /** Returns a new array with the elements in reversed order. */
   def reverse: js.Array[A] = {
     val len = xs.length

--- a/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
@@ -1828,7 +1828,7 @@ final class ArrayOps[A](private val xs: js.Array[A]) extends AnyVal {
     xs.length -= clampIndex(n)
 
   @noinline // js.WrappedArray itself is @inline, so the call below will produce a lot of code
-  def patchInPlace(from: Int, patch: scala.collection.Seq[A],
+  def patchInPlace(from: Int, patch: scala.collection.IterableOnce[A],
       replaced: Int): js.Array[A] = {
     new js.WrappedArray(xs).patchInPlace(from, patch, replaced)
     xs

--- a/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
@@ -102,6 +102,21 @@ final class ArrayOps[A](private val xs: js.Array[A]) extends AnyVal {
     if (isEmpty) None
     else Some(xs.apply(xs.length - 1))
 
+  /** Compares the size of this array to a test value.
+   *
+   *  @param otherSize
+   *    the test value that gets compared with the size.
+   *  @return
+   *    A value `x` where
+   *    {{{
+   *    x <  0       if this.size <  otherSize
+   *    x == 0       if this.size == otherSize
+   *    x >  0       if this.size >  otherSize
+   *    }}}
+   */
+  @inline def sizeCompare(otherSize: Int): Int =
+    Integer.compare(xs.length, otherSize)
+
   /** Compares the length of this array to a test value.
    *
    *  @param len
@@ -117,6 +132,42 @@ final class ArrayOps[A](private val xs: js.Array[A]) extends AnyVal {
    */
   @inline def lengthCompare(len: Int): Int =
     Integer.compare(xs.length, len)
+
+  /** Method mirroring [[SeqOps.sizeIs]] for consistency, except it returns an
+   *  `Int` because `size` is known and comparison is constant-time.
+   *
+   *  These operations are equivalent to
+   *  [[sizeCompare(Int) `sizeCompare(Int)`]], and allow the following more
+   *  readable usages:
+   *
+   *  {{{
+   *  this.sizeIs < size     // this.sizeCompare(size) < 0
+   *  this.sizeIs <= size    // this.sizeCompare(size) <= 0
+   *  this.sizeIs == size    // this.sizeCompare(size) == 0
+   *  this.sizeIs != size    // this.sizeCompare(size) != 0
+   *  this.sizeIs >= size    // this.sizeCompare(size) >= 0
+   *  this.sizeIs > size     // this.sizeCompare(size) > 0
+   *  }}}
+   */
+  def sizeIs: Int = xs.length
+
+  /** Method mirroring [[SeqOps.lengthIs]] for consistency, except it returns
+   *  an `Int` because `length` is known and comparison is constant-time.
+   *
+   *  These operations are equivalent to
+   *  [[lengthCompare(Int) `lengthCompare(Int)`]], and allow the following more
+   *  readable usages:
+   *
+   *  {{{
+   *  this.lengthIs < len     // this.lengthCompare(len) < 0
+   *  this.lengthIs <= len    // this.lengthCompare(len) <= 0
+   *  this.lengthIs == len    // this.lengthCompare(len) == 0
+   *  this.lengthIs != len    // this.lengthCompare(len) != 0
+   *  this.lengthIs >= len    // this.lengthCompare(len) >= 0
+   *  this.lengthIs > len     // this.lengthCompare(len) > 0
+   *  }}}
+   */
+  def lengthIs: Int = xs.length
 
   /** Selects an interval of elements.
    *

--- a/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
@@ -1295,13 +1295,14 @@ final class ArrayOps[A](private val xs: js.Array[A]) extends AnyVal {
    */
   def startsWith[B >: A](that: js.Array[B], offset: Int): Boolean = {
     // scalastyle:return off
+    val safeOffset = offset.max(0)
     val thatl = that.length
-    if (thatl > xs.length - offset) {
+    if (thatl > xs.length - safeOffset) {
       thatl == 0
     } else {
       var i = 0
       while (i < thatl) {
-        if (xs(i + offset) != that(i))
+        if (xs(i + safeOffset) != that(i))
           return false
         i += 1
       }

--- a/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
@@ -1904,6 +1904,12 @@ object ArrayOps {
       pos += 1
       r
     }
+
+    override def drop(n: Int): scala.collection.Iterator[A] = {
+      if (n > 0)
+        pos = Math.min(xs.length, pos + n)
+      this
+    }
   }
 
   private class ReverseIterator[A](private[this] val xs: js.Array[A])
@@ -1919,6 +1925,12 @@ object ArrayOps {
       val r = xs(pos)
       pos -= 1
       r
+    }
+
+    override def drop(n: Int): scala.collection.Iterator[A] = {
+      if (n > 0)
+        pos = Math.max(-1, pos - n)
+      this
     }
   }
 

--- a/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/ArrayOps.scala
@@ -1230,32 +1230,64 @@ final class ArrayOps[A](private val xs: js.Array[A]) extends AnyVal {
 
   /** Copy elements of this array to a Scala array.
    *
-   *  Fills the given array `dest` starting at index `start` with at most `len`
+   *  Fills the given array `xs` starting at index 0. Copying will stop once
+   *  either all the elements of this array have been copied, or the end of the
+   *  array is reached.
+   *
+   *  @param xs
+   *    the array to fill.
+   *  @tparam B
+   *    the type of the elements of the array.
+   */
+  def copyToArray[B >: A](xs: scala.Array[B]): Int =
+    copyToArray(xs, 0)
+
+  /** Copy elements of this array to a Scala array.
+   *
+   *  Fills the given array `xs` starting at index `start`. Copying will stop
+   *  once either all the elements of this array have been copied, or the end
+   *  of the array is reached.
+   *
+   *  @param xs
+   *    the array to fill.
+   *  @param start
+   *    the starting index within the destination array.
+   *  @tparam B
+   *    the type of the elements of the array.
+   */
+  def copyToArray[B >: A](xs: scala.Array[B], start: Int): Int =
+    copyToArray(xs, start, Int.MaxValue)
+
+
+  /** Copy elements of this array to a Scala array.
+   *
+   *  Fills the given array `xs` starting at index `start` with at most `len`
    *  values. Copying will stop once either all the elements of this array have
    *  been copied, or the end of the array is reached, or `len` elements have
    *  been copied.
    *
-   *  @param dest
+   *  @param xs
    *    the array to fill.
    *  @param start
-   *    the starting index.
+   *    the starting index within the destination array.
    *  @param len
    *    the maximal number of elements to copy.
    *  @tparam B
    *    the type of the elements of the array.
    */
-  def copyToArray[B >: A](dest: scala.Array[B], start: Int,
-      len: Int = Int.MaxValue): Int = {
+  def copyToArray[B >: A](xs: scala.Array[B], start: Int, len: Int): Int = {
+    val src = this.xs
+    val dest = xs
 
     // Copied from IterableOnce.elemsToCopyToArray
     @inline
     def elemsToCopyToArray(srcLen: Int, destLen: Int, start: Int, len: Int): Int =
       max(min(min(len, srcLen), destLen - start), 0)
 
-    val copied = elemsToCopyToArray(xs.length, dest.length, start, len)
+    val copied = elemsToCopyToArray(src.length, dest.length, start, len)
     var i = 0
     while (i < copied) {
-      dest(i + start) = xs(i)
+      dest(i + start) = src(i)
       i += 1
     }
     copied

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
@@ -58,6 +58,15 @@ object ArrayOpsTest {
 
   object FallbackImplicits {
     implicit class JSArrayOpsFallback[A](self: js.Any) {
+      def sizeCompare(otherSize: Int): Int =
+        throw new AssertionError("unreachable code")
+
+      def sizeIs: Int =
+        throw new AssertionError("unreachable code")
+
+      def lengthIs: Int =
+        throw new AssertionError("unreachable code")
+
       def partitionMap[A1, A2](f: Any => Either[A1, A2]): (js.Array[A1], js.Array[A2]) =
         throw new AssertionError("unreachable code")
     }
@@ -103,11 +112,59 @@ class ArrayOpsTest {
     assertEquals(None, js.Array[Int]().lastOption)
   }
 
+  @Test def sizeCompare(): Unit = {
+    assumeFalse("sizeCompare was added in 2.13",
+        scalaVersion.startsWith("2.10.") ||
+        scalaVersion.startsWith("2.11.") ||
+        scalaVersion.startsWith("2.12.") ||
+        scalaVersion == "2.13.0-M5")
+
+    import FallbackImplicits._
+    import js.Any.jsArrayOps
+
+    val array = js.Array(5, 7, 10)
+    assertEquals(0, array.sizeCompare(3))
+    assertTrue(array.sizeCompare(1) > 0)
+    assertTrue(array.sizeCompare(6) < 0)
+  }
+
   @Test def lengthCompare(): Unit = {
     val array = js.Array(5, 7, 10)
     assertEquals(0, array.lengthCompare(3))
     assertTrue(array.lengthCompare(1) > 0)
     assertTrue(array.lengthCompare(6) < 0)
+  }
+
+  @Test def sizeIs(): Unit = {
+    assumeFalse("sizeIs was added in 2.13",
+        scalaVersion.startsWith("2.10.") ||
+        scalaVersion.startsWith("2.11.") ||
+        scalaVersion.startsWith("2.12.") ||
+        scalaVersion == "2.13.0-M5")
+
+    import FallbackImplicits._
+    import js.Any.jsArrayOps
+
+    val array = js.Array(5, 7, 10)
+    assertTrue(array.sizeIs == 3)
+    assertTrue(array.sizeIs > 1)
+    assertTrue(array.sizeIs < 6)
+  }
+
+  @Test def lengthIs(): Unit = {
+    assumeFalse("lengthIs was added in 2.13",
+        scalaVersion.startsWith("2.10.") ||
+        scalaVersion.startsWith("2.11.") ||
+        scalaVersion.startsWith("2.12.") ||
+        scalaVersion == "2.13.0-M5")
+
+    import FallbackImplicits._
+    import js.Any.jsArrayOps
+
+    val array = js.Array(5, 7, 10)
+    assertTrue(array.lengthIs == 3)
+    assertTrue(array.lengthIs > 1)
+    assertTrue(array.lengthIs < 6)
   }
 
   @Test def slice(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
@@ -589,6 +589,13 @@ class ArrayOpsTest {
   @Test def startsWith(): Unit = {
     val array = js.Array(1, 5, 7, 2, 54, 2, 78, 0, 3)
 
+    val supportsNegativeStart = {
+      !scalaVersion.startsWith("2.10.") &&
+      !scalaVersion.startsWith("2.11.") &&
+      !scalaVersion.startsWith("2.12.") &&
+      scalaVersion != "2.13.0-M5"
+    }
+
     // js.Array
 
     assertTrue(array.startsWith(js.Array[Int]()))
@@ -601,9 +608,15 @@ class ArrayOpsTest {
     assertTrue(array.startsWith(js.Array[Int](), 2))
     assertTrue(array.startsWith(js.Array(7, 2), 2))
     assertTrue(array.startsWith(js.Array(7, 2, 54, 2, 78, 0, 3), 2))
+    if (supportsNegativeStart) {
+      assertTrue(array.startsWith(js.Array(1, 5, 7, 2), -1))
+      assertTrue(array.startsWith(js.Array(1, 5, 7, 2), Int.MinValue))
+    }
 
     assertFalse(array.startsWith(js.Array(7, 2, 34, 2), 2))
     assertFalse(array.startsWith(js.Array(7, 2, 54, 2, 78, 0, 3, 6, 4), 2))
+    if (supportsNegativeStart)
+      assertFalse(array.startsWith(js.Array(1, 5, 3, 2), -1))
 
     // List
 
@@ -617,9 +630,15 @@ class ArrayOpsTest {
     assertTrue(array.startsWith(List[Int](), 2))
     assertTrue(array.startsWith(List(7, 2), 2))
     assertTrue(array.startsWith(List(7, 2, 54, 2, 78, 0, 3), 2))
+    if (supportsNegativeStart) {
+      assertTrue(array.startsWith(List(1, 5, 7, 2), -1))
+      assertTrue(array.startsWith(List(1, 5, 7, 2), Int.MinValue))
+    }
 
     assertFalse(array.startsWith(List(7, 2, 34, 2), 2))
     assertFalse(array.startsWith(List(7, 2, 54, 2, 78, 0, 3, 6, 4), 2))
+    if (supportsNegativeStart)
+      assertFalse(array.startsWith(List(1, 5, 3, 2), -1))
   }
 
   @Test def endsWith(): Unit = {


### PR DESCRIPTION
~~Will need to be rebased on top of #3594 when it is merged. The two first commits of this PR belong to #3594.~~

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-8faf949
> testSuite/test
```
Note that `compiler/test` is broken at the moment, but that's independent of this PR.