### PR TITLE
Drop parenthesis from nullary method overrides

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/AbstractMapTest.scala
@@ -17,7 +17,7 @@ import java.{util => ju}
 import scala.reflect.ClassTag
 
 abstract class AbstractMapTest extends MapTest {
-  def factory(): AbstractMapFactory
+  def factory: AbstractMapFactory
 }
 
 abstract class AbstractMapFactory extends MapFactory {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
@@ -17,7 +17,7 @@ import java.{util => ju}
 import scala.reflect.ClassTag
 
 class HashMapTest extends MapTest {
-  def factory(): HashMapFactory = new HashMapFactory
+  def factory: HashMapFactory = new HashMapFactory
 }
 
 class HashMapFactory extends AbstractMapFactory {


### PR DESCRIPTION
This patch drops parenthesis from the `def factory` methods, since the
corresponding methods from the parent traits do not have parenthesis.

Dotty does not implicitly inserts parenthesis to nullary methods that so
if a nullary method overrides another nullary method then they both need
to either have parenthesis or not. Otherwise Dotty fails to compile such
methods.