### PR TITLE
Fix #3611: Serialize null file names in StackTraceElement as "".

### DIFF
--- a/test-common/src/main/scala/org/scalajs/testcommon/Serializer.scala
+++ b/test-common/src/main/scala/org/scalajs/testcommon/Serializer.scala
@@ -132,13 +132,13 @@ private[scalajs] object Serializer {
     def serialize(x: StackTraceElement, out: SerializeState): Unit = {
       out.write(x.getClassName())
       out.write(x.getMethodName())
-      out.write(x.getFileName())
+      out.write(Option(x.getFileName()).getOrElse(""))
       out.write(x.getLineNumber())
     }
 
     def deserialize(in: DeserializeState): StackTraceElement = {
       new StackTraceElement(in.read[String](), in.read[String](),
-          in.read[String](), in.read[Int]())
+          Option(in.read[String]()).filter(_.nonEmpty).orNull, in.read[Int]())
     }
   }
 

--- a/test-common/src/test/scala/org/scalajs/testcommon/SerializerTest.scala
+++ b/test-common/src/test/scala/org/scalajs/testcommon/SerializerTest.scala
@@ -28,4 +28,13 @@ class SerializerTest {
     assertEquals(in.toString(), out.toString())
     assertEquals(in.getStackTrace().size, out.getStackTrace().size)
   }
+
+  // # 3611
+  @Test
+  def serializeStackTraceElementWithNullFilename: Unit = {
+    val st = new StackTraceElement("MyClass", "myMethod", null, 1)
+    val deserialized = roundTrip(st)
+    assertNull(deserialized.getFileName)
+    assertEquals("MyClass.myMethod(Unknown Source)", deserialized.toString)
+  }
 }


### PR DESCRIPTION
Closes #3611 

I wonder where test for this should be added
`test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementTest.scala` is right place?