### PR TITLE
Constrain more the arguments of typed arrays' constructors and `set`.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/typedarray/BigInt64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/BigInt64Array.scala
@@ -30,7 +30,7 @@ class BigInt64Array private[this] () extends TypedArray[js.BigInt, BigInt64Array
    *
    *  Each elements must be BigInt (no conversion).
    */
-  def this(typedArray: TypedArray[js.BigInt, _]) = this()
+  def this(typedArray: BigInt64Array) = this()
 
   /** Creates a new BigInt64Array with the elements in the given array.
    *

--- a/library/src/main/scala/scala/scalajs/js/typedarray/BigUint64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/BigUint64Array.scala
@@ -31,7 +31,7 @@ class BigUint64Array private[this] ()
    *
    *  Each elements must be BigInt (no conversion).
    */
-  def this(typedArray: TypedArray[js.BigInt, _]) = this()
+  def this(typedArray: BigUint64Array) = this()
 
   /** Creates a new BigInt64Array with the elements in the given array.
    *

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float32Array.scala
@@ -29,10 +29,10 @@ class Float32Array private[this] () extends TypedArray[Float, Float32Array] {
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Float32Array) = this()
 
   /** Creates a new Float32Array with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Float]) = this()
 
   /** Creates a Float32Array view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Float64Array.scala
@@ -29,10 +29,10 @@ class Float64Array private[this] () extends TypedArray[Double, Float64Array] {
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Float64Array) = this()
 
   /** Creates a new Float64Array with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Double]) = this()
 
   /** Creates a Float64Array view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int16Array.scala
@@ -29,10 +29,10 @@ class Int16Array private[this] () extends TypedArray[Short, Int16Array] {
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Int16Array) = this()
 
   /** Creates a new Int16Array with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Short]) = this()
 
   /** Creates a Int16Array view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int32Array.scala
@@ -29,10 +29,10 @@ class Int32Array private[this] () extends TypedArray[Int, Int32Array] {
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Int32Array) = this()
 
   /** Creates a new Int32Array with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Int]) = this()
 
   /** Creates a Int32Array view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Int8Array.scala
@@ -29,10 +29,10 @@ class Int8Array private[this] () extends TypedArray[Byte, Int8Array] {
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Int8Array) = this()
 
   /** Creates a new Int8Array with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Byte]) = this()
 
   /** Creates a Int8Array view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArray.scala
@@ -44,18 +44,17 @@ trait TypedArray[T, Repr] extends ArrayBufferView with js.Iterable[T] {
   @JSBracketAccess
   def set(index: Int, value: T): Unit = js.native
 
-  // FIXME: Not type-safe. BigInt*Array should accept only BigInt, other TypedArray accept only non-BigInt number.
   /** Set the values of typedArray in this TypedArray */
-  def set(typedArray: TypedArray[_, _]): Unit = js.native
+  def set(typedArray: Repr): Unit = js.native
 
   /** Set the values of typedArray in this TypedArray at given offset */
-  def set(typedArray: TypedArray[_, _], offset: Int): Unit = js.native
+  def set(typedArray: Repr, offset: Int): Unit = js.native
 
   /** Set the values from array in this TypedArray */
-  def set(array: js.Iterable[_]): Unit = js.native
+  def set(array: js.Array[_ <: T]): Unit = js.native
 
   /** Set the values from array in this TypedArray at given offset */
-  def set(array: js.Iterable[_], offset: Int): Unit = js.native
+  def set(array: js.Array[_ <: T], offset: Int): Unit = js.native
 
   /** Create a new TypedArray view of this TypedArray at given location */
   def subarray(begin: Int, end: Int = ???): Repr = js.native

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint16Array.scala
@@ -29,10 +29,10 @@ class Uint16Array private[this] () extends TypedArray[Int, Uint16Array] {
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Uint16Array) = this()
 
   /** Creates a new Uint16Array with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Int]) = this()
 
   /** Creates a Uint16Array view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint32Array.scala
@@ -29,10 +29,10 @@ class Uint32Array private[this] () extends TypedArray[Double, Uint32Array] {
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Uint32Array) = this()
 
   /** Creates a new Uint32Array with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Double]) = this()
 
   /** Creates a Uint32Array view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8Array.scala
@@ -29,10 +29,10 @@ class Uint8Array private[this] () extends TypedArray[Short, Uint8Array] {
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Uint8Array) = this()
 
   /** Creates a new Uint8Array with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Short]) = this()
 
   /** Creates a Uint8Array view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/Uint8ClampedArray.scala
@@ -31,10 +31,10 @@ class Uint8ClampedArray private[this] ()
    *
    *  The elements are converted before being stored in the new Int8Array.
    */
-  def this(typedArray: TypedArray[_, _]) = this()
+  def this(typedArray: Uint8ClampedArray) = this()
 
   /** Creates a new Uint8ClampedArray with the elements in the given array */
-  def this(array: js.Iterable[_]) = this()
+  def this(array: js.Iterable[Int]) = this()
 
   /** Creates a Uint8ClampedArray view on the given ArrayBuffer */
   def this(buffer: ArrayBuffer, byteOffset: Int = 0, length: Int = ???) = this()

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
@@ -23,13 +23,12 @@ object TypedArrayConversionTest extends Requires.TypedArray
 
 class TypedArrayConversionTest {
 
-  def data(factor: Double): js.Array[Double] =
-    js.Array(-1, 1, 2, 3, 4, 5, 6, 7, 8).map((_: Int) * factor)
+  val data = js.Array[Int](-1, 1, 2, 3, 4, 5, 6, 7, 8)
 
   def sum(factor: Double): Double = (8 * 9 / 2 - 1) * factor
 
   @Test def convert_an_Int8Array_to_a_scala_Array_Byte(): Unit = {
-    val x = new Int8Array(data(1))
+    val x = new Int8Array(data.map(_.toByte))
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Byte]])
@@ -41,7 +40,7 @@ class TypedArrayConversionTest {
   }
 
   @Test def convert_an_Int16Array_to_a_scala_Array_Short(): Unit = {
-    val x = new Int16Array(data(100))
+    val x = new Int16Array(data.map(x => (100 * x).toShort))
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Short]])
@@ -53,7 +52,7 @@ class TypedArrayConversionTest {
   }
 
   @Test def convert_an_Uint16Array_to_a_scala_Array_Char(): Unit = {
-    val data = js.Array((1 to 6).map(_ * 10000): _*)
+    val data = js.Array(1, 2, 3, 4, 5, 6).map(x => 10000 * x)
     val sum = (6*7/2*10000).toChar
 
     val x = new Uint16Array(data)
@@ -68,7 +67,7 @@ class TypedArrayConversionTest {
   }
 
   @Test def convert_an_Int32Array_to_a_scala_Array_Int(): Unit = {
-    val x = new Int32Array(data(10000))
+    val x = new Int32Array(data.map(x => 10000 * x))
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Int]])
@@ -80,7 +79,7 @@ class TypedArrayConversionTest {
   }
 
   @Test def convert_a_Float32Array_to_a_scala_Array_Float(): Unit = {
-    val x = new Float32Array(data(0.2))
+    val x = new Float32Array(data.map(x => 0.2f * x.toFloat))
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Float]])
@@ -92,7 +91,7 @@ class TypedArrayConversionTest {
   }
 
   @Test def convert_a_Float64Array_to_a_scala_Array_Double(): Unit = {
-    val x = new Float64Array(data(0.2))
+    val x = new Float64Array(data.map(x => 0.2 * x.toDouble))
     val y = x.toArray
 
     assertTrue(y.getClass == classOf[scala.Array[Double]])

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
@@ -32,8 +32,8 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
   def fromFn[E](iterable: js.Iterable[E])(mapper: js.Function1[E, V]): T
   def fromFn[D, E](iterable: js.Iterable[E], thisObj: D)(mapper: js.ThisFunction1[D, E, V]): T
   def lenCtor(len: Int): T
-  def tarr(arr: js.Array[V]): TypedArray[V, _]
-  def tarrCtor(tarr: TypedArray[V, _]): T
+  def tarr(arr: js.Array[V]): T
+  def tarrCtor(tarr: T): T
   def itCtor(arr: js.Iterable[V]): T
   def bufCtor1(buf: ArrayBuffer): T
   def bufCtor2(buf: ArrayBuffer, start: Int): T
@@ -289,8 +289,8 @@ class Int8ArrayTest extends TypedArrayTest[Byte, Int8Array] {
     Int8Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Int8Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Int8Array = new Int8Array(len)
-  def tarr(tarr: js.Array[Byte]): TypedArray[Byte,_] = new Int8Array(tarr)
-  def tarrCtor(tarr: TypedArray[Byte, _]): Int8Array = new Int8Array(tarr)
+  def tarr(tarr: js.Array[Byte]): Int8Array = new Int8Array(tarr)
+  def tarrCtor(tarr: Int8Array): Int8Array = new Int8Array(tarr)
   def itCtor(arr: js.Iterable[Byte]): Int8Array = new Int8Array(arr)
   def bufCtor1(buf: ArrayBuffer): Int8Array = new Int8Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Int8Array = new Int8Array(buf, start)
@@ -309,8 +309,8 @@ class Uint8ArrayTest extends TypedArrayTest[Short, Uint8Array] {
     Uint8Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Uint8Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Uint8Array = new Uint8Array(len)
-  def tarr(tarr: js.Array[Short]): TypedArray[Short,_] = new Uint8Array(tarr)
-  def tarrCtor(tarr: TypedArray[Short, _]): Uint8Array = new Uint8Array(tarr)
+  def tarr(tarr: js.Array[Short]): Uint8Array = new Uint8Array(tarr)
+  def tarrCtor(tarr: Uint8Array): Uint8Array = new Uint8Array(tarr)
   def itCtor(arr: js.Iterable[Short]): Uint8Array = new Uint8Array(arr)
   def bufCtor1(buf: ArrayBuffer): Uint8Array = new Uint8Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Uint8Array = new Uint8Array(buf, start)
@@ -330,8 +330,8 @@ class Uint8ClampedArrayTest extends TypedArrayTest[Int, Uint8ClampedArray] {
     Uint8ClampedArray.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Uint8ClampedArray.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Uint8ClampedArray = new Uint8ClampedArray(len)
-  def tarr(tarr: js.Array[Int]): TypedArray[Int,_] = new Int32Array(tarr)
-  def tarrCtor(tarr: TypedArray[Int, _]): Uint8ClampedArray = new Uint8ClampedArray(tarr)
+  def tarr(tarr: js.Array[Int]): Uint8ClampedArray = new Uint8ClampedArray(tarr)
+  def tarrCtor(tarr: Uint8ClampedArray): Uint8ClampedArray = new Uint8ClampedArray(tarr)
   def itCtor(arr: js.Iterable[Int]): Uint8ClampedArray = new Uint8ClampedArray(arr)
   def bufCtor1(buf: ArrayBuffer): Uint8ClampedArray = new Uint8ClampedArray(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Uint8ClampedArray = new Uint8ClampedArray(buf, start)
@@ -350,8 +350,8 @@ class Int16ArrayTest extends TypedArrayTest[Short, Int16Array] {
     Int16Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Int16Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Int16Array = new Int16Array(len)
-  def tarr(tarr: js.Array[Short]): TypedArray[Short,_] = new Int16Array(tarr)
-  def tarrCtor(tarr: TypedArray[Short, _]): Int16Array = new Int16Array(tarr)
+  def tarr(tarr: js.Array[Short]): Int16Array = new Int16Array(tarr)
+  def tarrCtor(tarr: Int16Array): Int16Array = new Int16Array(tarr)
   def itCtor(arr: js.Iterable[Short]): Int16Array = new Int16Array(arr)
   def bufCtor1(buf: ArrayBuffer): Int16Array = new Int16Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Int16Array = new Int16Array(buf, start)
@@ -370,8 +370,8 @@ class Uint16ArrayTest extends TypedArrayTest[Int, Uint16Array] {
     Uint16Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Uint16Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Uint16Array = new Uint16Array(len)
-  def tarr(tarr: js.Array[Int]): TypedArray[Int,_] = new Int32Array(tarr)
-  def tarrCtor(tarr: TypedArray[Int, _]): Uint16Array = new Uint16Array(tarr)
+  def tarr(tarr: js.Array[Int]): Uint16Array = new Uint16Array(tarr)
+  def tarrCtor(tarr: Uint16Array): Uint16Array = new Uint16Array(tarr)
   def itCtor(arr: js.Iterable[Int]): Uint16Array =  new Uint16Array(arr)
   def bufCtor1(buf: ArrayBuffer): Uint16Array = new Uint16Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Uint16Array = new Uint16Array(buf, start)
@@ -390,8 +390,8 @@ class Int32ArrayTest extends TypedArrayTest[Int, Int32Array] {
     Int32Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Int32Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Int32Array = new Int32Array(len)
-  def tarr(tarr: js.Array[Int]): TypedArray[Int,_] = new Int32Array(tarr)
-  def tarrCtor(tarr: TypedArray[Int, _]): Int32Array = new Int32Array(tarr)
+  def tarr(tarr: js.Array[Int]): Int32Array = new Int32Array(tarr)
+  def tarrCtor(tarr: Int32Array): Int32Array = new Int32Array(tarr)
   def itCtor(arr: js.Iterable[Int]): Int32Array = new Int32Array(arr)
   def bufCtor1(buf: ArrayBuffer): Int32Array = new Int32Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Int32Array = new Int32Array(buf, start)
@@ -410,8 +410,8 @@ class Uint32ArrayTest extends TypedArrayTest[Double, Uint32Array] {
     Uint32Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Uint32Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Uint32Array = new Uint32Array(len)
-  def tarr(tarr: js.Array[Double]): TypedArray[Double,_] = new Uint32Array(tarr)
-  def tarrCtor(tarr: TypedArray[Double, _]): Uint32Array = new Uint32Array(tarr)
+  def tarr(tarr: js.Array[Double]): Uint32Array = new Uint32Array(tarr)
+  def tarrCtor(tarr: Uint32Array): Uint32Array = new Uint32Array(tarr)
   def itCtor(arr: js.Iterable[Double]): Uint32Array = new Uint32Array(arr)
   def bufCtor1(buf: ArrayBuffer): Uint32Array = new Uint32Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Uint32Array = new Uint32Array(buf, start)
@@ -430,8 +430,8 @@ class Float32ArrayTest extends TypedArrayTest[Float, Float32Array] {
     Float32Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Float32Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Float32Array = new Float32Array(len)
-  def tarr(tarr: js.Array[Float]): TypedArray[Float,_] = new Float32Array(tarr)
-  def tarrCtor(tarr: TypedArray[Float, _]): Float32Array = new Float32Array(tarr)
+  def tarr(tarr: js.Array[Float]): Float32Array = new Float32Array(tarr)
+  def tarrCtor(tarr: Float32Array): Float32Array = new Float32Array(tarr)
   def itCtor(arr: js.Iterable[Float]): Float32Array =  new Float32Array(arr)
   def bufCtor1(buf: ArrayBuffer): Float32Array = new Float32Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Float32Array = new Float32Array(buf, start)
@@ -450,8 +450,8 @@ class Float64ArrayTest extends TypedArrayTest[Double, Float64Array] {
     Float64Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = Float64Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): Float64Array = new Float64Array(len)
-  def tarr(tarr: js.Array[Double]): TypedArray[Double,_] = new Float64Array(tarr)
-  def tarrCtor(tarr: TypedArray[Double, _]): Float64Array = new Float64Array(tarr)
+  def tarr(tarr: js.Array[Double]): Float64Array = new Float64Array(tarr)
+  def tarrCtor(tarr: Float64Array): Float64Array = new Float64Array(tarr)
   def itCtor(arr: js.Iterable[Double]): Float64Array = new Float64Array(arr)
   def bufCtor1(buf: ArrayBuffer): Float64Array = new Float64Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): Float64Array = new Float64Array(buf, start)
@@ -472,7 +472,7 @@ class BigInt64ArrayTest extends TypedArrayTest[js.BigInt, BigInt64Array] {
   def bytesPerElement: Int = BigInt64Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): BigInt64Array = new BigInt64Array(len)
   def tarr(arr: js.Array[js.BigInt]): BigInt64Array = new BigInt64Array(arr)
-  def tarrCtor(tarr: TypedArray[js.BigInt, _]): BigInt64Array = new BigInt64Array(tarr)
+  def tarrCtor(tarr: BigInt64Array): BigInt64Array = new BigInt64Array(tarr)
   def itCtor(arr: js.Iterable[js.BigInt]): BigInt64Array = new BigInt64Array(arr)
   def bufCtor1(buf: ArrayBuffer): BigInt64Array = new BigInt64Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): BigInt64Array = new BigInt64Array(buf, start)
@@ -492,8 +492,8 @@ class BigUint64ArrayTest extends TypedArrayTest[js.BigInt, BigUint64Array] {
     BigUint64Array.from(iterable, fn, thisObj)
   def bytesPerElement: Int = BigUint64Array.BYTES_PER_ELEMENT
   def lenCtor(len: Int): BigUint64Array = new BigUint64Array(len)
-  def tarr(arr: js.Array[js.BigInt]): BigInt64Array = new BigInt64Array(arr)
-  def tarrCtor(tarr: TypedArray[js.BigInt, _]): BigUint64Array = new BigUint64Array(tarr)
+  def tarr(arr: js.Array[js.BigInt]): BigUint64Array = new BigUint64Array(arr)
+  def tarrCtor(tarr: BigUint64Array): BigUint64Array = new BigUint64Array(tarr)
   def itCtor(arr: js.Iterable[js.BigInt]): BigUint64Array = new BigUint64Array(arr)
   def bufCtor1(buf: ArrayBuffer): BigUint64Array = new BigUint64Array(buf)
   def bufCtor2(buf: ArrayBuffer, start: Int): BigUint64Array = new BigUint64Array(buf, start)


### PR DESCRIPTION
We now only accept arguments whose element type is exactly the same as the typed array being created or modified. The API was previously too relaxed especially when mixing `number`-based typed arrays and `BigInt`-based typed arrays.

The new restrictions are technically stronger than necessary, but they make sense. Copies between typed arrays of different element types should be rare enough that using `js.Dynamic` should be fine.

We also constrain the argument to `set` that was a `js.Iterable` to be a `js.Array`. Contrary to the constructors, which accept any iterable, the `set` methods only accept `Array`s in addition to typed arrays.