### PR TITLE
Remove dead-code definitions of `allFactories` in the test suite.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractSetTest.scala
@@ -20,11 +20,6 @@ abstract class AbstractSetTest extends SetTest {
   def factory: AbstractSetFactory
 }
 
-object AbstractSetFactory {
-  def allFactories: Iterator[AbstractSetFactory] =
-    HashSetFactory.allFactories
-}
-
 trait AbstractSetFactory extends SetFactory {
   def empty[E: ClassTag]: ju.AbstractSet[E]
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
@@ -170,11 +170,6 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
   }
 }
 
-object ArrayDequeFactory {
-  def allFactories: Iterator[ArrayDequeFactory] =
-    Iterator(new ArrayDequeFactory())
-}
-
 class ArrayDequeFactory extends AbstractCollectionFactory with DequeFactory {
   override def implementationName: String =
     "java.util.ArrayDeque"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -227,11 +227,6 @@ trait CollectionTest {
   }
 }
 
-object CollectionFactory {
-  def allFactories: Iterator[CollectionFactory] =
-    ListFactory.allFactories ++ SetFactory.allFactories
-}
-
 trait CollectionFactory {
   def implementationName: String
   def empty[E: ClassTag]: ju.Collection[E]

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DequeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DequeTest.scala
@@ -20,11 +20,6 @@ trait DequeTest extends CollectionTest {
   def factory: DequeFactory
 }
 
-object DequeFactory {
-  def allFactories: Iterator[DequeFactory] =
-    ArrayDequeFactory.allFactories
-}
-
 trait DequeFactory extends CollectionFactory {
   def empty[E: ClassTag]: ju.Deque[E]
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
@@ -20,11 +20,6 @@ class HashMapTest extends MapTest {
   def factory(): HashMapFactory = new HashMapFactory
 }
 
-object HashMapFactory {
-  def allFactories: Iterator[MapFactory] =
-    Iterator(new HashMapFactory) ++ LinkedHashMapFactory.allFactories
-}
-
 class HashMapFactory extends AbstractMapFactory {
   override def implementationName: String =
     "java.util.HashMap"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
@@ -22,11 +22,6 @@ class HashSetTest extends AbstractSetTest {
   def factory: HashSetFactory = new HashSetFactory
 }
 
-object HashSetFactory {
-  def allFactories: Iterator[HashSetFactory] =
-    Iterator(new HashSetFactory) ++ LinkedHashSetFactory.allFactories
-}
-
 class HashSetFactory extends AbstractSetFactory {
   def implementationName: String =
     "java.util.HashSet"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
@@ -207,13 +207,6 @@ abstract class LinkedHashMapTest extends HashMapTest {
 
 }
 
-object LinkedHashMapFactory {
-  def allFactories: Iterator[MapFactory] = {
-    Iterator(new LinkedHashMapFactory(true, Some(50)), new LinkedHashMapFactory(true, None),
-        new LinkedHashMapFactory(false, Some(50)), new LinkedHashMapFactory(false, None))
-  }
-}
-
 class LinkedHashMapFactory(val accessOrder: Boolean,
     override val withSizeLimit: Option[Int])
     extends HashMapFactory {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashSetTest.scala
@@ -61,11 +61,6 @@ class LinkedHashSetTest extends HashSetTest {
 
 }
 
-object LinkedHashSetFactory extends HashSetFactory {
-  def allFactories: Iterator[LinkedHashSetFactory] =
-    Iterator(new LinkedHashSetFactory)
-}
-
 class LinkedHashSetFactory extends HashSetFactory {
   override def implementationName: String =
     "java.util.LinkedHashSet"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
@@ -438,11 +438,6 @@ trait ListTest extends CollectionTest {
   }
 }
 
-object ListFactory {
-  def allFactories: Iterator[ListFactory] =
-    Iterator(new ArrayListFactory, new LinkedListFactory, new AbstractListFactory)
-}
-
 trait ListFactory extends CollectionFactory {
   def empty[E: ClassTag]: ju.List[E]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -1014,11 +1014,6 @@ object MapTest {
     new ju.AbstractMap.SimpleImmutableEntry(key, value)
 }
 
-object MapFactory {
-  def allFactories: Iterator[MapFactory] =
-    HashMapFactory.allFactories ++ SortedMapFactory.allFactories ++ ConcurrentMapFactory.allFactories
-}
-
 trait MapFactory {
   def implementationName: String
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/NavigableSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/NavigableSetTest.scala
@@ -135,11 +135,6 @@ trait NavigableSetTest extends SetTest {
   }
 }
 
-object NavigableSetFactory {
-  def allFactories: Iterator[NavigableSetFactory] =
-    ConcurrentSkipListSetFactory.allFactories
-}
-
 trait NavigableSetFactory extends SetFactory {
   def empty[E: ClassTag]: ju.NavigableSet[E]
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
@@ -214,11 +214,6 @@ trait SetTest extends CollectionTest {
   }
 }
 
-object SetFactory {
-  def allFactories: Iterator[SetFactory] =
-    AbstractSetFactory.allFactories ++ SortedSetFactory.allFactories ++ NavigableSetFactory.allFactories
-}
-
 trait SetFactory extends CollectionFactory {
   def empty[E: ClassTag]: ju.Set[E]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
@@ -50,10 +50,6 @@ trait SortedMapTest extends MapTest {
   }
 }
 
-object SortedMapFactory {
-  def allFactories: Iterator[SortedMapFactory] = Iterator.empty
-}
-
 trait SortedMapFactory extends MapFactory {
   def empty[K: ClassTag, V: ClassTag]: ju.SortedMap[K, V]
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
@@ -137,11 +137,6 @@ trait SortedSetTest extends SetTest {
   }
 }
 
-object SortedSetFactory {
-  def allFactories: Iterator[SortedSetFactory] =
-    Iterator.empty
-}
-
 trait SortedSetFactory extends SetFactory {
   def empty[E: ClassTag]: ju.SortedSet[E]
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
@@ -343,11 +343,6 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
   }
 }
 
-object TreeSetFactory extends TreeSetFactory {
-  def allFactories: Iterator[TreeSetFactory] =
-    Iterator(new TreeSetFactory, new TreeSetWithNullFactory)
-}
-
 class TreeSetFactory extends AbstractSetFactory with NavigableSetFactory
     with SortedSetFactory {
   def implementationName: String =

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
@@ -228,11 +228,6 @@ class ConcurrentHashMapTest extends MapTest {
   }
 }
 
-object ConcurrentHashMapFactory extends ConcurrentHashMapFactory {
-  def allFactories: Iterator[ConcurrentHashMapFactory] =
-    Iterator(ConcurrentHashMapFactory)
-}
-
 class ConcurrentHashMapFactory extends ConcurrentMapFactory {
   def implementationName: String =
     "java.util.concurrent.ConcurrentHashMap"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentMapTest.scala
@@ -18,11 +18,6 @@ import org.scalajs.testsuite.javalib.util.MapFactory
 
 import scala.reflect.ClassTag
 
-object ConcurrentMapFactory {
-  def allFactories: Iterator[ConcurrentMapFactory] =
-    ConcurrentHashMapFactory.allFactories
-}
-
 trait ConcurrentMapFactory extends MapFactory {
   def empty[K: ClassTag, V: ClassTag]: ju.concurrent.ConcurrentMap[K, V]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
@@ -410,11 +410,6 @@ class ConcurrentSkipListSetTest {
   }
 }
 
-object ConcurrentSkipListSetFactory extends ConcurrentSkipListSetFactory {
-  def allFactories: Iterator[ConcurrentSkipListSetFactory] =
-    Iterator(new ConcurrentSkipListSetFactory)
-}
-
 class ConcurrentSkipListSetFactory extends NavigableSetFactory {
   def implementationName: String =
     "java.util.concurrent.ConcurrentSkipListSet"


### PR DESCRIPTION
No review needed.