### PR TITLE
Fix cross-building plugin issue on Intellij IDEA

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -482,12 +482,12 @@ noToolsScalaVersions.each { scalaVersion ->
   quickMatrix.add([task: "test-suite-ecma-script6", scala: scalaVersion, java: mainJavaVersion, testSuite: "testSuite"])
 }
 allJavaVersions.each { javaVersion ->
-  quickMatrix.add([task: "tools-cli-stubs-sbtplugin", scala: "2.10.7", java: javaVersion])
+  quickMatrix.add([task: "tools-cli-stubs-sbtplugin", scala: "2.12.8", sbt_version_override: "", java: javaVersion])
 }
-quickMatrix.add([task: "tools-cli-stubs", scala: "2.12.8", java: mainJavaVersion])
+quickMatrix.add([task: "tools-cli-stubs", scala: "2.10.7", sbt_version_override: "0.13.17", java: mainJavaVersion])
 quickMatrix.add([task: "partestc", scala: "2.11.0", java: mainJavaVersion])
-quickMatrix.add([task: "sbtplugin-test", toolsscala: "2.10.7", sbt_version_override: "", java: mainJavaVersion])
-quickMatrix.add([task: "sbtplugin-test", toolsscala: "2.12.8", sbt_version_override: "1.0.0", java: mainJavaVersion])
+quickMatrix.add([task: "sbtplugin-test", toolsscala: "2.10.7", sbt_version_override: "0.13.17", java: mainJavaVersion])
+quickMatrix.add([task: "sbtplugin-test", toolsscala: "2.12.8", sbt_version_override: "", java: mainJavaVersion])
 
 // The 'full' matrix
 def fullMatrix = quickMatrix.clone()

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -819,6 +819,12 @@ object Build {
           normalizedName := "sbt-scalajs",
           bintrayProjectName := "sbt-scalajs-plugin", // "sbt-scalajs" was taken
           sbtPlugin := true,
+          sbtVersion in pluginCrossBuild := {
+            scalaVersion.value match {
+              case v if v.startsWith("2.10.") => "0.13.17"
+              case _ => "1.0.0"
+            }
+          },
           scalaBinaryVersion :=
             CrossVersion.binaryScalaVersion(scalaVersion.value),
           previousArtifactSetting,

--- a/sbt-plugin-test/project/build.properties
+++ b/sbt-plugin-test/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=1.0.0

--- a/sbt-plugin/src/main/scala-sbt-1.0/org/scalajs/sbtplugin/SBTCompat.scala
+++ b/sbt-plugin/src/main/scala-sbt-1.0/org/scalajs/sbtplugin/SBTCompat.scala
@@ -1,3 +1,15 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.sbtplugin
 
 import sbt._


### PR DESCRIPTION
Closes #3638.
Followed the [workaround for cross-building plugin](https://github.com/sbt/sbt/issues/3473#issuecomment-410184709)

As far as I tested, Intellij IDEA now be able to import sbt project.
