### PR TITLE
Fix #4021: Filter fields in Refiner exactly like BaseLinker.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -95,9 +95,9 @@ final class Refiner(config: CommonPhaseConfig) {
   private def refineClassDef(classDef: LinkedClass,
       info: Analysis.ClassInfo): LinkedClass = {
 
-    val fields =
-      if (info.isAnySubclassInstantiated) classDef.fields
-      else Nil
+    val fields = classDef.fields.filter { f =>
+      BaseLinker.isFieldDefNeeded(info, f)
+    }
 
     val methods = classDef.methods.filter { m =>
       val methodDef = m.value

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -42,8 +42,7 @@ class LinkerTest {
   def linkHelloWorld(): AsyncResult = await {
     val classDefs = Seq(
         mainTestClassDef({
-          JSMethodApply(JSGlobalRef("console"), StringLiteral("log"),
-              List(StringLiteral("Hello world!")))
+          consoleLog(StringLiteral("Hello world!"))
         })
     )
     testLink(classDefs, MainTestModuleInitializers)

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -91,6 +91,9 @@ object TestIRBuilder {
         List(argsParamDef), NoType, Some(body))(EOH, None)
   }
 
+  def consoleLog(expr: Tree): Tree =
+    JSMethodApply(JSGlobalRef("console"), StringLiteral("log"), List(expr))
+
   def predefPrintln(expr: Tree): Tree = {
     val PredefModuleClass = ClassName("scala.Predef$")
     val printlnMethodName = m("println", List(O), VoidRef)


### PR DESCRIPTION
Previously, the Refiner would eliminate *all* fields in non-instantiated classes. This would remove static fields even if they are needed, which causes invalid .js files to be generated.

The BaseLinker has been doing the right thing since the commit 9328d629294defc6eb75a7ffd0907068ce02f984, but the Refiner had not been updated. We now make them both do the same thing, which solves the issue.

Since the issue is not reproducible with Scala.js source code, we test this with a linker test.