### PR TITLE
Fix Reader read/skip/mark implementation

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -36,6 +36,8 @@ class BufferedReader(in: Reader, sz: Int) extends Reader {
   }
 
   override def mark(readAheadLimit: Int): Unit = {
+    if (readAheadLimit < 0)
+      throw new IllegalArgumentException("Read-ahead limit < 0")
     ensureOpen()
 
     val srcBuf = buf

--- a/javalib/src/main/scala/java/io/StringReader.scala
+++ b/javalib/src/main/scala/java/io/StringReader.scala
@@ -70,10 +70,15 @@ class StringReader(s: String) extends Reader {
   }
 
   override def skip(ns: Long): Long = {
-    // Apparently, StringReader.skip allows negative skips
-    val count = Math.max(Math.min(ns, s.length - pos).toInt, -pos)
-    pos += count
-    count.toLong
+    if (pos >= s.length) {
+      // Always return 0 if the entire string has been read or skipped
+      0
+    } else {
+      // Apparently, StringReader.skip allows negative skips
+      val count = Math.max(Math.min(ns, s.length - pos).toInt, -pos)
+      pos += count
+      count.toLong
+    }
   }
 
   private def ensureOpen(): Unit = {

--- a/javalib/src/main/scala/java/io/StringReader.scala
+++ b/javalib/src/main/scala/java/io/StringReader.scala
@@ -23,6 +23,8 @@ class StringReader(s: String) extends Reader {
   }
 
   override def mark(readAheadLimit: Int): Unit = {
+    if (readAheadLimit < 0)
+      throw new IllegalArgumentException("Read-ahead limit < 0")
     ensureOpen()
 
     mark = pos

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -18,10 +18,28 @@ import java.io._
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform._
 
 /** Tests for our implementation of java.io._ reader classes */
+class ReaderTest {
+  object MyReader extends java.io.Reader {
+    def read(dbuf: Array[Char], off: Int, len: Int): Int = {
+      java.util.Arrays.fill(dbuf, off, off + len, 'A')
+      len
+    }
+    def close(): Unit = ()
+  }
+
+  @Test def skip_should_always_skip_n_if_possible(): Unit = {
+    assumeFalse("Too slow in Rhino", executingInRhino)
+    assertEquals(42, MyReader.skip(42))
+    assertEquals(10000, MyReader.skip(10000)) // more than the 8192 batch size
+  }
+}
+
 class StringReaderTest {
   val str = "asdf"
   def newReader: StringReader = new StringReader(str)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -131,6 +131,10 @@ class StringReaderTest {
     assertTrue(newReader.markSupported)
   }
 
+  @Test def mark_should_throw_with_negative_lookahead(): Unit = {
+    expectThrows(classOf[IllegalArgumentException], newReader.mark(-10))
+  }
+
   @Test def skip_should_accept_negative_lookahead_as_lookback(): Unit = {
     // StringReader.skip accepts negative lookahead
     val r = newReader
@@ -294,6 +298,10 @@ class BufferedReaderTest {
 
   @Test def should_support_marking(): Unit = {
     assertTrue(newReader.markSupported)
+  }
+
+  @Test def mark_should_throw_with_negative_lookahead(): Unit = {
+    expectThrows(classOf[IllegalArgumentException], newReader.mark(-10))
   }
 }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -130,6 +130,29 @@ class StringReaderTest {
   @Test def should_support_marking(): Unit = {
     assertTrue(newReader.markSupported)
   }
+
+  @Test def skip_should_accept_negative_lookahead_as_lookback(): Unit = {
+    // StringReader.skip accepts negative lookahead
+    val r = newReader
+    assertEquals("already head", 0, r.skip(-1))
+    assertEquals('a', r.read())
+
+    assertEquals(1, r.skip(1))
+    assertEquals('d', r.read())
+
+    assertEquals(-2, r.skip(-2))
+    assertEquals('s', r.read())
+  }
+
+  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+    val r = newReader
+    assertEquals(4, r.skip(100))
+    assertEquals(-1, r.read())
+
+    assertEquals(0, r.skip(-100))
+    assertEquals(-1, r.read())
+  }
+
 }
 
 class BufferedReaderTest {
@@ -260,6 +283,15 @@ class BufferedReaderTest {
     assertEquals(null, r.readLine())
   }
 
+  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+    val r = newReader
+    assertEquals(25, r.skip(100))
+    assertEquals(-1, r.read())
+
+    assertEquals(0, r.skip(100))
+    assertEquals(-1, r.read())
+  }
+
   @Test def should_support_marking(): Unit = {
     assertTrue(newReader.markSupported)
   }
@@ -311,4 +343,19 @@ class InputStreamReaderTest {
     assertEquals(0, streamReader.read(new Array[Char](0)))
   }
 
+  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+    val data = "Lorem ipsum".getBytes()
+    val r = new InputStreamReader(new ByteArrayInputStream(data))
+    assertTrue(r.skip(100) > 0)
+    assertEquals(-1, r.read())
+
+    assertEquals(0, r.skip(100))
+    assertEquals(-1, r.read())
+  }
+
+  @Test def should_throw_IOException_since_mark_is_not_supported(): Unit = {
+    val data = "Lorem ipsum".getBytes()
+    val r = new InputStreamReader(new ByteArrayInputStream(data))
+    expectThrows(classOf[IOException], r.mark(0))
+  }
 }


### PR DESCRIPTION
This PR fixes the Scala.js implementation of `Reader` classes so they behave in same manner as JRE implementation.

## 1. read
[`Reader#read()`](https://docs.oracle.com/javase/8/docs/api/java/io/Reader.html#read--) should return -1 if the end of the stream has been reached.

## 2. skip
Return value of [`Reader#skip(int)`](https://docs.oracle.com/javase/8/docs/api/java/io/Reader.html#skip-long-) is stated as `The number of characters actually skipped` so it suposed to be `0` after reaching the end.
This is also [documented in `StringReader`](https://docs.oracle.com/javase/8/docs/api/java/io/StringReader.html#skip-long-).

## 3. mark
[`StringReader#mark(int)`](https://docs.oracle.com/javase/8/docs/api/java/io/StringReader.html#mark-int-) and [`BufferedReader#mark(int)`](https://docs.oracle.com/javase/8/docs/api/java/io/BufferedReader.html#mark-int-) are supposed to throw `IllegalArgumentException` if received negative limit


## <del>4. constructor</del>
<del>Their constructors are not documented to throw NPE when receiving a null, but it should be as same as JRE implementation so that users can notice NPE on construction before using methods.</del>
In Scala.js's javalib emulation, we don't throw NPE explicitly https://github.com/scala-js/scala-js/pull/3665#issuecomment-495544361

