### PR TITLE
FF ONLY Merge 0.6.x into master, June 7

### DIFF
--- a/assets/additional-doc-styles.css
+++ b/assets/additional-doc-styles.css
@@ -2,6 +2,10 @@
   background-color: #E68A00;
 }
 
+.badge-ecma2019 {
+  background-color: #E68A00;
+}
+
 .badge-non-std {
   background-color: #B94A48;
 }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -4524,6 +4524,11 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           genAsInstanceOf(js.JSUnaryOp(js.JSUnaryOp.typeof, arg),
               StringClass.tpe)
 
+        case JS_IMPORT =>
+          // js.import(arg)
+          val arg = genArgs1
+          js.JSImportCall(arg)
+
         case IN =>
           // js.special.in(arg1, arg2)
           val (arg1, arg2) = genArgs2

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -94,6 +94,10 @@ trait JSDefinitions {
     lazy val JSConstructorTagModule = getRequiredModule("scala.scalajs.js.ConstructorTag")
       lazy val JSConstructorTag_materialize = getMemberMethod(JSConstructorTagModule, newTermName("materialize"))
 
+    lazy val JSImportModule = getRequiredModule("scala.scalajs.js.import")
+    lazy val JSImportModuleClass = JSImportModule.moduleClass
+      lazy val JSImport_apply = getMemberMethod(JSImportModuleClass, nme.apply)
+
     lazy val SpecialPackageModule = getPackageObject("scala.scalajs.js.special")
       lazy val Special_in = getMemberMethod(SpecialPackageModule, newTermName("in"))
       lazy val Special_instanceof = getMemberMethod(SpecialPackageModule, newTermName("instanceof"))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
@@ -46,7 +46,9 @@ abstract class JSPrimitives {
 
   final val UNITVAL = JS_NATIVE + 1 // () value, which is undefined
 
-  final val CONSTRUCTOROF = UNITVAL + 1                                // runtime.constructorOf(clazz)
+  final val JS_IMPORT = UNITVAL + 1 // js.import.apply(specifier)
+
+  final val CONSTRUCTOROF = JS_IMPORT + 1                              // runtime.constructorOf(clazz)
   final val CREATE_INNER_JS_CLASS = CONSTRUCTOROF + 1                  // runtime.createInnerJSClass
   final val CREATE_LOCAL_JS_CLASS = CREATE_INNER_JS_CLASS + 1          // runtime.createLocalJSClass
   final val WITH_CONTEXTUAL_JS_CLASS_VALUE = CREATE_LOCAL_JS_CLASS + 1 // runtime.withContextualJSClassValue
@@ -86,6 +88,8 @@ abstract class JSPrimitives {
     addPrimitive(JSPackage_native, JS_NATIVE)
 
     addPrimitive(BoxedUnit_UNIT, UNITVAL)
+
+    addPrimitive(JSImport_apply, JS_IMPORT)
 
     addPrimitive(Runtime_constructorOf, CONSTRUCTOROF)
     addPrimitive(Runtime_createInnerJSClass, CREATE_INNER_JS_CLASS)

--- a/ir/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -343,6 +343,10 @@ object Hashers {
           mixTag(TagJSSuperConstructorCall)
           mixTreeOrJSSpreads(args)
 
+        case JSImportCall(arg) =>
+          mixTag(TagJSImportCall)
+          mixTree(arg)
+
         case LoadJSConstructor(cls) =>
           mixTag(TagLoadJSConstructor)
           mixClassRef(cls)

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -591,6 +591,11 @@ object Printers {
           print("super")
           printArgs(args)
 
+        case JSImportCall(arg) =>
+          print("import(")
+          print(arg)
+          print(')')
+
         case LoadJSConstructor(cls) =>
           print("constructorOf[")
           print(cls)

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -341,6 +341,10 @@ object Serializers {
           writeByte(TagJSSuperConstructorCall)
           writeTreeOrJSSpreads(args)
 
+        case JSImportCall(arg) =>
+          writeByte(TagJSImportCall)
+          writeTree(arg)
+
         case LoadJSConstructor(cls) =>
           writeByte(TagLoadJSConstructor)
           writeClassRef(cls)
@@ -912,6 +916,7 @@ object Serializers {
         case TagJSSuperBracketCall   =>
           JSSuperBracketCall(readTree(), readTree(), readTree(), readTreeOrJSSpreads())
         case TagJSSuperConstructorCall => JSSuperConstructorCall(readTreeOrJSSpreads())
+        case TagJSImportCall         => JSImportCall(readTree())
         case TagLoadJSConstructor    => LoadJSConstructor(readClassRef())
         case TagLoadJSModule         => LoadJSModule(readClassRef())
         case TagJSDelete             => JSDelete(readTree())

--- a/ir/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Tags.scala
@@ -68,7 +68,8 @@ private[ir] object Tags {
   final val TagJSSuperBracketSelect = TagJSBracketMethodApply + 1
   final val TagJSSuperBracketCall = TagJSSuperBracketSelect + 1
   final val TagJSSuperConstructorCall = TagJSSuperBracketCall + 1
-  final val TagLoadJSConstructor = TagJSSuperConstructorCall + 1
+  final val TagJSImportCall = TagJSSuperConstructorCall + 1
+  final val TagLoadJSConstructor = TagJSImportCall + 1
   final val TagLoadJSModule = TagLoadJSConstructor + 1
   final val TagJSDelete = TagLoadJSModule + 1
   final val TagJSUnaryOp = TagJSDelete + 1

--- a/ir/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -171,6 +171,9 @@ object Transformers {
         case JSSuperConstructorCall(args) =>
           JSSuperConstructorCall(args.map(transformExprOrJSSpread))
 
+        case JSImportCall(arg) =>
+          JSImportCall(transformExpr(arg))
+
         case JSDelete(prop) =>
           JSDelete(transformExpr(prop))
 

--- a/ir/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -173,6 +173,9 @@ object Traversers {
       case JSSuperConstructorCall(args) =>
         args.foreach(traverseTreeOrJSSpread)
 
+      case JSImportCall(arg) =>
+        traverse(arg)
+
       case JSDelete(prop) =>
         traverse(prop)
 

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -640,6 +640,21 @@ object Trees {
     val tpe = NoType
   }
 
+  /** JavaScript dynamic import of the form `import(arg)`.
+   *
+   *  This form is its own node, rather than using something like
+   *  {{{
+   *  JSFunctionApply(JSImport())
+   *  }}}
+   *  because `import` is not a first-class term in JavaScript.
+   *  `ImportCall` is a dedicated syntactic form that cannot be
+   *  dissociated.
+   */
+  case class JSImportCall(arg: Tree)(implicit val pos: Position)
+      extends Tree {
+    val tpe = AnyType // it is a JavaScript Promise
+  }
+
   /** Loads the constructor of a JS class (native or not).
    *
    *  `cls` must represent a non-trait JS class (native or not).

--- a/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -646,6 +646,10 @@ class PrintersTest {
     assertPrintEquals("super(4, 5)", JSSuperConstructorCall(List(i(4), i(5))))
   }
 
+  @Test def printJSImportCall(): Unit = {
+    assertPrintEquals("""import("foo.js")""", JSImportCall(StringLiteral("foo.js")))
+  }
+
   @Test def printLoadJSConstructor(): Unit = {
     assertPrintEquals("constructorOf[LTest]", LoadJSConstructor("LTest"))
   }

--- a/library/src/main/scala/scala/scalajs/js/import.scala
+++ b/library/src/main/scala/scala/scalajs/js/import.scala
@@ -1,0 +1,30 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+
+/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+ *  Dynamic `import(specifier)`.
+ *
+ *  This is an object rather than a simple `def` to reserve the possibility to
+ *  add "fields" to the function, notably to support the `import.meta`
+ *  meta-property of ECMAScript (still being specified).
+ */
+object `import` { // scalastyle:ignore
+  /** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+   *  Dynamic `import(specifier)`.
+   */
+  def apply[A <: js.Any](specifier: String): js.Promise[A] =
+    throw new java.lang.Error("stub")
+}

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -304,6 +304,8 @@ private[closure] class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
 
         node
 
+      case ImportCall(arg) =>
+        new Node(Token.DYNAMIC_IMPORT, transformExpr(arg))
       case Delete(prop) =>
         new Node(Token.DELPROP, transformExpr(prop))
       case UnaryOp(op, lhs) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1275,6 +1275,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           allowSideEffects && test(receiver) && test(method) && (args.forall(testJSArg))
         case JSSuperBracketSelect(superClass, qualifier, item) =>
           allowSideEffects && test(superClass) && test(qualifier) && test(item)
+        case JSImportCall(arg) =>
+          allowSideEffects && test(arg)
         case LoadJSModule(_) =>
           allowSideEffects
         case JSGlobalRef(_) =>
@@ -1763,6 +1765,11 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                     method),
                 StringLiteral("call"),
                 receiver :: args)
+          }
+
+        case JSImportCall(arg) =>
+          unnest(arg) { (newArg, env) =>
+            redo(JSImportCall(newArg))(env)
           }
 
         case JSDotSelect(qualifier, item) =>
@@ -2557,6 +2564,9 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
         case JSSuperBracketSelect(superClass, qualifier, item) =>
           genCallHelper("superGet", transformExprNoChar(superClass),
               transformExprNoChar(qualifier), transformExprNoChar(item))
+
+        case JSImportCall(arg) =>
+          js.ImportCall(transformExprNoChar(arg))
 
         case LoadJSConstructor(cls) =>
           extractWithGlobals(genJSClassConstructor(cls.className))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -363,6 +363,11 @@ object Printers {
           print(fun)
           printArgs(args)
 
+        case ImportCall(arg) =>
+          print("import(")
+          print(arg)
+          print(')')
+
         case Spread(items) =>
           print("...")
           print(items)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -157,6 +157,10 @@ object Trees {
    */
   case class Apply(fun: Tree, args: List[Tree])(implicit val pos: Position) extends Tree
 
+  /** Dynamic `import(arg)`. */
+  case class ImportCall(arg: Tree)(implicit val pos: Position)
+      extends Tree
+
   /** `...items`, the "spread" operator of ECMAScript 6.
    *
    *  It is only valid in ECMAScript 6, in the `args`/`items` of a [[New]],

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -980,6 +980,9 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
         for (arg <- args)
           typecheckExprOrSpread(arg, env)
 
+      case JSImportCall(arg) =>
+        typecheckExpr(arg, env)
+
       case LoadJSConstructor(cls) =>
         val clazz = lookupClass(cls)
         val valid = clazz.kind match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -597,6 +597,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case JSSuperConstructorCall(args) =>
         JSSuperConstructorCall(transformExprsOrSpreads(args))
 
+      case JSImportCall(arg) =>
+        JSImportCall(transformExpr(arg))
+
       case JSDelete(JSDotSelect(obj, prop)) =>
         JSDelete(JSDotSelect(transformExpr(obj), prop))
 

--- a/partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
+++ b/partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
@@ -47,7 +47,12 @@ class ScalaJSRunner(testFile: File, suiteRunner: SuiteRunner,
         new nest.NestUI(diffOnFail = options.showDiff, colorEnabled = true)) {
   private val compliantSems: List[String] = {
     scalaJSConfigFile("sem").fold(List.empty[String]) { file =>
-      Source.fromFile(file).getLines.toList
+      val source = Source.fromFile(file)
+      try {
+        source.getLines.toList
+      } finally {
+        source.close()
+      }
     }
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1446,9 +1446,13 @@ object Build {
         val testDir = (sourceDirectory in Test).value
         val scalaV = scalaVersion.value
 
+        val moduleKind = scalaJSLinkerConfig.value.moduleKind
+
         collectionsEraDependentDirectory(scalaV, testDir) ::
         includeIf(testDir / "require-modules",
-            scalaJSLinkerConfig.value.moduleKind != ModuleKind.NoModule)
+            moduleKind != ModuleKind.NoModule) :::
+        includeIf(testDir / "require-dynamic-import",
+            moduleKind == ModuleKind.ESModule) // this is an approximation that works for now
       },
 
       scalaJSLinkerConfig ~= { _.withSemantics(TestSuiteLinkerOptions.semantics _) },

--- a/test-suite/js/src/test/require-dynamic-import/org/scalajs/testsuite/jsinterop/DynamicImportTest.scala
+++ b/test-suite/js/src/test/require-dynamic-import/org/scalajs/testsuite/jsinterop/DynamicImportTest.scala
@@ -1,0 +1,47 @@
+/*                     __                                               *\
+**     ________ ___   / /  ___      __ ____  Scala.js Test Suite        **
+**    / __/ __// _ | / /  / _ | __ / // __/  (c) 2013-2016, LAMP/EPFL   **
+**  __\ \/ /__/ __ |/ /__/ __ |/_// /_\ \    http://scala-js.org/       **
+** /____/\___/_/ |_/____/_/ | |__/ /____/                               **
+**                          |/____/                                     **
+\*                                                                      */
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import org.junit.Assert._
+import org.junit.Test
+
+/* This is currently hard-coded for Node.js modules in particular.
+ * We are importing built-in Node.js modules, because we do not have any
+ * infrastructure to load non-built-in modules. In the future, we should use
+ * our own user-defined ES6 modules written in JavaScript.
+ */
+class DynamicImportTest {
+
+  @Test def testDynImportParsesAndExecutes(): Unit = {
+    /* Since we do not have support for asynchronous tests, all we can do here
+     * is test that `js.import` parses, links, and executes without error,
+     * returning a `Promise`. We can't actually wait for the promise to
+     * resolve and hence cannot test its result.
+     *
+     * We will be able to revisit this in Scala.js 1.x.
+     */
+
+    def isPromise(x: Any): Boolean = x.isInstanceOf[js.Promise[_]]
+
+    assertTrue(isPromise(js.`import`[js.Any]("fs")))
+
+    val failedPromise = js.`import`[js.Any]("non-existent-module")
+    assertTrue(isPromise(failedPromise))
+    // Recover to avoid the unhandled rejected Promise warning of Node.js
+    failedPromise.toFuture.recover {
+      case th: Throwable => ()
+    }
+  }
+
+}


### PR DESCRIPTION
Motivation: rebase #3689 on top of the merge to add full tests for `js.import`.
```
$ git checkout -b merge-0.6.x-into-master-june-7
Switched to a new branch 'merge-0.6.x-into-master-june-7'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   94372c8c1 (scalajs/0.6.x) Merge pull request #3688 from sjrd/dynamic-import
|\  
| * 17407e74c (origin/dynamic-import) Fix #3686: Add `js.import(specifier)` to support ES dynamic imports.
| * 12a900a9f Bump the emitted binary version of the IR to the next version.
* e4ec107b5 Merge pull request #3652 from exoego/resource-leak
* 559598fed Fix potential resource leak
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
Auto-merging linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
Auto-merging linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
Auto-merging linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
Auto-merging linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
Auto-merging linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
CONFLICT (content): Merge conflict in linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
Auto-merging linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
Auto-merging ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
Auto-merging ir/src/main/scala/org/scalajs/ir/Traversers.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/ir/Traversers.scala
Auto-merging ir/src/main/scala/org/scalajs/ir/Transformers.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/ir/Transformers.scala
Auto-merging ir/src/main/scala/org/scalajs/ir/Tags.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/ir/Tags.scala
Auto-merging ir/src/main/scala/org/scalajs/ir/Serializers.scala
CONFLICT (content): Merge conflict in ir/src/main/scala/org/scalajs/ir/Serializers.scala
Auto-merging ir/src/main/scala/org/scalajs/ir/Printers.scala
Auto-merging ir/src/main/scala/org/scalajs/ir/Hashers.scala
CONFLICT (modify/delete): ir/src/main/scala/org/scalajs/core/ir/Trees.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of ir/src/main/scala/org/scalajs/core/ir/Trees.scala left in tree.
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
Resolved 'compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala' using previous resolution.
Resolved 'compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala' using previous resolution.
Resolved 'compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala' using previous resolution.
Resolved 'ir/src/main/scala/org/scalajs/ir/Serializers.scala' using previous resolution.
Resolved 'ir/src/main/scala/org/scalajs/ir/Tags.scala' using previous resolution.
Resolved 'ir/src/main/scala/org/scalajs/ir/Transformers.scala' using previous resolution.
Resolved 'ir/src/main/scala/org/scalajs/ir/Traversers.scala' using previous resolution.
Resolved 'linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala' using previous resolution.
Resolved 'project/Build.scala' using previous resolution.
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
M  assets/additional-doc-styles.css
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
UU compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
DU ir/src/main/scala/org/scalajs/core/ir/Trees.scala
M  ir/src/main/scala/org/scalajs/ir/Hashers.scala
M  ir/src/main/scala/org/scalajs/ir/Printers.scala
UU ir/src/main/scala/org/scalajs/ir/Serializers.scala
UU ir/src/main/scala/org/scalajs/ir/Tags.scala
UU ir/src/main/scala/org/scalajs/ir/Transformers.scala
UU ir/src/main/scala/org/scalajs/ir/Traversers.scala
M  ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
A  library/src/main/scala/scala/scalajs/js/import.scala
M  linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
UU linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
M  linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
M  linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
M  partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
UU project/Build.scala
A  test-suite/js/src/test/require-dynamic-import/org/scalajs/testsuite/jsinterop/DynamicImportTest.scala
```
```
$ git rm -f ir/src/main/scala/org/scalajs/core/ir/Trees.scala
ir/src/main/scala/org/scalajs/core/ir/Trees.scala: needs merge
rm 'ir/src/main/scala/org/scalajs/core/ir/Trees.scala'
```
[...] Fix conflicts.
```
$ git diff > ../merge.diff
```
[`merge.diff`](https://gist.github.com/sjrd/ea75c235766961613cd944d1b1db0c45)
```
$ git add -u
```
```
$ git st
M  assets/additional-doc-styles.css
M  compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
M  compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
M  ir/src/main/scala/org/scalajs/ir/Hashers.scala
M  ir/src/main/scala/org/scalajs/ir/Printers.scala
M  ir/src/main/scala/org/scalajs/ir/Serializers.scala
M  ir/src/main/scala/org/scalajs/ir/Tags.scala
M  ir/src/main/scala/org/scalajs/ir/Transformers.scala
M  ir/src/main/scala/org/scalajs/ir/Traversers.scala
M  ir/src/main/scala/org/scalajs/ir/Trees.scala
M  ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
A  library/src/main/scala/scala/scalajs/js/import.scala
M  linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
M  linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
M  linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
M  linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
M  partest/src/main-partest-1.0.16/scala/tools/partest/scalajs/ScalaJSPartest.scala
M  project/Build.scala
A  test-suite/js/src/test/require-dynamic-import/org/scalajs/testsuite/jsinterop/DynamicImportTest.scala
```
```
$ git commit
[merge-0.6.x-into-master-june-7 3f7a4a2c7] Merge '0.6.x' into 'master'.
```
