### PR TITLE
Fix #3419 and #3596: Backup and restore .sjsir files ourselves.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -854,7 +854,7 @@ object Build {
           sbtVersion in pluginCrossBuild := {
             scalaVersion.value match {
               case v if v.startsWith("2.10.") => "0.13.17"
-              case _ => "1.0.0"
+              case _ => "1.2.1"
             }
           },
           scalaBinaryVersion :=

--- a/sbt-plugin-test/project/build.properties
+++ b/sbt-plugin-test/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.0.0
+sbt.version=1.2.8

--- a/sbt-plugin/src/main/scala-sbt-1.0/org/scalajs/sbtplugin/SBTCompat.scala
+++ b/sbt-plugin/src/main/scala-sbt-1.0/org/scalajs/sbtplugin/SBTCompat.scala
@@ -14,8 +14,6 @@ package org.scalajs.sbtplugin
 
 import sbt._
 
-import org.scalajs.core.tools.io.FileVirtualFile
-
 private[sbtplugin] object SBTCompat {
   type IncOptions = xsbti.compile.IncOptions
 
@@ -43,36 +41,11 @@ private[sbtplugin] object SBTCompat {
     }
   }
 
-  /** Patches the IncOptions so that .sjsir files are pruned as needed.
-   *
-   *  This complicated logic patches the ClassfileManager factory of the given
-   *  IncOptions with one that is aware of .sjsir files emitted by the Scala.js
-   *  compiler. This makes sure that, when a .class file must be deleted, the
-   *  corresponding .sjsir file are also deleted.
+  /** Patches the IncOptions so that .sjsir files are pruned, backed up and
+   *  restored as needed.
    */
   def scalaJSPatchIncOptions(incOptions: IncOptions): IncOptions = {
-    import xsbti.compile.{ClassFileManager, ClassFileManagerUtil}
-
-    val sjsirFileManager = new ClassFileManager {
-      private[this] val inherited =
-        ClassFileManagerUtil.getDefaultClassFileManager(incOptions)
-
-      def delete(classes: Array[File]): Unit = {
-        inherited.delete(classes.flatMap { classFile =>
-          if (classFile.getPath.endsWith(".class")) {
-            val f = FileVirtualFile.withExtension(classFile, ".class", ".sjsir")
-            if (f.exists) List(f)
-            else Nil
-          } else {
-            Nil
-          }
-        })
-      }
-
-      def generated(classes: Array[File]): Unit = {}
-      def complete(success: Boolean): Unit = {}
-    }
-
+    val sjsirFileManager = new SJSIRFileManager
     val newExternalHooks =
       incOptions.externalHooks.withExternalClassFileManager(sjsirFileManager)
     incOptions.withExternalHooks(newExternalHooks)

--- a/sbt-plugin/src/main/scala-sbt-1.0/org/scalajs/sbtplugin/SJSIRFileManager.scala
+++ b/sbt-plugin/src/main/scala-sbt-1.0/org/scalajs/sbtplugin/SJSIRFileManager.scala
@@ -1,0 +1,117 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.sbtplugin
+
+import java.io.File
+import java.nio.file.Files
+
+import scala.collection.mutable
+
+import sbt._
+
+import xsbti.compile.ClassFileManager
+
+/** A class file manager that prunes .sjsir files as needed.
+ *
+ *  This makes sure that, when a .class file must be deleted, the
+ *  corresponding .sjsir file is also deleted, as well as maintaining the
+ *  transactional aspect of incremental compilation in the presence of
+ *  compilation errors in an intermediate run (as product files need to be
+ *  backed up and later restored).
+ *
+ *  This code is adapted from Zinc `TransactionalClassFileManager`.
+ *  We need to duplicate the logic since forwarding to the default class
+ *  file manager doesn't work: we need to backup sjsir files in a different
+ *  temporary directory as class files.
+ *
+ *  We stole this from `TastyFileManager` in dotty, at
+ *  https://github.com/lampepfl/dotty/blob/0.17.0-RC1/sbt-dotty/src/dotty/tools/sbtplugin/TastyFileManager.scala
+ *
+ *  There are plans to upstream a generic version of this code in zinc in the
+ *  future: https://github.com/sbt/zinc/issues/579
+ */
+private[sbtplugin] final class SJSIRFileManager extends ClassFileManager {
+  private[this] var _tempDir: File = null
+
+  private[this] def tempDir: File = {
+    if (_tempDir == null)
+      _tempDir = Files.createTempDirectory("backup").toFile
+    _tempDir
+  }
+
+  private[this] val generatedSJSIRFiles = new mutable.HashSet[File]
+  private[this] val movedSJSIRFiles = new mutable.HashMap[File, File]
+
+  /* The incremental compiler works along the following general protocol:
+   * 1. it identifies the set of files that have been changed/added/removed
+   * 2. it compiles that set of files
+   *    a) it first `delete`s the products of changed and removed files
+   *    b) then it compiles the files
+   *    c) it registers produced files as `generated`
+   * 3. it detects whether a new round of compilation is necessary, and with
+   *    which files; if necessary, it loops back to 2.
+   * 4. when no new round is necessary, it `complete`s with `success = true` if
+   *    the whole cycle is successful, or `success = false` otherwise.
+   *
+   * Consequently, it is quite possible that, within one cycle, a given file is
+   * `generated` during one iteration, and `delete`d in a subsequent one. In
+   * this case, we would need to revert back to the file not being present in
+   * the final transactional output on `success = false`. This is why we have
+   * the `!generatedSJSIRFiles(t)` test in `delete()` below.
+   */
+
+  override def delete(classes: Array[File]): Unit = {
+    val files = sjsirFiles(classes)
+    val toBeBackedUp = files
+      .filter(t => !movedSJSIRFiles.contains(t) && !generatedSJSIRFiles(t))
+    for (c <- toBeBackedUp)
+      movedSJSIRFiles.put(c, backupFile(c))
+    IO.deleteFilesEmptyDirs(files)
+  }
+
+  override def generated(classes: Array[File]): Unit =
+    generatedSJSIRFiles ++= sjsirFiles(classes)
+
+  override def complete(success: Boolean): Unit = {
+    if (!success) {
+      IO.deleteFilesEmptyDirs(generatedSJSIRFiles)
+      for ((orig, tmp) <- movedSJSIRFiles)
+        IO.move(tmp, orig)
+    }
+
+    generatedSJSIRFiles.clear()
+    movedSJSIRFiles.clear()
+    if (_tempDir != null) {
+      IO.delete(_tempDir)
+      _tempDir = null
+    }
+  }
+
+  private def sjsirFiles(classes: Array[File]): Array[File] = {
+    classes.flatMap { classFile =>
+      if (classFile.getPath.endsWith(".class")) {
+        val f = new File(classFile.getPath.stripSuffix(".class") + ".sjsir")
+        if (f.exists) List(f)
+        else Nil
+      } else {
+        Nil
+      }
+    }
+  }
+
+  private def backupFile(c: File): File = {
+    val target = File.createTempFile("sbt", ".sjsir", tempDir)
+    IO.move(c, target)
+    target
+  }
+}

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -12,7 +12,7 @@ BIN_VERSIONS="2.10.7 2.11.12 2.12.8 2.13.0"
 CLI_VERSIONS="2.10.7 2.11.12 2.12.8 2.13.0"
 SBT_VERSION="2.10.7"
 SBT1_VERSION="2.12.8"
-SBT1_SBTVERSION="1.0.0"
+SBT1_SBTVERSION="1.2.1"
 
 COMPILER="compiler jUnitPlugin"
 LIBS="library javalibEx ir irJS tools toolsJS jsEnvs jsEnvsTestKit testAdapter stubs testInterface testBridge jUnitRuntime"


### PR DESCRIPTION
Rather than relying on zinc to do it based on the arguments to `delete()`, which it hasn't done since sbt 1.x.

The fix requires sbt 1.2.1+ to be meaningful, so we first upgrade our sbt plugin to use sbt 1.2.1.