### PR TITLE
Disambiguate overload of FileSystems.newFileSystem for JDK 13+.

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/PathIRContainer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/PathIRContainer.scala
@@ -58,7 +58,9 @@ object PathIRContainer {
 
       blocking {
         // Open zip/jar file as filesystem.
-        val fs = FileSystems.newFileSystem(path, null)
+        val fs = FileSystems.newFileSystem(path,
+            // Type ascription is necessary on JDK 13+.
+            null: ClassLoader)
         try {
           val i = fs.getRootDirectories().iterator()
           while (i.hasNext()) {


### PR DESCRIPTION
this turned up in the context of scala/community-build#873