### PR TITLE
Always attach path context when reading IR

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/IRFileImpl.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/IRFileImpl.scala
@@ -61,7 +61,7 @@ object IRFileImpl {
             s"Failed to deserialize a file compiled with Scala.js ${e.version}" +
             s" (supported: ${e.supported.mkString(", ")}): $path", e)
 
-      case e: IOException =>
+      case e: Exception =>
         throw new IOException(s"Failed to deserialize $path", e)
     }
   }


### PR DESCRIPTION
Because we are using buffers under the hood now, BufferUnderflowExceptions can happen as well.

At this point, it seems best to simply attach the path information to all exceptions.