### PR TITLE
Fix #3913: Make ByteArrayInputStream.read always return -1 at EOF.

### DIFF
--- a/javalib/src/main/scala/java/io/ByteArrayInputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayInputStream.scala
@@ -36,13 +36,13 @@ class ByteArrayInputStream(
     if (off < 0 || reqLen < 0 || reqLen > b.length - off)
       throw new IndexOutOfBoundsException
 
-    val len = Math.min(reqLen, count - pos)
-
-    if (reqLen == 0)
-      0  // 0 requested, 0 returned
-    else if (len == 0)
-      -1 // nothing to read at all
-    else {
+    if (pos == count) {
+      /* There is nothing left to read.
+       * #3913: return -1 even if reqLen == 0.
+       */
+      -1
+    } else {
+      val len = Math.min(reqLen, count - pos)
       System.arraycopy(buf, pos, b, off, len)
       pos += len
       len

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
@@ -14,10 +14,22 @@ package org.scalajs.testsuite.javalib.io
 
 import java.io._
 
-import scala.language.implicitConversions
+import org.junit.Test
+import org.junit.Assert._
 
 class ByteArrayInputStreamTest extends CommonStreamsTests {
   def mkStream(seq: Seq[Int]): InputStream = {
     new ByteArrayInputStream(seq.map(_.toByte).toArray)
+  }
+
+  @Test
+  def readWithZeroLengthReturnsMinus1AtEOF_issue_3913(): Unit = {
+    /* Contrary to the spec in the base class InputStream, read(_, _, 0) must
+     * return -1 if the stream is at the end of the buffer, instead of 0.
+     */
+    val stream = new ByteArrayInputStream(new Array(5))
+    val buf = new Array[Byte](10)
+    assertEquals(5, stream.read(buf, 0, 5))
+    assertEquals(-1, stream.read(buf, 0, 0))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
@@ -18,6 +18,7 @@ import scala.language.implicitConversions
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows._
 
@@ -165,5 +166,19 @@ trait CommonStreamsTests {
     assertEquals(254, stream.read())
     assertEquals(253, stream.read())
     assertEquals(-1, stream.read())
+  }
+
+  @Test
+  def readWithZeroLengthReturns0AtEOF(): Unit = {
+    val stream = mkStream(Seq(1, 2, 3, 4, 5))
+
+    // See comment in ByteArrayInputStreamTest
+    assumeFalse("ByteArrayInputStream has a contradicting spec",
+        stream.isInstanceOf[ByteArrayInputStream])
+
+    val buf = new Array[Byte](10)
+    assertEquals(5, stream.read(buf, 0, 5))
+    assertEquals(0, stream.read(buf, 0, 0))
+    assertEquals(-1, stream.read(buf, 0, 1))
   }
 }


### PR DESCRIPTION
Even when the requested length is 0.