### PR TITLE
Implement `j.u.c.ConcurrentHashMap` on top of `j.u.HashMap`.

### DIFF
--- a/javalib/src/main/scala/java/util/NullRejectingHashMap.scala
+++ b/javalib/src/main/scala/java/util/NullRejectingHashMap.scala
@@ -1,0 +1,104 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util
+
+/** A subclass of `HashMap` that systematically rejects `null` keys and values.
+ *
+ *  This class is used as the implementation of some other hashtable-like data
+ *  structures that require non-`null` keys and values to correctly implement
+ *  their specifications.
+ */
+private[util] class NullRejectingHashMap[K, V](
+    initialCapacity: Int, loadFactor: Double)
+    extends HashMap[K, V](initialCapacity, loadFactor) {
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this(initialCapacity: Int) =
+    this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
+
+  def this(m: Map[_ <: K, _ <: V]) = {
+    this(m.size())
+    putAll(m)
+  }
+
+  // Use Nodes that will reject `null`s in `setValue()`
+  override private[util] def newNode(key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V]): HashMap.Node[K, V] = {
+    new NullRejectingHashMap.Node(key, hash, value, previous, next)
+  }
+
+  override def get(key: Any): V = {
+    if (key == null)
+      throw new NullPointerException()
+    super.get(key)
+  }
+
+  override def containsKey(key: Any): Boolean = {
+    if (key == null)
+      throw new NullPointerException()
+    super.containsKey(key)
+  }
+
+  override def put(key: K, value: V): V = {
+    if (key == null || value == null)
+      throw new NullPointerException()
+    super.put(key, value)
+  }
+
+  @noinline
+  override def putAll(m: Map[_ <: K, _ <: V]): Unit = {
+    /* The only purpose of `impl` is to capture the wildcards as named types,
+     * so that we prevent type inference from inferring deprecated existential
+     * types.
+     */
+    @inline
+    def impl[K1 <: K, V1 <: V](m: Map[K1, V1]): Unit = {
+      val iter = m.entrySet().iterator()
+      while (iter.hasNext()) {
+        val entry = iter.next()
+        put(entry.getKey(), entry.getValue())
+      }
+    }
+    impl(m)
+  }
+
+  override def remove(key: Any): V = {
+    if (key == null)
+      throw new NullPointerException()
+    super.remove(key)
+  }
+
+  override def containsValue(value: Any): Boolean = {
+    if (value == null)
+      throw new NullPointerException()
+    super.containsValue(value)
+  }
+
+  override def clone(): AnyRef =
+    new NullRejectingHashMap[K, V](this)
+}
+
+private object NullRejectingHashMap {
+  private final class Node[K, V](key: K, hash: Int, value: V,
+      previous: HashMap.Node[K, V], next: HashMap.Node[K, V])
+      extends HashMap.Node[K, V](key, hash, value, previous, next) {
+
+    override def setValue(v: V): V = {
+      if (v == null)
+        throw new NullPointerException()
+      super.setValue(v)
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ConcurrentHashMap.scala
@@ -12,225 +12,227 @@
 
 package java.util.concurrent
 
-import java.lang.{reflect => jlr}
 import java.io.Serializable
 import java.util._
 
-import ScalaOps._
+class ConcurrentHashMap[K, V] private (initialCapacity: Int, loadFactor: Float)
+    extends AbstractMap[K, V] with ConcurrentMap[K, V] with Serializable {
 
-class ConcurrentHashMap[K >: Null, V >: Null]
-    extends AbstractMap[K, V] with ConcurrentMap[K, V] with Serializable { self =>
+  import ConcurrentHashMap._
+
+  def this() =
+    this(HashMap.DEFAULT_INITIAL_CAPACITY, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(initialCapacity: Int) =
-    this()
-
-  def this(initialCapacity: Int, loadFactor: Float) =
-    this()
-
-  def this(initialCapacity: Int, loadFactor: Float, concurrencyLevel: Int) =
-    this()
+    this(initialCapacity, HashMap.DEFAULT_LOAD_FACTOR)
 
   def this(initialMap: java.util.Map[_ <: K, _ <: V]) = {
-    this()
+    this(initialMap.size())
     putAll(initialMap)
   }
 
-  private val inner = new scala.collection.mutable.HashMap[Box[K], V]()
+  def this(initialCapacity: Int, loadFactor: Float, concurrencyLevel: Int) =
+    this(initialCapacity, loadFactor) // ignore concurrencyLevel
 
-  override def isEmpty(): Boolean = inner.isEmpty
+  private[this] val inner: InnerHashMap[K, V] =
+    new InnerHashMap[K, V](initialCapacity, loadFactor)
 
-  override def size(): Int = inner.size
+  override def size(): Int =
+    inner.size()
+
+  override def isEmpty(): Boolean =
+    inner.isEmpty()
 
   override def get(key: Any): V =
-    inner.get(Box(key.asInstanceOf[K])).getOrElse(null)
+    inner.get(key)
 
-  override def containsKey(key: Any): Boolean = {
-    if (key == null)
-      throw new NullPointerException()
-    inner.exists { case (ik, _) => Objects.equals(key, ik()) }
-  }
+  override def containsKey(key: Any): Boolean =
+    inner.containsKey(key)
 
-  override def containsValue(value: Any): Boolean = {
-    if (value == null)
-      throw new NullPointerException()
-    inner.exists { case (_, iv) => Objects.equals(value, iv) }
-  }
+  override def containsValue(value: Any): Boolean =
+    inner.containsValue(value)
 
-  override def put(key: K, value: V): V = {
-    if (key != null && value != null)
-      inner.put(Box(key), value).getOrElse(null)
-    else
-      throw new NullPointerException()
-  }
-
-  def putIfAbsent(key: K, value: V): V = {
-    if (key == null || value == null)
-      throw new NullPointerException()
-
-    val bKey = Box(key)
-    inner.get(bKey).getOrElse {
-      inner.put(bKey, value)
-      null
-    }
-  }
-
-  override def putAll(m: Map[_ <: K, _ <: V]): Unit = {
-    for (e <- m.entrySet().scalaOps)
-      put(e.getKey, e.getValue)
-  }
+  override def put(key: K, value: V): V =
+    inner.put(key, value)
 
   override def remove(key: Any): V =
-    inner.remove(Box(key.asInstanceOf[K])).getOrElse(null)
-
-  override def remove(key: Any, value: Any): Boolean = {
-    val old = inner(Box(key.asInstanceOf[K]))
-    if (Objects.equals(value, old))
-      inner.remove(Box(key.asInstanceOf[K])).isDefined
-    else
-      false
-  }
-
-  override def replace(key: K, oldValue: V, newValue: V): Boolean = {
-    if (key != null && oldValue != null && newValue != null) {
-      val old = inner(Box(key))
-      if (Objects.equals(oldValue, old)) {
-        put(key, newValue)
-        true
-      } else {
-        false
-      }
-    } else {
-      throw new NullPointerException()
-    }
-  }
-
-  override def replace(key: K, value: V): V = {
-    if (key != null && value != null) {
-      if (inner(Box(key)) != null) put(key, value)
-      else null
-    } else {
-      throw new NullPointerException()
-    }
-  }
+    inner.remove(key)
 
   override def clear(): Unit =
     inner.clear()
 
   override def keySet(): ConcurrentHashMap.KeySetView[K, V] =
-    new ConcurrentHashMap.KeySetView[K, V](this)
+    new ConcurrentHashMap.KeySetView[K, V](inner.keySet())
 
-  def entrySet(): Set[Map.Entry[K, V]] = {
-    new AbstractSet[Map.Entry[K, V]] {
-      override def size(): Int = self.size
+  override def values(): Collection[V] =
+    inner.values()
 
-      def iterator(): Iterator[Map.Entry[K, V]] = {
-        new Iterator[Map.Entry[K, V]] {
-          private val keysCopy = inner.keysIterator
+  override def entrySet(): Set[Map.Entry[K, V]] =
+    inner.entrySet()
 
-          private var lastKey: Box[K] = null
+  override def hashCode(): Int =
+    inner.hashCode()
 
-          def hasNext(): Boolean = keysCopy.hasNext
+  override def toString(): String =
+    inner.toString()
 
-          def next(): Map.Entry[K, V] = {
-            val k = keysCopy.next()
-            val v = inner(k)
-            lastKey = k
-            new AbstractMap.SimpleImmutableEntry(k(), v)
-          }
+  override def equals(o: Any): Boolean =
+    inner.equals(o)
 
-          def remove(): Unit = {
-            if (lastKey != null) {
-              inner.remove(lastKey)
-              lastKey = null
-            } else {
-              throw new IllegalStateException()
-            }
-          }
-        }
+  def putIfAbsent(key: K, value: V): V = {
+    if (value == null)
+      throw new NullPointerException()
+    val old = inner.get(key) // throws if `key` is null
+    if (old == null)
+      inner.put(key, value)
+    old
+  }
+
+  def remove(key: Any, value: Any): Boolean = {
+    if (value == null)
+      throw new NullPointerException()
+    val old = inner.get(key) // throws if `key` is null
+    if (value.equals(old)) { // false if `old` is null
+      inner.remove(key)
+      true
+    } else {
+      false
+    }
+  }
+
+  override def replace(key: K, oldValue: V, newValue: V): Boolean = {
+    if (oldValue == null || newValue == null)
+      throw new NullPointerException()
+    val old = inner.get(key) // throws if `key` is null
+    if (oldValue.equals(old)) { // false if `old` is null
+      inner.put(key, newValue)
+      true
+    } else {
+      false
+    }
+  }
+
+  override def replace(key: K, value: V): V = {
+    if (value == null)
+      throw new NullPointerException()
+    val old = inner.get(key) // throws if `key` is null
+    if (old != null)
+      inner.put(key, value)
+    old
+  }
+
+  def contains(value: Any): Boolean =
+    containsValue(value)
+
+  def keys(): Enumeration[K] =
+    Collections.enumeration(inner.keySet())
+
+  def elements(): Enumeration[V] =
+    Collections.enumeration(values())
+}
+
+object ConcurrentHashMap {
+  import HashMap.Node
+
+  /** Inner HashMap that contains the real implementation of a
+   *  ConcurrentHashMap.
+   *
+   *  It is a null-rejecting hash map because some algorithms rely on the fact
+   *  that `get(key) == null` means the key was not in the map.
+   *
+   *  It also has snapshotting iterators to make sure they are *weakly
+   *  consistent*.
+   */
+  private final class InnerHashMap[K, V](initialCapacity: Int, loadFactor: Float)
+      extends NullRejectingHashMap[K, V](initialCapacity, loadFactor) {
+
+    override private[util] def nodeIterator(): Iterator[HashMap.Node[K, V]] =
+      new NodeIterator
+
+    override private[util] def keyIterator(): Iterator[K] =
+      new KeyIterator
+
+    override private[util] def valueIterator(): Iterator[V] =
+      new ValueIterator
+
+    private def makeSnapshot(): ArrayList[Node[K, V]] = {
+      val snapshot = new ArrayList[Node[K, V]](size())
+      val iter = super.nodeIterator()
+      while (iter.hasNext())
+        snapshot.add(iter.next())
+      snapshot
+    }
+
+    private final class NodeIterator extends AbstractCHMIterator[Node[K, V]] {
+      protected[this] def extract(node: Node[K, V]): Node[K, V] = node
+    }
+
+    private final class KeyIterator extends AbstractCHMIterator[K] {
+      protected[this] def extract(node: Node[K, V]): K = node.key
+    }
+
+    private final class ValueIterator extends AbstractCHMIterator[V] {
+      protected[this] def extract(node: Node[K, V]): V = node.value
+    }
+
+    private abstract class AbstractCHMIterator[A] extends Iterator[A] {
+      private[this] val innerIter = makeSnapshot().iterator()
+      private[this] var lastNode: Node[K, V] = _ // null
+
+      protected[this] def extract(node: Node[K, V]): A
+
+      def hasNext(): Boolean =
+        innerIter.hasNext()
+
+      def next(): A = {
+        val node = innerIter.next()
+        lastNode = node
+        extract(node)
+      }
+
+      def remove(): Unit = {
+        val last = lastNode
+        if (last eq null)
+          throw new IllegalStateException("next must be called at least once before remove")
+        removeNode(last)
+        lastNode = null
       }
     }
   }
 
-  def keys(): Enumeration[K] =
-    inner.keys.iterator.map(_.inner).asJavaEnumeration
+  /* `KeySetView` is a public class in the JDK API. The result of
+   * `ConcurrentHashMap.keySet()` must be statically typed as a `KeySetView`,
+   * hence the existence of this class, although it forwards all its operations
+   * to the inner key set.
+   */
+  class KeySetView[K, V] private[ConcurrentHashMap] (inner: Set[K])
+      extends Set[K] with Serializable {
 
-  def elements(): Enumeration[V] =
-    inner.values.iterator.asJavaEnumeration
-}
+    def contains(o: Any): Boolean = inner.contains(o)
 
-object ConcurrentHashMap {
+    def remove(o: Any): Boolean = inner.remove(o)
 
-  class KeySetView[K >: Null, V >: Null] private[ConcurrentHashMap] (
-      chm: ConcurrentHashMap[K, V]) extends Set[K] with Serializable {
+    def iterator(): Iterator[K] = inner.iterator()
 
-    def size(): Int = chm.size
+    def size(): Int = inner.size()
 
-    def isEmpty(): Boolean = chm.isEmpty
+    def isEmpty(): Boolean = inner.isEmpty()
 
-    def contains(o: Any): Boolean = chm.containsKey(o)
+    def toArray(): Array[AnyRef] = inner.toArray()
 
-    def iterator(): Iterator[K] = {
-      new Iterator[K] {
-        val iter = chm.entrySet.iterator()
+    def toArray[T <: AnyRef](a: Array[T]): Array[T] = inner.toArray[T](a)
 
-        def hasNext(): Boolean = iter.hasNext()
+    def add(e: K): Boolean = inner.add(e)
 
-        def next(): K = iter.next().getKey()
+    def containsAll(c: Collection[_]): Boolean = inner.containsAll(c)
 
-        def remove(): Unit = iter.remove()
-      }
-    }
+    def addAll(c: Collection[_ <: K]): Boolean = inner.addAll(c)
 
-    def toArray(): Array[AnyRef] = {
-      val result = new Array[AnyRef](size())
-      for (keyAndIdx <- iterator().scalaOps.zipWithIndex.scalaOps)
-        result(keyAndIdx._2) = keyAndIdx._1.asInstanceOf[AnyRef]
-      result
-    }
+    def removeAll(c: Collection[_]): Boolean = inner.removeAll(c)
 
-    def toArray[T <: AnyRef](a: Array[T]): Array[T] = {
-      val toFill: Array[T] =
-        if (a.size >= size) a
-        else jlr.Array.newInstance(a.getClass.getComponentType, size).asInstanceOf[Array[T]]
+    def retainAll(c: Collection[_]): Boolean = inner.retainAll(c)
 
-      val iter = iterator
-      for (i <- 0 until size)
-        toFill(i) = iter.next().asInstanceOf[T]
-      if (toFill.size > size)
-        toFill(size) = null.asInstanceOf[T]
-      toFill
-    }
-
-    def add(e: K): Boolean =
-      throw new UnsupportedOperationException()
-
-    def remove(o: Any): Boolean = chm.remove(o) != null
-
-    def containsAll(c: Collection[_]): Boolean =
-      c.scalaOps.forall(item => chm.containsKey(item.asInstanceOf[K]))
-
-    def addAll(c: Collection[_ <: K]): Boolean =
-      throw new UnsupportedOperationException()
-
-    def removeAll(c: Collection[_]): Boolean =
-      removeWhere(c.contains(_))
-
-    def retainAll(c: Collection[_]): Boolean =
-      removeWhere(!c.contains(_))
-
-    def clear(): Unit = chm.clear()
-
-    private def removeWhere(p: Any => Boolean): Boolean = {
-      val iter = chm.entrySet.iterator
-      var changed = false
-      while (iter.hasNext) {
-        if (p(iter.next().getKey())) {
-          iter.remove()
-          changed = true
-        }
-      }
-      changed
-    }
+    def clear(): Unit = inner.clear()
   }
 
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
@@ -14,9 +14,11 @@ package org.scalajs.testsuite.javalib.util.concurrent
 
 import scala.language.implicitConversions
 
+import scala.collection.mutable
 import scala.reflect.ClassTag
 
 import java.{util => ju}
+import java.util.concurrent.{ConcurrentHashMap => CHM}
 
 import org.junit.Assert._
 import org.junit.Test
@@ -66,6 +68,163 @@ class ConcurrentHashMapTest extends MapTest {
     assertEquals("def", chm.putIfAbsent("abc", "ghi"))
     assertEquals("456", chm.putIfAbsent("123", "789"))
     assertEquals("def", chm.putIfAbsent("abc", "jkl"))
+  }
+
+  @Test def testIteratorsAreWeaklyConsistent(): Unit = {
+    /* The Javadoc says the following about weakly consistent iterators:
+     * > they are guaranteed to traverse elements as they existed upon
+     * > construction exactly once, and may (but are not guaranteed to) reflect
+     * > any modifications subsequent to construction.
+     *
+     * The two subsentences seem to be contradictory, notably in terms of
+     * removal. Experimentation shows that iterators *can* reflect removals
+     * subsequent to construction.
+     *
+     * Therefore, we interpreted that the only actual guarantees are the
+     * following:
+     *
+     * - If a key existed when the iterator was created, and it is not removed,
+     *   then eventually the iterator will yield it.
+     * - An iterator never yields the same key twice.
+     * - If an iterator yields a given key, then the associated value can be
+     *   any value associated with the key at some point since the iterator was
+     *   created (but not another, arbitrary value).
+     *
+     * This test aims at testing those guarantees, and only those guarantees,
+     * using random schedulings of concurrent `put` and `remove` operations
+     * while the iterator is used.
+     */
+
+    // Creates a new map with the state before creating the iterator
+    def createInitialMap(): CHM[String, String] = {
+      val m = factory.empty[String, String]
+      m.put("initial", "init")
+      m.put("there forever", "always")
+      m.put("mutated", "first value")
+      for (i <- 0 until 30)
+        m.put(i.toString(), s"value $i")
+      m
+    }
+
+    /* A list of operations that will randomly scheduled concurrently with the
+     * iteration.
+     */
+    val concurrentOperations = List[CHM[String, String] => Unit](
+        _.put("foo", "bar"),
+        _.put("babar", "baz"),
+        _.put("babar", "bazbaz"),
+        _.put("hello", "world"),
+        _.put("mutated", "second value"),
+        _.remove("initial"),
+        _.remove("hello")
+    )
+
+    // Per key, the set of values that we can possibly observe
+    val possibleValuesFor: Map[String, Set[String]] = {
+      Map(
+          "initial" -> Set("init"),
+          "there forever" -> Set("always"),
+          "mutated" -> Set("first value", "second value"),
+          "foo" -> Set("bar"),
+          "babar" -> Set("baz", "bazbaz"),
+          "hello" -> Set("world")
+      ) ++ (0 until 30).map(i => i.toString() -> Set(s"value $i"))
+    }
+
+    // The set of all the values that we can possibly observe (for values())
+    val allPossibleValues: Set[String] = possibleValuesFor.flatMap(_._2).toSet
+
+    /* The list of keys that we *must* observe at some point, because they
+     * exist before the iterator is created, and they are never removed.
+     */
+    val mandatoryKeys: List[String] =
+      List("there forever", "mutated") ++ (0 until 30).map(_.toString())
+
+    /* The list of values that we *must* observe at some point, because they
+     * are uniquely associated with a key that we must observe at some point.
+     */
+    val mandatoryValues: List[String] =
+      mandatoryKeys.map(possibleValuesFor(_)).filter(_.size == 1).map(_.head)
+
+    // The initial seed was generated at random
+    val topLevelRandom = new java.util.Random(2972838770879131323L)
+
+    // Test 30 different interleavings for entrySet()
+    for (_ <- 0 until 30) {
+      val random = new scala.util.Random(topLevelRandom.nextLong())
+      var shuffledOps = random.shuffle(concurrentOperations)
+      val m = createInitialMap()
+      val encounteredKeys = mutable.Set.empty[String]
+      val entryIter = m.entrySet().iterator()
+
+      while (entryIter.hasNext()) {
+        // Schedule 0-to-many concurrent operations before the next call to next()
+        while (shuffledOps.nonEmpty && random.nextBoolean()) {
+          shuffledOps.head(m)
+          shuffledOps = shuffledOps.tail
+        }
+
+        val entry = entryIter.next()
+        val key = entry.getKey()
+        val value = entry.getValue()
+        assertTrue(s"duplicate iteration of key '$key'", encounteredKeys.add(key))
+        assertTrue(s"unexpected key '$key'", possibleValuesFor.contains(key))
+        assertTrue(s"unexpected value '$value' for key '$key'",
+            possibleValuesFor(key).contains(value))
+      }
+
+      for (key <- mandatoryKeys)
+        assertTrue(s"missing key '$key'", encounteredKeys.contains(key))
+    }
+
+    // Test 30 different interleavings for keySet()
+    for (_ <- 0 until 30) {
+      val random = new scala.util.Random(topLevelRandom.nextLong())
+      var shuffledOps = random.shuffle(concurrentOperations)
+      val m = createInitialMap()
+      val encounteredKeys = mutable.Set.empty[String]
+      val keyIter = m.keySet().iterator()
+
+      while (keyIter.hasNext()) {
+        // Schedule 0-to-many concurrent operations before the next call to next()
+        while (shuffledOps.nonEmpty && random.nextBoolean()) {
+          shuffledOps.head(m)
+          shuffledOps = shuffledOps.tail
+        }
+
+        val key = keyIter.next()
+        assertTrue(s"duplicate iteration of key '$key'", encounteredKeys.add(key))
+        assertTrue(s"unexpected key '$key'", possibleValuesFor.contains(key))
+      }
+
+      for (key <- mandatoryKeys)
+        assertTrue(s"missing key '$key'", encounteredKeys.contains(key))
+    }
+
+    // Test 30 different interleavings for values()
+    for (_ <- 0 until 30) {
+      val random = new scala.util.Random(topLevelRandom.nextLong())
+      var shuffledOps = random.shuffle(concurrentOperations)
+      val m = createInitialMap()
+      val encounteredValues = mutable.Set.empty[String]
+      val valueIter = m.values().iterator()
+
+      while (valueIter.hasNext()) {
+        // Schedule 0-to-many concurrent operations before the next call to next()
+        while (shuffledOps.nonEmpty && random.nextBoolean()) {
+          shuffledOps.head(m)
+          shuffledOps = shuffledOps.tail
+        }
+
+        val value = valueIter.next()
+        encounteredValues.add(value)
+        assertTrue(s"unexpected value '$value'",
+            allPossibleValues.contains(value))
+      }
+
+      for (value <- mandatoryValues)
+        assertTrue(s"missing value '$value'", encounteredValues.contains(value))
+    }
   }
 }
 


### PR DESCRIPTION
This allows to get rid of the dependency on `s.c.m.HashMap`, and leverages the many recent improvements to `j.u.HashMap`.