### PR TITLE
Fix #3283: Fix incremental linking on configuration changes

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -298,7 +298,7 @@ def Tasks = [
     sbt ++$scala irJS$v/test linkerJS$v/test &&
     sbt 'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSStage in testSuite.v$v := FastOptStage' \
-        ++$scala irJS$v/test linkerJS$v/test &&
+        ++$scala irJS$v/test linkerJS$v/test linkerInterfaceJS$v/test &&
     sbt ++$scala testSuite$v/bootstrap:test &&
     sbt 'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSStage in testSuite.v$v := FastOptStage' \
@@ -311,7 +311,7 @@ def Tasks = [
   "tools": '''
     setJavaVersion $java
     npm install &&
-    sbt ++$scala ir$v/test logging$v/compile linkerInterface$v/compile \
+    sbt ++$scala ir$v/test logging$v/compile linkerInterface$v/test \
         linker$v/compile jsEnvs$v/test nodeJSEnv$v/test testAdapter$v/test \
         ir$v/mimaReportBinaryIssues logging$v/mimaReportBinaryIssues \
         linkerInterface$v/mimaReportBinaryIssues linker$v/mimaReportBinaryIssues \
@@ -341,8 +341,7 @@ def Tasks = [
         ir$v/scalastyle compiler$v/scalastyle \
         compiler$v/test:scalastyle \
         logging$v/scalastyle logging$v/test:scalastyle \
-        linkerInterface$v/scalastyle \
-        linkerInterface$v/scalastyle \
+        linkerInterface$v/scalastyle linkerInterface$v/test:scalastyle \
         linker$v/scalastyle linker$v/test:scalastyle \
         jsEnvs$v/scalastyle jsEnvsTestKit$v/scalastyle nodeJSEnv$v/scalastyle \
         jsEnvs$v/test:scalastyle nodeJSEnv$v/test:scalastyle testAdapter$v/scalastyle \

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/CheckedBehavior.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/CheckedBehavior.scala
@@ -24,4 +24,16 @@ object CheckedBehavior {
   case object Compliant extends CheckedBehavior
   case object Fatal extends CheckedBehavior
   case object Unchecked extends CheckedBehavior
+
+  private[interface] implicit object CheckedBehaviorFingerprint
+      extends Fingerprint[CheckedBehavior] {
+
+    override def fingerprint(behavior: CheckedBehavior): String = {
+      behavior match {
+        case Compliant => "Compliant"
+        case Fatal     => "Fatal"
+        case Unchecked => "Unchecked"
+      }
+    }
+  }
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESFeatures.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESFeatures.scala
@@ -12,6 +12,8 @@
 
 package org.scalajs.linker.interface
 
+import Fingerprint.FingerprintBuilder
+
 /** ECMAScript features to use when linking to JavaScript.
  *
  *  The options in `ESFeatures` specify what features of modern versions of
@@ -94,4 +96,15 @@ object ESFeatures {
    *  - `allowBigIntsForLongs`: false
    */
   val Defaults: ESFeatures = new ESFeatures()
+
+  private[interface] implicit object ESFeaturesFingerprint
+      extends Fingerprint[ESFeatures] {
+
+    override def fingerprint(esFeatures: ESFeatures): String = {
+      new FingerprintBuilder("ESFeatures")
+        .addField("useECMAScript2015", esFeatures.useECMAScript2015)
+        .addField("allowBigIntsForLongs", esFeatures.allowBigIntsForLongs)
+        .build()
+    }
+  }
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Fingerprint.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Fingerprint.scala
@@ -1,0 +1,75 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import scala.collection.mutable
+
+private[interface] trait Fingerprint[T] {
+
+  /** Generate a fingerprint of an object.
+   *
+   * A fingerprint is an injective one-way serialization representing the
+   * object.
+   *
+   * @param obj Object to fingerprint
+   * @return A fingerprint of the object
+   */
+  def fingerprint(obj: T): String
+}
+
+private[interface] object Fingerprint {
+  def fingerprint[T: Fingerprint](obj: T): String =
+    implicitly[Fingerprint[T]].fingerprint(obj)
+
+  final class FingerprintBuilder(name: String) {
+    private val fields = new mutable.ListBuffer[String]
+
+    def addField[T: Fingerprint](name: String, value: T): FingerprintBuilder = {
+      fields.append(s"$name=${fingerprint(value)}")
+      this
+    }
+
+    def build(): String = fields.mkString(s"$name(", ",", ")")
+  }
+
+  implicit object BooleanFingerprint extends Fingerprint[Boolean] {
+    override def fingerprint(bool: Boolean): String = bool.toString
+  }
+
+  implicit object IntFingerprint extends Fingerprint[Int] {
+    override def fingerprint(int: Int): String = int.toString
+  }
+
+  implicit object StringFingerprint extends Fingerprint[String] {
+    override def fingerprint(str: String): String = str
+  }
+
+  implicit def optionFingerprint[T: Fingerprint]: Fingerprint[Option[T]] = {
+    new Fingerprint[Option[T]] {
+      override def fingerprint(opt: Option[T]): String = opt match {
+        case Some(x) => s"Some(${implicitly[Fingerprint[T]].fingerprint(x)})"
+        case None    => "None"
+      }
+    }
+  }
+
+  implicit def listFingerprint[T: Fingerprint]: Fingerprint[List[T]] = {
+    new Fingerprint[List[T]] {
+      override def fingerprint(list: List[T]): String = {
+        list
+          .map(implicitly[Fingerprint[T]].fingerprint)
+          .mkString("List(", ",", ")")
+      }
+    }
+  }
+}

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleInitializer.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleInitializer.scala
@@ -17,6 +17,8 @@ import org.scalajs.ir.Types._
 
 import org.scalajs.linker.interface.unstable.ModuleInitializerImpl
 
+import Fingerprint.FingerprintBuilder
+
 /** A module initializer for a Scala.js application.
  *
  *  When linking a Scala.js application, a sequence of `ModuleInitializer`s can
@@ -87,4 +89,39 @@ object ModuleInitializer {
         MethodName(mainMethodName, ArrayOfStringTypeRef :: Nil, VoidRef),
         args)
   }
+
+  private implicit object MethodNameFingerprint
+      extends Fingerprint[MethodName] {
+
+    override def fingerprint(methodName: MethodName): String =
+      methodName.nameString
+  }
+
+  private implicit object ClassNameFingerprint extends Fingerprint[ClassName] {
+    override def fingerprint(className: ClassName): String =
+      className.nameString
+  }
+
+  private implicit object ModuleInitializerFingerprint
+      extends Fingerprint[ModuleInitializer] {
+
+    override def fingerprint(moduleInitializer: ModuleInitializer): String =
+      moduleInitializer.impl match {
+        case VoidMainMethod(className, encodedMainMethodName) =>
+          new FingerprintBuilder("VoidMainMethod")
+            .addField("className", className)
+            .addField("encodedMainMethodName", encodedMainMethodName)
+            .build()
+
+        case MainMethodWithArgs(className, encodedMainMethodName, args) =>
+          new FingerprintBuilder("MainMethodWithArgs")
+            .addField("className", className)
+            .addField("encodedMainMethodName", encodedMainMethodName)
+            .addField("args", args)
+            .build()
+      }
+  }
+
+  def fingerprint(moduleInitializer: ModuleInitializer): String =
+    Fingerprint.fingerprint(moduleInitializer)
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleKind.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleKind.scala
@@ -49,4 +49,15 @@ object ModuleKind {
    */
   case object CommonJSModule extends ModuleKind
 
+  private[interface] implicit object ModuleKindFingerprint
+      extends Fingerprint[ModuleKind] {
+
+    override def fingerprint(moduleKind: ModuleKind): String = {
+      moduleKind match {
+        case NoModule       => "NoModule"
+        case ESModule       => "ESModule"
+        case CommonJSModule => "CommonJSModule"
+      }
+    }
+  }
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
@@ -13,6 +13,7 @@
 package org.scalajs.linker.interface
 
 import CheckedBehavior._
+import Fingerprint.FingerprintBuilder
 
 final class Semantics private (
     val asInstanceOfs: CheckedBehavior,
@@ -177,6 +178,45 @@ object Semantics {
     def regexReplace(regex: scala.util.matching.Regex,
         replacement: String): RuntimeClassNameMapper = {
       regexReplace(regex.pattern, replacement)
+    }
+
+    private[interface] implicit object RuntimeClassNameMapperFingerprint
+        extends Fingerprint[RuntimeClassNameMapper] {
+
+      override def fingerprint(mapper: RuntimeClassNameMapper): String = {
+        mapper match {
+          case KeepAll    => "KeepAll"
+          case DiscardAll => "DiscardAll"
+
+          case RegexReplace(pattern, flags, replacement) =>
+            new FingerprintBuilder("RegexReplace")
+              .addField("pattern", pattern)
+              .addField("flags", flags)
+              .addField("replacement", replacement)
+              .build()
+
+          case AndThen(first, second) =>
+            new FingerprintBuilder("AndThen")
+              .addField("first", fingerprint(first))
+              .addField("second", fingerprint(second))
+              .build()
+        }
+      }
+    }
+  }
+
+  private[interface] implicit object SemanticsFingerprint
+      extends Fingerprint[Semantics] {
+
+    override def fingerprint(semantics: Semantics): String = {
+      new FingerprintBuilder("Semantics")
+        .addField("asInstanceOfs", semantics.asInstanceOfs)
+        .addField("arrayIndexOutOfBounds", semantics.arrayIndexOutOfBounds)
+        .addField("moduleInit", semantics.moduleInit)
+        .addField("strictFloats", semantics.strictFloats)
+        .addField("productionMode", semantics.productionMode)
+        .addField("runtimeClassNameMapper", semantics.runtimeClassNameMapper)
+        .build()
     }
   }
 

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -16,6 +16,8 @@ import scala.language.implicitConversions
 
 import java.net.URI
 
+import Fingerprint.FingerprintBuilder
+
 /** Configuration of a standard linker. */
 final class StandardConfig private (
     /** Scala.js semantics. */
@@ -157,6 +159,31 @@ final class StandardConfig private (
 
 object StandardConfig {
   import StandardConfigPlatformExtensions.ConfigExt
+
+  private implicit object StandardConfigFingerprint
+      extends Fingerprint[StandardConfig] {
+
+    override def fingerprint(config: StandardConfig): String = {
+      new FingerprintBuilder("StandardConfig")
+        .addField("semantics", config.semantics)
+        .addField("moduleKind", config.moduleKind)
+        .addField("esFeatures", config.esFeatures)
+        .addField("checkIR", config.checkIR)
+        .addField("optimizer", config.optimizer)
+        .addField("parallel", config.parallel)
+        .addField("sourceMap", config.sourceMap)
+        .addField("relativizeSourceMapBase",
+            config.relativizeSourceMapBase.map(_.toASCIIString()))
+        .addField("closureCompilerIfAvailable",
+            config.closureCompilerIfAvailable)
+        .addField("prettyPrint", config.prettyPrint)
+        .addField("batchMode", config.batchMode)
+        .build()
+    }
+  }
+
+  def fingerprint(config: StandardConfig): String =
+    Fingerprint.fingerprint(config)
 
   /** Returns the default [[StandardConfig]].
    *

--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/FingerprintBuilderTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/FingerprintBuilderTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import org.junit.Test
+import org.junit.Assert._
+
+import Fingerprint._
+
+class FingerprintBuilderTest {
+  @Test
+  def noFields(): Unit = {
+    val fingerprint = new FingerprintBuilder("Test0").build()
+    assertEquals("Test0()", fingerprint)
+  }
+
+  @Test
+  def oneField(): Unit = {
+    val fingerprint = new FingerprintBuilder("Test1")
+      .addField("test1", true)
+      .build()
+    assertEquals("Test1(test1=true)", fingerprint)
+  }
+
+  @Test
+  def multipleFields(): Unit = {
+    val fingerprint = new FingerprintBuilder("Test2")
+      .addField("test1", Some(1): Option[Int])
+      .addField("test2", None: Option[Int])
+      .addField("test3", List.empty[Int])
+      .addField("test4", List(1, 2, 3))
+      .build()
+    assertEquals(
+        "Test2(test1=Some(1),test2=None,test3=List(),test4=List(1,2,3))",
+        fingerprint)
+  }
+}

--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/ModuleInitializerFingerprintTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/ModuleInitializerFingerprintTest.scala
@@ -1,0 +1,51 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import org.junit.Test
+import org.junit.Assert._
+
+class ModuleInitializerFingerprintTest {
+  def assertFingerprintsNotEquals(mi1: ModuleInitializer, mi2: ModuleInitializer): Unit = {
+    assertNotEquals(ModuleInitializer.fingerprint(mi1),
+        ModuleInitializer.fingerprint(mi2))
+  }
+
+  @Test
+  def noFingerprintCollisionClassName(): Unit = {
+    val mi1 = ModuleInitializer.mainMethod("Test1", "main1")
+    val mi2 = ModuleInitializer.mainMethod("Test2", "main1")
+    assertFingerprintsNotEquals(mi1, mi2)
+  }
+
+  @Test
+  def noFingerprintCollisionMainMethodName(): Unit = {
+    val mi1 = ModuleInitializer.mainMethod("Test1", "main1")
+    val mi2 = ModuleInitializer.mainMethod("Test1", "main2")
+    assertFingerprintsNotEquals(mi1, mi2)
+  }
+
+  @Test
+  def noFingerprintCollisionType(): Unit = {
+    val mi1 = ModuleInitializer.mainMethod("Test1", "main1")
+    val mi2 = ModuleInitializer.mainMethodWithArgs("Test1", "main1", List())
+    assertFingerprintsNotEquals(mi1, mi2)
+  }
+
+  @Test
+  def noFingerprintCollisionArgs(): Unit = {
+    val mi1 = ModuleInitializer.mainMethodWithArgs("Test1", "main1", List())
+    val mi2 = ModuleInitializer.mainMethodWithArgs("Test1", "main1", List("x"))
+    assertFingerprintsNotEquals(mi1, mi2)
+  }
+}

--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigFingerprintTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigFingerprintTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import java.net.URI
+
+import org.junit.Test
+import org.junit.Assert._
+
+import Semantics.RuntimeClassNameMapper._
+
+class StandardConfigFingerprintTest {
+  def assertFingerprintsNotEquals(sc1: StandardConfig, sc2: StandardConfig): Unit = {
+    assertNotEquals(StandardConfig.fingerprint(sc1),
+        StandardConfig.fingerprint(sc2))
+  }
+
+  @Test
+  def noFingerprintCollisionCheckIR(): Unit = {
+    val sc1 = StandardConfig().withCheckIR(false)
+    val sc2 = StandardConfig().withCheckIR(true)
+    assertFingerprintsNotEquals(sc1, sc2)
+  }
+
+  @Test
+  def noFingerprintCollisionRelativizeSourceMapBase(): Unit = {
+    val sc1 = StandardConfig().withRelativizeSourceMapBase(None)
+    val sc2 = StandardConfig().withRelativizeSourceMapBase(Some(new URI("a")))
+    assertFingerprintsNotEquals(sc1, sc2)
+  }
+
+  @Test
+  def noFingerprintCollisionESFeatures(): Unit = {
+    val sc1 = StandardConfig().withESFeatures(_.withUseECMAScript2015(true))
+    val sc2 = StandardConfig().withESFeatures(_.withUseECMAScript2015(false))
+    assertFingerprintsNotEquals(sc1, sc2)
+  }
+
+  @Test
+  def noFingerprintCollisionRuntimeClassNameMapper(): Unit = {
+    val sc1 = StandardConfig().withSemantics(_.withRuntimeClassNameMapper(
+        keepAll() andThen discardAll()))
+    val sc2 = StandardConfig().withSemantics(_.withRuntimeClassNameMapper(
+        regexReplace("""\d+""".r, "0")))
+    assertFingerprintsNotEquals(sc1, sc2)
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -716,6 +716,7 @@ object Build {
       id = "linkerInterface", base = file("linker-interface/jvm")
   ).settings(
       commonLinkerInterfaceSettings,
+      libraryDependencies += "com.novocode" % "junit-interface" % "0.11" % "test",
   ).dependsOn(irProject, logging)
 
   lazy val linkerInterfaceJS: MultiScalaProject = MultiScalaProject(
@@ -724,8 +725,8 @@ object Build {
       MyScalaJSPlugin
   ).settings(
       commonLinkerInterfaceSettings,
-  ).withScalaJSCompiler.dependsOn(
-      library, irProjectJS, loggingJS,
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
+      library, irProjectJS, loggingJS, jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test",
   )
 
   lazy val linkerPrivateLibrary: Project = (project in file("linker-private-library")).enablePlugins(

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -176,6 +176,10 @@ object ScalaJSPlugin extends AutoPlugin {
         "Module initializers of the Scala.js application, to be called when it starts.",
         AMinusTask)
 
+    val scalaJSModuleInitializersFingerprints = TaskKey[Seq[String]]("scalaJSModuleInitializersFingerprints",
+        "An internal task used to track changes to the `scalaJSModuleInitializers` setting",
+        KeyRanks.Invisible)
+
     val scalaJSUseMainModuleInitializer = SettingKey[Boolean]("scalaJSUseMainModuleInitializer",
         "If true, adds the `mainClass` as a module initializer of the Scala.js module",
         APlusSetting)
@@ -194,6 +198,10 @@ object ScalaJSPlugin extends AutoPlugin {
         "scalaJSLinkerConfig",
         "Configuration of the Scala.js linker",
         BPlusSetting)
+
+    val scalaJSLinkerConfigFingerprint = TaskKey[String]("scalaJSLinkerConfigFingerprint",
+        "An internal task used to track changes to the `scalaJSLinkerConfig` setting",
+        KeyRanks.Invisible)
 
     val scalaJSStage = SettingKey[Stage]("scalaJSStage",
         "The optimization stage at which run and test are executed", APlusSetting)

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/Main.scala.first
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/Main.scala.first
@@ -1,0 +1,7 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("Hello world")
+  }
+}

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/Main.scala.second
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/Main.scala.second
@@ -1,0 +1,8 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    // This file changes the printed message:
+    println("Hi planet")
+  }
+}

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := "2.12.10"
+
+enablePlugins(ScalaJSPlugin)
+
+scalaJSUseMainModuleInitializer := false

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/project/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/test
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/test
@@ -1,0 +1,16 @@
+$ copy-file Main.scala.first Main.scala
+> fastOptJS
+$ copy-file target/scala-2.12/change-config-and-source-fastopt.js target/scala-2.12/output-1.js
+
+# When the linker config and source both change, re-running fastOptJS should re-link:
+> set scalaJSUseMainModuleInitializer := true
+$ copy-file Main.scala.second Main.scala
+> fastOptJS
+-$ must-mirror target/scala-2.12/change-config-and-source-fastopt.js target/scala-2.12/output-1.js
+$ newer target/scala-2.12/change-config-and-source-fastopt.js target/scala-2.12/output-1.js
+$ copy-file target/scala-2.12/change-config-and-source-fastopt.js target/scala-2.12/output-2.js
+
+# However, this re-linking should not happen more than once:
+> fastOptJS
+$ must-mirror target/scala-2.12/change-config-and-source-fastopt.js target/scala-2.12/output-2.js
+-$ newer target/scala-2.12/change-config-and-source-fastopt.js target/scala-2.12/output-2.js

--- a/sbt-plugin/src/sbt-test/incremental/change-config/Main.scala
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/Main.scala
@@ -1,0 +1,7 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    println("Hello world")
+  }
+}

--- a/sbt-plugin/src/sbt-test/incremental/change-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/build.sbt
@@ -1,0 +1,5 @@
+scalaVersion := "2.12.10"
+
+enablePlugins(ScalaJSPlugin)
+
+scalaJSUseMainModuleInitializer := false

--- a/sbt-plugin/src/sbt-test/incremental/change-config/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/project/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/incremental/change-config/test
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/test
@@ -1,0 +1,14 @@
+> fastOptJS
+$ copy-file target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-1.js
+
+# When the linker config changes, re-running fastOptJS should re-link:
+> set scalaJSUseMainModuleInitializer := true
+> fastOptJS
+-$ must-mirror target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-1.js
+$ newer target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-1.js
+$ copy-file target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-2.js
+
+# However, this re-linking should not happen more than once:
+> fastOptJS
+$ must-mirror target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-2.js
+-$ newer target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-2.js


### PR DESCRIPTION
This PR fixes #3283 by adding a JSON serializer and deserializer for `scalaJSModuleInitializers` and `scalaJSLinkerConfig`, so that the previous value of these settings can be compared to the current value. If the value has changed, linking is re-done.