### PR TITLE
Fix two (fatal) compilation warnings in nscplugin with recent Scala versions

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -4760,19 +4760,22 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
     }
 
     private object JSUnaryOpMethodName {
-      private val map = Map(
+      private val map = Map[Name, js.JSUnaryOp.Code](
         nme.UNARY_+ -> js.JSUnaryOp.+,
         nme.UNARY_- -> js.JSUnaryOp.-,
         nme.UNARY_~ -> js.JSUnaryOp.~,
         nme.UNARY_! -> js.JSUnaryOp.!
       )
 
-      def unapply(name: TermName): Option[js.JSUnaryOp.Code] =
+      /* We use Name instead of TermName to work around
+       * https://github.com/scala/bug/issues/11534
+       */
+      def unapply(name: Name): Option[js.JSUnaryOp.Code] =
         map.get(name)
     }
 
     private object JSBinaryOpMethodName {
-      private val map = Map(
+      private val map = Map[Name, js.JSBinaryOp.Code](
         nme.ADD -> js.JSBinaryOp.+,
         nme.SUB -> js.JSBinaryOp.-,
         nme.MUL -> js.JSBinaryOp.*,
@@ -4795,7 +4798,10 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         nme.ZOR  -> js.JSBinaryOp.||
       )
 
-      def unapply(name: TermName): Option[js.JSBinaryOp.Code] =
+      /* We use Name instead of TermName to work around
+       * https://github.com/scala/bug/issues/11534
+       */
+      def unapply(name: Name): Option[js.JSBinaryOp.Code] =
         map.get(name)
     }
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
@@ -111,8 +111,7 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
       ScalaJSPlugin.this.generatedJSAST(clDefs)
   }
 
-  override def processOptions(options: List[String],
-      error: String => Unit): Unit = {
+  override def init(options: List[String], error: String => Unit): Boolean = {
     import ScalaJSOptions.URIMap
     import scalaJSOpts._
 
@@ -161,6 +160,8 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
           "Use another mapSourceURI option.")
     else if (absSourceMap.isDefined && relSourceMap.isEmpty)
       error("absSourceMap requires the use of relSourceMap")
+
+    true // this plugin is always enabled
   }
 
   override val optionsHelp: Option[String] = Some(s"""

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
@@ -60,7 +60,7 @@ abstract class DirectTest {
 
       override lazy val plugins = {
         val scalaJSPlugin = newScalaJSPlugin(global)
-        scalaJSPlugin.processOptions(scalaJSPlugin.options,
+        scalaJSPlugin.init(scalaJSPlugin.options,
             msg => throw new IllegalArgumentException(msg))
         scalaJSPlugin :: Nil
       }


### PR DESCRIPTION
Locally tested with:
```scala
> ++2.12.10!
> testSuite/test
> compiler/test
```
This will be necessary before we can enable 2.12.9+ in our CI on master.