### PR TITLE
[no-master] Backport `js.special.strictEquals`.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/special/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/special/package.scala
@@ -26,6 +26,23 @@ package scala.scalajs.js
  */
 package object special {
 
+  /** Tests whether two values are equal according to ECMAScript's
+   *  *Strict Equality Comparison* (`===`).
+   *
+   *  In Scala.js 0.6.x, this is equivalent to `x eq y`. It is provided to ease
+   *  cross-compilation with Scala.js 1.x, where the definition of `x eq y` has
+   *  been changed such that:
+   *
+   *  - `strictEquals(NaN, NaN)` is `false` whereas `NaN eq NaN` is `true`
+   *  - `strictEquals(+0.0, -0.0)` is `true` whereas `+0.0 eq -0.0` is `false`
+   *
+   *  @return
+   *    the result of `x === y` where `===` is the ECMAScript operator.
+   */
+  @inline
+  def strictEquals(x: scala.Any, y: scala.Any): Boolean =
+    x.asInstanceOf[AnyRef] eq y.asInstanceOf[AnyRef]
+
   /** Deletes a property of an object.
    *
    *  This method is the exact equivalent of the `delete obj[key]` statement

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
@@ -24,6 +24,20 @@ import org.scalajs.testsuite.utils.Platform._
 class SpecialTest {
   import SpecialTest._
 
+  // scala.scalajs.js.special.strictEquals
+
+  @Test def strictEqualsTest(): Unit = {
+    import js.special.strictEquals
+
+    val o1 = new js.Object
+    val o2 = new js.Object
+    assertTrue(strictEquals(o1, o1))
+    assertFalse(strictEquals(o1, o2))
+    assertTrue(strictEquals(+0.0, -0.0))
+    assertTrue(strictEquals(-0.0, +0.0))
+    assertFalse(strictEquals(Double.NaN, Double.NaN))
+  }
+
   // scala.scalajs.js.special.delete
 
   @Test def should_provide_an_equivalent_of_the_JS_delete_keyword_issue_255(): Unit = {


### PR DESCRIPTION
Since the definition of `x eq y` has changed in Scala.js 1.x, it might be necessary to use `js.special.strictEquals` where previously `eq` was correct. This can make cross-compilation a bit difficult.

This commit backports the definition of `js.special.strictEquals` to 0.6.x, with a trivial implementation that delegates to `eq`. Tests are directly imported from 1.x.