### PR TITLE
Fix #3697: Improve error message when no main module initializer was found

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -909,15 +909,23 @@ object ScalaJSPluginInternal {
         (scalaJSModuleInitializers in (This, Zero, This)).value,
 
       scalaJSModuleInitializers ++= {
+        val mainClasses = scalaJSDiscoveredMainClasses.value
         if (scalaJSUseMainModuleInitializer.value) {
           Seq(scalaJSMainModuleInitializer.value.getOrElse {
-            throw new MessageOnlyException(
-                "No main module initializer was specified (possibly because " +
-                "no or multiple main classes were found), but " +
-                "scalaJSUseMainModuleInitializer was set to true. " +
-                "You can explicitly specify it either with " +
-                "`mainClass := Some(...)` or with " +
-                "`scalaJSMainModuleInitializer := Some(...)`")
+            if (mainClasses.isEmpty) {
+              throw new MessageOnlyException(
+                  "No main module initializer was specified, but " +
+                  "scalaJSUseMainModuleInitializer was set to true. " +
+                  "You can explicitly specify it either with " +
+                  "`mainClass := Some(...)` or with " +
+                  "`scalaJSMainModuleInitializer := Some(...)`")
+            } else {
+              throw new MessageOnlyException(
+                  s"Multiple main classes (${mainClasses.keys}) were found. " +
+                  "You can explicitly specify the one you want with " +
+                  "`mainClass := Some(...)` or with " +
+                  "`scalaJSMainModuleInitializer := Some(...)`")
+            }
           })
         } else {
           Seq.empty


### PR DESCRIPTION
Closes #3697

Mentioning `mainClass in Compile := ...` as suggested in https://github.com/scala-js/scala-js/issues/3697#issuecomment-501726873 are not included, since right now I think `mainClass := ...` is sufficient for most use-cases.

