### PR TITLE
[no-master] Handle primitives in reflective call target determination

### DIFF
--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/analyzer/Analyzer.scala
@@ -498,8 +498,12 @@ private final class Analyzer(semantics: Semantics,
         right: ir.Types.ReferenceType): Boolean = {
       import ir.Types._
 
+      def isPrimitive(className: String) =
+        Definitions.PrimitiveClasses.contains(className)
+
       def classIsMoreSpecific(leftCls: String, rightCls: String): Boolean = {
         leftCls != rightCls &&
+        !isPrimitive(leftCls) && !isPrimitive(rightCls) &&
         lookupClass(leftCls).ancestors.contains(lookupClass(rightCls))
       }
 


### PR DESCRIPTION
This back-ports the fix for the problem discovered in #3621.