### PR TITLE
Add exception constructor with suppression and stack trace

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Throwables.scala
+++ b/javalanglib/src/main/scala/java/lang/Throwables.scala
@@ -219,7 +219,10 @@ class ClassFormatError(s: String) extends LinkageError(s) {
   def this() = this(null)
 }
 
-class Error(s: String, e: Throwable) extends Throwable(s, e) {
+class Error protected (s: String, e: Throwable,
+    enableSuppression: scala.Boolean, writableStackTrace: scala.Boolean)
+    extends Throwable(s, e, enableSuppression, writableStackTrace) {
+  def this(message: String, cause: Throwable) = this(message, cause, true, true)
   def this() = this(null, null)
   def this(s: String) = this(s, null)
   def this(e: Throwable) = this(if (e == null) null else e.toString, e)
@@ -330,7 +333,10 @@ class EnumConstantNotPresentException(e: Class[_ <: Enum[_]], c: String)
   def constantName(): String = c
 }
 
-class Exception(s: String, e: Throwable) extends Throwable(s, e) {
+class Exception protected (s: String, e: Throwable,
+    enableSuppression: scala.Boolean, writableStackTrace: scala.Boolean)
+    extends Throwable(s, e, enableSuppression, writableStackTrace) {
+  def this(message: String, cause: Throwable) = this(message, cause, true, true)
   def this(e: Throwable) = this(if (e == null) null else e.toString, e)
   def this(s: String) = this(s, null)
   def this() = this(null, null)
@@ -404,7 +410,10 @@ class RejectedExecutionException(s: String, e: Throwable) extends RuntimeExcepti
   def this() = this(null, null)
 }
 
-class RuntimeException(s: String, e: Throwable) extends Exception(s, e) {
+class RuntimeException protected (s: String, e: Throwable,
+    enableSuppression: scala.Boolean, writableStackTrace: scala.Boolean)
+    extends Exception(s, e, enableSuppression, writableStackTrace) {
+  def this(message: String, cause: Throwable) = this(message, cause, true, true)
   def this(e: Throwable) = this(if (e == null) null else e.toString, e)
   def this(s: String) = this(s, null)
   def this() = this(null, null)


### PR DESCRIPTION
The `Error`, `Exception` and `RuntimeException` classes are missing a protected constructor, introduced in Java 1.7, that takes `enableSuppression` and `writableStackTrace` parameters.

Scala.js has this constructor in the `Throwable` class but it is not implemented for the above subclasses.