### PR TITLE
Do not rely on JavaConverters in our implementation of java.util.

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import Compat.JDKCollectionConvertersCompat.Converters._
+import ScalaOps._
 
 import java.lang.{reflect => jlr}
 
@@ -25,7 +25,7 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   def isEmpty(): Boolean = size == 0
 
   def contains(o: Any): Boolean =
-    iterator.asScala.exists(o === _)
+    this.scalaOps.exists(o === _)
 
   def toArray(): Array[AnyRef] =
     toArray(new Array[AnyRef](size))
@@ -62,10 +62,10 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   }
 
   def containsAll(c: Collection[_]): Boolean =
-    c.iterator.asScala.forall(this.contains(_))
+    c.scalaOps.forall(this.contains(_))
 
   def addAll(c: Collection[_ <: E]): Boolean =
-    c.asScala.foldLeft(false)((prev, elem) => add(elem) || prev)
+    c.scalaOps.foldLeft(false)((prev, elem) => add(elem) || prev)
 
   def removeAll(c: Collection[_]): Boolean =
     removeWhere(c.contains(_))
@@ -89,5 +89,5 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   }
 
   override def toString(): String =
-    iterator.asScala.mkString("[", ",", "]")
+    this.scalaOps.mkString("[", ",", "]")
 }

--- a/javalib/src/main/scala/java/util/AbstractList.scala
+++ b/javalib/src/main/scala/java/util/AbstractList.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import Compat.JDKCollectionConvertersCompat.Converters._
+import ScalaOps._
 
 abstract class AbstractList[E] protected () extends AbstractCollection[E]
     with List[E] {
@@ -35,7 +35,7 @@ abstract class AbstractList[E] protected () extends AbstractCollection[E]
     throw new UnsupportedOperationException
 
   def indexOf(o: Any): Int =
-    iterator.asScala.indexWhere(_ === o)
+    this.scalaOps.indexWhere(_ === o)
 
   def lastIndexOf(o: Any): Int = {
     @tailrec
@@ -52,7 +52,7 @@ abstract class AbstractList[E] protected () extends AbstractCollection[E]
 
   def addAll(index: Int, c: Collection[_ <: E]): Boolean = {
     checkIndexOnBounds(index)
-    for ((elem, i) <- c.iterator.asScala.zipWithIndex)
+    for ((elem, i) <- c.iterator().scalaOps.zipWithIndex.scalaOps)
       add(index + i, elem)
     !c.isEmpty
   }
@@ -111,14 +111,14 @@ abstract class AbstractList[E] protected () extends AbstractCollection[E]
       o match {
         case o: List[_] =>
           val oIter = o.listIterator
-          this.asScala.forall(oIter.hasNext && _ === oIter.next()) && !oIter.hasNext
+          this.scalaOps.forall(oIter.hasNext && _ === oIter.next()) && !oIter.hasNext
         case _ => false
       }
     }
   }
 
   override def hashCode(): Int = {
-    this.asScala.foldLeft(1) {
+    this.scalaOps.foldLeft(1) {
       (prev, elem) => 31 * prev + (if (elem == null) 0 else elem.hashCode)
     }
   }

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import Compat.JDKCollectionConvertersCompat.Converters._
+import ScalaOps._
 
 object AbstractMap {
 
@@ -95,13 +95,13 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
   def isEmpty(): Boolean = size == 0
 
   def containsValue(value: Any): Boolean =
-    entrySet.iterator.asScala.exists(value === _.getValue)
+    entrySet.scalaOps.exists(value === _.getValue)
 
   def containsKey(key: Any): Boolean =
-    entrySet.iterator.asScala.exists(entry => entry === key)
+    entrySet.scalaOps.exists(entry => entry === key)
 
   def get(key: Any): V = {
-    entrySet.iterator.asScala.find(_.getKey === key).fold[V] {
+    entrySet.scalaOps.find(_.getKey === key).fold[V] {
       null.asInstanceOf[V]
     } { entry =>
       entry.getValue
@@ -128,7 +128,7 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
   }
 
   def putAll(m: Map[_ <: K, _ <: V]): Unit =
-    m.entrySet.iterator.asScala.foreach(e => put(e.getKey, e.getValue))
+    m.entrySet.scalaOps.foreach(e => put(e.getKey, e.getValue))
 
   def clear(): Unit =
     entrySet.clear()
@@ -177,18 +177,18 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
       o match {
         case m: Map[_, _] =>
           self.size == m.size &&
-          entrySet.asScala.forall(item => m.get(item.getKey) === item.getValue)
+          entrySet.scalaOps.forall(item => m.get(item.getKey) === item.getValue)
         case _ => false
       }
     }
   }
 
   override def hashCode(): Int =
-    entrySet.asScala.foldLeft(0)((prev, item) => item.hashCode + prev)
+    entrySet.scalaOps.foldLeft(0)((prev, item) => item.hashCode + prev)
 
   override def toString(): String = {
-    entrySet.iterator.asScala.map {
+    entrySet.iterator.scalaOps.map {
       e => s"${e.getKey}=${e.getValue}"
-    }.mkString("{", ", ", "}")
+    }.scalaOps.mkString("{", ", ", "}")
   }
 }

--- a/javalib/src/main/scala/java/util/AbstractSet.scala
+++ b/javalib/src/main/scala/java/util/AbstractSet.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import Compat.JDKCollectionConvertersCompat.Converters._
+import ScalaOps._
 
 abstract class AbstractSet[E] protected () extends AbstractCollection[E]
                                               with Set[E] {
@@ -29,11 +29,11 @@ abstract class AbstractSet[E] protected () extends AbstractCollection[E]
   }
 
   override def hashCode(): Int =
-    iterator.asScala.foldLeft(0)((prev, item) => item.hashCode + prev)
+    this.scalaOps.foldLeft(0)((prev, item) => item.hashCode + prev)
 
   override def removeAll(c: Collection[_]): Boolean = {
     if (size > c.size) {
-      c.asScala.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
+      c.scalaOps.foldLeft(false)((prev, elem) => this.remove(elem) || prev)
     } else {
       @tailrec
       def removeAll(iter: Iterator[E], modified: Boolean): Boolean = {

--- a/javalib/src/main/scala/java/util/Compat.scala
+++ b/javalib/src/main/scala/java/util/Compat.scala
@@ -56,32 +56,4 @@ private[util] object Compat {
 
   }
 
-  // !!! Duplicate code with org.scalajs.testcommon.RPCCore.JDKCollectionConvertersCompat
-  /** Magic to get cross-compiling access to `scala.jdk.CollectionConverters`
-   *  with a fallback on `scala.collection.JavaConverters`, without deprecation
-   *  warning in any Scala version.
-   */
-  object JDKCollectionConvertersCompat {
-    object Scope1 {
-      object jdk {
-        object CollectionConverters {
-          type Ops = Int
-        }
-      }
-    }
-    import Scope1._
-
-    object Scope2 {
-      import scala.collection.{JavaConverters => Ops}
-      object Inner {
-        import scala._
-        import jdk.CollectionConverters.Ops
-        val Converters = Ops
-      }
-    }
-
-    val Converters = Scope2.Inner.Converters
-  }
-  // !!! End duplicate code
-
 }

--- a/javalib/src/main/scala/java/util/HashSet.scala
+++ b/javalib/src/main/scala/java/util/HashSet.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.collection.mutable
 
-import Compat.JDKCollectionConvertersCompat.Converters._
+import ScalaOps._
 
 class HashSet[E] extends AbstractSet[E] with Set[E]
                                         with Cloneable
@@ -40,7 +40,7 @@ class HashSet[E] extends AbstractSet[E] with Set[E]
     inner.remove(Box(o.asInstanceOf[E]))
 
   override def containsAll(c: Collection[_]): Boolean =
-    c.iterator.asScala.forall(e => contains(e))
+    c.scalaOps.forall(e => contains(e))
 
   override def removeAll(c: Collection[_]): Boolean = {
     val iter = c.iterator

--- a/javalib/src/main/scala/java/util/LinkedList.scala
+++ b/javalib/src/main/scala/java/util/LinkedList.scala
@@ -14,7 +14,7 @@ package java.util
 
 import scala.annotation.tailrec
 
-import Compat.JDKCollectionConvertersCompat.Converters._
+import ScalaOps._
 
 class LinkedList[E]() extends AbstractSequentialList[E]
     with List[E] with Deque[E] with Cloneable with Serializable {
@@ -109,7 +109,7 @@ class LinkedList[E]() extends AbstractSequentialList[E]
   }
 
   override def contains(o: Any): Boolean =
-    iterator().asScala.exists(_ === o)
+    this.scalaOps.exists(_ === o)
 
   override def size(): Int =
     _size.toInt

--- a/javalib/src/main/scala/java/util/NavigableView.scala
+++ b/javalib/src/main/scala/java/util/NavigableView.scala
@@ -16,8 +16,8 @@ import scala.math.Ordering
 
 import scala.collection.mutable
 
-import Compat.JDKCollectionConvertersCompat.Converters._
 import Compat.SortedSetCompat
+import ScalaOps._
 
 private[util] class NavigableView[E](original: NavigableSet[E],
     inner: () => mutable.SortedSet[Box[E]],
@@ -26,7 +26,7 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     extends AbstractCollection[E] with NavigableSet[E] with SortedSet[E] {
 
   def size(): Int =
-    iterator.asScala.size
+    iterator.scalaOps.count(_ => true)
 
   override def contains(o: Any): Boolean =
     inner().contains(Box(o.asInstanceOf[E]))
@@ -75,7 +75,7 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     _iterator(inner().iterator.map(_.inner))
 
   def descendingIterator(): Iterator[E] =
-    _iterator(iterator.asScala.toList.reverse.iterator)
+    _iterator(iterator.scalaOps.toList.reverse.iterator)
 
   override def removeAll(c: Collection[_]): Boolean = {
     val iter = c.iterator()
@@ -89,16 +89,16 @@ private[util] class NavigableView[E](original: NavigableSet[E],
     original.addAll(c)
 
   def lower(e: E): E =
-    headSet(e, false).asScala.lastOption.getOrElse(null.asInstanceOf[E])
+    headSet(e, false).last()
 
   def floor(e: E): E =
-    headSet(e, true).asScala.lastOption.getOrElse(null.asInstanceOf[E])
+    headSet(e, true).last()
 
   def ceiling(e: E): E =
-    tailSet(e, true).asScala.headOption.getOrElse(null.asInstanceOf[E])
+    tailSet(e, true).first()
 
   def higher(e: E): E =
-    tailSet(e, false).asScala.headOption.getOrElse(null.asInstanceOf[E])
+    tailSet(e, false).first()
 
   def pollFirst(): E = {
     val polled = inner().headOption

--- a/javalib/src/main/scala/java/util/ScalaOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaOps.scala
@@ -1,0 +1,262 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util
+
+import scala.collection.immutable
+import scala.collection.mutable
+
+/** Make some Scala collection APIs available on Java collections. */
+private[util] object ScalaOps {
+
+  implicit class ToScalaIterableOps[A] private[ScalaOps] (
+      val __self: scala.collection.Iterable[A])
+      extends AnyVal {
+    def javaIterator(): Iterator[A] =
+      new JavaIteratorAdapter(__self.iterator)
+  }
+
+  private class JavaIteratorAdapter[A](scalaIterator: scala.collection.Iterator[A])
+      extends Iterator[A] {
+    def hasNext(): Boolean = scalaIterator.hasNext
+    def next(): A = scalaIterator.next()
+
+    def remove(): Unit =
+      throw new UnsupportedOperationException("remove")
+  }
+
+  implicit class ScalaIteratorOps[A] private[ScalaOps] (
+      val __self: scala.collection.Iterator[A])
+      extends AnyVal {
+
+    def asJavaEnumeration(): Enumeration[A] =
+      new JavaEnumerationAdapter(__self)
+  }
+
+  private class JavaEnumerationAdapter[A] private[ScalaOps] (
+      val __self: scala.collection.Iterator[A])
+      extends Enumeration[A] {
+
+    def hasMoreElements(): Boolean = __self.hasNext
+
+    def nextElement(): A = __self.next()
+  }
+
+  implicit class ToJavaIterableOps[A] private[ScalaOps] (
+      val __self: java.lang.Iterable[A])
+      extends AnyVal {
+    def scalaOps: JavaIterableOps[A] = new JavaIterableOps[A](__self)
+  }
+
+  class JavaIterableOps[A] private[ScalaOps] (
+      val __self: java.lang.Iterable[A])
+      extends AnyVal {
+
+    @inline def foreach[U](f: A => U): Unit =
+      __self.iterator().scalaOps.foreach(f)
+
+    @inline def count(f: A => Boolean): Int =
+      __self.iterator().scalaOps.count(f)
+
+    @inline def exists(f: A => Boolean): Boolean =
+      __self.iterator().scalaOps.exists(f)
+
+    @inline def forall(f: A => Boolean): Boolean =
+      __self.iterator().scalaOps.forall(f)
+
+    @inline def indexWhere(f: A => Boolean): Int =
+      __self.iterator().scalaOps.indexWhere(f)
+
+    @inline def find(f: A => Boolean): Option[A] =
+      __self.iterator().scalaOps.find(f)
+
+    @inline def foldLeft[B](z: B)(f: (B, A) => B): B =
+      __self.iterator().scalaOps.foldLeft(z)(f)
+
+    @inline def reduceLeft[B >: A](f: (B, A) => B): B =
+      __self.iterator().scalaOps.reduceLeft(f)
+
+    @inline def toList: immutable.List[A] =
+      __self.iterator().scalaOps.toList
+
+    @inline def toSeq: immutable.Seq[A] =
+      __self.iterator().scalaOps.toSeq
+
+    @inline def toSet: immutable.Set[A] =
+      __self.iterator().scalaOps.toSet
+
+    @inline def mkString(start: String, sep: String, end: String): String =
+      __self.iterator().scalaOps.mkString(start, sep, end)
+  }
+
+  implicit class ToJavaIteratorOps[A] private[ScalaOps] (
+      val __self: Iterator[A])
+      extends AnyVal {
+    def scalaOps: JavaIteratorOps[A] = new JavaIteratorOps[A](__self)
+  }
+
+  class JavaIteratorOps[A] private[ScalaOps] (val __self: Iterator[A])
+      extends AnyVal {
+
+    @inline def foreach[U](f: A => U): Unit = {
+      while (__self.hasNext())
+        f(__self.next())
+    }
+
+    @inline def count(f: A => Boolean): Int =
+      foldLeft(0)((prev, x) => if (f(x)) prev + 1 else prev)
+
+    @inline def exists(f: A => Boolean): Boolean = {
+      // scalastyle:off return
+      while (__self.hasNext()) {
+        if (f(__self.next()))
+          return true
+      }
+      false
+      // scalastyle:on return
+    }
+
+    @inline def forall(f: A => Boolean): Boolean =
+      !exists(x => !f(x))
+
+    @inline def indexWhere(f: A => Boolean): Int = {
+      // scalastyle:off return
+      var i = 0
+      while (__self.hasNext()) {
+        if (f(__self.next()))
+          return i
+        i += 1
+      }
+      -1
+      // scalastyle:on return
+    }
+
+    @inline def find(f: A => Boolean): Option[A] = {
+      // scalastyle:off return
+      while (__self.hasNext()) {
+        val x = __self.next()
+        if (f(x))
+          return Some(x)
+      }
+      None
+      // scalastyle:on return
+    }
+
+    @inline def foldLeft[B](z: B)(f: (B, A) => B): B = {
+      var result: B = z
+      while (__self.hasNext())
+        result = f(result, __self.next())
+      result
+    }
+
+    @inline def reduceLeft[B >: A](f: (B, A) => B): B = {
+      if (!__self.hasNext())
+        throw new NoSuchElementException("collection is empty")
+      foldLeft[B](__self.next())(f)
+    }
+
+    @inline def toList: immutable.List[A] = {
+      val builder = immutable.List.newBuilder[A]
+      foreach(builder += _)
+      builder.result()
+    }
+
+    @inline def toSeq: immutable.Seq[A] = toList
+
+    @inline def toSet: immutable.Set[A] = {
+      val builder = immutable.Set.newBuilder[A]
+      foreach(builder += _)
+      builder.result()
+    }
+
+    @inline def mkString(start: String, sep: String, end: String): String = {
+      var result: String = start
+      var first = true
+      while (__self.hasNext()) {
+        if (first)
+          first = false
+        else
+          result += sep
+        result += __self.next()
+      }
+      result + end
+    }
+
+    @inline def map[B](f: A => B): Iterator[B] =
+      new MappedIterator(__self, f)
+
+    @inline def withFilter(f: A => Boolean): IteratorWithFilter[A] =
+      new IteratorWithFilter(__self, f)
+
+    @inline def zipWithIndex: Iterator[(A, Int)] =
+      new IteratorWithIndex(__self)
+  }
+
+  @inline
+  private class MappedIterator[A, B](iter: Iterator[A], f: A => B)
+      extends Iterator[B] {
+
+    def hasNext(): Boolean = iter.hasNext()
+
+    def next(): B = f(iter.next())
+
+    def remove(): Unit = iter.remove()
+  }
+
+  @inline
+  final class IteratorWithFilter[A] private[ScalaOps] (
+      iter: Iterator[A], pred: A => Boolean) {
+
+    def foreach[U](f: A => U): Unit = {
+      for (x <- iter.scalaOps) {
+        if (pred(x))
+          f(x)
+      }
+    }
+
+    def withFilter(f: A => Boolean): IteratorWithFilter[A] =
+      new IteratorWithFilter(iter, x => pred(x) && f(x))
+  }
+
+  @inline
+  private class IteratorWithIndex[A](iter: Iterator[A])
+      extends Iterator[(A, Int)] {
+
+    private var lastIndex = -1
+
+    def hasNext(): Boolean = iter.hasNext()
+
+    def next(): (A, Int) = {
+      val index = lastIndex + 1
+      lastIndex = index
+      (iter.next(), index)
+    }
+
+    def remove(): Unit = iter.remove()
+  }
+
+  implicit class ToJavaEnumerationOps[A] private[ScalaOps] (
+      val __self: Enumeration[A])
+      extends AnyVal {
+    def scalaOps: JavaEnumerationOps[A] = new JavaEnumerationOps[A](__self)
+  }
+
+  class JavaEnumerationOps[A] private[ScalaOps] (val __self: Enumeration[A])
+      extends AnyVal {
+
+    @inline def foreach[U](f: A => U): Unit = {
+      while (__self.hasMoreElements())
+        f(__self.nextElement())
+    }
+  }
+
+}

--- a/javalib/src/main/scala/java/util/TreeSet.scala
+++ b/javalib/src/main/scala/java/util/TreeSet.scala
@@ -18,8 +18,8 @@ import scala.math.Ordering
 
 import scala.collection.mutable
 
-import Compat.JDKCollectionConvertersCompat.Converters._
 import Compat.SortedSetCompat
+import ScalaOps._
 
 class TreeSet[E] (_comparator: Comparator[_ >: E])
     extends AbstractSet[E]
@@ -222,16 +222,16 @@ class TreeSet[E] (_comparator: Comparator[_ >: E])
     inner.last.inner
 
   def lower(e: E): E =
-    headSet(e, false).asScala.lastOption.getOrElse(null.asInstanceOf[E])
+    headSet(e, false).last()
 
   def floor(e: E): E =
-    headSet(e, true).asScala.lastOption.getOrElse(null.asInstanceOf[E])
+    headSet(e, true).last()
 
   def ceiling(e: E): E =
-    tailSet(e, true).asScala.headOption.getOrElse(null.asInstanceOf[E])
+    tailSet(e, true).first()
 
   def higher(e: E): E =
-    tailSet(e, false).asScala.headOption.getOrElse(null.asInstanceOf[E])
+    tailSet(e, false).first()
 
   def pollFirst(): E = {
     val polled = inner.headOption

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -16,7 +16,7 @@ import java.lang.{reflect => jlr}
 import java.io.Serializable
 import java.util._
 
-import Compat.JDKCollectionConvertersCompat.Converters._
+import ScalaOps._
 
 class ConcurrentHashMap[K >: Null, V >: Null]
     extends AbstractMap[K, V] with ConcurrentMap[K, V] with Serializable { self =>
@@ -75,7 +75,7 @@ class ConcurrentHashMap[K >: Null, V >: Null]
   }
 
   override def putAll(m: Map[_ <: K, _ <: V]): Unit = {
-    for (e <- m.entrySet().asScala)
+    for (e <- m.entrySet().scalaOps)
       put(e.getKey, e.getValue)
   }
 
@@ -181,8 +181,12 @@ object ConcurrentHashMap {
       }
     }
 
-    def toArray(): Array[AnyRef] =
-      chm.keys().asInstanceOf[Enumeration[AnyRef]].asScala.toArray[AnyRef]
+    def toArray(): Array[AnyRef] = {
+      val result = new Array[AnyRef](size())
+      for (keyAndIdx <- iterator().scalaOps.zipWithIndex.scalaOps)
+        result(keyAndIdx._2) = keyAndIdx._1.asInstanceOf[AnyRef]
+      result
+    }
 
     def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
       val toFill: Array[T] =
@@ -203,7 +207,7 @@ object ConcurrentHashMap {
     def remove(o: Any): Boolean = chm.remove(o) != null
 
     def containsAll(c: Collection[_]): Boolean =
-      c.asScala.forall(item => chm.asScala.contains(item.asInstanceOf[K]))
+      c.scalaOps.forall(item => chm.containsKey(item.asInstanceOf[K]))
 
     def addAll(c: Collection[_ <: K]): Boolean =
       throw new UnsupportedOperationException()

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -17,7 +17,7 @@ import java.util._
 
 import scala.annotation.tailrec
 
-import Compat.JDKCollectionConvertersCompat.Converters._
+import ScalaOps._
 
 import scala.scalajs._
 
@@ -50,14 +50,14 @@ class CopyOnWriteArrayList[E <: AnyRef] private (private var inner: js.Array[E])
     size == 0
 
   def contains(o: scala.Any): Boolean =
-    iterator.asScala.exists(o === _)
+    iterator.scalaOps.exists(o === _)
 
   def indexOf(o: scala.Any): Int =
     indexOf(o.asInstanceOf[E], 0)
 
   def indexOf(e: E, index: Int): Int = {
     checkIndexInBounds(index)
-    index + listIterator(index).asScala.indexWhere(_ === e)
+    index + listIterator(index).scalaOps.indexWhere(_ === e)
   }
 
   def lastIndexOf(o: scala.Any): Int =
@@ -141,18 +141,18 @@ class CopyOnWriteArrayList[E <: AnyRef] private (private var inner: js.Array[E])
   }
 
   def containsAll(c: Collection[_]): Boolean =
-    c.iterator.asScala.forall(this.contains(_))
+    c.iterator.scalaOps.forall(this.contains(_))
 
   def removeAll(c: Collection[_]): Boolean = {
     copyIfNeeded()
-    c.asScala.foldLeft(false)((prev, elem) => remove(elem) || prev)
+    c.scalaOps.foldLeft(false)((prev, elem) => remove(elem) || prev)
   }
 
   def retainAll(c: Collection[_]): Boolean = {
-    val iter = iterator().asScala
+    val iter = iterator()
     clear()
     var modified = false
-    for (elem <- iter) {
+    for (elem <- iter.scalaOps) {
       if (c.contains(elem))
         innerPush(elem)
       else
@@ -163,7 +163,7 @@ class CopyOnWriteArrayList[E <: AnyRef] private (private var inner: js.Array[E])
 
   def addAllAbsent(c: Collection[_ <: E]): Int = {
     var added = 0
-    for (e <- c.iterator().asScala) {
+    for (e <- c.iterator().scalaOps) {
       if (addIfAbsent(e))
         added += 1
     }
@@ -181,12 +181,12 @@ class CopyOnWriteArrayList[E <: AnyRef] private (private var inner: js.Array[E])
   def addAll(index: Int, c: Collection[_ <: E]): Boolean = {
     checkIndexOnBounds(index)
     copyIfNeeded()
-    innerSplice(index, 0, c.asInstanceOf[Collection[E]].asScala.toSeq: _*)
+    innerSplice(index, 0, c.asInstanceOf[Collection[E]].scalaOps.toSeq: _*)
     !c.isEmpty
   }
 
   override def toString: String =
-    iterator().asScala.mkString("[", ",", "]")
+    iterator().scalaOps.mkString("[", ",", "]")
 
   override def equals(obj: Any): Boolean = {
     if (obj.asInstanceOf[AnyRef] eq this) {
@@ -195,14 +195,14 @@ class CopyOnWriteArrayList[E <: AnyRef] private (private var inner: js.Array[E])
       obj match {
         case obj: List[_] =>
           val oIter = obj.listIterator
-          this.asScala.forall(oIter.hasNext && _ === oIter.next()) && !oIter.hasNext
+          this.scalaOps.forall(oIter.hasNext && _ === oIter.next()) && !oIter.hasNext
         case _ => false
       }
     }
   }
 
   override def hashCode(): Int = {
-    iterator().asScala.foldLeft(1) {
+    iterator().scalaOps.foldLeft(1) {
       (prev, elem) => 31 * prev + (if (elem == null) 0 else elem.hashCode)
     }
   }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -23,6 +23,9 @@ object BinaryIncompatibilities {
   )
 
   val TestCommon = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[MissingClassProblem](
+          "org.scalajs.testcommon.RPCCore$JDKCollectionConvertersCompat$*")
   )
 
   val TestAdapter = TestCommon ++ Seq(

--- a/test-common/src/main/scala/org/scalajs/testcommon/RPCCore.scala
+++ b/test-common/src/main/scala/org/scalajs/testcommon/RPCCore.scala
@@ -38,7 +38,6 @@ import FutureUtil._
  */
 private[scalajs] abstract class RPCCore()(implicit ex: ExecutionContext) {
   import RPCCore._
-  import JDKCollectionConvertersCompat.Converters._
 
   /** Pending calls. */
   private[this] val pending = new ConcurrentHashMap[Long, PendingCall]
@@ -224,11 +223,14 @@ private[scalajs] abstract class RPCCore()(implicit ex: ExecutionContext) {
     val pendingCallIDs = (pending: java.util.Map[Long, _]).keySet()
     val exception = new ClosedException(closeReason)
 
-    for {
-      callID <- pendingCallIDs.asScala
-      failing <- Option(pending.remove(callID))
-    } {
-      failing.promise.failure(exception)
+    /* Directly use the Java Iterator because Scala's JavaConverters are
+     * tricky to use across 2.12- and 2.13+.
+     */
+    val pendingCallIDsIter = pendingCallIDs.iterator()
+    while (pendingCallIDsIter.hasNext()) {
+      val callID = pendingCallIDsIter.next()
+      for (failing <- Option(pending.remove(callID)))
+        failing.promise.failure(exception)
     }
   }
 
@@ -301,32 +303,4 @@ private[scalajs] object RPCCore {
       }
     }
   }
-
-  // !!! Duplicate code with java.util.Compat.JDKCollectionConvertersCompat
-  /** Magic to get cross-compiling access to `scala.jdk.CollectionConverters`
-   *  with a fallback on `scala.collection.JavaConverters`, without deprecation
-   *  warning in any Scala version.
-   */
-  private object JDKCollectionConvertersCompat {
-    object Scope1 {
-      object jdk {
-        object CollectionConverters {
-          type Ops = Int
-        }
-      }
-    }
-    import Scope1._
-
-    object Scope2 {
-      import scala.collection.{JavaConverters => Ops}
-      object Inner {
-        import scala._
-        import jdk.CollectionConverters.Ops
-        val Converters = Ops
-      }
-    }
-
-    val Converters = Scope2.Inner.Converters
-  }
-  // !!! End duplicate code
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashtableTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashtableTest.scala
@@ -203,16 +203,50 @@ class HashtableTest {
 
   @Test def entrySet(): Unit = {
     val ht = new ju.Hashtable[Int, Int]
-    assertTrue(ht.entrySet().isEmpty)
+    val entrySet = ht.entrySet()
+
+    assertTrue(entrySet.isEmpty)
     ht.put(1, 4)
-    assertEquals(Set(1), ht.entrySet().asScala.map(_.getKey))
-    assertEquals(Set(4), ht.entrySet().asScala.map(_.getValue))
+    assertEquals(Set(1), entrySet.asScala.map(_.getKey))
+    assertEquals(Set(4), entrySet.asScala.map(_.getValue))
     ht.put(2, 5)
-    assertEquals(Set(1, 2), ht.entrySet().asScala.map(_.getKey))
-    assertEquals(Set(4, 5), ht.entrySet().asScala.map(_.getValue))
+    assertEquals(Set(1, 2), entrySet.asScala.map(_.getKey))
+    assertEquals(Set(4, 5), entrySet.asScala.map(_.getValue))
     ht.put(3, 6)
-    assertEquals(Set(1, 2, 3), ht.entrySet().asScala.map(_.getKey))
-    assertEquals(Set(4, 5, 6), ht.entrySet().asScala.map(_.getValue))
+    assertEquals(Set(1, 2, 3), entrySet.asScala.map(_.getKey))
+    assertEquals(Set(4, 5, 6), entrySet.asScala.map(_.getValue))
+
+    // Directly test the iterator, including its mutation capabilities
+
+    val allKeys = Set(1, 2, 3)
+
+    val iter = entrySet.iterator()
+    assertTrue(iter.hasNext())
+    val firstEntry = iter.next()
+    val firstKey = firstEntry.getKey()
+    val expectedFirstValue = ht.get(firstKey)
+    assertTrue(allKeys.contains(firstKey))
+    assertEquals(expectedFirstValue, firstEntry.getValue())
+    assertEquals(expectedFirstValue, firstEntry.setValue(42))
+    assertEquals(42, ht.get(firstKey))
+    assertEquals(42, firstEntry.getValue())
+
+    assertTrue(iter.hasNext())
+    val secondEntry = iter.next()
+    val secondKey = secondEntry.getKey()
+    assertTrue((allKeys - firstKey).contains(secondKey))
+    iter.remove()
+
+    assertTrue(iter.hasNext())
+    val thirdEntry = iter.next()
+    val thirdKey = thirdEntry.getKey()
+    assertTrue((allKeys - firstKey - secondKey).contains(thirdKey))
+    assertEquals(ht.get(thirdKey), thirdEntry.getValue())
+
+    assertFalse(iter.hasNext())
+    assertEquals(allKeys - secondKey, entrySet.asScala.map(_.getKey))
+    assertTrue(ht.containsKey(firstKey) && ht.containsKey(thirdKey))
+    assertFalse(ht.containsKey(secondKey))
   }
 
   @Test def values(): Unit = {


### PR DESCRIPTION
Instead of using some compatibility hacks to access the Java collection converters across all versions of Scala, we simply get rid of them. Instead, we implement our own small set of combinators for operations that we actually use. We use the opportunity to make those combinators zero-cost.

This PR is prompted by yet another breaking change to the API of `JavaConverters` coming in 2.13.x. See https://github.com/scala/scala/pull/7987#discussion_r278158104