### PR TITLE
Recognize Metals as an IDE for the special treatment of the build.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -74,6 +74,11 @@ or, more typically,
 
     > partestSuite/testOnly -- --fastOpt
 
+## Metals-based IDEs
+
+We recommend [Metals](https://scalameta.org/metals/)-based IDEs such as VS Code
+to develop Scala.js itself. It can import the Scala.js build out-of-the-box.
+
 ## Eclipse
 
 If you want to develop in Eclipse, use


### PR DESCRIPTION
The same accommodations that were done for Eclipse are also valuable for Metals. Since the environment variable `METALS_ENABLED` is automatically added by Metals when it imports a build, this change gives a better out-of-the-box experience with Metals.

We also now mention Metals-based IDEs as the recommended tools to develop Scala.js in the Developing guide.