### PR TITLE
FF ONLY Merge 0.6.x into master, July 30

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Boolean.scala
+++ b/javalanglib/src/main/scala/java/lang/Boolean.scala
@@ -41,7 +41,7 @@ final class Boolean private ()
 }
 
 object Boolean {
-  final val TYPE = classOf[scala.Boolean]
+  final val TYPE = scala.Predef.classOf[scala.Boolean]
 
   /* TRUE and FALSE are supposed to be vals. However, they are better
    * optimized as defs, because they end up being just the constant true and

--- a/javalanglib/src/main/scala/java/lang/Byte.scala
+++ b/javalanglib/src/main/scala/java/lang/Byte.scala
@@ -45,7 +45,7 @@ final class Byte private () extends Number with Comparable[Byte] {
 }
 
 object Byte {
-  final val TYPE = classOf[scala.Byte]
+  final val TYPE = scala.Predef.classOf[scala.Byte]
   final val SIZE = 8
   final val BYTES = 1
 

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -47,7 +47,7 @@ class Character private ()
 }
 
 object Character {
-  final val TYPE = classOf[scala.Char]
+  final val TYPE = scala.Predef.classOf[scala.Char]
   final val MIN_VALUE = '\u0000'
   final val MAX_VALUE = '\uffff'
   final val SIZE = 16
@@ -114,10 +114,10 @@ object Character {
   }
 
   @inline
-  private[this] def getTypeLT256(codePoint: Int): scala.Byte =
+  private[this] def getTypeLT256(codePoint: Int): Int =
     charTypesFirst256(codePoint)
 
-  private[this] def getTypeGE256(codePoint: Int): scala.Byte = {
+  private[this] def getTypeGE256(codePoint: Int): Int = {
     // the idx is increased by 1 due to the differences in indexing
     // between charTypeIndices and charType
     val idx = Arrays.binarySearch(charTypeIndices, codePoint) + 1
@@ -448,8 +448,8 @@ object Character {
   //def getDirectionality(c: scala.Char): scala.Byte
 
   /* Conversions */
-  def toUpperCase(c: scala.Char): scala.Char = c.toString.toUpperCase()(0)
-  def toLowerCase(c: scala.Char): scala.Char = c.toString.toLowerCase()(0)
+  def toUpperCase(c: scala.Char): scala.Char = c.toString.toUpperCase().charAt(0)
+  def toLowerCase(c: scala.Char): scala.Char = c.toString.toLowerCase().charAt(0)
   //def toTitleCase(c: scala.Char): scala.Char
   //def getNumericValue(c: scala.Char): Int
 
@@ -508,7 +508,7 @@ object Character {
   // Based on Unicode 7.0.0
 
   // Types of characters from 0 to 255
-  private[this] lazy val charTypesFirst256 = Array[scala.Byte](15, 15, 15, 15,
+  private[this] lazy val charTypesFirst256: Array[Int] = Array(15, 15, 15, 15,
     15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
     15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 12, 24, 24, 24, 26, 24, 24, 24,
     21, 22, 24, 25, 24, 20, 24, 24, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 24, 24, 25,
@@ -541,11 +541,11 @@ object Character {
   //    .map(tup => tup._1 - tup._2)
   //  val charTypes = indicesAndTypes.map(_._2)
   //  println(charTypeIndicesDeltas.mkString(
-  //    "charTypeIndices: val deltas = Array[Int](", ", ", ")"))
-  //  println(charTypes.mkString("val charTypes = Array[scala.Byte](", ", ", ")"))
+  //    "charTypeIndices: val deltas = Array(", ", ", ")"))
+  //  println(charTypes.mkString("val charTypes = Array(", ", ", ")"))
   //
-  private[this] lazy val charTypeIndices = {
-    val deltas = Array[Int](257, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+  private[this] lazy val charTypeIndices: Array[Int] = {
+    val deltas = Array(257, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1,
       1, 1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -695,7 +695,7 @@ object Character {
     uncompressDeltas(deltas)
   }
 
-  private[this] lazy val charTypes = Array[scala.Byte](1, 2, 1, 2, 1, 2,
+  private[this] lazy val charTypes: Array[Int] = Array(1, 2, 1, 2, 1, 2,
     1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1,
     2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
     1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1,
@@ -859,8 +859,8 @@ object Character {
   //       0 :: isMirroredIndices.init).map(tup => tup._1 - tup._2)
   //  println(isMirroredIndicesDeltas.mkString(
   //     "isMirroredIndices: val deltas = Array[Int](", ", ", ")"))
-  private[this] lazy val isMirroredIndices = {
-    val deltas = Array[Int](40, 2, 18, 1, 1, 1, 28, 1, 1, 1, 29, 1, 1, 1,
+  private[this] lazy val isMirroredIndices: Array[Int] = {
+    val deltas = Array(40, 2, 18, 1, 1, 1, 28, 1, 1, 1, 29, 1, 1, 1,
       45, 1, 15, 1, 3710, 4, 1885, 2, 2460, 2, 10, 2, 54, 2, 14, 2, 177, 1,
       192, 4, 3, 6, 3, 1, 3, 2, 3, 4, 1, 4, 1, 1, 1, 1, 4, 9, 5, 1, 1, 18,
       5, 4, 9, 2, 1, 1, 1, 8, 2, 31, 2, 4, 5, 1, 9, 2, 2, 19, 5, 2, 9, 5, 2,
@@ -875,8 +875,14 @@ object Character {
   }
 
   private[this] def uncompressDeltas(deltas: Array[Int]): Array[Int] = {
-    for (i <- 1 until deltas.length)
-      deltas(i) += deltas(i - 1)
+    var acc = deltas(0)
+    var i = 1
+    val len = deltas.length
+    while (i != len) {
+      acc += deltas(i)
+      deltas(i) = acc
+      i += 1
+    }
     deltas
   }
 
@@ -887,7 +893,7 @@ object Character {
    *  point mapping to digits from 0 to 9.
    */
   private[this] lazy val nonASCIIZeroDigitCodePoints: Array[Int] = {
-    Array[Int](0x660, 0x6f0, 0x7c0, 0x966, 0x9e6, 0xa66, 0xae6, 0xb66, 0xbe6,
+    Array(0x660, 0x6f0, 0x7c0, 0x966, 0x9e6, 0xa66, 0xae6, 0xb66, 0xbe6,
         0xc66, 0xce6, 0xd66, 0xe50, 0xed0, 0xf20, 0x1040, 0x1090, 0x17e0,
         0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0, 0x1c40, 0x1c50,
         0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xaa50, 0xabf0, 0xff10, 0x104a0,

--- a/javalanglib/src/main/scala/java/lang/Class.scala
+++ b/javalanglib/src/main/scala/java/lang/Class.scala
@@ -85,7 +85,6 @@ final class Class[A] private (data0: Object) extends Object {
   @inline // optimize for the Unchecked case, where this becomes identity()
   def cast(obj: Object): A = {
     scala.scalajs.runtime.SemanticsUtils.asInstanceOfCheck(
-        (this eq classOf[Nothing]) ||
         (obj != null && !isJSType && !isInstance(obj)),
         new ClassCastException("" + obj + " is not an instance of " + getName))
     obj.asInstanceOf[A]

--- a/javalanglib/src/main/scala/java/lang/Double.scala
+++ b/javalanglib/src/main/scala/java/lang/Double.scala
@@ -66,7 +66,7 @@ final class Double private () extends Number with Comparable[Double] {
 }
 
 object Double {
-  final val TYPE = classOf[scala.Double]
+  final val TYPE = scala.Predef.classOf[scala.Double]
   final val POSITIVE_INFINITY = 1.0 / 0.0
   final val NEGATIVE_INFINITY = 1.0 / -0.0
   final val NaN = 0.0 / 0.0
@@ -186,7 +186,7 @@ object Double {
 
       val mantissa =
         js.Dynamic.global.parseInt(truncatedMantissaStr, 16).asInstanceOf[scala.Double]
-      assert(mantissa != 0.0 && mantissa != scala.Double.PositiveInfinity)
+      // Assert: mantissa != 0.0 && mantissa != scala.Double.PositiveInfinity
 
       val binaryExpDouble =
         js.Dynamic.global.parseInt(binaryExpStr, 10).asInstanceOf[scala.Double]

--- a/javalanglib/src/main/scala/java/lang/Enum.scala
+++ b/javalanglib/src/main/scala/java/lang/Enum.scala
@@ -30,7 +30,7 @@ abstract class Enum[E <: Enum[E]] protected (_name: String, _ordinal: Int)
   override protected final def clone(): AnyRef =
     throw new CloneNotSupportedException("Enums are not cloneable")
 
-  final def compareTo(o: E): Int = _ordinal.compareTo(o.ordinal)
+  final def compareTo(o: E): Int = Integer.compare(_ordinal, o.ordinal)
 
   // Not implemented:
   // final def getDeclaringClass(): Class[E]

--- a/javalanglib/src/main/scala/java/lang/Float.scala
+++ b/javalanglib/src/main/scala/java/lang/Float.scala
@@ -50,7 +50,7 @@ final class Float private () extends Number with Comparable[Float] {
 }
 
 object Float {
-  final val TYPE = classOf[scala.Float]
+  final val TYPE = scala.Predef.classOf[scala.Float]
   final val POSITIVE_INFINITY = 1.0f / 0.0f
   final val NEGATIVE_INFINITY = 1.0f / -0.0f
   final val NaN = 0.0f / 0.0f

--- a/javalanglib/src/main/scala/java/lang/FloatingPointBits.scala
+++ b/javalanglib/src/main/scala/java/lang/FloatingPointBits.scala
@@ -215,10 +215,10 @@ private[lang] object FloatingPointBits {
 
     val bias = (1 << (ebits-1)) - 1 // constant
 
-    if (v.isNaN) {
+    if (Double.isNaN(v)) {
       // http://dev.w3.org/2006/webapi/WebIDL/#es-type-mapping
       (false, (1 << ebits) - 1, pow(2, fbits-1))
-    } else if (v.isInfinite) {
+    } else if (Double.isInfinite(v)) {
       (v < 0, (1 << ebits) - 1, 0.0)
     } else if (v == 0.0) {
       (1 / v == scala.Double.NegativeInfinity, 0, 0.0)

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -45,7 +45,7 @@ final class Integer private () extends Number with Comparable[Integer] {
 }
 
 object Integer {
-  final val TYPE = classOf[scala.Int]
+  final val TYPE = scala.Predef.classOf[scala.Int]
   final val MIN_VALUE = -2147483648
   final val MAX_VALUE = 2147483647
   final val SIZE = 32

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -51,7 +51,7 @@ final class Long private () extends Number with Comparable[Long] {
 object Long {
   import scala.scalajs.runtime.RuntimeLong
 
-  final val TYPE = classOf[scala.Long]
+  final val TYPE = scala.Predef.classOf[scala.Long]
   final val MIN_VALUE = -9223372036854775808L
   final val MAX_VALUE = 9223372036854775807L
   final val SIZE = 64
@@ -68,11 +68,14 @@ object Long {
    */
   private lazy val StringRadixInfos: js.Array[StringRadixInfo] = {
     val r = new js.Array[StringRadixInfo]()
+    var radix = 0
 
-    for (_ <- 0 until Character.MIN_RADIX)
+    while (radix < Character.MIN_RADIX) {
       r += null
+      radix += 1
+    }
 
-    for (radix <- Character.MIN_RADIX to Character.MAX_RADIX) {
+    while (radix <= Character.MAX_RADIX) {
       /* Find the biggest chunk size we can use.
        *
        * - radixPowLength should be the biggest signed int32 value that is an
@@ -95,6 +98,7 @@ object Long {
       val overflowBarrier = Long.divideUnsigned(-1L, radixPowLengthLong)
       r += new StringRadixInfo(chunkLength, radixPowLengthLong,
           paddingZeros, overflowBarrier)
+      radix += 1
     }
 
     r
@@ -290,7 +294,7 @@ object Long {
           secondResult
         } else {
           // Third and final chunk. This one can overflow
-          assert(secondChunkEnd + chunkLen == length)
+          // Assert: secondChunkEnd + chunkLen == length
 
           val overflowBarrier = radixInfo.overflowBarrier
           val thirdChunk = parseChunk(secondChunkEnd, length)

--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -105,7 +105,7 @@ object Math {
     if (assumingES6 || !js.isUndefined(g.Math.cbrt)) {
       js.Math.cbrt(a)
     } else {
-      if (a == 0 || a.isNaN || a.isPosInfinity || a.isNegInfinity) {
+      if (a == 0 || Double.isNaN(a) || Double.isInfinite(a)) {
         a
       } else {
         val sign = if (a < 0.0) -1.0 else 1.0
@@ -213,7 +213,7 @@ object Math {
       // http://en.wikipedia.org/wiki/Hypot#Implementation
       if (abs(a) == scala.Double.PositiveInfinity || abs(b) == scala.Double.PositiveInfinity)
         scala.Double.PositiveInfinity
-      else if (a.isNaN || b.isNaN)
+      else if (Double.isNaN(a) || Double.isNaN(b))
         scala.Double.NaN
       else if (a == 0 && b == 0)
         0.0
@@ -234,7 +234,7 @@ object Math {
       js.Math.expm1(a)
     } else {
       // https://github.com/ghewgill/picomath/blob/master/javascript/expm1.js
-      if (a == 0 || a.isNaN)
+      if (a == 0 || Double.isNaN(a))
         a
       // Power Series http://en.wikipedia.org/wiki/Power_series
       // for small values of a, exp(a) = 1 + a + (a*a)/2
@@ -249,7 +249,7 @@ object Math {
     if (assumingES6 || !js.isUndefined(g.Math.sinh)) {
       js.Math.sinh(a)
     } else {
-      if (a.isNaN || a == 0.0 || abs(a) == scala.Double.PositiveInfinity) a
+      if (Double.isNaN(a) || a == 0.0 || abs(a) == scala.Double.PositiveInfinity) a
       else (exp(a) - exp(-a)) / 2.0
     }
   }
@@ -258,7 +258,7 @@ object Math {
     if (assumingES6 || !js.isUndefined(g.Math.cosh)) {
       js.Math.cosh(a)
     } else {
-      if (a.isNaN)
+      if (Double.isNaN(a))
         a
       else if (a == 0.0)
         1.0
@@ -273,7 +273,7 @@ object Math {
     if (assumingES6 || !js.isUndefined(g.Math.tanh)) {
       js.Math.tanh(a)
     } else {
-      if (a.isNaN || a == 0.0)
+      if (Double.isNaN(a) || a == 0.0)
         a
       else if (abs(a) == scala.Double.PositiveInfinity)
         signum(a)

--- a/javalanglib/src/main/scala/java/lang/Short.scala
+++ b/javalanglib/src/main/scala/java/lang/Short.scala
@@ -44,7 +44,7 @@ final class Short private () extends Number with Comparable[Short] {
 }
 
 object Short {
-  final val TYPE = classOf[scala.Short]
+  final val TYPE = scala.Predef.classOf[scala.Short]
   final val SIZE = 16
   final val BYTES = 2
 

--- a/javalanglib/src/main/scala/java/lang/StackTrace.scala
+++ b/javalanglib/src/main/scala/java/lang/StackTrace.scala
@@ -93,7 +93,7 @@ private[lang] object StackTrace {
    *  env that manages to use either without surgery in the Scala.js linker.
    *  So we keep support of stack trace detection for those engines.
    */
-  private lazy val isRhino: Boolean = {
+  private lazy val isRhino: scala.Boolean = {
     try {
       js.Dynamic.global.Packages.org.mozilla.javascript.JavaScriptException
       true
@@ -131,6 +131,9 @@ private[lang] object StackTrace {
    */
   private def normalizedLinesToStackTrace(
       lines: js.Array[String]): Array[StackTraceElement] = {
+
+    import Integer.parseInt
+
     val NormalizedFrameLine = """^([^\@]*)\@(.*):([0-9]+)$""".re
     val NormalizedFrameLineWithColumn = """^([^\@]*)\@(.*):([0-9]+):([0-9]+)$""".re
 
@@ -143,13 +146,13 @@ private[lang] object StackTrace {
         if (mtch1 ne null) {
           val (className, methodName) = extractClassMethod(mtch1(1).get)
           trace.push(JSStackTraceElem(className, methodName, mtch1(2).get,
-              mtch1(3).get.toInt, mtch1(4).get.toInt))
+              parseInt(mtch1(3).get), parseInt(mtch1(4).get)))
         } else {
           val mtch2 = NormalizedFrameLine.exec(line)
           if (mtch2 ne null) {
             val (className, methodName) = extractClassMethod(mtch2(1).get)
             trace.push(JSStackTraceElem(className,
-                methodName, mtch2(2).get, mtch2(3).get.toInt))
+                methodName, mtch2(2).get, parseInt(mtch2(3).get)))
           } else {
             // just in case
             trace.push(JSStackTraceElem("<jscode>", line, null, -1))

--- a/javalanglib/src/main/scala/java/lang/System.scala
+++ b/javalanglib/src/main/scala/java/lang/System.scala
@@ -239,18 +239,18 @@ object System {
 
     private[System] def loadSystemProperties(): js.Dictionary[String] = {
       js.Dictionary(
-          "java.version" -> "1.8",
-          "java.vm.specification.version" -> "1.8",
-          "java.vm.specification.vendor" -> "Oracle Corporation",
-          "java.vm.specification.name" -> "Java Virtual Machine Specification",
-          "java.vm.name" -> "Scala.js",
-          "java.vm.version" -> linkingInfo.linkerVersion,
-          "java.specification.version" -> "1.8",
-          "java.specification.vendor" -> "Oracle Corporation",
-          "java.specification.name" -> "Java Platform API Specification",
-          "file.separator" -> "/",
-          "path.separator" -> ":",
-          "line.separator" -> "\n"
+          ("java.version", "1.8"),
+          ("java.vm.specification.version", "1.8"),
+          ("java.vm.specification.vendor", "Oracle Corporation"),
+          ("java.vm.specification.name", "Java Virtual Machine Specification"),
+          ("java.vm.name", "Scala.js"),
+          ("java.vm.version", linkingInfo.linkerVersion),
+          ("java.specification.version", "1.8"),
+          ("java.specification.vendor", "Oracle Corporation"),
+          ("java.specification.name", "Java Platform API Specification"),
+          ("file.separator", "/"),
+          ("path.separator", ":"),
+          ("line.separator", "\n")
       )
     }
 
@@ -316,7 +316,7 @@ object System {
   def gc(): Unit = Runtime.getRuntime().gc()
 }
 
-private[lang] final class JSConsoleBasedPrintStream(isErr: Boolean)
+private[lang] final class JSConsoleBasedPrintStream(isErr: scala.Boolean)
     extends PrintStream(new JSConsoleBasedPrintStream.DummyOutputStream) {
 
   import JSConsoleBasedPrintStream._

--- a/javalanglib/src/main/scala/java/lang/ThreadLocal.scala
+++ b/javalanglib/src/main/scala/java/lang/ThreadLocal.scala
@@ -13,7 +13,7 @@
 package java.lang
 
 class ThreadLocal[T] {
-  private var hasValue: Boolean = false
+  private var hasValue: scala.Boolean = false
   private var v: T = _
 
   protected def initialValue(): T = null.asInstanceOf[T]

--- a/javalanglib/src/main/scala/java/lang/Void.scala
+++ b/javalanglib/src/main/scala/java/lang/Void.scala
@@ -29,5 +29,5 @@ final class Void private () extends AnyRef {
 }
 
 object Void {
-  final val TYPE = classOf[scala.Unit]
+  final val TYPE = scala.Predef.classOf[scala.Unit]
 }

--- a/javalanglib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalanglib/src/main/scala/java/lang/reflect/Array.scala
@@ -14,16 +14,22 @@ package java.lang.reflect
 
 import scala.scalajs.js
 
-import js.JSConverters._
-
 import java.lang.Class
 
 object Array {
   def newInstance(componentType: Class[_], length: Int): AnyRef =
     componentType.newArrayOfThisClass(js.Array(length))
 
-  def newInstance(componentType: Class[_], dimensions: scala.Array[Int]): AnyRef =
-    componentType.newArrayOfThisClass(dimensions.toJSArray)
+  def newInstance(componentType: Class[_], dimensions: scala.Array[Int]): AnyRef = {
+    val jsDims = js.Array[Int]()
+    val len = dimensions.length
+    var i = 0
+    while (i != len) {
+      jsDims.push(dimensions(i))
+      i += 1
+    }
+    componentType.newArrayOfThisClass(jsDims)
+  }
 
   def getLength(array: AnyRef): Int = array match {
     // yes, this is kind of stupid, but that's how it is
@@ -41,14 +47,14 @@ object Array {
 
   def get(array: AnyRef, index: Int): AnyRef = array match {
     case array: Array[Object]  => array(index)
-    case array: Array[Boolean] => new java.lang.Boolean(array(index))
-    case array: Array[Char]    => new java.lang.Character(array(index))
-    case array: Array[Byte]    => new java.lang.Byte(array(index))
-    case array: Array[Short]   => new java.lang.Short(array(index))
-    case array: Array[Int]     => new java.lang.Integer(array(index))
-    case array: Array[Long]    => new java.lang.Long(array(index))
-    case array: Array[Float]   => new java.lang.Float(array(index))
-    case array: Array[Double]  => new java.lang.Double(array(index))
+    case array: Array[Boolean] => java.lang.Boolean.valueOf(array(index))
+    case array: Array[Char]    => java.lang.Character.valueOf(array(index))
+    case array: Array[Byte]    => java.lang.Byte.valueOf(array(index))
+    case array: Array[Short]   => java.lang.Short.valueOf(array(index))
+    case array: Array[Int]     => java.lang.Integer.valueOf(array(index))
+    case array: Array[Long]    => java.lang.Long.valueOf(array(index))
+    case array: Array[Float]   => java.lang.Float.valueOf(array(index))
+    case array: Array[Double]  => java.lang.Double.valueOf(array(index))
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
 

--- a/javalib/src/main/scala/java/io/BufferedReader.scala
+++ b/javalib/src/main/scala/java/io/BufferedReader.scala
@@ -36,6 +36,8 @@ class BufferedReader(in: Reader, sz: Int) extends Reader {
   }
 
   override def mark(readAheadLimit: Int): Unit = {
+    if (readAheadLimit < 0)
+      throw new IllegalArgumentException("Read-ahead limit < 0")
     ensureOpen()
 
     val srcBuf = buf

--- a/javalib/src/main/scala/java/io/StringReader.scala
+++ b/javalib/src/main/scala/java/io/StringReader.scala
@@ -23,6 +23,8 @@ class StringReader(s: String) extends Reader {
   }
 
   override def mark(readAheadLimit: Int): Unit = {
+    if (readAheadLimit < 0)
+      throw new IllegalArgumentException("Read-ahead limit < 0")
     ensureOpen()
 
     mark = pos
@@ -70,10 +72,15 @@ class StringReader(s: String) extends Reader {
   }
 
   override def skip(ns: Long): Long = {
-    // Apparently, StringReader.skip allows negative skips
-    val count = Math.max(Math.min(ns, s.length - pos).toInt, -pos)
-    pos += count
-    count.toLong
+    if (pos >= s.length) {
+      // Always return 0 if the entire string has been read or skipped
+      0
+    } else {
+      // Apparently, StringReader.skip allows negative skips
+      val count = Math.max(Math.min(ns, s.length - pos).toInt, -pos)
+      pos += count
+      count.toLong
+    }
   }
 
   private def ensureOpen(): Unit = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -821,6 +821,15 @@ object Build {
       ensureSAMSupportSetting,
       noClassFilesSettings,
 
+      /* When writing code in the java.lang package, references to things
+       * like `Boolean` or `Double` refer to `j.l.Boolean` or `j.l.Double`.
+       * Usually this is not what we want (we want the primitive types
+       * instead), but the implicits available in `Predef` hide mistakes by
+       * introducing boxing and unboxing where required. The `-Yno-predef`
+       * flag prevents these mistakes from happening.
+       */
+      scalacOptions += "-Yno-predef",
+
       resourceGenerators in Compile += Def.task {
         val output = (resourceManaged in Compile).value / "java/lang/Object.sjsir"
         val data = JavaLangObject.irBytes
@@ -1297,7 +1306,7 @@ object Build {
       // To support calls to static methods in interfaces
       scalacOptions in Test ++= {
         /* Starting from 2.11.12, scalac refuses to emit calls to static methods
-         * in interfaces unless the -target:jvm-1.8 flag is given. 
+         * in interfaces unless the -target:jvm-1.8 flag is given.
          * scalac 2.12+ emits JVM 8 bytecode by default, of course, so it is not
          * needed for later versions.
          */

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -58,13 +58,12 @@ class RuntimeTypesTest {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     def test(x: Any): Unit = {
       try {
-        classOf[Nothing].cast(x)
+        val result = classOf[Nothing].cast(x)
         fail("casting " + x + " to Nothing did not fail")
+        identity(result) // discard `result` without warning
       } catch {
-        case th: Throwable =>
-          assertTrue(th.isInstanceOf[ClassCastException])
-          assertEquals(x + " is not an instance of scala.runtime.Nothing$",
-              th.getMessage)
+        case th: ClassCastException =>
+          // ok
       }
     }
     test("a")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -22,6 +22,21 @@ import org.junit.Assert._
 import org.scalajs.testsuite.utils.AssertThrows._
 
 /** Tests for our implementation of java.io._ reader classes */
+class ReaderTest {
+  object MyReader extends java.io.Reader {
+    def read(dbuf: Array[Char], off: Int, len: Int): Int = {
+      java.util.Arrays.fill(dbuf, off, off + len, 'A')
+      len
+    }
+    def close(): Unit = ()
+  }
+
+  @Test def skip_should_always_skip_n_if_possible(): Unit = {
+    assertEquals(42, MyReader.skip(42))
+    assertEquals(10000, MyReader.skip(10000)) // more than the 8192 batch size
+  }
+}
+
 class StringReaderTest {
   val str = "asdf"
   def newReader: StringReader = new StringReader(str)
@@ -112,6 +127,33 @@ class StringReaderTest {
   @Test def should_support_marking(): Unit = {
     assertTrue(newReader.markSupported)
   }
+
+  @Test def mark_should_throw_with_negative_lookahead(): Unit = {
+    expectThrows(classOf[IllegalArgumentException], newReader.mark(-10))
+  }
+
+  @Test def skip_should_accept_negative_lookahead_as_lookback(): Unit = {
+    // StringReader.skip accepts negative lookahead
+    val r = newReader
+    assertEquals("already head", 0, r.skip(-1))
+    assertEquals('a', r.read())
+
+    assertEquals(1, r.skip(1))
+    assertEquals('d', r.read())
+
+    assertEquals(-2, r.skip(-2))
+    assertEquals('s', r.read())
+  }
+
+  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+    val r = newReader
+    assertEquals(4, r.skip(100))
+    assertEquals(-1, r.read())
+
+    assertEquals(0, r.skip(-100))
+    assertEquals(-1, r.read())
+  }
+
 }
 
 class BufferedReaderTest {
@@ -242,8 +284,21 @@ class BufferedReaderTest {
     assertEquals(null, r.readLine())
   }
 
+  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+    val r = newReader
+    assertEquals(25, r.skip(100))
+    assertEquals(-1, r.read())
+
+    assertEquals(0, r.skip(100))
+    assertEquals(-1, r.read())
+  }
+
   @Test def should_support_marking(): Unit = {
     assertTrue(newReader.markSupported)
+  }
+
+  @Test def mark_should_throw_with_negative_lookahead(): Unit = {
+    expectThrows(classOf[IllegalArgumentException], newReader.mark(-10))
   }
 }
 
@@ -293,4 +348,19 @@ class InputStreamReaderTest {
     assertEquals(0, streamReader.read(new Array[Char](0)))
   }
 
+  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+    val data = "Lorem ipsum".getBytes()
+    val r = new InputStreamReader(new ByteArrayInputStream(data))
+    assertTrue(r.skip(100) > 0)
+    assertEquals(-1, r.read())
+
+    assertEquals(0, r.skip(100))
+    assertEquals(-1, r.read())
+  }
+
+  @Test def should_throw_IOException_since_mark_is_not_supported(): Unit = {
+    val data = "Lorem ipsum".getBytes()
+    val r = new InputStreamReader(new ByteArrayInputStream(data))
+    expectThrows(classOf[IOException], r.mark(0))
+  }
 }


### PR DESCRIPTION
Motivation: bring everything I need to pursue #3717 on master.
```
$ git checkout -b merge-0.6.x-into-master-july-30
Switched to a new branch 'merge-0.6.x-into-master-july-30'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   5f8ba2a07 (scalajs/0.6.x) Merge pull request #3723 from gzm0/no-new-boxed
|\  
| * c37f7b235 Avoid constructors of primitive boxes
|/  
*   8bd923434 Merge pull request #3716 from sjrd/optimize-array-apply
|\  
| * 9ac9780b6 Allow the Array.apply opt to apply to constant arrays of `j.l.Character`.
| * 054a1fb71 Optimize calls to `Array.apply()` overloads with literal varargs.
|/  
*   7e7051b3c Merge pull request #3719 from sjrd/no-early-nothing-check-in-class-cast
|\  
| * bfda91783 (origin/no-early-nothing-check-in-class-cast) Do not eagerly throw for `Nothing` in `Class.cast()`.
|/  
*   e7d273921 (origin/0.6.x) Merge pull request #3665 from exoego/fix-stringreader-skip
|\  
| * ed5d5f433 Throw when Reader.mark() is given a negative read-ahead limit.
| * 5180897c2 Do not allow negative skips in StringReader.skip(n) when EOF has been reached.
| * cde963b26 Skip n bytes if possible in the default Reader.skip(n).
|/  
* cc8d047da Merge pull request #3718 from sjrd/no-predef-in-javalanglib
* 9d8b86a25 Compile the javalanglib with -Yno-predef.
```
```
$ git merge --no-commit scalajs/0.6.x 
Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging javalanglib/src/main/scala/java/lang/Void.scala
Auto-merging javalanglib/src/main/scala/java/lang/System.scala
Auto-merging javalanglib/src/main/scala/java/lang/Short.scala
Auto-merging javalanglib/src/main/scala/java/lang/Long.scala
Auto-merging javalanglib/src/main/scala/java/lang/Integer.scala
Auto-merging javalanglib/src/main/scala/java/lang/Float.scala
Auto-merging javalanglib/src/main/scala/java/lang/Double.scala
Auto-merging javalanglib/src/main/scala/java/lang/Class.scala
CONFLICT (content): Merge conflict in javalanglib/src/main/scala/java/lang/Class.scala
Auto-merging javalanglib/src/main/scala/java/lang/Character.scala
Auto-merging javalanglib/src/main/scala/java/lang/Byte.scala
Auto-merging javalanglib/src/main/scala/java/lang/Boolean.scala
Auto-merging compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
CONFLICT (content): Merge conflict in compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
Recorded preimage for 'compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala'
Recorded preimage for 'javalanglib/src/main/scala/java/lang/Class.scala'
Recorded preimage for 'project/Build.scala'
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
M  compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
M  javalanglib/src/main/scala/java/lang/Boolean.scala
M  javalanglib/src/main/scala/java/lang/Byte.scala
M  javalanglib/src/main/scala/java/lang/Character.scala
UU javalanglib/src/main/scala/java/lang/Class.scala
M  javalanglib/src/main/scala/java/lang/Double.scala
M  javalanglib/src/main/scala/java/lang/Enum.scala
M  javalanglib/src/main/scala/java/lang/Float.scala
M  javalanglib/src/main/scala/java/lang/Integer.scala
M  javalanglib/src/main/scala/java/lang/Long.scala
M  javalanglib/src/main/scala/java/lang/Math.scala
M  javalanglib/src/main/scala/java/lang/Short.scala
M  javalanglib/src/main/scala/java/lang/System.scala
M  javalanglib/src/main/scala/java/lang/ThreadLocal.scala
M  javalanglib/src/main/scala/java/lang/Void.scala
M  javalanglib/src/main/scala/java/lang/reflect/Array.scala
M  javalib/src/main/scala/java/io/BufferedReader.scala
M  javalib/src/main/scala/java/io/Reader.scala
M  javalib/src/main/scala/java/io/StringReader.scala
UU project/Build.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
```
[...] Fix conflicts and compile errors (notably master-specific errors added by `-Yno-predef` in javalanglib)
```
$ git diff > ../merge.diff
```
[`merge.diff`](https://gist.github.com/sjrd/44aece46bd53937892cd7bca949e2ef6)
```
$ git add -u
```
```
$ git commit
Recorded resolution for 'compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala'.
Recorded resolution for 'javalanglib/src/main/scala/java/lang/Class.scala'.
Recorded resolution for 'project/Build.scala'.
[merge-0.6.x-into-master-july-30 ffdac7b24] Merge '0.6.x' into 'master'.
```
