### PR TITLE
Optimize calls to `Array.apply()` overloads with literal varargs.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -54,7 +54,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
   import jsInterop.{jsNameOf, compat068FullJSNameOf, jsNativeLoadSpecOf, JSName}
   import JSTreeExtractors._
 
-  import treeInfo.hasSynthCaseSymbol
+  import treeInfo.{hasSynthCaseSymbol, StripCast}
 
   import platform.isMaybeBoxed
 
@@ -1904,6 +1904,23 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
               ex
             }
           }
+
+        /* !!! Copy-pasted from `CleanUp.scala` upstream and simplified with
+         * our `WrapArray` extractor.
+         *
+         * Replaces `Array(Predef.wrapArray(ArrayValue(...).$asInstanceOf[...]), <tag>)`
+         * with just `ArrayValue(...).$asInstanceOf[...]`
+         *
+         * See scala/bug#6611; we must *only* do this for literal vararg arrays.
+         *
+         * This is normally done by `cleanup` but it comes later than this phase.
+         */
+        case Apply(appMeth, Apply(wrapRefArrayMeth, (arg @ StripCast(ArrayValue(_, _))) :: Nil) :: _ :: Nil)
+            if wrapRefArrayMeth.symbol == WrapArray.wrapRefArrayMethod && appMeth.symbol == ArrayModule_genericApply =>
+          genStatOrExpr(arg, isStat)
+        case Apply(appMeth, elem0 :: WrapArray(rest @ ArrayValue(elemtpt, _)) :: Nil)
+            if appMeth.symbol == ArrayModule_apply(elemtpt.tpe) =>
+          genStatOrExpr(treeCopy.ArrayValue(rest, rest.elemtpt, elem0 :: rest.elems), isStat)
 
         case app: Apply =>
           genApply(app, isStat)
@@ -4983,11 +5000,14 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
     }
 
     object WrapArray {
-      private val isWrapArray: Set[Symbol] = {
-        val wrapArrayModule =
-          if (hasNewCollections) ScalaRunTimeModule
-          else PredefModule
+      private val wrapArrayModule =
+        if (hasNewCollections) ScalaRunTimeModule
+        else PredefModule
 
+      val wrapRefArrayMethod: Symbol =
+        getMemberMethod(wrapArrayModule, nme.wrapRefArray)
+
+      private val isWrapArray: Set[Symbol] = {
         Seq(
             nme.wrapRefArray,
             nme.wrapByteArray,

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/OptimizationTest.scala
@@ -50,6 +50,45 @@ class OptimizationTest extends JSASTTest {
   }
 
   @Test
+  def testArrayApplyOptimization: Unit = {
+    /* Make sure Array(...) is optimized away completely for several kinds
+     * of data types, with both the generic overload and the ones specialized
+     * for primitives.
+     */
+    """
+    class A {
+      val a = Array(5, 7, 9, -3)
+      val b = Array("hello", "world")
+      val c = Array('a', 'b')
+      val d = Array(Nil)
+      val e = Array(5.toByte, 7.toByte, 9.toByte, -3.toByte)
+    }
+    """.
+    hasNot("any LoadModule of the scala.Array companion") {
+      case js.LoadModule(jstpe.ClassType("s_Array$")) =>
+    }
+
+    /* Using [] with primitives produces suboptimal trees, which cannot be
+     * optimized. We should improve this in the future, if possible. This is
+     * particularly annoying for Byte and Short, as it means that we need to
+     * write `.toByte` for every single element if we want the optimization to
+     * kick in.
+     *
+     * Scala/JVM has the same limitation.
+     */
+    """
+    class A {
+      val a = Array[Int](5, 7, 9, -3)
+      val b = Array[Byte](5, 7, 9, -3)
+    }
+    """.
+    hasExactly(2, "calls to Array.apply methods") {
+      case js.Apply(js.LoadModule(jstpe.ClassType("s_Array$")), js.Ident(methodName, _), _)
+          if methodName.startsWith("apply__") =>
+    }
+  }
+
+  @Test
   def testJSArrayApplyOptimization: Unit = {
     /* Make sure js.Array(...) is optimized away completely for several kinds
      * of data types.

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -237,10 +237,10 @@ object Character {
   }
 
   @inline
-  private[this] def getTypeLT256(codePoint: Int): scala.Byte =
+  private[this] def getTypeLT256(codePoint: Int): Int =
     charTypesFirst256(codePoint)
 
-  private[this] def getTypeGE256(codePoint: Int): scala.Byte = {
+  private[this] def getTypeGE256(codePoint: Int): Int = {
     // the idx is increased by 1 due to the differences in indexing
     // between charTypeIndices and charType
     val idx = Arrays.binarySearch(charTypeIndices, codePoint) + 1
@@ -628,7 +628,7 @@ object Character {
   // Based on Unicode 7.0.0
 
   // Types of characters from 0 to 255
-  private[this] lazy val charTypesFirst256 = Array[scala.Byte](15, 15, 15, 15,
+  private[this] lazy val charTypesFirst256: Array[Int] = Array(15, 15, 15, 15,
     15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
     15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 12, 24, 24, 24, 26, 24, 24, 24,
     21, 22, 24, 25, 24, 20, 24, 24, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 24, 24, 25,
@@ -661,11 +661,11 @@ object Character {
   //    .map(tup => tup._1 - tup._2)
   //  val charTypes = indicesAndTypes.map(_._2)
   //  println(charTypeIndicesDeltas.mkString(
-  //    "charTypeIndices: val deltas = Array[Int](", ", ", ")"))
-  //  println(charTypes.mkString("val charTypes = Array[scala.Byte](", ", ", ")"))
+  //    "charTypeIndices: val deltas = Array(", ", ", ")"))
+  //  println(charTypes.mkString("val charTypes = Array(", ", ", ")"))
   //
-  private[this] lazy val charTypeIndices = {
-    val deltas = Array[Int](257, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  private[this] lazy val charTypeIndices: Array[Int] = {
+    val deltas = Array(257, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -815,7 +815,7 @@ object Character {
     uncompressDeltas(deltas)
   }
 
-  private[this] lazy val charTypes = Array[scala.Byte](1, 2, 1, 2, 1, 2,
+  private[this] lazy val charTypes: Array[Int] = Array(1, 2, 1, 2, 1, 2,
     1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1,
     2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
     1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1,
@@ -979,8 +979,8 @@ object Character {
   //       0 :: isMirroredIndices.init).map(tup => tup._1 - tup._2)
   //  println(isMirroredIndicesDeltas.mkString(
   //     "isMirroredIndices: val deltas = Array[Int](", ", ", ")"))
-  private[this] lazy val isMirroredIndices = {
-    val deltas = Array[Int](40, 2, 18, 1, 1, 1, 28, 1, 1, 1, 29, 1, 1, 1,
+  private[this] lazy val isMirroredIndices: Array[Int] = {
+    val deltas = Array(40, 2, 18, 1, 1, 1, 28, 1, 1, 1, 29, 1, 1, 1,
       45, 1, 15, 1, 3710, 4, 1885, 2, 2460, 2, 10, 2, 54, 2, 14, 2, 177, 1,
       192, 4, 3, 6, 3, 1, 3, 2, 3, 4, 1, 4, 1, 1, 1, 1, 4, 9, 5, 1, 1, 18,
       5, 4, 9, 2, 1, 1, 1, 8, 2, 31, 2, 4, 5, 1, 9, 2, 2, 19, 5, 2, 9, 5, 2,
@@ -1013,7 +1013,7 @@ object Character {
    *  point mapping to digits from 0 to 9.
    */
   private[this] lazy val nonASCIIZeroDigitCodePoints: Array[Int] = {
-    Array[Int](0x660, 0x6f0, 0x7c0, 0x966, 0x9e6, 0xa66, 0xae6, 0xb66, 0xbe6,
+    Array(0x660, 0x6f0, 0x7c0, 0x966, 0x9e6, 0xa66, 0xae6, 0xb66, 0xbe6,
         0xc66, 0xce6, 0xd66, 0xe50, 0xed0, 0xf20, 0x1040, 0x1090, 0x17e0,
         0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0, 0x1c40, 0x1c50,
         0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xaa50, 0xabf0, 0xff10, 0x104a0,


### PR DESCRIPTION
In Scala/JVM, this optimization is performed by the `cleanup` phase, but it comes after our back-end, so we have to reimplement it ourselves.

We then also change some uses of `Array.apply` in `Character.scala` so that the new optimization can kick in.