### PR TITLE
Actual tests for `js.import`.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1624,7 +1624,7 @@ object Build {
 
       inConfig(Bootstrap)(testSuiteBootstrapSetting)
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      library, jUnitRuntime, testBridge % "test"
+      library, jUnitRuntime, testBridge % "test", jUnitAsyncJS % "test"
   )
 
   lazy val testSuiteJVM: Project = (project in file("test-suite/jvm")).settings(


### PR DESCRIPTION
This is a followup to #3688 with actual tests for the asynchronous result of `js.import`, now that we can use async tests.