### PR TITLE
Only export relevant projects to IDEs.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -537,6 +537,7 @@ object Build {
       commonSettings,
       name := "Scala.js",
       publishArtifact in Compile := false,
+      NoIDEExport.noIDEExportSettings,
 
       {
         val allProjects: Seq[Project] = Seq(
@@ -1110,6 +1111,7 @@ object Build {
       },
       name := "Scala library for Scala.js",
       publishArtifact in Compile := false,
+      NoIDEExport.noIDEExportSettings,
       delambdafySetting,
       noClassFilesSettings,
 
@@ -1245,6 +1247,7 @@ object Build {
       fatalWarningsSettings,
       name := "Scala.js aux library",
       publishArtifact in Compile := false,
+      NoIDEExport.noIDEExportSettings,
       delambdafySetting,
       noClassFilesSettings,
       scalaJSExternalCompileSettings
@@ -2027,6 +2030,7 @@ object Build {
       commonSettings,
       fatalWarningsSettings,
       name := "Scala.js partest suite",
+      NoIDEExport.noIDEExportSettings,
 
       fork in Test := true,
       javaOptions in Test += "-Xmx1G",
@@ -2069,6 +2073,7 @@ object Build {
   ).settings(
       commonSettings,
       publishArtifact in Compile := false,
+      NoIDEExport.noIDEExportSettings,
 
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s"),
   ).zippedSettings(partest)(partest =>

--- a/project/MultiScalaProject.scala
+++ b/project/MultiScalaProject.scala
@@ -83,15 +83,22 @@ object MultiScalaProject {
     "2.13" -> Seq("2.13.0", "2.13.1"),
   )
 
+  private final val ideVersion = "2.12"
+
   private def projectID(id: String, major: String) = id + major.replace('.', '_')
 
   def apply(id: String, base: File): MultiScalaProject = {
     val projects = for {
       (major, minors) <- versions
     } yield {
+      val noIDEExportSettings =
+        if (major == ideVersion) Nil
+        else NoIDEExport.noIDEExportSettings
+
       major -> Project(id = projectID(id, major), base = new File(base, "." + major)).settings(
         scalaVersion := minors.last,
         crossScalaVersions := minors,
+        noIDEExportSettings,
       )
     }
 

--- a/project/NoIDEExport.scala
+++ b/project/NoIDEExport.scala
@@ -1,0 +1,41 @@
+package build
+
+import sbt._
+import Keys._
+
+/** Settings to prevent projects from being exported to IDEs. */
+object NoIDEExport {
+  /* We detect whether bloop is on the classpath (which will be the case during
+   * import in Metals) and if yes, we deactivate the bloop export for
+   * irrelevant projects.
+   *
+   * Notably, we deactivate all non-2.12 projects in `MultiScalaProject`, since
+   * it is enough to have IDE support for the default Scala version.
+   */
+
+  private lazy val bloopGenerateKey: Option[TaskKey[Option[File]]] = {
+    val optBloopKeysClass = try {
+      Some(Class.forName("bloop.integrations.sbt.BloopKeys"))
+    } catch {
+      case _: ClassNotFoundException => None
+    }
+
+    optBloopKeysClass.map { bloopKeysClass =>
+      val bloopGenerateGetter = bloopKeysClass.getMethod("bloopGenerate")
+      bloopGenerateGetter.invoke(null).asInstanceOf[TaskKey[Option[File]]]
+    }
+  }
+
+  /** Settings to prevent the project from being exported to IDEs. */
+  lazy val noIDEExportSettings: Seq[Setting[_]] = {
+    bloopGenerateKey match {
+      case None =>
+        Nil
+      case Some(key) =>
+        Seq(
+            key in Compile := None,
+            key in Test := None,
+        )
+    }
+  }
+}


### PR DESCRIPTION
We detect whether bloop is on the classpath (which will be the case during import in Metals) and if yes, we deactivate the bloop export for irrelevant projects.

Notably, we deactivate all non-2.12 projects in `MultiScalaProject`, since it is enough to have IDE support for the default Scala version.