### PR TITLE
Fix #2627: IR-check duplicate definitions of Scala members.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/Definitions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Definitions.scala
@@ -343,6 +343,12 @@ object Definitions {
     override def toString(): String =
       "MethodName<" + nameString + ">"
 
+    def displayName: String = {
+      simpleName.nameString + "(" +
+      paramTypeRefs.map(_.displayName).mkString(",") + ")" +
+      resultTypeRef.fold("")(_.displayName)
+    }
+
     /** Returns `true` iff this is the name of an instance constructor. */
     def isConstructor: Boolean = kind == ConstructorKind
 

--- a/ir/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Types.scala
@@ -182,13 +182,30 @@ object Types {
       printer.print(this)
       writer.toString()
     }
+
+    def displayName: String
   }
 
   sealed abstract class NonArrayTypeRef extends TypeRef
 
   /** Primitive type reference. */
   final case class PrimRef private[ir] (tpe: PrimTypeWithRef)
-      extends NonArrayTypeRef
+      extends NonArrayTypeRef {
+
+    val displayName: String = tpe match {
+      case NoType      => "void"
+      case BooleanType => "boolean"
+      case CharType    => "char"
+      case ByteType    => "byte"
+      case ShortType   => "short"
+      case IntType     => "int"
+      case LongType    => "long"
+      case FloatType   => "float"
+      case DoubleType  => "double"
+      case NullType    => "null"
+      case NothingType => "nothing"
+    }
+  }
 
   final val VoidRef = PrimRef(NoType)
   final val BooleanRef = PrimRef(BooleanType)
@@ -203,11 +220,16 @@ object Types {
   final val NothingRef = PrimRef(NothingType)
 
   /** Class (or interface) type. */
-  final case class ClassRef(className: ClassName) extends NonArrayTypeRef
+  final case class ClassRef(className: ClassName) extends NonArrayTypeRef {
+    def displayName: String = className.nameString
+  }
 
   /** Array type. */
   final case class ArrayTypeRef(base: NonArrayTypeRef, dimensions: Int)
-      extends TypeRef
+      extends TypeRef {
+
+    def displayName: String = "[" * dimensions + base.displayName
+  }
 
   object ArrayTypeRef {
     def of(innerType: TypeRef): ArrayTypeRef = innerType match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -39,20 +39,6 @@ trait Analysis {
 
 object Analysis {
 
-  private val PrimRefDisplayNames: Map[PrimRef, String] = Map(
-      VoidRef -> "void",
-      BooleanRef -> "boolean",
-      CharRef -> "char",
-      ByteRef -> "byte",
-      ShortRef -> "short",
-      IntRef -> "int",
-      LongRef -> "long",
-      FloatRef -> "float",
-      DoubleRef -> "double",
-      NullRef -> "null",
-      NothingRef -> "nothing"
-  )
-
   /** Class node in a reachability graph produced by the [[Analyzer]].
    *
    *  Warning: this trait is not meant to be extended by third-party libraries
@@ -102,17 +88,7 @@ object Analysis {
     def nonExistent: Boolean
     def syntheticKind: MethodSyntheticKind
 
-    def displayName: String = {
-      def typeRefDisplayName(tpe: TypeRef): String = tpe match {
-        case primRef: PrimRef               => PrimRefDisplayNames(primRef)
-        case ClassRef(encodedName)          => encodedName.nameString
-        case ArrayTypeRef(base, dimensions) => "[" * dimensions + typeRefDisplayName(base)
-      }
-
-      encodedName.simpleName.nameString + "(" +
-      encodedName.paramTypeRefs.map(typeRefDisplayName).mkString(",") + ")" +
-      encodedName.resultTypeRef.fold("")(typeRefDisplayName)
-    }
+    def displayName: String = encodedName.displayName
 
     def fullDisplayName: String =
       this.namespace.prefixString + owner.displayName + "." + displayName

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -114,4 +114,6 @@ object TestIRBuilder {
 
   implicit def methodName2MethodIdent(name: MethodName): MethodIdent =
     MethodIdent(name)
+
+  def int(x: Int): IntLiteral = IntLiteral(x)
 }


### PR DESCRIPTION
Based on #3814. Only the last 2 commits belong to this PR.