### PR TITLE
Fix #3839: Treat objects/classes nested in `@JSGlobalScope` as global refs.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSGlobalScopeTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSGlobalScopeTest.scala
@@ -165,6 +165,44 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
+  def rejectInvalidJSIdentifiersInNestedObjectClass: Unit = {
+    """
+    @js.native
+    @JSGlobalScope
+    object EnclosingGlobalScope extends js.Any {
+      @js.native
+      class `not-a-valid-JS-identifier` extends js.Object
+
+      @js.native
+      @JSName("not-a-valid-JS-identifier")
+      object A extends js.Object
+
+      @js.native
+      @JSName("foo.bar")
+      object B extends js.Object
+
+      @js.native
+      @JSName("")
+      object C extends js.Object
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:43: error: The name of a JS global variable must be a valid JS identifier (got 'not-a-valid-JS-identifier')
+      |      class `not-a-valid-JS-identifier` extends js.Object
+      |            ^
+      |newSource1.scala:47: error: The name of a JS global variable must be a valid JS identifier (got 'not-a-valid-JS-identifier')
+      |      object A extends js.Object
+      |             ^
+      |newSource1.scala:51: error: The name of a JS global variable must be a valid JS identifier (got 'foo.bar')
+      |      object B extends js.Object
+      |             ^
+      |newSource1.scala:55: error: The name of a JS global variable must be a valid JS identifier (got '')
+      |      object C extends js.Object
+      |             ^
+    """
+  }
+
+  @Test
   def rejectJSOperators: Unit = {
     """
     object Main {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -368,6 +368,10 @@ class InteroperabilityTest {
       var interoperabilityTestGlobalScopeValueAsInt = function() {
         return parseInt(interoperabilityTestGlobalScopeValue);
       };
+      var InteroperabilityTestGlobalScopeObject = {foo: 456};
+      var InteroperabilityTestGlobalScopeClass = function() {
+        this.bar = 654;
+      };
     """)
 
     // Use alias for convenience: see end of file for definition
@@ -378,6 +382,14 @@ class InteroperabilityTest {
 
     Global.interoperabilityTestGlobalScopeValue = "42"
     assertEquals(42, Global.interoperabilityTestGlobalScopeValueAsInt)
+
+    assertEquals("object", js.typeOf(Global.InteroperabilityTestGlobalScopeObject))
+    assertEquals(456, Global.InteroperabilityTestGlobalScopeObject.foo)
+
+    assertEquals("function",
+        js.typeOf(js.constructorOf[Global.InteroperabilityTestGlobalScopeClassRenamed]))
+    val obj = new Global.InteroperabilityTestGlobalScopeClassRenamed
+    assertEquals(654, obj.bar)
   }
 
   @Test def should_protect_receiver_of_JS_apply_if_its_a_select_issue_804(): Unit = {
@@ -877,6 +889,17 @@ class InteroperabilityTestVariadicCtor(inargs: Any*) extends js.Object {
 object InteroperabilityTestGlobalScope extends js.Object {
   var interoperabilityTestGlobalScopeValue: String = js.native
   def interoperabilityTestGlobalScopeValueAsInt(): Int = js.native
+
+  @js.native
+  object InteroperabilityTestGlobalScopeObject extends js.Object {
+    val foo: Int = js.native
+  }
+
+  @js.native
+  @JSName("InteroperabilityTestGlobalScopeClass")
+  class InteroperabilityTestGlobalScopeClassRenamed extends js.Object {
+    val bar: Int = js.native
+  }
 }
 
 class SomeValueClass(val i: Int) extends AnyVal {


### PR DESCRIPTION
An `@js.native` object or class that is nested in an `@JSGlobalScope` object must be treated as a definition for a global ref. It is very similar to being annotated with `@JSGlobal`, except that path selections are not accepted, since `@JSName("foo.bar")` is supposed to mean selecting a member named `foo.bar`, whereas `@JSGlobal("foo.bar")` is supposed to mean selecting the global ref `foo`, and inside it select the member named `bar`.