### PR TITLE
Fix typos

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -3582,7 +3582,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
      *  trying to optimize it away as a reversed If.
      *
      *  If there was no `return` to the label at all, simply avoid generating
-     *  the `Labeled` block alltogether.
+     *  the `Labeled` block altogether.
      *
      *  If there was more than one `return`, do not optimize anything, as
      *  nothing could be good enough for `genOptimizedMatchEndLabeled` to do

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
@@ -169,7 +169,7 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
       |     Change the location the source URIs in the emitted IR point to
       |     - strips away the prefix FROM_URI (if it matches)
       |     - optionally prefixes the TO_URI, where stripping has been performed
-      |     - any number of occurences are allowed. Processing is done on a first match basis.
+      |     - any number of occurrences are allowed. Processing is done on a first match basis.
       |  -P:$name:fixClassOf
       |     Repair calls to Predef.classOf that reach Scala.js.
       |     WARNING: This is a tremendous hack! Expect ugly errors if you use this option.

--- a/examples/reversi/src/main/scala/reversi/Reversi.scala
+++ b/examples/reversi/src/main/scala/reversi/Reversi.scala
@@ -118,7 +118,7 @@ class Reversi(jQuery: JQueryStatic, playground: JQuery) {
       }
     }
 
-    // Draw squares now, and everytime they change ownership
+    // Draw squares now, and every time they change ownership
     for (square <- allSquares) {
       drawSquare(square)
       square.onOwnerChange = { (prevOwner, newOwner) =>

--- a/javalib/src/main/scala/java/util/RedBlackTree.scala
+++ b/javalib/src/main/scala/java/util/RedBlackTree.scala
@@ -495,7 +495,7 @@ private[util] object RedBlackTree {
        * `node` before deleting `node`. We can do this because we know that
        * `succ` has a null `left` child.
        *
-       * In fact we transplant the `onlyChildOfSucc` (orignally at
+       * In fact we transplant the `onlyChildOfSucc` (originally at
        * `succ.right`) in place of `succ`, then transplant `succ` in place of
        * `node` (also acquiring its color), and finally fixing up the tree
        * around `onlyChildOfSucc`.

--- a/javalib/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
+++ b/javalib/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
@@ -17,7 +17,7 @@
  * This file acts as bridge for scala.scalajs.js.typedarray to be able to
  * access the additional public API provided by java.nio, but which is not
  * part of the JDK API. Because javalib/ does not export its .class files,
- * we cannot call this additonal API directly from library/, even though the
+ * we cannot call this additional API directly from library/, even though the
  * members are public.
  *
  * In library/, this file has only the signatures, with stub implementations.

--- a/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/TypedArrayBufferBridge.scala
@@ -17,7 +17,7 @@
  * This file acts as bridge for scala.scalajs.js.typedarray to be able to
  * access the additional public API provided by java.nio, but which is not
  * part of the JDK API. Because javalib/ does not export its .class files,
- * we cannot call this additonal API directly from library/, even though the
+ * we cannot call this additional API directly from library/, even though the
  * members are public.
  *
  * In library/, this file has only the signatures, with stub implementations.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -29,7 +29,7 @@ import org.scalajs.linker.backend.javascript.Trees._
 
 import EmitterNames._
 
-/** Collection of tree generators that are used accross the board.
+/** Collection of tree generators that are used across the board.
  *  This class is fully stateless.
  *
  *  Also carries around config (semantics and esFeatures).

--- a/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/ComSupport.scala
+++ b/nodejs-env/src/main/scala/org/scalajs/jsenv/nodejs/ComSupport.scala
@@ -33,7 +33,7 @@ private final class ComRun(run: JSRun, handleMessage: String => Unit,
     serverSocket: ServerSocket) extends JSComRun {
   import ComRun._
 
-  /** Promise that completes once the reciever thread is completed. */
+  /** Promise that completes once the receiver thread is completed. */
   private[this] val promise = Promise[Unit]()
 
   @volatile

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1339,7 +1339,7 @@ object Build {
            * (but not .class files)
            */
           mappings in packageBin := {
-            /* From library, we must take everyting, except the
+            /* From library, we must take everything, except the
              * java.nio.TypedArrayBufferBridge object, whose actual
              * implementation is in javalib.
              */

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -481,7 +481,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
       },
 
       // Override default to avoid triggering a test:fastOptJS in a test:compile
-      // without loosing autocompletion.
+      // without losing autocompletion.
       definedTestNames := {
         definedTests.map(_.map(_.name).distinct)
           .storeAs(definedTestNames).triggeredBy(loadedTestFrameworks).value

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -367,7 +367,7 @@ class RegressionTest {
 
   @Test def should_not_restrict_mutability_of_fields_issue_1021(): Unit = {
     class A {
-      /* This var is refered to in the lambda passed to `foreach`. Therefore
+      /* This var is referred to in the lambda passed to `foreach`. Therefore
        * it is altered in another compilation unit (even though it is
        * private[this]).
        * This test makes sure the compiler doesn't wrongly mark it as


### PR DESCRIPTION
Should be non-semantic spelling fixes.

Uses https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines to find likely typos, with https://github.com/bwignall/typochecker to help automate the checking.