### PR TITLE
[no-master] Fix #3571: Always load reflective call return types

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
@@ -499,13 +499,8 @@ private final class Analyzer(semantics: Semantics,
       import ir.Types._
 
       def classIsMoreSpecific(leftCls: String, rightCls: String): Boolean = {
-        leftCls != rightCls && {
-          val leftInfo = _classInfos.get(leftCls)
-          val rightInfo = _classInfos.get(rightCls)
-          leftInfo.zip(rightInfo).exists { case (l, r) =>
-            l.ancestors.contains(r)
-          }
-        }
+        leftCls != rightCls &&
+        lookupClass(leftCls).ancestors.contains(lookupClass(rightCls))
       }
 
       (left, right) match {


### PR DESCRIPTION
This caused reflective call determination to behave differently
depending on whether a result type was loaded or not.