### PR TITLE
Move initialization of L0 to CoreJSLib

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -26,7 +26,9 @@ object BinaryIncompatibilities {
 
       // private, not an issue.
       exclude[DirectMissingMethodProblem](
-          "org.scalajs.linker.backend.closure.ClosureAstTransformer.this"),
+        "org.scalajs.linker.backend.closure.ClosureAstTransformer.this"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.backend.emitter.Emitter#CoreJSLibCache.tree"),
       exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.emitter.CoreJSLib#CoreJSLibBuilder.org$scalajs$linker$backend$emitter$CoreJSLib$CoreJSLibBuilder$$defineStandardDispatcher$default$3$1"),
       exclude[DirectMissingMethodProblem](


### PR DESCRIPTION
This brings it closer to its counterpart and allows us to leverage existing CoreJSLib infrastructure for tree generation.