### PR TITLE
Hide private fields of anonymous JS classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -116,6 +116,7 @@ trait JSDefinitions {
       lazy val Runtime_createInnerJSClass         = getMemberMethod(RuntimePackageModule, newTermName("createInnerJSClass"))
       lazy val Runtime_createLocalJSClass         = getMemberMethod(RuntimePackageModule, newTermName("createLocalJSClass"))
       lazy val Runtime_withContextualJSClassValue = getMemberMethod(RuntimePackageModule, newTermName("withContextualJSClassValue"))
+      lazy val Runtime_privateFieldsSymbol        = getMemberMethod(RuntimePackageModule, newTermName("privateFieldsSymbol"))
       lazy val Runtime_linkingInfo                = getMemberMethod(RuntimePackageModule, newTermName("linkingInfo"))
 
     lazy val Tuple2_apply = getMemberMethod(TupleClass(2).companionModule, nme.apply)

--- a/library/src/main/scala/scala/scalajs/runtime/PrivateFieldsSymbolHolder.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/PrivateFieldsSymbolHolder.scala
@@ -1,0 +1,31 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.runtime
+
+import scala.scalajs.js
+
+private[runtime] object PrivateFieldsSymbolHolder {
+  val privateFieldsSymbol: Any = {
+    if (scala.scalajs.LinkingInfo.assumingES6 ||
+        js.typeOf(js.Symbol) != "undefined") {
+      js.Symbol("privateFields")
+    } else {
+      def rand32(): String = {
+        val s = (js.Math.random() * 4294967296.0).asInstanceOf[js.Dynamic]
+          .applyDynamic("toString")(16).asInstanceOf[String]
+        "00000000".substring(s.length) + s
+      }
+      rand32() + rand32() + rand32() + rand32()
+    }
+  }
+}

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -91,6 +91,10 @@ package object runtime {
   def withContextualJSClassValue[A](jsclass: AnyRef, inner: A): A =
     throw new Error("stub")
 
+  @inline
+  def privateFieldsSymbol(): Any =
+    PrivateFieldsSymbolHolder.privateFieldsSymbol
+
   /** Information known at link-time, given the output configuration.
    *
    *  See [[LinkingInfo]] for details.

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -77,18 +77,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
       classDef.kind match {
         case ClassKind.AbstractJSType | ClassKind.NativeJSClass |
             ClassKind.NativeJSModuleClass =>
-          val fieldsOK = if (classDef.kind == ClassKind.AbstractJSType) {
-            /* Private instance fields are allowed in abstract JS types. This
-             * is necessary for anonymous JS classes, whose definitions are
-             * inlined and their ClassDef turned into an abstract JS type.
-             */
-            checkFieldDefs(classDef)
-            true
-          } else {
-            classDef.fields.isEmpty
-          }
-
-          if (!fieldsOK ||
+          if (classDef.fields.nonEmpty ||
               classDef.methods.exists(!_.value.flags.namespace.isStatic) ||
               classDef.exportedMembers.nonEmpty ||
               classDef.topLevelExports.nonEmpty) {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
@@ -524,6 +524,34 @@ class NonNativeJSTypeTest {
     assertEquals(1, call(x => x))
   }
 
+  @Test def anonymous_classes_private_fields_are_not_visible_issue2748(): Unit = {
+    trait TheOuter extends js.Object {
+      val id: String
+      val paint: js.UndefOr[TheInner] = js.undefined
+    }
+
+    trait TheInner extends js.Object {
+      val options: js.UndefOr[String] = js.undefined
+    }
+
+    def someValue = "some-value"
+
+    val pcFn = someValue
+
+    val r0 = new TheOuter {
+      override val id: String = "some-" + pcFn
+      override val paint: js.UndefOr[TheInner] = {
+        new TheInner {
+          override val options: js.UndefOr[String] = "{" + pcFn + "}"
+        }
+      }
+    }
+
+    assertEquals(
+        """{"id":"some-some-value","paint":{"options":"{some-value}"}}""",
+        js.JSON.stringify(r0))
+  }
+
   @Test def local_object_is_lazy(): Unit = {
     var initCount: Int = 0
 


### PR DESCRIPTION
They are hidden in a separate object, which is itself stored in a non-enumerable field of the anonymous object. When possible, that field has a `Symbol` name. Otherwise, it is a string that is randomly generated at run-time with the same enthropy as a UUID.

Fixes #2748 because the non-enumerable field does not show up in `JSON.stringify` nor other kinds of cursory inspections (it can be found with `getOwnPropertySymbols()` and `getOwnPropertyDescriptors()`).

Fixes #3777 because we get rid of the `FieldDef`s that were declared in abstract JS types. The IR checker checks anew that abstract JS types do not have field declarations.