### PR TITLE
Implement `java.util.function.Consumer`.

### DIFF
--- a/javalib/src/main/scala/java/util/function/Consumer.scala
+++ b/javalib/src/main/scala/java/util/function/Consumer.scala
@@ -1,0 +1,30 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util.function
+
+import scala.scalajs.js.annotation.JavaDefaultMethod
+
+@FunctionalInterface
+trait Consumer[T] { self =>
+  def accept(t: T): Unit
+
+  @JavaDefaultMethod
+  def andThen(after: Consumer[_ >: T]): Consumer[T] = {
+    new Consumer[T] {
+      def accept(t: T): Unit = {
+        self.accept(t)
+        after.accept(t)
+      }
+    }
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/ConsumerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/ConsumerTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util.function
+
+import java.util.function.Consumer
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.AssertThrows._
+
+class ConsumerTest {
+  import ConsumerTest._
+
+  @Test def accept(): Unit = {
+    // Side-effects
+    var current: Int = 0
+    val add = makeConsumer[Int](num => current += num)
+
+    add.accept(1)
+    assertTrue(current == 1)
+
+    add.accept(2)
+    assertTrue(current == 3)
+  }
+
+  @Test def andThen(): Unit = {
+    // Side-effects
+    var current: Int = 0
+    val add = makeConsumer[Int](num => current += num)
+    val multiply = makeConsumer[Int](num => current *= num)
+    val addAndMultiply = add.andThen(multiply)
+
+    addAndMultiply.accept(2)
+    assertTrue(current == 4)
+
+    addAndMultiply.accept(3)
+    assertTrue(current == 21)
+
+    // Sequential operations
+    val throwingConsumer =
+      makeConsumer[Any](x => throw new ThrowingConsumerException(x))
+    val dontCallConsumer =
+      makeConsumer[Any](x => throw new AssertionError(s"dontCallConsumer.accept($x)"))
+
+    assertThrows(classOf[ThrowingConsumerException],
+        throwingConsumer.andThen(dontCallConsumer).accept(0))
+
+    assertThrows(classOf[ThrowingConsumerException],
+        add.andThen(throwingConsumer).accept(1))
+    assertTrue(current == 22)
+  }
+}
+
+object ConsumerTest {
+  final class ThrowingConsumerException(x: Any)
+      extends Exception(s"throwing consumer called with $x")
+
+  def makeConsumer[T](f: T => Unit): Consumer[T] = {
+    new Consumer[T] {
+      def accept(t: T): Unit = f(t)
+    }
+  }
+}


### PR DESCRIPTION
This PR implements `java.util.function.Consumer`. I implemented the class based on the [Java 8 Javadocs](https://docs.oracle.com/javase/8/docs/api/java/util/function/Consumer.html) and did not look at any existing implementations. The tests are patterned after the existing Scala.js tests for [Predicate](https://github.com/scala-js/scala-js/blob/master/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/PredicateTest.scala).

The motivation for implementing the class is that it is required by the Akka.js [CircuitBreaker](https://github.com/akka/akka/blob/master/akka-actor/src/main/scala/akka/pattern/CircuitBreaker.scala), which is required to implement circuit breakers in [Lagom.js](https://github.com/mliarakos/lagom-js).