### PR TITLE
Cross-compile with the deprecated `JavaConverters` without warnings.

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import scala.collection.JavaConverters._
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 import java.lang.{reflect => jlr}
 

--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import scala.collection.JavaConverters._
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 abstract class AbstractList[E] protected () extends AbstractCollection[E]
     with List[E] {

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import scala.collection.JavaConverters._
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 object AbstractMap {
 

--- a/javalib/src/main/scala/java/util/AbstractSet.scala
+++ b/javalib/src/main/scala/java/util/AbstractSet.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import scala.collection.JavaConverters._
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 abstract class AbstractSet[E] protected () extends AbstractCollection[E]
                                               with Set[E] {

--- a/javalib/src/main/scala/java/util/Collections.scala
+++ b/javalib/src/main/scala/java/util/Collections.scala
@@ -19,7 +19,7 @@ import scala.language.implicitConversions
 
 import scala.annotation.tailrec
 
-import scala.collection.JavaConverters._
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 object Collections {
 

--- a/javalib/src/main/scala/java/util/Compat.scala
+++ b/javalib/src/main/scala/java/util/Compat.scala
@@ -56,4 +56,32 @@ private[util] object Compat {
 
   }
 
+  // !!! Duplicate code with org.scalajs.testcommon.RPCCore.JDKCollectionConvertersCompat
+  /** Magic to get cross-compiling access to `scala.jdk.CollectionConverters`
+   *  with a fallback on `scala.collection.JavaConverters`, without deprecation
+   *  warning in any Scala version.
+   */
+  object JDKCollectionConvertersCompat {
+    object Scope1 {
+      object jdk {
+        object CollectionConverters {
+          type Ops = Int
+        }
+      }
+    }
+    import Scope1._
+
+    object Scope2 {
+      import scala.collection.{JavaConverters => Ops}
+      object Inner {
+        import scala._
+        import jdk.CollectionConverters.Ops
+        val Converters = Ops
+      }
+    }
+
+    val Converters = Scope2.Inner.Converters
+  }
+  // !!! End duplicate code
+
 }

--- a/javalib/src/main/scala/java/util/HashSet.scala
+++ b/javalib/src/main/scala/java/util/HashSet.scala
@@ -13,7 +13,8 @@
 package java.util
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 class HashSet[E] extends AbstractSet[E] with Set[E]
                                         with Cloneable

--- a/javalib/src/main/scala/java/util/Hashtable.scala
+++ b/javalib/src/main/scala/java/util/Hashtable.scala
@@ -15,7 +15,8 @@ package java.util
 import java.{util => ju}
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
+
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 class Hashtable[K, V] private (inner: mutable.HashMap[Box[Any], V])
     extends ju.Dictionary[K,V] with ju.Map[K, V] with Cloneable with Serializable {

--- a/javalib/src/main/scala/java/util/LinkedList.scala
+++ b/javalib/src/main/scala/java/util/LinkedList.scala
@@ -13,7 +13,8 @@
 package java.util
 
 import scala.annotation.tailrec
-import scala.collection.JavaConverters._
+
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 class LinkedList[E]() extends AbstractSequentialList[E]
     with List[E] with Deque[E] with Cloneable with Serializable {

--- a/javalib/src/main/scala/java/util/NavigableView.scala
+++ b/javalib/src/main/scala/java/util/NavigableView.scala
@@ -15,8 +15,8 @@ package java.util
 import scala.math.Ordering
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
 
+import Compat.JDKCollectionConvertersCompat.Converters._
 import Compat.SortedSetCompat
 
 private[util] class NavigableView[E](original: NavigableSet[E],

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -14,7 +14,7 @@ package java.util
 
 import java.{util => ju}
 
-import scala.collection.JavaConverters._
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 class Properties(protected val defaults: Properties)
     extends ju.Hashtable[AnyRef, AnyRef] {

--- a/javalib/src/main/scala/java/util/TreeSet.scala
+++ b/javalib/src/main/scala/java/util/TreeSet.scala
@@ -17,8 +17,8 @@ import java.lang.Comparable
 import scala.math.Ordering
 
 import scala.collection.mutable
-import scala.collection.JavaConverters._
 
+import Compat.JDKCollectionConvertersCompat.Converters._
 import Compat.SortedSetCompat
 
 class TreeSet[E] (_comparator: Comparator[_ >: E])

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -16,7 +16,7 @@ import java.lang.{reflect => jlr}
 import java.io.Serializable
 import java.util._
 
-import scala.collection.JavaConverters._
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 class ConcurrentHashMap[K >: Null, V >: Null]
     extends AbstractMap[K, V] with ConcurrentMap[K, V] with Serializable { self =>

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -17,7 +17,7 @@ import java.util._
 
 import scala.annotation.tailrec
 
-import scala.collection.JavaConverters._
+import Compat.JDKCollectionConvertersCompat.Converters._
 
 import scala.scalajs._
 


### PR DESCRIPTION
In Scala 2.13, `scala.collection.JavaConverters` has been deprecated in favor of `scala.jdk.CollectionConverters.Ops`. This commit introduces some magic to keep cross-compiling across 2.10 through 2.13 without any warning in any version.

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-bd28253
> testSuite/test
```