### PR TITLE
[no-master] Upgrade to sbt 0.13.18.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.17
+sbt.version=0.13.18


### PR DESCRIPTION
sbt 0.13.17 is not able to communicate with Scala 2.13.x on Windows. Officially it doesn't work on Linux either, but for some reason it has worked for us so far, which is why we did not detect the issue.

Only our build is upgraded. We still build and test the sbt plugin against 0.13.17.