### PR TITLE
Fix #3880: Align ScalaJSCrossVersion with ScalaJSVersions

### DIFF
--- a/ir/src/test/scala/org/scalajs/ir/VersionChecksTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/VersionChecksTest.scala
@@ -52,7 +52,7 @@ class VersionChecksTest {
     bad("2.2.0-M1", "2.2")
 
     // binary is pre-release in non-matching version.
-    bad("2.3.0", "2.2-M1") 
+    bad("2.3.0", "2.2-M1")
     bad("2.2.1", "2.2-M1")
     bad("2.3.0-M1", "2.2-M1")
     bad("2.2.0", "2.2-M1")
@@ -85,5 +85,18 @@ class VersionChecksTest {
 
     assertThrows(v.checkSupported("3.2"))
     assertThrows(v.checkSupported("2.1-M1"))
+  }
+
+  @Test def binaryCrossVersion: Unit = {
+    def test(full: String, emitted: String, cross: String): Unit =
+      assertEquals(cross, new VersionChecks(full, emitted).binaryCross)
+
+    test("1.0.0", "1.0", "1")
+    test("1.0.2", "1.0", "1")
+    test("1.0.2-M1", "1.0", "1")
+    test("1.0.0-SNAPSHOT", "1.0-SNAPSHOT", "1.0-SNAPSHOT")
+    test("1.0.0-M1", "1.0-M1", "1.0-M1")
+    test("1.2.0-SNAPSHOT", "1.2-SNAPSHOT", "1")
+    test("1.2.0-M1", "1.2-M1", "1.2-M1")
   }
 }

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
@@ -17,20 +17,11 @@ import sbt._
 import org.scalajs.ir.ScalaJSVersions
 
 object ScalaJSCrossVersion {
-  val currentBinaryVersion = ScalaJSVersions.binaryCross
+  private val sjsPrefix = "sjs" + ScalaJSVersions.binaryCross + "_"
 
-  def scalaJSMapped(cross: CrossVersion): CrossVersion = cross match {
-    case CrossVersion.Disabled =>
-      CrossVersion.constant("sjs" + currentBinaryVersion)
-    case cross: sbt.librarymanagement.Constant =>
-      cross.withValue("sjs" + currentBinaryVersion + "_" + cross.value)
-    case cross: CrossVersion.Binary =>
-      cross.withPrefix("sjs" + currentBinaryVersion + "_" + cross.prefix)
-    case cross: CrossVersion.Full =>
-      cross.withPrefix("sjs" + currentBinaryVersion + "_" + cross.prefix)
-  }
+  val binary: CrossVersion =
+    CrossVersion.binaryWith(prefix = sjsPrefix, suffix = "")
 
-  val binary: CrossVersion = scalaJSMapped(CrossVersion.binary)
-
-  val full: CrossVersion = scalaJSMapped(CrossVersion.full)
+  val full: CrossVersion =
+    CrossVersion.fullWith(prefix = sjsPrefix, suffix = "")
 }

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
@@ -17,18 +17,7 @@ import sbt._
 import org.scalajs.ir.ScalaJSVersions
 
 object ScalaJSCrossVersion {
-  private final val ReleaseVersion =
-    raw"""(\d+)\.(\d+)\.(\d+)""".r
-  private final val MinorSnapshotVersion =
-    raw"""(\d+)\.(\d+)\.([1-9]\d*)-SNAPSHOT""".r
-
-  val currentBinaryVersion = binaryScalaJSVersion(ScalaJSVersions.binaryEmitted)
-
-  def binaryScalaJSVersion(full: String): String = full match {
-    case ReleaseVersion(major, _, _)       => major
-    case MinorSnapshotVersion(major, _, _) => major
-    case _                                 => full
-  }
+  val currentBinaryVersion = ScalaJSVersions.binaryCross
 
   def scalaJSMapped(cross: CrossVersion): CrossVersion = cross match {
     case CrossVersion.Disabled =>


### PR DESCRIPTION
Since we dropped the patch version in the `binaryEmitted` version, the regex parsing in `ScalaJSCrossVersion` was wrong.

We move the entire parsing and translation logic into `VersionChecks` where we can properly test it and it is more easily available to non-sbt consumers.

Note that this introduces a behavioral change: Minor pre-release versions are cross versioned with their full version, not their major version only.