### PR TITLE
Respect sbt `repositories` when fetching the linker

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -198,10 +198,14 @@ object ScalaJSPlugin extends AutoPlugin {
           val s = streams.value
           val log = s.log
           val retrieveDir = s.cacheDirectory / "scalajs-linker" / scalaJSVersion
+          // We can't use `dependencyResolution.value` because it's only defined in
+          // the project scope
           val lm = {
             import sbt.librarymanagement.ivy._
+            val resolvers = Classpaths.appRepositories(appConfiguration.value)
+              .getOrElse(Vector(Resolver.defaultLocal, Resolver.mavenCentral))
             val ivyConfig = InlineIvyConfiguration()
-              .withResolvers(Vector(Resolver.defaultLocal, Resolver.mavenCentral))
+              .withResolvers(resolvers)
               .withLog(log)
             IvyDependencyResolution(ivyConfig)
           }


### PR DESCRIPTION
sbt has a ~/.sbt/repositories file that can be used to add extra default
resolvers, this is especially useful for setting up a cache or a proxy
(see https://www.scala-sbt.org/1.x/docs/Proxy-Repositories.html for more
information).

So far, sbt-scalajs did not respect this setting and instead manually
specified a list of resolvers, this commit fixes this. Ideally we would
just use `dependencyResolution.value` but sbt does not define this task
in the global scope.