### PR TITLE
Fix #3938: Handle new cases of `Array.apply` arising in 2.13.2+.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -1909,18 +1909,22 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
          * our `WrapArray` extractor.
          *
          * Replaces `Array(Predef.wrapArray(ArrayValue(...).$asInstanceOf[...]), <tag>)`
-         * with just `ArrayValue(...).$asInstanceOf[...]`
+         * with just `ArrayValue(...)`
          *
          * See scala/bug#6611; we must *only* do this for literal vararg arrays.
          *
          * This is normally done by `cleanup` but it comes later than this phase.
          */
-        case Apply(appMeth, Apply(wrapRefArrayMeth, (arg @ StripCast(ArrayValue(_, _))) :: Nil) :: _ :: Nil)
+        case Apply(appMeth, Apply(wrapRefArrayMeth, StripCast(arg @ ArrayValue(_, _)) :: Nil) :: _ :: Nil)
             if wrapRefArrayMeth.symbol == WrapArray.wrapRefArrayMethod && appMeth.symbol == ArrayModule_genericApply =>
-          genStatOrExpr(arg, isStat)
+          genArrayValue(arg)
         case Apply(appMeth, elem0 :: WrapArray(rest @ ArrayValue(elemtpt, _)) :: Nil)
             if appMeth.symbol == ArrayModule_apply(elemtpt.tpe) =>
-          genStatOrExpr(treeCopy.ArrayValue(rest, rest.elemtpt, elem0 :: rest.elems), isStat)
+          genArrayValue(rest, elem0 :: rest.elems)
+        case Apply(appMeth, elem :: (nil: RefTree) :: Nil)
+            if nil.symbol == NilModule && appMeth.symbol == ArrayModule_apply(elem.tpe.widen) &&
+            treeInfo.isExprSafeToInline(nil) =>
+          genArrayValue(tree, elem :: Nil)
 
         case app: Apply =>
           genApply(app, isStat)
@@ -2953,14 +2957,19 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       js.NewArray(arrayType, arguments)
     }
 
-    /** Gen JS code for an array literal.
-     */
-    def genArrayValue(tree: Tree): js.Tree = {
-      implicit val pos = tree.pos
+    /** Gen JS code for an array literal. */
+    def genArrayValue(tree: ArrayValue): js.Tree = {
       val ArrayValue(tpt @ TypeTree(), elems) = tree
+      genArrayValue(tree, elems)
+    }
 
+    /** Gen JS code for an array literal, in the context of `tree` (its `tpe`
+     *  and `pos`) but with the elements `elems`.
+     */
+    def genArrayValue(tree: Tree, elems: List[Tree]): js.Tree = {
+      implicit val pos = tree.pos
       val arrType = toReferenceType(tree.tpe).asInstanceOf[jstpe.ArrayType]
-      js.ArrayValue(arrType, elems map genExpr)
+      js.ArrayValue(arrType, elems.map(genExpr))
     }
 
     /** Gen JS code for a Match, i.e., a switch-able pattern match.

--- a/compiler/src/test/scala/org/scalajs/core/compiler/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/core/compiler/test/OptimizationTest.scala
@@ -62,6 +62,10 @@ class OptimizationTest extends JSASTTest {
       val c = Array('a', 'b')
       val d = Array(Nil)
       val e = Array(5.toByte, 7.toByte, 9.toByte, -3.toByte)
+
+      // Also with exactly 1 element of a primitive type (#3938)
+      val f = Array('a')
+      val g = Array(5.toByte)
     }
     """.
     hasNot("any LoadModule of the scala.Array companion") {
@@ -80,9 +84,11 @@ class OptimizationTest extends JSASTTest {
     class A {
       val a = Array[Int](5, 7, 9, -3)
       val b = Array[Byte](5, 7, 9, -3)
+      val c = Array[Int](5)
+      val d = Array[Byte](5)
     }
     """.
-    hasExactly(2, "calls to Array.apply methods") {
+    hasExactly(4, "calls to Array.apply methods") {
       case js.Apply(js.LoadModule(jstpe.ClassType("s_Array$")), js.Ident(methodName, _), _)
           if methodName.startsWith("apply__") =>
     }


### PR DESCRIPTION
This is a port of the changes to the `Array.apply` optimization made upstream in https://github.com/scala/scala/commit/71367089d39ff8f5f7875688f189f91293bb95fd

We now also recognize `Array.apply(primElem, Nil)` as a shape to optimize into `ArrayValue(arrayType, primElem :: Nil)`.

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.2-bin-a2fbeae
> testSuite/test
> compiler/test
```
Also locally cherry-picked into `release-v1.0.0`, fixed conflicts and tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.2-bin-a2fbeae
> testSuite2_13/test
> compiler2_13/test
```