### PR TITLE
FF ONLY Merge release-v1.0.0 into master, January 23

### DIFF
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/OptimizationTest.scala
@@ -35,6 +35,10 @@ class OptimizationTest extends JSASTTest {
       val c = Array('a', 'b')
       val d = Array(Nil)
       val e = Array(5.toByte, 7.toByte, 9.toByte, -3.toByte)
+
+      // Also with exactly 1 element of a primitive type (#3938)
+      val f = Array('a')
+      val g = Array(5.toByte)
     }
     """.
     hasNot("any LoadModule of the scala.Array companion") {
@@ -53,9 +57,11 @@ class OptimizationTest extends JSASTTest {
     class A {
       val a = Array[Int](5, 7, 9, -3)
       val b = Array[Byte](5, 7, 9, -3)
+      val c = Array[Int](5)
+      val d = Array[Byte](5)
     }
     """.
-    hasExactly(2, "calls to Array.apply methods") {
+    hasExactly(4, "calls to Array.apply methods") {
       case js.Apply(_, js.LoadModule(ArrayModuleClass), js.MethodIdent(methodName), _)
           if methodName.simpleName == applySimpleMethodName =>
     }


### PR DESCRIPTION
```
$ git checkout -b merge-release-1.0.0-into-master-january-23
Switched to a new branch 'merge-release-1.0.0-into-master-january-23'
```
```
$ export mb=$(git merge-base scalajs/release-v1.0.0 scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/release-v1.0.0 | cat
* 4beccc448 (scalajs/release-v1.0.0, origin/release-v1.0.0, origin/merge-0.6.x-into-release-1.0.0-january-22, release-v1.0.0) Merge '0.6.x' into 'release-v1.0.0'.
* 19a5102f2 Merge pull request #3940 from sjrd/fix-array-apply-opt-in-scala-2.13.2
* ce483a6c4 Fix #3938: Handle new cases of `Array.apply` arising in 2.13.2+.
```
```
$ git merge --no-commit scalajs/release-v1.0.0 
Automatic merge went well; stopped before committing as requested
```
Clean merge.
```
$ git commit
[merge-release-1.0.0-into-master-january-23 51aaa722d] Merge 'release-v1.0.0' into 'master'.
```
