### PR TITLE
FF ONLY Merge 0.6.x into release-v1.0.0, January 22

### DIFF
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
@@ -35,6 +35,10 @@ class OptimizationTest extends JSASTTest {
       val c = Array('a', 'b')
       val d = Array(Nil)
       val e = Array(5.toByte, 7.toByte, 9.toByte, -3.toByte)
+
+      // Also with exactly 1 element of a primitive type (#3938)
+      val f = Array('a')
+      val g = Array(5.toByte)
     }
     """.
     hasNot("any LoadModule of the scala.Array companion") {
@@ -53,9 +57,11 @@ class OptimizationTest extends JSASTTest {
     class A {
       val a = Array[Int](5, 7, 9, -3)
       val b = Array[Byte](5, 7, 9, -3)
+      val c = Array[Int](5)
+      val d = Array[Byte](5)
     }
     """.
-    hasExactly(2, "calls to Array.apply methods") {
+    hasExactly(4, "calls to Array.apply methods") {
       case js.Apply(_, js.LoadModule(ArrayModuleClass), js.MethodIdent(methodName), _)
           if methodName.simpleName == applySimpleMethodName =>
     }


### PR DESCRIPTION
Motivation: get the fix into `master` ASAP so that our nightly-against-nightly build can discover new regressions, instead of hiding them with this one.
```
$ git checkout -b merge-0.6.x-into-release-1.0.0-january-22
Switched to a new branch 'merge-0.6.x-into-release-1.0.0-january-22'
```
```
$ export mb=$(git merge-base scala-js/0.6.x scala-js/release-v1.0.0)
fatal: Not a valid object name scala-js/0.6.x
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/release-v1.0.0)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* 19a5102f2 (scalajs/0.6.x) Merge pull request #3940 from sjrd/fix-array-apply-opt-in-scala-2.13.2
* ce483a6c4 Fix #3938: Handle new cases of `Array.apply` arising in 2.13.2+.
```
```
$ git merge --no-commit scalajs/0.6.x 
Auto-merging compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
CONFLICT (content): Merge conflict in compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
Recorded preimage for 'compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala'
Recorded preimage for 'compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala'
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
UU compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
```
[...] Fix conflicts
```diff
$ git diff | cat
diff --cc compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
index 895b1d29a,5c245bc89..000000000
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@@ -3286,24 -2948,28 +3290,29 @@@ abstract class GenJSCode[G <: Global wi
       *  specify up to `dimensions` lengths for the first dimensions of the
       *  array.
       */
 -    def genNewArray(arrayType: jstpe.ArrayType, arguments: List[js.Tree])(
 +    def genNewArray(arrayTypeRef: jstpe.ArrayTypeRef, arguments: List[js.Tree])(
          implicit pos: Position): js.Tree = {
 -      assert(arguments.length <= arrayType.dimensions,
 +      assert(arguments.length <= arrayTypeRef.dimensions,
            "too many arguments for array constructor: found " + arguments.length +
 -          " but array has only " + arrayType.dimensions + " dimension(s)")
 +          " but array has only " + arrayTypeRef.dimensions +
 +          " dimension(s)")
  
 -      js.NewArray(arrayType, arguments)
 +      js.NewArray(arrayTypeRef, arguments)
      }
  
-     /** Gen JS code for an array literal.
-      */
-     def genArrayValue(tree: Tree): js.Tree = {
-       implicit val pos = tree.pos
+     /** Gen JS code for an array literal. */
+     def genArrayValue(tree: ArrayValue): js.Tree = {
        val ArrayValue(tpt @ TypeTree(), elems) = tree
+       genArrayValue(tree, elems)
+     }
  
+     /** Gen JS code for an array literal, in the context of `tree` (its `tpe`
+      *  and `pos`) but with the elements `elems`.
+      */
+     def genArrayValue(tree: Tree, elems: List[Tree]): js.Tree = {
+       implicit val pos = tree.pos
 -      val arrType = toReferenceType(tree.tpe).asInstanceOf[jstpe.ArrayType]
 -      js.ArrayValue(arrType, elems.map(genExpr))
 +      val arrayTypeRef = toTypeRef(tree.tpe).asInstanceOf[jstpe.ArrayTypeRef]
-       js.ArrayValue(arrayTypeRef, elems map genExpr)
++      js.ArrayValue(arrayTypeRef, elems.map(genExpr))
      }
  
      /** Gen JS code for a Match, i.e., a switch-able pattern match.
diff --cc compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
index 0e671c635,275e2a524..000000000
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
@@@ -53,11 -84,13 +57,13 @@@ class OptimizationTest extends JSASTTes
      class A {
        val a = Array[Int](5, 7, 9, -3)
        val b = Array[Byte](5, 7, 9, -3)
+       val c = Array[Int](5)
+       val d = Array[Byte](5)
      }
      """.
-     hasExactly(2, "calls to Array.apply methods") {
+     hasExactly(4, "calls to Array.apply methods") {
 -      case js.Apply(js.LoadModule(jstpe.ClassType("s_Array$")), js.Ident(methodName, _), _)
 -          if methodName.startsWith("apply__") =>
 +      case js.Apply(_, js.LoadModule(ArrayModuleClass), js.MethodIdent(methodName), _)
 +          if methodName.simpleName == applySimpleMethodName =>
      }
    }
  
```
```
$ git add -u
```
```
$ git commit
Recorded resolution for 'compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala'.
Recorded resolution for 'compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala'.
[merge-0.6.x-into-release-1.0.0-january-22 4beccc448] Merge '0.6.x' into 'release-v1.0.0'.
```
