### PR TITLE
[no-master] Fix #3872: Fix parsing of Scala versions in scalajsc.

### DIFF
--- a/cli/src/main/resources/scalajsc
+++ b/cli/src/main/resources/scalajsc
@@ -2,9 +2,9 @@
 
 SCALA_BIN_VER="@SCALA_BIN_VER@"
 SCALAJS_VER="@SCALAJS_VER@"
-SCALA_VER=$(scalac -version 2>&1 | grep -o '[0-9]\.[0-9][0-9]\.[0-9]')
+SCALA_VER=$(scalac -version 2>&1 | grep -o '[0-9]\.[0-9]\+\.[0-9]\+')
 
-if [ "$(echo $SCALA_VER | cut -b 1-4)" != "$SCALA_BIN_VER" ]; then
+if [ "$(echo $SCALA_VER | cut -d '.' -f 1-2)" != "$SCALA_BIN_VER" ]; then
     echo "This bundle of Scala.js CLI is for $SCALA_BIN_VER. Your scala version is $SCALA_VER!" >&2
     exit 1
 fi


### PR DESCRIPTION
In particular, support any number of digits for the minor and patch versions.

There are changes only in the Unix variant of the script. The Windows variant already supports any number of digits in the patch version. It still only tolerates minor versions with exactly 2 digits, because it seems hard to support other formats, and we are not going to hit that problem in the life span of Scala.js 0.6.x.