### PR TITLE
Implement java.util.{Linked,}HashMap from scratch.

### DIFF
--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -12,153 +12,509 @@
 
 package java.util
 
-import scala.collection.mutable
+import scala.annotation.tailrec
 
-class HashMap[K, V] protected (inner: mutable.Map[Box[K], V])
+import java.{util => ju}
+
+import ScalaOps._
+
+class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     extends AbstractMap[K, V] with Serializable with Cloneable {
   self =>
 
-  def this() =
-    this(mutable.HashMap.empty[Box[K], V])
+  import HashMap._
 
-  def this(initialCapacity: Int, loadFactor: Float) = {
-    this()
-    if (initialCapacity < 0)
-      throw new IllegalArgumentException("initialCapacity < 0")
-    else if (loadFactor < 0.0)
-      throw new IllegalArgumentException("loadFactor <= 0.0")
-  }
+  if (initialCapacity < 0)
+    throw new IllegalArgumentException("initialCapacity < 0")
+  if (loadFactor <= 0.0)
+    throw new IllegalArgumentException("loadFactor <= 0.0")
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(initialCapacity: Int) =
     this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(m: Map[_ <: K, _ <: V]) = {
-    this()
+    this(m.size())
     putAll(m)
   }
 
-  override def clear(): Unit =
-    inner.clear()
+  /** The actual hash table.
+   *
+   *  In each bucket, nodes are sorted by increasing value of `hash`.
+   *
+   *  Deviation from the JavaDoc: we do not use `initialCapacity` as is for the
+   *  number of buckets. Instead we round it up to the next power of 2. This
+   *  allows some algorithms to be more efficient, notably `index()` and
+   *  `growTable()`. Since the number of buckets is not observable from the
+   *  outside, this deviation does not change any semantics.
+   */
+  private[this] var table = new Array[Node[K, V]](tableSizeFor(initialCapacity))
 
-  override def clone(): AnyRef = {
-    new HashMap(inner.clone())
+  /** The next size value at which to resize (capacity * load factor). */
+  private[this] var threshold: Int = newThreshold(table.length)
+
+  private[this] var contentSize: Int = 0
+
+  /* Internal API for LinkedHashMap: these methods are overridden in
+   * LinkedHashMap to implement its insertion- or access-order.
+   */
+
+  private[util] def newNode(key: K, hash: Int, value: V,
+      previous: Node[K, V], next: Node[K, V]): Node[K, V] = {
+    new Node(key, hash, value, previous, next)
+  }
+
+  private[util] def nodeWasAccessed(node: Node[K, V]): Unit = ()
+
+  private[util] def nodeWasAdded(node: Node[K, V]): Unit = ()
+
+  private[util] def nodeWasRemoved(node: Node[K, V]): Unit = ()
+
+  // Public API
+
+  override def size(): Int =
+    contentSize
+
+  override def isEmpty(): Boolean =
+    contentSize == 0
+
+  override def get(key: Any): V = {
+    val node = findNode(key)
+    if (node eq null) {
+      null.asInstanceOf[V]
+    } else {
+      nodeWasAccessed(node)
+      node.value
+    }
   }
 
   override def containsKey(key: Any): Boolean =
-    inner.contains(Box(key.asInstanceOf[K]))
-
-  override def containsValue(value: Any): Boolean =
-    inner.valuesIterator.contains(value.asInstanceOf[V])
-
-  override def entrySet(): Set[Map.Entry[K, V]] =
-    new EntrySet
-
-  override def get(key: Any): V =
-    inner.get(Box(key.asInstanceOf[K])).getOrElse(null.asInstanceOf[V])
-
-  override def isEmpty(): Boolean =
-    inner.isEmpty
-
-  override def keySet(): Set[K] =
-    new KeySet
+    findNode(key) ne null
 
   override def put(key: K, value: V): V =
-    inner.put(Box(key), value).getOrElse(null.asInstanceOf[V])
+    put0(key, value)
+
+  override def putAll(m: Map[_ <: K, _ <: V]): Unit = {
+    m match {
+      case m: ju.HashMap[_, _] =>
+        val iter = m.nodeIterator()
+        while (iter.hasNext()) {
+          val next = iter.next()
+          put0(next.key, next.value, next.hash)
+        }
+      case _ =>
+        super.putAll(m)
+    }
+  }
 
   override def remove(key: Any): V = {
-    val boxedKey = Box(key.asInstanceOf[K])
-    inner.get(boxedKey).fold(null.asInstanceOf[V]) { value =>
-      inner -= boxedKey
-      value
+    val node = remove0(key)
+    if (node eq null) null.asInstanceOf[V]
+    else node.value
+  }
+
+  override def clear(): Unit = {
+    ju.Arrays.fill(table.asInstanceOf[Array[AnyRef]], null)
+    contentSize = 0
+  }
+
+  override def containsValue(value: Any): Boolean =
+    valueIterator().scalaOps.exists(Objects.equals(value, _))
+
+  override def keySet(): ju.Set[K] =
+    new KeySet
+
+  override def values(): ju.Collection[V] =
+    new Values
+
+  def entrySet(): ju.Set[ju.Map.Entry[K, V]] =
+    new EntrySet
+
+  override def clone(): AnyRef =
+    new HashMap[K, V](this)
+
+  // Elementary operations
+
+  @inline private def index(hash: Int): Int =
+    hash & (table.length - 1)
+
+  @inline
+  private def findNode(key: Any): Node[K, V] = {
+    val hash = computeHash(key)
+    findNode0(key, hash, index(hash))
+  }
+
+  @inline
+  private def findNodeAndIndexForRemoval(key: Any): (Node[K, V], Int) = {
+    val hash = computeHash(key)
+    val idx = index(hash)
+    val node = findNode0(key, hash, idx)
+    (node, idx)
+  }
+
+  private def findNode0(key: Any, hash: Int, idx: Int): Node[K, V] = {
+    @inline
+    @tailrec
+    def loop(node: Node[K, V]): Node[K, V] = {
+      if (node eq null) null
+      else if (hash == node.hash && Objects.equals(key, node.key)) node
+      else if (hash < node.hash) null
+      else loop(node.next)
+    }
+    loop(table(idx))
+  }
+
+  // Heavy lifting: modifications
+
+  /** Adds a key-value pair to this map
+   *
+   *  @param key the key to add
+   *  @param value the value to add
+   *  @return the old value associated with `key`, or `null` if there was none
+   */
+  @inline
+  private[this] def put0(key: K, value: V): V =
+    put0(key, value, computeHash(key))
+
+  /** Adds a key-value pair to this map
+   *
+   *  @param key the key to add
+   *  @param value the value to add
+   *  @param hash the **improved** hashcode of `key` (see computeHash)
+   *  @return the old value associated with `key`, or `null` if there was none
+   */
+  private[this] def put0(key: K, value: V, hash: Int): V = {
+    if (contentSize + 1 >= threshold)
+      growTable()
+    val idx = index(hash)
+    put0(key, value, hash, idx)
+  }
+
+  /** Adds a key-value pair to this map
+   *
+   *  @param key the key to add
+   *  @param value the value to add
+   *  @param hash the **improved** hashcode of `key` (see computeHash)
+   *  @param idx the index in the `table` corresponding to the `hash`
+   *  @return the old value associated with `key`, or `null` if there was none
+   */
+  private[this] def put0(key: K, value: V, hash: Int, idx: Int): V = {
+    // scalastyle:off return
+    val newNode = table(idx) match {
+      case null =>
+        val newNode = this.newNode(key, hash, value, null, null)
+        table(idx) = newNode
+        newNode
+      case first =>
+        var prev: Node[K, V] = null
+        var n = first
+        while ((n ne null) && n.hash <= hash) {
+          if (n.hash == hash && Objects.equals(key, n.key)) {
+            nodeWasAccessed(n)
+            val old = n.value
+            n.value = value
+            return old
+          }
+          prev = n
+          n = n.next
+        }
+        val newNode = this.newNode(key, hash, value, prev, n)
+        if (prev eq null)
+          table(idx) = newNode
+        else
+          prev.next = newNode
+        if (n ne null)
+          n.previous = newNode
+        newNode
+    }
+    contentSize += 1
+    nodeWasAdded(newNode)
+    null.asInstanceOf[V]
+    // scalastyle:on return
+  }
+
+  /** Removes a key from this map if it exists.
+   *
+   *  @param key the key to remove
+   *  @return the node that contained `key` if it was present, otherwise null
+   */
+  private def remove0(key: Any): Node[K, V] = {
+    val (node, idx) = findNodeAndIndexForRemoval(key)
+    if (node ne null)
+      remove0(node, idx)
+    node
+  }
+
+  private[util] final def removeNode(node: Node[K, V]): Unit =
+    remove0(node, index(node.hash))
+
+  private def remove0(node: Node[K, V], idx: Int): Unit = {
+    val previous = node.previous
+    val next = node.next
+    if (previous eq null)
+      table(idx) = next
+    else
+      previous.next = next
+    if (next ne null)
+      next.previous = previous
+    contentSize -= 1
+    nodeWasRemoved(node)
+  }
+
+  /** Grow the size of the table (always times 2). */
+  private[this] def growTable(): Unit = {
+    val oldTable = table
+    val oldlen = oldTable.length
+    val newlen = oldlen * 2
+    val newTable = new Array[Node[K, V]](newlen)
+    table = newTable
+    threshold = newThreshold(newlen)
+
+    /* Split the nodes of each bucket from the old table into the "low" and
+     * "high" indices of the new table. Since the new table contains exactly
+     * twice as many buckets as the old table, every index `i` from the old
+     * table is split into indices `i` and `oldlen + i` in the new table.
+     */
+    var i = 0
+    while (i < oldlen) {
+      var lastLow: Node[K, V] = null
+      var lastHigh: Node[K, V] = null
+      var node = oldTable(i)
+      while (node ne null) {
+        if ((node.hash & oldlen) == 0) {
+          // go to low
+          node.previous = lastLow
+          if (lastLow eq null)
+            newTable(i) = node
+          else
+            lastLow.next = node
+          lastLow = node
+        } else {
+          // go to high
+          node.previous = lastHigh
+          if (lastHigh eq null)
+            newTable(oldlen + i) = node
+          else
+            lastHigh.next = node
+          lastHigh = node
+        }
+        node = node.next
+      }
+      if (lastLow ne null)
+        lastLow.next = null
+      if (lastHigh ne null)
+        lastHigh.next = null
+      i += 1
     }
   }
 
-  override def size(): Int =
-    inner.size
+  /** Rounds up `capacity` to a power of 2, with a maximum of 2^30. */
+  @inline private[this] def tableSizeFor(capacity: Int): Int =
+    Math.min(Integer.highestOneBit(Math.max(capacity - 1, 4)) * 2, 1 << 30)
 
-  override def values(): Collection[V] =
-    new ValuesView
+  @inline private[this] def newThreshold(size: Int): Int =
+    (size.toDouble * loadFactor).toInt
 
-  private class EntrySet extends AbstractSet[Map.Entry[K, V]]
-                            with AbstractMapView[Map.Entry[K, V]] {
-    override def iterator(): Iterator[Map.Entry[K, V]] = {
-      new AbstractMapViewIterator[Map.Entry[K, V]] {
-        override protected def getNextForm(key: Box[K]): Map.Entry[K, V] = {
-          new AbstractMap.SimpleEntry(key.inner, inner(key)) {
-            override def setValue(value: V): V = {
-              inner.update(key, value)
-              super.setValue(value)
-            }
+  // Iterators
+
+  private[util] def nodeIterator(): ju.Iterator[Node[K, V]] =
+    new NodeIterator
+
+  private[util] def keyIterator(): ju.Iterator[K] =
+    new KeyIterator
+
+  private[util] def valueIterator(): ju.Iterator[V] =
+    new ValueIterator
+
+  // The cast works around the lack of definition-site variance
+  private[util] final def entrySetIterator(): ju.Iterator[Map.Entry[K, V]] =
+    nodeIterator().asInstanceOf[ju.Iterator[Map.Entry[K, V]]]
+
+  private final class NodeIterator extends AbstractHashMapIterator[Node[K, V]] {
+    protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+  }
+
+  private final class KeyIterator extends AbstractHashMapIterator[K] {
+    protected[this] def extract(node: Node[K, V]): K = node.key
+  }
+
+  private final class ValueIterator extends AbstractHashMapIterator[V] {
+    protected[this] def extract(node: Node[K, V]): V = node.value
+  }
+
+  private abstract class AbstractHashMapIterator[A] extends ju.Iterator[A] {
+    private[this] val len = table.length
+    private[this] var nextIdx: Int = _ // 0
+    private[this] var nextNode: Node[K, V] = _ // null
+    private[this] var lastNode: Node[K, V] = _ // null
+
+    protected[this] def extract(node: Node[K, V]): A
+
+    /* Movements of `nextNode` and `nextIdx` are spread over `hasNext()` to
+     * simplify initial conditions, and preserving as much performance as
+     * possible while guaranteeing that constructing the iterator remains O(1)
+     * (the first linear behavior can happen when calling `hasNext()`, not
+     * before).
+     */
+
+    def hasNext(): Boolean = {
+      // scalastyle:off return
+      if (nextNode ne null) {
+        true
+      } else {
+        while (nextIdx < len) {
+          val node = table(nextIdx)
+          nextIdx += 1
+          if (node ne null) {
+            nextNode = node
+            return true
           }
         }
+        false
       }
+      // scalastyle:on return
+    }
+
+    def next(): A = {
+      if (!hasNext())
+        throw new NoSuchElementException("next on empty iterator")
+      val node = nextNode
+      lastNode = node
+      nextNode = node.next
+      extract(node)
+    }
+
+    def remove(): Unit = {
+      val last = lastNode
+      if (last eq null)
+        throw new IllegalStateException("next must be called at least once before remove")
+      removeNode(last)
+      lastNode = null
     }
   }
 
-  private class KeySet extends AbstractSet[K] with AbstractMapView[K] {
-    override def remove(o: Any): Boolean = {
-      val boxedKey = Box(o.asInstanceOf[K])
-      val contains = inner.contains(boxedKey)
-      if (contains)
-        inner -= boxedKey
-      contains
-    }
+  // Views
 
-    override def iterator(): Iterator[K] = {
-      new AbstractMapViewIterator[K] {
-        protected def getNextForm(key: Box[K]): K =
-          key.inner
-      }
-    }
-  }
+  private final class KeySet extends AbstractSet[K] {
+    def iterator(): Iterator[K] =
+      keyIterator()
 
-  private class ValuesView extends AbstractMapView[V] {
-    override def size(): Int =
-      inner.size
+    def size(): Int =
+      self.size()
 
-    override def iterator(): Iterator[V] = {
-      new AbstractMapViewIterator[V] {
-        protected def getNextForm(key: Box[K]): V = inner(key)
-      }
-    }
-  }
+    override def contains(o: Any): Boolean =
+      containsKey(o)
 
-  private trait AbstractMapView[E] extends AbstractCollection[E] {
-    override def size(): Int =
-      inner.size
+    override def remove(o: Any): Boolean =
+      self.remove0(o) ne null
 
     override def clear(): Unit =
-      inner.clear()
+      self.clear()
   }
 
-  private abstract class AbstractMapViewIterator[E] extends Iterator[E] {
-    protected val innerIterator = inner.keySet.iterator
+  private final class Values extends AbstractCollection[V] {
+    def iterator(): ju.Iterator[V] =
+      valueIterator()
 
-    protected var lastKey: Option[Box[K]] = None
+    def size(): Int =
+      self.size()
 
-    protected def getNextForm(key: Box[K]): E
+    override def clear(): Unit =
+      self.clear()
+  }
 
-    final override def next: E = {
-      lastKey = Some(innerIterator.next())
-      getNextForm(lastKey.get)
+  private final class EntrySet extends AbstractSet[Map.Entry[K, V]] {
+    def iterator(): Iterator[Map.Entry[K, V]] =
+      entrySetIterator()
+
+    def size(): Int =
+      self.size()
+
+    override def contains(o: Any): Boolean = o match {
+      case o: Map.Entry[_, _] =>
+        val node = findNode(o.getKey())
+        (node ne null) && Objects.equals(node.getValue(), o.getValue())
+      case _ =>
+        false
     }
 
-    final override def hasNext: Boolean =
-      innerIterator.hasNext
-
-    final override def remove(): Unit = {
-      lastKey match {
-        case Some(key) =>
-          inner.remove(key)
-          lastKey = None
-        case None =>
-          throw new IllegalStateException
-      }
+    override def remove(o: Any): Boolean = o match {
+      case o: Map.Entry[_, _] =>
+        val key = o.getKey()
+        val (node, idx) = findNodeAndIndexForRemoval(key)
+        if ((node ne null) && Objects.equals(node.getValue(), o.getValue())) {
+          remove0(node, idx)
+          true
+        } else {
+          false
+        }
+      case _ =>
+        false
     }
+
+    override def clear(): Unit =
+      self.clear()
   }
 }
 
 object HashMap {
-  private[HashMap] final val DEFAULT_INITIAL_CAPACITY = 16
-  private[HashMap] final val DEFAULT_LOAD_FACTOR = 0.75f
+  private[util] final val DEFAULT_INITIAL_CAPACITY = 16
+  private[util] final val DEFAULT_LOAD_FACTOR = 0.75f
+
+  /** Computes the improved hash of an original (`any.hashCode()`) hash. */
+  @inline private def improveHash(originalHash: Int): Int = {
+    /* Improve the hash by xoring the high 16 bits into the low 16 bits just in
+     * case entropy is skewed towards the high-value bits. We only use the
+     * lowest bits to determine the hash bucket.
+     *
+     * This function is also its own inverse. That is, for all ints i,
+     * improveHash(improveHash(i)) = i
+     * this allows us to retrieve the original hash when we need it, and that
+     * is why unimproveHash simply forwards to this method.
+     */
+    originalHash ^ (originalHash >>> 16)
+  }
+
+  /** Performs the inverse operation of improveHash.
+   *
+   *  In this case, it happens to be identical to improveHash.
+   */
+  @inline private def unimproveHash(improvedHash: Int): Int =
+    improveHash(improvedHash)
+
+  /** Computes the improved hash of this key */
+  @inline private def computeHash(k: Any): Int =
+    if (k == null) 0
+    else improveHash(k.hashCode())
+
+  private[util] class Node[K, V](val key: K, val hash: Int, var value: V,
+      var previous: Node[K, V], var next: Node[K, V])
+      extends Map.Entry[K, V] {
+
+    def getKey(): K = key
+
+    def getValue(): V = value
+
+    def setValue(v: V): V = {
+      val oldValue = value
+      value = v
+      oldValue
+    }
+
+    override def equals(that: Any): Boolean = that match {
+      case that: Map.Entry[_, _] =>
+        Objects.equals(getKey(), that.getKey()) &&
+        Objects.equals(getValue(), that.getValue())
+      case _ =>
+        false
+    }
+
+    override def hashCode(): Int =
+      unimproveHash(hash) ^ Objects.hashCode(value)
+
+    override def toString(): String =
+      "" + getKey + "=" + getValue
+  }
 }

--- a/javalib/src/main/scala/java/util/LinkedHashSet.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashSet.scala
@@ -12,23 +12,21 @@
 
 package java.util
 
-import scala.collection.mutable
+class LinkedHashSet[E] private[util] (inner: LinkedHashMap[E, Any])
+    extends HashSet[E](inner) with Set[E] with Cloneable with Serializable {
 
-class LinkedHashSet[E] extends HashSet[E] with Set[E]
-                                          with Cloneable
-                                          with Serializable {
   def this(initialCapacity: Int, loadFactor: Float) =
-    this()
+    this(new LinkedHashMap[E, Any](initialCapacity, loadFactor))
 
   def this(initialCapacity: Int) =
-    this()
+    this(new LinkedHashMap[E, Any](initialCapacity))
+
+  def this() =
+    this(new LinkedHashMap[E, Any]())
 
   def this(c: java.util.Collection[_ <: E]) = {
-    this()
+    this(c.size())
     addAll(c)
   }
-
-  override protected val inner: mutable.Set[Box[E]] =
-    new mutable.LinkedHashSet[Box[E]]()
 
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
@@ -47,11 +47,11 @@ abstract class LinkedHashMapTest extends HashMapTest {
   val withSizeLimit = factory.withSizeLimit
 
   @Test def should_iterate_in_insertion_order_after_building(): Unit = {
-    val lhm = factory.empty[jl.Integer, String]
-    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+    val lhm = factory.empty[String, String]
+    (0 until 100).foreach(key => lhm.put(key.toString(), s"elem $key"))
 
-    def expectedKey(index: Int): Int =
-      withSizeLimit.getOrElse(0) + index
+    def expectedKey(index: Int): String =
+      (withSizeLimit.getOrElse(0) + index).toString()
 
     def expectedValue(index: Int): String =
       s"elem ${expectedKey(index)}"
@@ -74,13 +74,13 @@ abstract class LinkedHashMapTest extends HashMapTest {
   }
 
   @Test def should_iterate_in_the_same_order_after_removal_of_elements(): Unit = {
-    val lhm = factory.empty[jl.Integer, String]
-    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+    val lhm = factory.empty[String, String]
+    (0 until 100).foreach(key => lhm.put(key.toString(), s"elem $key"))
 
-    (0 until 100 by 3).foreach(key => lhm.remove(key))
+    (0 until 100 by 3).foreach(key => lhm.remove(key.toString()))
 
     val expectedKey =
-      ((100 - withSizeLimit.getOrElse(100)) to 100).filter(_ % 3 != 0).toArray
+      ((100 - withSizeLimit.getOrElse(100)) to 100).filter(_ % 3 != 0).map(_.toString()).toArray
 
     def expectedValue(index: Int): String =
       s"elem ${expectedKey(index)}"
@@ -103,15 +103,15 @@ abstract class LinkedHashMapTest extends HashMapTest {
   }
 
   @Test def should_iterate_in_order_after_adding_elements(): Unit = {
-    val lhm = factory.empty[jl.Integer, String]
-    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+    val lhm = factory.empty[String, String]
+    (0 until 100).foreach(key => lhm.put(key.toString(), s"elem $key"))
 
-    lhm.put(0, "new 0")
-    lhm.put(100, "elem 100")
-    lhm.put(42, "new 42")
-    lhm.put(52, "new 52")
-    lhm.put(1, "new 1")
-    lhm.put(98, "new 98")
+    lhm.put("0", "new 0")
+    lhm.put("100", "elem 100")
+    lhm.put("42", "new 42")
+    lhm.put("52", "new 52")
+    lhm.put("1", "new 1")
+    lhm.put("98", "new 98")
 
     val expectedKey = {
       if (factory.accessOrder) {
@@ -122,11 +122,11 @@ abstract class LinkedHashMapTest extends HashMapTest {
         if (withSizeLimit.isDefined) (55 until 100) ++ List(0, 100, 42, 52, 1)
         else 0 to 100
       }
-    }.toArray
+    }.map(_.toString()).toArray
 
     def expectedElem(index: Int): String = {
       val key = expectedKey(index)
-      if (key == 0 || key == 1 || key == 42 || key == 52 || key == 98)
+      if (key == "0" || key == "1" || key == "42" || key == "52" || key == "98")
         s"new $key"
       else
         s"elem $key"
@@ -151,15 +151,15 @@ abstract class LinkedHashMapTest extends HashMapTest {
   }
 
   @Test def should_iterate_in__after_accessing_elements(): Unit = {
-    val lhm = factory.empty[jl.Integer, String]
-    (0 until 100).foreach(key => lhm.put(key, s"elem $key"))
+    val lhm = factory.empty[String, String]
+    (0 until 100).foreach(key => lhm.put(key.toString(), s"elem $key"))
 
-    lhm.get(42)
-    lhm.get(52)
-    lhm.get(5)
+    lhm.get("42")
+    lhm.get("52")
+    lhm.get("5")
 
-    def expectedKey(index: Int): Int = {
-      if (accessOrder) {
+    def expectedKey(index: Int): String = {
+      val intKey = if (accessOrder) {
         // elements ordered by insertion order except for those accessed
         if (withSizeLimit.isEmpty) {
           if (index < 5) index // no elements removed in this range
@@ -182,6 +182,7 @@ abstract class LinkedHashMapTest extends HashMapTest {
         // accesses shouldn't modify the order
         withSizeLimit.getOrElse(0) + index
       }
+      intKey.toString()
     }
 
     def expectedValue(index: Int): String =
@@ -213,7 +214,8 @@ object LinkedHashMapFactory {
   }
 }
 
-class LinkedHashMapFactory(val accessOrder: Boolean, val withSizeLimit: Option[Int])
+class LinkedHashMapFactory(val accessOrder: Boolean,
+    override val withSizeLimit: Option[Int])
     extends HashMapFactory {
   def orderName: String =
     if (accessOrder) "access-order"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -63,6 +63,17 @@ trait MapTest {
     assertEquals("two", mp.get("TWO"))
   }
 
+  @Test def should_store_strings_large_map(): Unit = {
+    val largeMap = factory.empty[String, Int]
+    for (i <- 0 until 1000)
+      largeMap.put(i.toString(), i)
+    val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+    assertEquals(expectedSize, largeMap.size())
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i, largeMap.get(i.toString()))
+    assertNull(largeMap.get("1000"))
+  }
+
   @Test def should_store_integers(): Unit = {
     val mp = factory.empty[Int, Int]
 
@@ -70,6 +81,17 @@ trait MapTest {
     assertEquals(1, mp.size())
     val one = mp.get(100)
     assertEquals(12345, one)
+  }
+
+  @Test def should_store_integers_large_map(): Unit = {
+    val largeMap = factory.empty[Int, Int]
+    for (i <- 0 until 1000)
+      largeMap.put(i, i * 2)
+    val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+    assertEquals(expectedSize, largeMap.size())
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i * 2, largeMap.get(i))
+    assertNull(largeMap.get(1000))
   }
 
   @Test def should_store_doubles_also_in_corner_cases(): Unit = {
@@ -624,4 +646,6 @@ trait MapFactory {
   def allowsNullKeysQueries: Boolean = true
 
   def allowsNullValuesQueries: Boolean = true
+
+  def withSizeLimit: Option[Int] = None
 }


### PR DESCRIPTION
And then `Hashtable`, `HashSet` and `LinkedHashSet` on top of them.

Previously, they were implemented on top of `s.c.m.HashMap` and `s.c.m.LinkedHashMap`, with various hacks to implement Java features and behaviors:

* Non-cooperative equality
* `Iterator.remove()`
* Access-order for `LinkedHashMap`
* `removeEldestEntry()` for `LinkedHashMap`.
* Mutable `Map.Entry`

All those hacks resulted in significantly more memory allocation (at least two objects for each `get`, and one `Map.Entry` for each element during iterations).

The new implementation, done from scratch, has direct internal support for all these operations:

* It never allocates during lookup and removal
* Iteration never allocates besides the instance of `Iterator`
* It allocates at most one object during `put`
* It guarantees strict O(1) `Iterator.remove()`
* It directly calls `Object.equals()` rather than using `==`

The implementation was initially inspired by the implementation of `s.c.m.HashMap` in Scala 2.13.0 (in particular the core data structure and algorithms), but was heavily changed to accommodate the requirements of the Java API.

The test suite is slightly enhanced with whitebox tests that exercise the new algorithms, in particular table growth.