### PR TITLE
FF ONLY Merge 0.6.x into master, September 30

### DIFF
--- a/scalalib/overrides-2.12/scala/collection/immutable/RedBlackTree.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/RedBlackTree.scala
@@ -1,12 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2005-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
-
-
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala
 package collection
@@ -93,13 +95,18 @@ object RedBlackTree {
     result
   }
 
-
   def foreach[A,B,U](tree:Tree[A,B], f:((A,B)) => U):Unit = if (tree ne null) _foreach(tree,f)
+  def foreachEntry[A,B,U](tree:Tree[A,B], f:(A,B) => U):Unit = if (tree ne null) _foreachEntry(tree,f)
 
   private[this] def _foreach[A, B, U](tree: Tree[A, B], f: ((A, B)) => U) {
     if (tree.left ne null) _foreach(tree.left, f)
     f((tree.key, tree.value))
     if (tree.right ne null) _foreach(tree.right, f)
+  }
+  private[this] def _foreachEntry[A, B, U](tree: Tree[A, B], f: (A, B) => U): Unit = {
+    if (tree.left ne null) _foreachEntry(tree.left, f)
+    f(tree.key, tree.value)
+    if (tree.right ne null) _foreachEntry(tree.right, f)
   }
 
   def foreachKey[A, U](tree:Tree[A,_], f: A => U):Unit = if (tree ne null) _foreachKey(tree,f)
@@ -168,8 +175,8 @@ object RedBlackTree {
   }
 
   /* Based on Stefan Kahrs' Haskell version of Okasaki's Red&Black Trees
-   * Constructing Red-Black Trees, Ralf Hinze: http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz
-   * Red-Black Trees in a Functional Setting, Chris Okasaki: https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf */
+   * Constructing Red-Black Trees, Ralf Hinze: [[http://www.cs.ox.ac.uk/ralf.hinze/publications/WAAAPL99b.ps.gz]]
+   * Red-Black Trees in a Functional Setting, Chris Okasaki: [[https://wiki.rice.edu/confluence/download/attachments/2761212/Okasaki-Red-Black.pdf]] */
   private[this] def del[A, B](tree: Tree[A, B], k: A)(implicit ordering: Ordering[A]): Tree[A, B] = if (tree eq null) null else {
     def balance(x: A, xv: B, tl: Tree[A, B], tr: Tree[A, B]) = if (isRedTree(tl)) {
       if (isRedTree(tr)) {


### PR DESCRIPTION
Motivation: restore the community build (#3785) by merging in #3788.
```
$ git checkout -b merge-0.6.x-into-master-september-30
Switched to a new branch 'merge-0.6.x-into-master-september-30'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   7d63935ed (scalajs/0.6.x, origin/0.6.x) Merge pull request #3788 from sjrd/update-overrides-redblacktree-2.12.11
|\  
| * 340147fa1 Update the override for `RedBlackTree.scala` for 2.12.11.
* |   89e16bdf4 Merge pull request #3789 from sjrd/backport-js-special-stricteq
|\ \  
| * | 1f23aa75a [no-master] Backport `js.special.strictEquals`.
| |/  
* |   cde50038c Merge pull request #3787 from sjrd/sbt-0.13.8
|\ \  
| |/  
|/|   
| * a9c69380b (origin/sbt-0.13.8) [no-master] Upgrade to sbt 0.13.18.
|/  
* ae1e04535 Merge pull request #3783 from sjrd/fix-wrong-array-clone-inline-0.6.x
* 38decc1b4 [no-master] Fix #3778: Never inline `clone__O` if the receiver can be an array.
```
```
$ git merge -s ours 89e16bdf4
Merge made by the 'ours' strategy.
```
```
$ git show
commit 514a342040a210fb5dca23430982fb8d260e100d (HEAD -> merge-0.6.x-into-master-september-30)
Merge: 5ddfc6493 89e16bdf4
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Mon Sep 30 13:32:19 2019 +0200

    Skip the [no-master] commits 38decc1b4, a9c69380b and 1f23aa75a.

```
```
$ git merge --no-commit scalajs/0.6.x
Automatic merge went well; stopped before committing as requested
```
```
$ git st
M  scalalib/overrides-2.12/scala/collection/immutable/RedBlackTree.scala
```
```
$ git commit
[merge-0.6.x-into-master-september-30 9a035be67] Merge '0.6.x' into 'master'.
```
