### PR TITLE
Fix #3950: Generate static forwarders for static nested objects

### DIFF
--- a/project/TestSuiteLinkerOptions.scala
+++ b/project/TestSuiteLinkerOptions.scala
@@ -29,7 +29,9 @@ object TestSuiteLinkerOptions {
     List(
         ModuleInitializer.mainMethod(module, "mainNoArgs"),
         ModuleInitializer.mainMethodWithArgs(module, "mainWithArgs"),
-        ModuleInitializer.mainMethodWithArgs(module, "mainWithArgs", List("foo", "bar"))
+        ModuleInitializer.mainMethodWithArgs(module, "mainWithArgs", List("foo", "bar")),
+        ModuleInitializer.mainMethod(module + "$NoLinkedClass", "main"),
+        ModuleInitializer.mainMethod(module + "$WithLinkedClass", "main")
     )
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitializersTest.scala
@@ -23,7 +23,9 @@ class ModuleInitializersTest {
         Array[AnyRef](
             NoArgs,
             WithArgs + "()",
-            WithArgs + "(foo, bar)"
+            WithArgs + "(foo, bar)",
+            NestedNoLinkedClass,
+            NestedWithLinkedClass
         ),
         moduleInitializersEffects.toArray[AnyRef])
   }
@@ -32,6 +34,8 @@ class ModuleInitializersTest {
 object ModuleInitializersTest {
   final val NoArgs = "NoArgs"
   final val WithArgs = "WithArgs"
+  final val NestedNoLinkedClass = "NestedNoLinkedClass"
+  final val NestedWithLinkedClass = "NestedWithLinkedClass"
 
   val moduleInitializersEffects =
     new scala.collection.mutable.ListBuffer[String]
@@ -45,4 +49,16 @@ object ModuleInitializers {
 
   def mainWithArgs(args: Array[String]): Unit =
     moduleInitializersEffects += WithArgs + args.mkString("(", ", ", ")")
+
+  object NoLinkedClass {
+    def main(): Unit =
+      moduleInitializersEffects += NestedNoLinkedClass
+  }
+
+  class WithLinkedClass
+
+  object WithLinkedClass {
+    def main(): Unit =
+      moduleInitializersEffects += NestedWithLinkedClass
+  }
 }


### PR DESCRIPTION
We use the module initializer infrastructure to test this.