### PR TITLE
Fix #3933: Use fresh names everywhere in GenJSExports.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ScalaJSDefinedTest.scala
@@ -196,6 +196,11 @@ class ScalaJSDefinedTest {
     assertEquals(15, dyn.sum())
   }
 
+  @Test def constructor_with_param_name_clashes_issue_3933(): Unit = {
+    val obj = new ConstructorWithParamNameClashes(1, 2, 3, 4, 5, 6)
+    assertEquals(List(1, 2, 3, 4, 5, 6), obj.allArgs)
+  }
+
   @Test def default_values_for_fields(): Unit = {
     val obj = new DefaultFieldValues
     assertEquals(0, obj.int)
@@ -1891,6 +1896,12 @@ object ScalaJSDefinedTest {
 
   class SimpleConstructorParamAccessors(x: Int, y: Int) extends js.Object {
     def sum(): Int = x + y
+  }
+
+  class ConstructorWithParamNameClashes(arg: Int, arg$1: Int, arg$2: Int,
+      prep: Int, prep$1: Int, prep$2: Int)
+      extends js.Object {
+    val allArgs = List(arg, arg$1, arg$2, prep, prep$1, prep$2)
   }
 
   class DefaultFieldValues extends js.Object {


### PR DESCRIPTION
The logic in `GenJSExports.scala` was always using compiler-generated local names that were not fresh. This was fine before, because the local scope of an exporter method was never mixed with that of user-defined code of even scalac-generated code. However, it became problematic with the introduction of Scala.js-defined classes, because their constructors precisely create such mixes.

We now use proper fresh local names everywhere when creating exporter methods.

---

We will need to merge this into `release-v1.0.0` once this PR is merged. There will be merge conflicts, but no "semantic" conflict AFAICT.