### PR TITLE
FF ONLY Merge 0.6.x into master, October 2

### DIFF
--- a/javalib/src/main/scala/java/util/IdentityHashMap.scala
+++ b/javalib/src/main/scala/java/util/IdentityHashMap.scala
@@ -18,7 +18,11 @@ import scala.annotation.tailrec
 
 import ScalaOps._
 
-class IdentityHashMap[K, V](inner: HashMap[IdentityHashMap.IdentityBox[K], V])
+/* The additional `internal` parameter works around
+ * https://github.com/scala/bug/issues/11755
+ */
+class IdentityHashMap[K, V] private (
+    inner: HashMap[IdentityHashMap.IdentityBox[K], V], internal: Boolean)
     extends AbstractMap[K, V] with Map[K, V] with Serializable with Cloneable {
   self =>
 
@@ -26,7 +30,7 @@ class IdentityHashMap[K, V](inner: HashMap[IdentityHashMap.IdentityBox[K], V])
 
   def this(expectedMaxSize: Int) = {
     this(new HashMap[IdentityHashMap.IdentityBox[K], V](
-        expectedMaxSize, HashMap.DEFAULT_LOAD_FACTOR))
+        expectedMaxSize, HashMap.DEFAULT_LOAD_FACTOR), internal = true)
   }
 
   def this() =
@@ -41,7 +45,7 @@ class IdentityHashMap[K, V](inner: HashMap[IdentityHashMap.IdentityBox[K], V])
 
   override def clone(): AnyRef = {
     new IdentityHashMap(
-        inner.clone().asInstanceOf[HashMap[IdentityBox[K], V]])
+        inner.clone().asInstanceOf[HashMap[IdentityBox[K], V]], internal = true)
   }
 
   override def containsKey(key: Any): Boolean =


### PR DESCRIPTION
Clean merge; no review.
Motivation: fix the community build by bringing #3794 on master.
```
$ git checkout -b merge-0.6.x-into-master-october-2
Switched to a new branch 'merge-0.6.x-into-master-october-2'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* fc41c3a0d (scalajs/0.6.x) Merge pull request #3794 from sjrd/fix-compilation-failure-2.13.1
* abd081e63 Fix #3792: Work around a 2.13.1 regression in overload resolution.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging javalib/src/main/scala/java/util/IdentityHashMap.scala
Automatic merge went well; stopped before committing as requested
```
```
$ git st
M  javalib/src/main/scala/java/util/IdentityHashMap.scala
```
```
$ git commit
[merge-0.6.x-into-master-october-2 df715c099] Merge '0.6.x' into 'master'.
```
