### PR TITLE
Introduce dedicated types for the kinds of `Ident`s and their `Name`s.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -20,8 +20,8 @@ import scala.reflect.{ClassTag, classTag}
 import scala.reflect.internal.Flags
 
 import org.scalajs.ir
-import ir.{Trees => js, Types => jstpe}
-import ir.Trees.OptimizerHints
+import org.scalajs.ir.{Definitions => defs, Trees => js, Types => jstpe}
+import org.scalajs.ir.Trees.OptimizerHints
 
 import org.scalajs.nscplugin.util.ScopedVar
 import ScopedVar.withScopedVars
@@ -667,7 +667,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
       val superClass = {
         val superClassSym = currentClassSym.superClass
         if (isNestedJSClass(superClassSym)) {
-          js.VarRef(js.Ident(JSSuperClassParamName))(jstpe.AnyType)
+          js.VarRef(js.LocalIdent(JSSuperClassParamName))(jstpe.AnyType)
         } else {
           js.LoadJSConstructor(encodeClassRef(superClassSym))
         }
@@ -1105,19 +1105,19 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
   }
 
   private def genFormalArg(index: Int)(implicit pos: Position): js.ParamDef = {
-    js.ParamDef(js.Ident("arg$" + index), jstpe.AnyType,
+    js.ParamDef(js.LocalIdent(defs.LocalName("arg$" + index)), jstpe.AnyType,
         mutable = false, rest = false)
   }
 
   private def genRestFormalArg()(implicit pos: Position): js.ParamDef = {
-    js.ParamDef(js.Ident("arg$rest"), jstpe.AnyType,
+    js.ParamDef(js.LocalIdent(defs.LocalName("arg$rest")), jstpe.AnyType,
         mutable = false, rest = true)
   }
 
   private def genFormalArgRef(index: Int, minArgc: Int)(
       implicit pos: Position): js.Tree = {
     if (index <= minArgc)
-      js.VarRef(js.Ident("arg$" + index))(jstpe.AnyType)
+      js.VarRef(js.LocalIdent(defs.LocalName("arg$" + index)))(jstpe.AnyType)
     else
       js.JSSelect(genRestArgRef(), js.IntLiteral(index - 1 - minArgc))
   }
@@ -1135,7 +1135,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
   }
 
   private def genRestArgRef()(implicit pos: Position): js.Tree =
-    js.VarRef(js.Ident("arg$rest"))(jstpe.AnyType)
+    js.VarRef(js.LocalIdent(defs.LocalName("arg$rest")))(jstpe.AnyType)
 
   private def hasRepeatedParam(sym: Symbol) = {
     enteringPhase(currentRun.uncurryPhase) {

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -16,7 +16,7 @@ import scala.collection.mutable
 
 import scala.tools.nsc.Global
 
-import org.scalajs.ir.Trees.isValidIdentifier
+import org.scalajs.ir.Trees.isValidJSIdentifier
 
 /**
  *  Prepare export generation
@@ -324,7 +324,7 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
           }
 
           // The top-level name must be a valid JS identifier
-          if (!isValidIdentifier(name)) {
+          if (!isValidJSIdentifier(name)) {
             reporter.error(annot.pos,
                 "The top-level export name must be a valid JavaScript " +
                 "identifier")

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -18,7 +18,7 @@ import nsc._
 import scala.collection.immutable.ListMap
 import scala.collection.mutable
 
-import org.scalajs.ir.Trees.{isValidIdentifier, JSNativeLoadSpec}
+import org.scalajs.ir.Trees.{isValidJSIdentifier, JSNativeLoadSpec}
 
 /** Prepares classes extending js.Any for JavaScript interop
  *
@@ -725,7 +725,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
 
         def parseGlobalPath(pathName: String): Global = {
           val globalRef :: path = parsePath(pathName)
-          if (!isValidIdentifier(globalRef)) {
+          if (!isValidJSIdentifier(globalRef)) {
             reporter.error(pos,
                 "The name of a JS global variable must be a valid JS " +
                 s"identifier (got '$globalRef')")

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
@@ -14,8 +14,7 @@ package org.scalajs.nscplugin
 
 import scala.tools.nsc._
 
-import org.scalajs.ir
-import ir.{Definitions, Types}
+import org.scalajs.ir.Types
 
 /** Conversions from scalac `Type`s to the IR `Type`s and `TypeRef`s. */
 trait TypeConversions[G <: Global with Singleton] extends SubComponent {

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
@@ -55,7 +55,7 @@ class OptimizationTest extends JSASTTest {
     }
     """.
     hasExactly(2, "calls to Array.apply methods") {
-      case js.Apply(_, js.LoadModule(jstpe.ClassRef("s_Array$")), js.Ident(methodName, _), _)
+      case js.Apply(_, js.LoadModule(jstpe.ClassRef("s_Array$")), js.MethodIdent(methodName, _), _)
           if methodName.startsWith("apply__") =>
     }
   }

--- a/ir/src/main/scala/org/scalajs/ir/EntryPointsInfo.scala
+++ b/ir/src/main/scala/org/scalajs/ir/EntryPointsInfo.scala
@@ -12,10 +12,11 @@
 
 package org.scalajs.ir
 
+import Definitions.ClassName
 import Trees._
 
 final class EntryPointsInfo(
-    val encodedName: String,
+    val encodedName: ClassName,
     val hasEntryPoint: Boolean
 )
 

--- a/ir/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Printers.scala
@@ -105,7 +105,11 @@ object Printers {
 
     def printAnyNode(node: IRNode): Unit = {
       node match {
-        case node: Ident             => print(node)
+        case node: LocalIdent        => print(node)
+        case node: LabelIdent        => print(node)
+        case node: FieldIdent        => print(node)
+        case node: MethodIdent       => print(node)
+        case node: ClassIdent        => print(node)
         case node: ParamDef          => print(node)
         case node: Tree              => print(node)
         case node: JSSpread          => print(node)
@@ -1015,7 +1019,19 @@ object Printers {
         print(')')
     }
 
-    def print(ident: Ident): Unit =
+    def print(ident: LocalIdent): Unit =
+      printEscapeJS(ident.name, out)
+
+    def print(ident: LabelIdent): Unit =
+      printEscapeJS(ident.name, out)
+
+    def print(ident: FieldIdent): Unit =
+      printEscapeJS(ident.name, out)
+
+    def print(ident: MethodIdent): Unit =
+      printEscapeJS(ident.name, out)
+
+    def print(ident: ClassIdent): Unit =
       printEscapeJS(ident.name, out)
 
     def printJSMemberName(name: Tree): Unit = name match {

--- a/ir/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Types.scala
@@ -14,6 +14,7 @@ package org.scalajs.ir
 
 import scala.annotation.tailrec
 
+import Definitions.{ClassName, FieldName}
 import Trees._
 
 object Types {
@@ -132,7 +133,7 @@ object Types {
   case object NullType extends PrimTypeWithRef
 
   /** Class (or interface) type. */
-  final case class ClassType(className: String) extends Type
+  final case class ClassType(className: ClassName) extends Type
 
   /** Array type. */
   final case class ArrayType(arrayTypeRef: ArrayTypeRef) extends Type
@@ -145,12 +146,12 @@ object Types {
    *  The compiler itself never generates record types.
    */
   final case class RecordType(fields: List[RecordType.Field]) extends Type {
-    def findField(name: String): RecordType.Field =
+    def findField(name: FieldName): RecordType.Field =
       fields.find(_.name == name).get
   }
 
   object RecordType {
-    final case class Field(name: String, originalName: Option[String],
+    final case class Field(name: FieldName, originalName: Option[String],
         tpe: Type, mutable: Boolean)
   }
 
@@ -200,7 +201,7 @@ object Types {
   final val NothingRef = PrimRef(NothingType)
 
   /** Class (or interface) type. */
-  final case class ClassRef(className: String) extends NonArrayTypeRef
+  final case class ClassRef(className: ClassName) extends NonArrayTypeRef
 
   /** Array type. */
   final case class ArrayTypeRef(base: NonArrayTypeRef, dimensions: Int)
@@ -235,7 +236,7 @@ object Types {
    *                    subclass of another class/interface.
    */
   def isSubtype(lhs: Type, rhs: Type)(
-      isSubclass: (String, String) => Boolean): Boolean = {
+      isSubclass: (ClassName, ClassName) => Boolean): Boolean = {
     import Definitions._
 
     (lhs != NoType && rhs != NoType) && {

--- a/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -49,9 +49,22 @@ class PrintersTest {
     assertEquals(expected.stripMargin.trim, sw.toString())
   }
 
-  private implicit def string2ident(name: String): Ident = Ident(name)
-  private implicit def string2classType(cls: String): ClassType = ClassType(cls)
-  private implicit def string2classRef(cls: String): ClassRef = ClassRef(cls)
+  private implicit def string2localIdent(name: String): LocalIdent =
+    LocalIdent(LocalName(name))
+  private implicit def string2labelIdent(name: String): LabelIdent =
+    LabelIdent(LabelName(name))
+  private implicit def string2fieldIdent(name: String): FieldIdent =
+    FieldIdent(FieldName(name))
+  private implicit def string2methodIdent(name: String): MethodIdent =
+    MethodIdent(MethodName(name))
+  private implicit def string2classIdent(name: String): ClassIdent =
+    ClassIdent(ClassName(name))
+  private implicit def string2classType(cls: String): ClassType =
+    ClassType(ClassName(cls))
+  private implicit def string2classRef(cls: String): ClassRef =
+    ClassRef(ClassName(cls))
+  private implicit def string2fieldName(name: String): FieldName =
+    FieldName(name)
 
   private def b(value: Boolean): BooleanLiteral = BooleanLiteral(value)
   private def i(value: Int): IntLiteral = IntLiteral(value)
@@ -59,7 +72,7 @@ class PrintersTest {
   private def f(value: Float): FloatLiteral = FloatLiteral(value)
   private def d(value: Double): DoubleLiteral = DoubleLiteral(value)
 
-  private def ref(ident: Ident, tpe: Type): VarRef = VarRef(ident)(tpe)
+  private def ref(ident: LocalIdent, tpe: Type): VarRef = VarRef(ident)(tpe)
 
   private def arrayType(baseClassName: String, dimensions: Int): ArrayType =
     ArrayType(ArrayTypeRef(baseClassName, dimensions))
@@ -949,8 +962,8 @@ class PrintersTest {
   }
 
   @Test def printClassDefParents(): Unit = {
-    def makeForParents(superClass: Option[Ident],
-        interfaces: List[Ident]): ClassDef = {
+    def makeForParents(superClass: Option[ClassIdent],
+        interfaces: List[ClassIdent]): ClassDef = {
       ClassDef("LTest", ClassKind.Class, None, superClass, interfaces, None,
           None, Nil, Nil)(
           NoOptHints)

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleInitializer.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleInitializer.scala
@@ -13,7 +13,7 @@
 package org.scalajs.linker.interface
 
 import org.scalajs.ir.Definitions._
-import org.scalajs.ir.Types.ClassType
+import org.scalajs.ir.Types._
 
 import org.scalajs.linker.interface.unstable.ModuleInitializerImpl
 
@@ -37,6 +37,9 @@ abstract class ModuleInitializer private[interface] () {
 object ModuleInitializer {
   import ModuleInitializerImpl._
 
+  private val ArrayOfStringTypeRef =
+    ArrayTypeRef(ClassRef(BoxedStringClass), 1)
+
   /** Makes an [[ModuleInitializer]] that calls a zero-argument method returning
    *  `Unit` in a top-level `object`.
    *
@@ -49,7 +52,7 @@ object ModuleInitializer {
   def mainMethod(moduleClassName: String,
       mainMethodName: String): ModuleInitializer = {
     VoidMainMethod(encodeClassName(moduleClassName + "$"),
-        mainMethodName + "__V")
+        encodeMethodName(mainMethodName, Nil, Some(VoidRef)))
   }
 
   /** Makes an [[ModuleInitializer]] that calls a method of a top-level
@@ -84,6 +87,7 @@ object ModuleInitializer {
   def mainMethodWithArgs(moduleClassName: String, mainMethodName: String,
       args: List[String]): ModuleInitializer = {
     MainMethodWithArgs(encodeClassName(moduleClassName + "$"),
-        mainMethodName + "__AT__V", args)
+        encodeMethodName(mainMethodName, ArrayOfStringTypeRef :: Nil, Some(VoidRef)),
+        args)
   }
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/ModuleInitializerImpl.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/ModuleInitializerImpl.scala
@@ -12,6 +12,8 @@
 
 package org.scalajs.linker.interface.unstable
 
+import org.scalajs.ir.Definitions._
+
 import org.scalajs.linker.interface.ModuleInitializer
 
 /** A module initializer for a Scala.js application.
@@ -33,11 +35,11 @@ sealed abstract class ModuleInitializerImpl extends ModuleInitializer {
 object ModuleInitializerImpl {
   def fromModuleInitializer(mi: ModuleInitializer): ModuleInitializerImpl = mi.impl
 
-  final case class VoidMainMethod(moduleClassName: String,
-      encodedMainMethodName: String)
+  final case class VoidMainMethod(moduleClassName: ClassName,
+      encodedMainMethodName: MethodName)
       extends ModuleInitializerImpl
 
-  final case class MainMethodWithArgs(moduleClassName: String,
-      encodedMainMethodName: String, args: List[String])
+  final case class MainMethodWithArgs(moduleClassName: ClassName,
+      encodedMainMethodName: MethodName, args: List[String])
       extends ModuleInitializerImpl
 }

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -136,7 +136,7 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
       classDef <- linkingUnit.classDefs
       member <- classDef.exportedMembers
       name <- exportName(member.value)
-      if isValidIdentifier(name)
+      if isValidJSIdentifier(name)
     } yield {
       name
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -20,7 +20,7 @@ import org.scalajs.logging._
 
 import org.scalajs.ir
 import org.scalajs.ir.ClassKind
-import org.scalajs.ir.Definitions.{decodeClassName, decodeMethodName}
+import org.scalajs.ir.Definitions._
 import org.scalajs.ir.Trees.MemberNamespace
 import org.scalajs.ir.Types._
 
@@ -33,7 +33,7 @@ import org.scalajs.ir.Types._
 trait Analysis {
   import Analysis._
 
-  def classInfos: scala.collection.Map[String, ClassInfo]
+  def classInfos: scala.collection.Map[ClassName, ClassInfo]
   def errors: scala.collection.Seq[Error]
 }
 
@@ -60,7 +60,7 @@ object Analysis {
    *  versions, possibly causing `LinkageError`s if you extend it.
    */
   trait ClassInfo {
-    def encodedName: String
+    def encodedName: ClassName
     def kind: ClassKind
     def superClass: Option[ClassInfo]
     def interfaces: scala.collection.Seq[ClassInfo]
@@ -80,7 +80,7 @@ object Analysis {
     def linkedFrom: scala.collection.Seq[From]
     def instantiatedFrom: scala.collection.Seq[From]
     def methodInfos(
-        namespace: MemberNamespace): scala.collection.Map[String, MethodInfo]
+        namespace: MemberNamespace): scala.collection.Map[MethodName, MethodInfo]
 
     def displayName: String = decodeClassName(encodedName)
   }
@@ -93,7 +93,7 @@ object Analysis {
    */
   trait MethodInfo {
     def owner: ClassInfo
-    def encodedName: String
+    def encodedName: MethodName
     def namespace: MemberNamespace
     def isAbstract: Boolean
     def isReflProxy: Boolean
@@ -145,7 +145,8 @@ object Analysis {
      *  }
      *  }}}
      */
-    final case class ReflectiveProxy(target: String) extends MethodSyntheticKind
+    final case class ReflectiveProxy(target: MethodName)
+        extends MethodSyntheticKind
 
     /** Bridge to a default method.
      *
@@ -161,7 +162,8 @@ object Analysis {
      *  }
      *  }}}
      */
-    final case class DefaultBridge(targetInterface: String) extends MethodSyntheticKind
+    final case class DefaultBridge(targetInterface: ClassName)
+        extends MethodSyntheticKind
   }
 
   sealed trait Error {
@@ -170,7 +172,7 @@ object Analysis {
 
   final case class MissingJavaLangObjectClass(from: From) extends Error
   final case class InvalidJavaLangObjectClass(from: From) extends Error
-  final case class CycleInInheritanceChain(encodedClassNames: List[String], from: From) extends Error
+  final case class CycleInInheritanceChain(encodedClassNames: List[ClassName], from: From) extends Error
   final case class MissingClass(info: ClassInfo, from: From) extends Error
 
   final case class MissingSuperClass(subClassInfo: ClassInfo, from: From)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterDefinitions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterDefinitions.scala
@@ -15,17 +15,33 @@ package org.scalajs.linker.backend.emitter
 import org.scalajs.ir.Definitions._
 
 private[emitter] object EmitterDefinitions {
+  val ArithmeticExceptionClass =
+    ClassName("jl_ArithmeticException")
+
+  val ArrayIndexOutOfBoundsExceptionClass =
+    ClassName("jl_ArrayIndexOutOfBoundsException")
+
+  val ClassCastExceptionClass =
+    ClassName("jl_ClassCastException")
+
+  val CloneNotSupportedExceptionClass =
+    ClassName("jl_CloneNotSupportedException")
+
+  val UndefinedBehaviorErrorClass =
+    ClassName("sjsr_UndefinedBehaviorError")
+
   /* In theory, some of the following could be computed from the Class
    * Hierarchy. However, that would be require dealing with incremental runs,
    * which would be overkill since these things are in fact known to be static.
    */
 
-  final val CharSequenceClass = "jl_CharSequence"
-  final val SerializableClass = "Ljava_io_Serializable"
-  final val ComparableClass = "jl_Comparable"
-  final val NumberClass = "jl_Number"
+  val CharSequenceClass = ClassName("jl_CharSequence")
+  val CloneableClass = ClassName("jl_Cloneable")
+  val SerializableClass = ClassName("Ljava_io_Serializable")
+  val ComparableClass = ClassName("jl_Comparable")
+  val NumberClass = ClassName("jl_Number")
 
-  final val ThrowableClass = "jl_Throwable"
+  val ThrowableClass = ClassName("jl_Throwable")
 
   val NonObjectAncestorsOfStringClass =
     Set(CharSequenceClass, ComparableClass, SerializableClass)
@@ -46,5 +62,30 @@ private[emitter] object EmitterDefinitions {
 
   val HijackedClassesAndTheirSuperClasses =
     HijackedClasses ++ Set(ObjectClass, NumberClass)
+
+  // Method names
+
+  val ObjectArgConstructorName = MethodName("init___O")
+  val StringArgConstructorName = MethodName("init___T")
+  val ThrowableArgConsructorName = MethodName("init___jl_Throwable")
+
+  val getClassMethodName = MethodName("getClass__jl_Class")
+  val cloneMethodName = MethodName("clone__O")
+  val finalizeMethodName = MethodName("finalize__V")
+  val notifyMethodName = MethodName("notify__V")
+  val notifyAllMethodName = MethodName("notifyAll__V")
+  val toStringMethodName = MethodName("toString__T")
+  val equalsMethodName = MethodName("equals__O__Z")
+  val hashCodeMethodName = MethodName("hashCode__I")
+  val compareToMethodName = MethodName("compareTo__O__I")
+  val lengthMethodName = MethodName("length__I")
+  val charAtMethodName = MethodName("charAt__I__C")
+  val subSequenceMethodName = MethodName("subSequence__I__I__jl_CharSequence")
+  val byteValueMethodName = MethodName("byteValue__B")
+  val shortValueMethodName = MethodName("shortValue__S")
+  val intValueMethodName = MethodName("intValue__I")
+  val longValueMethodName = MethodName("longValue__J")
+  val floatValueMethodName = MethodName("floatValue__F")
+  val doubleValueMethodName = MethodName("doubleValue__D")
 
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -12,7 +12,8 @@
 
 package org.scalajs.linker.backend.emitter
 
-import org.scalajs.ir.Trees.{AnyFieldDef, Ident, JSNativeLoadSpec}
+import org.scalajs.ir.Definitions._
+import org.scalajs.ir.Trees.{AnyFieldDef, JSNativeLoadSpec}
 import org.scalajs.ir.Types.Type
 
 private[emitter] trait GlobalKnowledge {
@@ -20,7 +21,7 @@ private[emitter] trait GlobalKnowledge {
   def isParentDataAccessed: Boolean
 
   /** Tests whether the specified class name refers to an `Interface`. */
-  def isInterface(className: String): Boolean
+  def isInterface(className: ClassName): Boolean
 
   /** All the `FieldDef`s, included inherited ones, of a Scala class.
    *
@@ -28,7 +29,7 @@ private[emitter] trait GlobalKnowledge {
    *  `ModuleClass`.
    */
   def getAllScalaClassFieldDefs(
-      className: String): List[(String, List[AnyFieldDef])]
+      className: ClassName): List[(ClassName, List[AnyFieldDef])]
 
   /** Tests whether the specified class uses an inlineable init.
    *
@@ -42,13 +43,13 @@ private[emitter] trait GlobalKnowledge {
    *  new \$c_Foo().init___XY(args)
    *  }}}
    */
-  def hasInlineableInit(className: String): Boolean
+  def hasInlineableInit(className: ClassName): Boolean
 
   /** Tests whether the specified class locally stores its super class. */
-  def hasStoredSuperClass(className: String): Boolean
+  def hasStoredSuperClass(className: ClassName): Boolean
 
   /** Gets the types of the `jsClassCaptures` of the given class. */
-  def getJSClassCaptureTypes(className: String): Option[List[Type]]
+  def getJSClassCaptureTypes(className: ClassName): Option[List[Type]]
 
   /** `None` for non-native JS classes/objects; `Some(spec)` for native JS
    *  classes/objects.
@@ -56,22 +57,22 @@ private[emitter] trait GlobalKnowledge {
    *  It is invalid to call this method with a class that is not a JS class
    *  or object (native or not), or one that has JS class captures.
    */
-  def getJSNativeLoadSpec(className: String): Option[JSNativeLoadSpec]
+  def getJSNativeLoadSpec(className: ClassName): Option[JSNativeLoadSpec]
 
   /** The `encodedName` of the superclass of a (non-native) JS class.
    *
    *  It is invalid to call this method with a class that is not a non-native
    *  JS class.
    */
-  def getSuperClassOfJSClass(className: String): String
+  def getSuperClassOfJSClass(className: ClassName): ClassName
 
   /** The `FieldDef`s of a non-native JS class.
    *
    *  It is invalid to call this method with a class that is not a non-native
    *  JS class.
    */
-  def getJSClassFieldDefs(className: String): List[AnyFieldDef]
+  def getJSClassFieldDefs(className: ClassName): List[AnyFieldDef]
 
   /** The global variables that mirror a given static field. */
-  def getStaticFieldMirrors(className: String, field: String): List[String]
+  def getStaticFieldMirrors(className: ClassName, field: FieldName): List[String]
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
@@ -12,56 +12,59 @@
 
 package org.scalajs.linker.backend.emitter
 
-private[linker] object LongImpl {
-  final val RuntimeLongClass = "sjsr_RuntimeLong"
-  final val RuntimeLongModuleClass = "sjsr_RuntimeLong$"
+import org.scalajs.ir.Definitions._
 
-  final val lo = "lo__I"
-  final val hi = "hi__I"
+private[linker] object LongImpl {
+  final val RuntimeLongClass = ClassName("sjsr_RuntimeLong")
+  final val RuntimeLongModuleClass = ClassName("sjsr_RuntimeLong$")
+
+  final val lo = MethodName("lo__I")
+  final val hi = MethodName("hi__I")
 
   private final val SigUnary   = "__sjsr_RuntimeLong"
   private final val SigBinary  = "__sjsr_RuntimeLong__sjsr_RuntimeLong"
   private final val SigShift   = "__I__sjsr_RuntimeLong"
   private final val SigCompare = "__sjsr_RuntimeLong__Z"
 
-  final val UNARY_- = "unary$und$minus" + SigUnary
-  final val UNARY_~ = "unary$und$tilde" + SigUnary
+  final val UNARY_- = MethodName("unary$und$minus" + SigUnary)
+  final val UNARY_~ = MethodName("unary$und$tilde" + SigUnary)
 
-  final val + = "$$plus"    + SigBinary
-  final val - = "$$minus"   + SigBinary
-  final val * = "$$times"   + SigBinary
-  final val / = "$$div"     + SigBinary
-  final val % = "$$percent" + SigBinary
+  final val + = MethodName("$$plus"    + SigBinary)
+  final val - = MethodName("$$minus"   + SigBinary)
+  final val * = MethodName("$$times"   + SigBinary)
+  final val / = MethodName("$$div"     + SigBinary)
+  final val % = MethodName("$$percent" + SigBinary)
 
-  final val | = "$$bar" + SigBinary
-  final val & = "$$amp" + SigBinary
-  final val ^ = "$$up"  + SigBinary
+  final val | = MethodName("$$bar" + SigBinary)
+  final val & = MethodName("$$amp" + SigBinary)
+  final val ^ = MethodName("$$up"  + SigBinary)
 
-  final val <<  = "$$less$less"               + SigShift
-  final val >>> = "$$greater$greater$greater" + SigShift
-  final val >>  = "$$greater$greater"         + SigShift
+  final val <<  = MethodName("$$less$less"               + SigShift)
+  final val >>> = MethodName("$$greater$greater$greater" + SigShift)
+  final val >>  = MethodName("$$greater$greater"         + SigShift)
 
-  final val === = "equals"       + SigCompare
-  final val !== = "notEquals"    + SigCompare
-  final val <   = "$$less"       + SigCompare
-  final val <=  = "$$less$eq"    + SigCompare
-  final val >   = "$$greater"    + SigCompare
-  final val >=  = "$$greater$eq" + SigCompare
+  final val === = MethodName("equals"      + SigCompare)
+  final val !== = MethodName("notEquals"   + SigCompare)
+  final val <   = MethodName("$$less"       + SigCompare)
+  final val <=  = MethodName("$$less$eq"    + SigCompare)
+  final val >   = MethodName("$$greater"    + SigCompare)
+  final val >=  = MethodName("$$greater$eq" + SigCompare)
 
-  final val toInt    = "toInt"    + "__I"
-  final val toDouble = "toDouble" + "__D"
+  final val toInt    = MethodName("toInt"    + "__I")
+  final val toDouble = MethodName("toDouble" + "__D")
 
-  final val byteValue   = "byteValue__B"
-  final val shortValue  = "shortValue__S"
-  final val intValue    = "intValue__I"
-  final val longValue   = "longValue__J"
-  final val floatValue  = "floatValue__F"
-  final val doubleValue = "doubleValue__D"
+  final val byteValue   = MethodName("byteValue__B")
+  final val shortValue  = MethodName("shortValue__S")
+  final val intValue    = MethodName("intValue__I")
+  final val longValue   = MethodName("longValue__J")
+  final val floatValue  = MethodName("floatValue__F")
+  final val doubleValue = MethodName("doubleValue__D")
 
-  final val equals_    = "equals__O__Z"
-  final val hashCode_  = "hashCode__I"
-  final val compareTo  = "compareTo__jl_Long__I"
-  final val compareToO = "compareTo__O__I"
+  final val toString_  = MethodName("toString__T")
+  final val equals_    = MethodName("equals__O__Z")
+  final val hashCode_  = MethodName("hashCode__I")
+  final val compareTo  = MethodName("compareTo__jl_Long__I")
+  final val compareToO = MethodName("compareTo__O__I")
 
   private val OperatorMethods = Set(
       UNARY_-, UNARY_~, this.+, this.-, *, /, %, |, &, ^, <<, >>>, >>,
@@ -75,23 +78,24 @@ private[linker] object LongImpl {
 
   // Methods used for intrinsics
 
-  final val divideUnsigned    = "divideUnsigned__sjsr_RuntimeLong__sjsr_RuntimeLong"
-  final val remainderUnsigned = "remainderUnsigned__sjsr_RuntimeLong__sjsr_RuntimeLong"
+  final val compareToRTLong   = MethodName("compareTo__sjsr_RuntimeLong__I")
+  final val divideUnsigned    = MethodName("divideUnsigned__sjsr_RuntimeLong__sjsr_RuntimeLong")
+  final val remainderUnsigned = MethodName("remainderUnsigned__sjsr_RuntimeLong__sjsr_RuntimeLong")
 
   val AllIntrinsicMethods = Set(
-      divideUnsigned, remainderUnsigned)
+      compareToRTLong, divideUnsigned, remainderUnsigned)
 
   // Constructors
 
-  final val initFromParts = "init___I__I"
+  final val initFromParts = MethodName("init___I__I")
 
   val AllConstructors = Set(
       initFromParts)
 
   // Methods on the companion
 
-  final val fromInt    = "fromInt__I__sjsr_RuntimeLong"
-  final val fromDouble = "fromDouble__D__sjsr_RuntimeLong"
+  final val fromInt    = MethodName("fromInt__I__sjsr_RuntimeLong")
+  final val fromDouble = MethodName("fromDouble__D__sjsr_RuntimeLong")
 
   val AllModuleMethods = Set(
       fromInt, fromDouble)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -19,8 +19,6 @@ import ir.Position
 import ir.Position.NoPosition
 
 object Trees {
-  import ir.Trees.requireValidIdent
-
   /** AST node of JavaScript. */
   abstract sealed class Tree {
     val pos: Position
@@ -45,7 +43,8 @@ object Trees {
 
   case class Ident(name: String, originalName: Option[String])(
       implicit val pos: Position) extends PropertyName {
-    requireValidIdent(name)
+    require(ir.Trees.isValidJSIdentifier(name),
+        s"'$name' is not a valid JS identifier")
   }
 
   object Ident {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/MethodSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/MethodSynthesizer.scala
@@ -19,8 +19,9 @@ import scala.concurrent._
 import org.scalajs.linker.analyzer._
 
 import org.scalajs.ir
-import ir.Trees._
-import ir.Types._
+import org.scalajs.ir.Definitions._
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
 
 import Analysis._
 
@@ -48,7 +49,7 @@ private[frontend] final class MethodSynthesizer(
 
   private def synthesizeReflectiveProxy(
       classInfo: ClassInfo, methodInfo: MethodInfo,
-      targetName: String, analysis: Analysis)(
+      targetName: MethodName, analysis: Analysis)(
       implicit ec: ExecutionContext): Future[MethodDef] = {
     val encodedName = methodInfo.encodedName
 
@@ -57,8 +58,8 @@ private[frontend] final class MethodSynthesizer(
     } yield {
       implicit val pos = targetMDef.pos
 
-      val targetIdent = targetMDef.name.asInstanceOf[Ident].copy() // for the new pos
-      val proxyIdent = Ident(encodedName, None)
+      val targetIdent = targetMDef.name.copy() // for the new pos
+      val proxyIdent = MethodIdent(encodedName, None)
       val params = targetMDef.args.map(_.copy()) // for the new pos
       val currentClassType = ClassType(classInfo.encodedName)
 
@@ -79,7 +80,7 @@ private[frontend] final class MethodSynthesizer(
 
   private def synthesizeDefaultBridge(
       classInfo: ClassInfo, methodInfo: MethodInfo,
-      targetInterface: String, analysis: Analysis)(
+      targetInterface: ClassName, analysis: Analysis)(
       implicit ec: ExecutionContext): Future[MethodDef] = {
     val encodedName = methodInfo.encodedName
 
@@ -90,7 +91,7 @@ private[frontend] final class MethodSynthesizer(
     } yield {
       implicit val pos = targetMDef.pos
 
-      val targetIdent = targetMDef.name.asInstanceOf[Ident].copy() // for the new pos
+      val targetIdent = targetMDef.name.copy() // for the new pos
       val bridgeIdent = targetIdent
       val params = targetMDef.args.map(_.copy()) // for the new pos
       val currentClassType = ClassType(classInfo.encodedName)
@@ -106,7 +107,7 @@ private[frontend] final class MethodSynthesizer(
   }
 
   private def findInheritedMethodDef(analysis: Analysis,
-      classInfo: ClassInfo, methodName: String,
+      classInfo: ClassInfo, methodName: MethodName,
       p: MethodInfo => Boolean = _ => true)(
       implicit ec: ExecutionContext): Future[MethodDef] = {
     @tailrec
@@ -159,6 +160,7 @@ private[frontend] final class MethodSynthesizer(
 
 private[frontend] object MethodSynthesizer {
   trait InputProvider {
-    def loadClassDef(encodedName: String)(implicit ec: ExecutionContext): Future[ClassDef]
+    def loadClassDef(encodedName: ClassName)(
+        implicit ec: ExecutionContext): Future[ClassDef]
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -15,10 +15,9 @@ package org.scalajs.linker.standard
 import scala.collection.mutable
 
 import org.scalajs.ir
-import ir.Trees._
-import ir.Position
-import ir.ClassKind
-import ir.Definitions
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.{ClassKind, Definitions, Position}
+import org.scalajs.ir.Definitions.ClassName
 
 /** A ClassDef after linking.
  *
@@ -36,11 +35,11 @@ import ir.Definitions
  */
 final class LinkedClass(
     // Stuff from Tree
-    val name: Ident,
+    val name: ClassIdent,
     val kind: ClassKind,
     val jsClassCaptures: Option[List[ParamDef]],
-    val superClass: Option[Ident],
-    val interfaces: List[Ident],
+    val superClass: Option[ClassIdent],
+    val interfaces: List[ClassIdent],
     val jsSuperClass: Option[Tree],
     val jsNativeLoadSpec: Option[JSNativeLoadSpec],
     val fields: List[AnyFieldDef],
@@ -51,13 +50,13 @@ final class LinkedClass(
     val pos: Position,
 
     // Actual Linking info
-    val ancestors: List[String],
+    val ancestors: List[ClassName],
     val hasInstances: Boolean,
     val hasInstanceTests: Boolean,
     val hasRuntimeTypeInfo: Boolean,
     val version: Option[String]) {
 
-  def encodedName: String = name.name
+  def encodedName: ClassName = name.name
 
   val hasEntryPoint: Boolean = {
     topLevelExports.nonEmpty ||
@@ -91,11 +90,11 @@ final class LinkedClass(
   }
 
   private def copy(
-      name: Ident = this.name,
+      name: ClassIdent = this.name,
       kind: ClassKind = this.kind,
       jsClassCaptures: Option[List[ParamDef]] = this.jsClassCaptures,
-      superClass: Option[Ident] = this.superClass,
-      interfaces: List[Ident] = this.interfaces,
+      superClass: Option[ClassIdent] = this.superClass,
+      interfaces: List[ClassIdent] = this.interfaces,
       jsSuperClass: Option[Tree] = this.jsSuperClass,
       jsNativeLoadSpec: Option[JSNativeLoadSpec] = this.jsNativeLoadSpec,
       fields: List[AnyFieldDef] = this.fields,
@@ -104,7 +103,7 @@ final class LinkedClass(
       topLevelExports: List[Versioned[TopLevelExportDef]] = this.topLevelExports,
       optimizerHints: OptimizerHints = this.optimizerHints,
       pos: Position = this.pos,
-      ancestors: List[String] = this.ancestors,
+      ancestors: List[ClassName] = this.ancestors,
       hasInstances: Boolean = this.hasInstances,
       hasInstanceTests: Boolean = this.hasInstanceTests,
       hasRuntimeTypeInfo: Boolean = this.hasRuntimeTypeInfo,

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -428,14 +428,14 @@ object AnalyzerTest {
   private val fromAnalyzer = FromCore("analyzer")
   private val fromUnitTest = FromCore("unit test")
 
-  private def validParentForKind(kind: ClassKind): Option[String] = {
+  private def validParentForKind(kind: ClassKind): Option[ClassName] = {
     import ClassKind._
     kind match {
       case Class | ModuleClass | HijackedClass | NativeJSClass |
           NativeJSModuleClass =>
         Some(ObjectClass)
       case JSClass | JSModuleClass =>
-        Some("sjs_js_Object")
+        Some(ClassName("sjs_js_Object"))
       case Interface | AbstractJSType =>
         None
     }
@@ -455,9 +455,10 @@ object AnalyzerTest {
       classDefs.map(c => c.name.name -> Infos.generateClassInfo(c)).toMap
 
     def inputProvider(loader: Option[TestIRRepo.InfoLoader]) = new Analyzer.InputProvider {
-      def classesWithEntryPoints(): Iterable[String] = classesWithEntryPoints0
+      def classesWithEntryPoints(): Iterable[ClassName] = classesWithEntryPoints0
 
-      def loadInfo(encodedName: String)(implicit ec: ExecutionContext): Option[Future[Infos.ClassInfo]] = {
+      def loadInfo(encodedName: ClassName)(
+          implicit ec: ExecutionContext): Option[Future[Infos.ClassInfo]] = {
         /* Note: We could use Future.successful here to complete the future
          * immediately. However, in order to exercise as much asynchronizity as
          * possible, we don't.

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -100,13 +100,15 @@ class OptimizerTest {
 
     for (linkingUnit <- linkToLinkingUnit(classDefs, MainTestModuleInitializers)) yield {
       val linkedClass = linkingUnit.classDefs.find(_.encodedName == MainTestClassDefEncodedName).get
+      val WitnessMethodName = MethodName("witness__O")
+      val CloneMethodName = MethodName("clone__O")
       linkedClass.hasNot("any call to Foo.witness()") {
-        case Apply(_, receiver, Ident("witness__O", _), _) =>
+        case Apply(_, receiver, MethodIdent(WitnessMethodName, _), _) =>
           receiver.tpe == ClassType("LFoo")
       }.hasNot("any reference to ObjectClone") {
         case LoadModule(ClassRef("jl_ObjectClone$")) => true
       }.hasExactly(3, "calls to clone()") {
-        case Apply(_, _, Ident("clone__O", _), _) => true
+        case Apply(_, _, MethodIdent(CloneMethodName, _), _) => true
       }
     }
   }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -30,18 +30,18 @@ object TestIRBuilder {
   val EOH = OptimizerHints.empty
 
   def classDef(
-      encodedName: String,
+      encodedName: ClassName,
       kind: ClassKind = ClassKind.Class,
       jsClassCaptures: Option[List[ParamDef]] = None,
-      superClass: Option[String] = None,
-      interfaces: List[String] = Nil,
+      superClass: Option[ClassName] = None,
+      interfaces: List[ClassName] = Nil,
       jsSuperClass: Option[Tree] = None,
       jsNativeLoadSpec: Option[JSNativeLoadSpec] = None,
       memberDefs: List[MemberDef] = Nil,
       topLevelExportDefs: List[TopLevelExportDef] = Nil): ClassDef = {
-    ClassDef(Ident(encodedName), kind, jsClassCaptures,
-        superClass.map(Ident(_)), interfaces.map(Ident(_)), jsSuperClass,
-        jsNativeLoadSpec, memberDefs, topLevelExportDefs)(
+    ClassDef(ClassIdent(encodedName), kind, jsClassCaptures,
+        superClass.map(ClassIdent(_)), interfaces.map(ClassIdent(_)),
+        jsSuperClass, jsNativeLoadSpec, memberDefs, topLevelExportDefs)(
         EOH)
   }
 
@@ -61,28 +61,48 @@ object TestIRBuilder {
     )
   }
 
-  def trivialCtor(enclosingClassName: String): MethodDef = {
+  def trivialCtor(enclosingClassName: ClassName): MethodDef = {
     val flags = MemberFlags.empty.withNamespace(MemberNamespace.Constructor)
-    MethodDef(flags, Ident("init___"), Nil, NoType,
+    MethodDef(flags, MethodIdent(NoArgConstructorName), Nil, NoType,
         Some(ApplyStatically(EAF.withConstructor(true),
             This()(ClassType(enclosingClassName)),
-            ClassRef(ObjectClass), Ident("init___"), Nil)(NoType)))(
+            ClassRef(ObjectClass), MethodIdent(NoArgConstructorName),
+            Nil)(NoType)))(
         EOH, None)
   }
 
   def mainMethodDef(body: Tree): MethodDef = {
     val stringArrayType = ArrayType(ArrayTypeRef(ClassRef(BoxedStringClass), 1))
     val argsParamDef = paramDef("args", stringArrayType)
-    MethodDef(MemberFlags.empty, Ident("main__AT__V"), List(argsParamDef),
+    MethodDef(MemberFlags.empty, "main__AT__V", List(argsParamDef),
         NoType, Some(body))(EOH, None)
   }
 
-  def paramDef(name: String, ptpe: Type): ParamDef =
-    ParamDef(Ident(name, Some(name)), ptpe, mutable = false, rest = false)
+  def paramDef(name: LocalName, ptpe: Type): ParamDef =
+    ParamDef(LocalIdent(name), ptpe, mutable = false, rest = false)
 
   def mainModuleInitializers(moduleClassName: String): List[ModuleInitializer] =
     ModuleInitializer.mainMethodWithArgs(moduleClassName, "main") :: Nil
 
-  implicit def string2ident(name: String): Ident =
-    Ident(name)
+  implicit def string2LocalName(name: String): LocalName =
+    LocalName(name)
+  implicit def string2LabelName(name: String): LabelName =
+    LabelName(name)
+  implicit def string2FieldName(name: String): FieldName =
+    FieldName(name)
+  implicit def string2MethodName(name: String): MethodName =
+    MethodName(name)
+  implicit def string2ClassName(name: String): ClassName =
+    ClassName(name)
+
+  implicit def string2LocalIdent(name: String): LocalIdent =
+    LocalIdent(LocalName(name))
+  implicit def string2LabelIdent(name: String): LabelIdent =
+    LabelIdent(LabelName(name))
+  implicit def string2FieldIdent(name: String): FieldIdent =
+    FieldIdent(FieldName(name))
+  implicit def string2MethodIdent(name: String): MethodIdent =
+    MethodIdent(MethodName(name))
+  implicit def string2ClassIdent(name: String): ClassIdent =
+    ClassIdent(ClassName(name))
 }

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -29,7 +29,7 @@ object JavaLangObject {
     val EAF = ApplyFlags.empty
 
     val classDef = ClassDef(
-      Ident("O", Some("java.lang.Object")),
+      ClassIdent(ObjectClass, Some("java.lang.Object")),
       ClassKind.Class,
       None,
       None,
@@ -40,7 +40,7 @@ object JavaLangObject {
         /* def this() = () */
         MethodDef(
           MemberFlags.empty.withNamespace(MemberNamespace.Constructor),
-          Ident("init___", Some("<init>")),
+          MethodIdent(NoArgConstructorName, Some("<init>")),
           Nil,
           NoType,
           Some(Skip()))(OptimizerHints.empty, None),
@@ -48,7 +48,7 @@ object JavaLangObject {
         /* def getClass(): java.lang.Class[_] = <getclass>(this) */
         MethodDef(
           MemberFlags.empty,
-          Ident("getClass__jl_Class", Some("getClass__jl_Class")),
+          MethodIdent(MethodName("getClass__jl_Class"), Some("getClass__jl_Class")),
           Nil,
           ClassType(ClassClass),
           Some {
@@ -58,28 +58,28 @@ object JavaLangObject {
         /* def hashCode(): Int = System.identityHashCode(this) */
         MethodDef(
           MemberFlags.empty,
-          Ident("hashCode__I", Some("hashCode__I")),
+          MethodIdent(MethodName("hashCode__I"), Some("hashCode__I")),
           Nil,
           IntType,
           Some {
             Apply(
               EAF,
-              LoadModule(ClassRef("jl_System$")),
-              Ident("identityHashCode__O__I", Some("identityHashCode")),
+              LoadModule(ClassRef(ClassName("jl_System$"))),
+              MethodIdent(MethodName("identityHashCode__O__I"), Some("identityHashCode")),
               List(This()(ThisType)))(IntType)
           })(OptimizerHints.empty, None),
 
         /* def equals(that: Object): Boolean = this eq that */
         MethodDef(
           MemberFlags.empty,
-          Ident("equals__O__Z", Some("equals__O__Z")),
-          List(ParamDef(Ident("that", Some("that")), AnyType,
+          MethodIdent(MethodName("equals__O__Z"), Some("equals__O__Z")),
+          List(ParamDef(LocalIdent(LocalName("that"), Some("that")), AnyType,
             mutable = false, rest = false)),
           BooleanType,
           Some {
             BinaryOp(BinaryOp.===,
               This()(ThisType),
-              VarRef(Ident("that", Some("that")))(AnyType))
+              VarRef(LocalIdent(LocalName("that"), Some("that")))(AnyType))
           })(OptimizerHints.empty.withInline(true), None),
 
         /* protected def clone(): Object =
@@ -88,17 +88,17 @@ object JavaLangObject {
          */
         MethodDef(
           MemberFlags.empty,
-          Ident("clone__O", Some("clone__O")),
+          MethodIdent(MethodName("clone__O"), Some("clone__O")),
           Nil,
           AnyType,
           Some {
-            If(IsInstanceOf(This()(ThisType), ClassType("jl_Cloneable")), {
-              Apply(EAF, LoadModule(ClassRef("jl_ObjectClone$")),
-                  Ident("clone__O__O", Some("clone")),
+            If(IsInstanceOf(This()(ThisType), ClassType(ClassName("jl_Cloneable"))), {
+              Apply(EAF, LoadModule(ClassRef(ClassName("jl_ObjectClone$"))),
+                  MethodIdent(MethodName("clone__O__O"), Some("clone")),
                   List(This()(ThisType)))(AnyType)
             }, {
-              Throw(New(ClassRef("jl_CloneNotSupportedException"),
-                Ident("init___", Some("<init>")), Nil))
+              Throw(New(ClassRef(ClassName("jl_CloneNotSupportedException")),
+                MethodIdent(MethodName("init___"), Some("<init>")), Nil))
             })(AnyType)
           })(OptimizerHints.empty.withInline(true), None),
 
@@ -107,7 +107,7 @@ object JavaLangObject {
          */
         MethodDef(
           MemberFlags.empty,
-          Ident("toString__T", Some("toString__T")),
+          MethodIdent(MethodName("toString__T"), Some("toString__T")),
           Nil,
           ClassType(BoxedStringClass),
           Some {
@@ -115,17 +115,17 @@ object JavaLangObject {
               Apply(
                 EAF,
                 Apply(EAF, This()(ThisType),
-                  Ident("getClass__jl_Class", Some("getClass__jl_Class")), Nil)(
+                  MethodIdent(MethodName("getClass__jl_Class"), Some("getClass__jl_Class")), Nil)(
                   ClassType(ClassClass)),
-                Ident("getName__T"), Nil)(ClassType(BoxedStringClass)),
+                MethodIdent(MethodName("getName__T")), Nil)(ClassType(BoxedStringClass)),
               // +
               StringLiteral("@")),
               // +
               Apply(
                 EAF,
-                LoadModule(ClassRef("jl_Integer$")),
-                Ident("toHexString__I__T"),
-                List(Apply(EAF, This()(ThisType), Ident("hashCode__I"), Nil)(IntType)))(
+                LoadModule(ClassRef(ClassName("jl_Integer$"))),
+                MethodIdent(MethodName("toHexString__I__T")),
+                List(Apply(EAF, This()(ThisType), MethodIdent(MethodName("hashCode__I")), Nil)(IntType)))(
                 ClassType(BoxedStringClass)))
           })(OptimizerHints.empty, None),
 
@@ -136,7 +136,7 @@ object JavaLangObject {
         /* def notify(): Unit = () */
         MethodDef(
           MemberFlags.empty,
-          Ident("notify__V", Some("notify__V")),
+          MethodIdent(MethodName("notify__V"), Some("notify__V")),
           Nil,
           NoType,
           Some(Skip()))(OptimizerHints.empty, None),
@@ -144,7 +144,7 @@ object JavaLangObject {
         /* def notifyAll(): Unit = () */
         MethodDef(
           MemberFlags.empty,
-          Ident("notifyAll__V", Some("notifyAll__V")),
+          MethodIdent(MethodName("notifyAll__V"), Some("notifyAll__V")),
           Nil,
           NoType,
           Some(Skip()))(OptimizerHints.empty, None),
@@ -152,7 +152,7 @@ object JavaLangObject {
         /* def finalize(): Unit = () */
         MethodDef(
           MemberFlags.empty,
-          Ident("finalize__V", Some("finalize__V")),
+          MethodIdent(MethodName("finalize__V"), Some("finalize__V")),
           Nil,
           NoType,
           Some(Skip()))(OptimizerHints.empty, None),
@@ -166,7 +166,7 @@ object JavaLangObject {
           Nil,
           {
             Apply(EAF, This()(ThisType),
-                Ident("toString__T", Some("toString__T")),
+                MethodIdent(MethodName("toString__T"), Some("toString__T")),
                 Nil)(ClassType(BoxedStringClass))
           })(OptimizerHints.empty, None)
       ),


### PR DESCRIPTION
~~Based on #3802 -- only the second commit belongs to this PR.~~

Instead of putting everything in generic `Ident`s with `String`s, we now have dedicated types a) of `Name`s and b) of `Ident`s for the following categories:

* Local variables, including parameters and captures
* Labels
* Fields
* Methods
* Classes

The `Name`s such as `LocalName` and `MethodName` are currently implemented as bare `String`s hidden behind a type alias, and protected by validation upon construction. They are all validated to be valid JS identifiers, which was what they already had to be before this commit.

In the future, this new abstraction will make it easier to introduce different rules for validation, and in particular to delay mangling to the emitter, and to have better structure for method names (whose signatures are meaningful).