### PR TITLE
Make ModuleInitializers a backend only concept

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.0.1-SNAPSHOT",
+    current = "1.1.0-SNAPSHOT",
     binaryEmitted = "1.0"
 )
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -67,12 +67,13 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
    *  @param unit [[standard.LinkingUnit LinkingUnit]] to emit
    *  @param output File to write to
    */
-  def emit(unit: LinkingUnit, output: LinkerOutput, logger: Logger)(
+  def emit(unit: LinkingUnit, moduleInitializers: Seq[ModuleInitializer],
+      output: LinkerOutput, logger: Logger)(
       implicit ec: ExecutionContext): Future[Unit] = {
     verifyUnit(unit)
 
     val emitterResult = logger.time("Emitter") {
-      emitter.emit(unit, logger)
+      emitter.emit(unit, moduleInitializers, logger)
     }
 
     val module = logger.time("Closure: Create trees)") {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -21,7 +21,7 @@ import java.nio.charset.StandardCharsets
 
 import org.scalajs.logging.Logger
 
-import org.scalajs.linker.interface.{IRFile, LinkerOutput}
+import org.scalajs.linker.interface.{IRFile, LinkerOutput, ModuleInitializer}
 import org.scalajs.linker.interface.unstable.OutputFileImpl
 import org.scalajs.linker.standard._
 
@@ -46,12 +46,13 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
    *  @param unit [[standard.LinkingUnit LinkingUnit]] to emit
    *  @param output File to write to
    */
-  def emit(unit: LinkingUnit, output: LinkerOutput, logger: Logger)(
+  def emit(unit: LinkingUnit, moduleInitializers: Seq[ModuleInitializer],
+      output: LinkerOutput, logger: Logger)(
       implicit ec: ExecutionContext): Future[Unit] = {
     verifyUnit(unit)
 
     val emitterResult = logger.time("Emitter") {
-      emitter.emit(unit, logger)
+      emitter.emit(unit, moduleInitializers, logger)
     }
 
     logger.timeFuture("BasicBackend: Write result") {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImpl.scala
@@ -47,18 +47,15 @@ final class LinkerFrontendImpl private (config: LinkerFrontendImpl.Config)
   /** Link and optionally optimize the given IR to a
    *  [[standard.LinkingUnit LinkingUnit]].
    */
-  def link(irFiles: Seq[IRFile],
-      moduleInitializers: Seq[ModuleInitializer],
-      symbolRequirements: SymbolRequirement, logger: Logger)(
-      implicit ec: ExecutionContext): Future[LinkingUnit] = {
+  def link(irFiles: Seq[IRFile], symbolRequirements: SymbolRequirement,
+      logger: Logger)(implicit ec: ExecutionContext): Future[LinkingUnit] = {
 
     val preOptimizerRequirements = optOptimizer.fold(symbolRequirements) {
       optimizer => symbolRequirements ++ optimizer.symbolRequirements
     }
 
     val linkResult = logger.timeFuture("Linker") {
-      linker.link(irFiles, moduleInitializers, logger,
-          preOptimizerRequirements, config.checkIR)
+      linker.link(irFiles, logger, preOptimizerRequirements, config.checkIR)
     }
 
     optOptimizer.fold(linkResult) { optimizer =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -41,12 +41,7 @@ final class Refiner(config: CommonPhaseConfig) {
     inputProvider.update(linkedClassesByName)
 
     val analysis = logger.timeFuture("Refiner: Compute reachability") {
-      val allSymbolRequirements = {
-        symbolRequirements ++
-        SymbolRequirement.fromModuleInitializer(unit.moduleInitializers)
-      }
-
-      analyze(allSymbolRequirements, logger)
+      analyze(symbolRequirements, logger)
     }
 
     for {
@@ -59,7 +54,7 @@ final class Refiner(config: CommonPhaseConfig) {
           refineClassDef(linkedClassesByName(info.className), info)
         }
 
-        new LinkingUnit(unit.coreSpec, linkedClassDefs.toList, unit.moduleInitializers)
+        new LinkingUnit(unit.coreSpec, linkedClassDefs.toList)
       }
 
       inputProvider.cleanAfterRun()

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -128,7 +128,7 @@ abstract class GenIncOptimizer private[optimizer] (config: CommonPhaseConfig) {
         linkedClass.optimized(methods = newMethods)
       }
 
-      new LinkingUnit(unit.coreSpec, newLinkedClasses, unit.moduleInitializers)
+      new LinkingUnit(unit.coreSpec, newLinkedClasses)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerBackend.scala
@@ -16,7 +16,7 @@ import scala.concurrent._
 
 import org.scalajs.logging._
 
-import org.scalajs.linker.interface.{IRFile, LinkerOutput}
+import org.scalajs.linker.interface.{IRFile, LinkerOutput, ModuleInitializer}
 
 /** A backend of a standard Scala.js linker.
  *
@@ -48,10 +48,12 @@ abstract class LinkerBackend {
    *  - contain the symbols listed in [[symbolRequirements]].
    *
    *  @param unit [[LinkingUnit]] to emit
+   *  @param moduleInitialiers module initializers to call
    *  @param output File to write to
    *  @param logger Logger to use
    */
-  def emit(unit: LinkingUnit, output: LinkerOutput, logger: Logger)(
+  def emit(unit: LinkingUnit, moduleInitializers: Seq[ModuleInitializer],
+      output: LinkerOutput, logger: Logger)(
       implicit ec: ExecutionContext): Future[Unit]
 
   /** Verify that a [[LinkingUnit]] can be processed by this [[LinkerBackend]].

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerFrontend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerFrontend.scala
@@ -34,7 +34,6 @@ abstract class LinkerFrontend {
 
   /** Link and optionally optimize the given IR to a [[LinkingUnit]]. */
   def link(irFiles: Seq[IRFile],
-      moduleInitializers: Seq[ModuleInitializer],
       symbolRequirements: SymbolRequirement, logger: Logger)(
       implicit ec: ExecutionContext): Future[LinkingUnit]
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkingUnit.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkingUnit.scala
@@ -16,6 +16,5 @@ import org.scalajs.linker.interface.ModuleInitializer
 
 final class LinkingUnit private[linker] (
     val coreSpec: CoreSpec,
-    val classDefs: List[LinkedClass],
-    val moduleInitializers: List[ModuleInitializer]
+    val classDefs: List[LinkedClass]
 )

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerImpl.scala
@@ -40,11 +40,16 @@ private final class StandardLinkerImpl private (
       throw new IllegalStateException("Linker used concurrently")
     }
 
+    val symbolRequirements = {
+      backend.symbolRequirements ++
+      SymbolRequirement.fromModuleInitializer(moduleInitializers)
+    }
+
     checkValid()
       .flatMap(_ => frontend.link(
-          irFiles ++ backend.injectedIRFiles, moduleInitializers,
-          backend.symbolRequirements, logger))
-      .flatMap(linkingUnit => backend.emit(linkingUnit, output, logger))
+          irFiles ++ backend.injectedIRFiles, symbolRequirements, logger))
+      .flatMap(linkingUnit => backend.emit(
+          linkingUnit, moduleInitializers, output, logger))
       .andThen { case t if t.isFailure => _valid = false }
       .andThen { case t => _linking.set(false) }
   }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -11,7 +11,25 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
+      // breaking in standard Linker API.
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.standard.LinkerBackend.emit"),
+      exclude[ReversedMissingMethodProblem](
+          "org.scalajs.linker.standard.LinkerBackend.emit"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.standard.LinkerFrontend.link"),
+      exclude[ReversedMissingMethodProblem](
+          "org.scalajs.linker.standard.LinkerFrontend.link"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.standard.LinkingUnit.moduleInitializers"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.standard.LinkingUnit.this"),
+
       // breaking in unstable Linker API.
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.backend.BasicLinkerBackend.emit"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.backend.closure.ClosureLinkerBackend.emit"),
       exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.emitter.Emitter.emitAll"),
       exclude[MissingClassProblem](
@@ -26,6 +44,10 @@ object BinaryIncompatibilities {
           "org.scalajs.linker.backend.javascript.Printers#JSTreePrinter.complete"),
       exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.javascript.Printers#JSTreePrinterWithSourceMap.complete"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.frontend.LinkerFrontendImpl.link"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.frontend.BaseLinker.link"),
 
       // private[backend], not an issue
       exclude[DirectMissingMethodProblem](


### PR DESCRIPTION
This simplifies symbol requirement handling and LinkingUnit transformation.

Downsides:
- Impossible to optimize module initializers
- LinkingUnit does not contain "all code" anymore