### PR TITLE
Do not eagerly throw for `Nothing` in `Class.cast()`.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Class.scala
+++ b/javalanglib/src/main/scala/java/lang/Class.scala
@@ -109,7 +109,6 @@ final class Class[A] private (data: ScalaJSClassData[A]) extends Object {
   @inline // optimize for the Unchecked case, where this becomes identity()
   def cast(obj: Object): A = {
     scala.scalajs.runtime.SemanticsUtils.asInstanceOfCheck(
-        (this eq scala.Predef.classOf[Nothing]) ||
         (obj != null && !isRawJSType && !isInstance(obj)),
         new ClassCastException("" + obj + " is not an instance of " + getName))
     obj.asInstanceOf[A]

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -64,13 +64,12 @@ class RuntimeTypesTest {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     def test(x: Any): Unit = {
       try {
-        classOf[Nothing].cast(x)
+        val result = classOf[Nothing].cast(x)
         fail("casting " + x + " to Nothing did not fail")
+        identity(result) // discard `result` without warning
       } catch {
-        case th: Throwable =>
-          assertTrue(th.isInstanceOf[ClassCastException])
-          assertEquals(x + " is not an instance of scala.runtime.Nothing$",
-              th.getMessage)
+        case th: ClassCastException =>
+          // ok
       }
     }
     test("a")


### PR DESCRIPTION
There is no need to, as the compiler will insert an explicit cast at call site to adapt the erased `A` (`Object`) to `Nothing` (assuming the call is not in statement position).

The test was a bit too restrictive, and has been relaxed not to expect a specific error message, and to only expect an exception when used in expression position.

The new behavior is consistent with Scala/JVM, since of course, on the JVM, `Class.cast()` does not know about `scala.runtime.Nothing$`.