### PR TITLE
Implement `java.util.PriorityQueue` from scratch.

### DIFF
--- a/javalib/src/main/scala/java/util/NaturalComparator.scala
+++ b/javalib/src/main/scala/java/util/NaturalComparator.scala
@@ -1,0 +1,47 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util
+
+/** A universal `Comparator` using the *natural ordering* of the elements.
+ *
+ *  A number of JDK APIs accept a possibly-null `Comparator`, and use the
+ *  *natural ordering* of elements when it is `null`. This universal comparator
+ *  can be used internally instead of systematically testing for `null`,
+ *  simplifying code paths.
+ *
+ *  The `compare()` method of this comparator throws `ClassCastException`s when
+ *  used with values that cannot be compared using natural ordering, assuming
+ *  Scala.js is configured with compliant `asInstanceOf`s. The behavior is
+ *  otherwise undefined.
+ */
+private[util] object NaturalComparator extends Comparator[Any] {
+  def compare(o1: Any, o2: Any): Int =
+    o1.asInstanceOf[Comparable[Any]].compareTo(o2)
+
+  /** Selects the given comparator if it is non-null, otherwise the natural
+   *  comparator.
+   */
+  def select[A](comparator: Comparator[A]): Comparator[_ >: A] =
+    if (comparator eq null) this
+    else comparator
+
+  /** Unselects the given comparator, returning `null` if it was the natural
+   *  comparator.
+   *
+   *  This method is useful to re-expose to a public API an internal comparator
+   *  that was obtained with `select()`.
+   */
+  def unselect[A](comparator: Comparator[A]): Comparator[A] =
+    if (comparator eq this) null
+    else comparator
+}

--- a/javalib/src/main/scala/java/util/PriorityQueue.scala
+++ b/javalib/src/main/scala/java/util/PriorityQueue.scala
@@ -12,136 +12,289 @@
 
 package java.util
 
-import java.lang.Comparable
-import scala.math.Ordering
-import scala.collection.mutable
 import scala.annotation.tailrec
-import scala.language.existentials
 
-class PriorityQueue[E] protected (ordering: Ordering[_ >: E], _comparator: Comparator[_ >: E])
-    extends AbstractQueue[E] with Serializable { self =>
+import scala.scalajs.js
+
+class PriorityQueue[E] private (
+    private val comp: Comparator[_ >: E], internal: Boolean)
+    extends AbstractQueue[E] with Serializable {
+
+  def this() =
+    this(NaturalComparator, internal = true)
 
   def this(initialCapacity: Int) = {
-    this(defaultOrdering[E], null.asInstanceOf[Comparator[_ >: E]])
+    this()
     if (initialCapacity < 1)
       throw new IllegalArgumentException()
   }
 
-  def this() =
-    this(11)
+  def this(comparator: Comparator[_ >: E]) = {
+    this(NaturalComparator.select(comparator), internal = true)
+  }
 
   def this(initialCapacity: Int, comparator: Comparator[_ >: E]) = {
-    this(PriorityQueue.safeGetOrdering[E](comparator), null.asInstanceOf[Comparator[E]])
+    this(comparator)
     if (initialCapacity < 1)
       throw new IllegalArgumentException()
   }
 
   def this(c: Collection[_ <: E]) = {
-    this(defaultOrdering[E], null.asInstanceOf[Comparator[E]])
+    this(c match {
+      case c: PriorityQueue[_] =>
+        c.comp.asInstanceOf[Comparator[_ >: E]]
+      case c: SortedSet[_] =>
+        NaturalComparator.select(c.comparator().asInstanceOf[Comparator[_ >: E]])
+      case _ =>
+        NaturalComparator
+    }, internal = true)
     addAll(c)
   }
 
   def this(c: PriorityQueue[_ <: E]) = {
-    this(PriorityQueue.safeGetOrdering[E](c.comparator()),
-        c.comparator().asInstanceOf[Comparator[E]])
+    this(c.comp.asInstanceOf[Comparator[_ >: E]], internal = true)
     addAll(c)
   }
 
   def this(sortedSet: SortedSet[_ <: E]) = {
-    this(PriorityQueue.safeGetOrdering[E](sortedSet.comparator()),
-        sortedSet.comparator().asInstanceOf[Comparator[E]])
+    this(NaturalComparator.select(
+        sortedSet.comparator().asInstanceOf[Comparator[_ >: E]]),
+        internal = true)
     addAll(sortedSet)
   }
 
-  private implicit object BoxOrdering extends Ordering[Box[E]] {
-    def compare(a: Box[E], b:Box[E]): Int = ordering.compare(b.inner, a.inner)
-  }
-
-  private val inner: mutable.PriorityQueue[Box[E]] = new mutable.PriorityQueue[Box[E]]()
+  // The index 0 is not used; the root is at index 1.
+  // This is standard practice in binary heaps, to simplify arithmetics.
+  private[this] val inner = js.Array[E](null.asInstanceOf[E])
 
   override def add(e: E): Boolean = {
-    if (e == null) throw new NullPointerException()
-    else {
-      inner += Box(e)
-      true
-    }
+    if (e == null)
+      throw new NullPointerException()
+    inner.push(e)
+    fixUp(inner.length - 1)
+    true
   }
 
   def offer(e: E): Boolean = add(e)
 
   def peek(): E =
-    inner.headOption.fold(null.asInstanceOf[E])(_.inner)
+    if (inner.length > 1) inner(1)
+    else null.asInstanceOf[E]
 
   override def remove(o: Any): Boolean = {
-    val boxed = Box(o.asInstanceOf[E])
-    val initialSize = inner.size
+    if (o == null) {
+      false
+    } else {
+      val len = inner.length
+      var i = 1
+      while (i != len && !o.equals(inner(i))) {
+        i += 1
+      }
 
-    @tailrec
-    def takeLeft(part: mutable.PriorityQueue[Box[E]]): mutable.PriorityQueue[Box[E]] = {
-      if (inner.isEmpty) part
-      else {
-        val next = inner.dequeue
-        if (boxed == next) part
-        else if (BoxOrdering.compare(boxed, next) > 0)
-          part += next
-        else takeLeft(part += next)
+      if (i != len) {
+        removeAt(i)
+        true
+      } else {
+        false
       }
     }
-
-    val left = takeLeft(new mutable.PriorityQueue[Box[E]]())
-    inner ++= left
-
-    (inner.size != initialSize)
   }
 
-  override def contains(o: Any): Boolean =
-    inner.exists(box => Objects.equals(o, box.inner))
+  private def removeExact(o: Any): Unit = {
+    val len = inner.length
+    var i = 1
+
+    /* This is tricky. We must use reference equality to find the exact object
+     * to remove, but if `o` is a positive or negative 0.0 or NaN, we must use
+     * `equals` to delete the correct element (i.e., not confuse +0.0 and -0.0,
+     * and considering `NaN` equal to itself).
+     */
+    o match {
+      case o: Double if o == 0.0 || java.lang.Double.isNaN(o) =>
+        while (i != len && !o.equals(inner(i))) {
+          i += 1
+        }
+      case _ =>
+        while (i != len && (o.asInstanceOf[AnyRef] ne inner(i).asInstanceOf[AnyRef])) {
+          i += 1
+        }
+    }
+
+    if (i == len)
+      throw new ConcurrentModificationException()
+    removeAt(i)
+  }
+
+  private def removeAt(i: Int): Unit = {
+    val newLength = inner.length - 1
+    if (i == newLength) {
+      inner.length = newLength
+    } else {
+      inner(i) = inner(newLength)
+      inner.length = newLength
+      fixUpOrDown(i)
+    }
+  }
+
+  override def contains(o: Any): Boolean = {
+    if (o == null) {
+      false
+    } else {
+      val len = inner.length
+      var i = 1
+      while (i != len && !o.equals(inner(i))) {
+        i += 1
+      }
+      i != len
+    }
+  }
 
   def iterator(): Iterator[E] = {
     new Iterator[E] {
-      private val iter = inner.clone.iterator
+      private[this] var inner: js.Array[E] = PriorityQueue.this.inner
+      private[this] var nextIdx: Int = 1
+      private[this] var last: E = _ // null
 
-      private var last: Option[E] = None
-
-      def hasNext(): Boolean = iter.hasNext
+      def hasNext(): Boolean = nextIdx < inner.length
 
       def next(): E = {
-        last = Some(iter.next().inner)
-        last.get
+        if (!hasNext())
+          throw new NoSuchElementException("empty iterator")
+        last = inner(nextIdx)
+        nextIdx += 1
+        last
       }
 
       def remove(): Unit = {
-        if (last.isEmpty) {
+        /* Once we start removing elements, the inner array of the enclosing
+         * PriorityQueue will be modified in arbitrary ways. In particular,
+         * entries yet to be iterated can be moved before `nextIdx` if the
+         * removal requires a `fixUp()`.
+         *
+         * Therefore, at the first removal, we take a snapshot of the remainder
+         * of the inner array yet to be iterated, and continue iterating over
+         * the snapshot.
+         *
+         * We use a linear lookup based on reference equality to precisely
+         * remove the entries that we are still iterating over (in
+         * `removeExact()`).
+         *
+         * This means that this method is O(n), contrary to typical
+         * expectations for `Iterator.remove()`. I could not come up with a
+         * better algorithm.
+         */
+
+        if (last == null)
           throw new IllegalStateException()
-        } else {
-          last.foreach(self.remove(_))
-          last = None
+        if (inner eq PriorityQueue.this.inner) {
+          inner = inner.jsSlice(nextIdx)
+          nextIdx = 0
         }
+        removeExact(last)
+        last = null.asInstanceOf[E]
       }
     }
   }
 
-  def size(): Int = inner.size
+  def size(): Int = inner.length - 1
 
   override def clear(): Unit =
-    inner.dequeueAll
+    inner.length = 1
 
-  def poll(): E =
-    if (inner.isEmpty) null.asInstanceOf[E]
-    else inner.dequeue().inner
-
-  def comparator(): Comparator[_ >: E] = _comparator
-}
-
-object PriorityQueue {
-
-  def safeGetOrdering[E](_comp: => Comparator[_]): Ordering[E] = {
-    val comp: Comparator[_] = _comp
-    val ord =
-      if (comp == null) defaultOrdering[E]
-      else Ordering.comparatorToOrdering(comp)
-
-    ord.asInstanceOf[Ordering[E]]
+  def poll(): E = {
+    val inner = this.inner // local copy
+    if (inner.length > 1) {
+      val newSize = inner.length - 1
+      val result = inner(1)
+      inner(1) = inner(newSize)
+      inner.length = newSize
+      fixDown(1)
+      result
+    } else {
+      null.asInstanceOf[E]
+    }
   }
 
+  def comparator(): Comparator[_ >: E] =
+    NaturalComparator.unselect(comp)
+
+  // Heavy lifting: heap fixup
+
+  /** Fixes the heap property around the child at index `m`, either up the
+   *  tree or down the tree, depending on which side is found to violate the
+   *  heap property.
+   */
+  private[this] def fixUpOrDown(m: Int): Unit = {
+    val inner = this.inner // local copy
+    if (m > 1 && comp.compare(inner(m >> 1), inner(m)) > 0)
+      fixUp(m)
+    else
+      fixDown(m)
+  }
+
+  /** Fixes the heap property from the child at index `m` up the tree, towards
+   *  the root.
+   */
+  private[this] def fixUp(m: Int): Unit = {
+    val inner = this.inner // local copy
+
+    /* At each step, even though `m` changes, the element moves with it, and
+     * hence inner(m) is always the same initial `innerAtM`.
+     */
+    val innerAtM = inner(m)
+
+    @inline @tailrec
+    def loop(m: Int): Unit = {
+      if (m > 1) {
+        val parent = m >> 1
+        val innerAtParent = inner(parent)
+        if (comp.compare(innerAtParent, innerAtM) > 0) {
+          inner(parent) = innerAtM
+          inner(m) = innerAtParent
+          loop(parent)
+        }
+      }
+    }
+
+    loop(m)
+  }
+
+  /** Fixes the heap property from the child at index `m` down the tree,
+   *  towards the leaves.
+   */
+  private[this] def fixDown(m: Int): Unit = {
+    val inner = this.inner // local copy
+    val size = inner.length - 1
+
+    /* At each step, even though `m` changes, the element moves with it, and
+     * hence inner(m) is always the same initial `innerAtM`.
+     */
+    val innerAtM = inner(m)
+
+    @inline @tailrec
+    def loop(m: Int): Unit = {
+      var j = 2 * m // left child of `m`
+      if (j <= size) {
+        var innerAtJ = inner(j)
+
+        // if the left child is greater than the right child, switch to the right child
+        if (j < size) {
+          val innerAtJPlus1 = inner(j + 1)
+          if (comp.compare(innerAtJ, innerAtJPlus1) > 0) {
+            j += 1
+            innerAtJ = innerAtJPlus1
+          }
+        }
+
+        // if the node `m` is greater than the selected child, swap and recurse
+        if (comp.compare(innerAtM, innerAtJ) > 0) {
+          inner(m) = innerAtJ
+          inner(j) = innerAtM
+          loop(j)
+        }
+      }
+    }
+
+    loop(m)
+  }
 }


### PR DESCRIPTION
~~Based on #3734. Only the last commit belongs to this PR.~~

Previously, it was implemented on top of `s.c.m.PriorityQueue`. Unlike other collections implemented on top of Scala collections, `PriorityQueue` had no serious hacks. It did have overhead in terms of allocations of `Box`es, though.

The new implementation, done from scratch, does not box elements, and offers direct support for all the methods of the JDK API.

The test suite of `PriorityQueue` is enhanced in the process. Notably, it includes all the standard tests for `Collection`s in `CollectionTest`.