### PR TITLE
Suppress stack trace of LinkingException's in sbt plugin since it is useless for users

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -322,9 +322,14 @@ object ScalaJSPluginInternal {
 
             IO.createDirectory(output.getParentFile)
 
-            linker.link(ir, moduleInitializers,
-                AtomicWritableFileVirtualJSFile(output),
-                sbtLogger2ToolsLogger(log))
+            try {
+              linker.link(ir, moduleInitializers,
+                  AtomicWritableFileVirtualJSFile(output),
+                  sbtLogger2ToolsLogger(log))
+            } catch {
+              case e: LinkingException =>
+                throw new MessageOnlyException(e.getMessage)
+            }
 
             logIRCacheStats(log)
 


### PR DESCRIPTION
Addresses https://github.com/scala-js/scala-js/issues/3596#issuecomment-502246833

From Scala.js user perspective, long stack trace of `LinkingException` does not help.