### PR TITLE
[no-master] Disable testing the test suite with PhantomJS on the CI.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -162,9 +162,6 @@ def Tasks = [
         testingExample/clean &&
     sbtretry 'set scalaJSOptimizerOptions in testingExample ~= (_.withDisableOptimizer(true))' \
         ++$scala testingExample/test:run testingExample/test &&
-    sbtretry 'set inScope(ThisScope in testingExample)(jsEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
-        'set scalaJSOptimizerOptions in testingExample ~= (_.withDisableOptimizer(true))' \
-        ++$scala testingExample/test:run testingExample/test &&
     sbtretry ++$scala library/test &&
     sbtretry ++$scala testSuiteJVM/test testSuiteJVM/clean &&
     sbtretry ++$scala 'testSuite/test:runMain org.scalajs.testsuite.junit.JUnitBootstrapTest' &&
@@ -225,10 +222,6 @@ def Tasks = [
         ++$scala $testSuite/test &&
     sbtretry 'set scalaJSSemantics in $testSuite ~= makeCompliant' \
         'set scalaJSOptimizerOptions in $testSuite ~= (_.withDisableOptimizer(true))' \
-        ++$scala $testSuite/test \
-        $testSuite/clean &&
-    sbtretry 'set inScope(ThisScope in $testSuite)(jsEnv := new org.scalajs.jsenv.RetryingComJSEnv(PhantomJSEnv().value))' \
-        'set parallelExecution in ($testSuite, Test) := false' \
         ++$scala $testSuite/test \
         $testSuite/clean &&
     sbtretry 'set scalacOptions in $testSuite += "-Xexperimental"' \


### PR DESCRIPTION
PhantomJS is still by far the biggest cause of spurious failures of the CI. Since I have not seen any genuine bug uncovered by testing on PhantomJS (only) in the last few *years*, the cost of this test overwhelmingly exceeds its potential benefits.

Therefore, in this commit we simply disable the last command that was running the test suite with PhantomJS, as well as the last command that was running non-optimized code with PhantomJS.

PhantomJS is still minimally tested by its unit tests, as well as in the helloworld and the testingExample (in standard fastOpt and fullOpt modes).