### PR TITLE
[no-master] Work around #3908: Disable StackTraceTest in bootstrap.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -744,7 +744,8 @@ object Build {
           val scalaJSEnv = {
             s"""
             {"javaSystemProperties": {
-              "scalajs.scalaVersion": "${scalaVersion.value}"
+              "scalajs.scalaVersion": "${scalaVersion.value}",
+              "scalajs.bootstrap": "true"
             }}
             """
           }

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -53,6 +53,8 @@ object Platform {
   def isInProductionMode: Boolean = sysProp("production-mode")
   def isInDevelopmentMode: Boolean = sysProp("development-mode")
 
+  def isInBootstrap: Boolean = sysProp("bootstrap")
+
   def hasCompliantAsInstanceOfs: Boolean = sysProp("compliant-asinstanceofs")
 
   def hasCompliantArrayIndexOutOfBounds: Boolean =

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
@@ -50,6 +50,8 @@ class StackTraceTest {
     assumeTrue("Assume node.js", executingInNodeJS)
     assumeFalse("Assume fullopt-stage", isInFullOpt)
 
+    assumeFalse("Does not work in bootstrap #3908", isInBootstrap)
+
     val Error = js.constructorOf[js.Error]
     val oldStackTraceLimit = Error.stackTraceLimit
     Error.stackTraceLimit = 20


### PR DESCRIPTION
With Node.js 13, the shape of stack traces reported during bootstrap are altered because the execution is within a big `eval`. Stack trace lines that were previously of the shape

    at $c_LSomeClass.someMethod__O__O (/.../file.js:15:17)

are now of the shape

    at $c_LSomeClass.eval [as someMethod__O__O] (/.../file.js:15:17)

Our `StackTrace.scala` analyzer does not understand this shape, which causes the `StackTraceTest` to fail during bootstrap.

This commit simply ignores the test during bootstrap, in order to repair the CI. Further investigation is needed to completely fix the issue.