### PR TITLE
Fix #3888: Always identify impl classes by their IMPLCLASS flag.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1514,7 +1514,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
               mutatedLocalVars := mutable.Set.empty
           ) {
             def isTraitImplForwarder = dd.rhs match {
-              case app: Apply => foreignIsImplClass(app.symbol.owner)
+              case app: Apply => isImplClass(app.symbol.owner)
               case _          => false
             }
 
@@ -2724,7 +2724,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           genPrimitiveJSCall(tree, isStat)
         else
           genApplyJSClassMethod(genExpr(receiver), sym, genActualArgs(sym, args))
-      } else if (foreignIsImplClass(sym.owner)) {
+      } else if (isImplClass(sym.owner)) {
         genTraitImplApply(sym, args map genExpr)
       } else if (sym.isClassConstructor) {
         /* See #66: we have to emit a statically linked call to avoid calling a

--- a/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/JSEncoding.scala
@@ -222,9 +222,6 @@ trait JSEncoding[G <: Global with Singleton] extends SubComponent {
     js.Ident(localSymbolName(sym), Some(sym.unexpandedName.decoded))
   }
 
-  def foreignIsImplClass(sym: Symbol): Boolean =
-    sym.isModuleClass && nme.isImplClassName(sym.name)
-
   def encodeClassType(sym: Symbol): jstpe.Type = {
     if (sym == definitions.ObjectClass) jstpe.AnyType
     else if (isRawJSType(sym.toTypeConstructor)) jstpe.AnyType
@@ -245,7 +242,7 @@ trait JSEncoding[G <: Global with Singleton] extends SubComponent {
   }
 
   def needsModuleClassSuffix(sym: Symbol): Boolean =
-    sym.isModuleClass && !foreignIsImplClass(sym)
+    sym.isModuleClass && !isImplClass(sym)
 
   def encodeComputedNameIdentity(sym: Symbol): String = {
     assert(sym.owner.isModuleClass, sym)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -784,6 +784,10 @@ class RegressionTest {
     assertEquals('a', d)
   }
 
+  @Test def nested_object_named_class_issue_3888(): Unit = {
+    assertEquals(6, `class`.foo(5))
+  }
+
 }
 
 object RegressionTest {
@@ -841,5 +845,9 @@ object RegressionTest {
 
     def overloaded(x: Any): Unit =
       fail("Bug3281.overloaded(x: Any) was called")
+  }
+
+  object `class` { // scalastyle:ignore
+    def foo(x: Int): Int = x + 1
   }
 }


### PR DESCRIPTION
Before, we sometimes used name-based identification of impl classes. This was introduced in ac54f189d225c7c66a7156f3b41594ee2f43a01d, before Scala.js 0.1! At the time, we were still using a custom `Global` subtrait instead of a compiler plugin, and a custom `.jstype` file reader instead of the normal class-file reader of scalac. The flag was not present in some cases of separate compilation. Now that we use a normal compiler plugin, this issue does not seem to manifest itself anymore. It seems this code was left there for 6 years for nothing.