### PR TITLE
Avoid using f interpolator macro

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/Utils.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Utils.scala
@@ -62,7 +62,7 @@ private[ir] object Utils {
             out.append(EscapeJSChars, 14, 16)
             writtenChars += 2
           } else {
-            out.append(f"\\u$c%04x")
+            out.append("\\u%04x".format(c))
             writtenChars += 6
           }
         }


### PR DESCRIPTION
This instance of the `f` interpolator macro causes bootstrapping issues while compiling the Dotty compiler.

I can work around this issue for now with by [pathching the source](https://github.com/lampepfl/dotty/pull/6179/files#diff-215113124f1de02f228327ba7abb45f7R556).