### PR TITLE
Throw UnsupportedEncodingException on bad charset.

### DIFF
--- a/javalib/src/main/scala/java/io/OutputStreamWriter.scala
+++ b/javalib/src/main/scala/java/io/OutputStreamWriter.scala
@@ -44,8 +44,14 @@ class OutputStreamWriter(private[this] var out: OutputStream,
   def this(out: OutputStream) =
     this(out, Charset.defaultCharset)
 
-  def this(out: OutputStream, charsetName: String) =
-    this(out, Charset.forName(charsetName))
+  def this(out: OutputStream, charsetName: String) = {
+    this(out, try {
+      Charset.forName(charsetName)
+    } catch {
+      case _: UnsupportedCharsetException =>
+        throw new UnsupportedEncodingException(charsetName)
+    })
+  }
 
   def getEncoding(): String =
     if (closed) null else enc.charset.name

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
@@ -134,4 +134,11 @@ class OutputStreamWriterTest {
     testW({ osw => osw.write("ab\ud83d"); osw.close() },
         Array('a', 'b', '?'), alreadyFlushed = true)
   }
+
+  @Test def constructor_throw_UnsupportedEncodingException_if_unsupported_charset_name_given(): Unit = {
+    val ex = expectThrows(classOf[UnsupportedEncodingException],
+      new OutputStreamWriter(new ByteArrayOutputStream(), "UNSUPPORTED-CHARSET"))
+    assertTrue("Cause should be null since constructor does not accept cause",
+      ex.getCause == null)
+  }
 }


### PR DESCRIPTION
[According to spec (javadoc)](https://docs.oracle.com/javase/8/docs/api/java/io/OutputStreamWriter.html#OutputStreamWriter-java.io.OutputStream-java.lang.String-), `OutputStreamWriter(OutputStream, String)` should throw `java.io.UnsupportedEncodingException` if the named encoding is not supported.
But current implementation throws `java.nio.charset.UnsupportedCharsetException` instead.
