### PR TITLE
Make JSEnvSuite compile warning free on Java 9

### DIFF
--- a/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvSuite.scala
+++ b/js-envs-test-kit/src/main/scala/org/scalajs/jsenv/test/JSEnvSuite.scala
@@ -43,7 +43,8 @@ final class JSEnvSuiteRunner(root: Class[_], config: JSEnvSuiteConfig)
     extends Suite(root, JSEnvSuiteRunner.getRunners(config).asJava) {
 
   /** Constructor for reflective instantiation via `@RunWith`. */
-  def this(suite: Class[_ <: JSEnvSuite]) = this(suite, suite.newInstance().config)
+  def this(suite: Class[_ <: JSEnvSuite]) =
+    this(suite, suite.getDeclaredConstructor().newInstance().config)
 
   /** Constructor for instantiation in a user defined Runner. */
   def this(config: JSEnvSuiteConfig) = this(null, config)


### PR DESCRIPTION
Class#newInstance is deprecated.