### PR TITLE
Fix #3827: Review original names

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -5617,12 +5617,12 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
 
       val classType = jstpe.ClassType(className)
 
-      // val f$1: Any
-      val fFieldIdent = js.FieldIdent(FieldName("f$1"), Some("f"))
+      // val f: Any
+      val fFieldIdent = js.FieldIdent(FieldName("f"))
       val fFieldDef = js.FieldDef(js.MemberFlags.empty, fFieldIdent,
           jstpe.AnyType)
 
-      // def this(f: Any) = { this.f$1 = f; super() }
+      // def this(f: Any) = { this.f = f; super() }
       val ctorDef = {
         val fParamDef = js.ParamDef(js.LocalIdent(LocalName("f")),
             jstpe.AnyType, mutable = false, rest = false)
@@ -5674,7 +5674,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         samsBuilder.result()
       }
 
-      // def samMethod(...params): resultType = this.f$f(...params)
+      // def samMethod(...params): resultType = this.f(...params)
       val samMethodDefs = for (sam <- sams) yield {
         val jsParams = for (param <- sam.tpe.params) yield {
           js.ParamDef(encodeLocalSym(param), toIRType(param.tpe),
@@ -5752,7 +5752,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         val paramTpe = paramTpes.getOrElse(paramSym.name, paramSym.tpe)
         val paramName = param.name
         val js.LocalIdent(name, origName) = paramName
-        val newOrigName = origName.getOrElse(name)
+        val newOrigName = origName.orElse(name)
         val newNameIdent = freshLocalIdent(name)(paramName.pos)
         val patchedParam = js.ParamDef(newNameIdent, jstpe.AnyType,
             mutable = false, rest = param.rest)(param.pos)

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -22,6 +22,7 @@ import scala.reflect.internal.Flags
 import org.scalajs.ir
 import org.scalajs.ir.{Trees => js, Types => jstpe}
 import org.scalajs.ir.Names.LocalName
+import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Trees.OptimizerHints
 
 import org.scalajs.nscplugin.util.ScopedVar
@@ -332,9 +333,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
           exported <- exporteds
           param <- exported.captureParamsFront ::: exported.captureParamsBack
         } yield {
-          implicit val pos = param.sym.pos
-          js.ParamDef(encodeLocalSym(param.sym), toIRType(param.tpe),
-              mutable = false, rest = false)
+          genParamDef(param.sym)
         })
       }
 
@@ -706,7 +705,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
       val jsVarArgPrep = repeatedTpe map { tpe =>
         val rhs = genJSArrayToVarArgs(genVarargRef(normalArgc, minArgc))
         val ident = freshLocalIdent("prep" + normalArgc)
-        js.VarDef(ident, rhs.tpe, mutable = false, rhs)
+        js.VarDef(ident, NoOriginalName, rhs.tpe, mutable = false, rhs)
       }
 
       // normal arguments
@@ -760,7 +759,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
           unboxedArg
         }
 
-        result += js.VarDef(freshLocalIdent("prep" + i),
+        result += js.VarDef(freshLocalIdent("prep" + i), NoOriginalName,
             verifiedOrDefault.tpe, mutable = false, verifiedOrDefault)
       }
 
@@ -1107,13 +1106,13 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
   }
 
   private def genFormalArg(index: Int)(implicit pos: Position): js.ParamDef = {
-    js.ParamDef(js.LocalIdent(LocalName("arg$" + index)), jstpe.AnyType,
-        mutable = false, rest = false)
+    js.ParamDef(js.LocalIdent(LocalName("arg$" + index)), NoOriginalName,
+        jstpe.AnyType, mutable = false, rest = false)
   }
 
   private def genRestFormalArg()(implicit pos: Position): js.ParamDef = {
-    js.ParamDef(js.LocalIdent(LocalName("arg$rest")), jstpe.AnyType,
-        mutable = false, rest = true)
+    js.ParamDef(js.LocalIdent(LocalName("arg$rest")), NoOriginalName,
+        jstpe.AnyType, mutable = false, rest = true)
   }
 
   private def genFormalArgRef(index: Int, minArgc: Int)(

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/MatchASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/MatchASTTest.scala
@@ -31,7 +31,7 @@ class MatchASTTest extends JSASTTest {
       }
     }
     """.hasExactly(1, "local variable") {
-      case js.VarDef(_, _, _, _) =>
+      case js.VarDef(_, _, _, _, _) =>
     }
   }
 
@@ -45,7 +45,7 @@ class MatchASTTest extends JSASTTest {
       }
     }
     """.hasExactly(1, "local variable") {
-      case js.VarDef(_, _, _, _) =>
+      case js.VarDef(_, _, _, _, _) =>
     }
   }
 

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
@@ -56,7 +56,7 @@ class OptimizationTest extends JSASTTest {
     }
     """.
     hasExactly(2, "calls to Array.apply methods") {
-      case js.Apply(_, js.LoadModule(ArrayModuleClass), js.MethodIdent(methodName, _), _)
+      case js.Apply(_, js.LoadModule(ArrayModuleClass), js.MethodIdent(methodName), _)
           if methodName.simpleName == applySimpleMethodName =>
     }
   }

--- a/ir/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -562,7 +562,7 @@ object Hashers {
         mixTag(TagRecordType)
         for (RecordType.Field(name, originalName, tpe, mutable) <- fields) {
           mixName(name)
-          originalName.foreach(mixString)
+          mixOriginalName(originalName)
           mixType(tpe)
           mixBoolean(mutable)
         }
@@ -571,7 +571,7 @@ object Hashers {
     def mixLocalIdent(ident: LocalIdent): Unit = {
       mixPos(ident.pos)
       mixName(ident.name)
-      ident.originalName.foreach(mixString)
+      mixOriginalName(ident.originalName)
     }
 
     def mixLabelIdent(ident: LabelIdent): Unit = {
@@ -582,26 +582,23 @@ object Hashers {
     def mixFieldIdent(ident: FieldIdent): Unit = {
       mixPos(ident.pos)
       mixName(ident.name)
-      ident.originalName.foreach(mixString)
+      mixOriginalName(ident.originalName)
     }
 
     def mixMethodIdent(ident: MethodIdent): Unit = {
       mixPos(ident.pos)
       mixMethodName(ident.name)
-      ident.originalName.foreach(mixString)
+      mixOriginalName(ident.originalName)
     }
 
     def mixClassIdent(ident: ClassIdent): Unit = {
       mixPos(ident.pos)
       mixName(ident.name)
-      ident.originalName.foreach(mixString)
+      mixOriginalName(ident.originalName)
     }
 
-    def mixName(name: Name): Unit = {
-      val encoded = name.encoded.bytes
-      digestStream.writeInt(encoded.length)
-      digestStream.write(encoded)
-    }
+    def mixName(name: Name): Unit =
+      mixBytes(name.encoded.bytes)
 
     def mixMethodName(name: MethodName): Unit = {
       mixName(name.simpleName)
@@ -610,6 +607,17 @@ object Hashers {
         mixTypeRef(typeRef)
       mixTypeRef(name.resultTypeRef)
       mixBoolean(name.isReflectiveProxy)
+    }
+
+    def mixOriginalName(originalName: OriginalName): Unit = {
+      mixBoolean(originalName.isDefined)
+      if (originalName.isDefined)
+        mixBytes(originalName.get.bytes)
+    }
+
+    private def mixBytes(bytes: Array[Byte]): Unit = {
+      digestStream.writeInt(bytes.length)
+      digestStream.write(bytes)
     }
 
     def mixPos(pos: Position): Unit = {

--- a/ir/src/main/scala/org/scalajs/ir/OriginalName.scala
+++ b/ir/src/main/scala/org/scalajs/ir/OriginalName.scala
@@ -1,0 +1,89 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.ir
+
+import Names._
+
+/** An optional original name.
+ *
+ *  Since an `OriginalName` is basically an optional `UTF8String`, original
+ *  names must always be well-formed Unicode strings. Unpaired surrogates are
+ *  not valid.
+ */
+final class OriginalName private (private val bytes: Array[Byte])
+    extends AnyVal {
+
+  /* The underlying field is a `bytes` instead of a `UTF8String` for two
+   * reasons:
+   * - a `UTF8String` cannot be `null`, and
+   * - the underlying val of a value class cannot itself be a custom value
+   *   class.
+   */
+
+  def isEmpty: Boolean = bytes == null
+  def isDefined: Boolean = bytes != null
+
+  /** Gets the underlying `UTF8String` without checking for emptiness. */
+  @inline private def unsafeGet: UTF8String =
+    UTF8String.unsafeCreate(bytes)
+
+  def get: UTF8String = {
+    if (isEmpty)
+      throw new NoSuchElementException("NoOriginalName.get")
+    unsafeGet
+  }
+
+  def orElse(name: Name): OriginalName =
+    orElse(name.encoded)
+
+  def orElse(name: MethodName): OriginalName =
+    orElse(name.simpleName)
+
+  def orElse(name: UTF8String): OriginalName =
+    if (isDefined) this
+    else OriginalName(name)
+
+  def getOrElse(name: Name): UTF8String =
+    getOrElse(name.encoded)
+
+  def getOrElse(name: MethodName): UTF8String =
+    getOrElse(name.simpleName)
+
+  def getOrElse(name: UTF8String): UTF8String =
+    if (isDefined) unsafeGet
+    else name
+
+  def getOrElse(name: String): UTF8String = {
+    /* Do not use `getOrElse(UTF8Sring(name))` so that we do not pay the cost
+     * of encoding the `name` in UTF-8 if `this.isDefined`.
+     */
+    if (isDefined) unsafeGet
+    else UTF8String(name)
+  }
+}
+
+object OriginalName {
+  val NoOriginalName: OriginalName = new OriginalName(null)
+
+  def apply(name: UTF8String): OriginalName =
+    new OriginalName(name.bytes)
+
+  def apply(name: Name): OriginalName =
+    apply(name.encoded)
+
+  def apply(name: MethodName): OriginalName =
+    apply(name.simpleName)
+
+  def apply(name: String): OriginalName =
+    apply(UTF8String(name))
+}

--- a/ir/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -25,7 +25,7 @@ object Traversers {
     def traverse(tree: Tree): Unit = tree match {
       // Definitions
 
-      case VarDef(ident, vtpe, mutable, rhs) =>
+      case VarDef(_, _, _, _, rhs) =>
         traverse(rhs)
 
       // Control flow constructs
@@ -56,11 +56,11 @@ object Traversers {
         traverse(body)
         traverse(cond)
 
-      case ForIn(obj, keyVar, body) =>
+      case ForIn(obj, _, _, body) =>
         traverse(obj)
         traverse(body)
 
-      case TryCatch(block, errVar, handler) =>
+      case TryCatch(block, _, _, handler) =>
         traverse(block)
         traverse(handler)
 
@@ -221,7 +221,7 @@ object Traversers {
       memberDef match {
         case _: AnyFieldDef =>
 
-        case MethodDef(_, _, _, _, body) =>
+        case MethodDef(_, _, _, _, _, body) =>
           body.foreach(traverse)
 
         case JSMethodDef(_, _, _, body) =>

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -48,44 +48,20 @@ object Trees {
 
   // Identifiers
 
-  case class LocalIdent(name: LocalName, originalName: OriginalName)(
-      implicit val pos: Position)
+  case class LocalIdent(name: LocalName)(implicit val pos: Position)
       extends IRNode
-
-  object LocalIdent {
-    def apply(name: LocalName)(implicit pos: Position): LocalIdent =
-      LocalIdent(name, NoOriginalName)
-  }
 
   case class LabelIdent(name: LabelName)(implicit val pos: Position)
       extends IRNode
 
-  case class FieldIdent(name: FieldName, originalName: OriginalName)(
-      implicit val pos: Position)
+  case class FieldIdent(name: FieldName)(implicit val pos: Position)
       extends IRNode
 
-  object FieldIdent {
-    def apply(name: FieldName)(implicit pos: Position): FieldIdent =
-      FieldIdent(name, NoOriginalName)
-  }
-
-  case class MethodIdent(name: MethodName, originalName: OriginalName)(
-      implicit val pos: Position)
+  case class MethodIdent(name: MethodName)(implicit val pos: Position)
       extends IRNode
 
-  object MethodIdent {
-    def apply(name: MethodName)(implicit pos: Position): MethodIdent =
-      MethodIdent(name, NoOriginalName)
-  }
-
-  case class ClassIdent(name: ClassName, originalName: OriginalName)(
-      implicit val pos: Position)
+  case class ClassIdent(name: ClassName)(implicit val pos: Position)
       extends IRNode
-
-  object ClassIdent {
-    def apply(name: ClassName)(implicit pos: Position): ClassIdent =
-      ClassIdent(name, NoOriginalName)
-  }
 
   /** Tests whether the given name is a valid JavaScript identifier name.
    *
@@ -115,15 +91,16 @@ object Trees {
 
   // Definitions
 
-  case class VarDef(name: LocalIdent, vtpe: Type, mutable: Boolean, rhs: Tree)(
+  case class VarDef(name: LocalIdent, originalName: OriginalName, vtpe: Type,
+      mutable: Boolean, rhs: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType // cannot be in expression position
 
     def ref(implicit pos: Position): VarRef = VarRef(name)(vtpe)
   }
 
-  case class ParamDef(name: LocalIdent, ptpe: Type, mutable: Boolean,
-      rest: Boolean)(
+  case class ParamDef(name: LocalIdent, originalName: OriginalName, ptpe: Type,
+      mutable: Boolean, rest: Boolean)(
       implicit val pos: Position) extends IRNode {
     def ref(implicit pos: Position): VarRef = VarRef(name)(ptpe)
   }
@@ -201,12 +178,14 @@ object Trees {
     val tpe = NoType // cannot be in expression position
   }
 
-  case class ForIn(obj: Tree, keyVar: LocalIdent, body: Tree)(
+  case class ForIn(obj: Tree, keyVar: LocalIdent,
+      keyVarOriginalName: OriginalName, body: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType
   }
 
-  case class TryCatch(block: Tree, errVar: LocalIdent, handler: Tree)(
+  case class TryCatch(block: Tree, errVar: LocalIdent,
+      errVarOriginalName: OriginalName, handler: Tree)(
       val tpe: Type)(implicit val pos: Position) extends Tree
 
   case class TryFinally(block: Tree, finalizer: Tree)(
@@ -965,6 +944,7 @@ object Trees {
 
   final class ClassDef(
       val name: ClassIdent,
+      val originalName: OriginalName,
       val kind: ClassKind,
       /** JS class captures.
        *
@@ -1009,6 +989,7 @@ object Trees {
   object ClassDef {
     def apply(
         name: ClassIdent,
+        originalName: OriginalName,
         kind: ClassKind,
         jsClassCaptures: Option[List[ParamDef]],
         superClass: Option[ClassIdent],
@@ -1019,8 +1000,9 @@ object Trees {
         topLevelExportDefs: List[TopLevelExportDef])(
         optimizerHints: OptimizerHints)(
         implicit pos: Position): ClassDef = {
-      new ClassDef(name, kind, jsClassCaptures, superClass, interfaces,
-          jsSuperClass, jsNativeLoadSpec, memberDefs, topLevelExportDefs)(
+      new ClassDef(name, originalName, kind, jsClassCaptures, superClass,
+          interfaces, jsSuperClass, jsNativeLoadSpec, memberDefs,
+          topLevelExportDefs)(
           optimizerHints)
     }
   }
@@ -1040,14 +1022,16 @@ object Trees {
     val ftpe: Type
   }
 
-  case class FieldDef(flags: MemberFlags, name: FieldIdent, ftpe: Type)(
+  case class FieldDef(flags: MemberFlags, name: FieldIdent,
+      originalName: OriginalName, ftpe: Type)(
       implicit val pos: Position) extends AnyFieldDef
 
   case class JSFieldDef(flags: MemberFlags, name: Tree, ftpe: Type)(
       implicit val pos: Position) extends AnyFieldDef
 
   case class MethodDef(flags: MemberFlags, name: MethodIdent,
-      args: List[ParamDef], resultType: Type, body: Option[Tree])(
+      originalName: OriginalName, args: List[ParamDef], resultType: Type,
+      body: Option[Tree])(
       val optimizerHints: OptimizerHints, val hash: Option[TreeHash])(
       implicit val pos: Position) extends MemberDef {
 

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -15,6 +15,7 @@ package org.scalajs.ir
 import scala.annotation.switch
 
 import Names._
+import OriginalName.NoOriginalName
 import Position.NoPosition
 import Types._
 
@@ -47,43 +48,43 @@ object Trees {
 
   // Identifiers
 
-  case class LocalIdent(name: LocalName, originalName: Option[String])(
+  case class LocalIdent(name: LocalName, originalName: OriginalName)(
       implicit val pos: Position)
       extends IRNode
 
   object LocalIdent {
     def apply(name: LocalName)(implicit pos: Position): LocalIdent =
-      LocalIdent(name, None)
+      LocalIdent(name, NoOriginalName)
   }
 
   case class LabelIdent(name: LabelName)(implicit val pos: Position)
       extends IRNode
 
-  case class FieldIdent(name: FieldName, originalName: Option[String])(
+  case class FieldIdent(name: FieldName, originalName: OriginalName)(
       implicit val pos: Position)
       extends IRNode
 
   object FieldIdent {
     def apply(name: FieldName)(implicit pos: Position): FieldIdent =
-      FieldIdent(name, None)
+      FieldIdent(name, NoOriginalName)
   }
 
-  case class MethodIdent(name: MethodName, originalName: Option[String])(
+  case class MethodIdent(name: MethodName, originalName: OriginalName)(
       implicit val pos: Position)
       extends IRNode
 
   object MethodIdent {
     def apply(name: MethodName)(implicit pos: Position): MethodIdent =
-      MethodIdent(name, None)
+      MethodIdent(name, NoOriginalName)
   }
 
-  case class ClassIdent(name: ClassName, originalName: Option[String])(
+  case class ClassIdent(name: ClassName, originalName: OriginalName)(
       implicit val pos: Position)
       extends IRNode
 
   object ClassIdent {
     def apply(name: ClassName)(implicit pos: Position): ClassIdent =
-      ClassIdent(name, None)
+      ClassIdent(name, NoOriginalName)
   }
 
   /** Tests whether the given name is a valid JavaScript identifier name.

--- a/ir/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Types.scala
@@ -148,7 +148,7 @@ object Types {
   }
 
   object RecordType {
-    final case class Field(name: FieldName, originalName: Option[String],
+    final case class Field(name: FieldName, originalName: OriginalName,
         tpe: Type, mutable: Boolean)
   }
 

--- a/ir/src/main/scala/org/scalajs/ir/UTF8String.scala
+++ b/ir/src/main/scala/org/scalajs/ir/UTF8String.scala
@@ -51,6 +51,15 @@ final class UTF8String private (private[ir] val bytes: Array[Byte])
 }
 
 object UTF8String {
+  /** Unsafely creates a `UTF8String` from a byte array.
+   *
+   *  This method does not validate the input array nor copies its contents. It
+   *  should only be used to recreate a `UTF8String` from a byte array that has
+   *  been extracted from a correctly validated `UTF8String`.
+   */
+  private[ir] def unsafeCreate(bytes: Array[Byte]): UTF8String =
+    new UTF8String(bytes)
+
   /** Creates a UTF-8 string from a byte array.
    *
    *  The input byte array will be copied to ensure the immutability of

--- a/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -18,6 +18,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import Names._
+import OriginalName.NoOriginalName
 import Printers._
 import Trees._
 import Types._
@@ -117,8 +118,8 @@ class PrintersTest {
 
     assertPrintEquals("(x: int, var y: any)",
         RecordType(List(
-            RecordType.Field("x", None, IntType, mutable = false),
-            RecordType.Field("y", None, AnyType, mutable = true))))
+            RecordType.Field("x", NoOriginalName, IntType, mutable = false),
+            RecordType.Field("y", NoOriginalName, AnyType, mutable = true))))
   }
 
   @Test def printTypeRef(): Unit = {
@@ -591,8 +592,8 @@ class PrintersTest {
     assertPrintEquals("(x = 3, y = 4)",
         RecordValue(
             RecordType(List(
-                RecordType.Field("x", None, IntType, mutable = false),
-                RecordType.Field("y", None, IntType, mutable = true))),
+                RecordType.Field("x", NoOriginalName, IntType, mutable = false),
+                RecordType.Field("y", NoOriginalName, IntType, mutable = true))),
             List(i(3), i(4))))
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -595,7 +595,7 @@ object Infos {
               // This should only happen when called from the Refiner
               args.foreach(traverse)
 
-            case VarDef(_, vtpe, _, _) =>
+            case VarDef(_, _, vtpe, _, _) =>
               builder.maybeAddReferencedClass(vtpe)
 
             case _ =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -14,6 +14,7 @@ package org.scalajs.linker.backend.emitter
 
 import org.scalajs.ir._
 import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Position._
 import org.scalajs.ir.Transformers._
 import org.scalajs.ir.Trees._
@@ -413,7 +414,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
       implicit val pos = field.pos
 
       val symbolValue = {
-        def description = origName.getOrElse(name.nameString)
+        def description = origName.getOrElse(name).toString()
         val args =
           if (semantics.productionMode) Nil
           else js.StringLiteral(description) :: Nil
@@ -459,7 +460,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
     implicit val pos = tree.pos
     if (hasStaticInitializer(tree)) {
       val field = envField("sct", tree.className, StaticInitializerName,
-          Some("<clinit>"))
+          StaticInitializerOriginalName)
       js.Apply(field, Nil) :: Nil
     } else {
       Nil
@@ -1271,7 +1272,8 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
   }
 
   private def envFunctionDef(field: String, subField: String,
-      args: List[js.ParamDef], body: js.Tree, origName: Option[String] = None)(
+      args: List[js.ParamDef], body: js.Tree,
+      origName: OriginalName = NoOriginalName)(
       implicit pos: Position): js.FunctionDef = {
 
     val globalVar = envField(field, subField, origName)
@@ -1288,7 +1290,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
   }
 
   private def envFieldDef(field: String, className: ClassName,
-      fieldName: FieldName, value: js.Tree, origName: Option[String],
+      fieldName: FieldName, value: js.Tree, origName: OriginalName,
       mutable: Boolean)(
       implicit pos: Position): js.Tree = {
 
@@ -1298,7 +1300,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
   }
 
   private def envFieldDef(field: String, className: ClassName,
-      methodName: MethodName, value: js.Tree, origName: Option[String])(
+      methodName: MethodName, value: js.Tree, origName: OriginalName)(
       implicit pos: Position): js.Tree = {
 
     envFieldDefGeneric(
@@ -1307,7 +1309,7 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
   }
 
   private def envFieldDef(field: String, subField: String, value: js.Tree,
-      origName: Option[String], mutable: Boolean,
+      origName: OriginalName, mutable: Boolean,
       keepFunctionExpression: Boolean)(
       implicit pos: Position): js.Tree = {
 
@@ -1359,6 +1361,9 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
 }
 
 private[emitter] object ClassEmitter {
+  private val StaticInitializerOriginalName: OriginalName =
+    OriginalName("<clinit>")
+
   private val ClassesWhoseDataReferToTheirInstanceTests =
     AncestorsOfHijackedClasses + BoxedStringClass
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -17,6 +17,7 @@ import scala.language.implicitConversions
 import org.scalajs.ir.ScalaJSVersions
 import org.scalajs.ir.Position
 import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Trees.{JSUnaryOp, JSBinaryOp}
 import org.scalajs.ir.Types._
 
@@ -605,7 +606,7 @@ private[emitter] object CoreJSLib {
         }
 
         def genHijackedMethodApply(className: ClassName): Tree =
-          Apply(envField("f", className, methodName, None), instance :: args)
+          Apply(envField("f", className, methodName, NoOriginalName), instance :: args)
 
         def genBodyNoSwitch(implementingHijackedClasses: List[ClassName]): Tree = {
           val normalCall = Apply(instance DOT genName(methodName), args)
@@ -1476,7 +1477,7 @@ private[emitter] object CoreJSLib {
 
     private def genScalaClassNew(className: ClassName, ctorName: MethodName,
         args: Tree*): Tree = {
-      Apply(envField("ct", className, ctorName, None),
+      Apply(envField("ct", className, ctorName, NoOriginalName),
           New(encodeClassVar(className), Nil) :: args.toList)
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
 
 import org.scalajs.ir.{ClassKind, Position}
 import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Trees.{JSNativeLoadSpec, MemberNamespace}
 
 import org.scalajs.logging._
@@ -178,7 +179,7 @@ final class Emitter private (config: CommonPhaseConfig,
           }
         } {
           implicit val pos = NoPosition
-          val field = envField("f", className, methodName, None).ident
+          val field = envField("f", className, methodName, NoOriginalName).ident
           builder.addJSTree(js.VarDef(field, None))
         }
       }
@@ -195,7 +196,7 @@ final class Emitter private (config: CommonPhaseConfig,
           })
         if (!ctorIsDefined) {
           implicit val pos = NoPosition
-          val field = envField("ct", className, ctorName, None).ident
+          val field = envField("ct", className, ctorName, NoOriginalName).ident
           builder.addJSTree(js.VarDef(field, None))
         }
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -542,7 +542,8 @@ final class Emitter private (config: CommonPhaseConfig,
               methodDef.args.map(_.ref))(
               methodDef.resultType)
           val newMethodDef = MethodDef(MemberFlags.empty, methodName,
-              methodDef.args, methodDef.resultType, Some(newBody))(
+              methodDef.originalName, methodDef.args, methodDef.resultType,
+              Some(newBody))(
               OptimizerHints.empty, None)
           new Versioned(newMethodDef, m.version)
         }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -18,6 +18,7 @@ import scala.collection.mutable
 
 import org.scalajs.ir._
 import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Position._
 import org.scalajs.ir.Transformers._
 import org.scalajs.ir.Trees._
@@ -396,15 +397,17 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
 
     // Record names
 
-    def makeRecordFieldIdent(tree: RecordSelect)(
+    def makeRecordFieldIdentForVarRef(tree: RecordSelect)(
         implicit pos: Position): js.Ident = {
 
       val recIdent = (tree.record: @unchecked) match {
         case VarRef(ident)                 => transformLocalVarIdent(ident)
         case Transient(JSVarRef(ident, _)) => ident
-        case record: RecordSelect          => makeRecordFieldIdent(record)
+        case record: RecordSelect          => makeRecordFieldIdentForVarRef(record)
       }
-      makeRecordFieldIdent(recIdent, tree.field.name, tree.field.originalName)
+
+      // Since this is only used for VarRefs, we never need an original name
+      makeRecordFieldIdent(recIdent, tree.field.name, NoOriginalName)
     }
 
     def makeRecordFieldIdent(recIdent: js.Ident,
@@ -497,7 +500,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
       val counterIdent = newSyntheticVar()
       val counter = js.VarRef(counterIdent)
 
-      val restParamIdent = transformLocalVarIdent(restParamDef.name)
+      val restParamIdent = transformLocalVarIdent(restParamDef.name,
+          restParamDef.originalName)
       val restParam = js.VarRef(restParamIdent)
 
       val arguments = js.VarRef(js.Ident("arguments"))
@@ -537,7 +541,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
         // VarDefs at the end of block. Normal VarDefs are handled in
         // transformBlockStats
 
-        case VarDef(_, _, _, rhs) =>
+        case VarDef(_, _, _, _, rhs) =>
           pushLhsInto(Lhs.Discard, rhs, tailPosLabels)
 
         // Statement-only language constructs
@@ -574,8 +578,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           }
 
         case Assign(lhs: RecordSelect, rhs) =>
-          val newLhs =
-            Transient(JSVarRef(makeRecordFieldIdent(lhs), mutable = true))(lhs.tpe)
+          val newLhs = Transient(JSVarRef(makeRecordFieldIdentForVarRef(lhs),
+              mutable = true))(lhs.tpe)
           pushLhsInto(Lhs.Assign(newLhs), rhs, tailPosLabels)
 
         case Assign(select @ JSPrivateSelect(qualifier, className, field), rhs) =>
@@ -693,11 +697,12 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             })
           }
 
-        case ForIn(obj, keyVar, body) =>
+        case ForIn(obj, keyVar, keyVarOriginalName, body) =>
           unnest(obj) { (newObj, env0) =>
             implicit val env = env0
 
-            val lhs = genEmptyImmutableLet(transformLocalVarIdent(keyVar))
+            val lhs = genEmptyImmutableLet(
+                transformLocalVarIdent(keyVar, keyVarOriginalName))
             js.ForIn(lhs, transformExprNoChar(newObj), {
               transformStat(body, Set.empty)(
                   env.withDef(keyVar, mutable = false))
@@ -789,7 +794,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                 else genZeroOf(field.ftpe)
 
               field match {
-                case FieldDef(_, name, _) =>
+                case FieldDef(_, name, _, _) =>
                   js.Assign(
                       genJSPrivateSelect(js.This(), enclosingClassName, name),
                       zero)
@@ -845,9 +850,10 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
       @tailrec
       def transformLoop(trees: List[Tree], env: Env,
           acc: List[js.Tree]): (List[js.Tree], Env) = trees match {
-        case VarDef(ident, tpe, mutable, rhs) :: ts =>
+        case VarDef(ident, originalName, tpe, mutable, rhs) :: ts =>
           val newEnv = env.withDef(ident, mutable)
-          val lhs = Lhs.VarDef(transformLocalVarIdent(ident), tpe, mutable)
+          val lhs = Lhs.VarDef(transformLocalVarIdent(ident, originalName),
+              tpe, mutable)
           val newTree = pushLhsInto(lhs, rhs, Set.empty)(env)
           transformLoop(ts, newEnv, newTree :: acc)
 
@@ -933,7 +939,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                 js.Block(jsStats) +=: extractedStatements
                 innerEnv = stats.foldLeft(innerEnv) { (prev, stat) =>
                   stat match {
-                    case VarDef(name, tpe, mutable, _) =>
+                    case VarDef(name, _, _, mutable, _) =>
                       prev.withDef(name, mutable)
                     case _ =>
                       prev
@@ -1286,7 +1292,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           val base = js.Assign(transformExpr(lhs, preserveChar = true),
               transformExpr(rhs, lhs.tpe))
           lhs match {
-            case SelectStatic(className, FieldIdent(field, _))
+            case SelectStatic(className, FieldIdent(field))
                 if moduleKind == ModuleKind.NoModule =>
               val mirrors =
                 globalKnowledge.getStaticFieldMirrors(className, field)
@@ -1473,12 +1479,13 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             }
           }
 
-        case TryCatch(block, errVar, handler) =>
+        case TryCatch(block, errVar, errVarOriginalName, handler) =>
           extractLet { newLhs =>
             val newBlock = pushLhsInto(newLhs, block, tailPosLabels)(env)
             val newHandler = pushLhsInto(newLhs, handler, tailPosLabels)(
                 env.withDef(errVar, mutable = false))
-            js.TryCatch(newBlock, transformLocalVarIdent(errVar), newHandler)
+            js.TryCatch(newBlock,
+                transformLocalVarIdent(errVar, errVarOriginalName), newHandler)
           }
 
         case TryFinally(block, finalizer) =>
@@ -1988,10 +1995,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           def genDispatchApply(): js.Tree =
             genCallHelper("dp_" + genName(methodName), newReceiver :: newArgs: _*)
 
-          def genHijackedMethodApply(className: ClassName): js.Tree = {
-            js.Apply(envField("f", className, methodName, method.originalName),
-                newReceiver :: newArgs)
-          }
+          def genHijackedMethodApply(className: ClassName): js.Tree =
+            js.Apply(envField("f", className, methodName), newReceiver :: newArgs)
 
           if (isMaybeHijackedClass(receiver.tpe) &&
               !methodName.isReflectiveProxy) {
@@ -2406,7 +2411,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           }
 
         case tree: RecordSelect =>
-          js.VarRef(makeRecordFieldIdent(tree))
+          js.VarRef(makeRecordFieldIdentForVarRef(tree))
 
         case IsInstanceOf(expr, testType) =>
           genIsInstanceOf(transformExprNoChar(expr), testType)
@@ -2571,7 +2576,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
           if (env.isLocalVar(name))
             js.VarRef(transformLocalVarIdent(name))
           else
-            envField("cc", genName(name.name), name.originalName)
+            envField("cc", genName(name.name))
 
         case Transient(JSVarRef(name, _)) =>
           js.VarRef(name)
@@ -2678,7 +2683,8 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
     )
 
     private def transformParamDef(paramDef: ParamDef): js.ParamDef = {
-      js.ParamDef(transformLocalVarIdent(paramDef.name), paramDef.rest)(
+      js.ParamDef(transformLocalVarIdent(paramDef.name, paramDef.originalName),
+          paramDef.rest)(
           paramDef.pos)
     }
 
@@ -2686,10 +2692,17 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
       js.Ident(genName(ident.name))(ident.pos)
 
     private def transformMethodIdent(ident: MethodIdent): js.Ident =
-      js.Ident(genName(ident.name), ident.originalName)(ident.pos)
+      js.Ident(genName(ident.name))(ident.pos)
 
     private def transformLocalVarIdent(ident: LocalIdent): js.Ident =
-      js.Ident(transformLocalName(ident.name), ident.originalName)(ident.pos)
+      js.Ident(transformLocalName(ident.name))(ident.pos)
+
+    private def transformLocalVarIdent(ident: LocalIdent,
+        originalName: OriginalName): js.Ident = {
+      val jsName = transformLocalName(ident.name)
+      js.Ident(jsName, genOriginalName(ident.name, originalName, jsName))(
+          ident.pos)
+    }
 
     private def transformGlobalVarIdent(name: String)(
         implicit pos: Position): js.Ident = {
@@ -2715,8 +2728,7 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
     private def genApplyStaticLike(field: String, className: ClassName,
         method: MethodIdent, args: List[js.Tree])(
         implicit pos: Position): js.Tree = {
-      js.Apply(envField(field, className, method.name, method.originalName),
-          args)
+      js.Apply(envField(field, className, method.name), args)
     }
 
     private def genFround(arg: js.Tree)(implicit pos: Position): js.Tree = {
@@ -2828,8 +2840,7 @@ private object FunctionEmitter {
 
     def withParams(params: List[ParamDef]): Env = {
       params.foldLeft(this) {
-        case (env, ParamDef(name, tpe, mutable, _)) =>
-          // ParamDefs may not contain record types
+        case (env, ParamDef(name, _, _, mutable, _)) =>
           env.withDef(name, mutable)
       }
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -20,6 +20,7 @@ import scala.collection.mutable
 
 import org.scalajs.ir._
 import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Types._
 import org.scalajs.ir.{Trees => irt}
 
@@ -474,7 +475,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
 
     spec match {
       case irt.JSNativeLoadSpec.Global(globalRef, path) =>
-        val globalVarRef = VarRef(Ident(globalRef, Some(globalRef)))
+        val globalVarRef = VarRef(Ident(globalRef))
         val globalVarNames = {
           if (keepOnlyDangerousVarNames && !trackAllGlobalRefs &&
               !GlobalRefUtils.isDangerousGlobalRef(globalRef)) {
@@ -572,7 +573,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
       if (containsOnlyValidChars()) "$i_" + module
       else buildValidName()
 
-    VarRef(Ident(avoidClashWithGlobalRef(varName), Some(module)))
+    VarRef(Ident(avoidClashWithGlobalRef(varName), OriginalName(module)))
   }
 
   def envField(field: String, typeRef: NonArrayTypeRef)(
@@ -584,18 +585,19 @@ private[emitter] final class JSGen(val semantics: Semantics,
     envField(field, genName(className))
 
   def envField(field: String, className: ClassName, fieldName: FieldName,
-      origName: Option[String])(
+      origName: OriginalName)(
       implicit pos: Position): VarRef = {
     envField(field, genName(className) + "__" + genName(fieldName), origName)
   }
 
   def envField(field: String, className: ClassName, methodName: MethodName,
-      origName: Option[String])(
+      origName: OriginalName)(
       implicit pos: Position): VarRef = {
     envField(field, genName(className) + "__" + genName(methodName), origName)
   }
 
-  def envField(field: String, subField: String, origName: Option[String] = None)(
+  def envField(field: String, subField: String,
+      origName: OriginalName = NoOriginalName)(
       implicit pos: Position): VarRef = {
     VarRef(envFieldIdent(field, subField, origName))
   }
@@ -625,7 +627,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
   }
 
   def envFieldIdent(field: String, subField: String,
-      origName: Option[String] = None)(
+      origName: OriginalName = NoOriginalName)(
       implicit pos: Position): Ident = {
     Ident(avoidClashWithGlobalRef("$" + field + "_" + subField), origName)
   }
@@ -634,9 +636,9 @@ private[emitter] final class JSGen(val semantics: Semantics,
     VarRef(envFieldIdent(field))
 
   def envFieldIdent(field: String)(implicit pos: Position): Ident =
-    envFieldIdent(field, None)
+    envFieldIdent(field, NoOriginalName)
 
-  def envFieldIdent(field: String, origName: Option[String])(
+  def envFieldIdent(field: String, origName: OriginalName)(
       implicit pos: Position): Ident = {
     Ident(avoidClashWithGlobalRef("$" + field), origName)
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -220,6 +220,53 @@ private[emitter] final class JSGen(val semantics: Semantics,
     })
   }
 
+  def genOriginalName(name: Name, originalName: OriginalName,
+      jsName: String): OriginalName = {
+    genOriginalName(name.encoded, originalName, jsName)
+  }
+
+  def genOriginalName(name: MethodName, originalName: OriginalName,
+      jsName: String): OriginalName = {
+    genOriginalName(name.simpleName, originalName, jsName)
+  }
+
+  private def genOriginalName(name: UTF8String, originalName: OriginalName,
+      jsName: String): OriginalName = {
+
+    def sameName: Boolean = {
+      /* This method compares a UTF-8 string and a (UTF-16) string
+       * element-wise, thus comparing bytes with chars, in order to avoid any
+       * recoding. We can do this here because:
+       *
+       * - for ASCII characters, the byte and char values are the same
+       * - for non-ASCII characters, the byte value is always negative while
+       *   the char values are always positive, so the comparison is always
+       *   false
+       * - the always-false result for non-ASCII characters is correct in the
+       *   case of `JSGen`, because all non-ASCII code points in `Name`s are
+       *   encoded in `genName()` byte-by-byte into Chars that have lost all
+       *   connection to what they meant, so any non-ASCII character will
+       *   require an original name to be generated.
+       */
+
+      // scalastyle:off return
+      if (name.length != jsName.length())
+        return false
+      var i = 0
+      while (i != name.length) {
+        if (name(i).toInt != jsName.charAt(i).toInt)
+          return false
+        i += 1
+      }
+      true
+      // scalastyle:on return
+    }
+
+    if (originalName.isDefined) originalName
+    else if (sameName) NoOriginalName
+    else OriginalName(name)
+  }
+
   def genZeroOf(tpe: Type)(implicit pos: Position): Tree = {
     tpe match {
       case BooleanType => BooleanLiteral(false)
@@ -278,17 +325,23 @@ private[emitter] final class JSGen(val semantics: Semantics,
 
   def genSelect(receiver: Tree, className: ClassName, field: irt.FieldIdent)(
       implicit pos: Position): Tree = {
-    DotSelect(receiver, genFieldIdent(className, field)(field.pos))
+    DotSelect(receiver, Ident(genFieldJSName(className, field))(field.pos))
   }
 
-  private def genFieldIdent(className: ClassName, field: irt.FieldIdent)(
-      implicit pos: Position): Ident = {
-    Ident(genName(className) + "__f_" + genName(field.name), field.originalName)
+  def genSelect(receiver: Tree, className: ClassName, field: irt.FieldIdent,
+      originalName: OriginalName)(
+      implicit pos: Position): Tree = {
+    val jsName = genFieldJSName(className, field)
+    val jsOrigName = genOriginalName(field.name, originalName, jsName)
+    DotSelect(receiver, Ident(jsName, jsOrigName)(field.pos))
   }
+
+  private def genFieldJSName(className: ClassName, field: irt.FieldIdent): String =
+    genName(className) + "__f_" + genName(field.name)
 
   def genSelectStatic(className: ClassName, item: irt.FieldIdent)(
       implicit pos: Position): VarRef = {
-    envField("t", className, item.name, item.originalName)
+    envField("t", className, item.name)
   }
 
   def genJSPrivateSelect(receiver: Tree, className: ClassName,
@@ -300,7 +353,7 @@ private[emitter] final class JSGen(val semantics: Semantics,
 
   def genJSPrivateFieldIdent(className: ClassName, field: irt.FieldIdent)(
       implicit pos: Position): Tree = {
-    envField("r", className, field.name, field.originalName)
+    envField("r", className, field.name)
   }
 
   def genIsInstanceOf(expr: Tree, tpe: Type)(
@@ -584,10 +637,20 @@ private[emitter] final class JSGen(val semantics: Semantics,
   def envField(field: String, className: ClassName)(implicit pos: Position): VarRef =
     envField(field, genName(className))
 
+  def envField(field: String, className: ClassName, fieldName: FieldName)(
+      implicit pos: Position): VarRef = {
+    envField(field, className, fieldName, NoOriginalName)
+  }
+
   def envField(field: String, className: ClassName, fieldName: FieldName,
       origName: OriginalName)(
       implicit pos: Position): VarRef = {
     envField(field, genName(className) + "__" + genName(fieldName), origName)
+  }
+
+  def envField(field: String, className: ClassName, methodName: MethodName)(
+      implicit pos: Position): VarRef = {
+    envField(field, className, methodName, NoOriginalName)
   }
 
   def envField(field: String, className: ClassName, methodName: MethodName,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -280,7 +280,7 @@ private[emitter] final class KnowledgeGuardian(config: CommonPhaseConfig) {
         val result = mutable.Map.empty[FieldName, List[String]]
         for (export <- linkedClass.topLevelExports) {
           export.value match {
-            case TopLevelFieldExportDef(exportName, FieldIdent(fieldName, _)) =>
+            case TopLevelFieldExportDef(exportName, FieldIdent(fieldName)) =>
               result(fieldName) = exportName :: result.getOrElse(fieldName, Nil)
             case _ =>
               ()

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/SourceMapWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/SourceMapWriter.scala
@@ -19,8 +19,9 @@ import java.{util => ju}
 import scala.collection.mutable.{ ListBuffer, HashMap, Stack, StringBuilder }
 
 import org.scalajs.ir
-import ir.Position
-import ir.Position._
+import org.scalajs.ir.OriginalName
+import org.scalajs.ir.Position
+import org.scalajs.ir.Position._
 
 private object SourceMapWriter {
   private val Base64Map =
@@ -154,9 +155,10 @@ private[javascript] class SourceMapWriter(
   }
 
   def startIdentNode(column: Int, originalPos: Position,
-      optOriginalName: Option[String]): Unit = {
+      optOriginalName: OriginalName): Unit = {
+    // TODO The then branch allocates a String; we should avoid that at some point
     val originalName =
-      if (optOriginalName.isDefined) optOriginalName.get
+      if (optOriginalName.isDefined) optOriginalName.get.toString()
       else null
     nodePosStack.push(originalPos, originalName)
     startSegment(column, originalPos, isIdent = true, originalName)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -15,8 +15,9 @@ package org.scalajs.linker.backend.javascript
 import scala.annotation.switch
 
 import org.scalajs.ir
-import ir.Position
-import ir.Position.NoPosition
+import org.scalajs.ir.{OriginalName, Position}
+import org.scalajs.ir.OriginalName.NoOriginalName
+import org.scalajs.ir.Position.NoPosition
 
 object Trees {
   /** AST node of JavaScript. */
@@ -41,7 +42,7 @@ object Trees {
     def pos: Position
   }
 
-  case class Ident(name: String, originalName: Option[String])(
+  case class Ident(name: String, originalName: OriginalName)(
       implicit val pos: Position) extends PropertyName {
     require(Ident.isValidJSIdentifierName(name),
         s"'$name' is not a valid JS identifier name")
@@ -49,7 +50,7 @@ object Trees {
 
   object Ident {
     def apply(name: String)(implicit pos: Position): Ident =
-      new Ident(name, Some(name))
+      new Ident(name, NoOriginalName)
 
     /** Tests whether the given string is a valid `IdentifierName` for the
      *  ECMAScript language specification.

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/MethodSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/MethodSynthesizer.scala
@@ -59,7 +59,7 @@ private[frontend] final class MethodSynthesizer(
       implicit val pos = targetMDef.pos
 
       val targetIdent = targetMDef.name.copy() // for the new pos
-      val proxyIdent = MethodIdent(methodName, None)
+      val proxyIdent = MethodIdent(methodName)
       val params = targetMDef.args.map(_.copy()) // for the new pos
       val currentClassType = ClassType(classInfo.className)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/MethodSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/MethodSynthesizer.scala
@@ -73,7 +73,8 @@ private[frontend] final class MethodSynthesizer(
         call
       }
 
-      MethodDef(MemberFlags.empty, proxyIdent, params, AnyType, Some(body))(
+      MethodDef(MemberFlags.empty, proxyIdent, targetMDef.originalName, params,
+          AnyType, Some(body))(
           OptimizerHints.empty, targetMDef.hash)
     }
   }
@@ -100,8 +101,8 @@ private[frontend] final class MethodSynthesizer(
           ApplyFlags.empty, This()(currentClassType), targetInterface,
           targetIdent, params.map(_.ref))(targetMDef.resultType)
 
-      MethodDef(MemberFlags.empty, bridgeIdent, params, targetMDef.resultType,
-          Some(body))(
+      MethodDef(MemberFlags.empty, bridgeIdent, targetMDef.originalName,
+          params, targetMDef.resultType, Some(body))(
           OptimizerHints.empty, targetMDef.hash)
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -124,7 +124,8 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
   def optimize(thisType: Type, originalDef: MethodDef): MethodDef = {
     try {
-      val MethodDef(static, name, params, resultType, optBody) = originalDef
+      val MethodDef(static, name, originalName, params, resultType, optBody) =
+        originalDef
       val body = optBody getOrElse {
         throw new AssertionError("Methods to optimize must be concrete")
       }
@@ -145,7 +146,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       val newBody =
         if (originalDef.methodName == NoArgConstructorName) tryElimStoreModule(newBody1)
         else newBody1
-      MethodDef(static, name, newParams, resultType,
+      MethodDef(static, name, originalName, newParams, resultType,
           Some(newBody))(originalDef.optimizerHints, None)(originalDef.pos)
     } catch {
       case NonFatal(cause) =>
@@ -192,18 +193,29 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
   private def addStateBackup(backup: StateBackup): Unit =
     stateBackupChain ::= backup
 
-  private def freshLocalName(base: LocalName, mutable: Boolean): LocalName = {
+  private def freshLocalNameWithoutOriginalName(base: LocalName,
+      mutable: Boolean): LocalName = {
     val result = localNameAllocator.freshName(base)
     if (mutable)
       mutableLocalNames += result
     result
   }
 
-  private def freshLocalName(base: Binding.Name, mutable: Boolean): LocalName = {
-    freshLocalName(base match {
-      case Binding.This           => LocalThisNameForFresh
-      case Binding.Local(name, _) => name
-    }, mutable)
+  private def freshLocalName(base: LocalName, originalName: OriginalName,
+      mutable: Boolean): (LocalName, OriginalName) = {
+    val newName = freshLocalNameWithoutOriginalName(base, mutable)
+    val newOriginalName = originalNameForFresh(base, originalName, newName)
+    (newName, newOriginalName)
+  }
+
+  private def freshLocalName(base: Binding.Name,
+      mutable: Boolean): (LocalName, OriginalName) = {
+    base match {
+      case Binding.This =>
+        freshLocalName(LocalThisNameForFresh, thisOriginalName, mutable)
+      case Binding.Local(name, originalName) =>
+        freshLocalName(name, originalName, mutable)
+    }
   }
 
   private def freshLabelName(base: LabelName): LabelName =
@@ -285,7 +297,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     val result = tree match {
       // Definitions
 
-      case VarDef(_, _, _, rhs) =>
+      case VarDef(_, _, _, _, rhs) =>
         /* A local var that is last (or alone) in its block is not terribly
          * useful. Get rid of it.
          * (Non-last VarDefs in blocks are handled in transformBlock.)
@@ -402,32 +414,32 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case _                     => DoWhile(newBody, newCond)
         }
 
-      case ForIn(obj, keyVar @ LocalIdent(name, originalName), body) =>
+      case ForIn(obj, keyVar @ LocalIdent(name), originalName, body) =>
         val newObj = transformExpr(obj)
-        val newName = freshLocalName(name, mutable = false)
-        val newOriginalName = originalName.orElse(name)
+        val (newName, newOriginalName) =
+          freshLocalName(name, originalName, mutable = false)
         val localDef = LocalDef(RefinedType(AnyType), mutable = false,
-            ReplaceWithVarRef(newName, newOriginalName, newSimpleState(true), None))
+            ReplaceWithVarRef(newName, newSimpleState(true), None))
         val newBody = {
           val bodyScope = scope.withEnv(scope.env.withLocalDef(name, localDef))
           transformStat(body)(bodyScope)
         }
-        ForIn(newObj, LocalIdent(newName, newOriginalName)(keyVar.pos), newBody)
+        ForIn(newObj, LocalIdent(newName)(keyVar.pos), newOriginalName, newBody)
 
-      case TryCatch(block, errVar @ LocalIdent(name, originalName), handler) =>
+      case TryCatch(block, errVar @ LocalIdent(name), originalName, handler) =>
         val newBlock = transform(block, isStat)
 
-        val newName = freshLocalName(name, false)
-        val newOriginalName = originalName.orElse(name)
+        val (newName, newOriginalName) =
+          freshLocalName(name, originalName, mutable = false)
         val localDef = LocalDef(RefinedType(AnyType), true,
-            ReplaceWithVarRef(newName, newOriginalName, newSimpleState(true), None))
+            ReplaceWithVarRef(newName, newSimpleState(true), None))
         val newHandler = {
           val handlerScope = scope.withEnv(scope.env.withLocalDef(name, localDef))
           transform(handler, isStat)(handlerScope)
         }
 
         val refinedType = constrainedLub(newBlock.tpe, newHandler.tpe, tree.tpe)
-        TryCatch(newBlock, LocalIdent(newName, newOriginalName)(errVar.pos),
+        TryCatch(newBlock, LocalIdent(newName)(errVar.pos), newOriginalName,
             newHandler)(refinedType)
 
       case TryFinally(block, finalizer) =>
@@ -661,10 +673,10 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case last :: Nil =>
         transform(last, isStat)
 
-      case (VarDef(nameIdent, vtpe, mutable, rhs)) :: rest =>
+      case (VarDef(nameIdent, originalName, vtpe, mutable, rhs)) :: rest =>
         trampoline {
           pretransformExpr(rhs) { trhs =>
-            withBinding(Binding(nameIdent, vtpe, mutable, trhs)) {
+            withBinding(Binding(nameIdent, originalName, vtpe, mutable, trhs)) {
               (restScope, cont1) =>
                 val newRest = transformList(rest)(restScope)
                 cont1(PreTransTree(newRest, RefinedType(newRest.tpe)))
@@ -739,7 +751,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case tree: Block =>
         pretransformBlock(tree)(cont)
 
-      case VarRef(LocalIdent(name, _)) =>
+      case VarRef(LocalIdent(name)) =>
         val localDef = scope.env.localDefs.getOrElse(name, {
           throw new AssertionError(
               s"Cannot find local def '$name' at $pos\n" +
@@ -877,11 +889,11 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           } else {
             tryOrRollback { cancelFun =>
               val captureBindings = for {
-                (ParamDef(nameIdent, tpe, mutable, rest), value) <-
+                (ParamDef(nameIdent, originalName, tpe, mutable, rest), value) <-
                   captureParams zip tcaptureValues
               } yield {
                 assert(!rest, s"Found a rest capture parameter at $pos")
-                Binding(nameIdent, tpe, mutable, value)
+                Binding(nameIdent, originalName, tpe, mutable, value)
               }
               withNewLocalDefs(captureBindings) { (captureLocalDefs, cont1) =>
                 val replacement = TentativeClosureReplacement(
@@ -913,9 +925,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case last :: Nil =>
         pretransformExpr(last)(cont)
 
-      case (VarDef(nameIdent, vtpe, mutable, rhs)) :: rest =>
+      case (VarDef(nameIdent, originalName, vtpe, mutable, rhs)) :: rest =>
         pretransformExpr(rhs) { trhs =>
-          withBinding(Binding(nameIdent, vtpe, mutable, trhs)) {
+          withBinding(Binding(nameIdent, originalName, vtpe, mutable, trhs)) {
             (restScope, cont1) =>
               pretransformList(rest)(cont1)(restScope)
           } (cont)
@@ -1126,11 +1138,10 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case PreTransLocalDef(localDef @ LocalDef(tpe, _, replacement)) =>
         replacement match {
-          case ReplaceWithRecordVarRef(name, originalName,
-              recordType, used, cancelFun) =>
+          case ReplaceWithRecordVarRef(name, recordType, used, cancelFun) =>
             used.value = true
             PreTransRecordTree(
-                VarRef(LocalIdent(name, originalName))(recordType), tpe, cancelFun)
+                VarRef(LocalIdent(name))(recordType), tpe, cancelFun)
 
           case InlineClassInstanceReplacement(structure, fieldLocalDefs, cancelFun) =>
             val recordType = structure.recordType
@@ -1170,8 +1181,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case PreTransLocalDef(localDef @ LocalDef(tpe, _, replacement)) =>
         replacement match {
-          case ReplaceWithRecordVarRef(name, originalName,
-              recordType, used, cancelFun) =>
+          case ReplaceWithRecordVarRef(name, recordType, used, cancelFun) =>
             Some((recordType, cancelFun))
 
           case InlineClassInstanceReplacement(structure, fieldLocalDefs, cancelFun) =>
@@ -1245,9 +1255,10 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case recordVarRef: VarRef =>
             createNewLong(recordVarRef)
           case _ =>
-            val varRefIdent = LocalIdent(freshLocalName(LocalName("x"), mutable = false))
+            val varRefIdent = LocalIdent(
+                freshLocalNameWithoutOriginalName(LocalName("x"), mutable = false))
             val recordVarDef =
-              VarDef(varRefIdent, tree.tpe, mutable = false, tree)
+              VarDef(varRefIdent, NoOriginalName, tree.tpe, mutable = false, tree)
             Block(recordVarDef, createNewLong(recordVarDef.ref))
         }
 
@@ -1325,29 +1336,29 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
   private def finishTransformBindings(bindingsAndStats: List[BindingOrStat],
       result: Tree): Tree = {
     bindingsAndStats.foldRight(result) {
-      case (Left(PreTransBinding(localDef, value)), innerBody) =>
+      case (Left(PreTransBinding(originalName, localDef, value)), innerBody) =>
         implicit val pos = value.pos
 
         val LocalDef(tpe, mutable, replacement) = localDef
 
-        val (name, originalName, used) = (replacement: @unchecked) match {
-          case ReplaceWithVarRef(name, originalName, used, _) =>
-            (name, originalName, used)
-          case ReplaceWithRecordVarRef(name, originalName, _, used, _) =>
-            (name, originalName, used)
+        val (name, used) = (replacement: @unchecked) match {
+          case ReplaceWithVarRef(name, used, _) =>
+            (name, used)
+          case ReplaceWithRecordVarRef(name, _, used, _) =>
+            (name, used)
         }
 
         if (used.value) {
-          val ident = LocalIdent(name, originalName)
+          val ident = LocalIdent(name)
           val varDef = resolveLocalDef(value) match {
             case PreTransRecordTree(valueTree, valueTpe, cancelFun) =>
               val recordType = valueTree.tpe.asInstanceOf[RecordType]
               if (!isImmutableType(recordType))
                 cancelFun()
-              VarDef(ident, recordType, mutable, valueTree)
+              VarDef(ident, originalName, recordType, mutable, valueTree)
 
             case PreTransTree(valueTree, valueTpe) =>
-              VarDef(ident, tpe.base, mutable, valueTree)
+              VarDef(ident, originalName, tpe.base, mutable, valueTree)
           }
 
           Block(varDef, innerBody)
@@ -1365,7 +1376,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
   private def keepOnlySideEffects(stat: Tree): Tree = stat match {
     case _:VarRef | _:This | _:Literal | _:SelectStatic =>
       Skip()(stat.pos)
-    case VarDef(_, _, _, rhs) =>
+    case VarDef(_, _, _, _, rhs) =>
       keepOnlySideEffects(rhs)
     case Block(init :+ last) =>
       keepOnlySideEffects(last) match {
@@ -1491,27 +1502,27 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     impls.forall(impl => impl.isForwarder && impl.inlineable) &&
     (getMethodBody(impls.head).body.get match {
       // Trait impl forwarder
-      case ApplyStatic(flags, staticCls, MethodIdent(methodName, _), _) =>
+      case ApplyStatic(flags, staticCls, MethodIdent(methodName), _) =>
         impls.tail.forall(getMethodBody(_).body.get match {
-          case ApplyStatic(`flags`, `staticCls`, MethodIdent(`methodName`, _), _) =>
+          case ApplyStatic(`flags`, `staticCls`, MethodIdent(`methodName`), _) =>
             true
           case _ =>
             false
         })
 
       // Shape of forwards to default methods
-      case ApplyStatically(flags, This(), className, MethodIdent(methodName, _), args) =>
+      case ApplyStatically(flags, This(), className, MethodIdent(methodName), args) =>
         impls.tail.forall(getMethodBody(_).body.get match {
-          case ApplyStatically(`flags`, This(), `className`, MethodIdent(`methodName`, _), _) =>
+          case ApplyStatically(`flags`, This(), `className`, MethodIdent(`methodName`), _) =>
             true
           case _ =>
             false
         })
 
       // Bridge method
-      case Apply(flags, This(), MethodIdent(methodName, _), referenceArgs) =>
+      case Apply(flags, This(), MethodIdent(methodName), referenceArgs) =>
         impls.tail.forall(getMethodBody(_).body.get match {
-          case Apply(`flags`, This(), MethodIdent(`methodName`, _), implArgs) =>
+          case Apply(`flags`, This(), MethodIdent(`methodName`), implArgs) =>
             referenceArgs.zip(implArgs) forall {
               case (MaybeUnbox(_, unboxID1), MaybeUnbox(_, unboxID2)) =>
                 unboxID1 == unboxID2
@@ -1553,7 +1564,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       cont: PreTransCont)(
       implicit scope: Scope): TailRec[Tree] = {
     val ApplyStatically(flags, receiver, className,
-        methodIdent @ MethodIdent(methodName, _), args) = tree
+        methodIdent @ MethodIdent(methodName), args) = tree
     implicit val pos = tree.pos
 
     def treeNotInlined0(transformedReceiver: Tree, transformedArgs: List[Tree]) =
@@ -1606,7 +1617,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       cont: PreTransCont)(
       implicit scope: Scope): TailRec[Tree] = {
     val ApplyStatic(flags, className,
-        methodIdent @ MethodIdent(methodName, _), args) = tree
+        methodIdent @ MethodIdent(methodName), args) = tree
     implicit val pos = tree.pos
 
     def treeNotInlined0(transformedArgs: List[Tree]) =
@@ -1839,7 +1850,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case PreTransLocalDef(localDef) =>
         (localDef.replacement match {
           case TentativeClosureReplacement(_, _, _, _, _, _)    => true
-          case ReplaceWithRecordVarRef(_, _, _, _, _)           => true
+          case ReplaceWithRecordVarRef(_, _, _, _)              => true
           case InlineClassBeingConstructedReplacement(_, _, _)  => true
           case InlineClassInstanceReplacement(_, _, _)          => true
           case _ =>
@@ -1873,7 +1884,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
     attemptedInlining += target
 
-    val MethodDef(flags, _, formals, resultType, optBody) = getMethodBody(target)
+    val MethodDef(flags, _, _, formals, resultType, optBody) = getMethodBody(target)
     assert(flags.namespace.isStatic == optReceiver.isEmpty,
         "There must be receiver if and only if the method is not static")
     val body = optBody.getOrElse {
@@ -1903,7 +1914,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
         pretransformSelectCommon(body.tpe, optReceiver.get, className, field,
             isLhsOfAssign = false)(cont)
 
-      case Assign(lhs @ Select(This(), className, field), VarRef(LocalIdent(rhsName, _)))
+      case Assign(lhs @ Select(This(), className, field), VarRef(LocalIdent(rhsName)))
           if formals.size == 1 && formals.head.name.name == rhsName =>
         assert(isStat, "Found Assign in expression position")
         assert(optReceiver.isDefined,
@@ -1936,10 +1947,10 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     }
 
     val argsBindings = for {
-      (ParamDef(nameIdent, tpe, mutable, rest), arg) <- formals zip args
+      (ParamDef(nameIdent, originalName, tpe, mutable, rest), arg) <- formals zip args
     } yield {
       assert(!rest, s"Trying to inline a body with a rest parameter at $pos")
-      Binding(nameIdent, tpe, mutable, arg)
+      Binding(nameIdent, originalName, tpe, mutable, arg)
     }
 
     withBindings(optReceiverBinding ++: argsBindings) { (bodyScope, cont1) =>
@@ -2262,9 +2273,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     }
 
     val argsBindings = for {
-      (ParamDef(nameIdent, tpe, mutable, _), arg) <- formals zip args
+      (ParamDef(nameIdent, originalName, tpe, mutable, _), arg) <- formals zip args
     } yield {
-      Binding(nameIdent, tpe, mutable, arg)
+      Binding(nameIdent, originalName, tpe, mutable, arg)
     }
 
     withBindings(argsBindings) { (bodyScope, cont1) =>
@@ -2295,8 +2306,10 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case Assign(s @ Select(ths: This, className, field), value) :: rest
           if !inputFieldsLocalDefs(FieldID(className, field)).mutable =>
         pretransformExpr(value) { tvalue =>
+          val fieldID = FieldID(className, field)
+          val originalName = structure.fieldOriginalName(fieldID)
           val binding = Binding(
-              Binding.Local(field.name.toLocalName, field.originalName),
+              Binding.Local(field.name.toLocalName, originalName),
               s.tpe, false, tvalue)
           withNewLocalDef(binding) { (localDef, cont1) =>
             if (localDef.contains(thisLocalDef)) {
@@ -2306,7 +2319,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
               cancelFun()
             }
             val newFieldsLocalDefs =
-              inputFieldsLocalDefs.updated(FieldID(className, field), localDef)
+              inputFieldsLocalDefs.updated(fieldID, localDef)
             val newThisLocalDef = LocalDef(thisLocalDef.tpe, false,
                 InlineClassBeingConstructedReplacement(structure, newFieldsLocalDefs, cancelFun))
             val restScope =
@@ -2356,9 +2369,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           } (cont)
         }
 
-      case VarDef(nameIdent, tpe, mutable, rhs) :: rest =>
+      case VarDef(nameIdent, originalName, tpe, mutable, rhs) :: rest =>
         pretransformExpr(rhs) { trhs =>
-          withBinding(Binding(nameIdent, tpe, mutable, trhs)) { (restScope, cont1) =>
+          withBinding(Binding(nameIdent, originalName, tpe, mutable, trhs)) { (restScope, cont1) =>
             inlineClassConstructorBodyList(allocationSite, structure,
                 thisLocalDef, inputFieldsLocalDefs,
                 className, rest, cancelFun)(buildInner)(cont1)(restScope)
@@ -3968,14 +3981,13 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       body: Tree,
       alreadyInlining: Set[Scope.InliningID]): (List[ParamDef], Tree) = {
     val (paramLocalDefs, newParamDefs) = (for {
-      p @ ParamDef(ident @ LocalIdent(name, originalName), ptpe, mutable, rest) <- params
+      p @ ParamDef(ident @ LocalIdent(name), originalName, ptpe, mutable, rest) <- params
     } yield {
-      val newName = freshLocalName(name, mutable)
-      val newOriginalName = originalName.orElse(newName)
+      val (newName, newOriginalName) = freshLocalName(name, originalName, mutable)
       val localDef = LocalDef(RefinedType(ptpe), mutable,
-          ReplaceWithVarRef(newName, newOriginalName, newSimpleState(true), None))
-      val newParamDef = ParamDef(
-          LocalIdent(newName, newOriginalName)(ident.pos), ptpe, mutable, rest)(p.pos)
+          ReplaceWithVarRef(newName, newSimpleState(true), None))
+      val newParamDef = ParamDef(LocalIdent(newName)(ident.pos),
+          newOriginalName, ptpe, mutable, rest)(p.pos)
       ((name -> localDef), newParamDef)
     }).unzip
 
@@ -4228,25 +4240,20 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
         }
       } else {
         // Otherwise, we effectively declare a new binding
-        val newName = freshLocalName(bindingName, mutable)
-        val newOriginalName = bindingName match {
-          case Binding.This                  => thisOriginalName
-          case Binding.Local(name, origName) => origName.orElse(name)
-        }
+        val (newName, newOriginalName) = freshLocalName(bindingName, mutable)
 
         val used = newSimpleState(false)
 
         val (replacement, refinedType) = resolveRecordType(value) match {
           case Some((recordType, cancelFun)) =>
-            (ReplaceWithRecordVarRef(newName, newOriginalName, recordType,
-                used, cancelFun), value.tpe)
+            (ReplaceWithRecordVarRef(newName, recordType, used, cancelFun), value.tpe)
 
           case None =>
-            (ReplaceWithVarRef(newName, newOriginalName, used, None), tpe)
+            (ReplaceWithVarRef(newName, used, None), tpe)
         }
 
         val localDef = LocalDef(refinedType, mutable, replacement)
-        val preTransBinding = PreTransBinding(localDef, value)
+        val preTransBinding = PreTransBinding(newOriginalName, localDef, value)
 
         buildInner(localDef, { tinner =>
           cont(addPreTransBinding(preTransBinding, tinner))
@@ -4273,11 +4280,10 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           buildInner(LocalDef(refinedType, false,
               ReplaceWithConstant(literal)), cont)
 
-        case PreTransTree(VarRef(LocalIdent(refName, refOriginalName)), _)
+        case PreTransTree(VarRef(LocalIdent(refName)), _)
             if !localIsMutable(refName) =>
           buildInner(LocalDef(refinedType, false,
-              ReplaceWithVarRef(refName, refOriginalName,
-                  newSimpleState(true), None)), cont)
+              ReplaceWithVarRef(refName, newSimpleState(true), None)), cont)
 
         case _ =>
           withDedicatedVar(refinedType)
@@ -4438,7 +4444,7 @@ private[optimizer] object OptimizerCore {
     private[OptimizerCore] val recordType: RecordType = {
       val allocator = new FreshNameAllocator.Field
       val recordFields = for {
-        (className, f @ FieldDef(flags, FieldIdent(name, originalName), ftpe)) <- allFields
+        (className, f @ FieldDef(flags, FieldIdent(name), originalName, ftpe)) <- allFields
       } yield {
         assert(!flags.namespace.isStatic,
             s"unexpected static field in InlineableClassStructure at ${f.pos}")
@@ -4453,6 +4459,9 @@ private[optimizer] object OptimizerCore {
         yield FieldID(className, fieldDef) -> recordField
       elems.toMap
     }
+
+    private[OptimizerCore] def fieldOriginalName(fieldID: FieldID): OriginalName =
+      recordFieldNames(fieldID).originalName
 
     override def equals(that: Any): Boolean = that match {
       case that: InlineableClassStructure =>
@@ -4555,20 +4564,20 @@ private[optimizer] object OptimizerCore {
     }
 
     def newReplacement(implicit pos: Position): Tree = replacement match {
-      case ReplaceWithVarRef(name, originalName, used, _) =>
+      case ReplaceWithVarRef(name, used, _) =>
         used.value = true
-        VarRef(LocalIdent(name, originalName))(tpe.base)
+        VarRef(LocalIdent(name))(tpe.base)
 
       /* Allocate an instance of RuntimeLong on the fly.
        * See the comment in finishTransformExpr about why it is desirable and
        * safe to do so.
        */
-      case ReplaceWithRecordVarRef(name, originalName, recordType, used, _)
+      case ReplaceWithRecordVarRef(name, recordType, used, _)
           if tpe.base == ClassType(LongImpl.RuntimeLongClass) =>
         used.value = true
-        createNewLong(VarRef(LocalIdent(name, originalName))(recordType))
+        createNewLong(VarRef(LocalIdent(name))(recordType))
 
-      case ReplaceWithRecordVarRef(_, _, _, _, cancelFun) =>
+      case ReplaceWithRecordVarRef(_, _, _, cancelFun) =>
         cancelFun()
 
       case ReplaceWithThis() =>
@@ -4618,12 +4627,10 @@ private[optimizer] object OptimizerCore {
   private sealed abstract class LocalDefReplacement
 
   private final case class ReplaceWithVarRef(name: LocalName,
-      originalName: OriginalName,
       used: SimpleState[Boolean],
       longOpTree: Option[() => Tree]) extends LocalDefReplacement
 
   private final case class ReplaceWithRecordVarRef(name: LocalName,
-      originalName: OriginalName,
       recordType: RecordType,
       used: SimpleState[Boolean],
       cancelFun: CancelFun) extends LocalDefReplacement
@@ -4740,8 +4747,8 @@ private[optimizer] object OptimizerCore {
     def contains(localDef: LocalDef): Boolean = this match {
       case PreTransBlock(bindingsAndStats, result) =>
         result.contains(localDef) || bindingsAndStats.exists {
-          case Left(PreTransBinding(_, value)) => value.contains(localDef)
-          case Right(_)                        => false
+          case Left(PreTransBinding(_, _, value)) => value.contains(localDef)
+          case Right(_)                           => false
         }
       case PreTransUnaryOp(_, lhs) =>
         lhs.contains(localDef)
@@ -4761,8 +4768,8 @@ private[optimizer] object OptimizerCore {
    *  Even though it is not encoded in the type system, `localDef.replacement`
    *  must be a [[ReplaceWithVarRef]] or a [[ReplaceWithRecordVarRef]].
    */
-  private final case class PreTransBinding(localDef: LocalDef,
-      value: PreTransform) {
+  private final case class PreTransBinding(originalName: OriginalName,
+      localDef: LocalDef, value: PreTransform) {
 
     assert(
         localDef.replacement.isInstanceOf[ReplaceWithVarRef] ||
@@ -4771,8 +4778,8 @@ private[optimizer] object OptimizerCore {
         localDef.replacement)
 
     def isAlreadyUsed: Boolean = (localDef.replacement: @unchecked) match {
-      case ReplaceWithVarRef(_, _, used, _)          => used.value
-      case ReplaceWithRecordVarRef(_, _, _, used, _) => used.value
+      case ReplaceWithVarRef(_, used, _)          => used.value
+      case ReplaceWithRecordVarRef(_, _, used, _) => used.value
     }
   }
 
@@ -4998,9 +5005,9 @@ private[optimizer] object OptimizerCore {
     final case class Local(name: LocalName, originalName: OriginalName)
         extends Name
 
-    def apply(localIdent: LocalIdent, declaredType: Type, mutable: Boolean,
-        value: PreTransform): Binding = {
-      apply(Local(localIdent.name, localIdent.originalName), declaredType,
+    def apply(localIdent: LocalIdent, originalName: OriginalName,
+        declaredType: Type, mutable: Boolean, value: PreTransform): Binding = {
+      apply(Local(localIdent.name, originalName), declaredType,
           mutable, value)
     }
 
@@ -5041,8 +5048,8 @@ private[optimizer] object OptimizerCore {
 
     val RecordType(List(loField, hiField)) = recordVarRef.tpe
     createNewLong(
-        RecordSelect(recordVarRef, FieldIdent(loField.name, loField.originalName))(IntType),
-        RecordSelect(recordVarRef, FieldIdent(hiField.name, hiField.originalName))(IntType))
+        RecordSelect(recordVarRef, FieldIdent(loField.name))(IntType),
+        RecordSelect(recordVarRef, FieldIdent(hiField.name))(IntType))
   }
 
   /** Creates a new instance of `RuntimeLong` from its `lo` and `hi` parts. */
@@ -5246,7 +5253,7 @@ private[optimizer] object OptimizerCore {
     var isForwarder: Boolean = false
 
     protected def updateInlineable(): Unit = {
-      val MethodDef(_, MethodIdent(methodName, _), params, _, optBody) = originalDef
+      val MethodDef(_, MethodIdent(methodName), _, params, _, optBody) = originalDef
       val body = optBody getOrElse {
         throw new AssertionError("Methods in optimizer must be concrete")
       }
@@ -5257,8 +5264,8 @@ private[optimizer] object OptimizerCore {
           ((args.size == params.size + 1) &&
               (args.head.isInstanceOf[This]) &&
               (args.tail.zip(params).forall {
-                case (VarRef(LocalIdent(aname, _)),
-                    ParamDef(LocalIdent(pname, _), _, _, _)) => aname == pname
+                case (VarRef(LocalIdent(aname)),
+                    ParamDef(LocalIdent(pname), _, _, _, _)) => aname == pname
                 case _ => false
               }))
 
@@ -5266,7 +5273,7 @@ private[optimizer] object OptimizerCore {
         case ApplyStatically(_, This(), className, method, args) =>
           args.size == params.size &&
           args.zip(params).forall {
-            case (VarRef(LocalIdent(aname, _)), ParamDef(LocalIdent(pname, _), _, _, _)) =>
+            case (VarRef(LocalIdent(aname)), ParamDef(LocalIdent(pname), _, _, _, _)) =>
               aname == pname
             case _ =>
               false
@@ -5276,8 +5283,8 @@ private[optimizer] object OptimizerCore {
         case Apply(_, This(), method, args) =>
           (args.size == params.size) &&
           args.zip(params).forall {
-            case (MaybeUnbox(VarRef(LocalIdent(aname, _)), _),
-                ParamDef(LocalIdent(pname, _), _, _, _)) => aname == pname
+            case (MaybeUnbox(VarRef(LocalIdent(aname)), _),
+                ParamDef(LocalIdent(pname), _, _, _, _)) => aname == pname
             case _ => false
           }
 
@@ -5331,7 +5338,7 @@ private[optimizer] object OptimizerCore {
       true
     case ApplyStatically(_, This(), _, _, Nil) =>
       true
-    case ApplyStatic(_, _, MethodIdent(methodName, _), This() :: Nil) =>
+    case ApplyStatic(_, _, MethodIdent(methodName), This() :: Nil) =>
       methodName.simpleName == TraitInitSimpleMethodName
     case _ =>
       false
@@ -5497,6 +5504,12 @@ private[optimizer] object OptimizerCore {
 
     final class Snapshot[N <: Name] private[FreshNameAllocator] (
         private[FreshNameAllocator] val usedNamesToNextCounter: Map[N, Int])
+  }
+
+  def originalNameForFresh(base: Name, originalName: OriginalName,
+      freshName: Name): OriginalName = {
+    if (originalName.isDefined || (freshName eq base)) originalName
+    else OriginalName(base)
   }
 
   final class FieldID private (val ownerClassName: ClassName, val name: FieldName) {

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -300,7 +300,7 @@ class AnalyzerTest {
         classDef("B", superClass = Some("A"),
             memberDefs = List(
                 trivialCtor("B"),
-                MethodDef(EMF, fooMethodName, Nil, IntType, Some(int(5)))(EOH, None)
+                MethodDef(EMF, fooMethodName, NON, Nil, IntType, Some(int(5)))(EOH, None)
             ))
     )
 
@@ -315,7 +315,7 @@ class AnalyzerTest {
 
   @Test
   def conflictingDefaultMethods(): AsyncResult = await {
-    val defaultMethodDef = MethodDef(EMF, m("foo", Nil, V), Nil,
+    val defaultMethodDef = MethodDef(EMF, m("foo", Nil, V), NON, Nil,
         NoType, Some(Skip()))(EOH, None)
     val classDefs = Seq(
         classDef("I1", kind = ClassKind.Interface,
@@ -387,7 +387,7 @@ class AnalyzerTest {
     val classDefs = Seq(
         classDef("A", superClass = Some(ObjectClass), memberDefs = List(
             trivialCtor("A"),
-            MethodDef(EMF, m("test", Nil, V), Nil, NoType, Some(Block(
+            MethodDef(EMF, m("test", Nil, V), NON, Nil, NoType, Some(Block(
                 Apply(EAF, systemMod, m("getProperty", List(T), T), List(emptyStr))(StringType),
                 Apply(EAF, systemMod, m("getProperty", List(T, T), T), List(emptyStr))(StringType),
                 Apply(EAF, systemMod, m("setProperty", List(T, T), T), List(emptyStr))(StringType),
@@ -425,9 +425,9 @@ class AnalyzerTest {
         classDef("X", superClass = Some(ObjectClass),
             memberDefs = List(
                 trivialCtor("X"),
-                MethodDef(EMF, fooAMethodName, Nil, ClassType("A"),
+                MethodDef(EMF, fooAMethodName, NON, Nil, ClassType("A"),
                     Some(Null()))(EOH, None),
-                MethodDef(EMF, fooBMethodName, Nil, ClassType("B"),
+                MethodDef(EMF, fooBMethodName, NON, Nil, ClassType("B"),
                     Some(Null()))(EOH, None)
             )
         )
@@ -458,26 +458,26 @@ class AnalyzerTest {
     val classDefs = Seq(
         classDef("I1", kind = ClassKind.Interface,
             memberDefs = List(
-                MethodDef(EMF, barMethodName, Nil, IntType, None)(EOH, None)
+                MethodDef(EMF, barMethodName, NON, Nil, IntType, None)(EOH, None)
             )),
         classDef("I2", kind = ClassKind.Interface,
             memberDefs = List(
-                MethodDef(EMF, barMethodName, Nil, IntType, None)(EOH, None)
+                MethodDef(EMF, barMethodName, NON, Nil, IntType, None)(EOH, None)
             )),
         classDef("A", superClass = Some(ObjectClass), interfaces = List("I1"),
             memberDefs = List(
                 trivialCtor("A"),
-                MethodDef(EMF, fooMethodName, Nil, IntType, None)(EOH, None)
+                MethodDef(EMF, fooMethodName, NON, Nil, IntType, None)(EOH, None)
             )),
         classDef("B", superClass = Some("A"), interfaces = List("I2"),
             memberDefs = List(
                 trivialCtor("B"),
-                MethodDef(EMF, fooMethodName, Nil, IntType, Some(int(5)))(EOH, None)
+                MethodDef(EMF, fooMethodName, NON, Nil, IntType, Some(int(5)))(EOH, None)
             )),
         classDef("C", superClass = Some("B"),
             memberDefs = List(
                 trivialCtor("C"),
-                MethodDef(EMF, barMethodName, Nil, IntType, Some(int(5)))(EOH, None)
+                MethodDef(EMF, barMethodName, NON, Nil, IntType, Some(int(5)))(EOH, None)
             ))
     )
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -61,7 +61,7 @@ class IRCheckerTest {
                 /* This method is called, but unreachable because there are no
                  * instances of `Bar`. It will therefore not make `Foo` reachable.
                  */
-                MethodDef(EMF, methMethodName,
+                MethodDef(EMF, methMethodName, NON,
                     List(paramDef("foo", ClassType("Foo"))), NoType,
                     Some(Skip()))(
                     EOH, None)
@@ -72,7 +72,7 @@ class IRCheckerTest {
             superClass = Some(ObjectClass),
             memberDefs = List(
                 trivialCtor("Test$"),
-                MethodDef(EMF, nullBarMethodName, Nil, ClassType("Bar"),
+                MethodDef(EMF, nullBarMethodName, NON, Nil, ClassType("Bar"),
                     Some(Null()))(
                     EOH, None),
                 mainMethodDef(Block(
@@ -116,35 +116,35 @@ class IRCheckerTest {
 
                 // Duplicate fields
 
-                FieldDef(EMF, "foobar", IntType),
-                FieldDef(EMF, "foobar", BoxedStringType),
+                FieldDef(EMF, "foobar", NON, IntType),
+                FieldDef(EMF, "foobar", NON, BoxedStringType),
 
                 // Duplicate constructors
 
                 MethodDef(EMF.withNamespace(MemberNamespace.Constructor),
-                    stringCtorName, List(paramDef("x", BoxedStringType)),
+                    stringCtorName, NON, List(paramDef("x", BoxedStringType)),
                     NoType, Some(callPrimaryCtorBody))(
                     EOH, None),
 
                 MethodDef(EMF.withNamespace(MemberNamespace.Constructor),
-                    stringCtorName, List(paramDef("y", BoxedStringType)),
+                    stringCtorName, NON, List(paramDef("y", BoxedStringType)),
                     NoType, Some(callPrimaryCtorBody))(
                     EOH, None),
 
                 // Duplicate methods
 
-                MethodDef(EMF, babarMethodName, List(paramDef("x", IntType)),
+                MethodDef(EMF, babarMethodName, NON, List(paramDef("x", IntType)),
                     IntType, Some(babarMethodBody("x")))(
                     EOH, None),
 
-                MethodDef(EMF, babarMethodName, List(paramDef("y", IntType)),
+                MethodDef(EMF, babarMethodName, NON, List(paramDef("y", IntType)),
                     IntType, Some(babarMethodBody("y")))(
                     EOH, None)
             )
         ),
 
         mainTestClassDef(Block(
-            VarDef("foo", FooType, mutable = false,
+            VarDef("foo", NON, FooType, mutable = false,
                 New(FooClass, stringCtorName, List(StringLiteral("hello")))),
             Apply(EAF, VarRef("foo")(FooType), babarMethodName, List(int(5)))(IntType)
         ))

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -17,6 +17,8 @@ import scala.language.implicitConversions
 import org.scalajs.ir
 import org.scalajs.ir.ClassKind
 import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName
+import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Trees._
 import org.scalajs.ir.Types._
 
@@ -28,6 +30,7 @@ object TestIRBuilder {
   val EAF = ApplyFlags.empty
   val EMF = MemberFlags.empty
   val EOH = OptimizerHints.empty
+  val NON = NoOriginalName
 
   val V = VoidRef
   val I = IntRef
@@ -47,7 +50,7 @@ object TestIRBuilder {
       jsNativeLoadSpec: Option[JSNativeLoadSpec] = None,
       memberDefs: List[MemberDef] = Nil,
       topLevelExportDefs: List[TopLevelExportDef] = Nil): ClassDef = {
-    ClassDef(ClassIdent(className), kind, jsClassCaptures,
+    ClassDef(ClassIdent(className), NON, kind, jsClassCaptures,
         superClass.map(ClassIdent(_)), interfaces.map(ClassIdent(_)),
         jsSuperClass, jsNativeLoadSpec, memberDefs, topLevelExportDefs)(
         EOH)
@@ -71,7 +74,7 @@ object TestIRBuilder {
 
   def trivialCtor(enclosingClassName: ClassName): MethodDef = {
     val flags = MemberFlags.empty.withNamespace(MemberNamespace.Constructor)
-    MethodDef(flags, MethodIdent(NoArgConstructorName), Nil, NoType,
+    MethodDef(flags, MethodIdent(NoArgConstructorName), NON, Nil, NoType,
         Some(ApplyStatically(EAF.withConstructor(true),
             This()(ClassType(enclosingClassName)),
             ObjectClass, MethodIdent(NoArgConstructorName),
@@ -84,12 +87,12 @@ object TestIRBuilder {
     val stringArrayType = ArrayType(stringArrayTypeRef)
     val argsParamDef = paramDef("args", stringArrayType)
     MethodDef(MemberFlags.empty,
-        m("main", List(stringArrayTypeRef), VoidRef),
+        m("main", List(stringArrayTypeRef), VoidRef), NON,
         List(argsParamDef), NoType, Some(body))(EOH, None)
   }
 
   def paramDef(name: LocalName, ptpe: Type): ParamDef =
-    ParamDef(LocalIdent(name), ptpe, mutable = false, rest = false)
+    ParamDef(LocalIdent(name), NON, ptpe, mutable = false, rest = false)
 
   def mainModuleInitializers(moduleClassName: String): List[ModuleInitializer] =
     ModuleInitializer.mainMethodWithArgs(moduleClassName, "main") :: Nil

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -9,6 +9,7 @@ import java.io.ByteArrayOutputStream
 import org.scalajs.ir
 import org.scalajs.ir._
 import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Trees._
 import org.scalajs.ir.Types._
 import org.scalajs.ir.Position.NoPosition
@@ -34,6 +35,7 @@ object JavaLangObject {
 
     val classDef = ClassDef(
       ClassIdent(ObjectClass),
+      NoOriginalName,
       ClassKind.Class,
       None,
       None,
@@ -45,6 +47,7 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty.withNamespace(MemberNamespace.Constructor),
           MethodIdent(NoArgConstructorName),
+          NoOriginalName,
           Nil,
           NoType,
           Some(Skip()))(OptimizerHints.empty, None),
@@ -53,6 +56,7 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("getClass", Nil, ClassClassRef)),
+          NoOriginalName,
           Nil,
           ClassType(ClassClass),
           Some {
@@ -63,6 +67,7 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("hashCode", Nil, IntRef)),
+          NoOriginalName,
           Nil,
           IntType,
           Some {
@@ -77,7 +82,8 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("equals", List(ObjectClassRef), BooleanRef)),
-          List(ParamDef(LocalIdent(LocalName("that")), AnyType,
+          NoOriginalName,
+          List(ParamDef(LocalIdent(LocalName("that")), NoOriginalName, AnyType,
             mutable = false, rest = false)),
           BooleanType,
           Some {
@@ -93,6 +99,7 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("clone", Nil, ObjectClassRef)),
+          NoOriginalName,
           Nil,
           AnyType,
           Some {
@@ -112,6 +119,7 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("toString", Nil, StringClassRef)),
+          NoOriginalName,
           Nil,
           ClassType(BoxedStringClass),
           Some {
@@ -141,6 +149,7 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("notify", Nil, VoidRef)),
+          NoOriginalName,
           Nil,
           NoType,
           Some(Skip()))(OptimizerHints.empty, None),
@@ -149,6 +158,7 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("notifyAll", Nil, VoidRef)),
+          NoOriginalName,
           Nil,
           NoType,
           Some(Skip()))(OptimizerHints.empty, None),
@@ -157,6 +167,7 @@ object JavaLangObject {
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("finalize", Nil, VoidRef)),
+          NoOriginalName,
           Nil,
           NoType,
           Some(Skip()))(OptimizerHints.empty, None),


### PR DESCRIPTION
* Encode original names as optional `UTF8String`s.
* Store original names only on definitions, not on every usage.