### PR TITLE
Make `binaryCross` version same as major for minor milestones.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -34,31 +34,19 @@ class VersionChecks private[ir] (
 
   private val (binaryMajor, binaryMinor, binaryPreRelease) = parseBinary(binaryEmitted)
 
-  /** The cross binary version
+  /** The cross binary version.
    *
    *  This is the version advertised in artifacts released by Scala.js users.
    *
-   *  For non-pre release versions, this is only the major version, since binary
-   *  minor versions are backwards compatible.
-   *
-   *  For pre-release versions, the story is a bit more complicated:
-   *
-   *  - Any pre-release version with a minor version == 0 is ''before'' the
-   *    final major version is released and typically fully breaking. Therefore,
-   *    the full [[binaryEmitted]] version is used.
-   *  - A SNAPSHOT pre-release version with minor version > 0 is a development
-   *    version with compatible binary version. Nothing should be published
-   *    using this version, but being able to ''read'' artifacts in the major
-   *    line is critical for fast testing. Therefore, only the major version is
-   *    used.
-   *  - A non-SNAPSHOT pre-release version with minor version > 0 is a milestone
-   *    or release candidate version that is published. As such, artifacts may
-   *    be published with it but will not be able to be read by the main line
-   *    versions. Therefore, the full [[binaryEmitted]] version is used.
+   *  - For a pre-release version with a minor version == 0, it is the full
+   *    [[binaryEmitted]]. Such a version is ''before'' the final major version
+   *    is released, and as such any release is typically fully breaking.
+   *  - For a non-pre-release, or the pre-release of a minor version, it is
+   *    only the major version, since binary minor versions are backwards
+   *    compatible.
    */
   final val binaryCross: String = {
-    val needsFull =
-      binaryPreRelease.fold(false)(_ != "SNAPSHOT" || binaryMinor == 0)
+    val needsFull = binaryPreRelease.isDefined && binaryMinor == 0
     if (needsFull) binaryEmitted
     else binaryMajor.toString
   }

--- a/ir/src/test/scala/org/scalajs/ir/VersionChecksTest.scala
+++ b/ir/src/test/scala/org/scalajs/ir/VersionChecksTest.scala
@@ -97,6 +97,7 @@ class VersionChecksTest {
     test("1.0.0-SNAPSHOT", "1.0-SNAPSHOT", "1.0-SNAPSHOT")
     test("1.0.0-M1", "1.0-M1", "1.0-M1")
     test("1.2.0-SNAPSHOT", "1.2-SNAPSHOT", "1")
-    test("1.2.0-M1", "1.2-M1", "1.2-M1")
+    test("1.2.0-M1", "1.2-M1", "1")
+    test("1.3.0-M1", "1.2", "1")
   }
 }


### PR DESCRIPTION
For example, in version 1.2.0-M1 that emits IR v1.2-M1, the binary cross version is now `1` instead of `1.2-M1`. This makes the behavior between snapshots and milestones uniform.

More importantly, this change allows to always derive the binary cross from the full Scala.js version, using 2 simple rules:

* If the version is `x.y.z-w`, then the binary cross is `x.y-w`.
* If the version is `x.y.z`, then the binary cross is `x`.

Before this change, in a situation where the full Scala.js version is a milestone (e.g., 1.3.0-M1), it was not possible to derive the binary cross version from it. It might be 1.3-M1 if the binary emitted version was 1.3-M1, but it might also be 1 if the binary emitted version was 1.2, for example.

Some build tools do not have access to the binary emitted version; they only have access to the full Scala.js version. It is important for them to be able to derive the binary cross version from the full version only.