### PR TITLE
Check that methods called exist on the static type, even if abstract.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -80,7 +80,7 @@ object Analysis {
     def owner: ClassInfo
     def methodName: MethodName
     def namespace: MemberNamespace
-    def isAbstract: Boolean
+    def isAbstractReachable: Boolean
     def isReachable: Boolean
     def calledFrom: scala.collection.Seq[From]
     def instantiatedSubclasses: scala.collection.Seq[ClassInfo]

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -99,7 +99,8 @@ final class BaseLinker(config: CommonPhaseConfig) {
 
     for {
       analysis <- Analyzer.computeReachability(config, symbolRequirements,
-          allowAddingSyntheticMethods = true, inputProvider)
+          allowAddingSyntheticMethods = true, checkAbstractReachability = true,
+          inputProvider)
     } yield {
       if (analysis.errors.nonEmpty) {
         reportErrors(analysis.errors)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -72,7 +72,8 @@ final class Refiner(config: CommonPhaseConfig) {
       implicit ec: ExecutionContext): Future[Analysis] = {
     for {
       analysis <- Analyzer.computeReachability(config, symbolRequirements,
-          allowAddingSyntheticMethods = false, inputProvider)
+          allowAddingSyntheticMethods = false,
+          checkAbstractReachability = false, inputProvider)
     } yield {
       /* There must not be linking errors at this point. If there are, it is a
        * bug in the optimizer.


### PR DESCRIPTION
Previously, the following program would link:

```scala
class A
class B {
  def foo(): Int = 1
}
val a: A = new B()
a.foo()
```
even though `foo` is not declared in `A`, because `A` itself is never instantiated.

This is not a problem for the current JavaScript emitter, nor for the optimizer, but it can be problematic in the future for:

* IR-checking that method calls are correct (#1419)
* a potential Wasm back-end, which might want to rely on the abstract methods being declared to build virtual method tables.

This commit performs the bare minimum that needs to be done before 1.0.0 in order to future-proof those two things: in the base linker (only), check that methods called exist on the static type of the argument, potentially as abstract methods.