### PR TITLE
[no-master] Unfork our dependency on the Google Closure Compiler.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -624,7 +624,7 @@ object Build {
       base = file("tools/jvm"),
       settings = commonToolsSettings ++ Seq(
           libraryDependencies ++= Seq(
-              "org.scala-js" % "closure-compiler-java-6" % "v20160517",
+              "com.google.javascript" % "closure-compiler" % "v20160517",
               "com.googlecode.json-simple" % "json-simple" % "1.1.1" exclude("junit", "junit"),
               "com.novocode" % "junit-interface" % "0.9" % "test"
           ) ++ (
@@ -1939,7 +1939,7 @@ object Build {
                     else
                       "org.scala-lang.modules" %% "scala-partest" % "1.1.4"
                   },
-                  "org.scala-js" % "closure-compiler-java-6" % "v20160517",
+                  "com.google.javascript" % "closure-compiler" % "v20160517",
                   "org.mozilla" % "rhino" % "1.7.6",
                   "com.googlecode.json-simple" % "json-simple" % "1.1.1" exclude("junit", "junit")
               ) ++ (

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -8,7 +8,7 @@ addSbtPlugin("org.scalastyle" % "scalastyle-sbt-plugin" % "1.0.0")
 
 addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.0")
 
-libraryDependencies += "org.scala-js" % "closure-compiler-java-6" % "v20160517"
+libraryDependencies += "com.google.javascript" % "closure-compiler" % "v20160517"
 
 libraryDependencies += "org.mozilla" % "rhino" % "1.7.6"
 


### PR DESCRIPTION
Backport of eeaa76ca6a785ae0b8df01fa6fa09deb1c5559fc.

Now that we do not support JDK 6 anymore, we can go back to using the official artifacts of GCC.