### PR TITLE
Support `Match` nodes with non-int-literals in the back-end.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -477,7 +477,38 @@ class RegressionTest {
     assertThrows(classOf[MatchError], bug.bug(2, false))
   }
 
-  @Test def return_x_match_issue_2928(): Unit = {
+  @Test def return_x_match_issue_2928_ints(): Unit = {
+    // scalastyle:off return
+
+    def testNonUnit(x: Int): Boolean = {
+      return x match {
+        case 1 => true
+        case _ => false
+      }
+    }
+
+    var r: Option[Boolean] = None
+
+    def testUnit(x: Int): Unit = {
+      return x match {
+        case 1 => r = Some(true)
+        case _ => r = Some(false)
+      }
+    }
+
+    assertEquals(true, testNonUnit(1))
+    assertEquals(false, testNonUnit(2))
+
+    testUnit(1)
+    assertEquals(Some(true), r)
+    r = None
+    testUnit(2)
+    assertEquals(Some(false), r)
+
+    // scalastyle:on return
+  }
+
+  @Test def return_x_match_issue_2928_strings(): Unit = {
     // scalastyle:off return
 
     def testNonUnit(x: String): Boolean = {
@@ -503,6 +534,41 @@ class RegressionTest {
     assertEquals(Some(true), r)
     r = None
     testUnit("not true")
+    assertEquals(Some(false), r)
+
+    // scalastyle:on return
+  }
+
+  @Test def return_x_match_issue_2928_lists(): Unit = {
+    // scalastyle:off return
+
+    def testNonUnit(x: List[String]): Boolean = {
+      return x match {
+        case "True" :: Nil => true
+        case _             => false
+      }
+    }
+
+    var r: Option[Boolean] = None
+
+    def testUnit(x: List[String]): Unit = {
+      return x match {
+        case "True" :: Nil => r = Some(true)
+        case _             => r = Some(false)
+      }
+    }
+
+    assertEquals(true, testNonUnit("True" :: Nil))
+    assertEquals(false, testNonUnit("not true" :: Nil))
+    assertEquals(false, testNonUnit("True" :: "second" :: Nil))
+
+    testUnit("True" :: Nil)
+    assertEquals(Some(true), r)
+    r = None
+    testUnit("not true" :: Nil)
+    assertEquals(Some(false), r)
+    r = None
+    testUnit("True" :: "second" :: Nil)
     assertEquals(Some(false), r)
 
     // scalastyle:on return


### PR DESCRIPTION
See https://github.com/scala/scala/pull/8451 upstream (not yet merged, but fully approved)

---

Since Scala 2.13.2, the pattern matcher will keep `Match` nodes that match on `String`s and `null`s as is, to be desugared later in `cleanup`. This was implemented upstream in https://github.com/scala/scala/pull/8451

We implement a more general translation that will accept any kind of scalac `Literal`. If the scrutinee is an integer and all cases are int literals, we emit a `js.Match` as before. Otherwise, we emit an `if..else` chain with `===` comparisons.

---

Locally tested with:
```
> set resolvers in Global += "scala-pr-validation" at "https://scala-ci.typesafe.com/artifactory/scala-pr-validation-snapshots/"
> ++2.13.2-bin-9f25ca0-SNAPSHOT
> testSuite/test
> compiler/test
[...] copy the big test case from the PR in HelloWorld.scala and:
> helloworld/run
```

---

As noted at https://github.com/scala/scala/pull/8451#issuecomment-552495496, 0.6.x already works out of the box with the change upstream.

It actually raises the question whether we should revert the design of our `js.Match` to accept any kind of `js.Literal`s and really iron out the linker (notably for IR literals that are not JS literals, such as `ClassOf` and `LongLiteral`) instead of changing the compiler back-end. This PR implements the less disruptive change.