### PR TITLE
Make AbstractCollection#toString & sub-classes match Java 8 specification.

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -89,5 +89,5 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   }
 
   override def toString(): String =
-    this.scalaOps.mkString("[", ",", "]")
+    this.scalaOps.mkString("[", ", ", "]")
 }

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -221,7 +221,6 @@ class CopyOnWriteArrayList[E <: AnyRef] private (private var inner: js.Array[E])
 
   override def toString: String =
     iterator().scalaOps.mkString("[", ", ", "]")
-    iterator().scalaOps.toString()
 
   override def equals(obj: Any): Boolean = {
     if (obj.asInstanceOf[AnyRef] eq this) {

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -220,7 +220,8 @@ class CopyOnWriteArrayList[E <: AnyRef] private (private var inner: js.Array[E])
   }
 
   override def toString: String =
-    iterator().scalaOps.mkString("[", ",", "]")
+    iterator().scalaOps.mkString("[", ", ", "]")
+    iterator().scalaOps.toString()
 
   override def equals(obj: Any): Boolean = {
     if (obj.asInstanceOf[AnyRef] eq this) {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -288,6 +288,45 @@ trait CollectionTest {
     assertTrue(msg, resultIsValid)
   }
 
+  @Test def toStringInCustomClassShouldWork(): Unit = {
+
+    val elements = Array[Int](-1, -2, -3)
+    val sep = "; "
+
+    val expected = ">" +
+        elements(0) + sep +
+        elements(1) + sep +
+        elements(2) + 
+        "<"
+
+    class Custom[E] extends ju.AbstractCollection[E] {
+      self =>
+
+      def iterator(): ju.Iterator[E] = {
+        new ju.Iterator[E]  {
+          def hasNext(): Boolean = false
+          def next(): E = throw new NoSuchElementException()
+          override def remove(): Unit = throw new UnsupportedOperationException
+        }
+      }
+
+      def size = 0
+
+      override def toString(): String = expected
+    }
+
+    val coll = new Custom
+
+    val result = coll.toString()
+
+    val resultIsValid = (result == expected)
+
+    val msg = "result '" + result +
+        "' did not match expected '" + expected + "'"
+
+    assertTrue(msg, resultIsValid)
+  }
+
 }
 
 object CollectionFactory {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -238,6 +238,56 @@ trait CollectionTest {
     assertEquals(5, coll.size())
     assertEquals(coll.iterator().asScala.toSet, Set(-45, 0, 12, 32, 42))
   }
+
+  @Test def toStringShouldConvertEmptyCollection(): Unit = {
+    val coll = factory.empty[Double]
+
+    val expected = "[]"
+    val result = coll.toString()
+    assertEquals(expected, result)
+  }
+
+  @Test def toStringShouldConvertOneElementCollection(): Unit = {
+    val coll = factory.fromElements[Double](1.01)
+
+    val expected = "[1.01]"
+    val result = coll.toString()
+    assertEquals(expected, result)
+  }
+
+  @Test def toStringShouldUseCommaSpace(): Unit = {
+    // Check/change regex pattern below if making changes here.
+    val coll = factory.fromElements[Double](88.42, -23.36, 60.173)
+
+    val result = coll.toString()
+
+    // The major interest here is if the Java 8 comma-space idiom
+    // is used correctly. 
+
+    // As long as this test is being run, might as well check that
+    // the output elements look the floating point numbers given
+    // to the factory.
+
+    // The order of the elements in the output is not specified by
+    // AbstractCollection. Some sub-classes, such as Deque & TreeSet,
+    // do define orders. HashMap is a concrete class which does not.
+
+    val element = "-?\\d{2}\\.\\d{2,3}"
+    val commaSpace = ", "
+
+    val pattern = "\\[" +
+        element + commaSpace +
+        element + commaSpace +
+        element + "\\]"
+
+    val resultIsValid =  result.matches(pattern)
+
+    val msg = "result '" + result +
+        "' did not match expected pattern '" + pattern + "'"
+
+    assertTrue(msg, resultIsValid)
+  }
+
 }
 
 object CollectionFactory {


### PR DESCRIPTION
Make AbstractCollection#toString match Java 8 specification.

   * The Java 8 specification for (AbstractCollection)[https://docs.oracle.com/
javase/8/docs/api/java/util/AbstractCollection.html#toString--] describes
    the resultant string as using comma-space as the separator for collections
    with size greater than one.

     Prior to this PR, ArrayDeque.scala, ArrayList, and other
     sub-classes of AbstractCollection would create a string such as
     "[a,b]". This PR corrects that to the specified "[a, b]".

   * Testing: I added three test cases to CollectionTest.scala.
      I test the zero, one, and three element cases. I also added
      a test for a custom class which overrides toString.

      I was not clever enough to figure out a way to test the case of
      instances of sub-classes of AbstractCollections containing nulls.
      Certainly ArrayDeque & ArrayList test for and reject the
      addition of null elements.

      Any Collection containing nulls would have to be tested at a level
      lower that CollectionTest. I know of no such collection, but that
      just reveals the limits of my knowledge & research.  From
      an understanding of the internals of AbstractCollection#toString,
      I expect it to handle collections containing nulls just fine.

   * Documentation: Even though this PR is a one character change 
      in two places, it warrants a brief release note.  Somebody is bound to be
      parsing the current output, probably as a CSV (comma separated
      value) list.

      I checked the Scala-js web site landing page and the documentation
      page and did not see anything affected by this PR. I did not
      check the videos, which might show present output.   I will
      remain vigilant for required changes.
