### PR TITLE
DO NOT MERGE RFC Interface for module splitting

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Linker.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Linker.scala
@@ -23,8 +23,21 @@ import org.scalajs.logging.Logger
  *  .js file.
  */
 abstract class Linker private[interface] () {
-  def link(irFiles: Seq[IRFile],
+  final def link(irFiles: Seq[IRFile],
       moduleInitializers: Seq[ModuleInitializer],
       output: LinkerOutput, logger: Logger)(
+      implicit ec: ExecutionContext): Future[Unit] = {
+    val module = ModuleOutputSpec.Module("core")
+      .withInitializers(moduleInitializers: _*)
+
+    val spec = ModuleOutputSpec()
+      .addModule(ModuleOutputSpec.Selector.default, module)
+
+    val moduleOutput = ModuleLinkerOutput(module.id, output)
+
+    link(irFiles, spec, Seq(moduleOutput), logger)
+  }
+
+  def link(irFiles: Seq[IRFile], moduleSpec: ModuleOutputSpec, outputs: Seq[ModuleLinkerOutput], logger: Logger)(
       implicit ec: ExecutionContext): Future[Unit]
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/LinkerOutput.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/LinkerOutput.scala
@@ -21,7 +21,7 @@ import java.net.URI
 
 import org.scalajs.linker.interface.unstable.OutputFileImpl
 
-/** Output specification for a linker run.
+/** Output specification for a single JavaScript file and its source map.
  *
  *  @param jsFile The JavaScript file a [[Linker]] writes to.
  *

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleLinkerOutput.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleLinkerOutput.scala
@@ -1,0 +1,54 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+/** A single Module output specification for a linker run.
+ *
+ *  The fields [[moduleID]] and [[isInternal]] uniquely identify this output in
+ *  a [[Linker]] run.
+ *
+ *  @param moduleID The ID of the module this linker output represents.
+ *
+ *  @param isInternal Whether this is an internal (or an external) module.
+ *
+ *  @param output The [[LinkerOutput]] for this module.
+ *
+ *  @param moduleName Name of this module for import. A [[Linker]] will use
+ *      this name to include this module from one of its dependees. Must be set,
+ *      if this module is internal.
+ */
+final class ModuleLinkerOutput private (
+    val moduleID: ModuleOutputSpec.ModuleID,
+    val isInternal: Boolean,
+    val output: LinkerOutput,
+    val moduleName: Option[String]
+) {
+  private def this(moduleID: ModuleOutputSpec.ModuleID, output: LinkerOutput) =
+    this(moduleID, false, output, None)
+
+  def withInternal: ModuleLinkerOutput =
+    copy(isInternal = true)
+
+  def withModuleName(moduleName: String): ModuleLinkerOutput =
+    copy(moduleName = Some(moduleName))
+
+  private def copy(isInternal: Boolean = isInternal,
+      moduleName: Option[String] = moduleName): ModuleLinkerOutput = {
+    new ModuleLinkerOutput(moduleID, isInternal, output, moduleName)
+  }
+}
+
+object ModuleLinkerOutput {
+  def apply(moduleID: ModuleOutputSpec.ModuleID, output: LinkerOutput) =
+    new ModuleLinkerOutput(moduleID, output)
+}

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleOutputSpec.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleOutputSpec.scala
@@ -1,0 +1,68 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+/** Module output specification. */
+final class ModuleOutputSpec private (modules: Seq[(ModuleOutputSpec.Selector, ModuleOutputSpec.Module)]) {
+  private def this() = this(Nil)
+
+  def addModule(selector: ModuleOutputSpec.Selector, module: ModuleOutputSpec.Module): ModuleOutputSpec = {
+    // TODO ensure selectors don't conflict.
+    ???
+    new ModuleOutputSpec(modules :+ (selector, module))
+  }
+}
+
+object ModuleOutputSpec {
+  def apply(): ModuleOutputSpec = new ModuleOutputSpec()
+
+  final class ModuleID private[ModuleOutputSpec] (val id: String) extends AnyVal
+
+  final class Module private (
+      val id: ModuleID,
+      initializers: Seq[ModuleInitializer],
+      deps: Seq[ModuleID]
+  ) {
+    private def this(id: ModuleID) = this(id, Nil, Nil)
+
+    def withInitializers(initializers: ModuleInitializer*): Module =
+      copy(initializers = initializers)
+
+    def withDeps(deps: ModuleID*): Module =
+      copy(deps = deps)
+
+    private def copy(
+        initializers: Seq[ModuleInitializer] = initializers,
+        deps: Seq[ModuleID] = deps): Module = {
+      new Module(id, initializers, deps)
+    }
+  }
+
+  object Module {
+    def apply(id: String): Module = new Module(new ModuleID(id))
+  }
+
+  sealed abstract class Selector {
+    def ++(that: Selector): Selector = ???
+  }
+
+  private final case class PackageName(name: String) extends Selector
+  private final case class ClassName(name: String) extends Selector
+  private final case object Default extends Selector
+
+  object Selector {
+    def default: Selector = Default
+    def packageName(name: String): Selector = PackageName(name)
+    def className(name: String): Selector = ClassName(name)
+  }
+}


### PR DESCRIPTION
If you come here as an sbt user, in this design, `ModuleOutputSpec` is what you'd have to provide in your build (`ModuleLinkerOutput` would probably be calculated automatically).