### PR TITLE
Fix #4017: Stub out s.c.i.VM in Scala 2.12.x.

### DIFF
--- a/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+// Backport from scala.runtime moved into s.c.immutable and made package
+// private to avoid the need for MiMa whitelisting.
+/* private[immutable] */ object VM {
+  def releaseFence(): Unit = ()
+}


### PR DESCRIPTION
It was added upstream in https://github.com/scala/scala/commit/74906219c112b37780faaa366e3972697410688e

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.12.12-bin-22d4cae
> testSuite/test
```