### PR TITLE
Detach VirtualScalaJSIRFile from ScalaJSIRContainer

### DIFF
--- a/linker/js/src/main/scala/org/scalajs/linker/irio/NodeVirtualIRFiles.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/irio/NodeVirtualIRFiles.scala
@@ -28,10 +28,6 @@ import java.nio._
 
 import org.scalajs.ir
 
-trait NodeScalaJSIRContainer extends ScalaJSIRContainer {
-  val path: String
-}
-
 object NodeScalaJSIRContainer {
   import NodeInterop._
 
@@ -95,10 +91,11 @@ object NodeScalaJSIRContainer {
     (e.asInstanceOf[js.Dynamic].code: Any) == "ENOENT"
 }
 
-private class NodeVirtualScalaJSIRFile(
-    val path: String,
-    val version: Option[String]
-) extends VirtualScalaJSIRFile with NodeScalaJSIRContainer {
+abstract class NodeScalaJSIRContainer private[irio] (
+    val path: String, val version: Option[String]) extends ScalaJSIRContainer
+
+private class NodeVirtualScalaJSIRFile(path: String, version: Option[String])
+    extends NodeScalaJSIRContainer(path, version) with VirtualScalaJSIRFile {
   import NodeInterop._
 
   def entryPointsInfo(implicit ec: ExecutionContext): Future[ir.EntryPointsInfo] = {
@@ -147,10 +144,13 @@ private class NodeVirtualScalaJSIRFile(
 
     VirtualScalaJSIRFile.withPathExceptionContext(path, result)
   }
+
+  def sjsirFiles(implicit ec: ExecutionContext): Future[List[VirtualScalaJSIRFile]] =
+    Future.successful(this :: Nil)
 }
 
-private class NodeVirtualJarScalaJSIRContainer(
-    val path: String, val version: Option[String]) extends NodeScalaJSIRContainer {
+private class NodeVirtualJarScalaJSIRContainer(path: String, version: Option[String])
+    extends NodeScalaJSIRContainer(path, version) {
   import NodeInterop._
 
   def sjsirFiles(implicit ec: ExecutionContext): Future[List[VirtualScalaJSIRFile]] = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/irio/VirtualIRFiles.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/irio/VirtualIRFiles.scala
@@ -59,15 +59,29 @@ trait ScalaJSIRContainer {
 /** A virtual Scala.js IR file.
  *  It contains the class info and the IR tree.
  */
-trait VirtualScalaJSIRFile extends ScalaJSIRContainer {
+trait VirtualScalaJSIRFile {
+  /** Abstract path of the file.
+   *
+   *  The path of the file is used for lookup and caching (together with the
+   *  version).
+   */
+  val path: String
+
+  /** An optional implementation-dependent "version" token.
+   *
+   *  If non-empty, a different version must be returned when the content
+   *  changes. It should be equal if the content has not changed, but it is
+   *  not mandatory.
+   *  Such a token can be used by caches: the file need not be read and
+   *  processed again if its version has not changed.
+   */
+  val version: Option[String]
+
   /** Entry points information for this file. */
   def entryPointsInfo(implicit ec: ExecutionContext): Future[ir.EntryPointsInfo]
 
   /** IR Tree of this file. */
   def tree(implicit ec: ExecutionContext): Future[ir.Trees.ClassDef]
-
-  final def sjsirFiles(implicit ec: ExecutionContext): Future[List[VirtualScalaJSIRFile]] =
-    Future.successful(this :: Nil)
 }
 
 object VirtualScalaJSIRFile {


### PR DESCRIPTION
It is an implementation detail that some classes implement both
interfaces. We move this implementation detail to the
implementations.