### PR TITLE
Fix #2680: Use Symbols for the private fields of JS classes.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -474,6 +474,14 @@ final class Emitter private (config: CommonPhaseConfig,
     val (linkedInlineableInit, linkedMethods) =
       classEmitter.extractInlineableInit(linkedClass)(classCache)
 
+    // Symbols for private JS fields
+    if (kind.isJSClass) {
+      val fieldDefs = classTreeCache.privateJSFields.getOrElseUpdate {
+        classEmitter.genCreatePrivateJSFieldDefsOfJSClass(linkedClass)
+      }
+      fieldDefs.foreach(addToMainBase(_))
+    }
+
     // Static-like methods
     for (m <- linkedMethods) {
       val methodDef = m.value
@@ -783,6 +791,7 @@ final class Emitter private (config: CommonPhaseConfig,
 
 private object Emitter {
   private final class DesugaredClassCache {
+    val privateJSFields = new OneTimeCache[List[js.Tree]]
     val exportedMembers = new OneTimeCache[WithGlobals[js.Tree]]
     val instanceTests = new OneTimeCache[js.Tree]
     val typeData = new OneTimeCache[WithGlobals[js.Tree]]

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -288,19 +288,16 @@ private[emitter] final class JSGen(val semantics: Semantics,
     envField("t", className, item.name, item.originalName)
   }
 
-  /* The similarity with `genSelect` is accidental. It will probably evolve in
-   * the future, to emit selections of symbols that are private to the
-   * Scala.js-generated code.
-   */
-  def genJSPrivateSelect(receiver: Tree, cls: ClassRef, field: irt.FieldIdent)(
+  def genJSPrivateSelect(receiver: Tree, className: ClassName,
+      field: irt.FieldIdent)(
       implicit pos: Position): Tree = {
-    DotSelect(receiver, genJSPrivateFieldIdent(cls.className, field)(field.pos))
+    BracketSelect(receiver,
+        genJSPrivateFieldIdent(className, field)(field.pos))
   }
 
-  // The similarity with `genFieldIdent is accidental. See above.
-  def genJSPrivateFieldIdent(cls: ClassName, field: irt.FieldIdent)(
-      implicit pos: Position): Ident = {
-    Ident(genName(cls) + "__f_" + genName(field.name), field.originalName)
+  def genJSPrivateFieldIdent(className: ClassName, field: irt.FieldIdent)(
+      implicit pos: Position): Tree = {
+    envField("r", className, field.name, field.originalName)
   }
 
   def genIsInstanceOf(expr: Tree, tpe: Type)(

--- a/project/NodeJSEnvForcePolyfills.scala
+++ b/project/NodeJSEnvForcePolyfills.scala
@@ -45,6 +45,7 @@ final class NodeJSEnvForcePolyfills(config: NodeJSEnv.Config) extends JSEnv {
           |delete Math.tanh;
           |
           |delete global.Promise;
+          |delete global.Symbol;
           |
           |delete global.Int8Array;
           |delete global.Int16Array;


### PR DESCRIPTION
Based on #3814. Only the last commit belongs to this PR.

---

Any encoding of field names as identifiers that we could come up would inevitably be prone to clashes, as we can never know which fields would be declared in superclasses, or worse, in subclasses.

Therefore, we now create one `Symbol` for each private field declaration, and we use that. When Symbols are not supported by the engine, we dynamically generate random names that have the same entropy as UUIDs. This does not guarantee that there will never be any clash, but it makes the likelihood close to zero.

There is no additional test, because there is no way to write a test that would have failed before this commit, and would still be relevant after this commit, given that the compilation has completely changed. Even removing the constraint that a test would need to fail before the commit, I cannot think of any test that would be relevant for this commit.