### PR TITLE
Upgrade Node.js on Appveyor to 12

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 image: Visual Studio 2015
 environment:
   global:
-    NODEJS_VERSION: "8"
+    NODEJS_VERSION: "12"
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     SCALA_VERSION: 2.12.4
 install:


### PR DESCRIPTION
This is necessary for the BigInt tests that got merged in 0.6.x.