### PR TITLE
Fix #3901: Do not fill `groupStartMap` for non-matching groups.

### DIFF
--- a/javalib/src/main/scala/java/util/regex/GroupStartMapper.scala
+++ b/javalib/src/main/scala/java/util/regex/GroupStartMapper.scala
@@ -187,7 +187,13 @@ private[regex] object GroupStartMapper {
 
     def propagate(matchResult: js.RegExp.ExecResult,
         groupStartMap: js.Array[Int], start: Int, end: Int): Unit = {
-      groupStartMap(number) = start
+      /* #3901: A GroupNode within a negative look-ahead node may receive
+       * `start != -1` from above, yet not match anything itself. We must
+       * always keep the default `-1` if this group node does not match
+       * anything.
+       */
+      if (matchResult(newGroup).isDefined)
+        groupStartMap(number) = start
       inner.propagateFromStart(matchResult, groupStartMap, start)
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -146,6 +146,7 @@ class RegexMatcherTest  {
     parseExpect("ab(?:ac)+?ac", "abacacac", 0 -> 6)
     parseExpect("ab(?:(c){2})*d", "abccccd", 0 -> 7, 5 -> 6)
     parseExpect("ab((?=abab(ab))a(b))*a", "abababab", 0 -> 5, 2 -> 4, 6 -> 8, 3 -> 4)
+    parseExpect("(?!(a))(b)", "b", 0 -> 1, -1 -> -1, 0 -> 1) // #3901
   }
 
   @Test def parseRegex_backgroups_test(): Unit = {


### PR DESCRIPTION
`groupStartMap` is initially filled with `-1` everywhere, which is the correct value for non-matching groups. When propagating the `start` and `end` of a `GroupNode`, we previously always overrode that value with `start`, which can `>= 0` even for non-matching groups if they are within a negative look-ahead. This is incorrect, as non-matching groups must always report `-1` as their `start`.

We now explicitly avoid overriding the initial `-1` for non-matching groups. This more closely corresponds to what was done in `GroupStartMap.setEndReturnStart` and `setStartReturnEnd` before the big rewrite of 56dd7abb9c32ae519c8327ee574295687ca96127.