### PR TITLE
Add js.BigInt for ES2019 (ES10)

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/BigInt.scala
+++ b/library/src/main/scala/scala/scalajs/js/BigInt.scala
@@ -1,0 +1,125 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+ *
+ *  A built-in object that provides a way to represent whole numbers larger than
+ *  2 ^ 53 - 1, which is the largest number JavaScript can reliably represent
+ *  with the Number primitive.
+ *
+ *  BigInt can be used for arbitrarily large integers.
+ *
+ *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+ */
+@js.native
+@JSGlobal
+final class BigInt private[this] () extends js.Object {
+
+  def +(other: BigInt): BigInt = js.native
+  def *(other: BigInt): BigInt = js.native
+  def -(other: BigInt): BigInt = js.native
+  def %(other: BigInt): BigInt = js.native
+
+  def &(other: BigInt): BigInt = js.native
+  def |(other: BigInt): BigInt = js.native
+  def ^(other: BigInt): BigInt = js.native
+  def <<(other: BigInt): BigInt = js.native
+  def >>(other: BigInt): BigInt = js.native
+  // no >>> since BigInt is always signed
+
+  // scalastyle:off disallow.space.before.token
+  def unary_- : BigInt = js.native
+  def unary_~ : BigInt = js.native
+  // unary_+ is not supported by BigInts
+  // scalastyle:on disallow.space.before.token
+
+  def <(x: BigInt): Boolean = js.native
+  def <=(x: BigInt): Boolean = js.native
+  def >(x: BigInt): Boolean = js.native
+  def >=(x: BigInt): Boolean = js.native
+
+  /** Returns a localized string representation of this BigInt.
+   *
+   *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString
+   *  @param locale A string with a BCP 47 language tag, or an array of such
+   *                strings. For the general form and interpretation of the
+   *                locales argument, see the Intl page.
+   *  @param options An object with some or all of the properties.
+   */
+  def toLocaleString(locale: String,
+      options: BigInt.ToLocaleStringOptions = js.native): String = js.native
+
+  /** Returns a string representation of this BigInt.
+   *
+   *  The trailing "n" is not part of the string.
+   *
+   *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toString
+   */
+  override def toString(): String = js.native
+}
+
+
+/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+ *
+ *  A companion object of BigInt class.
+ *
+ *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+ */
+@js.native
+@JSGlobal
+object BigInt extends js.Object {
+  /** Returns a BigInt from a whole Double.
+   *
+   *  This overload is exposed to allow users to create a BigInt from a Double
+   *  which is greater than Int.MaxValue.
+   *
+   *  @throws RangeError if value has a fractional portion
+   *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt
+   */
+  def apply(value: Double): BigInt = js.native
+
+  /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt */
+  def apply(value: Int): BigInt = js.native
+
+  /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt */
+  def apply(value: String): BigInt = js.native
+
+  /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asIntN */
+  def asIntN(width: Int, bigint: BigInt): BigInt = js.native
+
+  /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN */
+  def asUintN(width: Int, bigint: BigInt): BigInt = js.native
+
+  // scalastyle:off line.size.limit
+  /** Type of the `options` parameter of [[BigInt.toLocaleString]].
+   *
+   *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString#Parameters
+   */
+  // scalastyle:on line.size.limit
+  trait ToLocaleStringOptions extends Object {
+    var localeMatcher: js.UndefOr[String] = js.undefined
+    var style: js.UndefOr[String] = js.undefined
+    var currency: js.UndefOr[String] = js.undefined
+    var currencyDisplay: js.UndefOr[String] = js.undefined
+    var useGrouping: js.UndefOr[Boolean] = js.undefined
+    var minimumIntegerDigits: js.UndefOr[Int] = js.undefined
+    var minimumFractionDigits: js.UndefOr[Int] = js.undefined
+    var maximumFractionDigits: js.UndefOr[Int] = js.undefined
+    var minimumSignificantDigits: js.UndefOr[Int] = js.undefined
+    var maximumSignificantDigits: js.UndefOr[Int] = js.undefined
+  }
+}

--- a/library/src/main/scala/scala/scalajs/js/typedarray/BigInt64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/BigInt64Array.scala
@@ -1,0 +1,51 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js.typedarray
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+ *
+ *  A [[TypedArray]] of signed 64-bit integers represented as [[js.BigInt]].
+ */
+@js.native
+@JSGlobal
+class BigInt64Array private[this] () extends TypedArray[js.BigInt, BigInt64Array] {
+
+  /** Constructs a BigInt64Array with the given length. Initialized to all 0 */
+  def this(length: Int) = this()
+
+  /** Creates a new BigInt64Array with the same elements than the given TypedArray
+   *
+   *  Each elements must be BigInt (no conversion).
+   */
+  def this(typedArray: TypedArray[js.BigInt, _]) = this()
+
+  /** Creates a new BigInt64Array with the elements in the given array.
+   *
+   *  Each elements must be BigInt (no conversion).
+   */
+  def this(array: js.Iterable[js.BigInt]) = this()
+
+  /** Creates a BigInt64Array view on the given ArrayBuffer */
+  def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = js.native) = this()
+
+}
+
+/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+ *  [[BigInt64Array]] companion
+ */
+@js.native
+@JSGlobal
+object BigInt64Array extends TypedArrayStatic[js.BigInt, BigInt64Array]

--- a/library/src/main/scala/scala/scalajs/js/typedarray/BigUint64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/BigUint64Array.scala
@@ -1,0 +1,53 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js.typedarray
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+ *
+ *  A [[TypedArray]] of unsigned 64-bit integers represented as [[js.BigInt]].
+ */
+@js.native
+@JSGlobal
+class BigUint64Array private[this] ()
+    extends TypedArray[js.BigInt, BigUint64Array] {
+
+  /** Constructs a BigUint64Array with the given length. Initialized to all 0 */
+  def this(length: Int) = this()
+
+  /** Creates a new BigInt64Array with the same elements than the given TypedArray
+   *
+   *  Each elements must be BigInt (no conversion).
+   */
+  def this(typedArray: TypedArray[js.BigInt, _]) = this()
+
+  /** Creates a new BigInt64Array with the elements in the given array.
+   *
+   *  Each elements must be BigInt (no conversion).
+   */
+  def this(array: js.Iterable[js.BigInt]) = this()
+
+  /** Creates a BigInt64Array view on the given ArrayBuffer */
+  def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = js.native) = this()
+
+}
+
+
+/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+ *  [[BigUint64Array]] companion
+ */
+@js.native
+@JSGlobal
+object BigUint64Array extends TypedArrayStatic[js.BigInt, BigUint64Array]

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
@@ -44,6 +44,7 @@ trait TypedArray[T, Repr] extends ArrayBufferView with js.Iterable[T] {
   @JSBracketAccess
   def set(index: Int, value: T): Unit = js.native
 
+  // FIXME: Not type-safe. BigInt*Array should accept only BigInt, other TypedArray accept only non-BigInt number.
   /** Set the values of typedArray in this TypedArray */
   def set(typedArray: TypedArray[_, _]): Unit = js.native
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/BigIntTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/BigIntTest.scala
@@ -1,0 +1,134 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.library
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{BeforeClass, Test}
+import org.scalajs.testsuite.utils.Platform
+
+import scala.scalajs.js
+
+object BigIntTest {
+  @BeforeClass
+  def assumeRuntimeSupportsBigInt(): Unit = {
+    assumeTrue(Platform.executingInNodeJS)
+    val bigIntConstructor =
+      js.Dynamic.global.BigInt.asInstanceOf[js.UndefOr[js.Any]]
+    assumeTrue(bigIntConstructor.isDefined)
+  }
+}
+
+class BigIntTest {
+
+  @Test def apply(): Unit = {
+    val fromString = js.BigInt("9007199254740992")
+    assertEquals(fromString.toString(), "9007199254740992")
+
+    val fromInt = js.BigInt(2147483647)
+    assertEquals(fromInt.toString(), "2147483647")
+
+    val fromDouble = js.BigInt(4294967295d)
+    assertEquals(fromDouble.toString(), "4294967295")
+  }
+
+  @Test def asIntN(): Unit = {
+    val x = js.BigInt.asIntN(8, js.BigInt("256"))
+    assertEquals(x, js.BigInt("0"))
+  }
+
+  @Test def asUintN(): Unit = {
+    val x = js.BigInt(-123)
+    assertEquals(js.BigInt.asUintN(50, x), js.BigInt("1125899906842501"))
+  }
+
+  @Test def toLocaleString(): Unit = {
+    assumeTrue(Platform.executingInNodeJS)
+
+    val bi = js.BigInt("42123456789123456789")
+    assertEquals(bi.toString(), "42123456789123456789")
+
+    val currency = bi
+      .toLocaleString("de-DE", new js.BigInt.ToLocaleStringOptions {
+        style = "currency"
+        currency = "EUR"
+      })
+    // Internationalization support is limited by default in Node.js.
+    // https://nodejs.org/api/intl.html#intl_internationalization_support
+    // toLocaleString may return as same as by toString
+    assertTrue(
+        currency == "€ 42,123,456,789,123,456,789.00" ||
+        currency == "42123456789123456789")
+  }
+
+  @Test def valueOf(): Unit = {
+    val bi = js.BigInt("42123456789123456789")
+    assertEquals(bi, bi.valueOf())
+  }
+
+  @Test def operators(): Unit = {
+    val previousMaxSafe = js.BigInt("9007199254740991")
+    assertEquals(previousMaxSafe, js.BigInt("9007199254740991"))
+
+    val maxPlusOne = previousMaxSafe + js.BigInt(1)
+    assertEquals(maxPlusOne, js.BigInt("9007199254740992"))
+
+    val theFuture = previousMaxSafe + js.BigInt(2)
+    assertEquals(theFuture, js.BigInt("9007199254740993"))
+
+    val multi = previousMaxSafe * js.BigInt(2)
+    assertEquals(multi, js.BigInt("18014398509481982"))
+
+    val subtr = multi - js.BigInt(10)
+    assertEquals(subtr, js.BigInt("18014398509481972"))
+
+    val mod = multi % js.BigInt(10)
+    assertEquals(mod, js.BigInt("2"))
+
+    // TODO: Scala.js does not recongnize ** as operator
+    //    val bigN = js.BigInt(2) ** js.BigInt(54)
+    //    assertEquals(bigN, js.BigInt("18014398509481984"))
+
+    val negative = -js.BigInt("18014398509481984")
+    assertEquals(negative, js.BigInt("-18014398509481984"))
+
+    val bitAnd = js.BigInt(123) & js.BigInt(31)
+    assertEquals(bitAnd, js.BigInt("27"))
+
+    val bitOr = js.BigInt(123) | js.BigInt(31)
+    assertEquals(bitOr, js.BigInt("127"))
+
+    val bitXor = js.BigInt(123) ^ js.BigInt(31)
+    assertEquals(bitXor, js.BigInt("100"))
+
+    val bitLeftShift = js.BigInt(123) << js.BigInt(31)
+    assertEquals(bitLeftShift, js.BigInt("264140488704"))
+
+    val bitRightShift = js.BigInt(12345678) >> js.BigInt(9)
+    assertEquals(bitRightShift, js.BigInt("24112"))
+
+    val bitNot = ~js.BigInt("42")
+    assertEquals(bitNot, js.BigInt("-43"))
+  }
+
+  @Test def compare_with_bigint(): Unit = {
+    val n = js.BigInt("42")
+    assertTrue(n == js.BigInt("42"))
+    assertTrue(n != js.BigInt("43"))
+    assertTrue(n > js.BigInt("41"))
+    assertTrue(n >= js.BigInt("41"))
+    assertTrue(n < js.BigInt("43"))
+    assertTrue(n <= js.BigInt("43"))
+  }
+
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
@@ -32,8 +32,9 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
   def fromFn[E](iterable: js.Iterable[E])(mapper: js.Function1[E, V]): T
   def fromFn[D, E](iterable: js.Iterable[E], thisObj: D)(mapper: js.ThisFunction1[D, E, V]): T
   def lenCtor(len: Int): T
-  def tarrCtor(tarr: TypedArray[_, _]): T
-  def itCtor(arr: js.Iterable[_]): T
+  def tarr(arr: js.Array[V]): TypedArray[V, _]
+  def tarrCtor(tarr: TypedArray[V, _]): T
+  def itCtor(arr: js.Iterable[V]): T
   def bufCtor1(buf: ArrayBuffer): T
   def bufCtor2(buf: ArrayBuffer, start: Int): T
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): T
@@ -43,27 +44,27 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
   @Test def should_provide_a_factory_method_of(): Unit = {
     val x = ofFn(intToV(0), intToV(1), intToV(2))
     assertEquals(3, x.length)
-    assertEquals(2, x(2))
+    assertEquals(intToV(2), x(2))
   }
 
   @Test def should_provide_a_factory_method_from(): Unit = {
     val x = fromFn(js.Array(intToV(0), intToV(1), intToV(2)))
     assertEquals(3, x.length)
-    assertEquals(2, x(2))
+    assertEquals(intToV(2), x(2))
   }
 
   @Test def should_provide_a_factory_method_from_with_mapping_function(): Unit = {
     val src = js.Array("", "a", "bc")
     val x = fromFn(src)((s: String) => intToV(s.length))
     assertEquals(3, x.length)
-    assertEquals(2, x(2))
+    assertEquals(intToV(2), x(2))
   }
 
   @Test def should_provide_a_factory_method_from_with_mapping_function_and_thisArg(): Unit = {
     val src = js.Array("", "a", "bc")
     val x = fromFn(src, 10)((thisArg: Int, s: String) => intToV(s.length * thisArg))
     assertEquals(3, x.length)
-    assertEquals(20, x(2))
+    assertEquals(intToV(20), x(2))
   }
 
   @Test def should_allow_constructing_a_new_name_with_length(): Unit = {
@@ -73,55 +74,55 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
   }
 
   @Test def should_allow_constructing_a_new_name_from_an_Int8Array(): Unit = {
-    val x = tarrCtor(new Float32Array(js.Array(3, 7)))
+    val x = tarrCtor(tarr(js.Array(3, 7).map(intToV)))
     assertTrue(hasType(x))
     assertEquals(2, x.length)
 
-    assertEquals(3, x(0))
-    assertEquals(7, x(1))
+    assertEquals(intToV(3), x(0))
+    assertEquals(intToV(7), x(1))
   }
 
   @Test def should_allow_constructing_a_new_name_from_a_js_Array(): Unit = {
-    val x = itCtor(js.Array(5,6,7))
+    val x = itCtor(js.Array(5,6,7).map(intToV))
     assertTrue(hasType(x))
     assertEquals(3, x.length)
 
-    assertEquals(5, x(0))
-    assertEquals(6, x(1))
-    assertEquals(7, x(2))
+    assertEquals(intToV(5), x(0))
+    assertEquals(intToV(6), x(1))
+    assertEquals(intToV(7), x(2))
   }
 
   @Test def should_allow_constructing_a_new_name_from_an_ArrayBuffer_1_arg(): Unit = {
-    val buf = itCtor(js.Array(5, 6, 7, 8)).buffer
+    val buf = itCtor(js.Array(5, 6, 7, 8).map(intToV)).buffer
     val x = bufCtor1(buf)
     assertTrue(hasType(x))
     assertEquals(4, x.length)
 
-    assertEquals(5, x(0))
-    assertEquals(6, x(1))
-    assertEquals(7, x(2))
-    assertEquals(8, x(3))
+    assertEquals(intToV(5), x(0))
+    assertEquals(intToV(6), x(1))
+    assertEquals(intToV(7), x(2))
+    assertEquals(intToV(8), x(3))
   }
 
   @Test def should_allow_constructing_a_new_name_from_an_ArrayBuffer_2_args(): Unit = {
-    val buf = itCtor(js.Array(5, 6, 7, 8)).buffer
+    val buf = itCtor(js.Array(5, 6, 7, 8).map(intToV)).buffer
     val x = bufCtor2(buf, bytesPerElement)
     assertTrue(hasType(x))
     assertEquals(3, x.length)
 
-    assertEquals(6, x(0))
-    assertEquals(7, x(1))
-    assertEquals(8, x(2))
+    assertEquals(intToV(6), x(0))
+    assertEquals(intToV(7), x(1))
+    assertEquals(intToV(8), x(2))
   }
 
   @Test def should_allow_constructing_a_new_name_from_an_ArrayBuffer_3_args(): Unit = {
-    val buf = itCtor(js.Array(5, 6, 7, 8)).buffer
+    val buf = itCtor(js.Array(5, 6, 7, 8).map(intToV)).buffer
     val x = bufCtor3(buf, bytesPerElement, 2)
     assertTrue(hasType(x))
     assertEquals(2, x.length)
 
-    assertEquals(6, x(0))
-    assertEquals(7, x(1))
+    assertEquals(intToV(6), x(0))
+    assertEquals(intToV(7), x(1))
   }
 
   @Test def should_allow_retrieving_the_should_allow_retrieving_the(): Unit = {
@@ -130,8 +131,8 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
   }
 
   @Test def should_allow_retrieving_an_should_allow_retrieving_an(): Unit = {
-    val x = itCtor(js.Array(5))
-    assertEquals(5, x(0))
+    val x = itCtor(js.Array(5).map(intToV))
+    assertEquals(intToV(5), x(0))
   }
 
   @Test def should_allow_setting_an_should_allow_setting_an(): Unit = {
@@ -140,13 +141,13 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     x(0) = intToV(5)
     x(1) = intToV(10)
 
-    assertEquals(5, x(0))
-    assertEquals(10, x(1))
+    assertEquals(intToV(5), x(0))
+    assertEquals(intToV(10), x(1))
   }
 
   @Test def should_provide_should_provide(): Unit = {
-    val x = itCtor(js.Array(10))
-    assertEquals(10, x.get(0))
+    val x = itCtor(js.Array(10).map(intToV))
+    assertEquals(intToV(10), x.get(0))
   }
 
   @Test def set_for_a_single_element(): Unit = {
@@ -154,95 +155,95 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     x.set(0, intToV(5))
     x.set(1, intToV(6))
 
-    assertEquals(5, x(0))
-    assertEquals(6, x(1))
-    assertEquals(0, x(2))
+    assertEquals(intToV(5), x(0))
+    assertEquals(intToV(6), x(1))
+    assertEquals(intToV(0), x(2))
   }
 
   @Test def set_for_a_js_Array_with_one_arguments(): Unit = {
     val x = lenCtor(10)
-    x.set(js.Array(5,6,7))
-    assertEquals(5, x(0))
-    assertEquals(6, x(1))
-    assertEquals(7, x(2))
-    assertEquals(0, x(3))
-    assertEquals(0, x(4))
-    assertEquals(0, x(5))
+    x.set(js.Array(5,6,7).map(intToV))
+    assertEquals(intToV(5), x(0))
+    assertEquals(intToV(6), x(1))
+    assertEquals(intToV(7), x(2))
+    assertEquals(intToV(0), x(3))
+    assertEquals(intToV(0), x(4))
+    assertEquals(intToV(0), x(5))
   }
 
   @Test def should_provide_set_for_a_js_Array_with_two_arguments(): Unit = {
     val x = lenCtor(10)
-    x.set(js.Array(5,6,7), 2)
-    assertEquals(0, x(0))
-    assertEquals(0, x(1))
-    assertEquals(5, x(2))
-    assertEquals(6, x(3))
-    assertEquals(7, x(4))
-    assertEquals(0, x(5))
+    x.set(js.Array(5,6,7).map(intToV), 2)
+    assertEquals(intToV(0), x(0))
+    assertEquals(intToV(0), x(1))
+    assertEquals(intToV(5), x(2))
+    assertEquals(intToV(6), x(3))
+    assertEquals(intToV(7), x(4))
+    assertEquals(intToV(0), x(5))
   }
 
   @Test def should_provide_set_for_a_TypedArray_with_one_argument(): Unit = {
     val x = lenCtor(10)
-    x.set(new Int8Array(js.Array(5,6,7)))
-    assertEquals(5, x(0))
-    assertEquals(6, x(1))
-    assertEquals(7, x(2))
-    assertEquals(0, x(3))
-    assertEquals(0, x(4))
-    assertEquals(0, x(5))
+    x.set(tarr(js.Array(5,6,7).map(intToV)))
+    assertEquals(intToV(5), x(0))
+    assertEquals(intToV(6), x(1))
+    assertEquals(intToV(7), x(2))
+    assertEquals(intToV(0), x(3))
+    assertEquals(intToV(0), x(4))
+    assertEquals(intToV(0), x(5))
   }
 
   @Test def should_provide_set_for_a_TypedArray_with_two_arguments(): Unit = {
     val x = lenCtor(10)
-    x.set(new Int8Array(js.Array(5,6,7)), 2)
-    assertEquals(0, x(0))
-    assertEquals(0, x(1))
-    assertEquals(5, x(2))
-    assertEquals(6, x(3))
-    assertEquals(7, x(4))
-    assertEquals(0, x(5))
+    x.set(tarr(js.Array(5,6,7).map(intToV)), 2)
+    assertEquals(intToV(0), x(0))
+    assertEquals(intToV(0), x(1))
+    assertEquals(intToV(5), x(2))
+    assertEquals(intToV(6), x(3))
+    assertEquals(intToV(7), x(4))
+    assertEquals(intToV(0), x(5))
   }
 
   @Test def subarray_with_one_argument(): Unit = {
-    val x = itCtor(js.Array(1,2,3,4,5,6,7,8,9))
+    val x = itCtor(js.Array(1,2,3,4,5,6,7,8,9).map(intToV))
     val y = x.subarray(2)
 
     assertEquals(7, y.length)
-    assertEquals(3, y(0))
+    assertEquals(intToV(3), y(0))
 
     x(2) = intToV(100)
 
-    assertEquals(100, y(0))
+    assertEquals(intToV(100), y(0))
   }
 
   @Test def subarray_with_two_arguments(): Unit = {
-    val x = itCtor(js.Array(1,2,3,4,5,6,7,8,9))
+    val x = itCtor(js.Array(1,2,3,4,5,6,7,8,9).map(intToV))
     val y = x.subarray(2, 4)
 
     assertEquals(2, y.length)
-    assertEquals(3, y(0))
+    assertEquals(intToV(3), y(0))
 
     x(2) = intToV(100)
 
-    assertEquals(100, y(0))
+    assertEquals(intToV(100), y(0))
   }
 
   @Test def buffer(): Unit = {
-    val x = itCtor(js.Array(1,2,3,4,5,6,7,8,9))
+    val x = itCtor(js.Array(1,2,3,4,5,6,7,8,9).map(intToV))
     val y = bufCtor3(x.buffer, 0, 2)
 
     assertSame(x.buffer, y.buffer)
   }
 
   @Test def byteLength(): Unit = {
-    val x = itCtor(js.Array(0 until bytesPerElement * 4: _*))
+    val x = itCtor(js.Array(0 until bytesPerElement * 4: _*).map(intToV))
     val y = bufCtor3(x.buffer, bytesPerElement, 3)
 
     assertEquals(3 * bytesPerElement, y.byteLength)
   }
 
   @Test def byteOffset(): Unit = {
-    val x = itCtor(js.Array(0 until bytesPerElement * 4: _*))
+    val x = itCtor(js.Array(0 until bytesPerElement * 4: _*).map(intToV))
     val y = bufCtor3(x.buffer, bytesPerElement, 3)
 
     assertEquals(bytesPerElement, y.byteOffset)
@@ -255,7 +256,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     import js.JSConverters._
 
     val testData: List[Int] = (1 to 10).toList
-    val typedArray: T = itCtor(testData.toJSArray)
+    val typedArray: T = itCtor(testData.toJSArray.map(intToV))
     val jsIterable: js.Iterable[V] = typedArray
     val iterable: Iterable[V] = jsIterable
 
@@ -268,13 +269,13 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
 
     import js.JSConverters._
 
-    val x = itCtor(Iterable(1, 2, 3, 4).toJSIterable)
+    val x = itCtor(Iterable(1, 2, 3, 4).map(intToV).toJSIterable)
 
     assertEquals(4, x.length)
-    assertEquals(1, x(0))
-    assertEquals(2, x(1))
-    assertEquals(3, x(2))
-    assertEquals(4, x(3))
+    assertEquals(intToV(1), x(0))
+    assertEquals(intToV(2), x(1))
+    assertEquals(intToV(3), x(2))
+    assertEquals(intToV(4), x(3))
   }
 }
 
@@ -288,8 +289,9 @@ class Int8ArrayTest extends TypedArrayTest[Byte, Int8Array] {
     Int8Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Int8Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Int8Array = new Int8Array(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Int8Array = new Int8Array(tarr)
-  def itCtor(arr: js.Iterable[_]): Int8Array = new Int8Array(arr)
+  def tarr(tarr: js.Array[Byte]): TypedArray[Byte,_] = new Int8Array(tarr)
+  def tarrCtor(tarr: TypedArray[Byte, _]): Int8Array = new Int8Array(tarr)
+  def itCtor(arr: js.Iterable[Byte]): Int8Array = new Int8Array(arr)
   def bufCtor1(buf: ArrayBuffer): Int8Array = new Int8Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Int8Array = new Int8Array(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Int8Array = new Int8Array(buf, start, end)
@@ -307,8 +309,9 @@ class Uint8ArrayTest extends TypedArrayTest[Short, Uint8Array] {
     Uint8Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Uint8Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Uint8Array = new Uint8Array(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Uint8Array = new Uint8Array(tarr)
-  def itCtor(arr: js.Iterable[_]): Uint8Array = new Uint8Array(arr)
+  def tarr(tarr: js.Array[Short]): TypedArray[Short,_] = new Uint8Array(tarr)
+  def tarrCtor(tarr: TypedArray[Short, _]): Uint8Array = new Uint8Array(tarr)
+  def itCtor(arr: js.Iterable[Short]): Uint8Array = new Uint8Array(arr)
   def bufCtor1(buf: ArrayBuffer): Uint8Array = new Uint8Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Uint8Array = new Uint8Array(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Uint8Array = new Uint8Array(buf, start, end)
@@ -327,8 +330,9 @@ class Uint8ClampedArrayTest extends TypedArrayTest[Int, Uint8ClampedArray] {
     Uint8ClampedArray.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Uint8ClampedArray.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Uint8ClampedArray = new Uint8ClampedArray(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Uint8ClampedArray = new Uint8ClampedArray(tarr)
-  def itCtor(arr: js.Iterable[_]): Uint8ClampedArray = new Uint8ClampedArray(arr)
+  def tarr(tarr: js.Array[Int]): TypedArray[Int,_] = new Int32Array(tarr)
+  def tarrCtor(tarr: TypedArray[Int, _]): Uint8ClampedArray = new Uint8ClampedArray(tarr)
+  def itCtor(arr: js.Iterable[Int]): Uint8ClampedArray = new Uint8ClampedArray(arr)
   def bufCtor1(buf: ArrayBuffer): Uint8ClampedArray = new Uint8ClampedArray(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Uint8ClampedArray = new Uint8ClampedArray(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Uint8ClampedArray = new Uint8ClampedArray(buf, start, end)
@@ -346,8 +350,9 @@ class Int16ArrayTest extends TypedArrayTest[Short, Int16Array] {
     Int16Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Int16Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Int16Array = new Int16Array(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Int16Array = new Int16Array(tarr)
-  def itCtor(arr: js.Iterable[_]): Int16Array = new Int16Array(arr)
+  def tarr(tarr: js.Array[Short]): TypedArray[Short,_] = new Int16Array(tarr)
+  def tarrCtor(tarr: TypedArray[Short, _]): Int16Array = new Int16Array(tarr)
+  def itCtor(arr: js.Iterable[Short]): Int16Array = new Int16Array(arr)
   def bufCtor1(buf: ArrayBuffer): Int16Array = new Int16Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Int16Array = new Int16Array(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Int16Array = new Int16Array(buf, start, end)
@@ -365,8 +370,9 @@ class Uint16ArrayTest extends TypedArrayTest[Int, Uint16Array] {
     Uint16Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Uint16Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Uint16Array = new Uint16Array(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Uint16Array = new Uint16Array(tarr)
-  def itCtor(arr: js.Iterable[_]): Uint16Array =  new Uint16Array(arr)
+  def tarr(tarr: js.Array[Int]): TypedArray[Int,_] = new Int32Array(tarr)
+  def tarrCtor(tarr: TypedArray[Int, _]): Uint16Array = new Uint16Array(tarr)
+  def itCtor(arr: js.Iterable[Int]): Uint16Array =  new Uint16Array(arr)
   def bufCtor1(buf: ArrayBuffer): Uint16Array = new Uint16Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Uint16Array = new Uint16Array(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Uint16Array = new Uint16Array(buf, start, end)
@@ -384,8 +390,9 @@ class Int32ArrayTest extends TypedArrayTest[Int, Int32Array] {
     Int32Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Int32Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Int32Array = new Int32Array(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Int32Array = new Int32Array(tarr)
-  def itCtor(arr: js.Iterable[_]): Int32Array = new Int32Array(arr)
+  def tarr(tarr: js.Array[Int]): TypedArray[Int,_] = new Int32Array(tarr)
+  def tarrCtor(tarr: TypedArray[Int, _]): Int32Array = new Int32Array(tarr)
+  def itCtor(arr: js.Iterable[Int]): Int32Array = new Int32Array(arr)
   def bufCtor1(buf: ArrayBuffer): Int32Array = new Int32Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Int32Array = new Int32Array(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Int32Array = new Int32Array(buf, start, end)
@@ -403,8 +410,9 @@ class Uint32ArrayTest extends TypedArrayTest[Double, Uint32Array] {
     Uint32Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Uint32Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Uint32Array = new Uint32Array(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Uint32Array = new Uint32Array(tarr)
-  def itCtor(arr: js.Iterable[_]): Uint32Array = new Uint32Array(arr)
+  def tarr(tarr: js.Array[Double]): TypedArray[Double,_] = new Uint32Array(tarr)
+  def tarrCtor(tarr: TypedArray[Double, _]): Uint32Array = new Uint32Array(tarr)
+  def itCtor(arr: js.Iterable[Double]): Uint32Array = new Uint32Array(arr)
   def bufCtor1(buf: ArrayBuffer): Uint32Array = new Uint32Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Uint32Array = new Uint32Array(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Uint32Array = new Uint32Array(buf, start, end)
@@ -422,8 +430,9 @@ class Float32ArrayTest extends TypedArrayTest[Float, Float32Array] {
     Float32Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Float32Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Float32Array = new Float32Array(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Float32Array = new Float32Array(tarr)
-  def itCtor(arr: js.Iterable[_]): Float32Array =  new Float32Array(arr)
+  def tarr(tarr: js.Array[Float]): TypedArray[Float,_] = new Float32Array(tarr)
+  def tarrCtor(tarr: TypedArray[Float, _]): Float32Array = new Float32Array(tarr)
+  def itCtor(arr: js.Iterable[Float]): Float32Array =  new Float32Array(arr)
   def bufCtor1(buf: ArrayBuffer): Float32Array = new Float32Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Float32Array = new Float32Array(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Float32Array = new Float32Array(buf, start, end)
@@ -441,11 +450,54 @@ class Float64ArrayTest extends TypedArrayTest[Double, Float64Array] {
     Float64Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Float64Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Float64Array = new Float64Array(len)
-  def tarrCtor(tarr: TypedArray[_, _]): Float64Array = new Float64Array(tarr)
-  def itCtor(arr: js.Iterable[_]): Float64Array = new Float64Array(arr)
+  def tarr(tarr: js.Array[Double]): TypedArray[Double,_] = new Float64Array(tarr)
+  def tarrCtor(tarr: TypedArray[Double, _]): Float64Array = new Float64Array(tarr)
+  def itCtor(arr: js.Iterable[Double]): Float64Array = new Float64Array(arr)
   def bufCtor1(buf: ArrayBuffer): Float64Array = new Float64Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Float64Array = new Float64Array(buf, start)
   def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): Float64Array = new Float64Array(buf, start, end)
   def hasType(obj: Any): Boolean = obj.isInstanceOf[Float64Array]
   def intToV(n: Int): Double = n.toDouble
+}
+
+object BigInt64ArrayTest extends Requires.TypedArray
+
+class BigInt64ArrayTest extends TypedArrayTest[js.BigInt, BigInt64Array] {
+  def ofFn(items: js.BigInt*): BigInt64Array = BigInt64Array.of(items: _*)
+  def fromFn(iterable: js.Iterable[js.BigInt]): BigInt64Array = BigInt64Array.from(iterable)
+  def fromFn[E](iterable: js.Iterable[E])(fn: js.Function1[E, js.BigInt]): BigInt64Array =
+    BigInt64Array.from(iterable, fn)
+  def fromFn[D, E](iterable: js.Iterable[E], thisObj: D)(fn: js.ThisFunction1[D, E, js.BigInt]): BigInt64Array =
+    BigInt64Array.from(iterable, fn, thisObj)
+  def bytesPerElement: Int = BigInt64Array.BYTES_PER_ELEMENT
+  def lenCtor(len: Int): BigInt64Array = new BigInt64Array(len)
+  def tarr(arr: js.Array[js.BigInt]): BigInt64Array = new BigInt64Array(arr)
+  def tarrCtor(tarr: TypedArray[js.BigInt, _]): BigInt64Array = new BigInt64Array(tarr)
+  def itCtor(arr: js.Iterable[js.BigInt]): BigInt64Array = new BigInt64Array(arr)
+  def bufCtor1(buf: ArrayBuffer): BigInt64Array = new BigInt64Array(buf)
+  def bufCtor2(buf: ArrayBuffer, start: Int): BigInt64Array = new BigInt64Array(buf, start)
+  def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): BigInt64Array = new BigInt64Array(buf, start, end)
+  def hasType(obj: Any): Boolean = obj.isInstanceOf[BigInt64Array]
+  def intToV(n: Int): js.BigInt = js.BigInt(n)
+}
+
+object BigUint64ArrayTest extends Requires.TypedArray
+
+class BigUint64ArrayTest extends TypedArrayTest[js.BigInt, BigUint64Array] {
+  def ofFn(items: js.BigInt*): BigUint64Array = BigUint64Array.of(items: _*)
+  def fromFn(iterable: js.Iterable[js.BigInt]): BigUint64Array = BigUint64Array.from(iterable)
+  def fromFn[E](iterable: js.Iterable[E])(fn: js.Function1[E, js.BigInt]): BigUint64Array =
+    BigUint64Array.from(iterable, fn)
+  def fromFn[D, E](iterable: js.Iterable[E], thisObj: D)(fn: js.ThisFunction1[D, E, js.BigInt]): BigUint64Array =
+    BigUint64Array.from(iterable, fn, thisObj)
+  def bytesPerElement: Int = BigUint64Array.BYTES_PER_ELEMENT
+  def lenCtor(len: Int): BigUint64Array = new BigUint64Array(len)
+  def tarr(arr: js.Array[js.BigInt]): BigInt64Array = new BigInt64Array(arr)
+  def tarrCtor(tarr: TypedArray[js.BigInt, _]): BigUint64Array = new BigUint64Array(tarr)
+  def itCtor(arr: js.Iterable[js.BigInt]): BigUint64Array = new BigUint64Array(arr)
+  def bufCtor1(buf: ArrayBuffer): BigUint64Array = new BigUint64Array(buf)
+  def bufCtor2(buf: ArrayBuffer, start: Int): BigUint64Array = new BigUint64Array(buf, start)
+  def bufCtor3(buf: ArrayBuffer, start: Int, end: Int): BigUint64Array = new BigUint64Array(buf, start, end)
+  def hasType(obj: Any): Boolean = obj.isInstanceOf[BigUint64Array]
+  def intToV(n: Int): js.BigInt = js.BigInt(n)
 }


### PR DESCRIPTION
JS's BigInt is available in popular JS runtime like Chrome, Firefox, and Node.js.
Its specification reached stage 4, so I think it is good time to add support it in Scala.js.
https://github.com/tc39/ecma262/pull/1515
https://github.com/tc39/proposals/pull/217

TODO:
- [x] BigInt
- [x] BigInt64Array
- [x] BigUint64Array