### PR TITLE
Fix #3644: Forward cause messages for RPCCore exceptions

### DIFF
--- a/test-common/src/main/scala/org/scalajs/testcommon/RPCCore.scala
+++ b/test-common/src/main/scala/org/scalajs/testcommon/RPCCore.scala
@@ -262,10 +262,10 @@ private[scalajs] object RPCCore {
   type OpCode = Byte
 
   /** Exception thrown if a remote invocation fails. */
-  class RPCException(c: Throwable) extends Exception(null, c)
+  class RPCException(c: Throwable) extends Exception(c)
 
   /** Exception thrown if the channel got closed. */
-  class ClosedException(c: Throwable) extends Exception(null, c)
+  class ClosedException(c: Throwable) extends Exception(c)
 
   private val ReplyOK: Byte = 0.toByte
   private val ReplyErr: Byte = 1.toByte


### PR DESCRIPTION
This will help guide users better to what failed as the
message (hopefully) will make it clear that it is not the RPC
subsystem itself that failed but merely forwarded exception.