### PR TITLE
Use a dedicated `PrimRef` for `TypeRef`s of primitive types.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -2726,6 +2726,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
             genNew(cls, ctor, genActualArgs(ctor, args))
           case arr: jstpe.ArrayTypeRef =>
             genNewArray(arr, args.map(genExpr))
+          case prim: jstpe.PrimRef =>
+            abort(s"unexpected primitive type $prim in New at $pos")
         }
       }
     }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -245,17 +245,13 @@ trait JSEncoding[G <: Global with Singleton] extends SubComponent {
   }
 
   /** Computes the internal name for a type. */
-  private def internalName(tpe: Type): String = toTypeRef(tpe) match {
-    case jstpe.ClassRef("sr_Nothing$") => ir.Definitions.NothingClass
-    case jstpe.ClassRef("sr_Null$")    => ir.Definitions.NullClass
-    case jstpe.ClassRef(cls)           => cls
-
-    case jstpe.ArrayTypeRef(cls, depth) =>
-      val builder = new java.lang.StringBuilder(cls.length + depth)
-      for (i <- 0 until depth)
-        builder.append('A')
-      builder.append(cls)
-      builder.toString()
+  private def internalName(tpe: Type): String = {
+    val patchedTypeRef = toTypeRef(tpe) match {
+      case jstpe.ClassRef("sr_Nothing$") => jstpe.NothingRef
+      case jstpe.ClassRef("sr_Null$")    => jstpe.NullRef
+      case typeRef                       => typeRef
+    }
+    ir.Definitions.encodeTypeRef(patchedTypeRef)
   }
 
   /** mangles names that are illegal in JavaScript by prepending a $

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
@@ -40,19 +40,19 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
     )
   }
 
-  private lazy val primitiveClassRefNameMap: Map[Symbol, String] = {
+  private lazy val primitiveRefMap: Map[Symbol, Types.NonArrayTypeRef] = {
     Map(
-        UnitClass    -> Definitions.VoidClass,
-        BooleanClass -> Definitions.BooleanClass,
-        CharClass    -> Definitions.CharClass,
-        ByteClass    -> Definitions.ByteClass,
-        ShortClass   -> Definitions.ShortClass,
-        IntClass     -> Definitions.IntClass,
-        LongClass    -> Definitions.LongClass,
-        FloatClass   -> Definitions.FloatClass,
-        DoubleClass  -> Definitions.DoubleClass,
-        NothingClass -> encodeClassFullName(RuntimeNothingClass),
-        NullClass    -> encodeClassFullName(RuntimeNullClass)
+        UnitClass    -> Types.VoidRef,
+        BooleanClass -> Types.BooleanRef,
+        CharClass    -> Types.CharRef,
+        ByteClass    -> Types.ByteRef,
+        ShortClass   -> Types.ShortRef,
+        IntClass     -> Types.IntRef,
+        LongClass    -> Types.LongRef,
+        FloatClass   -> Types.FloatRef,
+        DoubleClass  -> Types.DoubleRef,
+        NothingClass -> Types.ClassRef(encodeClassFullName(RuntimeNothingClass)),
+        NullClass    -> Types.ClassRef(encodeClassFullName(RuntimeNullClass))
     )
   }
 
@@ -67,16 +67,16 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
   def toTypeRef(t: Type): Types.TypeRef = {
     val (base, arrayDepth) = convert(t)
     if (arrayDepth == 0)
-      Types.ClassRef(makeClassRefName(base))
+      makeNonArrayTypeRef(base)
     else
       makeArrayTypeRef(base, arrayDepth)
   }
 
-  private def makeClassRefName(sym: Symbol): String =
-    primitiveClassRefNameMap.getOrElse(sym, encodeClassFullName(sym))
+  private def makeNonArrayTypeRef(sym: Symbol): Types.NonArrayTypeRef =
+    primitiveRefMap.getOrElse(sym, Types.ClassRef(encodeClassFullName(sym)))
 
   private def makeArrayTypeRef(base: Symbol, depth: Int): Types.ArrayTypeRef =
-    Types.ArrayTypeRef(makeClassRefName(base), depth)
+    Types.ArrayTypeRef(makeNonArrayTypeRef(base), depth)
 
   // The following code was modeled after backend.icode.TypeKinds.toTypeKind
 

--- a/ir/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -502,6 +502,20 @@ object Hashers {
     }
 
     def mixTypeRef(typeRef: TypeRef): Unit = typeRef match {
+      case PrimRef(tpe) =>
+        tpe match {
+          case NoType      => mixTag(TagVoidRef)
+          case BooleanType => mixTag(TagBooleanRef)
+          case CharType    => mixTag(TagCharRef)
+          case ByteType    => mixTag(TagByteRef)
+          case ShortType   => mixTag(TagShortRef)
+          case IntType     => mixTag(TagIntRef)
+          case LongType    => mixTag(TagLongRef)
+          case FloatType   => mixTag(TagFloatRef)
+          case DoubleType  => mixTag(TagDoubleRef)
+          case NullType    => mixTag(TagNullRef)
+          case NothingType => mixTag(TagNothingRef)
+        }
       case typeRef: ClassRef =>
         mixTag(TagClassRef)
         mixClassRef(typeRef)
@@ -514,7 +528,7 @@ object Hashers {
       mixString(classRef.className)
 
     def mixArrayTypeRef(arrayTypeRef: ArrayTypeRef): Unit = {
-      mixString(arrayTypeRef.baseClassName)
+      mixTypeRef(arrayTypeRef.base)
       mixInt(arrayTypeRef.dimensions)
     }
 
@@ -538,10 +552,9 @@ object Hashers {
         mixTag(TagClassType)
         mixString(className)
 
-      case ArrayType(ArrayTypeRef(baseClassName, dimensions)) =>
+      case ArrayType(arrayTypeRef) =>
         mixTag(TagArrayType)
-        mixString(baseClassName)
-        mixInt(dimensions)
+        mixArrayTypeRef(arrayTypeRef)
 
       case RecordType(fields) =>
         mixTag(TagRecordType)

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -456,7 +456,7 @@ object Printers {
 
         case NewArray(typeRef, lengths) =>
           print("new ")
-          print(typeRef.baseClassName)
+          print(typeRef.base)
           for (length <- lengths) {
             print('[')
             print(length)
@@ -967,7 +967,9 @@ object Printers {
       }
     }
 
-    def print(tpe: TypeRef): Unit = tpe match {
+    def print(typeRef: TypeRef): Unit = typeRef match {
+      case PrimRef(tpe) =>
+        print(tpe)
       case ClassRef(className) =>
         print(className)
       case ArrayTypeRef(base, dims) =>

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -673,6 +673,20 @@ object Serializers {
     }
 
     def writeTypeRef(typeRef: TypeRef): Unit = typeRef match {
+      case PrimRef(tpe) =>
+        tpe match {
+          case NoType      => buffer.writeByte(TagVoidRef)
+          case BooleanType => buffer.writeByte(TagBooleanRef)
+          case CharType    => buffer.writeByte(TagCharRef)
+          case ByteType    => buffer.writeByte(TagByteRef)
+          case ShortType   => buffer.writeByte(TagShortRef)
+          case IntType     => buffer.writeByte(TagIntRef)
+          case LongType    => buffer.writeByte(TagLongRef)
+          case FloatType   => buffer.writeByte(TagFloatRef)
+          case DoubleType  => buffer.writeByte(TagDoubleRef)
+          case NullType    => buffer.writeByte(TagNullRef)
+          case NothingType => buffer.writeByte(TagNothingRef)
+        }
       case typeRef: ClassRef =>
         buffer.writeByte(TagClassRef)
         writeClassRef(typeRef)
@@ -685,7 +699,7 @@ object Serializers {
       writeString(cls.className)
 
     def writeArrayTypeRef(typeRef: ArrayTypeRef): Unit = {
-      writeString(typeRef.baseClassName)
+      writeTypeRef(typeRef.base)
       buffer.writeInt(typeRef.dimensions)
     }
 
@@ -1109,10 +1123,19 @@ object Serializers {
 
     def readTypeRef(): TypeRef = {
       readByte() match {
-        case TagClassRef =>
-          readClassRef()
-        case TagArrayTypeRef =>
-          readArrayTypeRef()
+        case TagVoidRef      => VoidRef
+        case TagBooleanRef   => BooleanRef
+        case TagCharRef      => CharRef
+        case TagByteRef      => ByteRef
+        case TagShortRef     => ShortRef
+        case TagIntRef       => IntRef
+        case TagLongRef      => LongRef
+        case TagFloatRef     => FloatRef
+        case TagDoubleRef    => DoubleRef
+        case TagNullRef      => NullRef
+        case TagNothingRef   => NothingRef
+        case TagClassRef     => readClassRef()
+        case TagArrayTypeRef => readArrayTypeRef()
       }
     }
 
@@ -1120,7 +1143,7 @@ object Serializers {
       ClassRef(readString())
 
     def readArrayTypeRef(): ArrayTypeRef =
-      ArrayTypeRef(readString(), readInt())
+      ArrayTypeRef(readTypeRef().asInstanceOf[NonArrayTypeRef], readInt())
 
     def readApplyFlags(): ApplyFlags =
       ApplyFlags.fromBits(readInt())

--- a/ir/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Tags.scala
@@ -137,7 +137,18 @@ private[ir] object Tags {
 
   // Tags for TypeRefs
 
-  final val TagClassRef = 1
+  final val TagVoidRef = 1
+  final val TagBooleanRef = TagVoidRef + 1
+  final val TagCharRef = TagBooleanRef + 1
+  final val TagByteRef = TagCharRef + 1
+  final val TagShortRef = TagByteRef + 1
+  final val TagIntRef = TagShortRef + 1
+  final val TagLongRef = TagIntRef + 1
+  final val TagFloatRef = TagLongRef + 1
+  final val TagDoubleRef = TagFloatRef + 1
+  final val TagNullRef = TagDoubleRef + 1
+  final val TagNothingRef = TagNullRef + 1
+  final val TagClassRef = TagNothingRef + 1
   final val TagArrayTypeRef = TagClassRef + 1
 
   // Tags for JS native loading specs

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -1294,7 +1294,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
 
       case ModuleInitializer.MainMethodWithArgs(moduleClassName, mainMethodName,
           args) =>
-        val stringArrayTypeRef = ArrayTypeRef(BoxedStringClass, 1)
+        val stringArrayTypeRef = ArrayTypeRef(ClassRef(BoxedStringClass), 1)
         js.Apply(genLoadModule(moduleClassName) DOT mainMethodName,
             genArrayValue(stringArrayTypeRef, args.map(js.StringLiteral(_))) :: Nil)
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1914,8 +1914,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
          */
         val (_, paramTypeRefs, _) = Definitions.decodeMethodName(methodName)
         args.zip(paramTypeRefs).map {
-          case (arg, ClassRef("C")) => transformExpr(arg, preserveChar = true)
-          case (arg, _)             => transformExpr(arg, preserveChar = false)
+          case (arg, CharRef) => transformExpr(arg, preserveChar = true)
+          case (arg, _)       => transformExpr(arg, preserveChar = false)
         }
       }
     }
@@ -2394,8 +2394,10 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
               js.ArrayConstr(lengths.map(transformExprNoChar)))
 
         case ArrayValue(typeRef, elems) =>
-          val ArrayTypeRef(baseClassName, dimensions) = typeRef
-          val preserveChar = baseClassName == "C" && dimensions == 1
+          val preserveChar = typeRef match {
+            case ArrayTypeRef(CharRef, 1) => true
+            case _                        => false
+          }
           genArrayValue(typeRef, elems.map(transformExpr(_, preserveChar)))
 
         case ArrayLength(array) =>

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -48,7 +48,7 @@ class OptimizerTest {
       customMemberDefs: List[MemberDef]): Future[Unit] = {
 
     val thisFoo = This()(ClassType("LFoo"))
-    val intArrayTypeRef = ArrayTypeRef("I", 1)
+    val intArrayTypeRef = ArrayTypeRef(IntRef, 1)
     val intArrayType = ArrayType(intArrayTypeRef)
     val anArrayOfInts = ArrayValue(intArrayTypeRef, List(IntLiteral(1)))
     val newFoo = New(ClassRef("LFoo"), "init___", Nil)

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -71,7 +71,7 @@ object TestIRBuilder {
   }
 
   def mainMethodDef(body: Tree): MethodDef = {
-    val stringArrayType = ArrayType(ArrayTypeRef("T", 1))
+    val stringArrayType = ArrayType(ArrayTypeRef(ClassRef(BoxedStringClass), 1))
     val argsParamDef = paramDef("args", stringArrayType)
     MethodDef(MemberFlags.empty, Ident("main__AT__V"), List(argsParamDef),
         NoType, Some(body))(EOH, None)

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -363,16 +363,22 @@ object JavalibIRCleaner {
 
     private def transformArrayTypeRef(typeRef: ArrayTypeRef)(
         implicit pos: Position): ArrayTypeRef = {
-      if (jsTypes.contains(typeRef.baseClassName)) {
-        ArrayTypeRef(ObjectClass, typeRef.dimensions)
-      } else {
-        validateClassName(typeRef.baseClassName)
-        typeRef
+      typeRef.base match {
+        case _: PrimRef =>
+          typeRef
+        case ClassRef(baseClassName) =>
+          if (jsTypes.contains(baseClassName)) {
+            ArrayTypeRef(ClassRef(ObjectClass), typeRef.dimensions)
+          } else {
+            validateClassName(baseClassName)
+            typeRef
+          }
       }
     }
 
     private def transformTypeRef(typeRef: TypeRef)(
         implicit pos: Position): TypeRef = typeRef match {
+      case typeRef: PrimRef      => typeRef
       case typeRef: ClassRef     => transformClassRef(typeRef)
       case typeRef: ArrayTypeRef => transformArrayTypeRef(typeRef)
     }
@@ -397,7 +403,7 @@ object JavalibIRCleaner {
       tpe match {
         case ClassType(cls) =>
           validateClassName(cls)
-        case ArrayType(ArrayTypeRef(cls, _)) =>
+        case ArrayType(ArrayTypeRef(ClassRef(cls), _)) =>
           validateClassName(cls)
         case _ =>
           // ok


### PR DESCRIPTION
Before, we put primitive types together with class types as `ClassRef`s, using magical "class names" that actually represented primitives. Those special `ClassRef`s for primitives had to be special-cased virtually everywhere, by testing whether the class name was one of the magical names.

Now, we have a dedicated `PrimRef` instead. This simplifies a lot of code paths by using pattern-matching instead of tests for the class name. More interestingly, it allows to completely get rid of the magical class names.

The char codes associated with primitive type refs are now only used by the method signature encodings, and by some emitter-specific code (and although they use the same characters, that is simply by convention; it is not required for correctness).