### PR TITLE
Give a proper toString() to OriginalName for debugging.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/OriginalName.scala
+++ b/ir/src/main/scala/org/scalajs/ir/OriginalName.scala
@@ -70,6 +70,10 @@ final class OriginalName private (private val bytes: Array[Byte])
     if (isDefined) unsafeGet
     else UTF8String(name)
   }
+
+  override def toString(): String =
+    if (isDefined) s"OriginalName($unsafeGet)"
+    else "NoOriginalName"
 }
 
 object OriginalName {


### PR DESCRIPTION
Otherwise, they are undecipherable when printed for debugging purposes, and even throw a `NullPointerException` for `NoOriginalName`.