### PR TITLE
Fix compiler tests on Scala 2.13

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSExportTest.scala
@@ -852,14 +852,19 @@ class JSExportTest extends DirectTest with TestHelpers {
   @Test
   def noOverrideNamedExport: Unit = {
 
-    val indent = {
+    val overrideFinalMsg = {
       val version = scala.util.Properties.versionNumberString
       if (version.startsWith("2.10.") ||
           version.startsWith("2.11.") ||
           version.startsWith("2.12.")) {
-        " "
+        """overriding method $js$exported$meth$foo in class A of type (namedArgs: Any)Any;
+          | method $js$exported$meth$foo cannot override final member""".stripMargin
+      } else if (version == "2.13.0-M5") {
+        """overriding method $js$exported$meth$foo in class A of type (namedArgs: Any)Any;
+          |  method $js$exported$meth$foo cannot override final member""".stripMargin
       } else {
-        "  "
+        """cannot override final member:
+          |final def $js$exported$meth$foo(namedArgs: Any): Any (defined in class A)""".stripMargin
       }
     }
 
@@ -881,8 +886,7 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:4: warning: class JSExportNamed in package annotation is deprecated${since("0.6.11")}: Use @JSExport with an explicit option bag instead. See the Scaladoc for more details.
       |      @JSExportNamed
       |       ^
-      |newSource1.scala:9: error: overriding method $$js$$exported$$meth$$foo in class A of type (namedArgs: Any)Any;
-      |${indent}method $$js$$exported$$meth$$foo cannot override final member
+      |newSource1.scala:9: error: $overrideFinalMsg
       |      @JSExportNamed
       |       ^
       |newSource1.scala:10: warning: class JSExportNamed in package annotation is deprecated${since("0.6.11")}: Use @JSExport with an explicit option bag instead. See the Scaladoc for more details.

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/JSInteropTest.scala
@@ -36,6 +36,18 @@ class JSInteropTest extends DirectTest with TestHelpers {
       "JSGlobalScope" -> "@JSGlobalScope"
   )
 
+  private def ifHasNewRefChecks(msg: String): String = {
+    val version = scala.util.Properties.versionNumberString
+    if (version.startsWith("2.10.") ||
+        version.startsWith("2.11.") ||
+        version.startsWith("2.12.") ||
+        version == "2.13.0-M5") {
+      ""
+    } else {
+      msg.stripMargin.trim()
+    }
+  }
+
   @Test
   def warnJSPackageObjectDeprecated: Unit = {
 
@@ -2230,7 +2242,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     }
     class C extends B
     """ hasWarns
-    """
+    s"""
       |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in class A with JSName 'foo'
@@ -2239,6 +2251,16 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      def foo: Int
       |          ^
+      |${ifHasNewRefChecks("""
+        |newSource1.scala:12: warning: A member of a JS class is overriding another member with a different JS name.
+        |
+        |def foo: Int in class A with JSName 'foo'
+        |    is conflicting with
+        |def foo: Int in trait B with JSName 'bar'
+        |
+        |    class C extends B
+        |          ^
+      """)}
     """
 
     """
@@ -2251,7 +2273,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     }
     class C extends B
     """ hasWarns
-    """
+    s"""
       |newSource1.scala:10: warning: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in class A with JSName 'bar'
@@ -2260,6 +2282,16 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      def foo: Int
       |          ^
+      |${ifHasNewRefChecks("""
+        |newSource1.scala:12: warning: A member of a JS class is overriding another member with a different JS name.
+        |
+        |def foo: Int in class A with JSName 'bar'
+        |    is conflicting with
+        |def foo: Int in trait B with JSName 'foo'
+        |
+        |    class C extends B
+        |          ^
+      """)}
     """
 
     """
@@ -2623,7 +2655,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     }
     class C extends B
     """ hasWarns
-    """
+    s"""
       |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in class A with JSName 'foo'
@@ -2632,6 +2664,16 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      def foo: Int
       |          ^
+      |${ifHasNewRefChecks("""
+        |newSource1.scala:16: warning: A member of a JS class is overriding another member with a different JS name.
+        |
+        |def foo: Int in class A with JSName 'foo'
+        |    is conflicting with
+        |def foo: Int in trait B with JSName 'Syms.sym1'
+        |
+        |    class C extends B
+        |          ^
+      """)}
     """
 
     """
@@ -2648,7 +2690,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     }
     class C extends B
     """ hasWarns
-    """
+    s"""
       |newSource1.scala:14: warning: A member of a JS class is overriding another member with a different JS name.
       |
       |def foo: Int in class A with JSName 'Syms.sym1'
@@ -2657,6 +2699,16 @@ class JSInteropTest extends DirectTest with TestHelpers {
       |
       |      def foo: Int
       |          ^
+      |${ifHasNewRefChecks("""
+        |newSource1.scala:16: warning: A member of a JS class is overriding another member with a different JS name.
+        |
+        |def foo: Int in class A with JSName 'Syms.sym1'
+        |    is conflicting with
+        |def foo: Int in trait B with JSName 'foo'
+        |
+        |    class C extends B
+        |          ^
+      """)}
     """
 
     """


### PR DESCRIPTION
Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.0-pre-63769af
> testSuite/test
> javalibExTestSuite/test
> compiler/test
```
No review, because it's just adapting neg tests, and we need to cut 0.6.27 ASAP now that Scala 2.13.0-RC1 is being built.