### PR TITLE
Fix #3979: Duplicate 'use strict'; in fullOptJS

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -59,6 +59,7 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
         val code = withWriter { writer =>
           val printer = new Printers.JSTreePrinter(writer)
           writer.write(emitterResult.header)
+          writer.write("'use strict';\n")
           emitterResult.body.foreach(printer.printTopLevelTree _)
           writer.write(emitterResult.footer)
         }
@@ -74,6 +75,9 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
           writer.write(emitterResult.header)
           for (_ <- 0 until emitterResult.header.count(_ == '\n'))
             sourceMapWriter.nextLine()
+
+          writer.write("'use strict';\n")
+          sourceMapWriter.nextLine()
 
           emitterResult.body.foreach(printer.printTopLevelTree _)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -112,7 +112,7 @@ final class Emitter private (config: CommonPhaseConfig,
       } else {
         ""
       }
-      maybeTopLevelVarDecls + ifIIFE("(function(){") + "'use strict';\n"
+      maybeTopLevelVarDecls + ifIIFE("(function(){\n")
     }
 
     val footer = ifIIFE("}).call(this);\n")


### PR DESCRIPTION
GCC already emits a 'use strict' clause itself. We therefore only emit
one in the basic backend.

Note that putting the clause pre-GCC pass will also cause GCC to emit
it.

I have manually tested that both fastOptJS and fullOptJS contain
exactly one 'use strict' clause.