### PR TITLE
[javalib] Add Byte|Integer|Long.decode

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Byte.scala
+++ b/javalanglib/src/main/scala/java/lang/Byte.scala
@@ -81,4 +81,12 @@ object Byte {
 
   @inline def compare(x: scala.Byte, y: scala.Byte): scala.Int =
     x - y
+
+  def decode(s: String): Byte = {
+    val r = Integer.decode(s)
+    if (r < MIN_VALUE || r > MAX_VALUE)
+      throw new NumberFormatException(s"""For input string: "$s"""")
+    else
+      r.toByte
+  }
 }

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -12,6 +12,8 @@
 
 package java.lang
 
+import java.lang.Byte.parseByte
+
 import scala.scalajs.js
 
 /* This is a hijacked class. Its instances are primitive numbers.
@@ -268,4 +270,15 @@ object Integer {
 
   @inline private def asInt(n: scala.Double): scala.Int =
     (n.asInstanceOf[js.Dynamic] | 0.asInstanceOf[js.Dynamic]).asInstanceOf[Int]
+
+  def decode(s: String): Integer = {
+    val lowerCase = s.toLowerCase
+    val radix = if (lowerCase.contains("0x") || lowerCase.contains("#"))
+      16
+    else if (s.startsWith("0") || s.startsWith("+0") || s.startsWith("-0"))
+      8
+    else
+      10
+    parseInt(lowerCase.replaceAll("[x#]", ""), radix)
+  }
 }

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -12,8 +12,9 @@
 
 package java.lang
 
-import scala.annotation.{switch, tailrec}
+import java.lang.Integer.parseInt
 
+import scala.annotation.{ switch, tailrec }
 import scala.scalajs.js
 
 /* This is a hijacked class. Its instances are the representation of scala.Longs.
@@ -504,4 +505,15 @@ object Long {
 
   @inline def min(a: scala.Long, b: scala.Long): scala.Long =
     Math.min(a, b)
+
+  def decode(s: String): Long = {
+    val lowerCase = s.toLowerCase
+    val radix = if (lowerCase.contains("0x") || lowerCase.contains("#"))
+      16
+    else if (s.startsWith("0") || s.startsWith("+0") || s.startsWith("-0"))
+      8
+    else
+      10
+    parseLong(lowerCase.replaceAll("[x#]", ""), radix)
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
@@ -64,4 +64,61 @@ class ByteTest {
     test("")
     test("200") // out of range
   }
+
+  @Test def should_decode_decimal_string(): Unit = {
+    assertEquals(10.toByte, JByte.decode("10"))
+    assertEquals(20.toByte, JByte.decode("+20"))
+    assertEquals(-30.toByte, JByte.decode("-30"))
+  }
+
+  @Test def should_decode_octal_string_with_leading_0(): Unit = {
+    assertEquals(8.toByte, JByte.decode("010"))
+    assertEquals(16.toByte, JByte.decode("+020"))
+    assertEquals(-24.toByte, JByte.decode("-030"))
+  }
+
+  @Test def should_decode_hexadeciaml_string_with_hexadecimal_specifier(): Unit = {
+    assertEquals(16.toByte, JByte.decode("0x10"))
+    assertEquals(32.toByte, JByte.decode("+0x20"))
+    assertEquals(-48.toByte, JByte.decode("-0X30"))
+
+    assertEquals(16.toByte, JByte.decode("0X10"))
+    assertEquals(32.toByte, JByte.decode("+0X20"))
+    assertEquals(-48.toByte, JByte.decode("-0X30"))
+
+    assertEquals(16.toByte, JByte.decode("#10"))
+    assertEquals(32.toByte, JByte.decode("+#20"))
+    assertEquals(-48.toByte, JByte.decode("-#30"))
+  }
+
+  @Test def should_decode_min_and_max(): Unit = {
+    assertEquals(JByte.MIN_VALUE, JByte.decode(s"-0200"))
+    assertEquals(JByte.MIN_VALUE, JByte.decode(s"-0x80"))
+    assertEquals(JByte.MIN_VALUE, JByte.decode(s"-128"))
+
+    assertEquals(JByte.MAX_VALUE, JByte.decode(s"0177"))
+    assertEquals(JByte.MAX_VALUE, JByte.decode(s"0x7f"))
+    assertEquals(JByte.MAX_VALUE, JByte.decode(s"127"))
+  }
+
+  @Test def should_reject_strings_containing_other_than_numbers_when_decoding(): Unit = {
+    // underscore delimitters
+    assertThrows(classOf[NumberFormatException], JByte.decode("0_1_0"))
+    assertThrows(classOf[NumberFormatException], JByte.decode("0x1_0"))
+
+    // whitespaces
+    assertThrows(classOf[NumberFormatException], JByte.decode(" 010"))
+    assertThrows(classOf[NumberFormatException], JByte.decode("0x10 "))
+
+    // signs after radix specifier
+    assertThrows(classOf[NumberFormatException], JByte.decode("0+10"))
+    assertThrows(classOf[NumberFormatException], JByte.decode("0x-10"))
+  }
+
+  @Test def should_reject_when_decoding_out_of_range(): Unit = {
+    assertThrows(classOf[NumberFormatException], JByte.decode(s"128"))
+    assertThrows(classOf[NumberFormatException], JByte.decode(s"-129"))
+    assertThrows(classOf[NumberFormatException], JByte.decode(s"0x80"))
+    assertThrows(classOf[NumberFormatException], JByte.decode(s"-0x81"))
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
@@ -661,4 +661,61 @@ class IntegerTest {
     assertEquals("-10000000000000000000000000000000", Integer.toString(-2147483648, 2))
     assertEquals("-2147483648", Integer.toString(-2147483648, 10))
   }
+
+  @Test def should_decode_decimal_string(): Unit = {
+    assertEquals(1000, Integer.decode("1000"))
+    assertEquals(2000, Integer.decode("+2000"))
+    assertEquals(-4000, Integer.decode("-4000"))
+  }
+
+  @Test def should_decode_octal_string_with_leading_0(): Unit = {
+    assertEquals(512, Integer.decode("01000"))
+    assertEquals(1024, Integer.decode("+02000"))
+    assertEquals(-2048, Integer.decode("-04000"))
+  }
+
+  @Test def should_decode_hexadeciaml_string_with_hexadecimal_specifier(): Unit = {
+    assertEquals(65535, Integer.decode("0xFFFF"))
+    assertEquals(4095, Integer.decode("+0xfff"))
+    assertEquals(-255, Integer.decode("-0xFF"))
+
+    assertEquals(65535, Integer.decode("0XFffF"))
+    assertEquals(4095, Integer.decode("+0XFfF"))
+    assertEquals(-255, Integer.decode("-0XFf"))
+
+    assertEquals(65535, Integer.decode("#FFFF"))
+    assertEquals(4095, Integer.decode("+#fFF"))
+    assertEquals(-255, Integer.decode("-#Ff"))
+  }
+
+  @Test def should_decode_min_and_max(): Unit = {
+    assertEquals(Integer.MIN_VALUE, Integer.decode(s"-020000000000"))
+    assertEquals(Integer.MIN_VALUE, Integer.decode(s"-0x80000000"))
+    assertEquals(Integer.MIN_VALUE, Integer.decode(s"-2147483648"))
+
+    assertEquals(Integer.MAX_VALUE, Integer.decode(s"017777777777"))
+    assertEquals(Integer.MAX_VALUE, Integer.decode(s"0x7fffffff"))
+    assertEquals(Integer.MAX_VALUE, Integer.decode(s"2147483647"))
+  }
+
+  @Test def should_reject_strings_containing_other_than_numbers_when_decoding(): Unit = {
+    // underscore delimitters
+    assertThrows(classOf[NumberFormatException], Integer.decode("0_88_88"))
+    assertThrows(classOf[NumberFormatException], Integer.decode("0xFF_FF"))
+
+    // whitespaces
+    assertThrows(classOf[NumberFormatException], Integer.decode(" 088"))
+    assertThrows(classOf[NumberFormatException], Integer.decode("0xFF "))
+
+    // signs after radix specifier
+    assertThrows(classOf[NumberFormatException], Integer.decode("0+8888"))
+    assertThrows(classOf[NumberFormatException], Integer.decode("0x-FF"))
+  }
+
+  @Test def should_reject_when_decoding_out_of_range(): Unit = {
+    assertThrows(classOf[NumberFormatException], Integer.decode(s"2147483648"))
+    assertThrows(classOf[NumberFormatException], Integer.decode(s"-2147483649"))
+    assertThrows(classOf[NumberFormatException], Integer.decode(s"0x80000000"))
+    assertThrows(classOf[NumberFormatException], Integer.decode(s"-0x80000001"))
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
@@ -367,4 +367,62 @@ class LongTest {
     assertEquals(1, JLong.signum(98765432158845L))
     assertEquals(1, JLong.signum(Long.MaxValue))
   }
+
+
+  @Test def should_decode_decimal_string(): Unit = {
+    assertEquals(89000000005L, JLong.decode("89000000005"))
+    assertEquals(89000000005L, JLong.decode("+89000000005"))
+    assertEquals(-89000000005L, JLong.decode("-89000000005"))
+  }
+
+  @Test def should_decode_octal_string_with_leading_0(): Unit = {
+    assertEquals(456324454L, JLong.decode("03314572546"))
+    assertEquals(456324454L, JLong.decode("+03314572546"))
+    assertEquals(-456324454L, JLong.decode("-03314572546"))
+  }
+
+  @Test def should_decode_hexadeciaml_string_with_hexadecimal_specifier(): Unit = {
+    assertEquals(98765432158845L, JLong.decode("0x59d39e7ffa7d"))
+    assertEquals(98765432158845L, JLong.decode("+0x59d39e7ffa7d"))
+    assertEquals(-49575304457780L, JLong.decode("-0x2d16a6696e34"))
+
+    assertEquals(98765432158845L, JLong.decode("0X59d39e7ffa7d"))
+    assertEquals(98765432158845L, JLong.decode("+0X59d39e7ffa7d"))
+    assertEquals(-49575304457780L, JLong.decode("-0X2d16a6696e34"))
+
+    assertEquals(98765432158845L, JLong.decode("#59d39e7ffa7d"))
+    assertEquals(98765432158845L, JLong.decode("+#59d39e7ffa7d"))
+    assertEquals(-49575304457780L, JLong.decode("-#2d16a6696e34"))
+  }
+
+  @Test def should_decode_min_and_max(): Unit = {
+    assertEquals(JLong.MIN_VALUE, JLong.decode(s"-01000000000000000000000"))
+    assertEquals(JLong.MIN_VALUE, JLong.decode(s"-0x8000000000000000"))
+    assertEquals(JLong.MIN_VALUE, JLong.decode(s"-9223372036854775808"))
+
+    assertEquals(JLong.MAX_VALUE, JLong.decode(s"0777777777777777777777"))
+    assertEquals(JLong.MAX_VALUE, JLong.decode(s"0x7fffffffffffffff"))
+    assertEquals(JLong.MAX_VALUE, JLong.decode(s"9223372036854775807"))
+  }
+
+  @Test def should_reject_strings_containing_other_than_numbers_when_decoding(): Unit = {
+    // underscore delimitters
+    assertThrows(classOf[NumberFormatException], JLong.decode("0_88_88"))
+    assertThrows(classOf[NumberFormatException], JLong.decode("0xFF_FF"))
+
+    // whitespaces
+    assertThrows(classOf[NumberFormatException], JLong.decode(" 088"))
+    assertThrows(classOf[NumberFormatException], JLong.decode("0xFF "))
+
+    // signs after radix specifier
+    assertThrows(classOf[NumberFormatException], JLong.decode("0+8888"))
+    assertThrows(classOf[NumberFormatException], JLong.decode("0x-FF"))
+  }
+
+  @Test def should_reject_when_decoding_out_of_range(): Unit = {
+    assertThrows(classOf[NumberFormatException], JLong.decode(s"9223372036854775808"))
+    assertThrows(classOf[NumberFormatException], JLong.decode(s"-9223372036854775809"))
+    assertThrows(classOf[NumberFormatException], JLong.decode(s"0x8000000000000000"))
+    assertThrows(classOf[NumberFormatException], JLong.decode(s"-0x8000000000000001"))
+  }
 }


### PR DESCRIPTION
Revisit of #3681.

This is a cleanroom implementation of [`Byte.decode`](https://docs.oracle.com/javase/8/docs/api/java/lang/Byte.html#decode-java.lang.String-), [`Integer.decode`](https://docs.oracle.com/javase/8/docs/api/java/lang/Integer.html#decode-java.lang.String-), and [`Long.decode`](https://docs.oracle.com/javase/8/docs/api/java/lang/Long.html#decode-java.lang.String-).
Those are convenient for decoding octal string (`0755`) or hexadecimal string (`0xFFFF`).

