### PR TITLE
Fix tests because erased is a new keyword in dotty

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ target/
 /.idea/
 /.idea_modules/
 bin/
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -9,4 +9,4 @@ target/
 /.idea/
 /.idea_modules/
 bin/
-node_modules/
+/node_modules/

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -255,19 +255,19 @@ class StringTest {
   }
 
   @Test def split(): Unit = {
-    assertArrayEquals(Array[AnyRef]("Sc", "l", ".js"), erased("Scala.js".split("a")))
+    assertArrayEquals(Array[AnyRef]("Sc", "l", ".js"), erasedArray("Scala.js".split("a")))
     if (!executingInJVMOnJDK7OrLower) {
-      assertArrayEquals(Array[AnyRef]("a", "s", "d", "f"), erased("asdf".split("")))
-      assertArrayEquals(Array[AnyRef]("a", "s", "d", "f", ""), erased("asdf".split("", -1)))
+      assertArrayEquals(Array[AnyRef]("a", "s", "d", "f"), erasedArray("asdf".split("")))
+      assertArrayEquals(Array[AnyRef]("a", "s", "d", "f", ""), erasedArray("asdf".split("", -1)))
     }
   }
 
   @Test def split_with_char_as_argument(): Unit = {
-    assertArrayEquals(Array[AnyRef]("Scala","js"), erased("Scala.js".split('.')))
+    assertArrayEquals(Array[AnyRef]("Scala","js"), erasedArray("Scala.js".split('.')))
     for (i <- 0 to 32) {
       val c = i.toChar
       assertArrayEquals(Array[AnyRef]("blah", "blah", "blah", "blah"),
-          erased(s"blah${c}blah${c}blah${c}blah".split(c)))
+          erasedArray(s"blah${c}blah${c}blah${c}blah".split(c)))
     }
   }
 
@@ -438,7 +438,7 @@ class StringTest {
     assertTrue(compare("Java", "Scala") < 0)
   }
 
-  @inline private def erased(array: Array[String]): Array[AnyRef] = {
+  @inline private def erasedArrayArray(array: Array[String]): Array[AnyRef] = {
     array.asInstanceOf[Array[AnyRef]]
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -414,6 +414,7 @@ class StringTest {
       assertEquals(('a' + i % 6).toChar, str.charAt(i))
   }
 
+
   @Test def createFromLargeCodePointArray_issue2553(): Unit = {
     val largeCodePointArray =
       (1 to 100000).toArray.flatMap(_ => Array[Int]('a', 'b', 'c', 'd', 'e', 'f'))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -414,7 +414,6 @@ class StringTest {
       assertEquals(('a' + i % 6).toChar, str.charAt(i))
   }
 
-
   @Test def createFromLargeCodePointArray_issue2553(): Unit = {
     val largeCodePointArray =
       (1 to 100000).toArray.flatMap(_ => Array[Int]('a', 'b', 'c', 'd', 'e', 'f'))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -438,7 +438,7 @@ class StringTest {
     assertTrue(compare("Java", "Scala") < 0)
   }
 
-  @inline private def erasedArrayArray(array: Array[String]): Array[AnyRef] = {
+  @inline private def erasedArray(array: Array[String]): Array[AnyRef] = {
     array.asInstanceOf[Array[AnyRef]]
   }
 }


### PR DESCRIPTION
I am trying to work on make tests of Scala.js pass in Dotty.

This test will not pass in Dotty because erased is a keyword now.

`node_modules/` is added to `.gitignore`, will remove if this is unwanted.