### PR TITLE
Upgrade Google Closure Compiler

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -377,7 +377,7 @@ private class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
         genFunction(name.name, args, body)
 
       case Spread(items) =>
-        new Node(Token.SPREAD, transformExpr(items))
+        new Node(Token.ITER_SPREAD, transformExpr(items))
 
       case _ =>
         throw new TransformException(s"Unknown tree of class ${tree.getClass()}")
@@ -398,7 +398,7 @@ private class ClosureAstTransformer(relativizeBaseURI: Option[URI]) {
     val pos = if (param.pos.isDefined) param.pos else parentPos
     val node = transformName(param.name)(pos)
     if (param.rest)
-      setNodePosition(new Node(Token.REST, node), pos)
+      setNodePosition(new Node(Token.ITER_REST, node), pos)
     else
       node
   }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -779,7 +779,7 @@ object Build {
     commonLinkerSettings _
   ).settings(
       libraryDependencies ++= Seq(
-          "com.google.javascript" % "closure-compiler" % "v20190513",
+          "com.google.javascript" % "closure-compiler" % "v20200101",
           "com.novocode" % "junit-interface" % "0.9" % "test"
       ) ++ (
           parallelCollectionsDependencies(scalaVersion.value)


### PR DESCRIPTION
v20200101 is the last version that still works. Later
versions (starting v20200112) throw

    java.lang.IllegalStateException: AST should not contain const
    declaration.

Filed as #3975.