### PR TITLE
Fix #3922: Fix all the heuristic properties of `Charset`s.

### DIFF
--- a/javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
+++ b/javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
@@ -23,8 +23,9 @@ abstract class CharsetEncoder protected (cs: Charset,
   import CharsetEncoder._
 
   protected def this(cs: Charset, _averageBytesPerChar: Float,
-      _maxBytesPerChar: Float) =
-    this(cs, _averageBytesPerChar, _averageBytesPerChar, Array('?'.toByte))
+      _maxBytesPerChar: Float) = {
+    this(cs, _averageBytesPerChar, _maxBytesPerChar, Array('?'.toByte))
+  }
 
   // Config
 

--- a/javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
@@ -116,7 +116,8 @@ private[charset] abstract class UTF_16_Common protected (
   }
 
   private class Encoder extends CharsetEncoder(
-      UTF_16_Common.this, 2.0f, 2.0f,
+      UTF_16_Common.this, 2.0f,
+      if (endianness == AutoEndian) 4.0f else 2.0f,
       // Character 0xfffd
       if (endianness == LittleEndian) Array(-3, -1) else Array(-1, -3)) {
 

--- a/javalib/src/main/scala/java/nio/charset/UTF_8.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_8.scala
@@ -315,7 +315,7 @@ private[charset] object UTF_8 extends Charset("UTF-8", Array(
     }
   }
 
-  private class Encoder extends CharsetEncoder(UTF_8, 1.1f, 4.0f) {
+  private class Encoder extends CharsetEncoder(UTF_8, 1.1f, 3.0f) {
     def encodeLoop(in: CharBuffer, out: ByteBuffer): CoderResult = {
       if (in.hasArray && out.hasArray)
         encodeLoopArray(in, out)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
@@ -21,6 +21,13 @@ import org.junit.Assert._
 import BaseCharsetTest._
 
 class Latin1Test extends BaseCharsetTest(Charset.forName("ISO-8859-1")) {
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(1.0f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(1.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
+  }
+
   @Test def decode(): Unit = {
     // Simple tests
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
@@ -20,6 +20,13 @@ import org.junit.Assert._
 import BaseCharsetTest._
 
 class USASCIITest extends BaseCharsetTest(Charset.forName("US-ASCII")) {
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(1.0f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(1.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
+  }
+
   @Test def decode(): Unit = {
     // Simple tests
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
@@ -18,6 +18,7 @@ import java.nio.charset._
 import BaseCharsetTest._
 
 import org.junit.Test
+import org.junit.Assert._
 
 abstract class BaseUTF16Test(charset: Charset) extends BaseCharsetTest(charset) {
   @Test def decode(): Unit = {
@@ -106,7 +107,14 @@ abstract class BaseUTF16Test(charset: Charset) extends BaseCharsetTest(charset) 
   }
 }
 
-class UTF16BETest extends BaseUTF16Test(Charset.forName("UTF-16BE"))
+class UTF16BETest extends BaseUTF16Test(Charset.forName("UTF-16BE")) {
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(0.5f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
+  }
+}
 
 class UTF16LETest extends BaseUTF16Test(Charset.forName("UTF-16LE")) {
   import UTF16LETest._
@@ -122,6 +130,13 @@ class UTF16LETest extends BaseUTF16Test(Charset.forName("UTF-16LE")) {
     for (BufferPart(buf) <- outParts)
       flipByteBuffer(buf)
     super.testEncode(in)(outParts: _*)
+  }
+
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(0.5f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
   }
 }
 
@@ -165,5 +180,12 @@ class UTF16Test extends BaseUTF16Test(Charset.forName("UTF-16")) {
       outParts: OutPart[ByteBuffer]*): Unit = {
     if (in.remaining == 0) super.testEncode(in)(outParts: _*)
     else super.testEncode(in)(BufferPart(BigEndianBOM) +: outParts: _*)
+  }
+
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(0.5f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(4.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
@@ -21,6 +21,13 @@ import org.junit.Assert._
 import BaseCharsetTest._
 
 class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(1.0f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(1.1f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(3.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
+  }
+
   @Test def decode1byte(): Unit = {
     // 1-byte characters
     testDecode(bb"42 6f 6e 6a 6f 75 72")(cb"Bonjour")


### PR DESCRIPTION
* `Decoder.averageCharsPerByte()`
* `Decoder.maxCharsPerByte()`
* `Encoder.averageBytesPerChar()`
* `Encoder.maxBytesPerChar()`