### PR TITLE
Use scripted for concurrent linker test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -364,7 +364,8 @@ def Tasks = [
         linker/compile:doc jsEnvs/compile:doc \
         jsEnvsTestKit/compile:doc nodeJSEnv/compile:doc \
         testAdapter/compile:doc \
-        sbtPlugin/compile:doc
+        sbtPlugin/compile:doc &&
+    sbt sbtPlugin/scripted
   ''',
 
   "partestc": '''
@@ -393,7 +394,7 @@ def Tasks = [
         noDOM/testHtml multiTestJS/testHtml \
         test \
         noDOM/testScalaJSModuleInitializers \
-        noDOM/clean noDOM/concurrentUseOfLinkerTest \
+        noDOM/clean \
         multiTestJS/test:testScalaJSSourceMapAttribute &&
     sbt 'set scalaJSStage in Global := FullOptStage' \
         noDOM/testHtml multiTestJS/testHtml

--- a/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/Main.scala
+++ b/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/Main.scala
@@ -1,0 +1,5 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def main(args: Array[String]): Unit = println("Hello World")
+}

--- a/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/build.sbt
@@ -1,0 +1,48 @@
+import scala.concurrent.Await
+import scala.concurrent.duration.Duration
+
+import org.scalajs.linker.MemOutputFile
+import org.scalajs.linker.interface._
+import org.scalajs.sbtplugin.Loggers.sbtLogger2ToolsLogger
+
+lazy val concurrentFakeFullOptJS = taskKey[Any]("")
+lazy val concurrentUseOfLinkerTest = taskKey[Any]("")
+
+name := "Scala.js sbt test"
+
+version := scalaJSVersion
+scalaVersion := "2.12.8"
+
+enablePlugins(ScalaJSPlugin)
+
+/* This hopefully exposes concurrent uses of the linker. If it fails/gets
+ * flaky, there is a bug somewhere - #2202
+ */
+
+// A fake fullOptJS that we will run concurrently with the true fullOptJS
+concurrentFakeFullOptJS := Def.taskDyn {
+  val log = streams.value.log
+  val ir = (scalaJSIR in Compile).value.data
+  val moduleInitializers = (scalaJSModuleInitializers in Compile).value
+
+  Def.task {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
+    log.info("Fake full optimizing")
+    val linker = (scalaJSLinker in Compile in fullOptJS).value
+    val output = LinkerOutput(MemOutputFile())
+    Await.result(
+      linker.link(ir, moduleInitializers, output, sbtLogger2ToolsLogger(log)),
+      Duration.Inf)
+  }.tag((usesScalaJSLinkerTag in Compile in fullOptJS).value)
+}.value
+
+/* Depend on both fullOptJS and concurrentFakeFullOptJS, so that they
+ * are hopefully executed in parallel (potentially, but they should be
+ * blocked from actually doing so by the concurrent restrictions on
+ * usesScalaJSLinkerTag).
+ */
+concurrentUseOfLinkerTest := {
+  (fullOptJS in Compile).value
+  concurrentFakeFullOptJS.value
+}

--- a/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/project/build.properties
+++ b/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/project/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/test
+++ b/sbt-plugin/src/sbt-test/linker-tags/concurrent-linker-use/test
@@ -1,0 +1,1 @@
+> concurrentUseOfLinkerTest


### PR DESCRIPTION
This is so that the main sbt-plugin-test does not have a direct dependency on the Linker anymore (see #3805 for details).