### PR TITLE
Add js.Map and js.Set for ES6 (ES2015)

### DIFF
--- a/library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
@@ -209,7 +209,7 @@ trait LowPrioAnyImplicits extends LowestPrioAnyImplicits {
   implicit def wrapDictionary[A](dict: js.Dictionary[A]): js.WrappedDictionary[A] =
     new js.WrappedDictionary(dict)
   implicit def wrapSet[A](set: js.Set[A]): js.WrappedSet[A] =
-    new js.WrappedSet[A](set)
+    new js.WrappedSet(set)
   implicit def wrapMap[K, V](map: js.Map[K, V]): js.WrappedMap[K, V] =
     new js.WrappedMap(map)
 }

--- a/library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
@@ -208,6 +208,10 @@ trait LowPrioAnyImplicits extends LowestPrioAnyImplicits {
     new js.WrappedArray(array)
   implicit def wrapDictionary[A](dict: js.Dictionary[A]): js.WrappedDictionary[A] =
     new js.WrappedDictionary(dict)
+  implicit def wrapSet[A](set: js.Set[A]): js.WrappedSet[A] =
+    new js.WrappedSet[A](set)
+  implicit def wrapMap[K, V](map: js.Map[K, V]): js.WrappedMap[K, V] =
+    new js.WrappedMap(map)
 }
 
 sealed trait LowestPrioAnyImplicits {

--- a/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
@@ -115,7 +115,9 @@ object JSConverters extends JSConvertersLowPrioImplicits {
 
     @inline final def toJSMap: js.Map[K, V] = {
       val result = js.Map.empty[K, V]
-      __private_self.foreach { case (key, value) => result.set(key, value) }
+      __private_self.foreach { case (key, value) =>
+        result.asInstanceOf[js.Map.Raw[K, V]].set(key, value)
+      }
       result
     }
   }

--- a/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
@@ -123,12 +123,12 @@ object JSConverters extends JSConvertersLowPrioImplicits {
   }
 
   implicit final class JSRichSet[T] private[JSConverters] (
-      private val __private_set: Set[T])
+      private val __private_self: Set[T])
       extends AnyVal {
 
     @inline final def toJSSet: js.Set[T] = {
       val result = js.Set.empty[T]
-      __private_set.foreach { value => result.add(value) }
+      __private_self.foreach { value => result.add(value) }
       result
     }
   }

--- a/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
@@ -109,6 +109,28 @@ object JSConverters extends JSConvertersLowPrioImplicits {
     }
   }
 
+  implicit final class JSRichGenMapKV[K, V] private[JSConverters] (
+      private val map: Map[K, V])
+      extends AnyVal {
+
+    @inline final def toJSMap: js.Map[K, V] = {
+      val result = js.Map.empty[K, V]
+      map.foreach { case (key, value) => result.set(key, value) }
+      result
+    }
+  }
+
+  implicit final class JSRichSet[T] private[JSConverters] (
+      private val set: Set[T])
+      extends AnyVal {
+
+    @inline final def toJSSet: js.Set[T] = {
+      val result = js.Set.empty[T]
+      set.foreach { value => result.add(value) }
+      result
+    }
+  }
+
   @inline
   implicit def iterableOnceConvertible2JSRichIterableOnce[T, C](coll: C)(
       implicit ev: C => IterableOnce[T]): JSRichIterableOnce[T] =

--- a/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/JSConverters.scala
@@ -110,23 +110,23 @@ object JSConverters extends JSConvertersLowPrioImplicits {
   }
 
   implicit final class JSRichGenMapKV[K, V] private[JSConverters] (
-      private val map: Map[K, V])
+      private val __private_self: Map[K, V])
       extends AnyVal {
 
     @inline final def toJSMap: js.Map[K, V] = {
       val result = js.Map.empty[K, V]
-      map.foreach { case (key, value) => result.set(key, value) }
+      __private_self.foreach { case (key, value) => result.set(key, value) }
       result
     }
   }
 
   implicit final class JSRichSet[T] private[JSConverters] (
-      private val set: Set[T])
+      private val __private_set: Set[T])
       extends AnyVal {
 
     @inline final def toJSSet: js.Set[T] = {
       val result = js.Set.empty[T]
-      set.foreach { value => result.add(value) }
+      __private_set.foreach { value => result.add(value) }
       result
     }
   }

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
@@ -115,7 +115,7 @@ object WrappedMap {
   private final class MapIterator[K, +V](underlying: js.Map[K, V])
       extends scala.collection.Iterator[(K, V)] {
 
-    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys())
+    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys().asInstanceOf[js.Iterable[K]])
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < keys.length

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
@@ -1,0 +1,151 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.collection.mutable
+import scala.collection.mutable.Builder
+import scala.collection.View
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+/** Wrapper to use a js.Map as a scala.mutable.Map */
+@inline
+class WrappedMap[K, V](val underlying: js.Map[K, V])
+    extends mutable.AbstractMap[K, V]
+    with mutable.MapOps[K, V, mutable.Map, js.WrappedMap[K, V]] {
+
+  import WrappedMap._
+
+  protected[this] override def fromSpecific(
+      coll: scala.collection.IterableOnce[(K, V)]
+  ): js.WrappedMap[K, V] = {
+    val d = js.WrappedMap.empty[K, V]
+    d ++= coll
+    d
+  }
+
+  protected[this] override def newSpecificBuilder: Builder[(K, V), js.WrappedMap[K, V]] =
+    new WrappedMapBuilder[K, V]
+
+  def get(key: K): Option[V] = {
+    if (contains(key))
+      Some(underlying.get(key).asInstanceOf[V])
+    else
+      None
+  }
+
+  override def apply(key: K): V = {
+    if (contains(key))
+      underlying.get(key).asInstanceOf[V]
+    else
+      throw new NoSuchElementException("key not found: " + key)
+  }
+
+  override def size(): Int =
+    underlying.size
+
+  override def contains(key: K): Boolean = {
+    underlying.has(key)
+  }
+
+  def subtractOne(key: K): this.type = {
+    if (contains(key))
+      underlying.delete(key)
+    this
+  }
+
+  override def update(key: K, value: V): Unit =
+    underlying.set(key, value)
+
+  def addOne(kv: (K, V)): this.type = {
+    underlying.update(kv._1, kv._2)
+    this
+  }
+
+  def iterator: scala.collection.Iterator[(K, V)] =
+    new MapIterator(underlying)
+
+  @inline
+  override def keys: scala.collection.Iterable[K] =
+    js.Array.from(underlying.keys())
+
+  override def empty: js.WrappedMap[K, V] =
+    new js.WrappedMap(js.Map.empty)
+
+  // Overloads to return more precise types
+
+  def map[B](f: ((K, V)) => (K, B)): js.WrappedMap[K, B] = {
+    val b = new js.WrappedMap.WrappedMapBuilder[K, B]
+    val it = this.iterator
+    while (it.hasNext) {
+      b += f(it.next())
+    }
+    b.result()
+  }
+
+  def flatMap[B](
+      f: ((K, V)) => IterableOnce[(K, B)]): js.WrappedMap[K, B] = {
+    val b = new js.WrappedMap.WrappedMapBuilder[K, B]
+    val it = this.iterator
+    while (it.hasNext) {
+      b ++= f(it.next())
+    }
+    b.result()
+  }
+
+  def collect[B](
+      pf: PartialFunction[(K, V), (K, B)]): js.WrappedMap[K, B] = {
+    flatMap { a =>
+      if (pf.isDefinedAt(a)) new View.Single(pf(a))
+      else View.Empty
+    }
+  }
+
+}
+
+object WrappedMap {
+
+  private final class MapIterator[K, +V](underlying: js.Map[K, V])
+      extends scala.collection.Iterator[(K, V)] {
+
+    private[this] val keys = js.Array.from(underlying.keys())
+    private[this] var index: Int = 0
+
+    def hasNext(): Boolean = index < keys.length
+
+    def next(): (K, V) = {
+      val key = keys(index)
+      index += 1
+      (key, underlying.get(key).asInstanceOf[V])
+    }
+  }
+
+  def empty[K, V]: js.WrappedMap[K, V] = new js.WrappedMap(js.Map.empty)
+
+  private final class WrappedMapBuilder[K, V]
+      extends Builder[(K, V), js.WrappedMap[K, V]] {
+
+    private[this] var map: js.Map[K, V] = js.Map.empty
+
+    def addOne(elem: (K, V)): this.type = {
+      map.set(elem._1, elem._2)
+      this
+    }
+
+    def clear(): Unit = map = js.Map.empty
+
+    def result(): js.WrappedMap[K, V] = new js.WrappedMap(map)
+  }
+
+}

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
@@ -115,7 +115,8 @@ object WrappedMap {
   private final class MapIterator[K, +V](underlying: js.Map[K, V])
       extends scala.collection.Iterator[(K, V)] {
 
-    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys().asInstanceOf[js.Iterable[K]])
+    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]]
+      .keys().asInstanceOf[js.Iterable[K]])
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < keys.length

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
@@ -74,7 +74,7 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
 
   @inline
   override def keys: scala.collection.Iterable[K] =
-    js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys())
+    js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys().asInstanceOf[js.Iterable[K]])
 
   override def empty: js.WrappedMap[K, V] =
     new js.WrappedMap(js.Map.empty)

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedSet.scala
@@ -19,7 +19,7 @@ import scala.scalajs.js
 
 /** Wrapper to use a js.Set as a scala.mutable.Set */
 @inline
-class WrappedSet[T](val underlying: js.Set[T])
+final class WrappedSet[T](private val underlying: js.Set[T])
     extends mutable.AbstractSet[T]
        with mutable.SetOps[T, WrappedSet, WrappedSet[T]] {
 
@@ -29,25 +29,25 @@ class WrappedSet[T](val underlying: js.Set[T])
     underlying.size
 
   override def contains(value: T): Boolean =
-    underlying.has(value)
+    underlying.asInstanceOf[js.Set.Raw[T]].has(value)
 
   override def clear(): Unit =
     underlying.clear()
 
   override def addOne(elem: T): this.type = {
-    underlying.add(elem)
+    underlying.asInstanceOf[js.Set.Raw[T]].add(elem)
     this
   }
 
   override def subtractOne(elem: T): this.type = {
-    underlying.remove(elem)
+    underlying.asInstanceOf[js.Set.Raw[T]].delete(elem)
     this
   }
 
   override def add(elem: T): Boolean = {
-    if (underlying.has(elem)) false
+    if (underlying.asInstanceOf[js.Set.Raw[T]].has(elem)) false
     else {
-      underlying.add(elem)
+      underlying.asInstanceOf[js.Set.Raw[T]].add(elem)
       true
     }
   }
@@ -59,7 +59,7 @@ class WrappedSet[T](val underlying: js.Set[T])
     WrappedSet.newBuilder
 
   override def remove(elem: T): Boolean =
-    underlying.delete(elem)
+    underlying.asInstanceOf[js.Set.Raw[T]].delete(elem)
 
   override def iterableFactory: IterableFactory[WrappedSet] = WrappedSet
 
@@ -83,7 +83,7 @@ object WrappedSet extends IterableFactory[WrappedSet] {
   private final class SetIterator[+T](dict: js.Set[T])
     extends scala.collection.Iterator[T] {
 
-    private[this] val values = js.Array.from(dict.values())
+    private[this] val values = js.Array.from(dict.jsIterator())
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < values.length

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedSet.scala
@@ -83,7 +83,7 @@ object WrappedSet extends IterableFactory[WrappedSet] {
   private final class SetIterator[+T](dict: js.Set[T])
     extends scala.collection.Iterator[T] {
 
-    private[this] val values = js.Array.from(dict.jsIterator())
+    private[this] val values = js.Array.from(dict.jsIterator().asInstanceOf[js.Iterable[T]])
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < values.length

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedSet.scala
@@ -1,0 +1,119 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
+import scala.collection.IterableFactory
+import scala.scalajs.js
+
+/** Wrapper to use a js.Set as a scala.mutable.Set */
+@inline
+class WrappedSet[T](val underlying: js.Set[T])
+    extends mutable.AbstractSet[T]
+       with mutable.SetOps[T, WrappedSet, WrappedSet[T]] {
+
+  import WrappedSet._
+
+  override def size(): Int =
+    underlying.size
+
+  override def contains(value: T): Boolean =
+    underlying.has(value)
+
+  override def clear(): Unit =
+    underlying.clear()
+
+  override def addOne(elem: T): this.type = {
+    underlying.add(elem)
+    this
+  }
+
+  override def subtractOne(elem: T): this.type = {
+    underlying.remove(elem)
+    this
+  }
+
+  override def add(elem: T): Boolean = {
+    if (underlying.has(elem)) false
+    else {
+      underlying.add(elem)
+      true
+    }
+  }
+
+  override protected def fromSpecific(coll: IterableOnce[T]): WrappedSet[T] =
+    WrappedSet.from(coll)
+
+  override protected def newSpecificBuilder: mutable.Builder[T, WrappedSet[T]] =
+    WrappedSet.newBuilder
+
+  override def remove(elem: T): Boolean =
+    underlying.delete(elem)
+
+  override def iterableFactory: IterableFactory[WrappedSet] = WrappedSet
+
+  override def iterator: scala.collection.Iterator[T] =
+    new SetIterator(underlying)
+
+  override def empty: WrappedSet[T] =
+    new WrappedSet(js.Set.empty[T])
+}
+
+object WrappedSet extends IterableFactory[WrappedSet] {
+
+  def empty[A]: WrappedSet[A] =
+    new WrappedSet[A](js.Set.empty)
+
+  def newBuilder[A]: mutable.Builder[A, WrappedSet[A]] = new WrappedSetBuilder[A]
+
+  def from[A](source: IterableOnce[A]): WrappedSet[A] =
+    (newBuilder[A] ++= source).result()
+
+  private final class SetIterator[+T](dict: js.Set[T])
+    extends scala.collection.Iterator[T] {
+
+    private[this] val values = js.Array.from(dict.values())
+    private[this] var index: Int = 0
+
+    def hasNext(): Boolean = index < values.length
+
+    def next(): T = {
+      val value = values(index)
+      index += 1
+      value
+    }
+  }
+
+  private final class WrappedSetBuilder[A]
+    extends mutable.Builder[A, WrappedSet[A]] {
+
+    private[this] var set: js.Set[A] = js.Set.empty
+
+    @inline def addOne(elem: A): this.type = {
+      set.add(elem)
+      this
+    }
+
+    def clear(): Unit =
+      set = js.Set.empty
+
+    def result(): WrappedSet[A] =
+      new js.WrappedSet(set)
+  }
+
+
+
+}
+
+

--- a/library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
@@ -184,7 +184,7 @@ trait LowPrioAnyImplicits extends LowestPrioAnyImplicits {
   implicit def wrapDictionary[A](dict: Dictionary[A]): WrappedDictionary[A] =
     new WrappedDictionary(dict)
   implicit def wrapSet[A](set: Set[A]): WrappedSet[A] =
-    new WrappedSet[A](set)
+    new WrappedSet(set)
   implicit def wrapMap[K, V](map: Map[K, V]): WrappedMap[K, V] =
     new WrappedMap(map)
 }

--- a/library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
@@ -183,6 +183,10 @@ trait LowPrioAnyImplicits extends LowestPrioAnyImplicits {
     new WrappedArray(array)
   implicit def wrapDictionary[A](dict: Dictionary[A]): WrappedDictionary[A] =
     new WrappedDictionary(dict)
+  implicit def wrapSet[A](set: Set[A]): WrappedSet[A] =
+    new WrappedSet[A](set)
+  implicit def wrapMap[K, V](map: Map[K, V]): WrappedMap[K, V] =
+    new WrappedMap(map)
 }
 
 sealed trait LowestPrioAnyImplicits {

--- a/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
@@ -114,9 +114,9 @@ object JSConverters extends JSConvertersLowPrioImplicits {
       val map: GenMap[K, V]) extends AnyVal {
 
     @inline final def toJSMap: js.Map[K, V] = {
-      val result = js.Map.empty[K, V]
+      val result = js.Map.empty[K, V].asInstanceOf[js.Map.Raw[K, V]]
       map.foreach { case (key, value) => result.set(key, value) }
-      result
+      result.asInstanceOf[js.Map[K, V]]
     }
   }
 

--- a/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
@@ -110,6 +110,25 @@ object JSConverters extends JSConvertersLowPrioImplicits {
     }
   }
 
+  implicit final class JSRichGenMapKV[K, V](
+      val map: GenMap[K, V]) extends AnyVal {
+
+    @inline final def toJSMap: js.Map[K, V] = {
+      val result = js.Map.empty[K, V]
+      map.foreach { case (key, value) => result.set(key, value) }
+      result
+    }
+  }
+
+  implicit final class JSRichSet[T](val set: GenSet[T]) extends AnyVal {
+
+    @inline final def toJSSet: js.Set[T] = {
+      val result = js.Set.empty[T]
+      set.foreach { value => result.add(value) }
+      result
+    }
+  }
+
   @inline
   implicit def genTravConvertible2JSRichGenTrav[T, C](coll: C)(
       implicit ev: C => GenTraversableOnce[T]): JSRichGenTraversableOnce[T] =

--- a/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
@@ -120,11 +120,12 @@ object JSConverters extends JSConvertersLowPrioImplicits {
     }
   }
 
-  implicit final class JSRichSet[T](val set: GenSet[T]) extends AnyVal {
+  implicit final class JSRichSet[T](
+     val __private_self: GenSet[T]) extends AnyVal {
 
     @inline final def toJSSet: js.Set[T] = {
       val result = js.Set.empty[T]
-      set.foreach { value => result.add(value) }
+      __private_self.foreach { value => result.add(value) }
       result
     }
   }

--- a/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
@@ -110,7 +110,7 @@ object JSConverters extends JSConvertersLowPrioImplicits {
     }
   }
 
-  implicit final class JSRichGenMapKV[K, V](
+  implicit final class JSRichMapKV[K, V](
       val map: GenMap[K, V]) extends AnyVal {
 
     @inline final def toJSMap: js.Map[K, V] = {

--- a/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/JSConverters.scala
@@ -111,11 +111,11 @@ object JSConverters extends JSConvertersLowPrioImplicits {
   }
 
   implicit final class JSRichMapKV[K, V](
-      val map: GenMap[K, V]) extends AnyVal {
+      val __private_self: GenMap[K, V]) extends AnyVal {
 
     @inline final def toJSMap: js.Map[K, V] = {
       val result = js.Map.empty[K, V].asInstanceOf[js.Map.Raw[K, V]]
-      map.foreach { case (key, value) => result.set(key, value) }
+      __private_self.foreach { case (key, value) => result.set(key, value) }
       result.asInstanceOf[js.Map[K, V]]
     }
   }

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -28,14 +28,14 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
 
   def get(key: K): Option[V] = {
     if (contains(key))
-      Some(underlying.get(key).asInstanceOf[V])
+      Some(underlying.asInstanceOf[js.Map.Raw[K, V]].get(key))
     else
       None
   }
 
   override def apply(key: K): V = {
     if (contains(key))
-      underlying.get(key).asInstanceOf[V]
+      underlying.asInstanceOf[js.Map.Raw[K, V]].get(key)
     else
       throw new NoSuchElementException("key not found: " + key)
   }
@@ -43,9 +43,8 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
   override def size(): Int =
     underlying.size
 
-  override def contains(key: K): Boolean = {
-    underlying.contains(key)
-  }
+  override def contains(key: K): Boolean =
+    underlying.asInstanceOf[js.Map.Raw[K, V]].has(key)
 
   def -=(key: K): this.type = {
     underlying.delete(key)
@@ -85,7 +84,7 @@ object WrappedMap {
     def next(): (K, V) = {
       val key = keys(index)
       index += 1
-      (key, underlying.get(key).asInstanceOf[V])
+      (key, underlying.asInstanceOf[js.Map.Raw[K, V]].get(key))
     }
   }
 

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -19,7 +19,7 @@ import scala.scalajs.js
 
 /** Wrapper to use a js.Map as a scala.mutable.Map */
 @inline
-class WrappedMap[K, V](val underlying: js.Map[K, V])
+final class WrappedMap[K, V](private val underlying: js.Map[K, V])
     extends mutable.AbstractMap[K, V]
        with mutable.Map[K, V]
        with mutable.MapLike[K, V, js.WrappedMap[K, V]] {

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -1,0 +1,122 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
+import scala.collection.mutable.Builder
+import scala.scalajs.js
+
+/** Wrapper to use a js.Map as a scala.mutable.Map */
+@inline
+class WrappedMap[K, V](val underlying: js.Map[K, V])
+    extends mutable.AbstractMap[K, V]
+       with mutable.Map[K, V]
+       with mutable.MapLike[K, V, js.WrappedMap[K, V]] {
+
+  import WrappedMap._
+
+  def get(key: K): Option[V] = {
+    if (contains(key))
+      Some(underlying.get(key).asInstanceOf[V])
+    else
+      None
+  }
+
+  override def apply(key: K): V = {
+    if (contains(key))
+      underlying.get(key).asInstanceOf[V]
+    else
+      throw new NoSuchElementException("key not found: " + key)
+  }
+
+  override def size(): Int =
+    underlying.size
+
+  override def contains(key: K): Boolean = {
+    underlying.has(key)
+  }
+
+  def -=(key: K): this.type = {
+    underlying.delete(key)
+    this
+  }
+
+  override def update(key: K, value: V): Unit =
+    underlying.set(key, value)
+
+  def +=(kv: (K, V)): this.type = {
+    underlying.set(kv._1, kv._2)
+    this
+  }
+
+  def iterator: scala.collection.Iterator[(K, V)] =
+    new MapIterator(underlying)
+
+  @inline
+  override def keys: scala.collection.Iterable[K] =
+    js.Array.from(underlying.keys())
+
+  override def empty: js.WrappedMap[K, V] =
+    new js.WrappedMap(js.Map.empty[K, V])
+
+}
+
+object WrappedMap {
+
+  private final class MapIterator[K, +V](underlying: js.Map[K, V])
+      extends scala.collection.Iterator[(K, V)] {
+
+    private[this] val keys = js.Array.from(underlying.keys())
+    private[this] var index: Int = 0
+
+    def hasNext(): Boolean = index < keys.length
+
+    def next(): (K, V) = {
+      val key = keys(index)
+      index += 1
+      (key, underlying.get(key).asInstanceOf[V])
+    }
+  }
+
+  def empty[K, A]: js.WrappedMap[K, A] =
+    new js.WrappedMap[K, A](js.Map.empty)
+
+  implicit def canBuildFrom[K, A]: CanBuildFrom[js.WrappedMap[K, A], (K, A), js.WrappedMap[K, A]] = {
+    new CanBuildFrom[js.WrappedMap[K, A], (K, A), js.WrappedMap[K, A]] {
+      def apply(from: js.WrappedMap[K, A]): Builder[(K, A), js.WrappedMap[K, A]] =
+        new WrappedMapBuilder[K, A]
+      def apply(): Builder[(K, A), js.WrappedMap[K, A]] =
+        new WrappedMapBuilder[K, A]
+    }
+  }
+
+  private final class WrappedMapBuilder[K, A]
+    extends Builder[(K, A), js.WrappedMap[K, A]] {
+
+    private[this] var map: js.Map[K, A] = js.Map.empty
+
+    def +=(elem: (K, A)): this.type = {
+      map.set(elem._1, elem._2)
+      this
+    }
+
+    def clear(): Unit =
+      map = js.Map.empty
+
+    def result(): js.WrappedMap[K, A] =
+      new js.WrappedMap(map)
+  }
+
+}
+

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -44,7 +44,7 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
     underlying.size
 
   override def contains(key: K): Boolean = {
-    underlying.has(key)
+    underlying.contains(key)
   }
 
   def -=(key: K): this.type = {
@@ -53,10 +53,10 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
   }
 
   override def update(key: K, value: V): Unit =
-    underlying.set(key, value)
+    underlying.asInstanceOf[js.Map.Raw[K, V]].set(key, value)
 
   def +=(kv: (K, V)): this.type = {
-    underlying.set(kv._1, kv._2)
+    underlying.asInstanceOf[js.Map.Raw[K, V]].set(kv._1, kv._2)
     this
   }
 
@@ -65,7 +65,7 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
 
   @inline
   override def keys: scala.collection.Iterable[K] =
-    js.Array.from(underlying.keys())
+    js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys())
 
   override def empty: js.WrappedMap[K, V] =
     new js.WrappedMap(js.Map.empty[K, V])
@@ -77,7 +77,7 @@ object WrappedMap {
   private final class MapIterator[K, +V](underlying: js.Map[K, V])
       extends scala.collection.Iterator[(K, V)] {
 
-    private[this] val keys = js.Array.from(underlying.keys())
+    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys())
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < keys.length
@@ -107,7 +107,7 @@ object WrappedMap {
     private[this] var map: js.Map[K, A] = js.Map.empty
 
     def +=(elem: (K, A)): this.type = {
-      map.set(elem._1, elem._2)
+      map.asInstanceOf[js.Map.Raw[K, A]].set(elem._1, elem._2)
       this
     }
 

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -64,7 +64,7 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
 
   @inline
   override def keys: scala.collection.Iterable[K] =
-    js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys())
+    js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys().asInstanceOf[js.Iterable[K]])
 
   override def empty: js.WrappedMap[K, V] =
     new js.WrappedMap(js.Map.empty[K, V])
@@ -76,7 +76,7 @@ object WrappedMap {
   private final class MapIterator[K, +V](underlying: js.Map[K, V])
       extends scala.collection.Iterator[(K, V)] {
 
-    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys())
+    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys().asInstanceOf[js.Iterable[K]])
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < keys.length

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -76,7 +76,8 @@ object WrappedMap {
   private final class MapIterator[K, +V](underlying: js.Map[K, V])
       extends scala.collection.Iterator[(K, V)] {
 
-    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]].keys().asInstanceOf[js.Iterable[K]])
+    private[this] val keys = js.Array.from(underlying.asInstanceOf[js.Map.Raw[K, V]]
+      .keys().asInstanceOf[js.Iterable[K]])
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < keys.length

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -119,4 +119,3 @@ object WrappedMap {
   }
 
 }
-

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
@@ -1,0 +1,115 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.collection.generic.CanBuildFrom
+import scala.collection.mutable
+import scala.collection.mutable.Builder
+import scala.scalajs.js
+
+/** Wrapper to use a js.Set as a scala.mutable.Set */
+@inline
+class WrappedSet[T](val underlying: js.Set[T])
+    extends mutable.AbstractSet[T]
+       with mutable.Set[T]
+       with mutable.SetLike[T, js.WrappedSet[T]] {
+
+  import WrappedSet._
+
+  override def apply(key: T): Boolean =
+    contains(key)
+
+  override def size(): Int =
+    underlying.size
+
+  override def contains(value: T): Boolean = {
+    underlying.has(value)
+  }
+
+  override def add(elem: T): Boolean = {
+    if (underlying.has(elem)) false
+    else {
+      underlying.add(elem)
+      true
+    }
+  }
+
+  override def remove(elem: T): Boolean =
+    underlying.delete(elem)
+
+  def -=(key: T): this.type = {
+    underlying.delete(key)
+    this
+  }
+
+  def +=(value: T): this.type = {
+    underlying.add(value)
+    this
+  }
+
+  def iterator: scala.collection.Iterator[T] =
+    new SetIterator(underlying)
+
+  override def empty: js.WrappedSet[T] =
+    new js.WrappedSet(js.Set.empty[T])
+}
+
+object WrappedSet {
+
+  private final class SetIterator[+T](dict: js.Set[T])
+    extends scala.collection.Iterator[T] {
+
+    private[this] val values = js.Array.from(dict.values())
+    private[this] var index: Int = 0
+
+    def hasNext(): Boolean = index < values.length
+
+    def next(): T = {
+      val value = values(index)
+      index += 1
+      value
+    }
+  }
+
+  def empty[A]: js.WrappedSet[A] =
+    new js.WrappedSet[A](js.Set.empty)
+
+  implicit def canBuildFrom[A]: CanBuildFrom[js.WrappedSet[A], A, js.WrappedSet[A]] = {
+    new CanBuildFrom[js.WrappedSet[A], A, js.WrappedSet[A]] {
+      def apply(from: js.WrappedSet[A]): Builder[A, js.WrappedSet[A]] =
+        new WrappedSetBuilder[A]
+      def apply(): Builder[A, js.WrappedSet[A]] =
+        new WrappedSetBuilder[A]
+    }
+  }
+
+  private final class WrappedSetBuilder[A]
+    extends Builder[A, js.WrappedSet[A]] {
+
+    private[this] var set: js.Set[A] = js.Set.empty
+
+    def +=(elem: A): this.type = {
+      set.add(elem)
+      this
+    }
+
+    def clear(): Unit =
+      set = js.Set.empty
+
+    def result(): js.WrappedSet[A] =
+      new js.WrappedSet(set)
+  }
+
+}
+
+

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
@@ -33,27 +33,27 @@ final class WrappedSet[T](private val underlying: js.Set[T])
     underlying.size
 
   override def contains(value: T): Boolean = {
-    underlying.has(value)
+    underlying.asInstanceOf[js.Set.Raw[T]].has(value)
   }
 
   override def add(elem: T): Boolean = {
-    if (underlying.has(elem)) false
+    if (underlying.asInstanceOf[js.Set.Raw[T]].has(elem)) false
     else {
-      underlying.add(elem)
+      underlying.asInstanceOf[js.Set.Raw[T]].add(elem)
       true
     }
   }
 
   override def remove(elem: T): Boolean =
-    underlying.delete(elem)
+    underlying.asInstanceOf[js.Set.Raw[T]].delete(elem)
 
   def -=(key: T): this.type = {
-    underlying.delete(key)
+    remove(key)
     this
   }
 
   def +=(value: T): this.type = {
-    underlying.add(value)
+    underlying.asInstanceOf[js.Set.Raw[T]].add(value)
     this
   }
 
@@ -69,7 +69,7 @@ object WrappedSet {
   private final class SetIterator[+T](dict: js.Set[T])
     extends scala.collection.Iterator[T] {
 
-    private[this] val values = js.Array.from(dict.values())
+    private[this] val values = js.Array.from(dict.jsIterator())
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < values.length

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
@@ -19,7 +19,7 @@ import scala.scalajs.js
 
 /** Wrapper to use a js.Set as a scala.mutable.Set */
 @inline
-class WrappedSet[T](val underlying: js.Set[T])
+final class WrappedSet[T](private val underlying: js.Set[T])
     extends mutable.AbstractSet[T]
        with mutable.Set[T]
        with mutable.SetLike[T, js.WrappedSet[T]] {

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
@@ -111,5 +111,3 @@ object WrappedSet {
   }
 
 }
-
-

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
@@ -69,7 +69,7 @@ object WrappedSet {
   private final class SetIterator[+T](dict: js.Set[T])
     extends scala.collection.Iterator[T] {
 
-    private[this] val values = js.Array.from(dict.jsIterator())
+    private[this] val values = js.Array.from(dict.jsIterator().asInstanceOf[js.Iterable[T]])
     private[this] var index: Int = 0
 
     def hasNext(): Boolean = index < values.length

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -183,4 +183,10 @@ object Array extends Object {
 
   /** Returns true if the given value is an array. */
   def isArray(arg: Any): Boolean = native
+
+  /** Creates a new array from the given iterable */
+  def from[A](iterable: Iterable[A]): Array[A] = native
+
+  /** Creates a new array from the given iterator */
+  def from[A](iterator: Iterator[A]): Array[A] = native
 }

--- a/library/src/main/scala/scala/scalajs/js/Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/Array.scala
@@ -186,7 +186,4 @@ object Array extends Object {
 
   /** Creates a new array from the given iterable */
   def from[A](iterable: Iterable[A]): Array[A] = native
-
-  /** Creates a new array from the given iterator */
-  def from[A](iterator: Iterator[A]): Array[A] = native
 }

--- a/library/src/main/scala/scala/scalajs/js/Map.scala
+++ b/library/src/main/scala/scala/scalajs/js/Map.scala
@@ -34,40 +34,31 @@ class Map[K, V]() extends js.Object with js.Iterable[js.Tuple2[K, V]] {
 
   def delete(key: K): Boolean = js.native
 
-  def entries(): js.Iterator[js.Tuple2[K, V]] = js.native
-
-  @JSName("forEach")
-  def jsForEach[T](callbackfn: js.ThisFunction3[T, V, K, Map[K, V], _],
-                   thisArg: T): Unit = js.native
-  @JSName("forEach")
-  def jsForEach(callbackfn: js.Function3[V, K, Map[K, V], _]): Unit = js.native
-
   @JSName(js.Symbol.iterator)
   override def jsIterator(): Iterator[Tuple2[K, V]] = js.native
 
   def size: Int = js.native
-
-  def get(key: K): js.UndefOr[V] = js.native
-
-  def has(key: K): Boolean = js.native
-
-  def keys(): js.Iterator[K] = js.native
-
-  def set(key: K, value: V): this.type = js.native
-
-  def values(): js.Iterator[V] = js.native
 }
+
 
 /** Factory for [[js.Map]] instances. */
 object Map {
   /** Returns a new empty map */
   @inline def empty[K, V]: js.Map[K, V] = new Map[K, V]()
 
+  @js.native
+  private[js] trait Raw[K, V] extends js.Object {
+    def has(key: K): Boolean = js.native
+    def keys(): js.Iterator[K] = js.native
+    def set(key: K, value: V): js.Map[K, V] = js.native
+  }
+
   @inline
   def apply[K, V](properties: (K, V)*): js.Map[K, V] = {
     val map = empty[K, V]
+    val rawMap = map.asInstanceOf[js.Map.Raw[K, V]]
     for (pair <- properties)
-      map.set(pair._1, pair._2)
+      rawMap.set(pair._1, pair._2)
     map
   }
 }

--- a/library/src/main/scala/scala/scalajs/js/Map.scala
+++ b/library/src/main/scala/scala/scalajs/js/Map.scala
@@ -1,0 +1,72 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{ JSGlobal, JSName }
+
+/** The Map object holds key-value pairs and remembers the original insertion
+ *  order of the keys. Any value (both objects and primitive values) may be used
+ *  as either a key or a value.
+ *
+ *  @tparam K A type of key.
+ *  @tparam V A type of value.
+ *  @note The class [[js.Map]] is added in ES6 (ES2015).
+ *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
+ */
+@js.native
+@JSGlobal
+class Map[K, V]() extends js.Object with js.Iterable[js.Tuple2[K, V]] {
+  def this(array: js.Iterable[js.Tuple2[K, V]]) = this()
+
+  def clear(): Unit = js.native
+
+  def delete(key: K): Boolean = js.native
+
+  def entries(): js.Iterator[js.Tuple2[K, V]] = js.native
+
+  @JSName("forEach")
+  def jsForEach[T](callbackfn: js.ThisFunction3[T, V, K, Map[K, V], _],
+                   thisArg: T): Unit = js.native
+  @JSName("forEach")
+  def jsForEach(callbackfn: js.Function3[V, K, Map[K, V], _]): Unit = js.native
+
+  @JSName(js.Symbol.iterator)
+  override def jsIterator(): Iterator[Tuple2[K, V]] = js.native
+
+  def size: Int = js.native
+
+  def get(key: K): js.UndefOr[V] = js.native
+
+  def has(key: K): Boolean = js.native
+
+  def keys(): js.Iterator[K] = js.native
+
+  def set(key: K, value: V): this.type = js.native
+
+  def values(): js.Iterator[V] = js.native
+}
+
+/** Factory for [[js.Map]] instances. */
+object Map {
+  /** Returns a new empty map */
+  @inline def empty[K, V]: js.Map[K, V] = new Map[K, V]()
+
+  @inline
+  def apply[K, V](properties: (K, V)*): js.Map[K, V] = {
+    val map = empty[K, V]
+    for (pair <- properties)
+      map.set(pair._1, pair._2)
+    map
+  }
+}

--- a/library/src/main/scala/scala/scalajs/js/Map.scala
+++ b/library/src/main/scala/scala/scalajs/js/Map.scala
@@ -23,7 +23,6 @@ import scala.scalajs.js.annotation.{ JSGlobal, JSName }
  *
  *  @tparam K A type of key.
  *  @tparam V A type of value.
- *  @note The class [[js.Map]] is added in ES6 (ES2015).
  *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map
  */
 @js.native

--- a/library/src/main/scala/scala/scalajs/js/Map.scala
+++ b/library/src/main/scala/scala/scalajs/js/Map.scala
@@ -15,7 +15,9 @@ package scala.scalajs.js
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{ JSGlobal, JSName }
 
-/** The Map object holds key-value pairs and remembers the original insertion
+/** <span class="badge badge-ecma2015" style="float: right;">ECMAScript 2015</span>
+ *
+ *  The Map object holds key-value pairs and remembers the original insertion
  *  order of the keys. Any value (both objects and primitive values) may be used
  *  as either a key or a value.
  *

--- a/library/src/main/scala/scala/scalajs/js/Map.scala
+++ b/library/src/main/scala/scala/scalajs/js/Map.scala
@@ -51,6 +51,7 @@ object Map {
     def has(key: K): Boolean = js.native
     def keys(): js.Iterator[K] = js.native
     def set(key: K, value: V): js.Map[K, V] = js.native
+    def get(key: K): V = js.native
   }
 
   @inline

--- a/library/src/main/scala/scala/scalajs/js/Set.scala
+++ b/library/src/main/scala/scala/scalajs/js/Set.scala
@@ -25,7 +25,7 @@ import scala.scalajs.js.annotation.{ JSGlobal, JSName }
  */
 @js.native
 @JSGlobal
-class Set[T]() extends js.Object with js.Iterable[js.Tuple2[T, T]] {
+class Set[T]() extends js.Object with js.Iterable[T] {
   def this(array: js.Iterable[T]) = this()
 
   def clear(): Unit = js.native
@@ -43,7 +43,7 @@ class Set[T]() extends js.Object with js.Iterable[js.Tuple2[T, T]] {
   def keys(): js.Iterator[T] = js.native
 
   @JSName(js.Symbol.iterator)
-  override def jsIterator(): Iterator[Tuple2[T, T]] = js.native
+  override def jsIterator(): Iterator[T] = js.native
 
   def size: Int = js.native
 

--- a/library/src/main/scala/scala/scalajs/js/Set.scala
+++ b/library/src/main/scala/scala/scalajs/js/Set.scala
@@ -1,0 +1,68 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{ JSGlobal, JSName }
+
+/** The Set object lets you store unique values of any type, whether primitive
+ *  values or object references.
+ *
+ *  @tparam T A type of element.
+ *  @note The class [[js.Set]] is added in ES6 (ES2015).
+ *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
+ */
+@js.native
+@JSGlobal
+class Set[T]() extends js.Object with js.Iterable[js.Tuple2[T, T]] {
+  def this(array: js.Iterable[T]) = this()
+
+  def clear(): Unit = js.native
+
+  def delete(key: T): Boolean = js.native
+
+  def entries(): js.Iterator[js.Tuple2[T,T]] = js.native
+
+  @JSName("forEach")
+  def jsForEach[T](callbackfn: js.ThisFunction3[T, T, T, Set[T], _],
+                   thisArg: T): Unit = js.native
+  @JSName("forEach")
+  def jsForEach(callbackfn: js.Function3[T, T, Set[T], _]): Unit = js.native
+
+  def keys(): js.Iterator[T] = js.native
+
+  @JSName(js.Symbol.iterator)
+  override def jsIterator(): Iterator[Tuple2[T, T]] = js.native
+
+  def size: Int = js.native
+
+  def has(value: T): Boolean = js.native
+
+  def add(value: T): this.type = js.native
+
+  def values(): js.Iterator[T] = js.native
+}
+
+/** Factory for [[js.Set]] instances. */
+object Set {
+  /** Returns a new empty map */
+  @inline def empty[V]: js.Set[V] = new Set[V]()
+
+  @inline
+  def apply[V](values: V*): js.Set[V] = {
+    val set = empty[V]
+    for (value <- values)
+      set.add(value)
+    set
+  }
+}

--- a/library/src/main/scala/scala/scalajs/js/Set.scala
+++ b/library/src/main/scala/scala/scalajs/js/Set.scala
@@ -15,7 +15,9 @@ package scala.scalajs.js
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{ JSGlobal, JSName }
 
-/** The Set object lets you store unique values of any type, whether primitive
+/** <span class="badge badge-ecma2015" style="float: right;">ECMAScript 2015</span>
+ *
+ *  The Set object lets you store unique values of any type, whether primitive
  *  values or object references.
  *
  *  @tparam T A type of element.

--- a/library/src/main/scala/scala/scalajs/js/Set.scala
+++ b/library/src/main/scala/scala/scalajs/js/Set.scala
@@ -21,7 +21,6 @@ import scala.scalajs.js.annotation.{ JSGlobal, JSName }
  *  values or object references.
  *
  *  @tparam T A type of element.
- *  @note The class [[js.Set]] is added in ES6 (ES2015).
  *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
  */
 @js.native

--- a/library/src/main/scala/scala/scalajs/js/Set.scala
+++ b/library/src/main/scala/scala/scalajs/js/Set.scala
@@ -60,10 +60,5 @@ object Set {
   @inline def empty[V]: js.Set[V] = new Set[V]()
 
   @inline
-  def apply[V](values: V*): js.Set[V] = {
-    val set = empty[V]
-    for (value <- values)
-      set.add(value)
-    set
-  }
+  def apply[V](values: V*): js.Set[V] = new js.Set(js.Array(values: _*))
 }

--- a/library/src/main/scala/scala/scalajs/js/Set.scala
+++ b/library/src/main/scala/scala/scalajs/js/Set.scala
@@ -30,34 +30,23 @@ class Set[T]() extends js.Object with js.Iterable[T] {
 
   def clear(): Unit = js.native
 
-  def delete(key: T): Boolean = js.native
-
-  def entries(): js.Iterator[js.Tuple2[T,T]] = js.native
-
-  @JSName("forEach")
-  def jsForEach[T](callbackfn: js.ThisFunction3[T, T, T, Set[T], _],
-                   thisArg: T): Unit = js.native
-  @JSName("forEach")
-  def jsForEach(callbackfn: js.Function3[T, T, Set[T], _]): Unit = js.native
-
-  def keys(): js.Iterator[T] = js.native
-
   @JSName(js.Symbol.iterator)
   override def jsIterator(): Iterator[T] = js.native
 
   def size: Int = js.native
-
-  def has(value: T): Boolean = js.native
-
-  def add(value: T): this.type = js.native
-
-  def values(): js.Iterator[T] = js.native
 }
 
 /** Factory for [[js.Set]] instances. */
 object Set {
   /** Returns a new empty map */
   @inline def empty[V]: js.Set[V] = new Set[V]()
+
+  @js.native
+  private[js] trait Raw[T] extends js.Object {
+    def add(value: T): this.type = js.native
+    def has(value: T): Boolean = js.native
+    def delete(value: T): Boolean = js.native
+  }
 
   @inline
   def apply[V](values: V*): js.Set[V] = new js.Set(js.Array(values: _*))

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -29,6 +29,8 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+    exclude[ReversedMissingMethodProblem]("scala.scalajs.js.LowPrioAnyImplicits.wrapMap"),
+    exclude[ReversedMissingMethodProblem]("scala.scalajs.js.LowPrioAnyImplicits.wrapSet")
   )
 
   val TestInterface = Seq(

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -69,4 +69,8 @@ object Platform {
 
   private def sysProp(key: String): Boolean =
     System.getProperty("scalajs." + key, "false") == "true"
+
+  def hasInGlobal(name: String): Boolean =
+    !js.isUndefined(js.Dynamic.global.selectDynamic(name))
+
 }

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -69,8 +69,4 @@ object Platform {
 
   private def sysProp(key: String): Boolean =
     System.getProperty("scalajs." + key, "false") == "true"
-
-  def hasInGlobal(name: String): Boolean =
-    !js.isUndefined(js.Dynamic.global.selectDynamic(name))
-
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
@@ -41,7 +41,7 @@ class MapTest {
     val obj = js.Map.empty[String, Int]
     obj("hello") = 1
 
-    assertTrue(obj.get("hello") == 1)
+    assertTrue(obj.get("hello").get == 1)
     assertFalse(obj.get("world").isDefined)
   }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
@@ -1,0 +1,122 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.{ BeforeClass, Test }
+import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform
+
+import scala.scalajs.js
+
+object MapTest {
+  @BeforeClass
+  def assumeRuntimeSupportsMap(): Unit = {
+    assumeTrue("Assume Map exists in Global",
+      Platform.hasInGlobal("Map"))
+  }
+}
+
+class MapTest {
+
+  // scala.scalajs.js.Map
+
+  @Test def apply_should_throw_when_not_found(): Unit = {
+    val obj = js.Map("foo" -> "bar")
+    assertThrows(classOf[NoSuchElementException], obj("bar"))
+  }
+
+  @Test def should_provide_get(): Unit = {
+    val obj = js.Map.empty[String, Int]
+    obj("hello") = 1
+
+    assertTrue(obj.get("hello") == 1)
+    assertFalse(obj.get("world").isDefined)
+  }
+
+  @Test def should_provide_has(): Unit = {
+    val obj = js.Map(1 -> "foo")
+    assertTrue(obj.has(1))
+    assertFalse(obj.has(2))
+  }
+
+  @Test def should_provide_delete(): Unit = {
+    val obj = js.Map(1 -> "foo")
+    assertTrue(obj.delete(1))
+    assertFalse(obj.has(1))
+  }
+
+  @Test def should_provide_set(): Unit = {
+    val obj = js.Map(1 -> "foo")
+    assertTrue(obj.set(1, "bar").set(2, "babar") == obj)
+    assertTrue(obj.get(1).get == "bar")
+    assertTrue(obj.get(2).get == "babar")
+  }
+
+  @Test def `-=_should_ignore_deleting_a_non_existent_key`(): Unit = {
+    val obj = js.Map("a" -> "A")
+    assert(!obj.delete("b"))
+  }
+
+  @Test def should_provide_keys(): Unit = {
+    val obj = js.Map(1 -> "A", 2 -> "B")
+    val keys = obj.keys().toIterator.toSeq
+    assertEquals(2, keys.size)
+    assertTrue(keys.contains(1))
+    assertTrue(keys.contains(2))
+  }
+
+  @Test def should_provide_values(): Unit = {
+    val obj = js.Map("a" -> 1, "b" -> 3)
+    val values = obj.values().toIterator.toSeq
+    assertEquals(2, values.size)
+    assertTrue(values.contains(1))
+    assertTrue(values.contains(3))
+  }
+
+  @Test def should_provide_entries(): Unit = {
+    val obj = js.Map("a" -> 1, "b" -> 3)
+    val entries = obj.entries().toIterator.toSeq
+    assertEquals(2, entries.size)
+    assertTrue(entries(0)._1 == "a" && entries(0)._2 == 1)
+    assertTrue(entries(1)._1 == "b" && entries(1)._2 == 3)
+  }
+
+  @Test def should_provide_an_iterator(): Unit = {
+    val obj = js.Map("foo" -> 5, "bar" -> 42, "babar" -> 0)
+    var elems: List[(String, Int)] = Nil
+    for ((prop, value) <- obj) {
+      elems ::= (prop, value)
+    }
+    assertEquals(3, elems.size)
+    assertTrue(elems.contains(("foo", 5)))
+    assertTrue(elems.contains(("bar", 42)))
+    assertTrue(elems.contains(("babar", 0)))
+  }
+
+  // scala.scalajs.js.JSConverters.JSRichGenMapKV
+
+  @Test def should_provide_toJSMap(): Unit = {
+    import js.JSConverters._
+    val map1 = Map(1 -> "one", 2 -> "two").toJSMap
+    assertEquals("one", map1(1))
+    assertEquals("two", map1(2))
+
+    val map2 = Map("a" -> "foo", "b" -> "bar").toJSMap
+    assertEquals("foo", map2("a"))
+    assertEquals("bar", map2("b"))
+  }
+}
+
+

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
@@ -45,52 +45,9 @@ class MapTest {
     assertFalse(obj.get("world").isDefined)
   }
 
-  @Test def should_provide_has(): Unit = {
-    val obj = js.Map(1 -> "foo")
-    assertTrue(obj.has(1))
-    assertFalse(obj.has(2))
-  }
-
-  @Test def should_provide_delete(): Unit = {
-    val obj = js.Map(1 -> "foo")
-    assertTrue(obj.delete(1))
-    assertFalse(obj.has(1))
-  }
-
-  @Test def should_provide_set(): Unit = {
-    val obj = js.Map(1 -> "foo")
-    assertTrue(obj.set(1, "bar").set(2, "babar") == obj)
-    assertTrue(obj.get(1).get == "bar")
-    assertTrue(obj.get(2).get == "babar")
-  }
-
   @Test def `-=_should_ignore_deleting_a_non_existent_key`(): Unit = {
     val obj = js.Map("a" -> "A")
     assert(!obj.delete("b"))
-  }
-
-  @Test def should_provide_keys(): Unit = {
-    val obj = js.Map(1 -> "A", 2 -> "B")
-    val keys = obj.keys().toIterator.toSeq
-    assertEquals(2, keys.size)
-    assertTrue(keys.contains(1))
-    assertTrue(keys.contains(2))
-  }
-
-  @Test def should_provide_values(): Unit = {
-    val obj = js.Map("a" -> 1, "b" -> 3)
-    val values = obj.values().toIterator.toSeq
-    assertEquals(2, values.size)
-    assertTrue(values.contains(1))
-    assertTrue(values.contains(3))
-  }
-
-  @Test def should_provide_entries(): Unit = {
-    val obj = js.Map("a" -> 1, "b" -> 3)
-    val entries = obj.entries().toIterator.toSeq
-    assertEquals(2, entries.size)
-    assertTrue(entries(0)._1 == "a" && entries(0)._2 == 1)
-    assertTrue(entries(1)._1 == "b" && entries(1)._2 == 3)
   }
 
   @Test def should_provide_an_iterator(): Unit = {
@@ -116,6 +73,26 @@ class MapTest {
     val map2 = Map("a" -> "foo", "b" -> "bar").toJSMap
     assertEquals("foo", map2("a"))
     assertEquals("bar", map2("b"))
+  }
+
+  @Test def should_provide_contains(): Unit = {
+    val obj = js.Map(1 -> "foo")
+    assertTrue(obj.contains(1))
+    assertFalse(obj.contains(2))
+  }
+
+  @Test def should_provide_delete(): Unit = {
+    val obj = js.Map(1 -> "foo")
+    assertTrue(obj.delete(1))
+    assertFalse(obj.contains(1))
+  }
+
+  @Test def should_provide_update(): Unit = {
+    val obj = js.Map(1 -> "foo")
+    obj.update(1, "bar")
+    obj.update(2, "babar")
+    assertTrue(obj.get(1).get == "bar")
+    assertTrue(obj.get(2).get == "babar")
   }
 }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
@@ -24,7 +24,7 @@ object MapTest {
   @BeforeClass
   def assumeRuntimeSupportsMap(): Unit = {
     assumeTrue("Assume Map exists in Global",
-      Platform.hasInGlobal("Map"))
+      js.typeOf(js.constructorOf[js.Map[_, _]]) != "undefined")
   }
 }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SetTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SetTest.scala
@@ -23,7 +23,7 @@ object SetTest {
   @BeforeClass
   def assumeRuntimeSupportsSet(): Unit = {
     assumeTrue("Assume Set exists in Global",
-      Platform.hasInGlobal("Set"))
+      js.typeOf(js.constructorOf[js.Set[_]]) != "undefined")
   }
 }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SetTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SetTest.scala
@@ -31,54 +31,11 @@ class SetTest {
 
   // scala.scalajs.js.Set
 
-  @Test def should_provide_has(): Unit = {
-    val obj = js.Set("foo")
-    assertTrue(obj.has("foo"))
-    assertFalse(obj.has("bar"))
-  }
-
-  @Test def should_provide_add(): Unit = {
-    val obj = js.Set[String]()
-    assertTrue(obj.add("foo").add("bar") == obj)
-    assertTrue(obj.has("foo"))
-    assertTrue(obj.has("bar"))
-  }
-
-  @Test def should_provide_delete(): Unit = {
-    val obj = js.Set("foo")
-    assertTrue(obj.delete("foo"))
-    assertFalse(obj.has("foo"))
-  }
-
   @Test def should_provide_clear(): Unit = {
     val obj = js.Set("foo",  "bar")
     assertTrue(obj.size == 2)
     obj.clear()
     assertTrue(obj.size == 0)
-  }
-
-  @Test def should_provide_keys(): Unit = {
-    val obj = js.Set("a", "b")
-    val keys = js.Array.from(obj.keys())
-    assertEquals(2, keys.size)
-    assertTrue(keys.contains("a"))
-    assertTrue(keys.contains("b"))
-  }
-
-  @Test def should_provide_values(): Unit = {
-    val obj = js.Set("a", "b")
-    val values = js.Array.from(obj.values())
-    assertEquals(2, values.size)
-    assertTrue(values.contains("a"))
-    assertTrue(values.contains("b"))
-  }
-
-  @Test def should_provide_entries(): Unit = {
-    val obj = js.Set("a", "b")
-    val entries = js.Array.from(obj.entries())
-    assertEquals(2, entries.size)
-    assertTrue(entries(0)._1 == "a")
-    assertTrue(entries(1)._2 == "b")
   }
 
   @Test def should_provide_an_iterator(): Unit = {
@@ -101,6 +58,26 @@ class SetTest {
     assertTrue(obj(1))
     assertTrue(obj(2))
     assertFalse(obj(3))
+  }
+
+  @Test def should_provide_add(): Unit = {
+    val obj = js.Set[String]()
+    assertTrue(obj.size == 0)
+    assertTrue(obj.add("foo"))
+    assertTrue(obj.add("bar"))
+    assertTrue(obj.size == 2)
+  }
+
+  @Test def should_provide_contains(): Unit = {
+    val obj = js.Set("foo")
+    assertTrue(obj.contains("foo"))
+    assertFalse(obj.contains("bar"))
+  }
+
+  @Test def should_provide_delete(): Unit = {
+    val obj = js.Set("foo")
+    assertTrue(obj.remove("foo"))
+    assertFalse(obj.contains("foo"))
   }
 }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SetTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SetTest.scala
@@ -1,0 +1,107 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import org.junit.Assert._
+import org.junit.Assume.assumeTrue
+import org.junit.{ BeforeClass, Test }
+import org.scalajs.testsuite.utils.Platform
+
+import scala.scalajs.js
+
+object SetTest {
+  @BeforeClass
+  def assumeRuntimeSupportsSet(): Unit = {
+    assumeTrue("Assume Set exists in Global",
+      Platform.hasInGlobal("Set"))
+  }
+}
+
+class SetTest {
+
+  // scala.scalajs.js.Set
+
+  @Test def should_provide_has(): Unit = {
+    val obj = js.Set("foo")
+    assertTrue(obj.has("foo"))
+    assertFalse(obj.has("bar"))
+  }
+
+  @Test def should_provide_add(): Unit = {
+    val obj = js.Set[String]()
+    assertTrue(obj.add("foo").add("bar") == obj)
+    assertTrue(obj.has("foo"))
+    assertTrue(obj.has("bar"))
+  }
+
+  @Test def should_provide_delete(): Unit = {
+    val obj = js.Set("foo")
+    assertTrue(obj.delete("foo"))
+    assertFalse(obj.has("foo"))
+  }
+
+  @Test def should_provide_clear(): Unit = {
+    val obj = js.Set("foo",  "bar")
+    assertTrue(obj.size == 2)
+    obj.clear()
+    assertTrue(obj.size == 0)
+  }
+
+  @Test def should_provide_keys(): Unit = {
+    val obj = js.Set("a", "b")
+    val keys = js.Array.from(obj.keys())
+    assertEquals(2, keys.size)
+    assertTrue(keys.contains("a"))
+    assertTrue(keys.contains("b"))
+  }
+
+  @Test def should_provide_values(): Unit = {
+    val obj = js.Set("a", "b")
+    val values = js.Array.from(obj.values())
+    assertEquals(2, values.size)
+    assertTrue(values.contains("a"))
+    assertTrue(values.contains("b"))
+  }
+
+  @Test def should_provide_entries(): Unit = {
+    val obj = js.Set("a", "b")
+    val entries = js.Array.from(obj.entries())
+    assertEquals(2, entries.size)
+    assertTrue(entries(0)._1 == "a")
+    assertTrue(entries(1)._2 == "b")
+  }
+
+  @Test def should_provide_an_iterator(): Unit = {
+    val obj = js.Set("foo", "bar", "babar")
+    var elems: List[String] = Nil
+    for (value <- obj) {
+      elems ::= value
+    }
+    assertEquals(3, elems.size)
+    assertTrue(elems.contains("foo"))
+    assertTrue(elems.contains("bar"))
+    assertTrue(elems.contains("babar"))
+  }
+
+  // scala.scalajs.js.JSConverters.JSRichGenSet
+
+  @Test def should_provide_toJSSet(): Unit = {
+    import js.JSConverters._
+    val obj = Set(1, 2).toJSSet
+    assertTrue(obj(1))
+    assertTrue(obj(2))
+    assertFalse(obj(3))
+  }
+}
+
+

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
@@ -103,7 +103,15 @@ class ObjectTest {
     assertEquals(obj1("b"), "foo")
   }
 
-  // TODO: Add test for fromEntries(js.Map)
+  @Test def fromEntries_js_Map(): Unit = {
+    assumeTrue(
+      "Assuming newer methods existence, which are not honored by Rhino",
+      Platform.executingInNodeJS)
+    val map = js.Map("a" -> 42, "b" -> "foo")
+    val obj = js.Object.fromEntries(map)
+    assertEquals(obj("a"), 42)
+    assertEquals(obj("b"), "foo")
+  }
 }
 
 object ObjectTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedMapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedMapTest.scala
@@ -1,0 +1,152 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.library
+
+import org.junit.Assert._
+import org.junit.Assume.assumeTrue
+import org.junit.{ BeforeClass, Test }
+import org.scalajs.testsuite.utils.Platform
+
+import scala.collection.mutable
+import scala.reflect.ClassTag
+import scala.scalajs.js
+
+object WrappedMapTest {
+  @BeforeClass
+  def assumeRuntimeSupportsSet(): Unit = {
+    assumeTrue("Assume Map exists in Global",
+      Platform.hasInGlobal("Map"))
+  }
+}
+
+class WrappedMapTest {
+
+  // Methods we actually implement
+
+  @Test def get(): Unit = {
+    val map: mutable.Map[String, Any] =
+      js.Map("a" -> "a", "b" -> 6, "e" -> js.undefined)
+    assertTrue(map.get("a") == Some("a"))
+    assertTrue(map.get("b") == Some(6))
+    assertTrue(map.get("e") == Some(()))
+    assertTrue(map.get("f") == None)
+  }
+
+  @Test def `+=_and_-=`(): Unit = {
+    val jsMap = js.Map[Int, String]()
+    val map: mutable.Map[Int, String] = jsMap
+
+    map += 1 -> "hello world"
+    assertEquals("hello world", jsMap(1))
+    map += 3 -> "foo bar"
+    assertEquals("foo bar", jsMap(3))
+    map -= 1
+    assertFalse(jsMap.get(1).isDefined)
+  }
+
+  @Test def iterator(): Unit = {
+    val elems = ('a' to 'e').map(_.toString).zip(1 to 5)
+    val jsMap = js.Map[String, Int]()
+    val map: mutable.Map[String, Int] = jsMap
+
+    jsMap ++= elems
+
+    assertTrue(map.iterator.toList.sorted.sameElements(elems))
+  }
+
+
+  /* Methods that need to be overloaded in 2.13 collections to get the correct
+   * result type.
+   */
+
+  @Test def map(): Unit = {
+    def ct[A: ClassTag](x: A): ClassTag[A] = implicitly[ClassTag[A]]
+
+    val jsMap = js.Map[String, Int]("one" -> 1, "two" -> 2, "three" -> 3)
+
+    val mapChr = jsMap.map { case (k, v) => k(0)          -> v * 2 }
+    val mapStr = jsMap.map { case (k, v) => k(0).toString -> v * 2 }
+
+    assertNotSame(classOf[js.WrappedMap[_, _]], ct(mapChr).runtimeClass)
+    assertSame(classOf[js.WrappedMap[_, _]], ct(mapStr).runtimeClass)
+
+    assertEquals(2, mapChr.size)
+    assertEquals(2, mapStr.size)
+  }
+
+  @Test def flatMap(): Unit = {
+    def ct[A: ClassTag](x: A): ClassTag[A] = implicitly[ClassTag[A]]
+
+    val jsMap = js.Map[String, Int]("one" -> 1, "two" -> 2, "three" -> 3)
+
+    val flatMapChr = jsMap.flatMap {
+      case (k, v) => List(k(0) -> v * 2, k(1) -> v * 3)
+    }
+    val flatMapStr = jsMap.flatMap {
+      case (k, v) => List(k(0).toString -> v * 2, k(1).toString -> v * 3)
+    }
+
+    assertNotSame(classOf[js.WrappedMap[_, _]], ct(flatMapChr).runtimeClass)
+    assertSame(classOf[js.WrappedMap[_, _]], ct(flatMapStr).runtimeClass)
+
+    assertEquals(5, flatMapChr.size)
+    assertEquals(5, flatMapStr.size)
+  }
+
+
+  @Test def collect(): Unit = {
+    def ct[A: ClassTag](x: A): ClassTag[A] = implicitly[ClassTag[A]]
+
+    val jsMap = js.Map[String, Int]("one" -> 1, "two" -> 2, "three" -> 3)
+
+    val collectChr = jsMap.collect {
+      case (k, v) if v > 1 => k(0) -> v * 2
+    }
+    val collectStr = jsMap.collect {
+      case (k, v) if v > 1 => k(0).toString -> v * 2
+    }
+
+    assertNotSame(classOf[js.WrappedMap[_, _]], ct(collectChr).runtimeClass)
+    assertSame(classOf[js.WrappedMap[_, _]], ct(collectStr).runtimeClass)
+
+    assertEquals(1, collectChr.size)
+    assertEquals(1, collectStr.size)
+  }
+
+  // Some arbitrary methods to test the builders
+
+  @Test def withFilter(): Unit = {
+    val jsMap = js.Map[String, Int]()
+    val flt = jsMap.withFilter { case (k, v) => v > 5 || k == "a" }
+    def size: Int = flt.map(x => x).size
+
+    assertEquals(0, size)
+    jsMap += "a" -> 1
+    assertEquals(1, size)
+    jsMap += "b" -> 2
+    assertEquals(1, size)
+    jsMap += "c" -> 6
+    assertEquals(2, size)
+    jsMap += "b" -> 7
+    assertEquals(3, size)
+    jsMap -= "a"
+    assertEquals(2, size)
+  }
+
+  @Test def toList(): Unit = {
+    val jsMap = js.Map[String, Any]("a" -> "a", "b" -> 6, "e" -> js.undefined)
+    val list = jsMap.toList
+    assertEquals(3, list.size)
+  }
+
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedMapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedMapTest.scala
@@ -25,7 +25,7 @@ object WrappedMapTest {
   @BeforeClass
   def assumeRuntimeSupportsSet(): Unit = {
     assumeTrue("Assume Map exists in Global",
-      Platform.hasInGlobal("Map"))
+      js.typeOf(js.constructorOf[js.Map[_, _]]) != "undefined")
   }
 }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedSetTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedSetTest.scala
@@ -1,0 +1,104 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.library
+
+import org.junit.Assert._
+import org.junit.Assume.assumeTrue
+import org.junit.{ BeforeClass, Test }
+import org.scalajs.testsuite.utils.Platform
+
+import scala.collection.mutable
+import scala.scalajs.js
+
+object WrappedSetTest {
+  @BeforeClass
+  def assumeRuntimeSupportsSet(): Unit = {
+    assumeTrue("Assume Map exists in Global",
+      Platform.hasInGlobal("Set"))
+  }
+}
+
+class WrappedSetTest {
+
+  // Methods we actually implement
+
+  @Test def get(): Unit = {
+    val jsSet: mutable.Set[Any] = js.Set("a", 1, js.undefined)
+    assertTrue(jsSet("a"))
+    assertTrue(jsSet(1) )
+    assertTrue(jsSet(()))
+    assertTrue(!jsSet("f"))
+  }
+
+  @Test def add_and_remove(): Unit = {
+    val jsSet = js.Set[String]()
+    val set: mutable.Set[String] = jsSet
+
+    assertFalse(jsSet("hello"))
+    assertTrue(set.add("hello"))
+    assertFalse(set.add("hello"))
+    assertTrue(jsSet("hello"))
+
+    assertTrue(set.remove("hello"))
+    assertFalse(jsSet("hello"))
+  }
+
+  @Test def `+=_and_-=`(): Unit = {
+    val jsSet = js.Set[String]()
+    val set: mutable.Set[String] = jsSet
+
+    set += "hello"
+    assertTrue(jsSet("hello"))
+    set += "foo"
+    assertTrue(jsSet("foo"))
+    set -= "hello"
+    assertFalse(jsSet("hello"))
+  }
+
+  @Test def iterator(): Unit = {
+    val elems = 1 to 5
+    val jsSet = js.Set[Int]()
+    val set: mutable.Set[Int] = jsSet
+
+    jsSet ++= elems
+
+    assertTrue(set.iterator.toList.sorted.sameElements(elems))
+  }
+
+  // Some arbitrary methods to test the builders
+
+  @Test def withFilter(): Unit = {
+    val set = js.Set[Int]()
+    val flt = set.withFilter { case v => v > 5  }
+    def size: Int = flt.map(x => x).size
+
+    assertEquals(0, size)
+    set += 6
+    assertEquals(1, size)
+    set += 2
+    assertEquals(1, size)
+    set += 7
+    assertEquals(2, size)
+    set += 8
+    assertEquals(3, size)
+    set -= 7
+    assertEquals(2, size)
+  }
+
+  @Test def toList(): Unit = {
+    val set = js.Set("a", "b", "e")
+    val list = set.toList
+    assertEquals(3, list.size)
+  }
+
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedSetTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedSetTest.scala
@@ -24,7 +24,7 @@ object WrappedSetTest {
   @BeforeClass
   def assumeRuntimeSupportsSet(): Unit = {
     assumeTrue("Assume Map exists in Global",
-      Platform.hasInGlobal("Set"))
+      js.typeOf(js.constructorOf[js.Set[_]]) != "undefined")
   }
 }
 


### PR DESCRIPTION
This PR adds JS-native [Set[T]](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set
) and [Map[K, V]](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) types, and their conversions for interopratability with Scala collection.

This also exposes [`js.Array.from(js.Iterable), js.Array.from(js.Iterator)`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) which is used to implement `Map#keys()` and `MapIterator` for WrappedMap.