### PR TITLE
Do not rely on the implicit conversion option2Iterable.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/PrepJSInterop.scala
@@ -446,9 +446,12 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
           }
         }
 
-        val exports = exporters.get(clsSym).toIterable.flatten
-        // Add exports to the template
-        treeCopy.Template(tree, parents, self, body ++ exports)
+        // Add exports to the template, if there are any
+        exporters.get(clsSym).fold {
+          tree // nothing to change
+        } { exports =>
+          treeCopy.Template(tree, parents, self, body ::: exports.toList)
+        }
 
       case memDef: MemberDef =>
         val sym = memDef.symbol


### PR DESCRIPTION
`option2Iterable` might be deprecated in 2.13.0-RC2. See https://github.com/scala/scala/pull/8038.

The previous code was doing useless work anyway. We now completely avoid `treeCopy` when there are no exports for any given class.