### PR TITLE
Avoid dotty keyword enum in local variables names

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
@@ -304,18 +304,18 @@ class CollectionsTest extends CollectionsTestBase {
 
   @Test def enumeration(): Unit = {
     val coll = TrivialImmutableCollection(range: _*)
-    val enum = ju.Collections.enumeration(coll)
+    val enumeration = ju.Collections.enumeration(coll)
     for (elem <- range) {
-      assertTrue(enum.hasMoreElements)
-      assertEquals(elem, enum.nextElement())
+      assertTrue(enumeration.hasMoreElements)
+      assertEquals(elem, enumeration.nextElement())
     }
-    assertFalse(enum.hasMoreElements)
+    assertFalse(enumeration.hasMoreElements)
   }
 
   @Test def list(): Unit = {
     val elementCount = 30
 
-    val enum = new ju.Enumeration[Int] {
+    val enumeration = new ju.Enumeration[Int] {
       private var next: Int = 0
       def hasMoreElements(): Boolean = next != elementCount
       def nextElement(): Int = {
@@ -324,7 +324,7 @@ class CollectionsTest extends CollectionsTestBase {
       }
     }
 
-    val list = ju.Collections.list(enum)
+    val list = ju.Collections.list(enumeration)
     assertEquals(elementCount, list.size)
     for (i <- 0 until elementCount)
       assertEquals(i, list.get(i))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/Utils.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/Utils.scala
@@ -43,23 +43,23 @@ object Utils {
     }
   }
 
-  def enumerationIsEmpty(enum: ju.Enumeration[_]): Boolean =
-    !enum.hasMoreElements()
+  def enumerationIsEmpty(enumeration: ju.Enumeration[_]): Boolean =
+    !enumeration.hasMoreElements()
 
-  def enumerationSize(enum: ju.Enumeration[_]): Int = {
+  def enumerationSize(enumeration: ju.Enumeration[_]): Int = {
     var result = 0
-    while (enum.hasMoreElements()) {
-      enum.nextElement()
+    while (enumeration.hasMoreElements()) {
+      enumeration.nextElement()
       result += 1
     }
     result
   }
 
   def assertEnumSameElementsAsSet[A](expected: A*)(
-      enum: ju.Enumeration[_ <: A]): Unit = {
+      enumeration: ju.Enumeration[_ <: A]): Unit = {
     assertIteratorSameElementsAsSet(expected: _*)(new ju.Iterator[A] {
-      def hasNext(): Boolean = enum.hasMoreElements()
-      def next(): A = enum.nextElement()
+      def hasNext(): Boolean = enumeration.hasMoreElements()
+      def next(): A = enumeration.nextElement()
       override def remove(): Unit =
         throw new UnsupportedOperationException("Iterator.remove()")
     })


### PR DESCRIPTION
This patch renames variables that have name `enum` to `enumeration` since
`enum` is a keyword for `Dotty`.