### PR TITLE
Add implicit conversion from js.WrappedDictionary to js.Dictionary

### DIFF
--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedDictionary.scala
@@ -16,12 +16,14 @@ import scala.collection.mutable
 import scala.collection.mutable.Builder
 import scala.collection.View
 
+import scala.language.implicitConversions
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
 /** Wrapper to use a js.Dictionary as a scala.mutable.Map */
 @inline
-final class WrappedDictionary[A](dict: js.Dictionary[A])
+final class WrappedDictionary[A](private val dict: js.Dictionary[A])
     extends mutable.AbstractMap[String, A]
     with mutable.MapOps[String, A, mutable.Map, js.WrappedDictionary[A]] {
 
@@ -182,5 +184,8 @@ object WrappedDictionary {
     def result(): js.WrappedDictionary[A] =
       new js.WrappedDictionary(dict)
   }
+
+  implicit def toJSDictionary[A](wrappedDict: js.WrappedDictionary[A]): js.Dictionary[A] =
+    wrappedDict.dict
 
 }

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedDictionary.scala
@@ -12,6 +12,8 @@
 
 package scala.scalajs.js
 
+import scala.language.implicitConversions
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
@@ -22,7 +24,7 @@ import scala.collection.generic.CanBuildFrom
 
 /** Wrapper to use a js.Dictionary as a scala.mutable.Map */
 @inline
-final class WrappedDictionary[A](dict: js.Dictionary[A])
+final class WrappedDictionary[A](private val dict: js.Dictionary[A])
     extends mutable.AbstractMap[String, A]
        with mutable.Map[String, A]
        with mutable.MapLike[String, A, js.WrappedDictionary[A]] {
@@ -151,5 +153,8 @@ object WrappedDictionary {
     def result(): js.WrappedDictionary[A] =
       new js.WrappedDictionary(dict)
   }
+
+  implicit def toJSDictionary[A](wrappedDict: js.WrappedDictionary[A]): js.Dictionary[A] =
+    wrappedDict.dict
 
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
@@ -85,6 +85,15 @@ class DictionaryTest {
     assertEquals("foo", dict2("a"))
     assertEquals("bar", dict2("b"))
   }
+
+  @Test def should_provide_underlying_JSDictionary(): Unit = {
+    val original = js.Dictionary("a" -> 1, "b" -> 2, "c" -> 3)
+    val dict: js.Dictionary[Int] = original.filter(_._1 != "b")
+
+    assertEquals(1, dict("a"))
+    assertEquals(None, dict.get("b"))
+    assertEquals(3, dict("c"))
+  }
 }
 
 object DictionaryTest {


### PR DESCRIPTION
In Scala.js 0.6.32 I was able to get a filtered `js.Dictionary` by doing `js.Dictionary("a" -> 1, "b" -> 2, "c" -> 3).filter(_._1 == "b").dict`.

This is no longer possible as `WrapperDictionary`'s `dict` was privatized in #3917 where @gzm0 noted in a comment:

> Also, it seems there is an implicit conversion js.WrappedArray => js.Array but not for js.WrappedDictionary => js.Dictionary.

I assume the omission was not intentional, so I implemented the simple conversion.