### PR TITLE
Add standardized methods in js.Object

### DIFF
--- a/assets/additional-doc-styles.css
+++ b/assets/additional-doc-styles.css
@@ -2,7 +2,19 @@
   background-color: #E68A00;
 }
 
+.badge-ecma2015 {
+  background-color: #E68A00;
+}
+
+.badge-ecma2017 {
+  background-color: #E68A00;
+}
+
 .badge-ecma2019 {
+  background-color: #E68A00;
+}
+
+.badge-ecma2020 {
   background-color: #E68A00;
 }
 

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -123,6 +123,15 @@ object Object extends Object {
    */
   def getOwnPropertyNames(o: Object): Array[String] = native
 
+  /** <span class="badge badge-ecma2015" style="float: right;">ECMAScript 2015</span>
+   *
+   *  The Object.getOwnPropertySymbols() method returns an array of all symbol
+   *  properties found directly upon a given object.
+   *
+   *  MDN
+   */
+  def getOwnPropertySymbols(o: Object): Array[Symbol] = native
+
   /**
    * The Object.create() method creates a new object with the specified
    * prototype object and properties.
@@ -202,6 +211,37 @@ object Object extends Object {
    */
   def preventExtensions(o: Object): o.type = native
 
+  /** <span class="badge badge-ecma2015" style="float: right;">ECMAScript 2015</span>
+   *
+   *  Object.is() determines whether two values are the same value. Two values
+   *  are the same if one of the following holds:
+   *
+   *  <ul>
+   *    <li>both undefined
+   *    <li>both null
+   *    <li>both true or both false
+   *    <li>both strings of the same length with the same characters in the same
+   *        order
+   *    <li>both the same object (means both object have same reference)
+   *    <li>both numbers and
+   *      <ul>
+   *        <li>both +0
+   *        <li>both -0
+   *        <li>both NaN
+   *        <li>or both non-zero and both not NaN and both have the same value
+   *      </ul>
+   *    </li>
+   *  </ul>
+   *
+   *  This is not the same as being equal according to JavaScript's `===`
+   *  operator (exposed as `js.special.strictEquals`` in Scala.js). The `===`
+   *  operator treats the number values `-0` and `+0` as equal and treats `NaN`
+   *  as not equal to `NaN`.
+   *
+   *  MDN
+   */
+  def is(value1: scala.Any, value2: scala.Any): Boolean = native
+
   /**
    * Returns true if the object is sealed, otherwise false. An object is sealed
    * if it is not extensible and if all its properties are non-configurable and
@@ -256,4 +296,28 @@ object Object extends Object {
    *  this method (not just a subset).
    */
   def properties(o: Any): Array[String] = throw new java.lang.Error("stub")
+
+  /** <span class="badge badge-ecma2017" style="float: right;">ECMAScript 2017</span>
+   *
+   *  The Object.entries() method returns an array of a given object's own
+   *  enumerable string-keyed property [key, value] pairs, in the same order as
+   *  that provided by a for...in loop (the difference being that a for-in loop
+   *  enumerates properties in the prototype chain as well).
+   *
+   *  MDN
+   */
+  def entries(o: Object): Array[Tuple2[String, scala.Any]] = native
+
+  /** <span class="badge badge-ecma2017" style="float: right;">ECMAScript 2017</span>
+   */
+  def entries[A](dict: Dictionary[A]): Array[Tuple2[String, A]] = native
+
+  /** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
+   *
+   *  The Object.fromEntries() method transforms a list of key-value pairs into
+   *  an object.
+   *
+   *  MDN
+   */
+  def fromEntries[A](iterable: Iterable[Tuple2[String, A]]): Dictionary[A] = native
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
@@ -1,0 +1,115 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.library
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+import org.scalajs.testsuite.utils.Platform
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{ JSBracketAccess, JSName }
+
+class ObjectTest {
+  import ObjectTest._
+
+  private lazy val symA = js.Symbol("a")
+  private lazy val symB = js.Symbol.forKey("b")
+
+  @Test def getOwnPropertySymbols(): Unit = {
+    assumeTrue(
+        "Assuming newer methods existence, which are not honored by Rhino",
+        Platform.executingInNodeJS)
+    val obj = (new js.Object()).asInstanceOf[ObjectCreator]
+    obj(symA) = "localSymbol"
+    obj(symB) = "globalSymbol"
+    val objectSymbols = js.Object.getOwnPropertySymbols(obj)
+    assertArrayEquals(Array[AnyRef](symA, symB), objectSymbols.toArray[AnyRef])
+  }
+
+  @Test def is(): Unit = {
+    assumeTrue(
+        "Assuming newer methods existence, which are not honored by Rhino",
+        Platform.executingInNodeJS)
+    val a = new js.Object()
+    assertTrue(js.Object.is(a, a))
+    assertTrue(js.Object.is(Double.NaN, Double.NaN))
+    assertTrue(js.Object.is(0.0, +0.0))
+    assertTrue(js.Object.is(-0.0, -0.0))
+    assertTrue(js.Object.is("foo", "foo"))
+
+    val b = new js.Object()
+    assertFalse(js.Object.is(a, b))
+    assertFalse(js.Object.is(-0.0, +0.0))
+  }
+
+  @Test def entries_from_object(): Unit = {
+    assumeTrue(
+        "Assuming newer methods existence, which are not honored by Rhino",
+        Platform.executingInNodeJS)
+    val obj = new js.Object {
+      val a = 42
+      val b = "foo"
+    }
+    val entries = js.Object.entries(obj)
+    assertEquals(2, entries.length)
+
+    val js.Tuple2(key1, value1) = entries(0)
+    assertEquals("a", key1)
+    assertEquals(42, value1)
+
+    val js.Tuple2(key2, value2) = entries(1)
+    assertEquals("b", key2)
+    assertEquals("foo", value2.asInstanceOf[String])
+  }
+
+  @Test def entries_from_dictionary(): Unit = {
+    assumeTrue(
+        "Assuming newer methods existence, which are not honored by Rhino",
+        Platform.executingInNodeJS)
+    val dict = js.Dictionary[Int]("a" -> 42, "b" -> 0)
+    val entries = js.Object.entries(dict)
+    assertEquals(2, entries.length)
+
+    val js.Tuple2(key1, value1) = entries(0)
+    assertEquals("a", key1)
+    val value1IsInt: Int = value1
+    assertEquals(42, value1IsInt)
+
+    val js.Tuple2(key2, value2) = entries(1)
+    assertEquals("b", key2)
+    val value2IsInt: Int = value2
+    assertEquals(0, value2IsInt)
+  }
+
+  @Test def fromEntries_array(): Unit = {
+    assumeTrue(
+        "Assuming newer methods existence, which are not honored by Rhino",
+        Platform.executingInNodeJS)
+    // from Array
+    val array = js.Array(js.Tuple2("a", 42), js.Tuple2("b", "foo"))
+    val obj1 = js.Object.fromEntries(array)
+    assertEquals(obj1("a"), 42)
+    assertEquals(obj1("b"), "foo")
+  }
+
+  // TODO: Add test for fromEntries(js.Map)
+}
+
+object ObjectTest {
+  @js.native
+  private trait ObjectCreator extends js.Object {
+    @JSBracketAccess
+    def update(s: js.Symbol, v: js.Any): Unit = js.native
+  }
+}


### PR DESCRIPTION
* <del>[getOwnPropertyDescriptors](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertyDescriptors) in [ES2017](https://www.ecma-international.org/ecma-262/8.0/#sec-object.getownpropertydescriptors)</del>
* [getOwnPropertySymbols](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/getOwnPropertySymbols) in [ES2015](https://www.ecma-international.org/ecma-262/6.0/#sec-object.getownpropertysymbols)
* [entries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries) in [ES2017](https://www.ecma-international.org/ecma-262/8.0/#sec-object.entries)
* [is](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/is) in [ES2015](https://www.ecma-international.org/ecma-262/6.0/#sec-object.is)
* [fromEntries](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/fromEntries) as Stage 4 in [ES2020 Draft](https://tc39.es/ecma262/#sec-object.fromentries)
