### PR TITLE
Fix #3865: Set the emitted IR version to 0.6.29, and support 0.6.{29-30}.

### DIFF
--- a/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
@@ -31,14 +31,22 @@ object ScalaJSVersions {
    *
    *  This should be either of:
    *  - a prior release version (i.e. "0.5.0", *not* "0.5.0-SNAPSHOT")
-   *  - `current`
+   *  - a copy-paste of the *rhs* of `current` (*not* a reference to the val
+   *    `current`, so that we notice a potential "-SNAPSHOT" suffix to be
+   *    replaced on release, to avoid issues like #3865).
    */
-  val binaryEmitted: String = current
+  val binaryEmitted: String = "0.6.29"
 
   /** Versions whose binary files we can support (used by deserializer) */
   val binarySupported: Set[String] = {
+    /* Note: 0.6.30 was never meant to be a valid IR version, but it Scala.js
+     * v0.6.30 was published with accidentally advertising that it emits IR
+     * version 0.6.30, while itself not being able to consume IR v0.6.29. We
+     * therefore advertise that we support consuming IR v0.6.30 although we
+     * emit v0.6.29.
+     */
     Set("0.6.0", "0.6.3", "0.6.4", "0.6.5", "0.6.6", "0.6.8", "0.6.13",
-        "0.6.14", "0.6.15", "0.6.17", binaryEmitted)
+        "0.6.14", "0.6.15", "0.6.17", "0.6.29", "0.6.30", binaryEmitted)
   }
 
   // Just to be extra safe


### PR DESCRIPTION
We also change the "rules" for what to put in `binaryEmitted` so that hopefully we can avoid this issue in the future.

Locally tested with the [quick start example of ScalaCheck](https://www.scalacheck.org/#quickstart) v1.14.2 (which was [published with 0.6.29](https://github.com/typelevel/scalacheck/blob/ad11e730cf5797acc0aae2772966441e20ac129f/project/plugin.sbt#L15)) in `testing-example/src/test/...` and the following commands:
```
> set libraryDependencies in testingExample += "org.scalacheck" %% "scalacheck_sjs0.6" % "1.14.2" % "test"
> testingExample/test
```