### PR TITLE
Split `escapeJS` in `linker` and `js-envs`.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/JSUtils.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/JSUtils.scala
@@ -10,7 +10,7 @@
  * additional information regarding copyright ownership.
  */
 
-package org.scalajs.io
+package org.scalajs.jsenv
 
 object JSUtils {
 
@@ -35,17 +35,18 @@ object JSUtils {
     sb.toString
   }
 
-  // !!! BEGIN COPY-PASTED CODE with ir/.../Utils.scala
+  /* !!! BEGIN CODE VERY SIMILAR TO ir/.../Utils.scala and
+   * linker/.../javascript/Utils.scala
+   */
 
   private final val EscapeJSChars = "\\b\\t\\n\\v\\f\\r\\\"\\\\"
 
-  def printEscapeJS(str: String, out: java.lang.Appendable): Int = {
+  private def printEscapeJS(str: String, out: java.lang.StringBuilder): Unit = {
     /* Note that Java and JavaScript happen to use the same encoding for
      * Unicode, namely UTF-16, which means that 1 char from Java always equals
      * 1 char in JavaScript. */
     val end = str.length()
     var i = 0
-    var writtenChars = 0
     /* Loop prints all consecutive ASCII printable characters starting
      * from current i and one non ASCII printable character (if it exists).
      * The new i is set at the end of the appended characters.
@@ -62,7 +63,6 @@ object JSUtils {
       // Print ASCII printable characters from `start`
       if (start != i) {
         out.append(str, start, i)
-        writtenChars += i
       }
 
       // Print next non ASCII printable character
@@ -71,25 +71,22 @@ object JSUtils {
           if (7 < c && c < 14) {
             val i = 2 * (c - 8)
             out.append(EscapeJSChars, i, i + 2)
-            writtenChars += 2
           } else if (c == 34) {
             out.append(EscapeJSChars, 12, 14)
-            writtenChars += 2
           } else if (c == 92) {
             out.append(EscapeJSChars, 14, 16)
-            writtenChars += 2
           } else {
-            out.append(f"\\u$c%04x")
-            writtenChars += 6
+            out.append("\\u%04x".format(c))
           }
         }
         escapeJSEncoded(c)
         i += 1
       }
     }
-    writtenChars
   }
 
-  // !!! END COPY-PASTED CODE with ir/.../Utils.scala
+  /* !!! END CODE VERY SIMILAR TO ir/.../Utils.scala and
+   * linker/.../javascript/Utils.scala
+   */
 
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -26,8 +26,6 @@ import ir.Position
 import ir.Position.NoPosition
 import ir.Printers.IndentationManager
 
-import org.scalajs.io.JSUtils
-
 import Trees._
 
 /* Printers code was hand-optimized with raw performance in mind.
@@ -655,7 +653,7 @@ object Printers {
     }
 
     protected def printEscapeJS(s: String): Unit =
-      JSUtils.printEscapeJS(s, out)
+      Utils.printEscapeJS(s, out)
 
     protected def print(ident: Ident): Unit =
       printEscapeJS(ident.name)
@@ -702,7 +700,7 @@ object Printers {
     }
 
     override protected def printEscapeJS(s: String): Unit =
-      column += JSUtils.printEscapeJS(s, out)
+      column += Utils.printEscapeJS(s, out)
 
     override protected def print(ident: Ident): Unit = {
       if (ident.pos.isDefined)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/SourceMapWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/SourceMapWriter.scala
@@ -21,9 +21,6 @@ import scala.collection.mutable.{ ListBuffer, HashMap, Stack, StringBuilder }
 import org.scalajs.ir
 import ir.Position
 import ir.Position._
-import ir.Utils
-
-import org.scalajs.io.JSUtils
 
 private object SourceMapWriter {
   private val Base64Map =
@@ -40,7 +37,7 @@ private object SourceMapWriter {
 
   private def printJSONString(s: String, out: Writer) = {
     out.write('\"')
-    JSUtils.printEscapeJS(s, out)
+    Utils.printEscapeJS(s, out)
     out.write('\"')
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Utils.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Utils.scala
@@ -10,22 +10,23 @@
  * additional information regarding copyright ownership.
  */
 
-package org.scalajs.ir
+package org.scalajs.linker.backend.javascript
 
-private[ir] object Utils {
+private[javascript] object Utils {
 
-  /* !!! BEGIN CODE VERY SIMILAR TO linker/.../javascript/Utils.scala and
+  /* !!! BEGIN CODE VERY SIMILAR TO ir/.../Utils.scala and
    * js-envs/.../JSUtils.scala
    */
 
   private final val EscapeJSChars = "\\b\\t\\n\\v\\f\\r\\\"\\\\"
 
-  private[ir] def printEscapeJS(str: String, out: java.io.Writer): Unit = {
+  def printEscapeJS(str: String, out: java.io.Writer): Int = {
     /* Note that Java and JavaScript happen to use the same encoding for
      * Unicode, namely UTF-16, which means that 1 char from Java always equals
      * 1 char in JavaScript. */
     val end = str.length()
     var i = 0
+    var writtenChars = 0
     /* Loop prints all consecutive ASCII printable characters starting
      * from current i and one non ASCII printable character (if it exists).
      * The new i is set at the end of the appended characters.
@@ -42,6 +43,7 @@ private[ir] object Utils {
       // Print ASCII printable characters from `start`
       if (start != i) {
         out.write(str, start, i - start)
+        writtenChars += i
       }
 
       // Print next non ASCII printable character
@@ -50,61 +52,27 @@ private[ir] object Utils {
           if (7 < c && c < 14) {
             val i = 2 * (c - 8)
             out.write(EscapeJSChars, i, 2)
+            writtenChars += 2
           } else if (c == 34) {
             out.write(EscapeJSChars, 12, 2)
+            writtenChars += 2
           } else if (c == 92) {
             out.write(EscapeJSChars, 14, 2)
+            writtenChars += 2
           } else {
             out.write("\\u%04x".format(c))
+            writtenChars += 6
           }
         }
         escapeJSEncoded(c)
         i += 1
       }
     }
+    writtenChars
   }
 
-  /* !!! END CODE VERY SIMILAR TO linker/.../javascript/Utils.scala and
+  /* !!! END CODE VERY SIMILAR TO ir/.../Utils.scala and
    * js-envs/.../JSUtils.scala
    */
-
-  /** A ByteArrayOutput stream that allows to jump back to a given
-   *  position and complete some bytes. Methods must be called in the
-   *  following order only:
-   *  - [[markJump]]
-   *  - [[jumpBack]]
-   *  - [[continue]]
-   */
-  private[ir] class JumpBackByteArrayOutputStream
-      extends java.io.ByteArrayOutputStream {
-    protected var jumpBackPos: Int = -1
-    protected var headPos: Int = -1
-
-    /** Marks the current location for a jumpback */
-    def markJump(): Unit = {
-      assert(jumpBackPos == -1)
-      assert(headPos == -1)
-      jumpBackPos = count
-    }
-
-    /** Jumps back to the mark. Returns the number of bytes jumped */
-    def jumpBack(): Int = {
-      assert(jumpBackPos >= 0)
-      assert(headPos == -1)
-      val jumped = count - jumpBackPos
-      headPos = count
-      count = jumpBackPos
-      jumpBackPos = -1
-      jumped
-    }
-
-    /** Continues to write at the head. */
-    def continue(): Unit = {
-      assert(jumpBackPos == -1)
-      assert(headPos >= 0)
-      count = headPos
-      headPos = -1
-    }
-  }
 
 }

--- a/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
+++ b/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/NodeJSEnv.scala
@@ -18,9 +18,9 @@ import scala.annotation.tailrec
 import scala.collection.JavaConverters._
 
 import org.scalajs.jsenv._
+import org.scalajs.jsenv.JSUtils.escapeJS
 
 import org.scalajs.io._
-import org.scalajs.io.JSUtils.escapeJS
 import org.scalajs.logging._
 
 import java.io._

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -24,6 +24,7 @@ import org.scalajs.ir
 
 import org.scalajs.sbtplugin._
 import org.scalajs.jsenv.{JSEnv, RunConfig, Input}
+import org.scalajs.jsenv.JSUtils.escapeJS
 import org.scalajs.jsenv.nodejs.NodeJSEnv
 
 import ScalaJSPlugin.autoImport.{ModuleKind => _, _}
@@ -31,7 +32,6 @@ import ExternalCompile.scalaJSExternalCompileSettings
 import Loggers._
 
 import org.scalajs.io._
-import org.scalajs.io.JSUtils.escapeJS
 import org.scalajs.linker._
 import org.scalajs.linker.irio._
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -29,7 +29,6 @@ import sbt.complete.DefaultParsers._
 import org.portablescala.sbtplatformdeps.PlatformDepsPlugin.autoImport._
 
 import org.scalajs.io._
-import org.scalajs.io.JSUtils.escapeJS
 
 import org.scalajs.linker._
 import org.scalajs.linker.irio._

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/HTMLRunnerBuilder.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/HTMLRunnerBuilder.scala
@@ -22,9 +22,9 @@ import java.nio.file.{Files, StandardCopyOption}
 import sbt.testing.{Framework, TaskDef}
 
 import org.scalajs.io._
-import org.scalajs.io.JSUtils.escapeJS
 
 import org.scalajs.jsenv.{Input, UnsupportedInputException}
+import org.scalajs.jsenv.JSUtils.escapeJS
 
 import org.scalajs.testing.common._
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
@@ -17,10 +17,10 @@ import scala.concurrent.duration._
 import scala.collection.concurrent.TrieMap
 
 import org.scalajs.io._
-import org.scalajs.io.JSUtils.escapeJS
 import org.scalajs.logging._
 
 import org.scalajs.jsenv._
+import org.scalajs.jsenv.JSUtils.escapeJS
 
 import org.scalajs.testing.common._
 


### PR DESCRIPTION
And specialize them to the particular needs of each subproject:

* `java.lang.StringBuilder` versus `java.io.Writer` instead of the generic `java.lang.Appendable`.
* With or without tracking of how many characters are written out.

Also review and specialize the one in `ir`.

Potentially a prerequisite of #3646 as well.