### PR TITLE
Implement java.lang.Iterable.forEach.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Iterable.scala
+++ b/javalanglib/src/main/scala/java/lang/Iterable.scala
@@ -13,7 +13,17 @@
 package java.lang
 
 import java.util.Iterator
+import java.util.function.Consumer
+
+import scala.scalajs.js.annotation.JavaDefaultMethod
 
 trait Iterable[T] {
   def iterator(): Iterator[T]
+
+  @JavaDefaultMethod
+  def forEach(action: Consumer[_ >: T]): Unit = {
+    val iter = iterator()
+    while (iter.hasNext())
+      action.accept(iter.next())
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IterableTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IterableTest.scala
@@ -1,0 +1,86 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang
+
+import java.lang.{Iterable => JIterable}
+import java.{util => ju}
+import java.util.function.Consumer
+
+import scala.reflect.ClassTag
+
+import org.junit.Test
+import org.junit.Assert._
+
+/** Tests the implementation of the java standard library Iterable
+ */
+trait IterableTest {
+
+  def factory: IterableFactory
+
+  @Test def empty(): Unit = {
+    val iter = factory.fromElements[Int]()
+    var hit = false
+    iter.forEach(new Consumer[Int] {
+      def accept(x: Int): Unit = hit = true
+    })
+    assertTrue(!hit)
+  }
+
+  @Test def simpleSum(): Unit = {
+    val iter = factory.fromElements[Int](42, 50, 12, 0, -45, 102, 32, 75)
+    var sum = 0
+    iter.forEach(new Consumer[Int] {
+      def accept(x: Int): Unit = sum = sum + x
+    })
+    assertEquals(268, sum)
+  }
+}
+
+class IterableDefaultTest extends IterableTest {
+  def factory: IterableFactory = new IterableFactory {
+    override def implementationName: String = "java.lang.Iterable"
+
+    def empty[E: ClassTag]: JIterable[E] = {
+      new JIterable[E] {
+        override def iterator(): ju.Iterator[E] = {
+          new ju.Iterator[E] {
+            override def hasNext(): Boolean = false
+            override def next(): E = throw new NoSuchElementException()
+            override def remove(): Unit = throw new NoSuchElementException()
+          }
+        }
+      }
+    }
+
+    def fromElements[E: ClassTag](elems: E*): JIterable[E] = {
+      new JIterable[E] {
+        override def iterator(): ju.Iterator[E] = {
+          val l: Iterator[E] = elems.toIterator
+          new ju.Iterator[E] {
+            override def hasNext(): Boolean = l.hasNext
+            override def next(): E = l.next
+            override def remove(): Unit = throw new NoSuchElementException()
+          }
+        }
+      }
+    }
+  }
+}
+
+trait IterableFactory {
+  def implementationName: String
+
+  def empty[E: ClassTag]: JIterable[E]
+
+  def fromElements[E: ClassTag](elems: E*): JIterable[E]
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -17,13 +17,15 @@ import java.{util => ju, lang => jl}
 import org.junit.Test
 import org.junit.Assert._
 
+import org.scalajs.testsuite.javalib.lang.IterableFactory
+import org.scalajs.testsuite.javalib.lang.IterableTest
 import org.scalajs.testsuite.utils.AssertThrows._
 
 import scala.reflect.ClassTag
 
 import Utils._
 
-trait CollectionTest {
+trait CollectionTest extends IterableTest {
 
   def factory: CollectionFactory
 
@@ -287,14 +289,13 @@ trait CollectionTest {
 
 }
 
-trait CollectionFactory {
-  def implementationName: String
+trait CollectionFactory extends IterableFactory {
   def empty[E: ClassTag]: ju.Collection[E]
   def allowsMutationThroughIterator: Boolean = true
   def allowsNullElementQuery: Boolean = true
   def allowsNullElement: Boolean = true
 
-  def fromElements[E: ClassTag](elems: E*): ju.Collection[E] = {
+  override def fromElements[E: ClassTag](elems: E*): ju.Collection[E] = {
     val coll = empty[E]
     coll.addAll(TrivialImmutableCollection(elems: _*))
     coll


### PR DESCRIPTION

- adds the forEach method, but not the spliterator method
- added IterableTest and shoe-horned it under CollectionTest in the test class hierarchy