### PR TITLE
Fix the spec of eq/ne for NaN and +0.0 v -0.0.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -1367,7 +1367,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       private def mkOverrideNumsCond(numRef: js.VarRef,
           numBounds: (Int, Int))(implicit pos: Position) = numBounds match {
         case (lo, hi) if lo == hi =>
-          js.BinaryOp(js.BinaryOp.===, js.IntLiteral(lo), numRef)
+          js.BinaryOp(js.BinaryOp.Int_==, js.IntLiteral(lo), numRef)
 
         case (lo, hi) if lo == hi - 1 =>
           val lhs = js.BinaryOp(js.BinaryOp.Int_==, numRef, js.IntLiteral(lo))
@@ -4552,6 +4552,11 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           // js.import(arg)
           val arg = genArgs1
           js.JSImportCall(arg)
+
+        case STRICT_EQ =>
+          // js.special.strictEquals(arg1, arg2)
+          val (arg1, arg2) = genArgs2
+          js.JSBinaryOp(js.JSBinaryOp.===, arg1, arg2)
 
         case IN =>
           // js.special.in(arg1, arg2)

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -99,6 +99,7 @@ trait JSDefinitions {
       lazy val JSImport_apply = getMemberMethod(JSImportModuleClass, nme.apply)
 
     lazy val SpecialPackageModule = getPackageObject("scala.scalajs.js.special")
+      lazy val Special_strictEquals = getMemberMethod(SpecialPackageModule, newTermName("strictEquals"))
       lazy val Special_in = getMemberMethod(SpecialPackageModule, newTermName("in"))
       lazy val Special_instanceof = getMemberMethod(SpecialPackageModule, newTermName("instanceof"))
       lazy val Special_delete = getMemberMethod(SpecialPackageModule, newTermName("delete"))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
@@ -54,11 +54,12 @@ abstract class JSPrimitives {
   final val WITH_CONTEXTUAL_JS_CLASS_VALUE = CREATE_LOCAL_JS_CLASS + 1 // runtime.withContextualJSClassValue
   final val LINKING_INFO = WITH_CONTEXTUAL_JS_CLASS_VALUE + 1          // runtime.linkingInfo
 
-  final val IN = LINKING_INFO + 1   // js.special.in
-  final val INSTANCEOF = IN + 1     // js.special.instanceof
-  final val DELETE = INSTANCEOF + 1 // js.special.delete
-  final val FORIN = DELETE + 1      // js.special.forin
-  final val DEBUGGER = FORIN + 1    // js.special.debugger
+  final val STRICT_EQ = LINKING_INFO + 1 // js.special.strictEquals
+  final val IN = STRICT_EQ + 1           // js.special.in
+  final val INSTANCEOF = IN + 1          // js.special.instanceof
+  final val DELETE = INSTANCEOF + 1      // js.special.delete
+  final val FORIN = DELETE + 1           // js.special.forin
+  final val DEBUGGER = FORIN + 1         // js.special.debugger
 
   final val LastJSPrimitiveCode = DEBUGGER
 
@@ -98,6 +99,7 @@ abstract class JSPrimitives {
         WITH_CONTEXTUAL_JS_CLASS_VALUE)
     addPrimitive(Runtime_linkingInfo, LINKING_INFO)
 
+    addPrimitive(Special_strictEquals, STRICT_EQ)
     addPrimitive(Special_in, IN)
     addPrimitive(Special_instanceof, INSTANCEOF)
     addPrimitive(Special_delete, DELETE)

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -712,7 +712,7 @@ object Trees {
    */
   case class JSUnaryOp(op: JSUnaryOp.Code, lhs: Tree)(
       implicit val pos: Position) extends Tree {
-    val tpe = AnyType
+    val tpe = JSUnaryOp.resultTypeOf(op)
   }
 
   object JSUnaryOp {
@@ -725,6 +725,9 @@ object Trees {
     final val ! = 4
 
     final val typeof = 5
+
+    def resultTypeOf(op: Code): Type =
+      AnyType
   }
 
   /** Binary operation (always preserves pureness).
@@ -734,7 +737,7 @@ object Trees {
    */
   case class JSBinaryOp(op: JSBinaryOp.Code, lhs: Tree, rhs: Tree)(
       implicit val pos: Position) extends Tree {
-    val tpe = AnyType
+    val tpe = JSBinaryOp.resultTypeOf(op)
   }
 
   object JSBinaryOp {
@@ -767,6 +770,18 @@ object Trees {
 
     final val in         = 20
     final val instanceof = 21
+
+    def resultTypeOf(op: Code): Type = op match {
+      case === | !== =>
+        /* We assume that ECMAScript will never pervert `===` and `!==` to the
+         * point of them not returning a primitive boolean. This is important
+         * for the trees resulting from optimizing `BinaryOp.===` into
+         * `JSBinaryOp.===` to be well-typed.
+         */
+        BooleanType
+      case _ =>
+        AnyType
+    }
   }
 
   case class JSArrayConstr(items: List[TreeOrJSSpread])(

--- a/javalanglib/src/main/scala/java/lang/Double.scala
+++ b/javalanglib/src/main/scala/java/lang/Double.scala
@@ -31,22 +31,8 @@ final class Double private () extends Number with Comparable[Double] {
   @inline def longValue(): scala.Long = doubleValue.toLong
   @inline def floatValue(): scala.Float = doubleValue.toFloat
 
-  override def equals(that: Any): scala.Boolean = {
-    /* Since Double is hijacked as primitive numbers, reference equality (eq)
-     * is equivalent to value equality (==). We use `eq` here as an
-     * optimization to avoid the type test on the right-hand-side: since we
-     * know that `this` is a number, if `this eq that`, then so is `that`. And
-     * in the else branch, `that ne that` is true if and only if `that` is
-     * `NaN` (hence `false` if it is not a number to begin with).
-     */
-    if (this eq that.asInstanceOf[AnyRef]) {
-      // 0.0.equals(-0.0) must be false
-      doubleValue != 0.0 || (1/doubleValue == 1/that.asInstanceOf[scala.Double])
-    } else {
-      // NaN.equals(NaN) must be true
-      (this ne this) && (that.asInstanceOf[AnyRef] ne that.asInstanceOf[AnyRef])
-    }
-  }
+  @inline override def equals(that: Any): scala.Boolean =
+    this eq that.asInstanceOf[AnyRef]
 
   @inline override def hashCode(): Int =
     Double.hashCode(doubleValue)

--- a/javalanglib/src/main/scala/java/lang/Float.scala
+++ b/javalanglib/src/main/scala/java/lang/Float.scala
@@ -30,7 +30,7 @@ final class Float private () extends Number with Comparable[Float] {
   @inline def doubleValue(): scala.Double = floatValue.toDouble
 
   @inline override def equals(that: Any): scala.Boolean =
-    doubleValue.equals(that)
+    this eq that.asInstanceOf[AnyRef]
 
   @inline override def hashCode(): Int =
     Float.hashCode(floatValue)

--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -250,19 +250,8 @@ object IdentityHashMap {
       System.identityHashCode(inner)
   }
 
-  @inline private def same(v1: Any, v2: Any): Boolean = {
-    // v1.asInstanceOf[AnyRef] eq v2.asInstanceOf[AnyRef]
-    // Use the following until 1.0.0
-    // See https://github.com/scala-js/scala-js/pull/3747
-    val v1Ref = v1.asInstanceOf[AnyRef]
-    val v2Ref = v2.asInstanceOf[AnyRef]
-    if (v1Ref eq v2Ref) {
-      (v1Ref ne java.lang.Double.valueOf(0.0)) ||
-      (1.0 / v1Ref.asInstanceOf[Double] == 1.0 / v2Ref.asInstanceOf[Double]) // +0.0 v -0.0
-    } else {
-      (v1Ref ne v1Ref) && (v2Ref ne v2Ref) // NaN
-    }
-  }
+  @inline private def same(v1: Any, v2: Any): Boolean =
+    v1.asInstanceOf[AnyRef] eq v2.asInstanceOf[AnyRef]
 
   private def findSame[K](elem: K, c: Collection[_]): Boolean = {
     // scalastyle:off return

--- a/javalib/src/main/scala/java/util/PriorityQueue.scala
+++ b/javalib/src/main/scala/java/util/PriorityQueue.scala
@@ -103,23 +103,9 @@ class PriorityQueue[E] private (
   private def removeExact(o: Any): Unit = {
     val len = inner.length
     var i = 1
-
-    /* This is tricky. We must use reference equality to find the exact object
-     * to remove, but if `o` is a positive or negative 0.0 or NaN, we must use
-     * `equals` to delete the correct element (i.e., not confuse +0.0 and -0.0,
-     * and considering `NaN` equal to itself).
-     */
-    o match {
-      case o: Double if o == 0.0 || java.lang.Double.isNaN(o) =>
-        while (i != len && !o.equals(inner(i))) {
-          i += 1
-        }
-      case _ =>
-        while (i != len && (o.asInstanceOf[AnyRef] ne inner(i).asInstanceOf[AnyRef])) {
-          i += 1
-        }
+    while (i != len && (o.asInstanceOf[AnyRef] ne inner(i).asInstanceOf[AnyRef])) {
+      i += 1
     }
-
     if (i == len)
       throw new ConcurrentModificationException()
     removeAt(i)

--- a/library/src/main/scala/scala/scalajs/js/special/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/special/package.scala
@@ -51,6 +51,20 @@ package object special {
     result
   }
 
+  /** Tests whether two values are equal according to ECMAScript's
+   *  *Strict Equality Comparison* (`===`).
+   *
+   *  This is equivalent to `x eq y`, except that:
+   *
+   *  - `strictEquals(NaN, NaN)` is `false` whereas `NaN eq NaN` is `true`
+   *  - `strictEquals(+0.0, -0.0)` is `true` whereas `+0.0 eq -0.0` is `false`
+   *
+   *  @return
+   *    the result of `x === y` where `===` is the ECMAScript operator.
+   */
+  def strictEquals(x: scala.Any, y: scala.Any): Boolean =
+    throw new java.lang.Error("stub")
+
   /** Tests whether an object has a given enumerable property in its prototype
    *  chain.
    *

--- a/project/NodeJSEnvForcePolyfills.scala
+++ b/project/NodeJSEnvForcePolyfills.scala
@@ -30,6 +30,8 @@ final class NodeJSEnvForcePolyfills(config: NodeJSEnv.Config) extends JSEnv {
     val p = Files.write(
         Jimfs.newFileSystem().getPath("scalaJSEnvInfo.js"),
         """
+          |delete Object.is;
+          |
           |delete Math.fround;
           |delete Math.imul;
           |delete Math.clz32;

--- a/scalalib/overrides/scala/runtime/BoxesRunTime.scala
+++ b/scalalib/overrides/scala/runtime/BoxesRunTime.scala
@@ -44,7 +44,7 @@ object BoxesRunTime {
   def unboxToDouble(d: Any): Double = d.asInstanceOf[Double]
 
   def equals(x: Object, y: Object): Boolean =
-    if (x eq y) true
+    if (scala.scalajs.js.special.strictEquals(x, y)) true
     else equals2(x, y)
 
   @inline // only called by equals(), not by codegen

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/EqJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/EqJSTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.compiler
+
+import org.junit.Test
+import org.junit.Assert._
+
+/** Test that `eq` and `ne` have the additional guarantees provided by
+ *  Scala.js for instances of hijacked classes.
+ *
+ *  These tests would be too restrictive on the JVM.
+ */
+class EqJSTest {
+  @Test
+  def testEqNe(): Unit = {
+    @noinline def testNoInline(expected: Boolean, x: Any, y: Any): Unit = {
+      assertEquals(expected, x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef])
+      assertEquals(!expected, x.asInstanceOf[AnyRef] ne y.asInstanceOf[AnyRef])
+    }
+
+    @inline def test(expected: Boolean, x: Any, y: Any): Unit = {
+      testNoInline(expected, x, y)
+      assertEquals(expected, x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef])
+      assertEquals(!expected, x.asInstanceOf[AnyRef] ne y.asInstanceOf[AnyRef])
+    }
+
+    val o1 = new Object
+    val o2 = new Object
+
+    val t1 = ("foo", "bar")
+    val t2 = ("foo", "bar")
+
+    test(true, o1, o1)
+    test(false, o1, o2)
+    test(true, t1, t1)
+    test(false, t1, t2)
+    test(true, "foo", "foo")
+    test(false, "foo", "bar")
+    test(true, Double.NaN, Double.NaN)
+    test(true, 0.0, 0.0)
+    test(true, -0.0, -0.0)
+    test(false, 0.0, -0.0)
+    test(true, 0, 0.0)
+    test(true, 5, 5)
+    test(false, 5, 4)
+  }
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
@@ -22,6 +22,20 @@ import org.scalajs.testsuite.utils.AssertThrows._
 class SpecialTest {
   import SpecialTest._
 
+  // scala.scalajs.js.special.strictEquals
+
+  @Test def strictEqualsTest(): Unit = {
+    import js.special.strictEquals
+
+    val o1 = new js.Object
+    val o2 = new js.Object
+    assertTrue(strictEquals(o1, o1))
+    assertFalse(strictEquals(o1, o2))
+    assertTrue(strictEquals(+0.0, -0.0))
+    assertTrue(strictEquals(-0.0, +0.0))
+    assertFalse(strictEquals(Double.NaN, Double.NaN))
+  }
+
   // scala.scalajs.js.special.in
 
   @Test def inTest(): Unit = {

--- a/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/ObjectsTestOnJDK7.scala
+++ b/test-suite/shared/src/test/require-jdk7/org/scalajs/testsuite/javalib/util/ObjectsTestOnJDK7.scala
@@ -44,6 +44,9 @@ class ObjectsTestOnJDK7 {
     assertFalse(ju.Objects.deepEquals(1, 2))
     assertTrue(ju.Objects.deepEquals("abc", "abc"))
     assertFalse(ju.Objects.deepEquals("abc", "abd"))
+    assertFalse(ju.Objects.deepEquals(0.0, -0.0))
+    assertTrue(ju.Objects.deepEquals(0.0, 0.0))
+    assertTrue(ju.Objects.deepEquals(Double.NaN, Double.NaN))
     assertTrue(ju.Objects.deepEquals(Array(Array(1)), Array(Array(1))))
   }
 


### PR DESCRIPTION
Previously, `x eq x` would answer `false` if `x` was `NaN`; and `+0.0 eq -0.0` would answer `true`, although `+0.0.equals(-0.0)` answers `false`.

That behavior was intentionally spec'ed, but arguably the spec had been wrong all along. It was specified like that because we couldn't possibly incur the performance hit of a strict identity function for every single `eq` in the world, an operation that is supposed to be virtually free.

Nevertheless, the spec'ed behavior caused a number of issues, for example when using `eq` to cheaply test whether two values were definitely equal (that was incorrect for +0.0 and -0.0), or when using `eq` to find the exact occurrence of a value in a data structure by reference (that was incorrect for NaN).

In this commit, we change the spec to the much more clearly correct alternative where `NaN eq NaN` is true, and `+0.0 eq -0.0` is false. The full check is implemented with the ES 2015 builtin function `Object.is(x, y)`, which we polyfill when emitting ES 5.1.

In order not to have performance issues, the optimizer is enhanced to optimize `eq` down to JavaScript's `===` when it can prove that it is safe to do so. This happens when one of the following applies:

* Either operand can be proven not to be a primitive number, which can often be done by looking at its type. This is a *very* common scenario, notably in all tests of the form `x eq null` or of the form `someNode eq x` (where `someNode` is a value of some type `Node` of a data structure, for example).
* Both operands are known to be whole primitive numbers: `x eq y` can become `x === y` when `x` and `y` are both `int`s, for example.

These optimizations leave very few uses of `eq` as the full check with `Object.is`, all of which are actually desirable fixes. In the test suite, the optimization applies to 99.8% of the use sites of `eq` and `ne`.

This change means that there is no way to write user code corresponding to ECMAScript's `x === y` for arbitrary `x` and `y` anymore. Although it is possible to write it by hand on top of `eq`, it is a bit absurd to undo the effects of `Object.is` to recover the behavior of `===`. We add a new builtin `js.special.strictEquals(x, y)` for that purpose. It is used in the fast path of `BoxesRunTime.equals(x, y)`, which was the only place in the codebase where we really meant `===` when writing `eq`.