### PR TITLE
Add java.lang.Byte.decode

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Byte.scala
+++ b/javalanglib/src/main/scala/java/lang/Byte.scala
@@ -81,4 +81,15 @@ object Byte {
 
   @inline def compare(x: scala.Byte, y: scala.Byte): scala.Int =
     x - y
+
+  def decode(s: String): Byte = {
+    val lowerCase = s.toLowerCase
+    val radix = if (lowerCase.contains("0x") || lowerCase.contains("#"))
+      16
+    else if (s.startsWith("0") || s.startsWith("+0") || s.startsWith("-0"))
+      8
+    else
+      10
+    parseByte(lowerCase.replaceAll("[x#]", ""), radix)
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
@@ -64,4 +64,48 @@ class ByteTest {
     test("")
     test("200") // out of range
   }
+
+  @Test def should_decode_byte_strings(): Unit = {
+    def check(v: String, expected: Byte): Unit ={
+      assertEquals(expected, JByte.decode(v))
+    }
+
+    check(s"${JByte.MIN_VALUE}", JByte.MIN_VALUE)
+    check(s"${JByte.MAX_VALUE}", JByte.MAX_VALUE)
+
+    check("10", 10.toByte)
+    check("0x10", 16.toByte)
+    check("0X10", 16.toByte)
+    check("010", 8.toByte)
+    check("#10", 16.toByte)
+
+    check("+10", 10.toByte)
+    check("+0x10", 16.toByte)
+    check("+0X10", 16.toByte)
+    check("+010", 8.toByte)
+    check("+#10", 16.toByte)
+
+    check("-10", -10.toByte)
+    check("-0x10", -16.toByte)
+    check("-0X10", -16.toByte)
+    check("-010", -8.toByte)
+    check("-#10", -16.toByte)
+
+    check(Integer.toString(JByte.MIN_VALUE.toInt), JByte.MIN_VALUE)
+    check(Integer.toString(JByte.MAX_VALUE.toInt), JByte.MAX_VALUE)
+  }
+
+  @Test def should_reject_invalid_byte_strings_when_decoding(): Unit = {
+    def checkFailure(v: String): Unit = {
+      assertThrows(classOf[NumberFormatException], JByte.decode(v))
+    }
+
+    checkFailure("0x-10")
+    checkFailure("0x+10")
+    checkFailure("+")
+    checkFailure("-")
+    checkFailure(Integer.toString(JByte.MIN_VALUE.toInt - 1))
+    checkFailure(Integer.toString(JByte.MAX_VALUE.toInt + 1))
+    checkFailure("")
+  }
 }


### PR DESCRIPTION
[`Byte.decode`](https://docs.oracle.com/javase/8/docs/api/java/lang/Byte.html#decode-java.lang.String-) is useful since it can accept hexadecimal and octal numbers.

Test cases (not implementation) are [drawn from OpenJDK](https://github.com/openjdk/jdk/blob/6ef1da93ed67bb839785475335d494af19ed44d4/test/jdk/java/lang/Byte/Decode.java#L62).
