### PR TITLE
Fix #3778: Never inline `clone__O` if the receiver can be an array.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/ObjectClone.scala
+++ b/javalanglib/src/main/scala/java/lang/ObjectClone.scala
@@ -14,8 +14,6 @@ package java.lang
 
 import scala.scalajs.js
 
-import Utils._
-
 /** Implementation of `java.lang.Object.clone()`.
  *
  *  Called by the hard-coded IR of `java.lang.Object`.
@@ -69,7 +67,10 @@ private[lang] object ObjectClone {
       { (o: js.Object) =>
         val ownKeys = ownKeysFun(o)
         val descriptors = new js.Object
-        forArrayElems(ownKeys) { key =>
+        val len = ownKeys.length
+        var i = 0
+        while (i != len) {
+          val key = ownKeys(i)
           /* Almost equivalent to the JavaScript code
            *   descriptors[key] = Object.getOwnPropertyDescriptor(descriptors, key);
            * except that `defineProperty` will by-pass any existing setter for
@@ -81,6 +82,7 @@ private[lang] object ObjectClone {
             val writable = true
             val value = global.Object.getOwnPropertyDescriptor(o, key)
           })
+          i += 1
         }
         descriptors
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1433,6 +1433,15 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           targs.map(finishTransformExpr))(resultType), RefinedType(resultType)))
     }
 
+    def canBeArray(treceiver: PreTransform): Boolean = {
+      treceiver.tpe.base.isInstanceOf[ArrayType] || {
+        !treceiver.tpe.isExact && (treceiver.tpe.base match {
+          case AnyType | ClassType(ObjectClass) => true
+          case _                                => false
+        })
+      }
+    }
+
     treceiver.tpe.base match {
       case NothingType =>
         cont(treceiver)
@@ -1444,6 +1453,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case _ =>
         if (isReflProxyName(methodName)) {
           // Never inline reflective proxies
+          treeNotInlined
+        } else if (methodName == "clone__O" && canBeArray(treceiver)) {
+          // #3778 Never inline the `clone__O()` method if the receiver can be an array
           treeNotInlined
         } else {
           val cls = boxedClassForType(treceiver.tpe.base)

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -292,8 +292,8 @@ class AnalyzerTest {
 
   @Test
   def conflictingDefaultMethods(): AsyncResult = await {
-    val defaultMethodDef = MethodDef(MemberFlags.empty, Ident("foo__V"), Nil,
-        NoType, Some(Skip()))(emptyOptHints, None)
+    val defaultMethodDef = MethodDef(EMF, "foo__V", Nil,
+        NoType, Some(Skip()))(EOH, None)
     val classDefs = Seq(
         classDef("LI1", kind = ClassKind.Interface,
             memberDefs = List(defaultMethodDef)),
@@ -364,12 +364,12 @@ class AnalyzerTest {
     val classDefs = Seq(
         classDef("LA", superClass = Some(ObjectClass), memberDefs = List(
             trivialCtor("LA"),
-            MethodDef(MemberFlags.empty, Ident("test__V"), Nil, NoType, Some(Block(
-                Apply(EAF, systemMod, Ident("getProperty__T__T"), List(emptyStr))(StringType),
-                Apply(EAF, systemMod, Ident("getProperty__T__T__T"), List(emptyStr))(StringType),
-                Apply(EAF, systemMod, Ident("setProperty__T__T__T"), List(emptyStr))(StringType),
-                Apply(EAF, systemMod, Ident("clearProperty__T__T"), List(emptyStr))(StringType)
-            )))(emptyOptHints, None)
+            MethodDef(EMF, "test__V", Nil, NoType, Some(Block(
+                Apply(EAF, systemMod, "getProperty__T__T", List(emptyStr))(StringType),
+                Apply(EAF, systemMod, "getProperty__T__T__T", List(emptyStr))(StringType),
+                Apply(EAF, systemMod, "setProperty__T__T__T", List(emptyStr))(StringType),
+                Apply(EAF, systemMod, "clearProperty__T__T", List(emptyStr))(StringType)
+            )))(EOH, None)
         ))
     )
 
@@ -396,10 +396,10 @@ class AnalyzerTest {
         classDef("LX", superClass = Some(ObjectClass),
             memberDefs = List(
                 trivialCtor("LX"),
-                MethodDef(MemberFlags.empty, Ident("foo__LA"), Nil, ClassType("LA"),
-                    Some(Null()))(emptyOptHints, None),
-                MethodDef(MemberFlags.empty, Ident("foo__LB"), Nil, ClassType("LB"),
-                    Some(Null()))(emptyOptHints, None)
+                MethodDef(EMF, "foo__LA", Nil, ClassType("LA"),
+                    Some(Null()))(EOH, None),
+                MethodDef(EMF, "foo__LB", Nil, ClassType("LB"),
+                    Some(Null()))(EOH, None)
             )
         )
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -40,7 +40,7 @@ class IRCheckerTest {
   @Test
   def testMethodCallOnClassWithNoInstances(): AsyncResult = await {
     def callMethOn(receiver: Tree): Tree =
-      Apply(EAF, receiver, Ident("meth__LFoo__V"), List(Null()))(NoType)
+      Apply(EAF, receiver, "meth__LFoo__V", List(Null()))(NoType)
 
     val classDefs = Seq(
         // LFoo will be dropped by base linking
@@ -54,10 +54,10 @@ class IRCheckerTest {
                 /* This method is called, but unreachable because there are no
                  * instances of `Bar`. It will therefore not make `Foo` reachable.
                  */
-                MethodDef(MemberFlags.empty, Ident("meth__LFoo__V"),
+                MethodDef(EMF, "meth__LFoo__V",
                     List(paramDef("foo", ClassType("LFoo"))), NoType,
                     Some(Skip()))(
-                    emptyOptHints, None)
+                    EOH, None)
             )
         ),
 
@@ -65,12 +65,12 @@ class IRCheckerTest {
             superClass = Some(ObjectClass),
             memberDefs = List(
                 trivialCtor("LTest$"),
-                MethodDef(MemberFlags.empty, Ident("nullBar__LBar"), Nil, ClassType("LBar"),
+                MethodDef(EMF, "nullBar__LBar", Nil, ClassType("LBar"),
                     Some(Null()))(
-                    emptyOptHints, None),
+                    EOH, None),
                 mainMethodDef(Block(
                     callMethOn(Apply(EAF, This()(ClassType("LTest$")),
-                        Ident("nullBar__LBar"), Nil)(ClassType("LBar"))),
+                        "nullBar__LBar", Nil)(ClassType("LBar"))),
                     callMethOn(Null()),
                     callMethOn(Throw(Null()))
                 ))

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -42,21 +42,13 @@ class LinkerTest {
    */
   @Test
   def linkHelloWorld(): AsyncResult = await {
-    val name = "LHelloWorld$"
-    val mainMethodBody = {
-      JSMethodApply(JSGlobalRef(Ident("console")), StringLiteral("log"),
-          List(StringLiteral("Hello world!")))
-    }
     val classDefs = Seq(
-        classDef(name, kind = ClassKind.ModuleClass,
-            superClass = Some(ObjectClass),
-            memberDefs = List(
-                trivialCtor(name),
-                mainMethodDef(mainMethodBody)
-            )
-        )
+        mainTestClassDef({
+          JSMethodApply(JSGlobalRef("console"), StringLiteral("log"),
+              List(StringLiteral("Hello world!")))
+        })
     )
-    testLink(classDefs, mainModuleInitializers("HelloWorld"))
+    testLink(classDefs, MainTestModuleInitializers)
   }
 
   /** This test exposes a problem where a linker in error state is called

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -1,0 +1,196 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker
+
+import scala.concurrent._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.ir.ClassKind
+import org.scalajs.ir.EntryPointsInfo
+import org.scalajs.ir.Definitions._
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
+
+import org.scalajs.logging._
+
+import org.scalajs.junit.async._
+
+import org.scalajs.linker._
+import org.scalajs.linker.standard._
+
+import org.scalajs.linker.testutils._
+import org.scalajs.linker.testutils.IRAssertions._
+import org.scalajs.linker.testutils.TestIRBuilder._
+
+class OptimizerTest {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  import OptimizerTest._
+
+  /** Generic code for the three methods below.
+   *
+   *  Check that `clone()` is never inlined when the result can be an array,
+   *  in several scenarios.
+   */
+  private def testCloneOnArrayNotInlinedGeneric(
+      customMemberDefs: List[MemberDef]): Future[Unit] = {
+
+    val thisFoo = This()(ClassType("LFoo"))
+    val intArrayTypeRef = ArrayTypeRef("I", 1)
+    val intArrayType = ArrayType(intArrayTypeRef)
+    val anArrayOfInts = ArrayValue(intArrayTypeRef, List(IntLiteral(1)))
+    val newFoo = New(ClassRef("LFoo"), "init___", Nil)
+
+    def callCloneOn(receiver: Tree): Tree =
+      Apply(EAF, receiver, "clone__O", Nil)(AnyType)
+
+    val fooMemberDefs = List(
+        trivialCtor("LFoo"),
+
+        // @noinline def witness(): AnyRef = throw null
+        MethodDef(EMF, "witness__O", Nil, AnyType, Some {
+          Throw(Null())
+        })(EOH.withNoinline(true), None),
+
+        // @noinline def reachClone(): Object = clone()
+        MethodDef(EMF, "reachClone__O", Nil, AnyType, Some {
+          Apply(EAF, thisFoo, "clone__O", Nil)(AnyType)
+        })(EOH.withNoinline(true), None),
+
+        // @noinline def anArray(): Array[Int] = Array(1)
+        MethodDef(EMF, "anArray__AI", Nil, intArrayType, Some {
+          anArrayOfInts
+        })(EOH.withNoinline(true), None),
+
+        // @noinline def anObject(): AnyRef = Array(1)
+        MethodDef(EMF, "anObject__O", Nil, AnyType, Some {
+          anArrayOfInts
+        })(EOH.withNoinline(true), None)
+    ) ::: customMemberDefs
+
+    val classDefs = Seq(
+        classDef("LFoo",
+            superClass = Some(ObjectClass),
+            interfaces = List("jl_Cloneable"),
+            memberDefs = fooMemberDefs
+        ),
+        mainTestClassDef(Block(
+            // new Foo().reachClone() -- make Foo.clone() reachable for sure
+            Apply(EAF, newFoo, "reachClone__O", Nil)(AnyType),
+            // Array(1).clone() -- test with an exact static type of I[]
+            callCloneOn(anArrayOfInts),
+            // new Foo().anArray().clone() -- test with a static type of I[]
+            callCloneOn(Apply(EAF, newFoo, "anArray__AI", Nil)(intArrayType)),
+            // new Foo().anObject().clone() -- test with a static type of Object
+            callCloneOn(Apply(EAF, newFoo, "anObject__O", Nil)(AnyType))
+        ))
+    )
+
+    for (linkingUnit <- linkToLinkingUnit(classDefs, MainTestModuleInitializers)) yield {
+      val linkedClass = linkingUnit.classDefs.find(_.encodedName == MainTestClassDefEncodedName).get
+      linkedClass.hasNot("any call to Foo.witness()") {
+        case Apply(_, receiver, Ident("witness__O", _), _) =>
+          receiver.tpe == ClassType("LFoo")
+      }.hasNot("any reference to ObjectClone") {
+        case LoadModule(ClassRef("jl_ObjectClone$")) => true
+      }.hasExactly(3, "calls to clone()") {
+        case Apply(_, _, Ident("clone__O", _), _) => true
+      }
+    }
+  }
+
+  /** Never inline the `clone()` method of arrays. */
+  @Test
+  def testCloneOnArrayNotInlined_issue3778(): AsyncResult = await {
+    testCloneOnArrayNotInlinedGeneric(List(
+        // @inline override def clone(): AnyRef = witness()
+        MethodDef(EMF, "clone__O", Nil, AnyType, Some {
+          Apply(EAF, This()(ClassType("LFoo")), "witness__O", Nil)(AnyType)
+        })(EOH.withInline(true), None)
+    ))
+  }
+
+  /** Never inline the `clone()` method of arrays, even when the only
+   *  reachable `clone()` method is `Object.clone()`.
+   */
+  @Test
+  def testCloneOnArrayNotInlined_issue3778_onlyObjectClone(): AsyncResult = await {
+    testCloneOnArrayNotInlinedGeneric(Nil)
+  }
+
+  /** Never inline the `clone()` method of arrays, even when `Object.clone()`
+   *  and another `clone()` method are reachable.
+   */
+  @Test
+  def testCloneOnArrayNotInlined_issue3778_ObjectCloneAndAnotherClone(): AsyncResult = await {
+    testCloneOnArrayNotInlinedGeneric(List(
+        // @inline override def clone(): AnyRef = witness()
+        MethodDef(EMF, "clone__O", Nil, AnyType, Some {
+          Block(
+              Apply(EAF, This()(ClassType("LFoo")), "witness__O", Nil)(AnyType),
+              ApplyStatically(EAF, This()(ClassType("LFoo")),
+                  ClassRef(ObjectClass), "clone__O", Nil)(AnyType)
+          )
+        })(EOH.withInline(true), None)
+    ))
+  }
+
+}
+
+object OptimizerTest {
+  private final class StoreLinkingUnitLinkerBackend(
+      originalBackend: LinkerBackend)
+      extends LinkerBackend {
+
+    @volatile
+    private var _linkingUnit: LinkingUnit = _
+
+    val coreSpec: CoreSpec = originalBackend.coreSpec
+
+    val symbolRequirements: SymbolRequirement = originalBackend.symbolRequirements
+
+    def emit(unit: LinkingUnit, output: LinkerOutput, logger: Logger)(
+        implicit ec: ExecutionContext): Future[Unit] = {
+      _linkingUnit = unit
+      Future.successful(())
+    }
+
+    def linkingUnit: LinkingUnit = {
+      if (_linkingUnit == null)
+        throw new IllegalStateException("Cannot access linkingUnit before emit is called")
+      _linkingUnit
+    }
+  }
+
+  def linkToLinkingUnit(classDefs: Seq[ClassDef],
+      moduleInitializers: List[ModuleInitializer])(
+      implicit ec: ExecutionContext): Future[LinkingUnit] = {
+
+    val config = StandardLinker.Config()
+    val frontend = StandardLinkerFrontend(config)
+    val backend = new StoreLinkingUnitLinkerBackend(StandardLinkerBackend(config))
+    val linker = StandardLinkerImpl(frontend, backend)
+
+    val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
+    val output = LinkerOutput(LinkerOutput.newMemFile())
+
+    TestIRRepo.minilib.stdlibIRFiles.flatMap { stdLibFiles =>
+      linker.link(stdLibFiles ++ classDefsFiles, moduleInitializers,
+          output, new ScalaConsoleLogger(Level.Error))
+    }.map { _ =>
+      backend.linkingUnit
+    }
+  }
+}

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/IRAssertions.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/IRAssertions.scala
@@ -1,0 +1,144 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.testutils
+
+import scala.language.implicitConversions
+
+import scala.util.control.ControlThrowable
+
+import org.scalajs.ir.ClassKind
+import org.scalajs.ir.EntryPointsInfo
+import org.scalajs.ir.Definitions._
+import org.scalajs.ir.Traversers._
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
+
+import org.scalajs.linker.standard._
+
+import org.junit.Assert._
+
+object IRAssertions {
+  implicit def classDefAssertions(classDef: ClassDef): ClassDefAssertions =
+    new ClassDefAssertions(classDef)
+
+  implicit def linkedClassAssertions(linkedClass: LinkedClass): LinkedClassAssertions =
+    new LinkedClassAssertions(linkedClass)
+
+  type Pat = PartialFunction[IRNode, Boolean]
+
+  private def patToTotal(pat: Pat): IRNode => Boolean =
+    node => pat.applyOrElse(node, (_: IRNode) => false)
+
+  abstract class AbstractIRNodeAssertions[T](selfNode: T) {
+    protected def newTraverser(f: IRNode => Unit): TestTraverser[T]
+
+    private def find(pf: Pat): Boolean =
+      new TestFinder[T](patToTotal(pf))(newTraverser(_)).find(selfNode)
+
+    def has(trgName: String)(pf: Pat): this.type = {
+      assertTrue(s"AST should have $trgName", find(pf))
+      this
+    }
+
+    def hasNot(trgName: String)(pf: Pat): this.type = {
+      assertFalse(s"AST should not have $trgName", find(pf))
+      this
+    }
+
+    def hasExactly(count: Int, trgName: String)(pf: Pat): this.type = {
+      var actualCount = 0
+      val traverser = newTraverser(patToTotal(pf).andThen { matches =>
+        if (matches)
+          actualCount += 1
+      })
+      traverser.traverse(selfNode)
+      assertEquals(s"AST has the wrong number of $trgName", count, actualCount)
+      this
+    }
+  }
+
+  class ClassDefAssertions(classDef: ClassDef)
+      extends AbstractIRNodeAssertions(classDef) {
+
+    protected def newTraverser(f: IRNode => Unit): TestTraverser[ClassDef] = {
+      new TestTraverser[ClassDef](f) {
+        def baseTraverse(node: ClassDef): Unit = traverseClassDef(node)
+      }
+    }
+  }
+
+  class LinkedClassAssertions(linkedClass: LinkedClass)
+      extends AbstractIRNodeAssertions(linkedClass) {
+
+    protected def newTraverser(f: IRNode => Unit): TestTraverser[LinkedClass] = {
+      new TestTraverser[LinkedClass](f) {
+        def baseTraverse(node: LinkedClass): Unit = {
+          for (memberDef <- node.fields)
+            traverseMemberDef(memberDef)
+          for (memberDef <- node.methods)
+            traverseMemberDef(memberDef.value)
+          for (memberDef <- node.exportedMembers)
+            traverseMemberDef(memberDef.value)
+          for (topLevelExportDef <- node.topLevelExports)
+            traverseTopLevelExportDef(topLevelExportDef.value)
+        }
+      }
+    }
+  }
+
+  abstract class TestTraverser[T](f: IRNode => Unit) extends Traverser {
+    protected def baseTraverse(node: T): Unit
+
+    def traverse(node: T): Unit =
+      baseTraverse(node)
+
+    override def traverse(tree: Tree): Unit = {
+      f(tree)
+      super.traverse(tree)
+    }
+
+    override def traverseClassDef(classDef: ClassDef): Unit = {
+      f(classDef)
+      super.traverseClassDef(classDef)
+    }
+
+    override def traverseMemberDef(memberDef: MemberDef): Unit = {
+      f(memberDef)
+      super.traverseMemberDef(memberDef)
+    }
+
+    override def traverseTopLevelExportDef(
+        exportDef: TopLevelExportDef): Unit = {
+      f(exportDef)
+      super.traverseTopLevelExportDef(exportDef)
+    }
+  }
+
+  final class TestFinder[T](f: IRNode => Boolean)(
+      newTraverser: (IRNode => Unit) => TestTraverser[T]) {
+
+    private case object Found extends ControlThrowable
+
+    def find(node: T): Boolean = {
+      try {
+        newTraverser { innerNode =>
+          if (f(innerNode))
+            throw Found
+        }.traverse(node)
+        false
+      } catch {
+        case Found => true
+      }
+    }
+  }
+}

--- a/project/MiniLib.scala
+++ b/project/MiniLib.scala
@@ -4,6 +4,7 @@ object MiniLib {
   val Whitelist = {
     val inJavaLang = List(
         "Object",
+        "ObjectClone",
         "Class",
         "System",
         "System$IDHashCode",


### PR DESCRIPTION
The `clone__O()` method of arrays is very peculiar in our pipeline: it is the only method that is defined in array classes, for which no IR exists. There are several pieces of the linker that special-case `clone__O()` for arrays for that reason, but we were missing one detail: the optimizer must never try to inline `clone__O()` if the receiver can be an array.

Before this commit, the optimizer could erroneously do that, because the CHA done by `GenIncOptimizer` does not have any provision for array classes, and would return the only reachable `clone__O()` method if there was one in the classpath (on `Object` or on an arbitrary other class).

In this commit, we specifically forbid inlining of `clone__O()` if the receiver can be an array.

Since the test suite reaches the `clone__O()` method of many classes, it is impossible to reproduce the problematic behavior in the test suite. Instead, we user linker unit tests that make assertions about the IR produced by the optimizer.

---

I tested locally that the reproducing code in #3778 failed before this commit and is fixed by this commit, in the hello world.

Even though the bug also exists in 0.6.x, I submit the fix to master first, because testing the fix requires linker unit tests, an infrastructure that is not available in the 0.6.x branch. Once reviewed and merged in master, I'll backport the fix to 0.6.x (without tests).