### PR TITLE
Compile the javalanglib with -Yno-predef.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Boolean.scala
+++ b/javalanglib/src/main/scala/java/lang/Boolean.scala
@@ -41,7 +41,7 @@ final class Boolean private ()
 }
 
 object Boolean {
-  final val TYPE = classOf[scala.Boolean]
+  final val TYPE = scala.Predef.classOf[scala.Boolean]
 
   /* TRUE and FALSE are supposed to be vals. However, they are better
    * optimized as defs, because they end up being just the constant true and

--- a/javalanglib/src/main/scala/java/lang/Byte.scala
+++ b/javalanglib/src/main/scala/java/lang/Byte.scala
@@ -45,7 +45,7 @@ final class Byte private () extends Number with Comparable[Byte] {
 }
 
 object Byte {
-  final val TYPE = classOf[scala.Byte]
+  final val TYPE = scala.Predef.classOf[scala.Byte]
   final val SIZE = 8
   final val BYTES = 1
 

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -172,7 +172,7 @@ class Character(private val value: scala.Char)
 }
 
 object Character {
-  final val TYPE = classOf[scala.Char]
+  final val TYPE = scala.Predef.classOf[scala.Char]
   final val MIN_VALUE = '\u0000'
   final val MAX_VALUE = '\uffff'
   final val SIZE = 16
@@ -571,8 +571,8 @@ object Character {
   //def getDirectionality(c: scala.Char): scala.Byte
 
   /* Conversions */
-  def toUpperCase(c: scala.Char): scala.Char = c.toString.toUpperCase()(0)
-  def toLowerCase(c: scala.Char): scala.Char = c.toString.toLowerCase()(0)
+  def toUpperCase(c: scala.Char): scala.Char = c.toString.toUpperCase().charAt(0)
+  def toLowerCase(c: scala.Char): scala.Char = c.toString.toLowerCase().charAt(0)
   //def toTitleCase(c: scala.Char): scala.Char
   //def getNumericValue(c: scala.Char): Int
 
@@ -995,8 +995,14 @@ object Character {
   }
 
   private[this] def uncompressDeltas(deltas: Array[Int]): Array[Int] = {
-    for (i <- 1 until deltas.length)
-      deltas(i) += deltas(i - 1)
+    var acc = deltas(0)
+    var i = 1
+    val len = deltas.length
+    while (i != len) {
+      acc += deltas(i)
+      deltas(i) = acc
+      i += 1
+    }
     deltas
   }
 

--- a/javalanglib/src/main/scala/java/lang/Class.scala
+++ b/javalanglib/src/main/scala/java/lang/Class.scala
@@ -41,7 +41,9 @@ final class Class[A] private (data: ScalaJSClassData[A]) extends Object {
   def isInstance(obj: Object): scala.Boolean =
     data.isInstance(obj)
 
-  def isAssignableFrom(that: Class[_]): scala.Boolean =
+  def isAssignableFrom(that: Class[_]): scala.Boolean = {
+    import scala.Predef.classOf
+
     if (this.isPrimitive || that.isPrimitive) {
       /* This differs from the JVM specification to mimic the behavior of
        * runtime type tests of primitive numeric types.
@@ -63,6 +65,7 @@ final class Class[A] private (data: ScalaJSClassData[A]) extends Object {
     } else {
       this.isInstance(that.getFakeInstance())
     }
+  }
 
   private def getFakeInstance(): Object =
     data.getFakeInstance()
@@ -106,7 +109,7 @@ final class Class[A] private (data: ScalaJSClassData[A]) extends Object {
   @inline // optimize for the Unchecked case, where this becomes identity()
   def cast(obj: Object): A = {
     scala.scalajs.runtime.SemanticsUtils.asInstanceOfCheck(
-        (this eq classOf[Nothing]) ||
+        (this eq scala.Predef.classOf[Nothing]) ||
         (obj != null && !isRawJSType && !isInstance(obj)),
         new ClassCastException("" + obj + " is not an instance of " + getName))
     obj.asInstanceOf[A]

--- a/javalanglib/src/main/scala/java/lang/Double.scala
+++ b/javalanglib/src/main/scala/java/lang/Double.scala
@@ -58,7 +58,7 @@ final class Double private () extends Number with Comparable[Double] {
 }
 
 object Double {
-  final val TYPE = classOf[scala.Double]
+  final val TYPE = scala.Predef.classOf[scala.Double]
   final val POSITIVE_INFINITY = 1.0 / 0.0
   final val NEGATIVE_INFINITY = 1.0 / -0.0
   final val NaN = 0.0 / 0.0
@@ -175,7 +175,7 @@ object Double {
 
       val mantissa =
         js.Dynamic.global.parseInt(truncatedMantissaStr, 16).asInstanceOf[scala.Double]
-      assert(mantissa != 0.0 && mantissa != scala.Double.PositiveInfinity)
+      // Assert: mantissa != 0.0 && mantissa != scala.Double.PositiveInfinity
 
       val binaryExpDouble =
         js.Dynamic.global.parseInt(binaryExpStr, 10).asInstanceOf[scala.Double]

--- a/javalanglib/src/main/scala/java/lang/Enum.scala
+++ b/javalanglib/src/main/scala/java/lang/Enum.scala
@@ -30,7 +30,7 @@ abstract class Enum[E <: Enum[E]] protected (_name: String, _ordinal: Int)
   override protected final def clone(): AnyRef =
     throw new CloneNotSupportedException("Enums are not cloneable")
 
-  final def compareTo(o: E): Int = _ordinal.compareTo(o.ordinal)
+  final def compareTo(o: E): Int = Integer.compare(_ordinal, o.ordinal)
 
   // Not implemented:
   // final def getDeclaringClass(): Class[E]

--- a/javalanglib/src/main/scala/java/lang/Float.scala
+++ b/javalanglib/src/main/scala/java/lang/Float.scala
@@ -56,7 +56,7 @@ final class Float private () extends Number with Comparable[Float] {
 }
 
 object Float {
-  final val TYPE = classOf[scala.Float]
+  final val TYPE = scala.Predef.classOf[scala.Float]
   final val POSITIVE_INFINITY = 1.0f / 0.0f
   final val NEGATIVE_INFINITY = 1.0f / -0.0f
   final val NaN = 0.0f / 0.0f

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -61,7 +61,7 @@ final class Integer private () extends Number with Comparable[Integer] {
 }
 
 object Integer {
-  final val TYPE = classOf[scala.Int]
+  final val TYPE = scala.Predef.classOf[scala.Int]
   final val MIN_VALUE = -2147483648
   final val MAX_VALUE = 2147483647
   final val SIZE = 32

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -51,7 +51,7 @@ final class Long private () extends Number with Comparable[Long] {
 object Long {
   import scala.scalajs.runtime.RuntimeLong
 
-  final val TYPE = classOf[scala.Long]
+  final val TYPE = scala.Predef.classOf[scala.Long]
   final val MIN_VALUE = -9223372036854775808L
   final val MAX_VALUE = 9223372036854775807L
   final val SIZE = 64
@@ -68,11 +68,14 @@ object Long {
    */
   private lazy val StringRadixInfos: js.Array[StringRadixInfo] = {
     val r = new js.Array[StringRadixInfo]()
+    var radix = 0
 
-    for (_ <- 0 until Character.MIN_RADIX)
+    while (radix < Character.MIN_RADIX) {
       r += null
+      radix += 1
+    }
 
-    for (radix <- Character.MIN_RADIX to Character.MAX_RADIX) {
+    while (radix <= Character.MAX_RADIX) {
       /* Find the biggest chunk size we can use.
        *
        * - radixPowLength should be the biggest signed int32 value that is an
@@ -95,6 +98,7 @@ object Long {
       val overflowBarrier = Long.divideUnsigned(-1L, radixPowLengthLong)
       r += new StringRadixInfo(chunkLength, radixPowLengthLong,
           paddingZeros, overflowBarrier)
+      radix += 1
     }
 
     r
@@ -291,7 +295,7 @@ object Long {
           secondResult
         } else {
           // Third and final chunk. This one can overflow
-          assert(secondChunkEnd + chunkLen == length)
+          // Assert: secondChunkEnd + chunkLen == length
 
           val overflowBarrier = radixInfo.overflowBarrier
           val thirdChunk = parseChunk(secondChunkEnd, length)

--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -105,7 +105,7 @@ object Math {
     if (assumingES6 || !js.isUndefined(g.Math.cbrt)) {
       js.Math.cbrt(a)
     } else {
-      if (a == 0 || a.isNaN || a.isPosInfinity || a.isNegInfinity) {
+      if (a == 0 || Double.isNaN(a) || Double.isInfinite(a)) {
         a
       } else {
         val sign = if (a < 0.0) -1.0 else 1.0
@@ -213,7 +213,7 @@ object Math {
       // http://en.wikipedia.org/wiki/Hypot#Implementation
       if (abs(a) == scala.Double.PositiveInfinity || abs(b) == scala.Double.PositiveInfinity)
         scala.Double.PositiveInfinity
-      else if (a.isNaN || b.isNaN)
+      else if (Double.isNaN(a) || Double.isNaN(b))
         scala.Double.NaN
       else if (a == 0 && b == 0)
         0.0
@@ -234,7 +234,7 @@ object Math {
       js.Math.expm1(a)
     } else {
       // https://github.com/ghewgill/picomath/blob/master/javascript/expm1.js
-      if (a == 0 || a.isNaN)
+      if (a == 0 || Double.isNaN(a))
         a
       // Power Series http://en.wikipedia.org/wiki/Power_series
       // for small values of a, exp(a) = 1 + a + (a*a)/2
@@ -249,7 +249,7 @@ object Math {
     if (assumingES6 || !js.isUndefined(g.Math.sinh)) {
       js.Math.sinh(a)
     } else {
-      if (a.isNaN || a == 0.0 || abs(a) == scala.Double.PositiveInfinity) a
+      if (Double.isNaN(a) || a == 0.0 || abs(a) == scala.Double.PositiveInfinity) a
       else (exp(a) - exp(-a)) / 2.0
     }
   }
@@ -258,7 +258,7 @@ object Math {
     if (assumingES6 || !js.isUndefined(g.Math.cosh)) {
       js.Math.cosh(a)
     } else {
-      if (a.isNaN)
+      if (Double.isNaN(a))
         a
       else if (a == 0.0)
         1.0
@@ -273,7 +273,7 @@ object Math {
     if (assumingES6 || !js.isUndefined(g.Math.tanh)) {
       js.Math.tanh(a)
     } else {
-      if (a.isNaN || a == 0.0)
+      if (Double.isNaN(a) || a == 0.0)
         a
       else if (abs(a) == scala.Double.PositiveInfinity)
         signum(a)

--- a/javalanglib/src/main/scala/java/lang/Short.scala
+++ b/javalanglib/src/main/scala/java/lang/Short.scala
@@ -44,7 +44,7 @@ final class Short private () extends Number with Comparable[Short] {
 }
 
 object Short {
-  final val TYPE = classOf[scala.Short]
+  final val TYPE = scala.Predef.classOf[scala.Short]
   final val SIZE = 16
   final val BYTES = 2
 

--- a/javalanglib/src/main/scala/java/lang/System.scala
+++ b/javalanglib/src/main/scala/java/lang/System.scala
@@ -291,7 +291,7 @@ object System {
   def gc(): Unit = Runtime.getRuntime().gc()
 }
 
-private[lang] final class JSConsoleBasedPrintStream(isErr: Boolean)
+private[lang] final class JSConsoleBasedPrintStream(isErr: scala.Boolean)
     extends PrintStream(new JSConsoleBasedPrintStream.DummyOutputStream) {
 
   import JSConsoleBasedPrintStream._

--- a/javalanglib/src/main/scala/java/lang/ThreadLocal.scala
+++ b/javalanglib/src/main/scala/java/lang/ThreadLocal.scala
@@ -13,7 +13,7 @@
 package java.lang
 
 class ThreadLocal[T] {
-  private var hasValue: Boolean = false
+  private var hasValue: scala.Boolean = false
   private var v: T = _
 
   protected def initialValue(): T = null.asInstanceOf[T]

--- a/javalanglib/src/main/scala/java/lang/Void.scala
+++ b/javalanglib/src/main/scala/java/lang/Void.scala
@@ -15,5 +15,5 @@ package java.lang
 final class Void private ()
 
 object Void {
-  final val TYPE = classOf[scala.Unit]
+  final val TYPE = scala.Predef.classOf[scala.Unit]
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -923,6 +923,15 @@ object Build {
           delambdafySetting,
           noClassFilesSettings,
 
+          /* When writing code in the java.lang package, references to things
+           * like `Boolean` or `Double` refer to `j.l.Boolean` or `j.l.Double`.
+           * Usually this is not what we want (we want the primitive types
+           * instead), but the implicits available in `Predef` hide mistakes by
+           * introducing boxing and unboxing where required. The `-Yno-predef`
+           * flag prevents these mistakes from happening.
+           */
+          scalacOptions += "-Yno-predef",
+
           resourceGenerators in Compile += Def.task {
             val base = (resourceManaged in Compile).value
             Seq(


### PR DESCRIPTION
When writing code in the java.lang package, references to things like `Boolean` or `Double` refer to `j.l.Boolean` or `j.l.Double`. Usually this is not what we want (we want the primitive types instead), but the implicits available in `Predef` hide mistakes by introducing boxing and unboxing where required. The `-Yno-predef` flag prevents these mistakes from happening.