### PR TITLE
FF ONLY Merge 0.6.x into release-1.0.0 January 21

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
@@ -196,6 +196,11 @@ class NonNativeJSTypeTest {
     assertEquals(15, dyn.sum())
   }
 
+  @Test def constructor_with_param_name_clashes_issue_3933(): Unit = {
+    val obj = new ConstructorWithParamNameClashes(1, 2, 3, 4, 5, 6)
+    assertEquals(List(1, 2, 3, 4, 5, 6), obj.allArgs)
+  }
+
   @Test def default_values_for_fields(): Unit = {
     val obj = new DefaultFieldValues
     assertEquals(0, obj.int)
@@ -1951,6 +1956,12 @@ object NonNativeJSTypeTest {
 
   class SimpleConstructorParamAccessors(x: Int, y: Int) extends js.Object {
     def sum(): Int = x + y
+  }
+
+  class ConstructorWithParamNameClashes(arg: Int, arg$1: Int, arg$2: Int,
+      prep: Int, prep$1: Int, prep$2: Int)
+      extends js.Object {
+    val allArgs = List(arg, arg$1, arg$2, prep, prep$1, prep$2)
   }
 
   class DefaultFieldValues extends js.Object {


### PR DESCRIPTION
```
$ git checkout -b merge-0.6.x-into-release-1.0.0-january-21
Switched to a new branch 'merge-0.6.x-into-release-1.0.0-january-21'
```

```
$ export mb=$(git merge-base scala-js/0.6.x scala-js/release-v1.0.0)
$ git log --graph --oneline --decorate $mb..scala-js/0.6.x | cat
* 1303013c0 (sjrd/0.6.x, scala-js/0.6.x) Merge pull request #3934 from sjrd/fix-js-ctor-name-clash
* 787033acd Fix #3933: Use fresh names everywhere in GenJSExports.
```

```
$ git merge --no-commit 1303013c0

Auto-merging test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
Automatic merge failed; fix conflicts and then commit the result.
```

Fix conflicts.

```
$ git diff | cat
```

https://gist.github.com/gzm0/400eca19489165821a6f5dd4f8ea4d74

```
$ git add -u
```

```
$ git status -s
M  compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
M  test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
```

```
$ git commit
[merge-0.6.x-into-release-1.0.0-january-21 c53faae28] Merge '0.6.x' into 'release-v1.0.0'
```