### PR TITLE
Support the new flat patmat ASTs of Scala 2.12.9.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/OptimizationTest.scala
@@ -163,6 +163,47 @@ class OptimizationTest extends JSASTTest {
   }
 
   @Test
+  def noLabeledBlockForPatmatWithToplevelCaseClassesOnlyAndNoGuards: Unit = {
+    """
+    sealed abstract class Foo
+    final case class Foobar(x: Int) extends Foo
+    final case class Foobaz(y: String) extends Foo
+
+    class Test {
+      def testWithListsStat(xs: List[Int]): Unit = {
+        xs match {
+          case head :: tail => println(head + " " + tail)
+          case Nil          => println("nil")
+        }
+      }
+
+      def testWithListsExpr(xs: List[Int]): Int = {
+        xs match {
+          case head :: tail => head + tail.size
+          case Nil          => 0
+        }
+      }
+
+      def testWithFooStat(foo: Foo): Unit = {
+        foo match {
+          case Foobar(x) => println("foobar: " + x)
+          case Foobaz(y) => println(y)
+        }
+      }
+
+      def testWithFooExpr(foo: Foo): String = {
+        foo match {
+          case Foobar(x) => "foobar: " + x
+          case Foobaz(y) => "foobaz: " + y
+        }
+      }
+    }
+    """.hasNot("Labeled block") {
+      case js.Labeled(_, _, _) =>
+    }
+  }
+
+  @Test
   def switchWithoutGuards: Unit = {
     """
     class Test {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -3886,7 +3886,7 @@ private[optimizer] abstract class OptimizerCore(
   /** Tries and optimizes the remainings of a pattern match as if/elses.
    *
    *  !!! There is quite of bit of code duplication with
-   *      GenJSCode.genOptimizedLabeled.
+   *      GenJSCode.genOptimizedMatchEndLabeled.
    */
   def tryOptimizePatternMatch(oldLabelName: String, refinedType: Type,
       returnCount: Int, body: Tree): Option[Tree] = {


### PR DESCRIPTION
See https://github.com/scala/scala/pull/8061 upstream.

It is now possible for jumps to the next-case label to be buried in arbitrary positions within a case body. We support that by enclosing a case body with a labeled block, in case at least one `return` to the label could not be caught upstream.

Doing so produces significantly worse code for cases that only have one test (and hence one `return`), which are by far the most common scenario. Therefore, we add an optimization to rewrite cases with a
single `return` of the case to the previous style of `If`. This in turn allows the optimization of the `matchEnd` label to kick in, and production of better code.

When there are more than one `return`, the new flat structure is beneficial for our IR as much as for scalac Trees, and therefore we keep it as is.

Only merge this PR if and when https://github.com/scala/scala/pull/8061 is accepted upstream.

Locally tested with:
```
> set resolvers in Global += "pr" at "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/"
> ++2.12.9-bin-e77555d-SNAPSHOT
> set scalacOptions in testSuite += "-Ypatmat-flat-ast"
> testSuite/test
```
/cc @retronym