### PR TITLE
Enhance the test suite for `java.util.Map`s.

### DIFF
--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -421,6 +421,9 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     def size(): Int =
       self.size()
 
+    override def contains(o: Any): Boolean =
+      containsValue(o)
+
     override def clear(): Unit =
       self.clear()
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -27,19 +27,6 @@ trait CollectionTest {
 
   def factory: CollectionFactory
 
-  def testCollectionApi(): Unit = {
-    shouldStoreStrings()
-    shouldStoreIntegers()
-    shouldStoreDoubles()
-    shouldStoreCustomObjects()
-    shouldRemoveStoredElements()
-    shouldRemoveStoredElementsOnDoubleCornerCases()
-    shouldBeClearedWithOneOperation()
-    shouldCheckContainedPresence()
-    shouldCheckContainedPresenceForDoubleCornerCases()
-    shouldGiveProperIteratorOverElements()
-  }
-
   @Test def shouldStoreStrings(): Unit = {
     val coll = factory.empty[String]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
@@ -25,27 +25,6 @@ trait ListTest extends CollectionTest {
 
   def factory: ListFactory
 
-  def testListApi(): Unit = {
-    testCollectionApi()
-    shouldStoreStrings_List()
-    shouldStoreIntegers_List()
-    shouldStoreDoubles_List()
-    shouldStoreCustomObjects_List()
-    shouldRemoveStoredElements_List()
-    shouldRemoveStoredElementsOnDoubleCornerCases_List()
-    shouldBeClearedWithOneOperation_List()
-    shouldCheckContainedPresence_List()
-    shouldCheckContainedPresenceForDoubleCornerCases_List()
-    shouldGiveAProperSetOperation()
-    shouldGiveProperIteratorOverElements_List()
-    shouldGiveProperListIteratorOverElements()
-    shouldAddElementsAtAGivenIndex()
-    shouldGiveTheFirstIndexOfAnElement()
-    shouldGiveTheFirstOrLastIndexOfAnElementForDoubleCornerCases()
-    shouldGiveASublistBackedUpByTheOriginalList()
-    shouldIterateAndModifyElementsWithAListIteratorIfAllowed()
-  }
-
   @Test def shouldStoreStrings_List(): Unit = {
     val lst = factory.empty[String]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -28,29 +28,6 @@ trait MapTest {
 
   def factory: MapFactory
 
-  def testMapApi(): Unit = {
-    should_store_strings()
-    should_store_integers()
-    should_store_doubles_also_in_corner_cases()
-    should_store_custom_objects()
-    should_remove_stored_elements()
-    should_remove_stored_elements_on_double_corner_cases()
-    should_put_or_fail_on_null_keys()
-    should_put_or_fail_on_null_values()
-    should_be_cleared_with_one_operation()
-    should_check_contained_key_presence()
-    should_check_contained_value_presence()
-    should_give_proper_Collection_over_values()
-    should_give_proper_EntrySet_over_key_values_pairs()
-    should_put_a_whole_map_into()
-    values_should_mirror_the_related_map_size()
-    values_should_check_single_and_multiple_objects_presence()
-    values_should_side_effect_clear_remove_retain_on_the_related_map()
-    keySet_should_mirror_the_related_map_size()
-    keySet_should_check_single_and_multiple_objects_presence()
-    keySet_should_side_effect_clear_remove_retain_on_the_related_map()
-  }
-
   @Test def should_store_strings(): Unit = {
     val mp = factory.empty[String, String]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -20,15 +20,14 @@ import org.junit.Assert._
 import org.scalajs.testsuite.javalib.util.concurrent.ConcurrentMapFactory
 import org.scalajs.testsuite.utils.AssertThrows._
 
-import scala.collection.JavaConverters._
-import scala.collection.{mutable => mu}
 import scala.reflect.ClassTag
 
 trait MapTest {
+  import MapTest._
 
   def factory: MapFactory
 
-  @Test def should_store_strings(): Unit = {
+  @Test def testSizeGetPutWithStrings(): Unit = {
     val mp = factory.empty[String, String]
 
     assertEquals(0, mp.size())
@@ -38,9 +37,18 @@ trait MapTest {
     mp.put("TWO", "two")
     assertEquals(2, mp.size())
     assertEquals("two", mp.get("TWO"))
+    mp.put("ONE", "three")
+    assertEquals(2, mp.size())
+    assertEquals("three", mp.get("ONE"))
+
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get(TestObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
   }
 
-  @Test def should_store_strings_large_map(): Unit = {
+  @Test def testSizeGetPutWithStringsLargeMap(): Unit = {
     val largeMap = factory.empty[String, Int]
     for (i <- 0 until 1000)
       largeMap.put(i.toString(), i)
@@ -49,18 +57,35 @@ trait MapTest {
     for (i <- (1000 - expectedSize) until 1000)
       assertEquals(i, largeMap.get(i.toString()))
     assertNull(largeMap.get("1000"))
+
+    assertEquals(null, largeMap.get("THREE"))
+    assertEquals(null, largeMap.get(42))
+    assertEquals(null, largeMap.get(TestObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, largeMap.get(null))
   }
 
-  @Test def should_store_integers(): Unit = {
+  @Test def testSizeGetPutWithInts(): Unit = {
     val mp = factory.empty[Int, Int]
 
     mp.put(100, 12345)
     assertEquals(1, mp.size())
-    val one = mp.get(100)
-    assertEquals(12345, one)
+    assertEquals(12345, mp.get(100))
+    mp.put(150, 54321)
+    assertEquals(2, mp.size())
+    assertEquals(54321, mp.get(150))
+    mp.put(100, 3)
+    assertEquals(2, mp.size())
+    assertEquals(3, mp.get(100))
+
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(TestObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
   }
 
-  @Test def should_store_integers_large_map(): Unit = {
+  @Test def testSizeGetPutWithIntsLargeMap(): Unit = {
     val largeMap = factory.empty[Int, Int]
     for (i <- 0 until 1000)
       largeMap.put(i, i * 2)
@@ -69,9 +94,52 @@ trait MapTest {
     for (i <- (1000 - expectedSize) until 1000)
       assertEquals(i * 2, largeMap.get(i))
     assertNull(largeMap.get(1000))
+
+    assertEquals(null, largeMap.get(-42))
+    assertEquals(null, largeMap.get("THREE"))
+    assertEquals(null, largeMap.get(TestObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, largeMap.get(null))
   }
 
-  @Test def should_store_doubles_also_in_corner_cases(): Unit = {
+  @Test def testSizeGetPutWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+
+    mp.put(TestObj(100), TestObj(12345))
+    assertEquals(1, mp.size())
+    assertEquals(12345, mp.get(TestObj(100)).num)
+    mp.put(TestObj(150), TestObj(54321))
+    assertEquals(2, mp.size())
+    assertEquals(54321, mp.get(TestObj(150)).num)
+    mp.put(TestObj(100), TestObj(3))
+    assertEquals(2, mp.size())
+    assertEquals(3, mp.get(TestObj(100)).num)
+
+    assertEquals(null, mp.get("THREE"))
+    assertEquals(null, mp.get(42))
+    assertEquals(null, mp.get(TestObj(42)))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, mp.get(null))
+  }
+
+  @Test def testSizeGetPutWithCustomObjectsLargeMap(): Unit = {
+    val largeMap = factory.empty[TestObj, Int]
+    for (i <- 0 until 1000)
+      largeMap.put(TestObj(i), i * 2)
+    val expectedSize = factory.withSizeLimit.fold(1000)(Math.min(_, 1000))
+    assertEquals(expectedSize, largeMap.size())
+    for (i <- (1000 - expectedSize) until 1000)
+      assertEquals(i * 2, largeMap.get(TestObj(i)))
+    assertNull(largeMap.get(1000))
+
+    assertEquals(null, largeMap.get(TestObj(-42)))
+    assertEquals(null, largeMap.get("THREE"))
+    assertEquals(null, largeMap.get(42))
+    if (factory.allowsNullKeysQueries)
+      assertEquals(null, largeMap.get(null))
+  }
+
+  @Test def testSizeGetPutWithDoublesCornerCasesOfEquals(): Unit = {
     val mp = factory.empty[Double, Double]
 
     mp.put(1.2345, 11111.0)
@@ -95,28 +163,61 @@ trait MapTest {
     assertEquals(44444.0, four, 0.0)
   }
 
-  @Test def should_store_custom_objects(): Unit = {
-    case class TestObj(num: Int)
-
-    val mp = factory.empty[TestObj, TestObj]
-
-    mp.put(TestObj(100), TestObj(12345))
-    assertEquals(1, mp.size())
-    val one = mp.get(TestObj(100))
-    assertEquals(12345, one.num)
-  }
-
-  @Test def should_remove_stored_elements(): Unit = {
+  @Test def testRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
-    assertEquals(1, mp.size())
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+    assertEquals(31, mp.size())
     assertEquals("one", mp.remove("ONE"))
-    val newOne = mp.get("ONE")
     assertNull(mp.get("ONE"))
+    assertNull(mp.remove("ONE"))
+
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    assertNull(mp.remove(TestObj(42)))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
   }
 
-  @Test def should_remove_stored_elements_on_double_corner_cases(): Unit = {
+  @Test def testRemoveWithInts(): Unit = {
+    val mp = factory.empty[Int, String]
+
+    mp.put(543, "one")
+    for (i <- 0 until 30)
+      mp.put(i, s"value $i")
+    assertEquals(31, mp.size())
+    assertEquals("one", mp.remove(543))
+    assertNull(mp.get(543))
+    assertNull(mp.remove(543))
+
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    assertNull(mp.remove(TestObj(42)))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
+  }
+
+  @Test def testRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, String]
+
+    mp.put(TestObj(543), "one")
+    for (i <- 0 until 30)
+      mp.put(TestObj(i), s"value $i")
+    assertEquals(31, mp.size())
+    assertEquals("one", mp.remove(TestObj(543)))
+    assertNull(mp.get(TestObj(543)))
+    assertNull(mp.remove(TestObj(543)))
+
+    assertNull(mp.remove(TestObj(42)))
+    assertNull(mp.remove("foobar"))
+    assertNull(mp.remove(42))
+    if (factory.allowsNullKeys)
+      assertNull(mp.remove(null))
+  }
+
+  @Test def testRemoveWithDoublesCornerCasesOfEquals(): Unit = {
     val mp = factory.empty[Double, String]
 
     mp.put(1.2345, "11111.0")
@@ -149,29 +250,41 @@ trait MapTest {
     assertTrue(mp.isEmpty)
   }
 
-  @Test def should_put_or_fail_on_null_keys(): Unit = {
+  @Test def testGetPutRemoveNullKeys(): Unit = {
+    val mp = factory.empty[String, String]
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+
     if (factory.allowsNullKeys) {
-      val mp = factory.empty[String, String]
       mp.put(null, "one")
+      assertEquals(31, mp.size())
       assertEquals("one", mp.get(null))
+      assertEquals("one", mp.remove(null))
+      assertNull(mp.get(null))
+      assertNull(mp.remove(null))
     } else {
-      val mp = factory.empty[String, String]
       expectThrows(classOf[NullPointerException], mp.put(null, "one"))
     }
   }
 
-  @Test def should_put_or_fail_on_null_values(): Unit = {
+  @Test def testGetPutRemoveNullValues(): Unit = {
+    val mp = factory.empty[String, String]
+    for (i <- 0 until 30)
+      mp.put(s"key $i", s"value $i")
+
     if (factory.allowsNullValues) {
-      val mp = factory.empty[String, String]
       mp.put("one", null)
+      assertEquals(31, mp.size())
+      assertNull(mp.get("one"))
+      assertNull(mp.remove("one"))
+      assertEquals(30, mp.size())
       assertNull(mp.get("one"))
     } else {
-      val mp = factory.empty[String, String]
       expectThrows(classOf[NullPointerException], mp.put("one", null))
     }
   }
 
-  @Test def should_be_cleared_with_one_operation(): Unit = {
+  @Test def testClear(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
@@ -179,9 +292,17 @@ trait MapTest {
     assertEquals(2, mp.size())
     mp.clear()
     assertEquals(0, mp.size())
+    assertNull(mp.get("ONE"))
+    assertNull(mp.get("TWO"))
+
+    // can be reused after clear()
+    mp.put("TWO", "value 2")
+    mp.put("THREE", "value 3")
+    assertEquals("value 2", mp.get("TWO"))
+    assertEquals("value 3", mp.get("THREE"))
   }
 
-  @Test def should_check_contained_key_presence(): Unit = {
+  @Test def testContainsKey(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
@@ -190,10 +311,10 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(mp.containsKey(null))
     else
-      expectThrows(classOf[Throwable], mp.containsKey(null))
+      expectThrows(classOf[NullPointerException], mp.containsKey(null))
   }
 
-  @Test def should_check_contained_value_presence(): Unit = {
+  @Test def testContainsValue(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
@@ -202,14 +323,37 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(mp.containsValue(null))
     else
-      expectThrows(classOf[Throwable], mp.containsValue(null))
+      expectThrows(classOf[NullPointerException], mp.containsValue(null))
   }
 
-  @Test def should_give_proper_Collection_over_values(): Unit = {
+  @Test def testPutAll(): Unit = {
     val mp = factory.empty[String, String]
 
     mp.put("ONE", "one")
-    val values = mp.values
+
+    mp.putAll(TrivialImmutableMap("X" -> "y", "A" -> "b"))
+    assertEquals(3, mp.size())
+    assertEquals("one", mp.get("ONE"))
+    assertEquals("y", mp.get("X"))
+    assertEquals("b", mp.get("A"))
+
+    val nullMap = TrivialImmutableMap((null: String) -> "y", "X" -> "z")
+    if (factory.allowsNullKeys) {
+      mp.putAll(nullMap)
+      assertEquals("y", mp.get(null))
+      assertEquals("z", mp.get("X"))
+      assertEquals("one", mp.get("ONE"))
+      assertEquals("b", mp.get("A"))
+    } else {
+      expectThrows(classOf[NullPointerException], mp.putAll(nullMap))
+    }
+  }
+
+  @Test def testValuesSizeIteratorBasic(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+
+    val values = mp.values()
     assertEquals(1, values.size)
     val iter = values.iterator
     assertTrue(iter.hasNext)
@@ -217,14 +361,12 @@ trait MapTest {
     assertFalse(iter.hasNext)
   }
 
-  @Test def should_give_proper_EntrySet_over_key_values_pairs(): Unit = {
+  @Test def testEntrySetSizeIteratorBasic(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
-    val entrySet = mp.entrySet
 
+    val entrySet = mp.entrySet()
     assertEquals(1, entrySet.size)
-
     val iter = entrySet.iterator
     assertTrue(iter.hasNext)
     val next = iter.next
@@ -233,126 +375,99 @@ trait MapTest {
     assertEquals("one", next.getValue)
   }
 
-  @Test def should_give_proper_KeySet_over_keys(): Unit = {
+  @Test def testKeySetSizeIteratorBasic(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
-    val keySet = mp.keySet
 
+    val keySet = mp.keySet()
     assertEquals(1, keySet.size)
-
     val iter = keySet.iterator
     assertTrue(iter.hasNext)
     assertEquals("ONE", iter.next)
     assertFalse(iter.hasNext)
   }
 
-  @Test def should_put_a_whole_map_into(): Unit = {
+  @Test def testValuesIsViewForSize(): Unit = {
     val mp = factory.empty[String, String]
-
-    val m = mu.Map[String, String](
-      "X" -> "y")
-    mp.putAll(m.asJava)
-    assertEquals(1, mp.size)
-    assertEquals("y", mp.get("X"))
-
-    val nullMap = mu.Map[String, String](
-      (null: String) -> "y",
-      "X" -> "y")
-
-    if (factory.allowsNullKeys) {
-      mp.putAll(nullMap.asJava)
-      assertEquals("y", mp.get(null))
-      assertEquals("y", mp.get("X"))
-    } else {
-      expectThrows(classOf[NullPointerException], mp.putAll(nullMap.asJava))
-    }
-  }
-
-  class SimpleQueryableMap[K, V](inner: mu.HashMap[K, V])
-      extends ju.AbstractMap[K, V] {
-    def entrySet(): java.util.Set[java.util.Map.Entry[K, V]] = {
-      inner.map {
-        case (k, v) => new ju.AbstractMap.SimpleImmutableEntry(k, v)
-      }.toSet[java.util.Map.Entry[K, V]].asJava
-    }
-  }
-
-  @Test def values_should_mirror_the_related_map_size(): Unit = {
-    val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
+    val values = mp.values()
 
-    val values = mp.values
     assertEquals(2, values.size)
-
     mp.put("THREE", "three")
-
     assertEquals(3, values.size)
-
     mp.remove("ONE")
-
     assertEquals(2, values.size)
-
     assertFalse(values.isEmpty)
-
     mp.clear()
-
     assertEquals(0, values.size)
-
     assertTrue(values.isEmpty)
-
-    val hm1 = mu.HashMap(
-      "ONE" -> "one",
-      "TWO" -> "two")
-    val hm2 = mu.HashMap(
-      "ONE" -> null,
-      "TWO" -> "two")
-    val hm3 = mu.HashMap(
-      (null: String) -> "one",
-      "TWO" -> "two")
-    val hm4 = mu.HashMap(
-      (null: String) -> null,
-      "TWO" -> "two")
-
-    assertEquals(2, new SimpleQueryableMap(hm1).values.size)
-    assertEquals(2, new SimpleQueryableMap(hm2).values.size)
-    assertEquals(2, new SimpleQueryableMap(hm3).values.size)
-    assertEquals(2, new SimpleQueryableMap(hm4).values.size)
   }
 
-  @Test def values_should_check_single_and_multiple_objects_presence(): Unit = {
+  @Test def testValuesIsViewForQueriesWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
+    val values = mp.values()
 
-    val values = mp.values
     assertTrue(values.contains("one"))
     assertTrue(values.contains("two"))
     assertFalse(values.contains("three"))
     if (factory.allowsNullValuesQueries)
       assertFalse(values.contains(null))
     else
-      expectThrows(classOf[Throwable], mp.asScala.contains(null))
+      expectThrows(classOf[NullPointerException], values.contains(null))
 
     mp.put("THREE", "three")
 
     assertTrue(values.contains("three"))
 
-    val coll1 = Set("one", "two", "three").asJavaCollection
+    val coll1 = ju.Arrays.asList("one", "two", "three")
     assertTrue(values.containsAll(coll1))
 
-    val coll2 = Set("one", "two", "three", "four").asJavaCollection
+    val coll2 = ju.Arrays.asList("one", "two", "three", "four")
     assertFalse(values.containsAll(coll2))
 
-    val coll3 = Set("one", "two", "three", null).asJavaCollection
+    if (factory.allowsNullValuesQueries) {
+      val coll3 = ju.Arrays.asList("one", "two", "three", null)
+      assertFalse(values.containsAll(coll3))
+    }
+  }
+
+  @Test def testValuesIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    val values = mp.values()
+
+    assertTrue(values.contains(TestObj(11)))
+    assertTrue(values.contains(TestObj(22)))
+    assertFalse(values.contains(TestObj(33)))
+    if (factory.allowsNullValuesQueries)
+      assertFalse(values.contains(null))
+    else
+      expectThrows(classOf[NullPointerException], values.contains(null))
+
+    mp.put(TestObj(3), TestObj(33))
+
+    assertTrue(values.contains(TestObj(33)))
+
+    val coll1 = ju.Arrays.asList(TestObj(11), TestObj(22), TestObj(33))
+    assertTrue(values.containsAll(coll1))
+
+    val coll2 = ju.Arrays.asList(TestObj(11), TestObj(22), TestObj(33), TestObj(44))
     assertFalse(values.containsAll(coll2))
 
+    if (factory.allowsNullValuesQueries) {
+      val coll3 = ju.Arrays.asList(TestObj(11), TestObj(22), TestObj(33), null)
+      assertFalse(values.containsAll(coll3))
+    }
+  }
+
+  @Test def testValuesIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
     val nummp = factory.empty[Double, Double]
+    val numValues = nummp.values()
 
-    val numValues = nummp.values
     nummp.put(1, +0.0)
     assertTrue(numValues.contains(+0.0))
     assertFalse(numValues.contains(-0.0))
@@ -367,33 +482,14 @@ trait MapTest {
     assertTrue(numValues.contains(+0.0))
     assertTrue(numValues.contains(-0.0))
     assertTrue(numValues.contains(Double.NaN))
-
-    val hm1 = mu.HashMap(
-      1.0 -> null,
-      2.0 -> 2.0)
-    val hm2 = mu.HashMap(
-      (null: Any) -> 1.0,
-      2.0 -> 2.0)
-    val hm3 = mu.HashMap(
-      (null: Any) -> null,
-      2.0 -> 2.0)
-
-    assertFalse(new SimpleQueryableMap(hm1).values.contains(1.0))
-    assertTrue(new SimpleQueryableMap(hm2).values.contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm3).values.contains(1.0))
-
-    assertTrue(new SimpleQueryableMap(hm1).values.contains(null))
-    assertFalse(new SimpleQueryableMap(hm2).values.contains(null))
-    assertTrue(new SimpleQueryableMap(hm3).values.contains(null))
   }
 
-  @Test def values_should_side_effect_clear_remove_retain_on_the_related_map(): Unit = {
+  @Test def testValuesIsViewForRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
+    val values = mp.values()
 
-    val values = mp.values
     assertFalse(values.isEmpty)
     assertFalse(mp.isEmpty)
 
@@ -406,9 +502,7 @@ trait MapTest {
     mp.put("TWO", "two")
 
     assertTrue(mp.containsKey("ONE"))
-
     values.remove("one")
-
     assertFalse(mp.containsKey("ONE"))
 
     mp.put("ONE", "one")
@@ -418,7 +512,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    values.removeAll(List("one", "two").asJavaCollection)
+    values.removeAll(ju.Arrays.asList("one", "two"))
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -432,91 +526,143 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    values.retainAll(List("one", "two").asJavaCollection)
+    values.retainAll(ju.Arrays.asList("one", "two"))
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))
     assertFalse(mp.containsKey("THREE"))
   }
 
-  @Test def keySet_should_mirror_the_related_map_size(): Unit = {
-    val mp = factory.empty[String, String]
+  @Test def testValuesIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    val values = mp.values()
 
-    mp.put("ONE", "one")
-    mp.put("TWO", "two")
+    assertFalse(values.isEmpty)
+    assertFalse(mp.isEmpty)
 
-    val keySet = mp.keySet
-    assertEquals(2, keySet.size)
+    values.clear()
 
-    mp.put("THREE", "three")
+    assertTrue(values.isEmpty)
+    assertTrue(mp.isEmpty)
 
-    assertEquals(3, keySet.size)
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
 
-    mp.remove("ONE")
+    assertTrue(mp.containsKey(TestObj(1)))
+    values.remove(TestObj(11))
+    assertFalse(mp.containsKey(TestObj(1)))
 
-    assertEquals(2, keySet.size)
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(3), TestObj(33))
 
-    assertFalse(keySet.isEmpty)
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
 
-    mp.clear()
+    values.removeAll(ju.Arrays.asList(TestObj(11), TestObj(22)))
 
-    assertEquals(0, keySet.size)
+    assertFalse(mp.containsKey(TestObj(1)))
+    assertFalse(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
 
-    assertTrue(keySet.isEmpty)
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    mp.put(TestObj(3), TestObj(33))
 
-    val hm1 = mu.HashMap(
-      "ONE" -> "one",
-      "TWO" -> "two")
-    val hm2 = mu.HashMap(
-      "ONE" -> null,
-      "TWO" -> "two")
-    val hm3 = mu.HashMap(
-      (null: String) -> "one",
-      "TWO" -> "two")
-    val hm4 = mu.HashMap(
-      (null: String) -> null,
-      "TWO" -> "two")
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
 
-    assertEquals(2, new SimpleQueryableMap(hm1).keySet.size)
-    assertEquals(2, new SimpleQueryableMap(hm2).keySet.size)
-    assertEquals(2, new SimpleQueryableMap(hm3).keySet.size)
-    assertEquals(2, new SimpleQueryableMap(hm4).keySet.size)
+    values.retainAll(ju.Arrays.asList(TestObj(11), TestObj(22)))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertFalse(mp.containsKey(TestObj(3)))
   }
 
-  @Test def keySet_should_check_single_and_multiple_objects_presence(): Unit = {
+  @Test def testKeySetIsViewForSize(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
+    val keySet = mp.keySet()
 
-    val keySet = mp.keySet
+    assertEquals(2, keySet.size)
+    mp.put("THREE", "three")
+    assertEquals(3, keySet.size)
+    mp.remove("ONE")
+    assertEquals(2, keySet.size)
+    assertFalse(keySet.isEmpty)
+    mp.clear()
+    assertEquals(0, keySet.size)
+    assertTrue(keySet.isEmpty)
+  }
+
+  @Test def testKeySetIsViewForQueriesWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val keySet = mp.keySet()
+
     assertTrue(keySet.contains("ONE"))
     assertTrue(keySet.contains("TWO"))
     assertFalse(keySet.contains("THREE"))
     if (factory.allowsNullKeysQueries)
       assertFalse(keySet.contains(null))
     else
-      expectThrows(classOf[Throwable], mp.asScala.contains(null))
+      expectThrows(classOf[NullPointerException], keySet.contains(null))
 
     mp.put("THREE", "three")
 
     assertTrue(keySet.contains("THREE"))
 
-    val coll1 =
-      Set("ONE", "TWO", "THREE").asJavaCollection
+    val coll1 = ju.Arrays.asList("ONE", "TWO", "THREE")
     assertTrue(keySet.containsAll(coll1))
 
-    val coll2 =
-      Set("ONE", "TWO", "THREE", "FOUR").asJavaCollection
+    val coll2 = ju.Arrays.asList("ONE", "TWO", "THREE", "FOUR")
     assertFalse(keySet.containsAll(coll2))
 
-    val coll3 =
-      Set("ONE", "TWO", "THREE", null).asJavaCollection
+    if (factory.allowsNullKeysQueries) {
+      val coll3 = ju.Arrays.asList("ONE", "TWO", "THREE", null)
+      assertFalse(keySet.containsAll(coll3))
+    }
+  }
+
+  @Test def testKeySetIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    val keySet = mp.keySet()
+
+    assertTrue(keySet.contains(TestObj(1)))
+    assertTrue(keySet.contains(TestObj(2)))
+    assertFalse(keySet.contains(TestObj(3)))
+    if (factory.allowsNullKeysQueries)
+      assertFalse(keySet.contains(null))
+    else
+      expectThrows(classOf[NullPointerException], keySet.contains(null))
+
+    mp.put(TestObj(3), TestObj(33))
+
+    assertTrue(keySet.contains(TestObj(3)))
+
+    val coll1 = ju.Arrays.asList(TestObj(1), TestObj(2), TestObj(3))
+    assertTrue(keySet.containsAll(coll1))
+
+    val coll2 = ju.Arrays.asList(TestObj(1), TestObj(2), TestObj(4))
     assertFalse(keySet.containsAll(coll2))
 
+    if (factory.allowsNullKeysQueries) {
+      val coll3 = ju.Arrays.asList(TestObj(1), TestObj(2), null)
+      assertFalse(keySet.containsAll(coll3))
+    }
+  }
+
+  @Test def testKeySetIsViewForQueriesWithDoublesCornerCaseOfEquals(): Unit = {
     val nummp = factory.empty[Double, Double]
+    val numkeySet = nummp.keySet()
 
-    val numkeySet = nummp.keySet
     nummp.put(+0.0, 1)
     assertTrue(numkeySet.contains(+0.0))
     assertFalse(numkeySet.contains(-0.0))
@@ -531,33 +677,14 @@ trait MapTest {
     assertTrue(numkeySet.contains(+0.0))
     assertTrue(numkeySet.contains(-0.0))
     assertTrue(numkeySet.contains(Double.NaN))
-
-    val hm1 = mu.HashMap(
-      1.0 -> null,
-      2.0 -> 2.0)
-    val hm2 = mu.HashMap(
-      (null: Any) -> 1.0,
-      2.0 -> 2.0)
-    val hm3 = mu.HashMap(
-      (null: Any) -> null,
-      2.0 -> 2.0)
-
-    assertTrue(new SimpleQueryableMap(hm1).keySet.contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm2).keySet.contains(1.0))
-    assertFalse(new SimpleQueryableMap(hm3).keySet.contains(1.0))
-
-    assertFalse(new SimpleQueryableMap(hm1).keySet.contains(null))
-    assertTrue(new SimpleQueryableMap(hm2).keySet.contains(null))
-    assertTrue(new SimpleQueryableMap(hm3).keySet.contains(null))
   }
 
-  @Test def keySet_should_side_effect_clear_remove_retain_on_the_related_map(): Unit = {
+  @Test def testKeySetIsViewForRemoveWithStrings(): Unit = {
     val mp = factory.empty[String, String]
-
     mp.put("ONE", "one")
     mp.put("TWO", "two")
+    val keySet = mp.keySet()
 
-    val keySet = mp.keySet
     assertFalse(keySet.isEmpty)
     assertFalse(mp.isEmpty)
 
@@ -571,9 +698,7 @@ trait MapTest {
     mp.put("TWO", "two")
 
     assertTrue(mp.containsKey("ONE"))
-
     keySet.remove("ONE")
-
     assertFalse(mp.containsKey("ONE"))
 
     mp.put("ONE", "one")
@@ -583,7 +708,7 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    keySet.removeAll(List("ONE", "TWO").asJavaCollection)
+    keySet.removeAll(ju.Arrays.asList("ONE", "TWO", "FIVE"))
 
     assertFalse(mp.containsKey("ONE"))
     assertFalse(mp.containsKey("TWO"))
@@ -597,13 +722,296 @@ trait MapTest {
     assertTrue(mp.containsKey("TWO"))
     assertTrue(mp.containsKey("THREE"))
 
-    keySet.retainAll(List("ONE", "TWO").asJavaCollection)
+    keySet.retainAll(ju.Arrays.asList("ONE", "TWO", "FIVE"))
 
     assertTrue(mp.containsKey("ONE"))
     assertTrue(mp.containsKey("TWO"))
     assertFalse(mp.containsKey("THREE"))
   }
 
+  @Test def testKeySetIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    val keySet = mp.keySet()
+
+    assertFalse(keySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    keySet.clear()
+
+    assertTrue(keySet.isEmpty)
+
+    assertTrue(mp.isEmpty)
+
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    keySet.remove(TestObj(1))
+    assertFalse(mp.containsKey(TestObj(1)))
+
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
+
+    keySet.removeAll(ju.Arrays.asList(TestObj(1), TestObj(2), TestObj(5)))
+
+    assertFalse(mp.containsKey(TestObj(1)))
+    assertFalse(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
+
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    mp.put(TestObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
+
+    keySet.retainAll(ju.Arrays.asList(TestObj(1), TestObj(2), TestObj(5)))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertFalse(mp.containsKey(TestObj(3)))
+  }
+
+  @Test def testEntrySetIsViewForSize(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    assertEquals(2, entrySet.size)
+    mp.put("THREE", "three")
+    assertEquals(3, entrySet.size)
+    mp.remove("ONE")
+    assertEquals(2, entrySet.size)
+    assertFalse(entrySet.isEmpty)
+    mp.clear()
+    assertEquals(0, entrySet.size)
+    assertTrue(entrySet.isEmpty)
+  }
+
+  @Test def testEntrySetIsViewForQueriesWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    assertTrue(entrySet.contains(SIE("ONE", "one")))
+    assertTrue(entrySet.contains(SIE("TWO", "two")))
+    assertFalse(entrySet.contains(SIE("THREE", "three")))
+    assertFalse(entrySet.contains(SIE("ONE", "two")))
+    assertFalse(entrySet.contains(SIE("THREE", "one")))
+
+    mp.put("THREE", "three")
+
+    assertTrue(entrySet.contains(SIE("THREE", "three")))
+
+    val coll1 = ju.Arrays.asList(SIE("ONE", "one"), SIE("TWO", "two"),
+        SIE("THREE", "three"))
+    assertTrue(entrySet.containsAll(coll1))
+
+    val coll2 = ju.Arrays.asList(SIE("ONE", "one"), SIE("TWO", "two"),
+        SIE("THREE", "three"), SIE("FOUR", "four"))
+    assertFalse(entrySet.containsAll(coll2))
+
+    val coll3 = ju.Arrays.asList(SIE("ONE", "one"), SIE("TWO", "four"),
+        SIE("THREE", "three"))
+    assertFalse(entrySet.containsAll(coll3))
+
+    val coll4 = ju.Arrays.asList(SIE("ONE", "one"), SIE("four", "two"),
+        SIE("THREE", "three"))
+    assertFalse(entrySet.containsAll(coll4))
+  }
+
+  @Test def testEntrySetIsViewForQueriesWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    val entrySet = mp.entrySet()
+
+    assertTrue(entrySet.contains(SIE(TestObj(1), TestObj(11))))
+    assertTrue(entrySet.contains(SIE(TestObj(2), TestObj(22))))
+    assertFalse(entrySet.contains(SIE(TestObj(3), TestObj(33))))
+    assertFalse(entrySet.contains(SIE(TestObj(1), TestObj(22))))
+    assertFalse(entrySet.contains(SIE(TestObj(3), TestObj(11))))
+
+    mp.put(TestObj(3), TestObj(33))
+
+    assertTrue(entrySet.contains(SIE(TestObj(3), TestObj(33))))
+
+    val coll1 = ju.Arrays.asList(SIE(TestObj(1), TestObj(11)),
+        SIE(TestObj(2), TestObj(22)), SIE(TestObj(3), TestObj(33)))
+    assertTrue(entrySet.containsAll(coll1))
+
+    val coll2 = ju.Arrays.asList(SIE(TestObj(1), TestObj(11)),
+        SIE(TestObj(2), TestObj(22)), SIE(TestObj(3), TestObj(33)),
+        SIE(TestObj(4), TestObj(44)))
+    assertFalse(entrySet.containsAll(coll2))
+
+    val coll3 = ju.Arrays.asList(SIE(TestObj(1), TestObj(11)),
+        SIE(TestObj(2), TestObj(44)), SIE(TestObj(3), TestObj(33)))
+    assertFalse(entrySet.containsAll(coll3))
+
+    val coll4 = ju.Arrays.asList(SIE(TestObj(1), TestObj(11)),
+        SIE(TestObj(4), TestObj(22)), SIE(TestObj(3), TestObj(33)))
+    assertFalse(entrySet.containsAll(coll4))
+  }
+
+  @Test def testEntrySetIsViewForRemoveWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    assertFalse(entrySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    entrySet.clear()
+    assertTrue(entrySet.isEmpty)
+    assertTrue(mp.isEmpty)
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(entrySet.remove(SIE("ONE", "one")))
+    assertFalse(entrySet.remove(SIE("TWO", "four")))
+    assertFalse(entrySet.remove("TWO"))
+    assertFalse(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+
+    mp.put("ONE", "one")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    entrySet.removeAll(ju.Arrays.asList(SIE("ONE", "one"), SIE("TWO", "two"),
+        SIE("THREE", "four"), "THREE", 42))
+
+    assertFalse(mp.containsKey("ONE"))
+    assertFalse(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    mp.put("THREE", "three")
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertTrue(mp.containsKey("THREE"))
+
+    entrySet.retainAll(ju.Arrays.asList(SIE("ONE", "one"), SIE("TWO", "two"),
+        SIE("THREE", "four"), "THREE", 42))
+
+    assertTrue(mp.containsKey("ONE"))
+    assertTrue(mp.containsKey("TWO"))
+    assertFalse(mp.containsKey("THREE"))
+  }
+
+  @Test def testEntrySetIsViewForRemoveWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    val entrySet = mp.entrySet()
+
+    assertFalse(entrySet.isEmpty)
+    assertFalse(mp.isEmpty)
+
+    entrySet.clear()
+    assertTrue(entrySet.isEmpty)
+    assertTrue(mp.isEmpty)
+
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(entrySet.remove(SIE(TestObj(1), TestObj(11))))
+    assertFalse(entrySet.remove(SIE(TestObj(2), TestObj(44))))
+    assertFalse(entrySet.remove(TestObj(2)))
+    assertFalse(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
+
+    entrySet.removeAll(ju.Arrays.asList(SIE(TestObj(1), TestObj(11)),
+        SIE(TestObj(2), TestObj(22)), SIE(TestObj(3), TestObj(44)),
+        TestObj(3), 42))
+
+    assertFalse(mp.containsKey(TestObj(1)))
+    assertFalse(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
+
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    mp.put(TestObj(3), TestObj(33))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertTrue(mp.containsKey(TestObj(3)))
+
+    entrySet.retainAll(ju.Arrays.asList(SIE(TestObj(1), TestObj(11)),
+        SIE(TestObj(2), TestObj(22)), SIE(TestObj(3), TestObj(44)),
+        TestObj(3), 42))
+
+    assertTrue(mp.containsKey(TestObj(1)))
+    assertTrue(mp.containsKey(TestObj(2)))
+    assertFalse(mp.containsKey(TestObj(3)))
+  }
+
+  @Test def testEntrySetIsViewForSetValueWithStrings(): Unit = {
+    val mp = factory.empty[String, String]
+    mp.put("ONE", "one")
+    mp.put("TWO", "two")
+    val entrySet = mp.entrySet()
+
+    val entry = entrySet.iterator().next()
+    val key = entry.getKey()
+    assertTrue(key == "ONE" || key == "TWO")
+    val expectedValue = if (key == "ONE") "one" else "two"
+
+    assertEquals(expectedValue, entry.getValue())
+    assertEquals(expectedValue, entry.setValue("new value"))
+    assertEquals("new value", entry.getValue())
+    assertEquals("new value", mp.get(key))
+  }
+
+  @Test def testEntrySetIsViewForSetValueWithCustomObjects(): Unit = {
+    val mp = factory.empty[TestObj, TestObj]
+    mp.put(TestObj(1), TestObj(11))
+    mp.put(TestObj(2), TestObj(22))
+    val entrySet = mp.entrySet()
+
+    val entry = entrySet.iterator().next()
+    val key = entry.getKey()
+    assertTrue(key.num == 1 || key.num == 2)
+    val expectedValue = TestObj(if (key.num == 1) 11 else 22)
+
+    assertEquals(expectedValue, entry.getValue())
+    assertEquals(expectedValue, entry.setValue(TestObj(56)))
+    assertEquals(TestObj(56), entry.getValue())
+    assertEquals(TestObj(56), mp.get(key))
+  }
+
+}
+
+object MapTest {
+  final case class TestObj(num: Int)
+
+  def SIE[K, V](key: K, value: V): ju.Map.Entry[K, V] =
+    new ju.AbstractMap.SimpleImmutableEntry(key, value)
 }
 
 object MapFactory {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
@@ -28,20 +28,6 @@ trait SetTest extends CollectionTest {
 
   def factory: SetFactory
 
-  def testSetApi(): Unit = {
-    testCollectionApi()
-    shouldCheckSetSize()
-    shouldStoreIntegers_Set()
-    shouldStoreObjectsWithSameHashCodeButDifferentTypes()
-    shouldStoreDoublesAlsoInCornerCases()
-    shouldStoreCustomObjects_Set()
-    shouldRemoveStoredElements_Set()
-    shouldBeClearedWithOneOperation_Set()
-    shouldCheckContainedElemsPresence()
-    shouldPutAWholeCollectionInto()
-    shouldIterateOverElements()
-  }
-
   @Test def shouldCheckSetSize(): Unit = {
     val hs = factory.empty[String]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
@@ -23,16 +23,6 @@ trait SortedMapTest extends MapTest {
 
   def factory: SortedMapFactory
 
-  def testSortedMapApi(): Unit = {
-    testMapApi()
-    should_always_be_sorted()
-    should_return_the_firstKey()
-    should_return_the_lastKey()
-    should_return_a_proper_headMap()
-    should_return_a_proper_tailMap()
-    should_return_a_proper_subMap()
-  }
-
   // TODO: implement tests (when we port the first SortedMap)
 
   @Test def should_always_be_sorted(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
@@ -23,15 +23,6 @@ trait SortedSetTest extends SetTest {
 
   def factory: SortedSetFactory
 
-  def testSortedSetApi(): Unit = {
-    testSetApi()
-    shouldRetrieveTheFirstElement()
-    shouldRetrieveTheLastElement()
-    shouldReturnAProperHeadSet()
-    shouldReturnAProperTailSet()
-    shouldReturnAProperSubSet()
-  }
-
   @Test def shouldRetrieveTheFirstElement(): Unit = {
     val ssInt = factory.empty[Int]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TrivialImmutableMap.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TrivialImmutableMap.scala
@@ -1,0 +1,51 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util
+
+import java.{util => ju}
+import java.util.Map.Entry
+
+final class TrivialImmutableMap[K, V] private (contents: List[Entry[K, V]])
+    extends ju.AbstractMap[K, V] {
+
+  def entrySet(): ju.Set[Entry[K,V]] = {
+    new ju.AbstractSet[Entry[K, V]] {
+      def size(): Int = contents.size
+
+      def iterator(): ju.Iterator[Entry[K,V]] = {
+        new ju.Iterator[Entry[K, V]] {
+          private var remaining: List[Entry[K, V]] = contents
+
+          def hasNext(): Boolean = remaining.nonEmpty
+
+          def next(): Entry[K,V] = {
+            val head = remaining.head
+            remaining = remaining.tail
+            head
+          }
+
+          override def remove(): Unit =
+            throw new UnsupportedOperationException("Iterator.remove()")
+        }
+      }
+    }
+  }
+}
+
+object TrivialImmutableMap {
+  def apply[K, V](contents: List[Entry[K, V]]): TrivialImmutableMap[K, V] =
+    new TrivialImmutableMap(contents)
+
+  def apply[K, V](contents: (K, V)*): TrivialImmutableMap[K, V] =
+    apply(contents.toList.map(kv => new ju.AbstractMap.SimpleImmutableEntry(kv._1, kv._2)))
+}


### PR DESCRIPTION
Motivation: the discussion in #3721 made me realize that the tests for `j.u.Map`s were severely lacking in several aspects, most of all the view-ness of `entrySet()`.

* Add more tests for custom objects, for which `eq` is not the same as `equals()`.
* Add more tests for views, in particular for `entrySet()` views which were hardly covered.
* Do not rely on Scala collections and their Java views for the tests.

In the process, we also fix `m.values().contains(null)` for `NullRejectingHashMap`, which previously failed to throw a `NullPointerException`.

/cc @ekrich