### PR TITLE
Fix #3840: Rename `envField` to `codegenVar`.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -179,7 +179,7 @@ final class Emitter private (config: CommonPhaseConfig,
           }
         } {
           implicit val pos = NoPosition
-          val field = envField("f", className, methodName, NoOriginalName).ident
+          val field = codegenVar("f", className, methodName, NoOriginalName).ident
           builder.addJSTree(js.VarDef(field, None))
         }
       }
@@ -196,7 +196,7 @@ final class Emitter private (config: CommonPhaseConfig,
           })
         if (!ctorIsDefined) {
           implicit val pos = NoPosition
-          val field = envField("ct", className, ctorName, NoOriginalName).ident
+          val field = codegenVar("ct", className, ctorName, NoOriginalName).ident
           builder.addJSTree(js.VarDef(field, None))
         }
       }
@@ -372,7 +372,7 @@ final class Emitter private (config: CommonPhaseConfig,
 
     // $L0 = new RuntimeLong(0, 0)
     js.Assign(
-        jsGen.envField("L0"),
+        jsGen.codegenVar("L0"),
         js.New(jsGen.encodeClassVar(LongImpl.RuntimeLongClass),
             List(js.IntLiteral(0), js.IntLiteral(0)))
     )

--- a/test-suite-ex/src/test/scala/org/scalajs/testsuite/jsinterop/InternalNameClashesTestEx.scala
+++ b/test-suite-ex/src/test/scala/org/scalajs/testsuite/jsinterop/InternalNameClashesTestEx.scala
@@ -21,15 +21,15 @@ import org.junit.Assert._
 class InternalNameClashesTestEx {
   import InternalNameClashesTestEx._
 
-  @Test def testLocalVariableClashWithEnvField(): Unit = {
+  @Test def testLocalVariableClashWithCodegenVar(): Unit = {
     /* This tests that user-defined local variables cannot clash with
-     * compiler-generated "envFields".
+     * compiler-generated "codegenVars".
      */
     @noinline def someValue(): Int = 42
 
-    val $c_Lorg_scalajs_testsuite_jsinterop_InternalNameClashesTestEx$LocalVariableClashWithEnvField = someValue()
-    val foo = new LocalVariableClashWithEnvField(5)
-    assertEquals(42, $c_Lorg_scalajs_testsuite_jsinterop_InternalNameClashesTestEx$LocalVariableClashWithEnvField)
+    val $c_Lorg_scalajs_testsuite_jsinterop_InternalNameClashesTestEx$LocalVariableClashWithCodegenVar = someValue()
+    val foo = new LocalVariableClashWithCodegenVar(5)
+    assertEquals(42, $c_Lorg_scalajs_testsuite_jsinterop_InternalNameClashesTestEx$LocalVariableClashWithCodegenVar)
     assertEquals(5, foo.x)
   }
 
@@ -82,7 +82,7 @@ class InternalNameClashesTestEx {
 
 object InternalNameClashesTestEx {
   @noinline
-  class LocalVariableClashWithEnvField(val x: Int)
+  class LocalVariableClashWithCodegenVar(val x: Int)
 
   trait LocalVariableClashWithExplicitThisParamTrait {
     val x: Int
@@ -90,8 +90,8 @@ object InternalNameClashesTestEx {
     @noinline
     def test(y: Int): Int = {
       /* We test both $thiz and $$thiz because GlobalScopeTestEx references the
-       * global variable `$thiz`, causing env fields for `$thiz` to be renamed
-       * to `$$thiz`.
+       * global variable `$thiz`, causing codegen vars for `$thiz` to be
+       * renamed to `$$thiz`.
        */
       val $thiz = x + y
       val $$thiz = x * y


### PR DESCRIPTION
`envField` was a historical name that can traced back to when all compiler-generated variables were stored as fields of a global object `ScalaJS`. The name was not too bad until recently, when we started using the mechanism even for some local variables.

This commit renames all "env field" occurrences to "codegen var", since those are essentially codegen-chosen variable names.