### PR TITLE
Fix #3926: Wrap object lit in () if alone in an arrow function.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -533,6 +533,13 @@ object Printers {
             printSig(args)
             print("=> ")
             body match {
+              case Return(expr: ObjectConstr) =>
+                /* #3926 An ObjectConstr needs to be wrapped in () not to be
+                 * parsed as a block.
+                 */
+                print('(')
+                print(expr)
+                print(')')
               case Return(expr) =>
                 print(expr)
               case _ =>

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
@@ -78,6 +78,24 @@ class RegressionJSTest {
     assertEquals(4, sourceMapper(4))
   }
 
+  @Test def lambda_returning_object_literal_issue_3926(): Unit = {
+    @noinline
+    def f(): () => js.Dynamic =
+      () => js.Dynamic.literal(foo = 5)
+
+    val obj1 = f()()
+    assertEquals("object", js.typeOf(obj1))
+    assertEquals(5, obj1.foo)
+
+    @noinline
+    def g(): js.Function0[js.Dynamic] =
+      () => js.Dynamic.literal(bar = 6)
+
+    val obj2 = g()()
+    assertEquals("object", js.typeOf(obj2))
+    assertEquals(6, obj2.bar)
+  }
+
 }
 
 object RegressionJSTest {


### PR DESCRIPTION
Note that this is not an issue in 0.6.x because 0.6.x never emits arrow functions, even in ECMAScript 2015 mode.