### PR TITLE
Fix #3686: Add `js.import(specifier)` to support ES dynamic imports.

### DIFF
--- a/assets/additional-doc-styles.css
+++ b/assets/additional-doc-styles.css
@@ -2,6 +2,10 @@
   background-color: #E68A00;
 }
 
+.badge-ecma2019 {
+  background-color: #E68A00;
+}
+
 .badge-non-std {
   background-color: #B94A48;
 }

--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -4431,6 +4431,10 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
               genAsInstanceOf(js.JSUnaryOp(js.JSUnaryOp.typeof, arg),
                   StringClass.tpe)
 
+            case JS_IMPORT =>
+              // js.import(arg)
+              js.JSImportCall(arg)
+
             case OBJPROPS =>
               // js.Object.properties(arg)
               genApplyMethod(

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSDefinitions.scala
@@ -118,6 +118,10 @@ trait JSDefinitions {
     lazy val RawJSTypeAnnot = getRequiredClass("scala.scalajs.js.annotation.RawJSType")
     lazy val ExposedJSMemberAnnot = getRequiredClass("scala.scalajs.js.annotation.ExposedJSMember")
 
+    lazy val JSImportModule = getRequiredModule("scala.scalajs.js.import")
+    lazy val JSImportModuleClass = JSImportModule.moduleClass
+      lazy val JSImport_apply = getMemberMethod(JSImportModuleClass, nme.apply)
+
     lazy val SpecialPackageModule = getPackageObject("scala.scalajs.js.special")
       lazy val Special_delete = getMemberMethod(SpecialPackageModule, newTermName("delete"))
       lazy val Special_debugger = getMemberMethod(SpecialPackageModule, newTermName("debugger"))

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSPrimitives.scala
@@ -54,6 +54,8 @@ abstract class JSPrimitives {
 
   val UNITVAL = 349 // () value, which is undefined
 
+  val JS_IMPORT = 350 // js.import.apply(specifier)
+
   val CONSTRUCTOROF = 352 // runtime.constructorOf(clazz)
   val LINKING_INFO = 354  // $linkingInfo
 
@@ -110,6 +112,8 @@ abstract class JSPrimitives {
     addPrimitive(JSObject_properties, OBJPROPS)
 
     addPrimitive(BoxedUnit_UNIT, UNITVAL)
+
+    addPrimitive(JSImport_apply, JS_IMPORT)
 
     addPrimitive(Runtime_constructorOf, CONSTRUCTOROF)
     addPrimitive(Runtime_linkingInfo, LINKING_INFO)

--- a/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Hashers.scala
@@ -356,6 +356,10 @@ object Hashers {
           mixTag(TagJSSuperConstructorCall)
           mixTrees(args)
 
+        case JSImportCall(arg) =>
+          mixTag(TagJSImportCall)
+          mixTree(arg)
+
         case LoadJSConstructor(cls) =>
           mixTag(TagLoadJSConstructor)
           mixType(cls)

--- a/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Printers.scala
@@ -583,6 +583,11 @@ object Printers {
           print("super")
           printArgs(args)
 
+        case JSImportCall(arg) =>
+          print("import(")
+          print(arg)
+          print(')')
+
         case LoadJSConstructor(cls) =>
           print("constructorOf[")
           print(cls)

--- a/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
@@ -33,7 +33,7 @@ object ScalaJSVersions {
    *  - a prior release version (i.e. "0.5.0", *not* "0.5.0-SNAPSHOT")
    *  - `current`
    */
-  val binaryEmitted: String = "0.6.17"
+  val binaryEmitted: String = current
 
   /** Versions whose binary files we can support (used by deserializer) */
   val binarySupported: Set[String] = {

--- a/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Serializers.scala
@@ -307,6 +307,10 @@ object Serializers {
           writeByte(TagJSSuperConstructorCall)
           writeTrees(args)
 
+        case JSImportCall(arg) =>
+          writeByte(TagJSImportCall)
+          writeTree(arg)
+
         case LoadJSConstructor(cls) =>
           writeByte(TagLoadJSConstructor)
           writeClassType(cls)
@@ -784,6 +788,7 @@ object Serializers {
         case TagJSSuperBracketCall   =>
           JSSuperBracketCall(readClassType(), readTree(), readTree(), readTrees())
         case TagJSSuperConstructorCall => JSSuperConstructorCall(readTrees())
+        case TagJSImportCall         => JSImportCall(readTree())
         case TagLoadJSConstructor    => LoadJSConstructor(readClassType())
         case TagLoadJSModule         => LoadJSModule(readClassType())
         case TagJSSpread             => JSSpread(readTree())

--- a/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Tags.scala
@@ -111,6 +111,7 @@ private[ir] object Tags {
   final val TagSelectStatic = TagTopLevelMethodExportDef + 1
   final val TagTopLevelFieldExportDef = TagSelectStatic + 1
   final val TagTopLevelModuleExportDef = TagTopLevelFieldExportDef + 1
+  final val TagJSImportCall = TagTopLevelModuleExportDef + 1
 
   // Tags for Types
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Transformers.scala
@@ -162,6 +162,9 @@ object Transformers {
         case JSSuperConstructorCall(args) =>
           JSSuperConstructorCall(args map transformExpr)
 
+        case JSImportCall(arg) =>
+          JSImportCall(transformExpr(arg))
+
         case JSSpread(items) =>
           JSSpread(transformExpr(items))
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Traversers.scala
@@ -165,6 +165,9 @@ object Traversers {
       case JSSuperConstructorCall(args) =>
         args foreach traverse
 
+      case JSImportCall(arg) =>
+        traverse(arg)
+
       case JSSpread(items) =>
         traverse(items)
 

--- a/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/Trees.scala
@@ -578,6 +578,21 @@ object Trees {
     val tpe = NoType
   }
 
+  /** JavaScript dynamic import of the form `import(arg)`.
+   *
+   *  This form is its own node, rather than using something like
+   *  {{{
+   *  JSFunctionApply(JSImport())
+   *  }}}
+   *  because `import` is not a first-class term in JavaScript.
+   *  `ImportCall` is a dedicated syntactic form that cannot be
+   *  dissociated.
+   */
+  case class JSImportCall(arg: Tree)(implicit val pos: Position)
+      extends Tree {
+    val tpe = AnyType // it is a JavaScript Promise
+  }
+
   /** Loads the constructor of a JS class (native or not).
    *
    *  `cls` must represent a non-trait JS class (native or not).

--- a/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/core/ir/PrintersTest.scala
@@ -597,6 +597,10 @@ class PrintersTest {
     assertPrintEquals("super(4, 5)", JSSuperConstructorCall(List(i(4), i(5))))
   }
 
+  @Test def printJSImportCall(): Unit = {
+    assertPrintEquals("""import("foo.js")""", JSImportCall(StringLiteral("foo.js")))
+  }
+
   @Test def printLoadJSConstructor(): Unit = {
     assertPrintEquals("constructorOf[LTest]", LoadJSConstructor("LTest"))
   }

--- a/library/src/main/scala/scala/scalajs/js/import.scala
+++ b/library/src/main/scala/scala/scalajs/js/import.scala
@@ -1,0 +1,30 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+
+/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+ *  Dynamic `import(specifier)`.
+ *
+ *  This is an object rather than a simple `def` to reserve the possibility to
+ *  add "fields" to the function, notably to support the `import.meta`
+ *  meta-property of ECMAScript (still being specified).
+ */
+object `import` { // scalastyle:ignore
+  /** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+   *  Dynamic `import(specifier)`.
+   */
+  def apply[A <: js.Any](specifier: String): js.Promise[A] =
+    throw new java.lang.Error("stub")
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1647,7 +1647,9 @@ object Build {
 
           collectionsEraDependentDirectory(scalaV, testDir) ::
           includeIf(testDir / "require-modules",
-              scalaJSModuleKind.value != ModuleKind.NoModule)
+              scalaJSModuleKind.value != ModuleKind.NoModule) :::
+          includeIf(testDir / "require-dynamic-import",
+              scalaJSModuleKind.value == ModuleKind.ESModule) // this is an approximation that works for now
         },
 
         jsDependencies += ProvidedJS / "ScalaJSDefinedTestNatives.js" % "test",

--- a/test-suite/js/src/test/require-dynamic-import/org/scalajs/testsuite/jsinterop/DynamicImportTest.scala
+++ b/test-suite/js/src/test/require-dynamic-import/org/scalajs/testsuite/jsinterop/DynamicImportTest.scala
@@ -1,0 +1,47 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import org.junit.Assert._
+import org.junit.Test
+
+/* This is currently hard-coded for Node.js modules in particular.
+ * We are importing built-in Node.js modules, because we do not have any
+ * infrastructure to load non-built-in modules. In the future, we should use
+ * our own user-defined ES6 modules written in JavaScript.
+ */
+class DynamicImportTest {
+
+  @Test def testDynImportParsesAndExecutes(): Unit = {
+    /* Since we do not have support for asynchronous tests, all we can do here
+     * is test that `js.import` parses, links, and executes without error,
+     * returning a `Promise`. We can't actually wait for the promise to
+     * resolve and hence cannot test its result.
+     *
+     * We will be able to revisit this in Scala.js 1.x.
+     */
+
+    def isPromise(x: Any): Boolean = x.isInstanceOf[js.Promise[_]]
+
+    assertTrue(isPromise(js.`import`[js.Any]("fs")))
+
+    val failedPromise = js.`import`[js.Any]("non-existent-module")
+    assertTrue(isPromise(failedPromise))
+    // Recover to avoid the unhandled rejected Promise warning of Node.js
+    failedPromise.toFuture.recover {
+      case th: Throwable => ()
+    }
+  }
+
+}

--- a/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
+++ b/tools/jvm/src/main/scala/org/scalajs/core/tools/linker/backend/closure/ClosureAstTransformer.scala
@@ -294,6 +294,8 @@ private[closure] class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
 
         node
 
+      case ImportCall(arg) =>
+        new Node(Token.DYNAMIC_IMPORT, transformExpr(arg))
       case Delete(prop) =>
         new Node(Token.DELPROP, transformExpr(prop))
       case UnaryOp(op, lhs) =>

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Printers.scala
@@ -345,6 +345,11 @@ object Printers {
           print(fun)
           printArgs(args)
 
+        case ImportCall(arg) =>
+          print("import(")
+          print(arg)
+          print(')')
+
         case Spread(items) =>
           print("...")
           print(items)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/javascript/Trees.scala
@@ -151,6 +151,10 @@ object Trees {
    */
   case class Apply(fun: Tree, args: List[Tree])(implicit val pos: Position) extends Tree
 
+  /** Dynamic `import(arg)`. */
+  case class ImportCall(arg: Tree)(implicit val pos: Position)
+      extends Tree
+
   /** `...items`, the "spread" operator of ECMAScript 6.
    *
    *  It is only valid in ECMAScript 6, in the `args`/`items` of a [[New]],

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -1060,6 +1060,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           allowSideEffects && test(receiver) && test(method) && (args forall test)
         case JSSuperBracketSelect(_, qualifier, item) =>
           allowSideEffects && test(qualifier) && test(item)
+        case JSImportCall(arg) =>
+          allowSideEffects && test(arg)
         case LoadJSModule(_) =>
           allowSideEffects
 
@@ -1524,6 +1526,11 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                     method),
                 StringLiteral("call"),
                 receiver :: args)
+          }
+
+        case JSImportCall(arg) =>
+          unnest(arg) { (newArg, env) =>
+            redo(JSImportCall(newArg))(env)
           }
 
         case JSDotSelect(qualifier, item) =>
@@ -2057,6 +2064,9 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           val ctor = genRawJSClassConstructor(cls.className)
           genCallHelper("superGet", ctor DOT "prototype",
               transformExpr(qualifier), transformExpr(item))
+
+        case JSImportCall(arg) =>
+          js.ImportCall(transformExpr(arg))
 
         case LoadJSConstructor(cls) =>
           genRawJSClassConstructor(cls.className)

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/checker/IRChecker.scala
@@ -952,6 +952,9 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
         for (arg <- args)
           typecheckExprOrSpread(arg, env)
 
+      case JSImportCall(arg) =>
+        typecheckExpr(arg, env)
+
       case LoadJSConstructor(cls) =>
         val clazz = lookupClass(cls)
         val valid = clazz.kind match {

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -628,6 +628,9 @@ private[optimizer] abstract class OptimizerCore(
       case JSSuperConstructorCall(args) =>
         JSSuperConstructorCall(transformExprsOrSpreads(args))
 
+      case JSImportCall(arg) =>
+        JSImportCall(transformExpr(arg))
+
       case JSDelete(JSDotSelect(obj, prop)) =>
         JSDelete(JSDotSelect(transformExpr(obj), prop))
 


### PR DESCRIPTION
Tests are rudimentary, because full testing requires asynchronous tests, which are not available in 0.6.x. Full tests should be added in the 1.x series.

The changes in the Closure linker backend are useless at the moment, because dynamic imports are only supported by the parser and pretty-printer of GCC but not the rest of the compiler. Support should eventually come in a later version of GCC, though, at which point it will transfer for free to our GCC backend.

I locally tested the GCC support with a modified version of closure-compiler, see branch at https://github.com/sjrd/closure-compiler/compare/master...sjrd:dynamic-import

#3689 contains further tests on top of the master branch.