### PR TITLE
[no-master] Fix #3660: Use `$asDouble` in `compareTo` for `number`s.

### DIFF
--- a/tools/scalajsenv.js
+++ b/tools/scalajsenv.js
@@ -384,7 +384,7 @@ ScalaJS.comparableCompareTo = function(instance, rhs) {
       return instance === rhs ? 0 : (instance < rhs ? -1 : 1);
     case "number":
 //!if asInstanceOfs != Unchecked
-      ScalaJS.as.jl_Number(rhs);
+      ScalaJS.asDouble(rhs);
 //!endif
       return ScalaJS.m.jl_Double$().compare__D__D__I(instance, rhs);
     case "boolean":


### PR DESCRIPTION
Using `$as_jl_Number` was wrong on two accounts:

* It referenced an identifier that was potentially not defined, in the case where instance tests for `Number` are not reachable.
* It allowed non-`number`s to pass the instance test, which would be type-incorrect, as `j.l.Double.compareTo__D__D__I` takes a `Double`, not an arbitrary `Number`.

The new code corresponds to what Scala.js 1.x already does since 1c12d85dd08fd0cb4c57c4b60a998b7279fb9580, when we started using the actual implementation of hijacked classes in the IR rather than the hand-written code in `scalajsenv.js`.

Locally tested with
```
> partestSuite/testOnly -- --fullOpt run/t4148.scala run/t7763.scala
```
Which failed before this change, and succeeds afterwards. It also already succeeds on the `master` branch.