### PR TITLE
Publish the JS and JVM libs of a Scala version in the same run.

### DIFF
--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -10,8 +10,9 @@ fi
 SUFFIXES="2_11 2_12 2_13"
 
 COMPILER="compiler jUnitPlugin"
-LIBS="library irJS loggingJS linkerInterfaceJS linkerJS testInterface testBridge jUnitRuntime"
+JS_LIBS="library irJS loggingJS linkerInterfaceJS linkerJS testInterface testBridge jUnitRuntime"
 JVM_LIBS="ir logging linkerInterface linker jsEnvs jsEnvsTestKit nodeJSEnv testAdapter"
+LIBS="$JS_LIBS $JVM_LIBS"
 
 # Publish compiler
 for s in $SUFFIXES; do
@@ -26,15 +27,6 @@ done
 for s in $SUFFIXES; do
     ARGS=""
     for p in $LIBS; do
-        ARGS="$ARGS $p$s/publishSigned"
-    done
-    $CMD $ARGS
-done
-
-# Publish JVM libraries
-for v in $SUFFIXES; do
-    ARGS=""
-    for p in $JVM_LIBS; do
         ARGS="$ARGS $p$s/publishSigned"
     done
     $CMD $ARGS


### PR DESCRIPTION
This avoids uselessly rebooting sbt, which improves the time it takes to publish everything.

New output of `./scripts/publish.sh`:
```
sbt +compiler2_11/publishSigned +jUnitPlugin2_11/publishSigned
sbt +compiler2_12/publishSigned +jUnitPlugin2_12/publishSigned
sbt +compiler2_13/publishSigned +jUnitPlugin2_13/publishSigned
sbt library2_11/publishSigned irJS2_11/publishSigned loggingJS2_11/publishSigned linkerInterfaceJS2_11/publishSigned linkerJS2_11/publishSigned testInterface2_11/publishSigned testBridge2_11/publishSigned jUnitRuntime2_11/publishSigned ir2_11/publishSigned logging2_11/publishSigned linkerInterface2_11/publishSigned linker2_11/publishSigned jsEnvs2_11/publishSigned jsEnvsTestKit2_11/publishSigned nodeJSEnv2_11/publishSigned testAdapter2_11/publishSigned
sbt library2_12/publishSigned irJS2_12/publishSigned loggingJS2_12/publishSigned linkerInterfaceJS2_12/publishSigned linkerJS2_12/publishSigned testInterface2_12/publishSigned testBridge2_12/publishSigned jUnitRuntime2_12/publishSigned ir2_12/publishSigned logging2_12/publishSigned linkerInterface2_12/publishSigned linker2_12/publishSigned jsEnvs2_12/publishSigned jsEnvsTestKit2_12/publishSigned nodeJSEnv2_12/publishSigned testAdapter2_12/publishSigned
sbt library2_13/publishSigned irJS2_13/publishSigned loggingJS2_13/publishSigned linkerInterfaceJS2_13/publishSigned linkerJS2_13/publishSigned testInterface2_13/publishSigned testBridge2_13/publishSigned jUnitRuntime2_13/publishSigned ir2_13/publishSigned logging2_13/publishSigned linkerInterface2_13/publishSigned linker2_13/publishSigned jsEnvs2_13/publishSigned jsEnvsTestKit2_13/publishSigned nodeJSEnv2_13/publishSigned testAdapter2_13/publishSigned
sbt sbtPlugin/publishSigned
```