### PR TITLE
Use a `Type` rather than a `TypeRef` in `Is/AsInstanceOf`, ...

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -303,20 +303,15 @@ object Hashers {
           mixIdent(field)
           mixType(tree.tpe)
 
-        case IsInstanceOf(expr, cls) =>
+        case IsInstanceOf(expr, testType) =>
           mixTag(TagIsInstanceOf)
           mixTree(expr)
-          mixTypeRef(cls)
+          mixType(testType)
 
-        case AsInstanceOf(expr, cls) =>
+        case AsInstanceOf(expr, tpe) =>
           mixTag(TagAsInstanceOf)
           mixTree(expr)
-          mixTypeRef(cls)
-
-        case Unbox(expr, charCode) =>
-          mixTag(TagUnbox)
-          mixTree(expr)
-          mixInt(charCode)
+          mixType(tpe)
 
         case GetClass(expr) =>
           mixTag(TagGetClass)

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -496,22 +496,16 @@ object Printers {
           print('.')
           print(field)
 
-        case IsInstanceOf(expr, typeRef) =>
+        case IsInstanceOf(expr, testType) =>
           print(expr)
           print(".isInstanceOf[")
-          print(typeRef)
+          print(testType)
           print(']')
 
-        case AsInstanceOf(expr, typeRef) =>
+        case AsInstanceOf(expr, tpe) =>
           print(expr)
           print(".asInstanceOf[")
-          print(typeRef)
-          print(']')
-
-        case Unbox(expr, charCode) =>
-          print(expr)
-          print(".asInstanceOf[")
-          print(charCode)
+          print(tpe)
           print(']')
 
         case GetClass(expr) =>

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -294,17 +294,13 @@ object Serializers {
           writeTree(record); writeIdent(field)
           writeType(tree.tpe)
 
-        case IsInstanceOf(expr, typeRef) =>
+        case IsInstanceOf(expr, testType) =>
           writeByte(TagIsInstanceOf)
-          writeTree(expr); writeTypeRef(typeRef)
+          writeTree(expr); writeType(testType)
 
-        case AsInstanceOf(expr, typeRef) =>
+        case AsInstanceOf(expr, tpe) =>
           writeByte(TagAsInstanceOf)
-          writeTree(expr); writeTypeRef(typeRef)
-
-        case Unbox(expr, charCode) =>
-          writeByte(TagUnbox)
-          writeTree(expr); writeByte(charCode.toByte)
+          writeTree(expr); writeType(tpe)
 
         case GetClass(expr) =>
           writeByte(TagGetClass)
@@ -914,9 +910,8 @@ object Serializers {
         case TagArrayLength  => ArrayLength(readTree())
         case TagArraySelect  => ArraySelect(readTree(), readTree())(readType())
         case TagRecordValue  => RecordValue(readType().asInstanceOf[RecordType], readTrees())
-        case TagIsInstanceOf => IsInstanceOf(readTree(), readTypeRef())
-        case TagAsInstanceOf => AsInstanceOf(readTree(), readTypeRef())
-        case TagUnbox        => Unbox(readTree(), readByte().toChar)
+        case TagIsInstanceOf => IsInstanceOf(readTree(), readType())
+        case TagAsInstanceOf => AsInstanceOf(readTree(), readType())
         case TagGetClass     => GetClass(readTree())
 
         case TagJSNew                => JSNew(readTree(), readTreeOrJSSpreads())

--- a/ir/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Tags.scala
@@ -57,8 +57,7 @@ private[ir] object Tags {
   final val TagRecordSelect = TagRecordValue + 1
   final val TagIsInstanceOf = TagRecordSelect + 1
   final val TagAsInstanceOf = TagIsInstanceOf + 1
-  final val TagUnbox = TagAsInstanceOf + 1
-  final val TagGetClass = TagUnbox + 1
+  final val TagGetClass = TagAsInstanceOf + 1
 
   final val TagJSNew = TagGetClass + 1
   final val TagJSPrivateSelect = TagJSNew + 1

--- a/ir/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -130,14 +130,11 @@ object Transformers {
         case RecordSelect(record, field) =>
           RecordSelect(transformExpr(record), field)(tree.tpe)
 
-        case IsInstanceOf(expr, cls) =>
-          IsInstanceOf(transformExpr(expr), cls)
+        case IsInstanceOf(expr, testType) =>
+          IsInstanceOf(transformExpr(expr), testType)
 
-        case AsInstanceOf(expr, cls) =>
-          AsInstanceOf(transformExpr(expr), cls)
-
-        case Unbox(expr, charCode) =>
-          Unbox(transformExpr(expr), charCode)
+        case AsInstanceOf(expr, tpe) =>
+          AsInstanceOf(transformExpr(expr), tpe)
 
         case GetClass(expr) =>
           GetClass(transformExpr(expr))

--- a/ir/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -124,13 +124,10 @@ object Traversers {
       case RecordSelect(record, field) =>
         traverse(record)
 
-      case IsInstanceOf(expr, cls) =>
+      case IsInstanceOf(expr, _) =>
         traverse(expr)
 
-      case AsInstanceOf(expr, cls) =>
-        traverse(expr)
-
-      case Unbox(expr, charCode) =>
+      case AsInstanceOf(expr, _) =>
         traverse(expr)
 
       case GetClass(expr) =>

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -434,32 +434,14 @@ object Trees {
       implicit val pos: Position)
       extends Tree
 
-  case class IsInstanceOf(expr: Tree, typeRef: TypeRef)(
-      implicit val pos: Position) extends Tree {
+  case class IsInstanceOf(expr: Tree, testType: Type)(
+      implicit val pos: Position)
+      extends Tree {
     val tpe = BooleanType
   }
 
-  case class AsInstanceOf(expr: Tree, typeRef: TypeRef)(
-      implicit val pos: Position) extends Tree {
-    val tpe = typeRef match {
-      case ClassRef(className)   => ClassType(className)
-      case typeRef: ArrayTypeRef => ArrayType(typeRef)
-    }
-  }
-
-  case class Unbox(expr: Tree, charCode: Char)(
-      implicit val pos: Position) extends Tree {
-    val tpe = (charCode: @switch) match {
-      case 'Z' => BooleanType
-      case 'C' => CharType
-      case 'B' => ByteType
-      case 'S' => ShortType
-      case 'I' => IntType
-      case 'J' => LongType
-      case 'F' => FloatType
-      case 'D' => DoubleType
-    }
-  }
+  case class AsInstanceOf(expr: Tree, tpe: Type)(implicit val pos: Position)
+      extends Tree
 
   case class GetClass(expr: Tree)(implicit val pos: Position) extends Tree {
     val tpe = ClassType(Definitions.ClassClass)

--- a/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -569,10 +569,8 @@ class PrintersTest {
   @Test def printAsInstanceOf(): Unit = {
     assertPrintEquals("x.asInstanceOf[T]",
         AsInstanceOf(ref("x", AnyType), BoxedStringClass))
-  }
-
-  @Test def printUnbox(): Unit = {
-    assertPrintEquals("x.asInstanceOf[I]", Unbox(ref("x", AnyType), 'I'))
+    assertPrintEquals("x.asInstanceOf[int]",
+        AsInstanceOf(ref("x", AnyType), IntType))
   }
 
   @Test def printGetClass(): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -294,8 +294,16 @@ object Infos {
       this
     }
 
-    def addUsedInstanceTest(tpe: TypeRef): this.type =
-      addUsedInstanceTest(baseNameOf(tpe))
+    def maybeAddUsedInstanceTest(tpe: Type): this.type = {
+      tpe match {
+        case ClassType(className) =>
+          addUsedInstanceTest(className)
+        case ArrayType(ArrayTypeRef(baseClassName, _)) =>
+          addUsedInstanceTest(baseClassName)
+        case _ =>
+      }
+      this
+    }
 
     def addUsedInstanceTest(cls: String): this.type = {
       usedInstanceTests += cls
@@ -520,10 +528,10 @@ object Infos {
             case LoadModule(ClassRef(cls)) =>
               builder.addAccessedModule(cls)
 
-            case IsInstanceOf(_, tpe) =>
-              builder.addUsedInstanceTest(tpe)
+            case IsInstanceOf(_, testType) =>
+              builder.maybeAddUsedInstanceTest(testType)
             case AsInstanceOf(_, tpe) =>
-              builder.addUsedInstanceTest(tpe)
+              builder.maybeAddUsedInstanceTest(tpe)
 
             case BinaryOp(op, _, rhs) =>
               import BinaryOp._

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -969,7 +969,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
         /* Other hijacked classes have a special isInstanceOf test. */
         val xParam = js.ParamDef(js.Ident("x"), rest = false)
         WithGlobals(genArrowFunction(List(xParam), js.Return {
-          genIsInstanceOf(xParam.ref, ClassRef(className))
+          genIsInstanceOfHijackedClass(xParam.ref, className)
         }))
       } else if (isJSType) {
         /* Native JS classes have an instanceof operator-based isInstanceOf

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -464,10 +464,10 @@ private[emitter] object CoreJSLib {
             If(instance === Null(), {
               Return(Apply(instance DOT "getClass__jl_Class", Nil))
             }, {
-              If(genIsInstanceOfHijackedClass(instance, ClassRef(BoxedLongClass)), {
+              If(genIsInstanceOfHijackedClass(instance, BoxedLongClass), {
                 Return(genClassOf(BoxedLongClass))
               }, {
-                If(genIsInstanceOfHijackedClass(instance, ClassRef(BoxedCharacterClass)), {
+                If(genIsInstanceOfHijackedClass(instance, BoxedCharacterClass), {
                   Return(genClassOf(BoxedCharacterClass))
                 }, {
                   If(genIsScalaJSObject(instance), {
@@ -553,7 +553,7 @@ private[emitter] object CoreJSLib {
           val defaultCall: Tree = Return(implementationInObject.getOrElse(normalCall))
 
           val allButNormal = implementingHijackedClasses.foldRight(defaultCall) { (className, next) =>
-            If(genIsInstanceOfHijackedClass(instance, ClassRef(className)),
+            If(genIsInstanceOfHijackedClass(instance, className),
                 Return(genHijackedMethodApply(className)),
                 next)
           }
@@ -980,7 +980,7 @@ private[emitter] object CoreJSLib {
           val fullName = decodeClassName(className)
           val v = varRef("v")
           buf += envFunctionDef(name, paramList(v), {
-            If(genIsInstanceOfHijackedClass(v, ClassRef(className)) || (v === Null()), {
+            If(genIsInstanceOfHijackedClass(v, className) || (v === Null()), {
               Return(v)
             }, {
               genCallHelper("throwClassCastException", v, str(fullName))
@@ -1021,7 +1021,7 @@ private[emitter] object CoreJSLib {
         })
         buf += envFunctionDef("uJ", paramList(v), {
           Return(If(v === Null(), genLongZero(),
-              genAsInstanceOf(v, ClassRef(BoxedLongClass))))
+              genAsInstanceOfHijackedClass(v, BoxedLongClass)))
         })
         buf += envFunctionDef("uF", paramList(v), {
           /* Since asFloat(v) ensures that v is either null or a float, we can

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -136,92 +136,141 @@ private[emitter] final class JSGen(val semantics: Semantics,
     Ident(cls + "__f_" + field.name, field.originalName)
   }
 
-  def genIsInstanceOf(expr: Tree, typeRef: TypeRef)(
+  def genIsInstanceOf(expr: Tree, tpe: Type)(
       implicit globalKnowledge: GlobalKnowledge, pos: Position): Tree = {
     import TreeDSL._
 
-    typeRef match {
-      case ClassRef(className) =>
-        if (!HijackedClassesAndTheirSuperClasses.contains(className) &&
+    tpe match {
+      case ClassType(className) =>
+        if (HijackedClasses.contains(className)) {
+          genIsInstanceOfHijackedClass(expr, className)
+        } else if (className == ObjectClass) {
+          expr === Null()
+        } else if (className != NumberClass && // the only non-object superclass of hijacked classes
             !globalKnowledge.isInterface(className)) {
           expr instanceof encodeClassVar(className)
-        } else if (className == BoxedLongClass && !useBigIntForLongs) {
-          expr instanceof encodeClassVar(LongImpl.RuntimeLongClass)
         } else {
-          genIsAsInstanceOf(expr, typeRef, test = true)
+          Apply(envField("is", className), List(expr))
         }
-      case ArrayTypeRef(_, _)  =>
-        genIsAsInstanceOf(expr, typeRef, test = true)
+
+      case ArrayType(ArrayTypeRef(base, depth)) =>
+        Apply(envField("isArrayOf", base), List(expr, IntLiteral(depth)))
+
+      case UndefType   => expr === Undefined()
+      case BooleanType => typeof(expr) === "boolean"
+      case CharType    => expr instanceof envField("Char")
+      case ByteType    => genCallHelper("isByte", expr)
+      case ShortType   => genCallHelper("isShort", expr)
+      case IntType     => genCallHelper("isInt", expr)
+      case LongType    => genIsLong(expr)
+      case FloatType   => genIsFloat(expr)
+      case DoubleType  => typeof(expr) === "number"
+      case StringType  => typeof(expr) === "string"
+      case AnyType     => expr !== Null()
+
+      case NoType | NullType | NothingType | _:RecordType =>
+        throw new AssertionError(s"Unexpected type $tpe in genIsInstanceOf")
     }
   }
 
-  def genIsInstanceOfHijackedClass(expr: Tree, classRef: ClassRef)(
+  def genIsInstanceOfHijackedClass(expr: Tree, className: String)(
       implicit pos: Position): Tree = {
     import TreeDSL._
 
-    if (classRef.className == BoxedLongClass && !useBigIntForLongs)
-      expr instanceof encodeClassVar(LongImpl.RuntimeLongClass)
-    else
-      genIsAsInstanceOf(expr, classRef, test = true)
+    className match {
+      case BoxedUnitClass      => expr === Undefined()
+      case BoxedBooleanClass   => typeof(expr) === "boolean"
+      case BoxedCharacterClass => expr instanceof envField("Char")
+      case BoxedByteClass      => genCallHelper("isByte", expr)
+      case BoxedShortClass     => genCallHelper("isShort", expr)
+      case BoxedIntegerClass   => genCallHelper("isInt", expr)
+      case BoxedLongClass      => genIsLong(expr)
+      case BoxedFloatClass     => genIsFloat(expr)
+      case BoxedDoubleClass    => typeof(expr) === "number"
+      case BoxedStringClass    => typeof(expr) === "string"
+    }
   }
 
-  def genAsInstanceOf(expr: Tree, typeRef: TypeRef)(
-      implicit pos: Position): Tree =
-    genIsAsInstanceOf(expr, typeRef, test = false)
-
-  private def genIsAsInstanceOf(expr: Tree, typeRef: TypeRef, test: Boolean)(
-      implicit pos: Position): Tree = {
+  private def genIsLong(expr: Tree)(implicit pos: Position): Tree = {
     import TreeDSL._
 
-    typeRef match {
-      case ClassRef(className0) =>
-        val className =
-          if (className0 == BoxedLongClass && !useBigIntForLongs) LongImpl.RuntimeLongClass
-          else className0
+    if (useBigIntForLongs) genCallHelper("isLong", expr)
+    else expr instanceof encodeClassVar(LongImpl.RuntimeLongClass)
+  }
 
-        if (HijackedClasses.contains(className)) {
-          def genIsFloat(): Tree =
-            if (semantics.strictFloats) genCallHelper("isFloat", expr)
-            else typeof(expr) === "number"
+  private def genIsFloat(expr: Tree)(implicit pos: Position): Tree = {
+    import TreeDSL._
 
-          if (test) {
-            className match {
-              case BoxedUnitClass      => expr === Undefined()
-              case BoxedBooleanClass   => typeof(expr) === "boolean"
-              case BoxedCharacterClass => expr instanceof envField("Char")
-              case BoxedByteClass      => genCallHelper("isByte", expr)
-              case BoxedShortClass     => genCallHelper("isShort", expr)
-              case BoxedIntegerClass   => genCallHelper("isInt", expr)
-              case BoxedLongClass      => genCallHelper("isLong", expr)
-              case BoxedFloatClass     => genIsFloat()
-              case BoxedDoubleClass    => typeof(expr) === "number"
-              case BoxedStringClass    => typeof(expr) === "string"
-            }
-          } else {
-            className match {
-              case BoxedUnitClass      => genCallHelper("asUnit", expr)
-              case BoxedBooleanClass   => genCallHelper("asBoolean", expr)
-              case BoxedCharacterClass => genCallHelper("asChar", expr)
-              case BoxedByteClass      => genCallHelper("asByte", expr)
-              case BoxedShortClass     => genCallHelper("asShort", expr)
-              case BoxedIntegerClass   => genCallHelper("asInt", expr)
-              case BoxedLongClass      => genCallHelper("asLong", expr)
-              case BoxedFloatClass     => genCallHelper("asFloat", expr)
-              case BoxedDoubleClass    => genCallHelper("asDouble", expr)
-              case BoxedStringClass    => Apply(envField("as_T"), List(expr))
-            }
+    if (semantics.strictFloats) genCallHelper("isFloat", expr)
+    else typeof(expr) === "number"
+  }
+
+  def genAsInstanceOf(expr: Tree, tpe: Type)(implicit pos: Position): Tree = {
+    import TreeDSL._
+
+    if (semantics.asInstanceOfs == CheckedBehavior.Unchecked) {
+      tpe match {
+        case _:ClassType | _:ArrayType | AnyType =>
+          expr
+
+        case UndefType                     => Block(expr, Undefined())
+        case BooleanType                   => !(!expr)
+        case CharType                      => genCallHelper("uC", expr)
+        case ByteType | ShortType| IntType => expr | 0
+        case LongType                      => genCallHelper("uJ", expr)
+        case DoubleType                    => UnaryOp(irt.JSUnaryOp.+, expr)
+        case StringType                    => expr || StringLiteral("")
+
+        case FloatType =>
+          if (semantics.strictFloats) genCallHelper("fround", expr)
+          else UnaryOp(irt.JSUnaryOp.+, expr)
+
+        case NoType | NullType | NothingType | _:RecordType =>
+          throw new AssertionError(s"Unexpected type $tpe in genAsInstanceOf")
+      }
+    } else {
+      tpe match {
+        case ClassType(className) =>
+          className match {
+            case BoxedUnitClass      => genCallHelper("asUnit", expr)
+            case BoxedBooleanClass   => genCallHelper("asBoolean", expr)
+            case BoxedCharacterClass => genCallHelper("asChar", expr)
+            case BoxedByteClass      => genCallHelper("asByte", expr)
+            case BoxedShortClass     => genCallHelper("asShort", expr)
+            case BoxedIntegerClass   => genCallHelper("asInt", expr)
+            case BoxedLongClass      =>
+              if (useBigIntForLongs) genCallHelper("asLong", expr)
+              else Apply(envField("as", LongImpl.RuntimeLongClass), List(expr))
+            case BoxedFloatClass     => genCallHelper("asFloat", expr)
+            case BoxedDoubleClass    => genCallHelper("asDouble", expr)
+            case ObjectClass         => expr
+            case _                   => Apply(envField("as", className), List(expr))
           }
-        } else {
-          Apply(
-              envField(if (test) "is" else "as", className),
-              List(expr))
-        }
 
-      case ArrayTypeRef(base, depth) =>
-        Apply(
-            envField(if (test) "isArrayOf" else "asArrayOf", base),
-            List(expr, IntLiteral(depth)))
+        case ArrayType(ArrayTypeRef(base, depth)) =>
+          Apply(envField("asArrayOf", base), List(expr, IntLiteral(depth)))
+
+        case UndefType   => Block(genCallHelper("asUnit", expr), Undefined())
+        case BooleanType => genCallHelper("uZ", expr)
+        case CharType    => genCallHelper("uC", expr)
+        case ByteType    => genCallHelper("uB", expr)
+        case ShortType   => genCallHelper("uS", expr)
+        case IntType     => genCallHelper("uI", expr)
+        case LongType    => genCallHelper("uJ", expr)
+        case FloatType   => genCallHelper("uF", expr)
+        case DoubleType  => genCallHelper("uD", expr)
+        case StringType  => Apply(envField("as_T"), List(expr)) || StringLiteral("")
+        case AnyType     => expr
+
+        case NoType | NullType | NothingType | _:RecordType =>
+          throw new AssertionError(s"Unexpected type $tpe in genAsInstanceOf")
+      }
     }
+  }
+
+  def genAsInstanceOfHijackedClass(expr: Tree, className: String)(
+      implicit pos: Position): Tree = {
+    genAsInstanceOf(expr, ClassType(className))
   }
 
   def genCallHelper(helperName: String, args: Tree*)(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
@@ -70,6 +70,8 @@ private[emitter] object TreeDSL {
       BinaryOp(ir.Trees.JSBinaryOp.&, self, that)
     def |(that: Tree)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.|, self, that)
+    def |(that: Int)(implicit pos: Position): Tree =
+      BinaryOp(ir.Trees.JSBinaryOp.|, self, IntLiteral(that))
 
     def <<(that: Tree)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.<<, self, that)

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -92,7 +92,7 @@ object JavaLangObject {
           Nil,
           AnyType,
           Some {
-            If(IsInstanceOf(This()(ThisType), ClassRef("jl_Cloneable")), {
+            If(IsInstanceOf(This()(ThisType), ClassType("jl_Cloneable")), {
               Apply(EAF, LoadModule(ClassRef("jl_ObjectClone$")),
                   Ident("clone__O__O", Some("clone")),
                   List(This()(ThisType)))(AnyType)

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -283,10 +283,9 @@ object JavalibIRCleaner {
         case ArrayValue(typeRef, elems) =>
           ArrayValue(transformArrayTypeRef(typeRef), elems)
 
-        case IsInstanceOf(expr, typeRef) =>
-          IsInstanceOf(expr, transformTypeRef(typeRef))
-        case AsInstanceOf(expr, typeRef) =>
-          AsInstanceOf(expr, transformTypeRef(typeRef))
+        case t: IsInstanceOf =>
+          validateType(t.testType)
+          t
 
         case LoadJSConstructor(cls) =>
           genLoadFromLoadSpecOf(cls)


### PR DESCRIPTION
... and fuse `Unbox` into `AsInstanceOf`.

The use of a `TypeRef` was a historical artifact of when `Type`s did not have separate cases for the "int types" (i.e., `byte`, `short`, `int` and `char`). Since they can now represent all the primitive types separately, it is more appropriate to just use a `Type`.

This also fits the fact that type-refs to JS types are not valid in these nodes, just like they are not valid `Type`s.

And since we can represent primitive types in `AsInstanceOf`, we can fuse `Unbox` into it: an `AsInstanceOf` with a primitive type is an `Unbox`.

For symmetry, we add support for primitive types in `IsInstanceOf` nodes as well. For those, they are in fact equivalent to testing for the corresponding boxed classes. We use the support for primitive types in `IsInstanceOf` nodes in the overload resolution of exports.