### PR TITLE
Finalize all case classes and privatize AnyVal underlying vals.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -1120,10 +1120,8 @@ object Trees {
 
   // Miscellaneous
 
-  final class OptimizerHints private (val __private_bits: Int) extends AnyVal {
+  final class OptimizerHints private (private val bits: Int) extends AnyVal {
     import OptimizerHints._
-
-    @inline private def bits: Int = __private_bits
 
     def inline: Boolean = (bits & InlineMask) != 0
     def noinline: Boolean = (bits & NoinlineMask) != 0
@@ -1157,10 +1155,8 @@ object Trees {
       hints.bits
   }
 
-  final class ApplyFlags private (val __private_bits: Int) extends AnyVal {
+  final class ApplyFlags private (private val bits: Int) extends AnyVal {
     import ApplyFlags._
-
-    @inline private def bits: Int = __private_bits
 
     def isPrivate: Boolean = (bits & PrivateBit) != 0
 
@@ -1263,10 +1259,8 @@ object Trees {
       if (flags.isPrivate) PrivateStatic else PublicStatic
   }
 
-  final class MemberFlags private (val __private_bits: Int) extends AnyVal {
+  final class MemberFlags private (private val bits: Int) extends AnyVal {
     import MemberFlags._
-
-    @inline private def bits: Int = __private_bits
 
     def namespace: MemberNamespace =
       MemberNamespace.fromOrdinalUnchecked(bits & NamespaceMask)

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -20,6 +20,11 @@ import Position.NoPosition
 import Types._
 
 object Trees {
+  /* The case classes for IR Nodes are sealed instead of final because making
+   * them final triggers bugs with Scala 2.11.x and 2.12.{1-4}, in combination
+   * with their `implicit val pos`.
+   */
+
   /** Base class for all nodes in the IR.
    *
    *  Usually, one of the direct subclasses of `IRNode` should be used instead.
@@ -48,19 +53,19 @@ object Trees {
 
   // Identifiers
 
-  case class LocalIdent(name: LocalName)(implicit val pos: Position)
+  sealed case class LocalIdent(name: LocalName)(implicit val pos: Position)
       extends IRNode
 
-  case class LabelIdent(name: LabelName)(implicit val pos: Position)
+  sealed case class LabelIdent(name: LabelName)(implicit val pos: Position)
       extends IRNode
 
-  case class FieldIdent(name: FieldName)(implicit val pos: Position)
+  sealed case class FieldIdent(name: FieldName)(implicit val pos: Position)
       extends IRNode
 
-  case class MethodIdent(name: MethodName)(implicit val pos: Position)
+  sealed case class MethodIdent(name: MethodName)(implicit val pos: Position)
       extends IRNode
 
-  case class ClassIdent(name: ClassName)(implicit val pos: Position)
+  sealed case class ClassIdent(name: ClassName)(implicit val pos: Position)
       extends IRNode
 
   /** Tests whether the given name is a valid JavaScript identifier name.
@@ -91,27 +96,27 @@ object Trees {
 
   // Definitions
 
-  case class VarDef(name: LocalIdent, originalName: OriginalName, vtpe: Type,
-      mutable: Boolean, rhs: Tree)(
+  sealed case class VarDef(name: LocalIdent, originalName: OriginalName,
+      vtpe: Type, mutable: Boolean, rhs: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType // cannot be in expression position
 
     def ref(implicit pos: Position): VarRef = VarRef(name)(vtpe)
   }
 
-  case class ParamDef(name: LocalIdent, originalName: OriginalName, ptpe: Type,
-      mutable: Boolean, rest: Boolean)(
+  sealed case class ParamDef(name: LocalIdent, originalName: OriginalName,
+      ptpe: Type, mutable: Boolean, rest: Boolean)(
       implicit val pos: Position) extends IRNode {
     def ref(implicit pos: Position): VarRef = VarRef(name)(ptpe)
   }
 
   // Control flow constructs
 
-  case class Skip()(implicit val pos: Position) extends Tree {
+  sealed case class Skip()(implicit val pos: Position) extends Tree {
     val tpe = NoType // cannot be in expression position
   }
 
-  class Block private (val stats: List[Tree])(
+  sealed class Block private (val stats: List[Tree])(
       implicit val pos: Position) extends Tree {
     val tpe = stats.last.tpe
 
@@ -139,10 +144,10 @@ object Trees {
     def unapply(block: Block): Some[List[Tree]] = Some(block.stats)
   }
 
-  case class Labeled(label: LabelIdent, tpe: Type, body: Tree)(
+  sealed case class Labeled(label: LabelIdent, tpe: Type, body: Tree)(
       implicit val pos: Position) extends Tree
 
-  case class Assign(lhs: Tree, rhs: Tree)(
+  sealed case class Assign(lhs: Tree, rhs: Tree)(
       implicit val pos: Position) extends Tree {
     require(lhs match {
       case _:VarRef | _:Select | _:SelectStatic | _:ArraySelect |
@@ -156,15 +161,15 @@ object Trees {
     val tpe = NoType // cannot be in expression position
   }
 
-  case class Return(expr: Tree, label: LabelIdent)(
+  sealed case class Return(expr: Tree, label: LabelIdent)(
       implicit val pos: Position) extends Tree {
     val tpe = NothingType
   }
 
-  case class If(cond: Tree, thenp: Tree, elsep: Tree)(val tpe: Type)(
+  sealed case class If(cond: Tree, thenp: Tree, elsep: Tree)(val tpe: Type)(
       implicit val pos: Position) extends Tree
 
-  case class While(cond: Tree, body: Tree)(
+  sealed case class While(cond: Tree, body: Tree)(
       implicit val pos: Position) extends Tree {
     // cannot be in expression position, unless it is infinite
     val tpe = cond match {
@@ -173,27 +178,27 @@ object Trees {
     }
   }
 
-  case class DoWhile(body: Tree, cond: Tree)(
+  sealed case class DoWhile(body: Tree, cond: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType // cannot be in expression position
   }
 
-  case class ForIn(obj: Tree, keyVar: LocalIdent,
+  sealed case class ForIn(obj: Tree, keyVar: LocalIdent,
       keyVarOriginalName: OriginalName, body: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType
   }
 
-  case class TryCatch(block: Tree, errVar: LocalIdent,
+  sealed case class TryCatch(block: Tree, errVar: LocalIdent,
       errVarOriginalName: OriginalName, handler: Tree)(
       val tpe: Type)(implicit val pos: Position) extends Tree
 
-  case class TryFinally(block: Tree, finalizer: Tree)(
+  sealed case class TryFinally(block: Tree, finalizer: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = block.tpe
   }
 
-  case class Throw(expr: Tree)(implicit val pos: Position) extends Tree {
+  sealed case class Throw(expr: Tree)(implicit val pos: Position) extends Tree {
     val tpe = NothingType
   }
 
@@ -204,40 +209,42 @@ object Trees {
    *  implement alternatives.
    *  (This is not a pattern matching construct like in Scala.)
    */
-  case class Match(selector: Tree, cases: List[(List[IntLiteral], Tree)],
+  sealed case class Match(selector: Tree, cases: List[(List[IntLiteral], Tree)],
       default: Tree)(val tpe: Type)(implicit val pos: Position) extends Tree
 
-  case class Debugger()(implicit val pos: Position) extends Tree {
+  sealed case class Debugger()(implicit val pos: Position) extends Tree {
     val tpe = NoType // cannot be in expression position
   }
 
   // Scala expressions
 
-  case class New(className: ClassName, ctor: MethodIdent, args: List[Tree])(
+  sealed case class New(className: ClassName, ctor: MethodIdent,
+      args: List[Tree])(
       implicit val pos: Position) extends Tree {
     val tpe = ClassType(className)
   }
 
-  case class LoadModule(className: ClassName)(
+  sealed case class LoadModule(className: ClassName)(
       implicit val pos: Position) extends Tree {
     val tpe = ClassType(className)
   }
 
-  case class StoreModule(className: ClassName, value: Tree)(
+  sealed case class StoreModule(className: ClassName, value: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = NoType // cannot be in expression position
   }
 
-  case class Select(qualifier: Tree, className: ClassName, field: FieldIdent)(
+  sealed case class Select(qualifier: Tree, className: ClassName,
+      field: FieldIdent)(
       val tpe: Type)(
       implicit val pos: Position) extends Tree
 
-  case class SelectStatic(className: ClassName, field: FieldIdent)(
+  sealed case class SelectStatic(className: ClassName, field: FieldIdent)(
       val tpe: Type)(
       implicit val pos: Position) extends Tree
 
   /** Apply an instance method with dynamic dispatch (the default). */
-  case class Apply(flags: ApplyFlags, receiver: Tree, method: MethodIdent,
+  sealed case class Apply(flags: ApplyFlags, receiver: Tree, method: MethodIdent,
       args: List[Tree])(
       val tpe: Type)(implicit val pos: Position) extends Tree {
 
@@ -245,17 +252,17 @@ object Trees {
   }
 
   /** Apply an instance method with static dispatch (e.g., super calls). */
-  case class ApplyStatically(flags: ApplyFlags, receiver: Tree,
+  sealed case class ApplyStatically(flags: ApplyFlags, receiver: Tree,
       className: ClassName, method: MethodIdent, args: List[Tree])(
       val tpe: Type)(implicit val pos: Position) extends Tree
 
   /** Apply a static method. */
-  case class ApplyStatic(flags: ApplyFlags, className: ClassName,
+  sealed case class ApplyStatic(flags: ApplyFlags, className: ClassName,
       method: MethodIdent, args: List[Tree])(
       val tpe: Type)(implicit val pos: Position) extends Tree
 
   /** Unary operation (always preserves pureness). */
-  case class UnaryOp(op: UnaryOp.Code, lhs: Tree)(
+  sealed case class UnaryOp(op: UnaryOp.Code, lhs: Tree)(
       implicit val pos: Position) extends Tree {
 
     val tpe = UnaryOp.resultTypeOf(op)
@@ -308,7 +315,7 @@ object Trees {
   }
 
   /** Binary operation (always preserves pureness). */
-  case class BinaryOp(op: BinaryOp.Code, lhs: Tree, rhs: Tree)(
+  sealed case class BinaryOp(op: BinaryOp.Code, lhs: Tree, rhs: Tree)(
       implicit val pos: Position) extends Tree {
 
     val tpe = BinaryOp.resultTypeOf(op)
@@ -409,69 +416,73 @@ object Trees {
     }
   }
 
-  case class NewArray(typeRef: ArrayTypeRef, lengths: List[Tree])(
+  sealed case class NewArray(typeRef: ArrayTypeRef, lengths: List[Tree])(
       implicit val pos: Position) extends Tree {
     require(lengths.nonEmpty && lengths.size <= typeRef.dimensions)
 
     val tpe = ArrayType(typeRef)
   }
 
-  case class ArrayValue(typeRef: ArrayTypeRef, elems: List[Tree])(
+  sealed case class ArrayValue(typeRef: ArrayTypeRef, elems: List[Tree])(
       implicit val pos: Position) extends Tree {
     val tpe = ArrayType(typeRef)
   }
 
-  case class ArrayLength(array: Tree)(implicit val pos: Position) extends Tree {
+  sealed case class ArrayLength(array: Tree)(implicit val pos: Position)
+      extends Tree {
     val tpe = IntType
   }
 
-  case class ArraySelect(array: Tree, index: Tree)(val tpe: Type)(
+  sealed case class ArraySelect(array: Tree, index: Tree)(val tpe: Type)(
       implicit val pos: Position) extends Tree
 
-  case class RecordValue(tpe: RecordType, elems: List[Tree])(
+  sealed case class RecordValue(tpe: RecordType, elems: List[Tree])(
       implicit val pos: Position) extends Tree
 
-  case class RecordSelect(record: Tree, field: FieldIdent)(val tpe: Type)(
+  sealed case class RecordSelect(record: Tree, field: FieldIdent)(
+      val tpe: Type)(
       implicit val pos: Position)
       extends Tree
 
-  case class IsInstanceOf(expr: Tree, testType: Type)(
+  sealed case class IsInstanceOf(expr: Tree, testType: Type)(
       implicit val pos: Position)
       extends Tree {
     val tpe = BooleanType
   }
 
-  case class AsInstanceOf(expr: Tree, tpe: Type)(implicit val pos: Position)
+  sealed case class AsInstanceOf(expr: Tree, tpe: Type)(
+      implicit val pos: Position)
       extends Tree
 
-  case class GetClass(expr: Tree)(implicit val pos: Position) extends Tree {
+  sealed case class GetClass(expr: Tree)(implicit val pos: Position)
+      extends Tree {
     val tpe = ClassType(ClassClass)
   }
 
   // JavaScript expressions
 
-  case class JSNew(ctor: Tree, args: List[TreeOrJSSpread])(
+  sealed case class JSNew(ctor: Tree, args: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
-  case class JSPrivateSelect(qualifier: Tree, className: ClassName,
+  sealed case class JSPrivateSelect(qualifier: Tree, className: ClassName,
       field: FieldIdent)(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
-  case class JSSelect(qualifier: Tree, item: Tree)(
+  sealed case class JSSelect(qualifier: Tree, item: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
-  case class JSFunctionApply(fun: Tree, args: List[TreeOrJSSpread])(
+  sealed case class JSFunctionApply(fun: Tree, args: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
-  case class JSMethodApply(receiver: Tree, method: Tree,
+  sealed case class JSMethodApply(receiver: Tree, method: Tree,
       args: List[TreeOrJSSpread])(implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
@@ -506,7 +517,7 @@ object Trees {
    *  as if it were in an instance method of `Foo` with `qualifier` as the
    *  `this` value.
    */
-  case class JSSuperSelect(superClass: Tree, receiver: Tree, item: Tree)(
+  sealed case class JSSuperSelect(superClass: Tree, receiver: Tree, item: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
@@ -555,8 +566,10 @@ object Trees {
    *  super[method](...args)
    *  }}}
    */
-  case class JSSuperMethodCall(superClass: Tree, receiver: Tree, method: Tree,
-      args: List[TreeOrJSSpread])(implicit val pos: Position) extends Tree {
+  sealed case class JSSuperMethodCall(superClass: Tree, receiver: Tree,
+      method: Tree, args: List[TreeOrJSSpread])(
+      implicit val pos: Position)
+      extends Tree {
     val tpe = AnyType
   }
 
@@ -597,7 +610,7 @@ object Trees {
    *  }
    *  }}}
    */
-  case class JSSuperConstructorCall(args: List[TreeOrJSSpread])(
+  sealed case class JSSuperConstructorCall(args: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
     val tpe = NoType
   }
@@ -612,7 +625,7 @@ object Trees {
    *  `ImportCall` is a dedicated syntactic form that cannot be
    *  dissociated.
    */
-  case class JSImportCall(arg: Tree)(implicit val pos: Position)
+  sealed case class JSImportCall(arg: Tree)(implicit val pos: Position)
       extends Tree {
     val tpe = AnyType // it is a JavaScript Promise
   }
@@ -643,13 +656,13 @@ object Trees {
    *  If `Foo` is non-native, the presence of this node makes it instantiable,
    *  and therefore reachable.
    */
-  case class LoadJSConstructor(className: ClassName)(
+  sealed case class LoadJSConstructor(className: ClassName)(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
   /** Like [[LoadModule]] but for a JS module class. */
-  case class LoadJSModule(className: ClassName)(
+  sealed case class LoadJSModule(className: ClassName)(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
@@ -658,11 +671,12 @@ object Trees {
    *
    *  @param items An Array whose items will be spread (not an arbitrary iterable)
    */
-  case class JSSpread(items: Tree)(implicit val pos: Position)
+  sealed case class JSSpread(items: Tree)(implicit val pos: Position)
       extends IRNode with TreeOrJSSpread
 
   /** `delete qualifier[item]` */
-  case class JSDelete(qualifier: Tree, item: Tree)(implicit val pos: Position)
+  sealed case class JSDelete(qualifier: Tree, item: Tree)(
+      implicit val pos: Position)
       extends Tree {
 
     val tpe = NoType // cannot be in expression position
@@ -673,7 +687,7 @@ object Trees {
    *  Operations which do not preserve pureness are not allowed in this tree.
    *  These are notably ++ and --
    */
-  case class JSUnaryOp(op: JSUnaryOp.Code, lhs: Tree)(
+  sealed case class JSUnaryOp(op: JSUnaryOp.Code, lhs: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = JSUnaryOp.resultTypeOf(op)
   }
@@ -698,7 +712,7 @@ object Trees {
    *  Operations which do not preserve pureness are not allowed in this tree.
    *  These are notably +=, -=, *=, /= and %=
    */
-  case class JSBinaryOp(op: JSBinaryOp.Code, lhs: Tree, rhs: Tree)(
+  sealed case class JSBinaryOp(op: JSBinaryOp.Code, lhs: Tree, rhs: Tree)(
       implicit val pos: Position) extends Tree {
     val tpe = JSBinaryOp.resultTypeOf(op)
   }
@@ -747,17 +761,17 @@ object Trees {
     }
   }
 
-  case class JSArrayConstr(items: List[TreeOrJSSpread])(
+  sealed case class JSArrayConstr(items: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
-  case class JSObjectConstr(fields: List[(Tree, Tree)])(
+  sealed case class JSObjectConstr(fields: List[(Tree, Tree)])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
-  case class JSGlobalRef(name: String)(
+  sealed case class JSGlobalRef(name: String)(
       implicit val pos: Position) extends Tree {
     import JSGlobalRef._
 
@@ -800,12 +814,12 @@ object Trees {
       isJSIdentifierName(name) && !ReservedJSIdentifierNames.contains(name)
   }
 
-  case class JSTypeOfGlobalRef(globalRef: JSGlobalRef)(
+  sealed case class JSTypeOfGlobalRef(globalRef: JSGlobalRef)(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
-  case class JSLinkingInfo()(implicit val pos: Position) extends Tree {
+  sealed case class JSLinkingInfo()(implicit val pos: Position) extends Tree {
     val tpe = AnyType
   }
 
@@ -814,70 +828,71 @@ object Trees {
   /** Marker for literals. Literals are always pure. */
   sealed trait Literal extends Tree
 
-  case class Undefined()(implicit val pos: Position) extends Literal {
+  sealed case class Undefined()(implicit val pos: Position) extends Literal {
     val tpe = UndefType
   }
 
-  case class Null()(implicit val pos: Position) extends Literal {
+  sealed case class Null()(implicit val pos: Position) extends Literal {
     val tpe = NullType
   }
 
-  case class BooleanLiteral(value: Boolean)(
+  sealed case class BooleanLiteral(value: Boolean)(
       implicit val pos: Position) extends Literal {
     val tpe = BooleanType
   }
 
-  case class CharLiteral(value: Char)(
+  sealed case class CharLiteral(value: Char)(
       implicit val pos: Position) extends Literal {
     val tpe = CharType
   }
 
-  case class ByteLiteral(value: Byte)(
+  sealed case class ByteLiteral(value: Byte)(
       implicit val pos: Position) extends Literal {
     val tpe = ByteType
   }
 
-  case class ShortLiteral(value: Short)(
+  sealed case class ShortLiteral(value: Short)(
       implicit val pos: Position) extends Literal {
     val tpe = ShortType
   }
 
-  case class IntLiteral(value: Int)(
+  sealed case class IntLiteral(value: Int)(
       implicit val pos: Position) extends Literal {
     val tpe = IntType
   }
 
-  case class LongLiteral(value: Long)(
+  sealed case class LongLiteral(value: Long)(
       implicit val pos: Position) extends Literal {
     val tpe = LongType
   }
 
-  case class FloatLiteral(value: Float)(
+  sealed case class FloatLiteral(value: Float)(
       implicit val pos: Position) extends Literal {
     val tpe = FloatType
   }
 
-  case class DoubleLiteral(value: Double)(
+  sealed case class DoubleLiteral(value: Double)(
       implicit val pos: Position) extends Literal {
     val tpe = DoubleType
   }
 
-  case class StringLiteral(value: String)(
+  sealed case class StringLiteral(value: String)(
       implicit val pos: Position) extends Literal {
     val tpe = StringType
   }
 
-  case class ClassOf(typeRef: TypeRef)(
+  sealed case class ClassOf(typeRef: TypeRef)(
       implicit val pos: Position) extends Literal {
     val tpe = ClassType(ClassClass)
   }
 
   // Atomic expressions
 
-  case class VarRef(ident: LocalIdent)(val tpe: Type)(
+  sealed case class VarRef(ident: LocalIdent)(val tpe: Type)(
       implicit val pos: Position) extends Tree
 
-  case class This()(val tpe: Type)(implicit val pos: Position) extends Tree
+  sealed case class This()(val tpe: Type)(implicit val pos: Position)
+      extends Tree
 
   /** Closure with explicit captures.
    *
@@ -886,7 +901,7 @@ object Trees {
    *    an `this` parameter, and cannot be constructed (called with `new`).
    *    If `false`, it is a regular Function (`function`).
    */
-  case class Closure(arrow: Boolean, captureParams: List[ParamDef],
+  sealed case class Closure(arrow: Boolean, captureParams: List[ParamDef],
       params: List[ParamDef], body: Tree, captureValues: List[Tree])(
       implicit val pos: Position) extends Tree {
     val tpe = AnyType
@@ -902,7 +917,8 @@ object Trees {
    *    Actual values for the captured parameters (in the `ClassDef`'s
    *    `jsClassCaptures.get`)
    */
-  case class CreateJSClass(className: ClassName, captureValues: List[Tree])(
+  sealed case class CreateJSClass(className: ClassName,
+      captureValues: List[Tree])(
       implicit val pos: Position)
       extends Tree {
     val tpe = AnyType
@@ -918,7 +934,7 @@ object Trees {
    *  @param value
    *    The payload of the transient node, without any specified meaning.
    */
-  case class Transient(value: Transient.Value)(val tpe: Type)(
+  sealed case class Transient(value: Transient.Value)(val tpe: Type)(
       implicit val pos: Position)
       extends Tree
 
@@ -1022,14 +1038,14 @@ object Trees {
     val ftpe: Type
   }
 
-  case class FieldDef(flags: MemberFlags, name: FieldIdent,
+  sealed case class FieldDef(flags: MemberFlags, name: FieldIdent,
       originalName: OriginalName, ftpe: Type)(
       implicit val pos: Position) extends AnyFieldDef
 
-  case class JSFieldDef(flags: MemberFlags, name: Tree, ftpe: Type)(
+  sealed case class JSFieldDef(flags: MemberFlags, name: Tree, ftpe: Type)(
       implicit val pos: Position) extends AnyFieldDef
 
-  case class MethodDef(flags: MemberFlags, name: MethodIdent,
+  sealed case class MethodDef(flags: MemberFlags, name: MethodIdent,
       originalName: OriginalName, args: List[ParamDef], resultType: Type,
       body: Option[Tree])(
       val optimizerHints: OptimizerHints, val hash: Option[TreeHash])(
@@ -1042,7 +1058,7 @@ object Trees {
 
   sealed abstract class JSMethodPropDef extends MemberDef
 
-  case class JSMethodDef(flags: MemberFlags, name: Tree,
+  sealed case class JSMethodDef(flags: MemberFlags, name: Tree,
       args: List[ParamDef], body: Tree)(
       val optimizerHints: OptimizerHints, val hash: Option[TreeHash])(
       implicit val pos: Position)
@@ -1051,7 +1067,7 @@ object Trees {
     require(!flags.isMutable, "nonsensical mutable MethodDef")
   }
 
-  case class JSPropertyDef(flags: MemberFlags, name: Tree,
+  sealed case class JSPropertyDef(flags: MemberFlags, name: Tree,
       getterBody: Option[Tree], setterArgAndBody: Option[(ParamDef, Tree)])(
       implicit val pos: Position)
       extends JSMethodPropDef {
@@ -1084,7 +1100,7 @@ object Trees {
       isJSIdentifierName(exportName)
   }
 
-  case class TopLevelJSClassExportDef(exportName: String)(
+  sealed case class TopLevelJSClassExportDef(exportName: String)(
       implicit val pos: Position) extends TopLevelExportDef
 
   /** Export for a top-level object.
@@ -1092,13 +1108,14 @@ object Trees {
    *  This exports the singleton instance of the containing module class.
    *  The instance is initialized during ES module instantiation.
    */
-  case class TopLevelModuleExportDef(exportName: String)(
+  sealed case class TopLevelModuleExportDef(exportName: String)(
       implicit val pos: Position) extends TopLevelExportDef
 
-  case class TopLevelMethodExportDef(methodDef: JSMethodDef)(
+  sealed case class TopLevelMethodExportDef(methodDef: JSMethodDef)(
       implicit val pos: Position) extends TopLevelExportDef
 
-  case class TopLevelFieldExportDef(exportName: String, field: FieldIdent)(
+  sealed case class TopLevelFieldExportDef(exportName: String,
+      field: FieldIdent)(
       implicit val pos: Position) extends TopLevelExportDef
 
   // Miscellaneous

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
@@ -140,12 +140,12 @@ object Semantics {
      * `j.u.regex.Pattern`, because the latter does not have meaningful
      * equality.
      */
-    private case class RegexReplace(pattern: String, flags: Int,
+    private final case class RegexReplace(pattern: String, flags: Int,
         replacement: String)(
         val compiledPattern: java.util.regex.Pattern)
         extends RuntimeClassNameMapper
 
-    private case class AndThen(first: RuntimeClassNameMapper,
+    private final case class AndThen(first: RuntimeClassNameMapper,
         second: RuntimeClassNameMapper)
         extends RuntimeClassNameMapper
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatformExtensions.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/LinkerBackendImplPlatformExtensions.scala
@@ -17,10 +17,8 @@ import org.scalajs.linker.backend.closure.ClosureLinkerBackend
 object LinkerBackendImplPlatformExtensions {
   import LinkerBackendImpl.Config
 
-  final class ConfigExt private[backend] (val __private_self: Config)
+  final class ConfigExt private[backend] (private val self: Config)
       extends AnyVal {
-
-    @inline private def self: Config = __private_self
 
     /** Whether to actually use the Google Closure Compiler pass. */
     def closureCompiler: Boolean = self.closureCompilerIfAvailable

--- a/linker/jvm/src/main/scala/org/scalajs/linker/frontend/optimizer/ConcurrencyUtils.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/frontend/optimizer/ConcurrencyUtils.scala
@@ -32,10 +32,8 @@ private[optimizer] object ConcurrencyUtils {
   }
 
   implicit class AtomicAccOps[T] private[ConcurrencyUtils] (
-      val __private_self: AtomicAcc[T])
+      private val self: AtomicAcc[T])
       extends AnyVal {
-
-    @inline private def self: AtomicAcc[T] = __private_self
 
     @inline final def size: Int = self.get.size
 
@@ -63,10 +61,8 @@ private[optimizer] object ConcurrencyUtils {
   type TrieSet[T] = TrieMap[T, Null]
 
   implicit class TrieSetOps[T] private[ConcurrencyUtils] (
-      val __private_self: TrieSet[T])
+      private val self: TrieSet[T])
       extends AnyVal {
-
-    @inline private def self: TrieSet[T] = __private_self
 
     @inline final def +=(x: T): Unit = self.put(x, null)
   }
@@ -76,10 +72,8 @@ private[optimizer] object ConcurrencyUtils {
   }
 
   implicit class TrieMapOps[K, V] private[ConcurrencyUtils] (
-      val __private_self: TrieMap[K, V])
+      private val self: TrieMap[K, V])
       extends AnyVal {
-
-    @inline private def self: TrieMap[K, V] = __private_self
 
     @inline final def getOrPut(k: K, default: => V): V = {
       self.get(k).getOrElse {

--- a/linker/shared/src/main/scala/org/scalajs/linker/CollectionsCompat.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/CollectionsCompat.scala
@@ -15,7 +15,7 @@ package org.scalajs.linker
 import scala.collection.mutable
 
 private[linker] object CollectionsCompat {
-  implicit class MutableMapCompatOps[K, V](val __self: mutable.Map[K, V])
+  implicit class MutableMapCompatOps[K, V](private val self: mutable.Map[K, V])
       extends AnyVal {
 
     // filterInPlace replaces retain
@@ -23,9 +23,9 @@ private[linker] object CollectionsCompat {
       // Believe it or not, this is the implementation of `retain` in 2.12.x:
 
       // scala/bug#7269 toList avoids ConcurrentModificationException
-      for ((k, v) <- __self.toList) {
+      for ((k, v) <- self.toList) {
         if (!p(k, v))
-        __self -= k
+          self -= k
       }
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -280,7 +280,9 @@ private final class Analyzer(config: CommonPhaseConfig,
   private sealed trait LoadingResult
   private sealed trait ClassLoadingState
 
-  private case class CycleInfo(cycle: List[ClassName], root: LoadingClass)
+  // sealed instead of final because of spurious unchecked warnings
+  private sealed case class CycleInfo(cycle: List[ClassName],
+      root: LoadingClass)
       extends LoadingResult
 
   private final class LoadingClass(className: ClassName)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2785,14 +2785,14 @@ private object FunctionEmitter {
   }
 
   object Lhs {
-    case class Assign(lhs: Tree) extends Lhs
-    case class VarDef(name: js.Ident, tpe: Type, mutable: Boolean) extends Lhs
+    final case class Assign(lhs: Tree) extends Lhs
+    final case class VarDef(name: js.Ident, tpe: Type, mutable: Boolean) extends Lhs
 
     case object ReturnFromFunction extends Lhs {
       override def hasNothingType: Boolean = true
     }
 
-    case class Return(label: LabelIdent) extends Lhs {
+    final case class Return(label: LabelIdent) extends Lhs {
       override def hasNothingType: Boolean = true
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
@@ -20,10 +20,8 @@ import org.scalajs.ir.Position
 import org.scalajs.linker.backend.javascript.Trees._
 
 private[emitter] object TreeDSL {
-  implicit class TreeOps private[TreeDSL] (val __private_self: Tree)
+  implicit class TreeOps private[TreeDSL] (private val self: Tree)
       extends AnyVal {
-
-    @inline private def self: Tree = __private_self
 
     /** Select a member */
     def DOT(field: Ident)(implicit pos: Position): DotSelect =

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -20,6 +20,11 @@ import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Position.NoPosition
 
 object Trees {
+  /* The case classes for JS Trees are sealed instead of final because making
+   * them final triggers bugs with Scala 2.11.x and 2.12.{1-4}, in combination
+   * with their `implicit val pos`.
+   */
+
   /** AST node of JavaScript. */
   abstract sealed class Tree {
     val pos: Position
@@ -34,7 +39,8 @@ object Trees {
 
   // Comments
 
-  case class DocComment(text: String)(implicit val pos: Position) extends Tree
+  sealed case class DocComment(text: String)(implicit val pos: Position)
+      extends Tree
 
   // Identifiers and properties
 
@@ -42,7 +48,7 @@ object Trees {
     def pos: Position
   }
 
-  case class Ident(name: String, originalName: OriginalName)(
+  sealed case class Ident(name: String, originalName: OriginalName)(
       implicit val pos: Position) extends PropertyName {
     require(Ident.isValidJSIdentifierName(name),
         s"'$name' is not a valid JS identifier name")
@@ -79,7 +85,7 @@ object Trees {
     }
   }
 
-  case class ComputedName(tree: Tree) extends PropertyName {
+  sealed case class ComputedName(tree: Tree) extends PropertyName {
     def pos: Position = tree.pos
   }
 
@@ -92,22 +98,30 @@ object Trees {
     def ref(implicit pos: Position): Tree = VarRef(name)
   }
 
-  case class VarDef(name: Ident, rhs: Option[Tree])(implicit val pos: Position) extends LocalDef {
+  sealed case class VarDef(name: Ident, rhs: Option[Tree])(
+      implicit val pos: Position)
+      extends LocalDef {
     def mutable: Boolean = true
   }
 
   /** ES6 let or const (depending on the mutable flag). */
-  case class Let(name: Ident, mutable: Boolean, rhs: Option[Tree])(implicit val pos: Position) extends LocalDef
+  sealed case class Let(name: Ident, mutable: Boolean, rhs: Option[Tree])(
+      implicit val pos: Position)
+      extends LocalDef
 
-  case class ParamDef(name: Ident, rest: Boolean)(implicit val pos: Position) extends LocalDef {
+  sealed case class ParamDef(name: Ident, rest: Boolean)(
+      implicit val pos: Position)
+      extends LocalDef {
     def mutable: Boolean = true
   }
 
   // Control flow constructs
 
-  case class Skip()(implicit val pos: Position) extends Tree
+  sealed case class Skip()(implicit val pos: Position) extends Tree
 
-  class Block private (val stats: List[Tree])(implicit val pos: Position) extends Tree {
+  sealed class Block private (val stats: List[Tree])(
+      implicit val pos: Position)
+      extends Tree {
     override def toString(): String =
       stats.mkString("Block(", ",", ")")
   }
@@ -132,59 +146,89 @@ object Trees {
     def unapply(block: Block): Some[List[Tree]] = Some(block.stats)
   }
 
-  case class Labeled(label: Ident, body: Tree)(implicit val pos: Position) extends Tree
+  sealed case class Labeled(label: Ident, body: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class Assign(lhs: Tree, rhs: Tree)(implicit val pos: Position) extends Tree {
+  sealed case class Assign(lhs: Tree, rhs: Tree)(implicit val pos: Position)
+      extends Tree {
     require(lhs match {
       case _:VarRef | _:DotSelect | _:BracketSelect => true
       case _ => false
     }, s"Invalid lhs for Assign: $lhs")
   }
 
-  case class Return(expr: Tree)(implicit val pos: Position) extends Tree
+  sealed case class Return(expr: Tree)(implicit val pos: Position) extends Tree
 
-  case class If(cond: Tree, thenp: Tree, elsep: Tree)(implicit val pos: Position) extends Tree
-
-  case class While(cond: Tree, body: Tree, label: Option[Ident] = None)(implicit val pos: Position) extends Tree
-
-  case class DoWhile(body: Tree, cond: Tree, label: Option[Ident] = None)(implicit val pos: Position) extends Tree
-
-  case class ForIn(lhs: Tree, obj: Tree, body: Tree)(implicit val pos: Position) extends Tree
-
-  case class For(init: Tree, guard: Tree, update: Tree, body: Tree)(
+  sealed case class If(cond: Tree, thenp: Tree, elsep: Tree)(
       implicit val pos: Position)
       extends Tree
 
-  case class TryCatch(block: Tree, errVar: Ident, handler: Tree)(implicit val pos: Position) extends Tree
+  sealed case class While(cond: Tree, body: Tree, label: Option[Ident] = None)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class TryFinally(block: Tree, finalizer: Tree)(implicit val pos: Position) extends Tree
+  sealed case class DoWhile(body: Tree, cond: Tree, label: Option[Ident] = None)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class Throw(expr: Tree)(implicit val pos: Position) extends Tree
+  sealed case class ForIn(lhs: Tree, obj: Tree, body: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class Break(label: Option[Ident] = None)(implicit val pos: Position) extends Tree
+  sealed case class For(init: Tree, guard: Tree, update: Tree, body: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class Continue(label: Option[Ident] = None)(implicit val pos: Position) extends Tree
+  sealed case class TryCatch(block: Tree, errVar: Ident, handler: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class Switch(selector: Tree, cases: List[(Tree, Tree)], default: Tree)(implicit val pos: Position) extends Tree
+  sealed case class TryFinally(block: Tree, finalizer: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class Debugger()(implicit val pos: Position) extends Tree
+  sealed case class Throw(expr: Tree)(implicit val pos: Position) extends Tree
+
+  sealed case class Break(label: Option[Ident] = None)(
+      implicit val pos: Position)
+      extends Tree
+
+  sealed case class Continue(label: Option[Ident] = None)(
+      implicit val pos: Position)
+      extends Tree
+
+  sealed case class Switch(selector: Tree, cases: List[(Tree, Tree)],
+      default: Tree)(
+      implicit val pos: Position)
+      extends Tree
+
+  sealed case class Debugger()(implicit val pos: Position) extends Tree
 
   // Expressions
 
-  case class New(ctor: Tree, args: List[Tree])(implicit val pos: Position) extends Tree
+  sealed case class New(ctor: Tree, args: List[Tree])(
+      implicit val pos: Position)
+      extends Tree
 
-  case class DotSelect(qualifier: Tree, item: Ident)(implicit val pos: Position) extends Tree
+  sealed case class DotSelect(qualifier: Tree, item: Ident)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class BracketSelect(qualifier: Tree, item: Tree)(implicit val pos: Position) extends Tree
+  sealed case class BracketSelect(qualifier: Tree, item: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
   /** Syntactic apply.
    *  It is a method call if fun is a dot-select or bracket-select. It is a
    *  function call otherwise.
    */
-  case class Apply(fun: Tree, args: List[Tree])(implicit val pos: Position) extends Tree
+  sealed case class Apply(fun: Tree, args: List[Tree])(
+      implicit val pos: Position)
+      extends Tree
 
   /** Dynamic `import(arg)`. */
-  case class ImportCall(arg: Tree)(implicit val pos: Position)
+  sealed case class ImportCall(arg: Tree)(implicit val pos: Position)
       extends Tree
 
   /** `...items`, the "spread" operator of ECMAScript 6.
@@ -194,9 +238,9 @@ object Trees {
    *
    *  @param items An iterable whose items will be spread
    */
-  case class Spread(items: Tree)(implicit val pos: Position) extends Tree
+  sealed case class Spread(items: Tree)(implicit val pos: Position) extends Tree
 
-  case class Delete(prop: Tree)(implicit val pos: Position) extends Tree {
+  sealed case class Delete(prop: Tree)(implicit val pos: Position) extends Tree {
     require(prop match {
       case _:DotSelect | _:BracketSelect => true
       case _ => false
@@ -208,7 +252,9 @@ object Trees {
    *  Operations which do not preserve pureness are not allowed in this tree.
    *  These are notably ++ and --
    */
-  case class UnaryOp(op: UnaryOp.Code, lhs: Tree)(implicit val pos: Position) extends Tree
+  sealed case class UnaryOp(op: UnaryOp.Code, lhs: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
   object UnaryOp {
     /** Codes are the same as in the IR. */
@@ -216,7 +262,7 @@ object Trees {
   }
 
   /** `++x`, `x++`, `--x` or `x--`. */
-  case class IncDec(prefix: Boolean, inc: Boolean, arg: Tree)(
+  sealed case class IncDec(prefix: Boolean, inc: Boolean, arg: Tree)(
       implicit val pos: Position)
       extends Tree
 
@@ -225,67 +271,83 @@ object Trees {
    *  Operations which do not preserve pureness are not allowed in this tree.
    *  These are notably +=, -=, *=, /= and %=
    */
-  case class BinaryOp(op: BinaryOp.Code, lhs: Tree, rhs: Tree)(implicit val pos: Position) extends Tree
+  sealed case class BinaryOp(op: BinaryOp.Code, lhs: Tree, rhs: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
   object BinaryOp {
     /** Codes are the same as in the IR. */
     type Code = ir.Trees.JSBinaryOp.Code
   }
 
-  case class ArrayConstr(items: List[Tree])(implicit val pos: Position) extends Tree
+  sealed case class ArrayConstr(items: List[Tree])(implicit val pos: Position)
+      extends Tree
 
-  case class ObjectConstr(fields: List[(PropertyName, Tree)])(implicit val pos: Position) extends Tree
+  sealed case class ObjectConstr(fields: List[(PropertyName, Tree)])(
+      implicit val pos: Position)
+      extends Tree
 
   // Literals
 
   /** Marker for literals. Literals are always pure. */
   sealed trait Literal extends Tree
 
-  case class Undefined()(implicit val pos: Position) extends Literal
+  sealed case class Undefined()(implicit val pos: Position) extends Literal
 
-  case class Null()(implicit val pos: Position) extends Literal
+  sealed case class Null()(implicit val pos: Position) extends Literal
 
-  case class BooleanLiteral(value: Boolean)(implicit val pos: Position) extends Literal
+  sealed case class BooleanLiteral(value: Boolean)(implicit val pos: Position)
+      extends Literal
 
-  case class IntLiteral(value: Int)(implicit val pos: Position) extends Literal
+  sealed case class IntLiteral(value: Int)(implicit val pos: Position)
+      extends Literal
 
-  case class DoubleLiteral(value: Double)(implicit val pos: Position) extends Literal
+  sealed case class DoubleLiteral(value: Double)(implicit val pos: Position)
+      extends Literal
 
-  case class StringLiteral(value: String)(
+  sealed case class StringLiteral(value: String)(
       implicit val pos: Position) extends Literal with PropertyName
 
-  case class BigIntLiteral(value: BigInt)(
+  sealed case class BigIntLiteral(value: BigInt)(
       implicit val pos: Position) extends Literal
 
   // Atomic expressions
 
-  case class VarRef(ident: Ident)(implicit val pos: Position) extends Tree
+  sealed case class VarRef(ident: Ident)(implicit val pos: Position)
+      extends Tree
 
-  case class This()(implicit val pos: Position) extends Tree
+  sealed case class This()(implicit val pos: Position) extends Tree
 
-  case class Function(arrow: Boolean, args: List[ParamDef], body: Tree)(
+  sealed case class Function(arrow: Boolean, args: List[ParamDef], body: Tree)(
       implicit val pos: Position) extends Tree
 
   // Named function definition
 
-  case class FunctionDef(name: Ident, args: List[ParamDef], body: Tree)(
+  sealed case class FunctionDef(name: Ident, args: List[ParamDef], body: Tree)(
       implicit val pos: Position) extends Tree
 
   // ECMAScript 6 classes
 
-  case class ClassDef(className: Option[Ident], parentClass: Option[Tree],
-      members: List[Tree])(implicit val pos: Position) extends Tree
+  sealed case class ClassDef(className: Option[Ident],
+      parentClass: Option[Tree], members: List[Tree])(
+      implicit val pos: Position)
+      extends Tree
 
-  case class MethodDef(static: Boolean, name: PropertyName, args: List[ParamDef],
-      body: Tree)(implicit val pos: Position) extends Tree
+  sealed case class MethodDef(static: Boolean, name: PropertyName,
+      args: List[ParamDef], body: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class GetterDef(static: Boolean, name: PropertyName,
-      body: Tree)(implicit val pos: Position) extends Tree
+  sealed case class GetterDef(static: Boolean, name: PropertyName, body: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class SetterDef(static: Boolean, name: PropertyName, param: ParamDef,
-      body: Tree)(implicit val pos: Position) extends Tree
+  sealed case class SetterDef(static: Boolean, name: PropertyName,
+      param: ParamDef, body: Tree)(
+      implicit val pos: Position)
+      extends Tree
 
-  case class Super()(implicit val pos: Position) extends Tree
+  sealed case class Super()(implicit val pos: Position) extends Tree
 
   // ECMAScript 6 modules
 
@@ -294,7 +356,7 @@ object Trees {
    *  It must be a valid `IdentifierName`, as tested by
    *  [[ExportName.isValidExportName]].
    */
-  case class ExportName(name: String)(implicit val pos: Position) {
+  sealed case class ExportName(name: String)(implicit val pos: Position) {
     require(ExportName.isValidExportName(name),
         s"'$name' is not a valid export name")
   }
@@ -366,7 +428,8 @@ object Trees {
    *    `import { binding } from 'from'`.
    *  - When `_1.name == "default"`, it is equivalent to a default import.
    */
-  case class Import(bindings: List[(ExportName, Ident)], from: StringLiteral)(
+  sealed case class Import(bindings: List[(ExportName, Ident)],
+      from: StringLiteral)(
       implicit val pos: Position)
       extends Tree
 
@@ -377,7 +440,7 @@ object Trees {
    *  import * as <binding> from <from>
    *  }}}
    */
-  case class ImportNamespace(binding: Ident, from: StringLiteral)(
+  sealed case class ImportNamespace(binding: Ident, from: StringLiteral)(
       implicit val pos: Position)
       extends Tree
 
@@ -391,7 +454,7 @@ object Trees {
    *  module that are exported. The `_2` parts are the names under which they
    *  are exported to other modules.
    */
-  case class Export(bindings: List[(Ident, ExportName)])(
+  sealed case class Export(bindings: List[(Ident, ExportName)])(
       implicit val pos: Position)
       extends Tree
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -1392,11 +1392,8 @@ object IRChecker {
    *  IR is invalid, so all bets are off and we can be slow and allocate stuff;
    *  we don't care.
    */
-  private final class ErrorContext private (
-      val __private_nodeOrLinkedClass: Any)
+  private final class ErrorContext private (private val nodeOrLinkedClass: Any)
       extends AnyVal {
-
-    @inline private def nodeOrLinkedClass: Any = __private_nodeOrLinkedClass
 
     override def toString(): String = {
       val (pos, name) = nodeOrLinkedClass match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -1418,6 +1418,7 @@ object IRChecker {
       new ErrorContext(linkedClass)
   }
 
-  private case class LocalDef(name: LocalName, tpe: Type, mutable: Boolean)(
+  private final case class LocalDef(name: LocalName, tpe: Type,
+      mutable: Boolean)(
       val pos: Position)
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -4483,7 +4483,7 @@ private[optimizer] object OptimizerCore {
   private type CancelFun = () => Nothing
   private type PreTransCont = PreTransform => TailRec[Tree]
 
-  private case class RefinedType private (base: Type, isExact: Boolean,
+  private final case class RefinedType private (base: Type, isExact: Boolean,
       isNullable: Boolean)(val allocationSite: AllocationSite, dummy: Int = 0) {
 
     def isNothingType: Boolean = base == NothingType
@@ -4551,7 +4551,7 @@ private[optimizer] object OptimizerCore {
     }
   }
 
-  private case class LocalDef(
+  private final case class LocalDef(
       tpe: RefinedType,
       mutable: Boolean,
       replacement: LocalDefReplacement) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -4964,10 +4964,8 @@ private[optimizer] object OptimizerCore {
   }
 
   private implicit class OptimizerTreeOps private[OptimizerCore] (
-      val __private_self: Tree)
+      private val self: Tree)
       extends AnyVal {
-
-    @inline private def self: Tree = __private_self
 
     def toPreTransform: PreTransform = {
       self match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/package.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/package.scala
@@ -17,12 +17,14 @@ import scala.concurrent._
 import scala.util.{Try, Success, Failure}
 
 package object linker {
-  private[linker] implicit class FutureOps[T](val __self: Future[T]) extends AnyVal {
+  private[linker] implicit class FutureOps[T](private val self: Future[T])
+      extends AnyVal {
+
     def transformWith[S](f: Try[T] => Future[S])(implicit ec: ExecutionContext): Future[S] =
-      __self.map[Try[T]](Success(_)).recover { case t => Failure(t) }.flatMap(f)
+      self.map[Try[T]](Success(_)).recover { case t => Failure(t) }.flatMap(f)
 
     def finallyWith(f: => Future[Unit])(implicit ec: ExecutionContext): Future[T] = {
-      __self.transformWith {
+      self.transformWith {
         case Success(x) =>
           f.map(_ => x)
 

--- a/test-common/src/main/scala/org/scalajs/testing/common/TestBridgeMode.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/TestBridgeMode.scala
@@ -17,7 +17,7 @@ private[testing] sealed abstract class TestBridgeMode
 
 private[testing] object TestBridgeMode {
   case object FullBridge extends TestBridgeMode
-  case class HTMLRunner(tests: IsolatedTestSet) extends TestBridgeMode
+  final case class HTMLRunner(tests: IsolatedTestSet) extends TestBridgeMode
 
   implicit object TestBridgeModeSerializer extends Serializer[TestBridgeMode] {
     def serialize(x: TestBridgeMode, out: Serializer.SerializeState): Unit = x match {


### PR DESCRIPTION
The case classes for IR Trees and JS Trees are `sealed` instead, because making them `final` triggers bugs with Scala 2.11.x and 2.12.{1-4}, in combination with their `implicit val pos`.