### PR TITLE
Inline keepOnlyTrackedGlobalRefs in FunctionEmitter

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -382,8 +382,22 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
       if (!isOptimisticNamingRun || !globalVarNames.exists(localVarNames)) {
         /* At this point, filter out the global refs that do not need to be
          * tracked across functions and classes.
+         *
+         * By default, only dangerous global refs need to be tracked outside of
+         * functions, to power `mentionedDangerousGlobalRefs` In that case, the
+         * set is hopefully already emptied at this point for the large majority
+         * of methods, if not all.
+         *
+         * However, when integrating with GCC, we must tell it a list of all the
+         * global variables that are accessed in an externs file. In that case, we
+         * need to track all global variables across functions and classes. This is
+         * slower, but running GCC will take most of the time anyway in that case.
          */
-        WithGlobals(result, keepOnlyTrackedGlobalRefs(globalVarNames.toSet))
+        val globalRefs =
+          if (trackAllGlobalRefs) globalVarNames.toSet
+          else GlobalRefUtils.keepOnlyDangerousGlobalRefs(globalVarNames.toSet)
+
+        WithGlobals(result, globalRefs)
       } else {
         /* Clear the local var names, but *not* the global var names.
          * In the pessimistic run, we will use the knowledge gathered during

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -531,22 +531,6 @@ private[emitter] final class JSGen(val semantics: Semantics,
       codegenVarName
   }
 
-  /** Keeps only the global refs that need to be tracked.
-   *
-   *  By default, only dangerous global refs need to be tracked outside of
-   *  functions, to power `mentionedDangerousGlobalRefs` and therefore
-   *  `avoidClashWithGlobalRef`. In that case, the set is hopefully already
-   *  emptied at this point for the large majority of methods, if not all.
-   *
-   *  However, when integrating with GCC, we must tell it a list of all the
-   *  global variables that are accessed in an externs file. In that case, we
-   *  need to track all global variables across functions and classes. This is
-   *  slower, but running GCC will take most of the time anyway in that case.
-   */
-  def keepOnlyTrackedGlobalRefs(globalRefs: Set[String]): Set[String] =
-    if (trackAllGlobalRefs) globalRefs
-    else GlobalRefUtils.keepOnlyDangerousGlobalRefs(globalRefs)
-
   def genPropSelect(qual: Tree, item: PropertyName)(
       implicit pos: Position): Tree = {
     item match {

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -51,6 +51,8 @@ object BinaryIncompatibilities {
       exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.emitter.JSGen.genOriginalName"),
       exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.backend.emitter.JSGen.keepOnlyTrackedGlobalRefs"),
+      exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.emitter.JSGen.this"),
       exclude[MissingClassProblem](
           "org.scalajs.linker.backend.emitter.JSGen$"),


### PR DESCRIPTION
It was only used there.