### PR TITLE
[no-master] Deprecate `scala.scalajs.niocharset.StandardCharsets`.

### DIFF
--- a/javalib/src/main/scala/java/net/URI.scala
+++ b/javalib/src/main/scala/java/net/URI.scala
@@ -15,12 +15,10 @@ package java.net
 import scala.scalajs.js.RegExp
 import scala.scalajs.js
 
-import scala.scalajs.niocharset.StandardCharsets
-
 import scala.annotation.tailrec
 
 import java.nio._
-import java.nio.charset.CodingErrorAction
+import java.nio.charset.{CodingErrorAction, StandardCharsets}
 
 final class URI(origStr: String) extends Serializable with Comparable[URI] {
 

--- a/javalib/src/main/scala/java/nio/charset/Charset.scala
+++ b/javalib/src/main/scala/java/nio/charset/Charset.scala
@@ -18,7 +18,8 @@ import java.util.{Collections, HashSet, Arrays}
 import scala.scalajs.js
 
 abstract class Charset protected (canonicalName: String,
-    _aliases: Array[String]) extends AnyRef with Comparable[Charset] {
+    private val _aliases: Array[String])
+    extends AnyRef with Comparable[Charset] {
 
   private lazy val aliasesSet =
     Collections.unmodifiableSet(new HashSet(Arrays.asList(_aliases)))
@@ -85,38 +86,11 @@ object Charset {
 
   private lazy val CharsetMap = {
     val m = js.Dictionary.empty[Charset]
-
-    // All these lists where obtained by experimentation on the JDK
-
-    for (s <- Seq("iso-8859-1", "iso8859-1", "iso_8859_1", "iso8859_1",
-        "iso_8859-1", "8859_1", "iso_8859-1:1987",
-        "latin1", "csisolatin1", "l1",
-        "ibm-819", "ibm819", "cp819", "819",
-        "iso-ir-100"))
-      m(s) = ISO_8859_1
-
-    for (s <- Seq("us-ascii", "ascii7", "ascii", "csascii",
-        "default",
-        "cp367", "ibm367",
-        "iso646-us", "646", "iso_646.irv:1983", "iso_646.irv:1991",
-        "ansi_x3.4-1986", "ansi_x3.4-1968",
-        "iso-ir-6"))
-      m(s) = US_ASCII
-
-    for (s <- Seq("utf-8", "utf8", "unicode-1-1-utf-8"))
-      m(s) = UTF_8
-
-    for (s <- Seq("utf-16be", "utf_16be", "x-utf-16be",
-        "iso-10646-ucs-2", "unicodebigunmarked"))
-      m(s) = UTF_16BE
-
-    for (s <- Seq("utf-16le", "utf_16le", "x-utf-16le",
-        "unicodelittleunmarked"))
-      m(s) = UTF_16LE
-
-    for (s <- Seq("utf-16", "utf_16", "unicode", "unicodebig"))
-      m(s) = UTF_16
-
+    for (c <- js.Array(US_ASCII, ISO_8859_1, UTF_8, UTF_16BE, UTF_16LE, UTF_16)) {
+      m(c.name.toLowerCase) = c
+      for (alias <- c._aliases)
+        m(alias.toLowerCase) = c
+    }
     m
   }
 }

--- a/javalib/src/main/scala/java/nio/charset/ISO_8859_1.scala
+++ b/javalib/src/main/scala/java/nio/charset/ISO_8859_1.scala
@@ -10,11 +10,9 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.scalajs.niocharset
+package java.nio.charset
 
-import java.nio.charset._
-
-private[niocharset] object ISO_8859_1 extends ISO_8859_1_And_US_ASCII_Common(
+private[charset] object ISO_8859_1 extends ISO_8859_1_And_US_ASCII_Common(
     "ISO-8859-1", Array(
     "csISOLatin1", "IBM-819", "iso-ir-100", "8859_1", "ISO_8859-1", "l1",
     "ISO8859-1", "ISO_8859_1", "cp819", "ISO8859_1", "latin1",

--- a/javalib/src/main/scala/java/nio/charset/ISO_8859_1_And_US_ASCII_Common.scala
+++ b/javalib/src/main/scala/java/nio/charset/ISO_8859_1_And_US_ASCII_Common.scala
@@ -10,12 +10,11 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.scalajs.niocharset
+package java.nio.charset
 
 import scala.annotation.tailrec
 
 import java.nio._
-import java.nio.charset._
 
 /** This is a very specific common implementation for ISO_8859_1 and US_ASCII.
  *  Only a single constant changes between the two algorithms (`maxValue`).
@@ -23,7 +22,7 @@ import java.nio.charset._
  *
  *  `maxValue` is therefore either 0xff (ISO_8859_1) or 0x7f (US_ASCII).
  */
-private[niocharset] abstract class ISO_8859_1_And_US_ASCII_Common protected (
+private[charset] abstract class ISO_8859_1_And_US_ASCII_Common protected (
     name: String, aliases: Array[String],
     private val maxValue: Int) extends Charset(name, aliases) {
 

--- a/javalib/src/main/scala/java/nio/charset/StandardCharsets.scala
+++ b/javalib/src/main/scala/java/nio/charset/StandardCharsets.scala
@@ -12,15 +12,15 @@
 
 package java.nio.charset
 
+import java.nio.charset
+
 final class StandardCharsets private ()
 
 object StandardCharsets {
-  import scala.scalajs.niocharset.{StandardCharsets => SC}
-
-  def ISO_8859_1: Charset = SC.ISO_8859_1
-  def US_ASCII: Charset = SC.US_ASCII
-  def UTF_8: Charset = SC.UTF_8
-  def UTF_16BE: Charset = SC.UTF_16BE
-  def UTF_16LE: Charset = SC.UTF_16LE
-  def UTF_16: Charset = SC.UTF_16
+  def US_ASCII: Charset = charset.US_ASCII
+  def ISO_8859_1: Charset = charset.ISO_8859_1
+  def UTF_8: Charset = charset.UTF_8
+  def UTF_16BE: Charset = charset.UTF_16BE
+  def UTF_16LE: Charset = charset.UTF_16LE
+  def UTF_16: Charset = charset.UTF_16
 }

--- a/javalib/src/main/scala/java/nio/charset/US_ASCII.scala
+++ b/javalib/src/main/scala/java/nio/charset/US_ASCII.scala
@@ -10,11 +10,9 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.scalajs.niocharset
+package java.nio.charset
 
-import java.nio.charset._
-
-private[niocharset] object US_ASCII extends ISO_8859_1_And_US_ASCII_Common(
+private[charset] object US_ASCII extends ISO_8859_1_And_US_ASCII_Common(
     "US-ASCII", Array(
     "cp367", "ascii7", "ISO646-US", "646", "csASCII", "us", "iso_646.irv:1983",
     "ISO_646.irv:1991", "IBM367", "ASCII", "default", "ANSI_X3.4-1986",

--- a/javalib/src/main/scala/java/nio/charset/UTF_16.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16.scala
@@ -10,11 +10,9 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.scalajs.niocharset
+package java.nio.charset
 
-import java.nio.charset._
-
-private[niocharset] object UTF_16BE extends UTF_16_Common(
-    "UTF-16BE", Array(
-    "X-UTF-16BE", "UTF_16BE", "ISO-10646-UCS-2", "UnicodeBigUnmarked"),
-    endianness = UTF_16_Common.BigEndian)
+private[charset] object UTF_16 extends UTF_16_Common(
+    "UTF-16", Array(
+    "utf16", "UTF_16", "UnicodeBig", "unicode"),
+    endianness = UTF_16_Common.AutoEndian)

--- a/javalib/src/main/scala/java/nio/charset/UTF_16BE.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16BE.scala
@@ -10,11 +10,9 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.scalajs.niocharset
+package java.nio.charset
 
-import java.nio.charset._
-
-private[niocharset] object UTF_16 extends UTF_16_Common(
-    "UTF-16", Array(
-    "utf16", "UTF_16", "UnicodeBig", "unicode"),
-    endianness = UTF_16_Common.AutoEndian)
+private[charset] object UTF_16BE extends UTF_16_Common(
+    "UTF-16BE", Array(
+    "X-UTF-16BE", "UTF_16BE", "ISO-10646-UCS-2", "UnicodeBigUnmarked"),
+    endianness = UTF_16_Common.BigEndian)

--- a/javalib/src/main/scala/java/nio/charset/UTF_16LE.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16LE.scala
@@ -10,11 +10,9 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.scalajs.niocharset
+package java.nio.charset
 
-import java.nio.charset._
-
-private[niocharset] object UTF_16LE extends UTF_16_Common(
+private[charset] object UTF_16LE extends UTF_16_Common(
     "UTF-16LE", Array(
     "UnicodeLittleUnmarked", "UTF_16LE", "X-UTF-16LE"),
     endianness = UTF_16_Common.LittleEndian)

--- a/javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
@@ -10,16 +10,15 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.scalajs.niocharset
+package java.nio.charset
 
 import scala.annotation.tailrec
 
 import java.nio._
-import java.nio.charset._
 
 /** This is a very specific common implementation for UTF_16BE and UTF_16LE.
  */
-private[niocharset] abstract class UTF_16_Common protected (
+private[charset] abstract class UTF_16_Common protected (
     name: String, aliases: Array[String],
     private val endianness: Int) extends Charset(name, aliases) {
 
@@ -201,7 +200,7 @@ private[niocharset] abstract class UTF_16_Common protected (
   }
 }
 
-private[niocharset] object UTF_16_Common {
+private[charset] object UTF_16_Common {
   final val AutoEndian = 0
   final val BigEndian = 1
   final val LittleEndian = 2

--- a/javalib/src/main/scala/java/nio/charset/UTF_8.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_8.scala
@@ -10,14 +10,13 @@
  * additional information regarding copyright ownership.
  */
 
-package scala.scalajs.niocharset
+package java.nio.charset
 
 import scala.annotation.{switch, tailrec}
 
 import java.nio._
-import java.nio.charset._
 
-private[niocharset] object UTF_8 extends Charset("UTF-8", Array(
+private[charset] object UTF_8 extends Charset("UTF-8", Array(
     "UTF8", "unicode-1-1-utf-8")) {
 
   import java.lang.Character._

--- a/library/src/main/scala/scala/scalajs/niocharset/StandardCharsets.scala
+++ b/library/src/main/scala/scala/scalajs/niocharset/StandardCharsets.scala
@@ -12,34 +12,30 @@
 
 package scala.scalajs.niocharset
 
-import java.nio.charset._
+import java.nio.charset.{Charset, StandardCharsets => JStdCharsets}
 
-/** Standard charsets.
- *  This is basically the same as [[java.nio.charset.StandardCharsets]], but
- *  it is also available when compiling with a JDK 6.
- */
+/** Standard charsets. */
+@deprecated("Use java.nio.charset.StandardCharsets instead.", "0.6.28")
 object StandardCharsets {
-  import scala.scalajs.niocharset
-
   /** ISO-8859-1, aka latin1. */
-  def ISO_8859_1: Charset = niocharset.ISO_8859_1
+  def ISO_8859_1: Charset = JStdCharsets.ISO_8859_1
 
   /** US-ASCII. */
-  def US_ASCII: Charset = niocharset.US_ASCII
+  def US_ASCII: Charset = JStdCharsets.US_ASCII
 
   /** UTF-8. */
-  def UTF_8: Charset = niocharset.UTF_8
+  def UTF_8: Charset = JStdCharsets.UTF_8
 
   /** UTF-16 Big Endian without BOM. */
-  def UTF_16BE: Charset = niocharset.UTF_16BE
+  def UTF_16BE: Charset = JStdCharsets.UTF_16BE
 
   /** UTF-16 Little Endian without BOM. */
-  def UTF_16LE: Charset = niocharset.UTF_16LE
+  def UTF_16LE: Charset = JStdCharsets.UTF_16LE
 
   /** UTF-16 with an optional BOM.
    *  When encoding, Big Endian is always used.
    *  When decoding, the BOM specifies what endianness to use. If no BOM is
    *  found, it defaults to Big Endian.
    */
-  def UTF_16: Charset = niocharset.UTF_16
+  def UTF_16: Charset = JStdCharsets.UTF_16
 }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -32,6 +32,10 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+      // private[niocharset], not an issue
+      ProblemFilters.exclude[MissingClassProblem]("scala.scalajs.niocharset.ISO_*"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.scalajs.niocharset.US_*"),
+      ProblemFilters.exclude[MissingClassProblem]("scala.scalajs.niocharset.UTF_*")
   )
 
   val TestInterface = TestCommon ++ Seq(

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
@@ -15,6 +15,7 @@ package org.scalajs.testsuite.niocharset
 import scala.collection.JavaConverters._
 
 import java.nio.charset._
+import java.nio.charset.StandardCharsets._
 
 import org.junit.Test
 import org.junit.Assert._
@@ -26,35 +27,36 @@ class CharsetTest {
   def javaSet[A](elems: A*): java.util.Set[A] = Set(elems: _*).asJava
 
   @Test def defaultCharset(): Unit = {
-    assertSame("UTF-8", Charset.defaultCharset().name())
+    assertSame(UTF_8, Charset.defaultCharset())
   }
 
   @Test def forName(): Unit = {
-    assertEquals("ISO-8859-1", Charset.forName("ISO-8859-1").name())
-    assertEquals("ISO-8859-1", Charset.forName("Iso8859-1").name())
-    assertEquals("ISO-8859-1", Charset.forName("iso_8859_1").name())
-    assertEquals("ISO-8859-1", Charset.forName("LaTin1").name())
-    assertEquals("ISO-8859-1", Charset.forName("l1").name())
+    assertSame(ISO_8859_1, Charset.forName("ISO-8859-1"))
+    assertSame(ISO_8859_1, Charset.forName("Iso8859-1"))
+    assertSame(ISO_8859_1, Charset.forName("iso_8859_1"))
+    assertSame(ISO_8859_1, Charset.forName("LaTin1"))
+    assertSame(ISO_8859_1, Charset.forName("l1"))
 
-    assertEquals("US-ASCII", Charset.forName("US-ASCII").name())
-    assertEquals("US-ASCII", Charset.forName("Default").name())
+    assertSame(US_ASCII, Charset.forName("US-ASCII"))
+    assertSame(US_ASCII, Charset.forName("Default"))
 
-    assertEquals("UTF-8", Charset.forName("UTF-8").name())
-    assertEquals("UTF-8", Charset.forName("utf-8").name())
-    assertEquals("UTF-8", Charset.forName("UtF8").name())
+    assertSame(UTF_8, Charset.forName("UTF-8"))
+    assertSame(UTF_8, Charset.forName("utf-8"))
+    assertSame(UTF_8, Charset.forName("UtF8"))
+    assertSame(UTF_8, Charset.forName("UTF-8"))
 
-    assertEquals("UTF-16BE", Charset.forName("UTF-16BE").name())
-    assertEquals("UTF-16BE", Charset.forName("Utf_16BE").name())
-    assertEquals("UTF-16BE", Charset.forName("UnicodeBigUnmarked").name())
+    assertSame(UTF_16BE, Charset.forName("UTF-16BE"))
+    assertSame(UTF_16BE, Charset.forName("Utf_16BE"))
+    assertSame(UTF_16BE, Charset.forName("UnicodeBigUnmarked"))
 
-    assertEquals("UTF-16LE", Charset.forName("UTF-16le").name())
-    assertEquals("UTF-16LE", Charset.forName("Utf_16le").name())
-    assertEquals("UTF-16LE", Charset.forName("UnicodeLittleUnmarked").name())
+    assertSame(UTF_16LE, Charset.forName("UTF-16le"))
+    assertSame(UTF_16LE, Charset.forName("Utf_16le"))
+    assertSame(UTF_16LE, Charset.forName("UnicodeLittleUnmarked"))
 
-    assertEquals("UTF-16", Charset.forName("UTF-16").name())
-    assertEquals("UTF-16", Charset.forName("Utf_16").name())
-    assertEquals("UTF-16", Charset.forName("unicode").name())
-    assertEquals("UTF-16", Charset.forName("UnicodeBig").name())
+    assertSame(UTF_16, Charset.forName("UTF-16"))
+    assertSame(UTF_16, Charset.forName("Utf_16"))
+    assertSame(UTF_16, Charset.forName("unicode"))
+    assertSame(UTF_16, Charset.forName("UnicodeBig"))
 
     // Issue #2040
     expectThrows(classOf[UnsupportedCharsetException], Charset.forName("UTF_8"))


### PR DESCRIPTION
Backport of ac9e4e4, with a deprecation instead of a removal.

It was useful when Scala.js was supported on JDK 6, but not anymore. Instead, users should always use `java.nio.charset.StandardCharsets`.

The PR as a whole is a backport of #3243.