### PR TITLE
GitIgnore metals files/directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,8 @@ target/
 /.idea/
 /.idea_modules/
 bin/
+
+# metals files/directories
+/.bloop/
+/.metals/
+/project/metals.sbt


### PR DESCRIPTION
The git diff gets huge once you open the project in VSCode and run the metals import, also making the IDE slow.

Ignore the metals generated directories (`.metals`, `.bloop`, `project/metals.sbt`).