### PR TITLE
Fix #3957: Address deprecations of narrowing numeric conversions.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalanglib/src/main/scala/java/lang/reflect/Array.scala
@@ -95,8 +95,8 @@ object Array {
     case array: Array[Char]  => array(index)
     case array: Array[Byte]  => array(index)
     case array: Array[Short] => array(index)
-    case array: Array[Int]   => array(index)
-    case array: Array[Long]  => array(index)
+    case array: Array[Int]   => array(index).toFloat
+    case array: Array[Long]  => array(index).toFloat
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
 
@@ -106,7 +106,7 @@ object Array {
     case array: Array[Byte]   => array(index)
     case array: Array[Short]  => array(index)
     case array: Array[Int]    => array(index)
-    case array: Array[Long]   => array(index)
+    case array: Array[Long]   => array(index).toDouble
     case array: Array[Float]  => array(index)
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
@@ -163,15 +163,15 @@ object Array {
   def setInt(array: AnyRef, index: Int, value: Int): Unit = array match {
     case array: Array[Int]    => array(index) = value
     case array: Array[Long]   => array(index) = value
-    case array: Array[Float]  => array(index) = value
+    case array: Array[Float]  => array(index) = value.toFloat
     case array: Array[Double] => array(index) = value
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
 
   def setLong(array: AnyRef, index: Int, value: Long): Unit = array match {
     case array: Array[Long]   => array(index) = value
-    case array: Array[Float]  => array(index) = value
-    case array: Array[Double] => array(index) = value
+    case array: Array[Float]  => array(index) = value.toFloat
+    case array: Array[Double] => array(index) = value.toDouble
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
 

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -1483,7 +1483,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     /* A similar code like in doubleValue() could be repeated here,
      * but this simple implementation is quite efficient. */
     val powerOfTwo = this._bitLength - (_scale / Log2).toLong
-    val floatResult0: Float = signum()
+    val floatResult0: Float = signum().toFloat
     val floatResult: Float = {
       if (powerOfTwo < -149 || floatResult0 == 0.0f) // 'this' is very small
         floatResult0 * 0.0f
@@ -1716,7 +1716,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
         val frac = java.lang.Long.signum(fraction) * (5 + compRem)
         val intPart1 = intPart0 + roundingBehavior(intPart0.toInt & 1, frac, mc.roundingMode)
         // If after to add the increment the precision changed, we normalize the size
-        if (Math.log10(Math.abs(intPart1)) >= mc.precision)
+        if (Math.log10(Math.abs(intPart1).toDouble) >= mc.precision)
           (newScale0 - 1, intPart1 / 10)
         else
           (newScale0, intPart1)

--- a/javalib/src/main/scala/java/math/Conversion.scala
+++ b/javalib/src/main/scala/java/math/Conversion.scala
@@ -286,7 +286,7 @@ private[math] object Conversion {
 
   def bigInteger2Double(bi: BigInteger): Double = {
     if (bi.numberLength < 2 || ((bi.numberLength == 2) && (bi.digits(1) > 0))) {
-      bi.longValue()
+      bi.longValue().toDouble
     } else if (bi.numberLength > 32) {
       if (bi.sign > 0) Double.PositiveInfinity
       else Double.NegativeInfinity

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -36,7 +36,7 @@ class Date private (private val date: js.Date) extends Object
   def this(year: Int, month: Int, date: Int) =
     this(year, month, date, 0, 0, 0)
 
-  def this(date: Long) = this(new js.Date(date))
+  def this(date: Long) = this(new js.Date(date.toDouble))
 
   @Deprecated
   def this(date: String) = this(new js.Date(date))
@@ -98,7 +98,7 @@ class Date private (private val date: js.Date) extends Object
   @Deprecated
   def setSeconds(seconds: Int): Unit = date.setSeconds(seconds)
 
-  def setTime(time: Long): Unit = date.setTime(time)
+  def setTime(time: Long): Unit = date.setTime(time.toDouble)
 
   @Deprecated
   def setYear(year: Int): Unit = date.setFullYear(1900 + year)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -150,10 +150,10 @@ class FloatTest {
     assertTrue(compare(0.0f, 5.5f) < 0)
     assertTrue(compare(10.5f, 10.2f) > 0)
     assertTrue(compare(-2.1f, -1.0f) < 0)
-    assertEquals(0, compare(3.14f, 3.14f), 0.0f)
+    assertEquals(0, compare(3.14f, 3.14f))
 
     // From compareTo's point of view, NaN is equal to NaN
-    assertEquals(0, compare(Float.NaN, Float.NaN), 0.0f)
+    assertEquals(0, compare(Float.NaN, Float.NaN))
 
     // And -0.0 < 0.0
     assertTrue(compare(-0.0f, 0.0f) < 0)
@@ -167,10 +167,10 @@ class FloatTest {
     assertTrue(compare(0.0f, 5.5f) < 0)
     assertTrue(compare(10.5f, 10.2f) > 0)
     assertTrue(compare(-2.1f, -1.0f) < 0)
-    assertEquals(0, compare(3.14f, 3.14f), 0.0f)
+    assertEquals(0, compare(3.14f, 3.14f))
 
     // From compareTo's point of view, NaN is equal to NaN
-    assertEquals(0, compare(Float.NaN, Float.NaN), 0.0f)
+    assertEquals(0, compare(Float.NaN, Float.NaN))
 
     // And -0.0 < 0.0
     assertTrue(compare(-0.0f, 0.0f) < 0)


### PR DESCRIPTION
In the javalib and javalanglib, introduce explicit conversions instead of relying on the deprecated implicit conversions.

In the test suite, avoid useless conversions from `Int`s to `Float`s in a few assertions.

---

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.2-bin-fd1a71b
> testSuite/test
```