### PR TITLE
Fix #3914: Disable IR checker in fastOptJS

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -62,7 +62,7 @@ final class StandardConfig private (
         semantics = Semantics.Defaults,
         moduleKind = ModuleKind.NoModule,
         esFeatures = ESFeatures.Defaults,
-        checkIR = true,
+        checkIR = false,
         optimizer = true,
         parallel = true,
         sourceMap = true,

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -341,6 +341,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
         prevConfig
           .withSemantics(_.optimized)
           .withClosureCompiler(useClosure)
+          .withCheckIR(true)  // for safety, fullOpt is slow anyways.
       },
 
       scalaJSLinkedFile := Def.settingDyn {


### PR DESCRIPTION
To do this, we switch the default to false again.