### PR TITLE
add: UncaughtExceptionHandler interface to java.lang.Thread and more changes to Thread

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Thread.scala
+++ b/javalanglib/src/main/scala/java/lang/Thread.scala
@@ -12,12 +12,10 @@
 
 package java.lang
 
-/* We need a constructor to create SingleThread in the companion object, but
- * we don't want user code doing a 'new Thread()' to link, because that could
- * be confusing.
- * So we use a binary signature that no Java source file can ever produce.
+/* We need a constructor to create SingleThread in the companion object, but:
+ * PLEASE DO NOT USE THIS CLASS IN USER CODE!
  */
-class Thread private (dummy: Unit) extends Runnable {
+class Thread extends Runnable {
   private var interruptedState = false
   private[this] var name: String = "main" // default name of the main thread
 
@@ -39,10 +37,17 @@ class Thread private (dummy: Unit) extends Runnable {
     StackTrace.getCurrentStackTrace()
 
   def getId(): scala.Long = 1
+
+  // Javadocs:
+  // Returns the handler invoked when this thread abruptly terminates due to an uncaught exception. If this thread has not had an uncaught exception handler explicitly set then this thread's ThreadGroup object is returned, unless this thread has terminated, in which case null is returned.
+  // Therefore:
+  // JS VMs are running on a single thread, if this thread has been terminated it has to be this one, so, since it's terminated, we return null
+  def getUncaughtExceptionHandler(): Thread.UncaughtExceptionHandler = null
+
 }
 
 object Thread {
-  private[this] val SingleThread = new Thread(())
+  private[this] val SingleThread = new Thread()
 
   def currentThread(): Thread = SingleThread
 

--- a/javalanglib/src/main/scala/java/lang/Thread.scala
+++ b/javalanglib/src/main/scala/java/lang/Thread.scala
@@ -51,4 +51,8 @@ object Thread {
     currentThread.interruptedState = false
     ret
   }
+
+  trait UncaughtExceptionHandler {
+    def uncaughtException(t: Thread, e: Throwable): Unit
+  }
 }


### PR DESCRIPTION
This is due to the more stringent linker checks.