### PR TITLE
FF ONLY Merge 0.6.x into release-v1.0.0, January 17

### DIFF
--- a/assets/additional-doc-styles.css
+++ b/assets/additional-doc-styles.css
@@ -2,7 +2,19 @@
   background-color: #E68A00;
 }
 
+.badge-ecma2015 {
+  background-color: #E68A00;
+}
+
+.badge-ecma2017 {
+  background-color: #E68A00;
+}
+
 .badge-ecma2019 {
+  background-color: #E68A00;
+}
+
+.badge-ecma2020 {
   background-color: #E68A00;
 }
 

--- a/javalib/src/main/scala/java/io/ByteArrayInputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayInputStream.scala
@@ -36,13 +36,13 @@ class ByteArrayInputStream(
     if (off < 0 || reqLen < 0 || reqLen > b.length - off)
       throw new IndexOutOfBoundsException
 
-    val len = Math.min(reqLen, count - pos)
-
-    if (reqLen == 0)
-      0  // 0 requested, 0 returned
-    else if (len == 0)
-      -1 // nothing to read at all
-    else {
+    if (pos == count) {
+      /* There is nothing left to read.
+       * #3913: return -1 even if reqLen == 0.
+       */
+      -1
+    } else {
+      val len = Math.min(reqLen, count - pos)
       System.arraycopy(buf, pos, b, off, len)
       pos += len
       len

--- a/javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
+++ b/javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
@@ -23,8 +23,9 @@ abstract class CharsetEncoder protected (cs: Charset,
   import CharsetEncoder._
 
   protected def this(cs: Charset, _averageBytesPerChar: Float,
-      _maxBytesPerChar: Float) =
-    this(cs, _averageBytesPerChar, _averageBytesPerChar, Array('?'.toByte))
+      _maxBytesPerChar: Float) = {
+    this(cs, _averageBytesPerChar, _maxBytesPerChar, Array('?'.toByte))
+  }
 
   // Config
 

--- a/javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
@@ -116,7 +116,8 @@ private[charset] abstract class UTF_16_Common protected (
   }
 
   private class Encoder extends CharsetEncoder(
-      UTF_16_Common.this, 2.0f, 2.0f,
+      UTF_16_Common.this, 2.0f,
+      if (endianness == AutoEndian) 4.0f else 2.0f,
       // Character 0xfffd
       if (endianness == LittleEndian) Array(-3, -1) else Array(-1, -3)) {
 

--- a/javalib/src/main/scala/java/nio/charset/UTF_8.scala
+++ b/javalib/src/main/scala/java/nio/charset/UTF_8.scala
@@ -315,7 +315,7 @@ private[charset] object UTF_8 extends Charset("UTF-8", Array(
     }
   }
 
-  private class Encoder extends CharsetEncoder(UTF_8, 1.1f, 4.0f) {
+  private class Encoder extends CharsetEncoder(UTF_8, 1.1f, 3.0f) {
     def encodeLoop(in: CharBuffer, out: ByteBuffer): CoderResult = {
       if (in.hasArray && out.hasArray)
         encodeLoopArray(in, out)

--- a/javalib/src/main/scala/java/util/function/Consumer.scala
+++ b/javalib/src/main/scala/java/util/function/Consumer.scala
@@ -1,0 +1,30 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util.function
+
+import scala.scalajs.js.annotation.JavaDefaultMethod
+
+@FunctionalInterface
+trait Consumer[T] { self =>
+  def accept(t: T): Unit
+
+  @JavaDefaultMethod
+  def andThen(after: Consumer[_ >: T]): Consumer[T] = {
+    new Consumer[T] {
+      def accept(t: T): Unit = {
+        self.accept(t)
+        after.accept(t)
+      }
+    }
+  }
+}

--- a/javalib/src/main/scala/java/util/regex/GroupStartMapper.scala
+++ b/javalib/src/main/scala/java/util/regex/GroupStartMapper.scala
@@ -187,7 +187,13 @@ private[regex] object GroupStartMapper {
 
     def propagate(matchResult: js.RegExp.ExecResult,
         groupStartMap: js.Array[Int], start: Int, end: Int): Unit = {
-      groupStartMap(number) = start
+      /* #3901: A GroupNode within a negative look-ahead node may receive
+       * `start != -1` from above, yet not match anything itself. We must
+       * always keep the default `-1` if this group node does not match
+       * anything.
+       */
+      if (matchResult(newGroup).isDefined)
+        groupStartMap(number) = start
       inner.propagateFromStart(matchResult, groupStartMap, start)
     }
   }

--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@ -121,6 +121,15 @@ object Object extends js.Object {
    */
   def getOwnPropertyNames(o: js.Object): js.Array[String] = js.native
 
+  /** <span class="badge badge-ecma2015" style="float: right;">ECMAScript 2015</span>
+   *
+   *  The Object.getOwnPropertySymbols() method returns an array of all symbol
+   *  properties found directly upon a given object.
+   *
+   *  MDN
+   */
+  def getOwnPropertySymbols(o: js.Object): js.Array[js.Symbol] = js.native
+
   /**
    * The Object.create() method creates a new object with the specified
    * prototype object and properties.
@@ -201,6 +210,37 @@ object Object extends js.Object {
    */
   def preventExtensions(o: js.Object): o.type = js.native
 
+  /** <span class="badge badge-ecma2015" style="float: right;">ECMAScript 2015</span>
+   *
+   *  Object.is() determines whether two values are the same value. Two values
+   *  are the same if one of the following holds:
+   *
+   *  <ul>
+   *    <li>both undefined
+   *    <li>both null
+   *    <li>both true or both false
+   *    <li>both strings of the same length with the same characters in the same
+   *        order
+   *    <li>both the same object (means both object have same reference)
+   *    <li>both numbers and
+   *      <ul>
+   *        <li>both +0
+   *        <li>both -0
+   *        <li>both NaN
+   *        <li>or both non-zero and both not NaN and both have the same value
+   *      </ul>
+   *    </li>
+   *  </ul>
+   *
+   *  This is not the same as being equal according to JavaScript's `===`
+   *  operator (exposed as `js.special.strictEquals`` in Scala.js). The `===`
+   *  operator treats the number values `-0` and `+0` as equal and treats `NaN`
+   *  as not equal to `NaN`.
+   *
+   *  MDN
+   */
+  def is(value1: scala.Any, value2: scala.Any): Boolean = js.native
+
   /**
    * Returns true if the object is sealed, otherwise false. An object is sealed
    * if it is not extensible and if all its properties are non-configurable and
@@ -242,4 +282,30 @@ object Object extends js.Object {
    * MDN
    */
   def keys(o: js.Object): js.Array[String] = js.native
+
+  /** <span class="badge badge-ecma2017" style="float: right;">ECMAScript 2017</span>
+   *
+   *  The Object.entries() method returns an array of a given object's own
+   *  enumerable string-keyed property [key, value] pairs, in the same order as
+   *  that provided by a for...in loop (the difference being that a for-in loop
+   *  enumerates properties in the prototype chain as well).
+   *
+   *  MDN
+   */
+  def entries(o: js.Object): js.Array[js.Tuple2[String, scala.Any]] = js.native
+
+  /** <span class="badge badge-ecma2017" style="float: right;">ECMAScript 2017</span>
+   */
+  def entries[A](
+      dict: js.Dictionary[A]): js.Array[js.Tuple2[String, A]] = js.native
+
+  /** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
+   *
+   *  The Object.fromEntries() method transforms a list of key-value pairs into
+   *  an object.
+   *
+   *  MDN
+   */
+  def fromEntries[A](
+      iterable: js.Iterable[js.Tuple2[String, A]]): js.Dictionary[A] = js.native
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
@@ -1,0 +1,108 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.library
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+import org.scalajs.testsuite.utils.Platform
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.{ JSBracketAccess, JSName }
+
+class ObjectTest {
+  import ObjectTest._
+
+  private lazy val symA = js.Symbol("a")
+  private lazy val symB = js.Symbol.forKey("b")
+
+  @Test def getOwnPropertySymbols(): Unit = {
+    assumeTrue(
+        "Symbol is not defined (should only happen with NodeJSEnvForcePolyfills)",
+        js.typeOf(js.Dynamic.global.Symbol) != "undefined")
+
+    val obj = (new js.Object()).asInstanceOf[ObjectCreator]
+    obj(symA) = "localSymbol"
+    obj(symB) = "globalSymbol"
+    val objectSymbols = js.Object.getOwnPropertySymbols(obj)
+    assertArrayEquals(Array[AnyRef](symA, symB), objectSymbols.toArray[AnyRef])
+  }
+
+  @Test def is(): Unit = {
+    assumeTrue(
+        "Object.is is not defined (should only happen with NodeJSEnvForcePolyfills)",
+        js.typeOf(js.Dynamic.global.Object.is) != "undefined")
+
+    val a = new js.Object()
+    assertTrue(js.Object.is(a, a))
+    assertTrue(js.Object.is(Double.NaN, Double.NaN))
+    assertTrue(js.Object.is(0.0, +0.0))
+    assertTrue(js.Object.is(-0.0, -0.0))
+    assertTrue(js.Object.is("foo", "foo"))
+
+    val b = new js.Object()
+    assertFalse(js.Object.is(a, b))
+    assertFalse(js.Object.is(-0.0, +0.0))
+  }
+
+  @Test def entries_from_object(): Unit = {
+    val obj = new js.Object {
+      val a = 42
+      val b = "foo"
+    }
+    val entries = js.Object.entries(obj)
+    assertEquals(2, entries.length)
+
+    val js.Tuple2(key1, value1) = entries(0)
+    assertEquals("a", key1)
+    assertEquals(42, value1)
+
+    val js.Tuple2(key2, value2) = entries(1)
+    assertEquals("b", key2)
+    assertEquals("foo", value2.asInstanceOf[String])
+  }
+
+  @Test def entries_from_dictionary(): Unit = {
+    val dict = js.Dictionary[Int]("a" -> 42, "b" -> 0)
+    val entries = js.Object.entries(dict)
+    assertEquals(2, entries.length)
+
+    val js.Tuple2(key1, value1) = entries(0)
+    assertEquals("a", key1)
+    val value1IsInt: Int = value1
+    assertEquals(42, value1IsInt)
+
+    val js.Tuple2(key2, value2) = entries(1)
+    assertEquals("b", key2)
+    val value2IsInt: Int = value2
+    assertEquals(0, value2IsInt)
+  }
+
+  @Test def fromEntries_array(): Unit = {
+    // from Array
+    val array = js.Array(js.Tuple2("a", 42), js.Tuple2("b", "foo"))
+    val obj1 = js.Object.fromEntries(array)
+    assertEquals(obj1("a"), 42)
+    assertEquals(obj1("b"), "foo")
+  }
+
+  // TODO: Add test for fromEntries(js.Map)
+}
+
+object ObjectTest {
+  @js.native
+  private trait ObjectCreator extends js.Object {
+    @JSBracketAccess
+    def update(s: js.Symbol, v: js.Any): Unit = js.native
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
@@ -14,10 +14,22 @@ package org.scalajs.testsuite.javalib.io
 
 import java.io._
 
-import scala.language.implicitConversions
+import org.junit.Test
+import org.junit.Assert._
 
 class ByteArrayInputStreamTest extends CommonStreamsTests {
   def mkStream(seq: Seq[Int]): InputStream = {
     new ByteArrayInputStream(seq.map(_.toByte).toArray)
+  }
+
+  @Test
+  def readWithZeroLengthReturnsMinus1AtEOF_issue_3913(): Unit = {
+    /* Contrary to the spec in the base class InputStream, read(_, _, 0) must
+     * return -1 if the stream is at the end of the buffer, instead of 0.
+     */
+    val stream = new ByteArrayInputStream(new Array(5))
+    val buf = new Array[Byte](10)
+    assertEquals(5, stream.read(buf, 0, 5))
+    assertEquals(-1, stream.read(buf, 0, 0))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
@@ -18,6 +18,7 @@ import scala.language.implicitConversions
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows._
 
@@ -165,5 +166,19 @@ trait CommonStreamsTests {
     assertEquals(254, stream.read())
     assertEquals(253, stream.read())
     assertEquals(-1, stream.read())
+  }
+
+  @Test
+  def readWithZeroLengthReturns0AtEOF(): Unit = {
+    val stream = mkStream(Seq(1, 2, 3, 4, 5))
+
+    // See comment in ByteArrayInputStreamTest
+    assumeFalse("ByteArrayInputStream has a contradicting spec",
+        stream.isInstanceOf[ByteArrayInputStream])
+
+    val buf = new Array[Byte](10)
+    assertEquals(5, stream.read(buf, 0, 5))
+    assertEquals(0, stream.read(buf, 0, 0))
+    assertEquals(-1, stream.read(buf, 0, 1))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/ConsumerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/ConsumerTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util.function
+
+import java.util.function.Consumer
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.AssertThrows._
+
+class ConsumerTest {
+  import ConsumerTest._
+
+  @Test def accept(): Unit = {
+    // Side-effects
+    var current: Int = 0
+    val add = makeConsumer[Int](num => current += num)
+
+    add.accept(1)
+    assertTrue(current == 1)
+
+    add.accept(2)
+    assertTrue(current == 3)
+  }
+
+  @Test def andThen(): Unit = {
+    // Side-effects
+    var current: Int = 0
+    val add = makeConsumer[Int](num => current += num)
+    val multiply = makeConsumer[Int](num => current *= num)
+    val addAndMultiply = add.andThen(multiply)
+
+    addAndMultiply.accept(2)
+    assertTrue(current == 4)
+
+    addAndMultiply.accept(3)
+    assertTrue(current == 21)
+
+    // Sequential operations
+    val throwingConsumer =
+      makeConsumer[Any](x => throw new ThrowingConsumerException(x))
+    val dontCallConsumer =
+      makeConsumer[Any](x => throw new AssertionError(s"dontCallConsumer.accept($x)"))
+
+    assertThrows(classOf[ThrowingConsumerException],
+        throwingConsumer.andThen(dontCallConsumer).accept(0))
+
+    assertThrows(classOf[ThrowingConsumerException],
+        add.andThen(throwingConsumer).accept(1))
+    assertTrue(current == 22)
+  }
+}
+
+object ConsumerTest {
+  final class ThrowingConsumerException(x: Any)
+      extends Exception(s"throwing consumer called with $x")
+
+  def makeConsumer[T](f: T => Unit): Consumer[T] = {
+    new Consumer[T] {
+      def accept(t: T): Unit = f(t)
+    }
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -146,6 +146,7 @@ class RegexMatcherTest  {
     parseExpect("ab(?:ac)+?ac", "abacacac", 0 -> 6)
     parseExpect("ab(?:(c){2})*d", "abccccd", 0 -> 7, 5 -> 6)
     parseExpect("ab((?=abab(ab))a(b))*a", "abababab", 0 -> 5, 2 -> 4, 6 -> 8, 3 -> 4)
+    parseExpect("(?!(a))(b)", "b", 0 -> 1, -1 -> -1, 0 -> 1) // #3901
   }
 
   @Test def parseRegex_backgroups_test(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
@@ -21,6 +21,13 @@ import org.junit.Assert._
 import BaseCharsetTest._
 
 class Latin1Test extends BaseCharsetTest(Charset.forName("ISO-8859-1")) {
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(1.0f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(1.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
+  }
+
   @Test def decode(): Unit = {
     // Simple tests
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
@@ -20,6 +20,13 @@ import org.junit.Assert._
 import BaseCharsetTest._
 
 class USASCIITest extends BaseCharsetTest(Charset.forName("US-ASCII")) {
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(1.0f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(1.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
+  }
+
   @Test def decode(): Unit = {
     // Simple tests
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
@@ -18,6 +18,7 @@ import java.nio.charset._
 import BaseCharsetTest._
 
 import org.junit.Test
+import org.junit.Assert._
 
 abstract class BaseUTF16Test(charset: Charset) extends BaseCharsetTest(charset) {
   @Test def decode(): Unit = {
@@ -106,7 +107,14 @@ abstract class BaseUTF16Test(charset: Charset) extends BaseCharsetTest(charset) 
   }
 }
 
-class UTF16BETest extends BaseUTF16Test(Charset.forName("UTF-16BE"))
+class UTF16BETest extends BaseUTF16Test(Charset.forName("UTF-16BE")) {
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(0.5f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
+  }
+}
 
 class UTF16LETest extends BaseUTF16Test(Charset.forName("UTF-16LE")) {
   import UTF16LETest._
@@ -122,6 +130,13 @@ class UTF16LETest extends BaseUTF16Test(Charset.forName("UTF-16LE")) {
     for (BufferPart(buf) <- outParts)
       flipByteBuffer(buf)
     super.testEncode(in)(outParts: _*)
+  }
+
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(0.5f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
   }
 }
 
@@ -165,5 +180,12 @@ class UTF16Test extends BaseUTF16Test(Charset.forName("UTF-16")) {
       outParts: OutPart[ByteBuffer]*): Unit = {
     if (in.remaining == 0) super.testEncode(in)(outParts: _*)
     else super.testEncode(in)(BufferPart(BigEndianBOM) +: outParts: _*)
+  }
+
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(0.5f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(2.0f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(4.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
@@ -21,6 +21,13 @@ import org.junit.Assert._
 import BaseCharsetTest._
 
 class UTF8Test extends BaseCharsetTest(Charset.forName("UTF-8")) {
+  @Test def testHeuristicProperties(): Unit = {
+    assertEquals(1.0f, charset.newDecoder().averageCharsPerByte(), 0.0f)
+    assertEquals(1.0f, charset.newDecoder().maxCharsPerByte(), 0.0f)
+    assertEquals(1.1f, charset.newEncoder().averageBytesPerChar(), 0.0f)
+    assertEquals(3.0f, charset.newEncoder().maxBytesPerChar(), 0.0f)
+  }
+
   @Test def decode1byte(): Unit = {
     // 1-byte characters
     testDecode(bb"42 6f 6e 6a 6f 75 72")(cb"Bonjour")


### PR DESCRIPTION
```
$ git checkout -b merge-0.6.x-into-release-1.0.0-january-17
Switched to a new branch 'merge-0.6.x-into-release-1.0.0-january-17'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/release-v1.0.0)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   6f589c2f2 (scalajs/0.6.x) Merge pull request #3930 from sjrd/fix-bais-read-with-zero-len
|\  
| * 5f9af7e58 Fix #3913: Make ByteArrayInputStream.read always return -1 at EOF.
|/  
*   dcf288507 Merge pull request #3923 from sjrd/fix-charset-heuristic-properties
|\  
| * df335fc3e Fix #3922: Fix all the heuristic properties of `Charset`s.
|/  
*   368e57cfa Merge pull request #3916 from mliarakos/feature/javalib-consumer
|\  
| * 7fd9ebba8 Implement `java.util.function.Consumer`.
|/  
* 91e807b9e Add new methods in js.Object
*   7abe034a7 Merge pull request #3910 from sjrd/disable-phantomjs-test-suite-on-ci
|\  
| * 976d20faa [no-master] Disable testing the test suite with PhantomJS on the CI.
* |   75d8244dd Merge pull request #3907 from sjrd/fix-regex-start-end-regression-3901
|\ \  
| |/  
|/|   
| * 602005ded (origin/fix-regex-start-end-regression-3901) Fix #3901: Do not fill `groupStartMap` for non-matching groups.
|/  
*   de9fa18c3 (origin/0.6.x) Merge pull request #3909 from sjrd/disable-stacktracetest-in-bootstrap
|\  
| * cbd262db9 [no-master] Work around #3908: Disable StackTraceTest in bootstrap.
|/  
*   3d0e4e3f3 Merge pull request #3890 from sjrd/fix-nested-object-named-class
|\  
| * 36a92e3ff Fix #3888: Always identify impl classes by their IMPLCLASS flag.
|/  
* 6dbc8beb4 Towards 0.6.32.
* 29b644013 (tag: v0.6.31) Version 0.6.31.
*   91b554646 Merge pull request #3873 from sjrd/fix-cli-parse-version
|\  
| * c19399116 [no-master] Fix #3872: Fix parsing of Scala versions in scalajsc.
* |   7e98ae55e Merge pull request #3871 from sjrd/fix-supported-ir-versions
|\ \  
| |/  
|/|   
| * 62818633c Fix #3865: Set the emitted IR version to 0.6.29, and support 0.6.{29-30}.
|/  
* c6fd2a950 Towards 0.6.31.
* d7d342159 (tag: v0.6.30) Version 0.6.30.
```
```
$ git merge -s ours de9fa18c3
Merge made by the 'ours' strategy.
```
```
$ git show
commit 421d42dd841221eb09c3737c10fe6483839880b9 (HEAD -> merge-0.6.x-into-release-1.0.0-january-17)
Merge: 7caf032f3 de9fa18c3
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Fri Jan 17 14:35:38 2020 +0100

    Skip version commits and no-master commits.
    
    The following version commits are skipped: d7d342159, c6fd2a950,
    29b644013 and 6dbc8beb4.
    
    The following commits tagged `[no-master]` are skipped: c19399116 and
    cbd262db9.
    
    The following commits were not originally tagged `[no-master]`, but do
    not need going to 1.x either:
    
    * 62818633c, which fixes emitted and supported IR versions, should have
      been `[no-master]` to begin with.
    * 36a92e3ff, which was superseded by 281f83f in 1.x, with the test
      being added in b9bcdba.

```
```
$ git merge --no-commit 75d8244dd
Auto-merging test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
Automatic merge went well; stopped before committing as requested
```
[...] Run `testSuite2_12/test` at this point
```
$ git st
M  javalib/src/main/scala/java/util/regex/GroupStartMapper.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
```
```
$ git commit
[merge-0.6.x-into-release-1.0.0-january-17 8c9a5342e] Merge '0.6.x' into 'release-v1.0.0'.
```
```
$ git merge -s ours 7abe034a7
Merge made by the 'ours' strategy.
```
```
$ git show
commit 78175b509d12d3136e3f82319273878aeb19b8d5 (HEAD -> merge-0.6.x-into-release-1.0.0-january-17)
Merge: 8c9a5342e 7abe034a7
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Fri Jan 17 14:51:20 2020 +0100

    Skip the no-master commit 976d20faa.

```
```
$ git merge --no-commit scalajs/0.6.x 
Auto-merging library/src/main/scala/scala/scalajs/js/Object.scala
CONFLICT (content): Merge conflict in library/src/main/scala/scala/scalajs/js/Object.scala
Recorded preimage for 'library/src/main/scala/scala/scalajs/js/Object.scala'
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
M  assets/additional-doc-styles.css
M  javalib/src/main/scala/java/io/ByteArrayInputStream.scala
M  javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
M  javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
M  javalib/src/main/scala/java/nio/charset/UTF_8.scala
A  javalib/src/main/scala/java/util/function/Consumer.scala
UU library/src/main/scala/scala/scalajs/js/Object.scala
A  test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
A  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/ConsumerTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
```
[...] Fix conflicts
```diff
$ git diff | cat
diff --cc library/src/main/scala/scala/scalajs/js/Object.scala
index cb3b14f6d,ea2a115e7..000000000
--- a/library/src/main/scala/scala/scalajs/js/Object.scala
+++ b/library/src/main/scala/scala/scalajs/js/Object.scala
@@@ -119,8 -121,17 +119,17 @@@ object Object extends js.Object 
     *
     * MDN
     */
 -  def getOwnPropertyNames(o: Object): Array[String] = native
 +  def getOwnPropertyNames(o: js.Object): js.Array[String] = js.native
  
+   /** <span class="badge badge-ecma2015" style="float: right;">ECMAScript 2015</span>
+    *
+    *  The Object.getOwnPropertySymbols() method returns an array of all symbol
+    *  properties found directly upon a given object.
+    *
+    *  MDN
+    */
 -  def getOwnPropertySymbols(o: Object): Array[Symbol] = native
++  def getOwnPropertySymbols(o: js.Object): js.Array[js.Symbol] = js.native
+ 
    /**
     * The Object.create() method creates a new object with the specified
     * prototype object and properties.
@@@ -199,8 -209,39 +208,39 @@@
     *
     * MDN
     */
 -  def preventExtensions(o: Object): o.type = native
 +  def preventExtensions(o: js.Object): o.type = js.native
  
+   /** <span class="badge badge-ecma2015" style="float: right;">ECMAScript 2015</span>
+    *
+    *  Object.is() determines whether two values are the same value. Two values
+    *  are the same if one of the following holds:
+    *
+    *  <ul>
+    *    <li>both undefined
+    *    <li>both null
+    *    <li>both true or both false
+    *    <li>both strings of the same length with the same characters in the same
+    *        order
+    *    <li>both the same object (means both object have same reference)
+    *    <li>both numbers and
+    *      <ul>
+    *        <li>both +0
+    *        <li>both -0
+    *        <li>both NaN
+    *        <li>or both non-zero and both not NaN and both have the same value
+    *      </ul>
+    *    </li>
+    *  </ul>
+    *
+    *  This is not the same as being equal according to JavaScript's `===`
+    *  operator (exposed as `js.special.strictEquals`` in Scala.js). The `===`
+    *  operator treats the number values `-0` and `+0` as equal and treats `NaN`
+    *  as not equal to `NaN`.
+    *
+    *  MDN
+    */
 -  def is(value1: scala.Any, value2: scala.Any): Boolean = native
++  def is(value1: scala.Any, value2: scala.Any): Boolean = js.native
+ 
    /**
     * Returns true if the object is sealed, otherwise false. An object is sealed
     * if it is not extensible and if all its properties are non-configurable and
@@@ -241,5 -282,42 +281,31 @@@
     *
     * MDN
     */
 -  def keys(o: Object): Array[String] = native
 -
 -  /** Returns the names of all the enumerable properties of this object,
 -   *  including properties in its prototype chain.
 -   *
 -   *  This method returns the same set of names that would be enumerated by
 -   *  a for-in loop in JavaScript, but not necessarily in the same order.
 -   *
 -   *  If the underlying implementation guarantees an order for for-in loops,
 -   *  then this is guaranteed to be consistent with [[keys]], in the sense
 -   *  that the list returned by [[keys]] is a sublist of the list returned by
 -   *  this method (not just a subset).
 -   */
 -  def properties(o: Any): Array[String] = throw new java.lang.Error("stub")
 +  def keys(o: js.Object): js.Array[String] = js.native
+ 
+   /** <span class="badge badge-ecma2017" style="float: right;">ECMAScript 2017</span>
+    *
+    *  The Object.entries() method returns an array of a given object's own
+    *  enumerable string-keyed property [key, value] pairs, in the same order as
+    *  that provided by a for...in loop (the difference being that a for-in loop
+    *  enumerates properties in the prototype chain as well).
+    *
+    *  MDN
+    */
 -  def entries(o: Object): Array[Tuple2[String, scala.Any]] = native
++  def entries(o: js.Object): js.Array[js.Tuple2[String, scala.Any]] = js.native
+ 
+   /** <span class="badge badge-ecma2017" style="float: right;">ECMAScript 2017</span>
+    */
 -  def entries[A](dict: Dictionary[A]): Array[Tuple2[String, A]] = native
++  def entries[A](
++      dict: js.Dictionary[A]): js.Array[js.Tuple2[String, A]] = js.native
+ 
+   /** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
+    *
+    *  The Object.fromEntries() method transforms a list of key-value pairs into
+    *  an object.
+    *
+    *  MDN
+    */
 -  def fromEntries[A](iterable: Iterable[Tuple2[String, A]]): Dictionary[A] = native
++  def fromEntries[A](
++      iterable: js.Iterable[js.Tuple2[String, A]]): js.Dictionary[A] = js.native
  }
```
```
$ git add -u
```
```
$ git st
M  assets/additional-doc-styles.css
M  javalib/src/main/scala/java/io/ByteArrayInputStream.scala
M  javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
M  javalib/src/main/scala/java/nio/charset/UTF_16_Common.scala
M  javalib/src/main/scala/java/nio/charset/UTF_8.scala
A  javalib/src/main/scala/java/util/function/Consumer.scala
M  library/src/main/scala/scala/scalajs/js/Object.scala
A  test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
A  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/ConsumerTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/Latin1Test.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/USASCIITest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF16Test.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/UTF8Test.scala
```
```
$ git commit
Recorded resolution for 'library/src/main/scala/scala/scalajs/js/Object.scala'.
[merge-0.6.x-into-release-1.0.0-january-17 bcaf94a3b] Merge '0.6.x' into 'release-v1.0.0'.
```
