### PR TITLE
Make AbstractCollection#toString match Java 8 specification.

### DIFF
--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -89,5 +89,5 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   }
 
   override def toString(): String =
-    this.scalaOps.mkString("[", ",", "]")
+    this.scalaOps.mkString("[", ", ", "]")
 }

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -221,7 +221,7 @@ class CopyOnWriteArrayList[E <: AnyRef] private (private var inner: js.Array[E])
   }
 
   override def toString: String =
-    iterator().scalaOps.mkString("[", ",", "]")
+    iterator().scalaOps.mkString("[", ", ", "]")
 
   override def equals(obj: Any): Boolean = {
     if (obj.asInstanceOf[AnyRef] eq this) {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
@@ -174,4 +174,6 @@ class ArrayDequeFactory extends AbstractCollectionFactory with DequeFactory {
 
   def from[E](coll: ju.Collection[E]): ju.ArrayDeque[E] =
     new ju.ArrayDeque[E](coll)
+
+  override def allowsNullElement: Boolean = false
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedSetTest.scala
@@ -30,7 +30,7 @@ trait CollectionsOnCheckedSetTest extends CollectionsOnSetsTest {
             ct.runtimeClass.asInstanceOf[Class[E]])
       }
 
-      def allowsNullElement: Boolean =
+      override def allowsNullElement: Boolean =
         originalFactory.allowsNullElement
     }
   }
@@ -50,7 +50,7 @@ trait CollectionsOnCheckedSortedSetTest extends CollectionsOnSortedSetsTest {
             ct.runtimeClass.asInstanceOf[Class[E]])
       }
 
-      def allowsNullElement: Boolean =
+      override def allowsNullElement: Boolean =
         originalFactory.allowsNullElement
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSetFromMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSetFromMapTest.scala
@@ -28,7 +28,7 @@ trait CollectionsOnSetFromMapTest extends SetTest {
       def empty[E: ClassTag]: ju.Set[E] =
         ju.Collections.newSetFromMap[E](mapFactory.empty[E, jl.Boolean])
 
-      def allowsNullElement: Boolean =
+      override def allowsNullElement: Boolean =
         mapFactory.allowsNullKeys
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnSynchronizedSetTest.scala
@@ -28,7 +28,7 @@ trait CollectionsOnSynchronizedSetTest extends CollectionsOnSetsTest {
       override def empty[E: ClassTag]: ju.Set[E] =
         ju.Collections.synchronizedSet(originalFactory.empty[E])
 
-      def allowsNullElement: Boolean =
+      override def allowsNullElement: Boolean =
         originalFactory.allowsNullElement
     }
   }
@@ -46,7 +46,7 @@ trait CollectionsOnSynchronizedSortedSetTest extends CollectionsOnSortedSetsTest
       override def empty[E: ClassTag]: ju.SortedSet[E] =
         ju.Collections.synchronizedSortedSet(originalFactory.empty[E])
 
-      def allowsNullElement: Boolean =
+      override def allowsNullElement: Boolean =
         originalFactory.allowsNullElement
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
@@ -28,6 +28,4 @@ class HashSetFactory extends AbstractSetFactory {
 
   def empty[E: ClassTag]: ju.HashSet[E] =
     new ju.HashSet[E]()
-
-  def allowsNullElement: Boolean = true
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
@@ -333,7 +333,7 @@ class PriorityQueueTest extends CollectionTest {
     for (x <- List(1, 2, 30, 4, 3, 40, 35, 10))
       pq.add(x)
 
-    assertEquals("[1,2,30,4,3,40,35,10]", pq.toString())
+    assertEquals("[1, 2, 30, 4, 3, 40, 35, 10]", pq.toString())
 
     val iter = pq.iterator()
     assertEquals(1, iter.next())
@@ -344,13 +344,13 @@ class PriorityQueueTest extends CollectionTest {
     assertEquals(40, iter.next())
 
     iter.remove()
-    assertEquals("[1,2,10,4,3,30,35]", pq.toString())
+    assertEquals("[1, 2, 10, 4, 3, 30, 35]", pq.toString())
 
     assertEquals(35, iter.next())
     assertEquals(10, iter.next())
 
     iter.remove()
-    assertEquals("[1,2,30,4,3,35]", pq.toString())
+    assertEquals("[1, 2, 30, 4, 3, 35]", pq.toString())
 
     assertFalse(iter.hasNext())
   }
@@ -369,7 +369,7 @@ class PriorityQueueTest extends CollectionTest {
     for (x <- List(-1.0, -0.0, 0.0, 3.5, Double.NaN))
       pq.add(x)
 
-    assertEquals("[-1,0,0,3.5,NaN]", pq.toString())
+    assertEquals("[-1, 0, 0, 3.5, NaN]", pq.toString())
 
     val iter = pq.iterator()
     assertEquals(-1.0: Any, iter.next())
@@ -378,7 +378,7 @@ class PriorityQueueTest extends CollectionTest {
 
     iter.remove()
     assertEquals("+0.0 must have been removed, not -0.0",
-        "[-1,0,NaN,3.5]", pq.toString())
+        "[-1, 0, NaN, 3.5]", pq.toString())
     assertTrue("+0.0 must have been removed, not -0.0",
         pq.contains(-0.0) && !pq.contains(0.0))
 
@@ -386,7 +386,7 @@ class PriorityQueueTest extends CollectionTest {
     assertEquals(Double.NaN: Any, iter.next())
 
     iter.remove()
-    assertEquals("NaN must have been removed", "[-1,0,3.5]", pq.toString())
+    assertEquals("NaN must have been removed", "[-1, 0, 3.5]", pq.toString())
 
     assertFalse(iter.hasNext())
   }
@@ -418,7 +418,8 @@ class PriorityQueueTest extends CollectionTest {
     for (x <- List(first, second, third, fourth, fifth))
       pq.add(x)
 
-    assertEquals("[TestObj@10,TestObj@20,TestObj@21,TestObj@30,TestObj@40]",
+    assertEquals(
+        "[TestObj@10, TestObj@20, TestObj@21, TestObj@30, TestObj@40]",
         pq.toString())
 
     val iter = pq.iterator()
@@ -428,13 +429,13 @@ class PriorityQueueTest extends CollectionTest {
 
     iter.remove()
     assertEquals("third must have been removed, not second",
-        "[TestObj@10,TestObj@20,TestObj@40,TestObj@30]", pq.toString())
+        "[TestObj@10, TestObj@20, TestObj@40, TestObj@30]", pq.toString())
 
     assertSame(fourth, iter.next())
     assertSame(fifth, iter.next())
 
     iter.remove()
-    assertEquals("[TestObj@10,TestObj@20,TestObj@30]", pq.toString())
+    assertEquals("[TestObj@10, TestObj@20, TestObj@30]", pq.toString())
 
     assertFalse(iter.hasNext())
   }
@@ -475,4 +476,5 @@ class PriorityQueueFactory extends CollectionFactory {
   override def empty[E: ClassTag]: PriorityQueue[E] =
     new PriorityQueue()
 
+  override def allowsNullElement: Boolean = false
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
@@ -184,4 +184,6 @@ class ConcurrentLinkedQueueFactory extends AbstractCollectionFactory {
 
   def newFrom[E](coll: ju.Collection[E]): ConcurrentLinkedQueue[E] =
     new ConcurrentLinkedQueue[E](coll)
+
+  override def allowsNullElement: Boolean = false
 }


### PR DESCRIPTION
  * The Java 8 specification for (AbstractCollection)[https://docs.oracle.com/
    javase/8/docs/api/java/util/AbstractCollection.html#toString--] describes
    the resultant string as using comma-space as the separator for collections
    with size greater than one.

    Prior to this PR, ArrayDeque.scala, ArrayList, and other
    sub-classes of AbstractCollection would create a string such as
    "[a,b]". This PR corrects that to the specified "[a, b]".

  * This PR to the 0.6.x branch should merge cleanly with 1.0.0 mainline.
     At one point during development there was an issue with PriorityQueueTest
     not merging cleanly. That issue was resolved by using the most up-to-date
     0.6.x.

  * Testing: I added three test cases to CollectionTest.scala.
    I test the zero, one, and three element cases. I also added
    a test for a custom class which overrides toString.

     A number of edits were done to support testing both
     classes which allow nulls and those which do not.
   
  * Documentation: Even though this PR is a one character change
    in two places, it warrants a brief release note. Somebody is bound to be
    parsing the current output, probably as a CSV (comma separated
    value) list.

    I checked the Scala-js web site landing page and the documentation
    page and did not see anything affected by this PR. I did not
    check the videos, which might show present output. I will
    remain vigilant for required changes.