### PR TITLE
[no-master] Don't fix #3293: Drop support for JDK 6 and 7.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -426,7 +426,7 @@ def Tasks = [
 ]
 
 def mainJavaVersion = "1.8"
-def otherJavaVersions = [] // should be ["1.6", "1.7"] but that's broken (see #3293)
+def otherJavaVersions = []
 def allJavaVersions = otherJavaVersions.clone()
 allJavaVersions << mainJavaVersion
 
@@ -473,9 +473,7 @@ mainScalaVersions.each { scalaVersion ->
   }
   quickMatrix.add([task: "bootstrap", scala: scalaVersion, java: mainJavaVersion])
   if (!scalaVersion.startsWith("2.10.")) {
-    // #3293, should be: def javaVersion = scalaVersion.startsWith("2.11.") ? "1.7" : mainJavaVersion
-    def javaVersion = "1.8"
-    quickMatrix.add([task: "partest-fastopt", scala: scalaVersion, java: javaVersion])
+    quickMatrix.add([task: "partest-fastopt", scala: scalaVersion, java: mainJavaVersion])
   }
 }
 noToolsScalaVersions.each { scalaVersion ->
@@ -485,14 +483,10 @@ noToolsScalaVersions.each { scalaVersion ->
 }
 allJavaVersions.each { javaVersion ->
   quickMatrix.add([task: "tools-cli-stubs-sbtplugin", scala: "2.10.7", java: javaVersion])
-  if (javaVersion != "1.6") {
-    // Tools do not compile on JDK6, Scala 2.11.x (see #1235)
-    quickMatrix.add([task: "tools-cli-stubs", scala: "2.11.12", java: javaVersion])
-  }
 }
 quickMatrix.add([task: "tools-cli-stubs", scala: "2.12.8", java: mainJavaVersion])
-quickMatrix.add([task: "partestc", scala: "2.11.0", java: "1.8"]) // #3293, should be: 1.7
-quickMatrix.add([task: "sbtplugin-test", toolsscala: "2.10.7", sbt_version_override: "", java: "1.7"])
+quickMatrix.add([task: "partestc", scala: "2.11.0", java: mainJavaVersion])
+quickMatrix.add([task: "sbtplugin-test", toolsscala: "2.10.7", sbt_version_override: "", java: mainJavaVersion])
 quickMatrix.add([task: "sbtplugin-test", toolsscala: "2.12.8", sbt_version_override: "1.0.0", java: mainJavaVersion])
 
 // The 'full' matrix

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -353,11 +353,8 @@ object Build {
       scalacOptions in (Compile, doc) := {
         val baseOptions = (scalacOptions in (Compile, doc)).value
 
-        /* - need JDK7 to link the doc to java.nio.charset.StandardCharsets
-         * - in Scala 2.10, some ScalaDoc links fail
-         */
-        val fatalInDoc =
-          javaVersion.value >= 7 && scalaBinaryVersion.value != "2.10"
+        // in Scala 2.10, some ScalaDoc links fail
+        val fatalInDoc = scalaBinaryVersion.value != "2.10"
 
         if (fatalInDoc) baseOptions
         else baseOptions.filterNot(_ == "-Xfatal-warnings")
@@ -469,6 +466,8 @@ object Build {
         val fullVersion = System.getProperty("java.version")
         val v = fullVersion.stripPrefix("1.").takeWhile(_.isDigit).toInt
         sLog.value.info(s"Detected JDK version $v")
+        if (v < 8)
+          throw new MessageOnlyException("This build requires JDK 8 or later. Aborting.")
         v
       }
   )
@@ -1544,9 +1543,8 @@ object Build {
       val isScalaAtLeast212 =
         !scalaV.startsWith("2.10.") && !scalaV.startsWith("2.11.")
 
-      List(sharedTestDir / "scala") ++
-      includeIf(sharedTestDir / "require-jdk7", javaVersion.value >= 7) ++
-      includeIf(sharedTestDir / "require-jdk8", javaVersion.value >= 8) ++
+      List(sharedTestDir / "scala", sharedTestDir / "require-jdk7",
+          sharedTestDir / "require-jdk8") ++
       includeIf(testDir / "require-2.12", isJSTest && isScalaAtLeast212)
     },
 


### PR DESCRIPTION
Backport of 7fed6dd818b5e22612e8aae326b2b8320bb64f66.

We keep the JDK-dependent test directories (`require-jdk7` and `require-jdk8`) as is in this commit, so that it stays close to the backported commit.

I believe this is long overdue:

* Scala modules don't support JDK 6/7 anymore, even though they keep cross-compiling for 2.11.
* JDK 6/7 are stuck on old SSL stuff, which broke our build anyway (#3293)
* If someone is really stuck on such an old version of the JDK, it's fair for them to be stuck on an "old" version of Scala.js as well.
* Even ScalaTest has dropped JDK 6/7 support starting from their 3.1.x branch.

If we go through with this, there are a number of other PRs that we can backport: #3209, #3231, #3243 (s/remove/deprecate/), perhaps even #3513.