### PR TITLE
Fix #3948: Use sbt's `dependencyResolution` for the LinkerImpl.

### DIFF
--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/build.sbt
@@ -1,0 +1,10 @@
+name := "Scala.js sbt test"
+
+version in ThisBuild := scalaJSVersion
+scalaVersion in ThisBuild := "2.12.10"
+
+// Disable the IvyPlugin on the root project
+disablePlugins(sbt.plugins.IvyPlugin)
+
+lazy val `my-project` = project
+  .enablePlugins(ScalaJSPlugin)

--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/my-project/Main.scala
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/my-project/Main.scala
@@ -1,0 +1,5 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def main(args: Array[String]): Unit = println("Hello World")
+}

--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/project/build.properties
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/project/build.sbt
@@ -1,0 +1,3 @@
+val scalaJSVersion = sys.props("plugin.version")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)

--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/test
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/test
@@ -1,0 +1,1 @@
+> my-project/compile:fastOptJS


### PR DESCRIPTION
Based on #3946: only the last commit belongs to this PR. Alternative to #3943.

Instead of always creating a default `IvyDependencyResolution` to resolve the scalajs-linker artifact, used to create the `LinkerImpl`, we now use sbt's built-in `dependencyResolution` task.

However, since that task is only available per project (and not in the Global scope), we fetch it from the `LocalRootProject`. In the rare case that the root project disabled the built-in `IvyPlugin`, we fall back to the default `IvyDependencyResolution` as before.

With these changes, resolution of the scalajs-linker artifact will follow custom configurations, such as the `~/.sbt/repositories` file.

/cc @smarter