### PR TITLE
[no-master] Fix #2433: Configure automatic CLA check as a GitHub Action.

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,8 @@
+name: CLA
+on: [pull_request]
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: ./ci/check-cla.sh

--- a/ci/check-cla.sh
+++ b/ci/check-cla.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -eux
+
+AUTHOR=$GITHUB_ACTOR
+echo "Pull request submitted by $AUTHOR";
+signed=$(curl -s https://www.lightbend.com/contribute/cla/scala/check/$AUTHOR | jq -r ".signed");
+if [ "$signed" = "true" ] ; then
+  echo "CLA check for $AUTHOR successful";
+else
+  echo "CLA check for $AUTHOR failed";
+  echo "Please sign the Scala CLA to contribute to Scala.js.";
+  echo "Go to https://www.lightbend.com/contribute/cla/scala and then";
+  echo "comment on the pull request to ask for a new check.";
+  exit 1;
+fi;


### PR DESCRIPTION
Backport of e4b6a7eb5faa075cf3ab2f247302a29475dbac60 and 4b13cfe2a1398fc593ad1a54c221406f7af23cdd.

Apparently this needs to be in the 0.6.x branch to apply to PRs made against 0.6.x.