### PR TITLE
FF ONLY Merge 0.6.x into master, April 25

### DIFF
--- a/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/VM.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.collection.immutable
+
+// Backport from scala.runtime moved into s.c.immutable and made package
+// private to avoid the need for MiMa whitelisting.
+/* private[immutable] */ object VM {
+  def releaseFence(): Unit = ()
+}


### PR DESCRIPTION
Motivation: fix the nightly build on master
```
$ git checkout -b merge-0.6.x-into-master-april-25
Switched to a new branch 'merge-0.6.x-into-master-april-25'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* 647eda447 (scalajs/0.6.x) Merge pull request #4018 from sjrd/vm-releasefence-stub-2.12
* 0af88ea67 (origin/vm-releasefence-stub-2.12) Fix #4017: Stub out s.c.i.VM in Scala 2.12.x.
```
```
$ git merge --no-commit scalajs/0.6.x
Automatic merge went well; stopped before committing as requested
```
```
$ git st
A  scalalib/overrides-2.12/scala/collection/immutable/VM.scala
```
```
$ git commit
[merge-0.6.x-into-master-april-25 55a0b2897] Merge '0.6.x' into 'master'.
```

---

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.12.12-bin-22d4cae
> testSuite2_12/test
```