### PR TITLE
[no-master] Fix #3458: Hack around React's dev mode error triggering hack.

### DIFF
--- a/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
+++ b/js-envs/src/main/scala/org/scalajs/jsenv/nodejs/JSDOMNodeJSEnv.scala
@@ -84,6 +84,15 @@ class JSDOMNodeJSEnv private[jsenv] (
            |    var virtualConsole = new jsdom.VirtualConsole()
            |      .sendTo(console, { omitJSDOMErrors: true });
            |    virtualConsole.on("jsdomError", function (error) {
+           |      /* #3458 Counter-hack the hack that React's development mode
+           |       * uses to bypass browsers' debugging tools. If we detect
+           |       * that we are called from that hack, we do nothing.
+           |       */
+           |      var isWithinReactsInvokeGuardedCallbackDevHack_issue3458 =
+           |        new Error("").stack.indexOf("invokeGuardedCallbackDev") >= 0;
+           |      if (isWithinReactsInvokeGuardedCallbackDevHack_issue3458)
+           |        return;
+           |
            |      try {
            |        // Display as much info about the error as possible
            |        if (error.detail && error.detail.stack) {


### PR DESCRIPTION
This is a back-port from the commit scala-js/scala-js-env-jsdom-nodejs@c814a01217085ebf21be46b1bcf06863099018af

React's development mode has a funny way of triggering errors, which tries to convince that exceptions are uncaught (for their development tools to report them) even though React catches them for the "error boundaries" feature.

Since our jsdom handler for jsdom >= 10.0.0 reports uncaught exceptions as hard failures that fail the run, this creates a very bad interaction where every caught-but-not-really exception crashes the run.

We hack around this hack by detecting when our error handler is in fact called by React's own hack. In that case, we ignore the uncaught exception, and proceed with normal execution.

This is not tested! We rely on the correctness of the original fix in scalajs-env-jsdom-nodejs.

The code path for jsdom 9.x is not changed, since it does not trigger hard failures for uncaught exception, and was reported to correctly work with React in the bug report #3458.
