### PR TITLE
Setup MiMa for post-v1.0.0.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -14,6 +14,10 @@ object BinaryIncompatibilities {
   )
 
   val LinkerInterface = Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.interface.unstable.ModuleInitializerImpl#VoidMainMethod.moduleClassName"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.interface.unstable.ModuleInitializerImpl#MainMethodWithArgs.moduleClassName"),
   )
 
   val JSEnvs = Seq(
@@ -23,6 +27,12 @@ object BinaryIncompatibilities {
   )
 
   val SbtPlugin = Seq(
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.sbtplugin.ScalaJSCrossVersion.binaryScalaJSVersion"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.sbtplugin.ScalaJSCrossVersion.currentBinaryVersion"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.sbtplugin.ScalaJSCrossVersion.scalaJSMapped"),
   )
 
   val TestCommon = Seq(
@@ -31,10 +41,17 @@ object BinaryIncompatibilities {
   val TestAdapter = TestCommon ++ Seq(
   )
 
-  val CLI = Seq(
-  )
-
   val Library = Seq(
+      ProblemFilters.exclude[MissingClassProblem](
+          "scala.scalajs.js.JSArrayOps"),
+      ProblemFilters.exclude[MissingClassProblem](
+          "scala.scalajs.js.JSArrayOps$"),
+      ProblemFilters.exclude[ReversedMissingMethodProblem](
+          "scala.scalajs.runtime.LinkingInfo.fileLevelThis"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scala.scalajs.runtime.LinkingInfo.globalThis"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "scala.scalajs.js.special.package.globalThis"),
   )
 
   val TestInterface = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -134,18 +134,13 @@ object Build {
   val shouldPartest = settingKey[Boolean](
     "Whether we should partest the current scala version (and fail if we can't)")
 
-  /* MiMa configuration -- irrelevant while in 1.0.0-SNAPSHOT.
-  val previousVersion = "0.6.29"
-  val previousSJSBinaryVersion =
-    ScalaJSCrossVersion.binaryScalaJSVersion(previousVersion)
-  val previousBinaryCrossVersion =
-    CrossVersion.binaryMapped(v => s"sjs${previousSJSBinaryVersion}_$v")
+  val previousVersion = "1.0.0-RC1"
+  val previousBinaryCrossVersion = CrossVersion.binaryWith("sjs1.0-RC1_", "")
 
   val scalaVersionsUsedForPublishing: Set[String] =
-    Set("2.11.12", "2.12.10")
+    Set("2.11.12", "2.12.10", "2.13.1")
   val newScalaBinaryVersionsInThisRelease: Set[String] =
     Set()
-  */
 
   def hasNewCollections(version: String): Boolean = {
     !version.startsWith("2.11.") &&
@@ -174,7 +169,6 @@ object Build {
 
   val previousArtifactSetting: Setting[_] = {
     mimaPreviousArtifacts ++= {
-      /* MiMa is completely disabled while we are in 1.0.0-SNAPSHOT.
       val scalaV = scalaVersion.value
       val scalaBinaryV = scalaBinaryVersion.value
       if (!scalaVersionsUsedForPublishing.contains(scalaV)) {
@@ -198,10 +192,8 @@ object Build {
           (thisProjectID.organization % thisProjectID.name % previousVersion)
             .cross(previousCrossVersion)
             .extra(prevExtraAttributes.toSeq: _*)
-        Set(CrossVersion(scalaV, scalaBinaryV)(prevProjectID).cross(CrossVersion.Disabled))
+        Set(prevProjectID)
       }
-      */
-      Set.empty
     }
   }
 
@@ -934,6 +926,7 @@ object Build {
       bintrayProjectName := "sbt-scalajs-plugin", // "sbt-scalajs" was taken
       sbtPlugin := true,
       crossScalaVersions := Seq("2.12.10"),
+      scalaVersion := crossScalaVersions.value.head,
       sbtVersion := "1.0.0",
       scalaBinaryVersion :=
         CrossVersion.binaryScalaVersion(scalaVersion.value),


### PR DESCRIPTION
While in the RC cycle, we can still freely break binary compatibility, so we add the appropriate filters. Enabling MiMa now allows us to test ahead of time the MiMa setup so that it is ready for post-v1.0.0.