### PR TITLE
Do not check formal arguments of method calls to non-instantiated types.

### DIFF
--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -39,8 +39,6 @@ class AnalyzerTest {
   import scala.concurrent.ExecutionContext.Implicits.global
   import AnalyzerTest._
 
-  private val EAF = ApplyFlags.empty
-
   @Test
   def trivialOK(): AsyncResult = await {
     val analysis = computeAnalysis(Nil)

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -1,0 +1,106 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker
+
+import scala.concurrent._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.ir.ClassKind
+import org.scalajs.ir.Definitions._
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
+
+import org.scalajs.logging._
+
+import org.scalajs.junit.async._
+
+import org.scalajs.linker._
+import org.scalajs.linker.standard._
+
+import org.scalajs.linker.testutils._
+import org.scalajs.linker.testutils.TestIRBuilder._
+
+class IRCheckerTest {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  import IRCheckerTest._
+
+  @Test
+  def testMethodCallOnClassWithNoInstances(): AsyncResult = await {
+    def callMethOn(receiver: Tree): Tree =
+      Apply(EAF, receiver, Ident("meth__LFoo__V"), List(Null()))(NoType)
+
+    val classDefs = Seq(
+        // LFoo will be dropped by base linking
+        classDef("LFoo", superClass = Some(ObjectClass)),
+
+        classDef("LBar",
+            superClass = Some(ObjectClass),
+            memberDefs = List(
+                trivialCtor("LBar"),
+
+                /* This method is called, but unreachable because there are no
+                 * instances of `Bar`. It will therefore not make `Foo` reachable.
+                 */
+                MethodDef(MemberFlags.empty, Ident("meth__LFoo__V"),
+                    List(paramDef("foo", ClassType("LFoo"))), NoType,
+                    Some(Skip()))(
+                    emptyOptHints, None)
+            )
+        ),
+
+        classDef("LTest$", kind = ClassKind.ModuleClass,
+            superClass = Some(ObjectClass),
+            memberDefs = List(
+                trivialCtor("LTest$"),
+                MethodDef(MemberFlags.empty, Ident("nullBar__LBar"), Nil, ClassType("LBar"),
+                    Some(Null()))(
+                    emptyOptHints, None),
+                mainMethodDef(Block(
+                    callMethOn(Apply(EAF, This()(ClassType("LTest$")),
+                        Ident("nullBar__LBar"), Nil)(ClassType("LBar"))),
+                    callMethOn(Null()),
+                    callMethOn(Throw(Null()))
+                ))
+            )
+        )
+    )
+
+    testLinkNoIRError(classDefs, mainModuleInitializers("Test"))
+  }
+
+}
+
+object IRCheckerTest {
+  def testLinkNoIRError(classDefs: Seq[ClassDef],
+      moduleInitializers: List[ModuleInitializer])(
+      implicit ec: ExecutionContext): Future[Unit] = {
+
+    val config = StandardLinker.Config()
+      .withCheckIR(true)
+      .withOptimizer(false)
+    val linkerFrontend = StandardLinkerFrontend(config)
+    val symbolRequirements = StandardLinkerBackend(config).symbolRequirements
+
+    val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
+
+    val result = TestIRRepo.minilib.stdlibIRFiles.flatMap { stdLibFiles =>
+      linkerFrontend.link(stdLibFiles ++ classDefsFiles, moduleInitializers,
+        symbolRequirements, new ScalaConsoleLogger(Level.Error))
+    }
+
+    result.map(_ => ())
+  }
+}

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -56,10 +56,7 @@ class LinkerTest {
             )
         )
     )
-    val moduleInitializers = List(
-        ModuleInitializer.mainMethodWithArgs("HelloWorld", "main")
-    )
-    testLink(classDefs, moduleInitializers)
+    testLink(classDefs, mainModuleInitializers("HelloWorld"))
   }
 
   /** This test exposes a problem where a linker in error state is called
@@ -110,16 +107,7 @@ object LinkerTest {
       implicit ec: ExecutionContext): Future[Unit] = {
 
     val linker = StandardLinker(StandardLinker.Config())
-
-    val classDefsFiles = classDefs.map { classDef =>
-      new IRFileImpl("mem://" + classDef.name.name + ".sjsir", None) {
-        def tree(implicit ec: ExecutionContext): Future[ClassDef] = Future(classDef)
-
-        def entryPointsInfo(implicit ec: ExecutionContext): Future[EntryPointsInfo] =
-          tree.map(EntryPointsInfo.forClassDef)
-      }
-    }
-
+    val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
     val output = LinkerOutput(LinkerOutput.newMemFile())
 
     TestIRRepo.minilib.stdlibIRFiles.flatMap { stdLibFiles =>

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/MemClassDefIRFile.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/MemClassDefIRFile.scala
@@ -1,0 +1,36 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.testutils
+
+import scala.concurrent._
+
+import org.scalajs.ir.EntryPointsInfo
+import org.scalajs.ir.Trees.ClassDef
+
+import org.scalajs.linker.IRFile
+import org.scalajs.linker.standard.IRFileImpl
+
+private final class MemClassDefIRFile(classDef: ClassDef)
+    extends IRFileImpl("mem://" + classDef.name.name + ".sjsir", None) {
+
+  def tree(implicit ec: ExecutionContext): Future[ClassDef] =
+    Future(classDef)
+
+  def entryPointsInfo(implicit ec: ExecutionContext): Future[EntryPointsInfo] =
+    tree.map(EntryPointsInfo.forClassDef)
+}
+
+object MemClassDefIRFile {
+  def apply(classDef: ClassDef): IRFile =
+    new MemClassDefIRFile(classDef)
+}

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -18,10 +18,12 @@ import org.scalajs.ir.Definitions._
 import org.scalajs.ir.Trees._
 import org.scalajs.ir.Types._
 
+import org.scalajs.linker.ModuleInitializer
+
 object TestIRBuilder {
   implicit val noPosition: ir.Position = ir.Position.NoPosition
 
-  private val EAF = ApplyFlags.empty
+  val EAF = ApplyFlags.empty
 
   val emptyOptHints: OptimizerHints = OptimizerHints.empty
 
@@ -52,9 +54,14 @@ object TestIRBuilder {
 
   def mainMethodDef(body: Tree): MethodDef = {
     val stringArrayType = ArrayType(ArrayTypeRef("T", 1))
-    val argsParamDef = ParamDef(Ident("args", Some("args")), stringArrayType,
-        mutable = false, rest = false)
+    val argsParamDef = paramDef("args", stringArrayType)
     MethodDef(MemberFlags.empty, Ident("main__AT__V"), List(argsParamDef),
         NoType, Some(body))(emptyOptHints, None)
   }
+
+  def paramDef(name: String, ptpe: Type): ParamDef =
+    ParamDef(Ident(name, Some(name)), ptpe, mutable = false, rest = false)
+
+  def mainModuleInitializers(moduleClassName: String): List[ModuleInitializer] =
+    ModuleInitializer.mainMethodWithArgs(moduleClassName, "main") :: Nil
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -331,6 +331,26 @@ class RegressionTest {
     assertEquals(3, test(null))
   }
 
+  @Test def IR_checker_must_not_check_method_signatures_on_classes_with_no_instance(): Unit = {
+    assumeTrue("linking only", false)
+
+    class Foo // this class will be dropped by base linking
+
+    class Bar {
+      /* This method is called, but unreachable because there are no instances
+       * of `Bar`. It will therefore not make `Foo` reachable.
+       */
+      def meth(foo: Foo): String = foo.toString()
+    }
+
+    @noinline def nullBar(): Bar = null
+
+    // the IR checker must not try to infer the signature of these calls
+    nullBar().meth(null)
+    (null: Bar).meth(null)
+    (??? : Bar).meth(null) // scalastyle:ignore
+  }
+
   @Test def should_properly_order_ctor_statements_when_inlining_issue_1369(): Unit = {
     trait Bar {
       def x: Int


### PR DESCRIPTION
In a method call of the form `x.m__sig(...args)`, if the type of `x` does not have instances, the base linker might not have linked the classes referenced in `sig` at all. Therefore, we must not try to infer the type signature, as it can crash.