### PR TITLE
Bring overrides up-to-date with the latest 2.13 nightly.

### DIFF
--- a/scalalib/overrides-2.13/scala/Array.scala
+++ b/scalalib/overrides-2.13/scala/Array.scala
@@ -200,8 +200,11 @@ object Array {
   // Array(e0, ..., en) is translated to { val a = new Array(3); a(i) = ei; a }
   def apply[T: ClassTag](xs: T*): Array[T] = {
     val array = new Array[T](xs.length)
+    val iterator = xs.iterator
     var i = 0
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -210,8 +213,11 @@ object Array {
   def apply(x: Boolean, xs: Boolean*): Array[Boolean] = {
     val array = new Array[Boolean](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -220,8 +226,11 @@ object Array {
   def apply(x: Byte, xs: Byte*): Array[Byte] = {
     val array = new Array[Byte](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -230,8 +239,11 @@ object Array {
   def apply(x: Short, xs: Short*): Array[Short] = {
     val array = new Array[Short](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -240,8 +252,11 @@ object Array {
   def apply(x: Char, xs: Char*): Array[Char] = {
     val array = new Array[Char](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -250,8 +265,11 @@ object Array {
   def apply(x: Int, xs: Int*): Array[Int] = {
     val array = new Array[Int](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -260,8 +278,11 @@ object Array {
   def apply(x: Long, xs: Long*): Array[Long] = {
     val array = new Array[Long](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -270,8 +291,11 @@ object Array {
   def apply(x: Float, xs: Float*): Array[Float] = {
     val array = new Array[Float](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -280,8 +304,11 @@ object Array {
   def apply(x: Double, xs: Double*): Array[Double] = {
     val array = new Array[Double](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 
@@ -289,8 +316,11 @@ object Array {
   def apply(x: Unit, xs: Unit*): Array[Unit] = {
     val array = new Array[Unit](xs.length + 1)
     array(0) = x
+    val iterator = xs.iterator
     var i = 1
-    for (x <- xs.iterator) { array(i) = x; i += 1 }
+    while (iterator.hasNext) {
+      array(i) = iterator.next(); i += 1
+    }
     array
   }
 

--- a/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/NumericRange.scala
@@ -12,9 +12,8 @@
 
 package scala.collection.immutable
 
-import scala.collection.{AbstractIterator, Iterator}
-
-import java.lang.String
+import scala.collection.Stepper.EfficientSplit
+import scala.collection.{AbstractIterator, AnyStepper, Iterator, Stepper, StepperShape}
 
 /** `NumericRange` is a more generic version of the
   *  `Range` class which works with arbitrary types.
@@ -53,6 +52,18 @@ sealed class NumericRange[T](
     with Serializable { self =>
 
   override def iterator: Iterator[T] = new NumericRange.NumericRangeIterator(this, num)
+
+  override def stepper[B >: T, S <: Stepper[_]](implicit shape: StepperShape[B, S]): S with EfficientSplit = {
+    import scala.collection.convert._
+    import impl._
+    val s = shape.shape match {
+      case StepperShape.IntShape    => new IntNumericRangeStepper   (this.asInstanceOf[NumericRange[Int]],    0, length)
+      case StepperShape.LongShape   => new LongNumericRangeStepper  (this.asInstanceOf[NumericRange[Long]],   0, length)
+      case _         => shape.parUnbox(new AnyNumericRangeStepper[T](this, 0, length).asInstanceOf[AnyStepper[B] with EfficientSplit])
+    }
+    s.asInstanceOf[S with EfficientSplit]
+  }
+
 
   /** Note that NumericRange must be invariant so that constructs
     *  such as "1L to 10 by 5" do not infer the range type as AnyVal.

--- a/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala
+++ b/scalalib/overrides-2.13/scala/concurrent/ExecutionContext.scala
@@ -161,13 +161,13 @@ object ExecutionContext {
    *
    * Any `NonFatal` or `InterruptedException`s will be reported to the `defaultReporter`.
    */
-  final object parasitic extends ExecutionContextExecutor with BatchingExecutor {
+  object parasitic extends ExecutionContextExecutor with BatchingExecutor {
     override final def submitForExecution(runnable: Runnable): Unit = runnable.run()
     override final def execute(runnable: Runnable): Unit = submitSyncBatched(runnable)
     override final def reportFailure(t: Throwable): Unit = defaultReporter(t)
   }
 
-  final object Implicits {
+  object Implicits {
     /**
      * The implicit global `ExecutionContext`. Import `global` when you want to provide the global
      * `ExecutionContext` implicitly.


### PR DESCRIPTION
With changes mostly coming from https://github.com/scala/scala/pull/7458

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-ff33e9e
> testSuite/test
```