### PR TITLE
FF ONLY Merge 0.6.x into master, February 17

### DIFF
--- a/javalanglib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalanglib/src/main/scala/java/lang/reflect/Array.scala
@@ -101,8 +101,8 @@ object Array {
     case array: Array[Char]  => array(index)
     case array: Array[Byte]  => array(index)
     case array: Array[Short] => array(index)
-    case array: Array[Int]   => array(index)
-    case array: Array[Long]  => array(index)
+    case array: Array[Int]   => array(index).toFloat
+    case array: Array[Long]  => array(index).toFloat
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
 
@@ -112,7 +112,7 @@ object Array {
     case array: Array[Byte]   => array(index)
     case array: Array[Short]  => array(index)
     case array: Array[Int]    => array(index)
-    case array: Array[Long]   => array(index)
+    case array: Array[Long]   => array(index).toDouble
     case array: Array[Float]  => array(index)
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
@@ -169,15 +169,15 @@ object Array {
   def setInt(array: AnyRef, index: Int, value: Int): Unit = array match {
     case array: Array[Int]    => array(index) = value
     case array: Array[Long]   => array(index) = value
-    case array: Array[Float]  => array(index) = value
+    case array: Array[Float]  => array(index) = value.toFloat
     case array: Array[Double] => array(index) = value
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
 
   def setLong(array: AnyRef, index: Int, value: Long): Unit = array match {
     case array: Array[Long]   => array(index) = value
-    case array: Array[Float]  => array(index) = value
-    case array: Array[Double] => array(index) = value
+    case array: Array[Float]  => array(index) = value.toFloat
+    case array: Array[Double] => array(index) = value.toDouble
     case _ => throw new IllegalArgumentException("argument type mismatch")
   }
 

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -1483,7 +1483,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     /* A similar code like in doubleValue() could be repeated here,
      * but this simple implementation is quite efficient. */
     val powerOfTwo = this._bitLength - (_scale / Log2).toLong
-    val floatResult0: Float = signum()
+    val floatResult0: Float = signum().toFloat
     val floatResult: Float = {
       if (powerOfTwo < -149 || floatResult0 == 0.0f) // 'this' is very small
         floatResult0 * 0.0f
@@ -1716,7 +1716,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
         val frac = java.lang.Long.signum(fraction) * (5 + compRem)
         val intPart1 = intPart0 + roundingBehavior(intPart0.toInt & 1, frac, mc.roundingMode)
         // If after to add the increment the precision changed, we normalize the size
-        if (Math.log10(Math.abs(intPart1)) >= mc.precision)
+        if (Math.log10(Math.abs(intPart1).toDouble) >= mc.precision)
           (newScale0 - 1, intPart1 / 10)
         else
           (newScale0, intPart1)

--- a/javalib/src/main/scala/java/math/Conversion.scala
+++ b/javalib/src/main/scala/java/math/Conversion.scala
@@ -286,7 +286,7 @@ private[math] object Conversion {
 
   def bigInteger2Double(bi: BigInteger): Double = {
     if (bi.numberLength < 2 || ((bi.numberLength == 2) && (bi.digits(1) > 0))) {
-      bi.longValue()
+      bi.longValue().toDouble
     } else if (bi.numberLength > 32) {
       if (bi.sign > 0) Double.PositiveInfinity
       else Double.NegativeInfinity

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -36,7 +36,7 @@ class Date private (private val date: js.Date) extends Object
   def this(year: Int, month: Int, date: Int) =
     this(year, month, date, 0, 0, 0)
 
-  def this(date: Long) = this(new js.Date(date))
+  def this(date: Long) = this(new js.Date(date.toDouble))
 
   @Deprecated
   def this(date: String) = {
@@ -105,7 +105,7 @@ class Date private (private val date: js.Date) extends Object
   @Deprecated
   def setSeconds(seconds: Int): Unit = date.setSeconds(seconds)
 
-  def setTime(time: Long): Unit = date.setTime(time)
+  def setTime(time: Long): Unit = date.setTime(time.toDouble)
 
   @Deprecated
   def setYear(year: Int): Unit = date.setFullYear(1900 + year)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -150,10 +150,10 @@ class FloatTest {
     assertTrue(compare(0.0f, 5.5f) < 0)
     assertTrue(compare(10.5f, 10.2f) > 0)
     assertTrue(compare(-2.1f, -1.0f) < 0)
-    assertEquals(0, compare(3.14f, 3.14f), 0.0f)
+    assertEquals(0, compare(3.14f, 3.14f))
 
     // From compareTo's point of view, NaN is equal to NaN
-    assertEquals(0, compare(Float.NaN, Float.NaN), 0.0f)
+    assertEquals(0, compare(Float.NaN, Float.NaN))
 
     // And -0.0 < 0.0
     assertTrue(compare(-0.0f, 0.0f) < 0)
@@ -167,10 +167,10 @@ class FloatTest {
     assertTrue(compare(0.0f, 5.5f) < 0)
     assertTrue(compare(10.5f, 10.2f) > 0)
     assertTrue(compare(-2.1f, -1.0f) < 0)
-    assertEquals(0, compare(3.14f, 3.14f), 0.0f)
+    assertEquals(0, compare(3.14f, 3.14f))
 
     // From compareTo's point of view, NaN is equal to NaN
-    assertEquals(0, compare(Float.NaN, Float.NaN), 0.0f)
+    assertEquals(0, compare(Float.NaN, Float.NaN))
 
     // And -0.0 < 0.0
     assertTrue(compare(-0.0f, 0.0f) < 0)


### PR DESCRIPTION
Motivation: fix the nighlty-against-nightly build on master.
```
$ git checkout -b merge-0.6.x-into-master-february-17
Switched to a new branch 'merge-0.6.x-into-master-february-17'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
*   7966085d9 (scalajs/0.6.x) Merge pull request #3958 from sjrd/fix-deprecated-num-conversions
|\  
| * f8a78ec94 Fix #3957: Address deprecations of narrowing numeric conversions.
|/  
* 86260b504 (origin/0.6.x) Towards 0.6.33.
* e5b03ffef (tag: v0.6.32) Version 0.6.32.
```
```
$ git merge --no-commit scalajs/0.6.x
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging javalib/src/main/scala/java/util/Date.scala
Auto-merging javalib/src/main/scala/java/math/BigDecimal.scala
Auto-merging javalanglib/src/main/scala/java/lang/reflect/Array.scala
CONFLICT (modify/delete): ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala left in tree.
Recorded preimage for 'project/Build.scala'
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
DU ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
M  javalanglib/src/main/scala/java/lang/reflect/Array.scala
M  javalib/src/main/scala/java/math/BigDecimal.scala
M  javalib/src/main/scala/java/math/Conversion.scala
M  javalib/src/main/scala/java/util/Date.scala
UU project/Build.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
```
```
$ git rm -f ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala: needs merge
rm 'ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala'
```
[...] Fix conflicts
```diff
$ git diff | cat
diff --cc project/Build.scala
index ed2c9a9d7,b33e02fce..000000000
--- a/project/Build.scala
+++ b/project/Build.scala
```
```
$ git add -u
```
```
$ git st
M  javalanglib/src/main/scala/java/lang/reflect/Array.scala
M  javalib/src/main/scala/java/math/BigDecimal.scala
M  javalib/src/main/scala/java/math/Conversion.scala
M  javalib/src/main/scala/java/util/Date.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
```
```
$ git commit
Recorded resolution for 'project/Build.scala'.
[merge-0.6.x-into-master-february-17 3bbaf5aed] Merge '0.6.x' into 'master'.
```

---

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.2-bin-fd1a71b
> testSuite2_13/test
> testSuiteJVM2_13/test
> ir2_13/test
> irJS2_13/test
> linker2_13/test
> linkerJS2_13/test
```