### PR TITLE
Fix #4038: Update Symbol.toString() to match 2.13.3+.

### DIFF
--- a/scalalib/overrides-2.13.0/scala/Symbol.scala
+++ b/scalalib/overrides-2.13.0/scala/Symbol.scala
@@ -1,0 +1,113 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.scalajs.js
+
+/** This class provides a simple way to get unique objects for equal strings.
+ *  Since symbols are interned, they can be compared using reference equality.
+ *  Instances of `Symbol` can be created easily with Scala's built-in quote
+ *  mechanism.
+ *
+ *  For instance, the Scala term `'mysym` will
+ *  invoke the constructor of the `Symbol` class in the following way:
+ *  `Symbol("mysym")`.
+ *
+ *  @author  Martin Odersky, Iulian Dragos
+ *  @since   1.7
+ */
+final class Symbol private (val name: String) extends Serializable {
+  /** Converts this symbol to a string.
+   */
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+// Modified to use Scala.js specific cache
+object Symbol extends JSUniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class JSUniquenessCache[V]
+{
+  private val cache = js.Dictionary.empty[V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}
+
+/** This is private so it won't appear in the library API, but
+  * abstracted to offer some hope of reusability.  */
+/* DELETED for Scala.js
+private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
+{
+
+  import java.lang.ref.WeakReference
+  import java.util.WeakHashMap
+  import java.util.concurrent.locks.ReentrantReadWriteLock
+
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
+
+  protected def valueFromKey(k: K): V
+  protected def keyFromValue(v: V): Option[K]
+
+  def apply(name: K): V = {
+    def cached(): V = {
+      rlock.lock
+      try {
+        val reference = map get name
+        if (reference == null) null
+        else reference.get  // will be null if we were gc-ed
+      }
+      finally rlock.unlock
+    }
+    def updateCache(): V = {
+      wlock.lock
+      try {
+        val res = cached()
+        if (res != null) res
+        else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
+          map remove name
+          val sym = valueFromKey(name)
+          map.put(name, new WeakReference(sym))
+          sym
+        }
+      }
+      finally wlock.unlock
+    }
+
+    val res = cached()
+    if (res == null) updateCache()
+    else res
+  }
+  def unapply(other: V): Option[K] = keyFromValue(other)
+}
+*/

--- a/scalalib/overrides-2.13.1/scala/Symbol.scala
+++ b/scalalib/overrides-2.13.1/scala/Symbol.scala
@@ -1,0 +1,113 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.scalajs.js
+
+/** This class provides a simple way to get unique objects for equal strings.
+ *  Since symbols are interned, they can be compared using reference equality.
+ *  Instances of `Symbol` can be created easily with Scala's built-in quote
+ *  mechanism.
+ *
+ *  For instance, the Scala term `'mysym` will
+ *  invoke the constructor of the `Symbol` class in the following way:
+ *  `Symbol("mysym")`.
+ *
+ *  @author  Martin Odersky, Iulian Dragos
+ *  @since   1.7
+ */
+final class Symbol private (val name: String) extends Serializable {
+  /** Converts this symbol to a string.
+   */
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+// Modified to use Scala.js specific cache
+object Symbol extends JSUniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class JSUniquenessCache[V]
+{
+  private val cache = js.Dictionary.empty[V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}
+
+/** This is private so it won't appear in the library API, but
+  * abstracted to offer some hope of reusability.  */
+/* DELETED for Scala.js
+private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
+{
+
+  import java.lang.ref.WeakReference
+  import java.util.WeakHashMap
+  import java.util.concurrent.locks.ReentrantReadWriteLock
+
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
+
+  protected def valueFromKey(k: K): V
+  protected def keyFromValue(v: V): Option[K]
+
+  def apply(name: K): V = {
+    def cached(): V = {
+      rlock.lock
+      try {
+        val reference = map get name
+        if (reference == null) null
+        else reference.get  // will be null if we were gc-ed
+      }
+      finally rlock.unlock
+    }
+    def updateCache(): V = {
+      wlock.lock
+      try {
+        val res = cached()
+        if (res != null) res
+        else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
+          map remove name
+          val sym = valueFromKey(name)
+          map.put(name, new WeakReference(sym))
+          sym
+        }
+      }
+      finally wlock.unlock
+    }
+
+    val res = cached()
+    if (res == null) updateCache()
+    else res
+  }
+  def unapply(other: V): Option[K] = keyFromValue(other)
+}
+*/

--- a/scalalib/overrides-2.13.2/scala/Symbol.scala
+++ b/scalalib/overrides-2.13.2/scala/Symbol.scala
@@ -1,0 +1,113 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.scalajs.js
+
+/** This class provides a simple way to get unique objects for equal strings.
+ *  Since symbols are interned, they can be compared using reference equality.
+ *  Instances of `Symbol` can be created easily with Scala's built-in quote
+ *  mechanism.
+ *
+ *  For instance, the Scala term `'mysym` will
+ *  invoke the constructor of the `Symbol` class in the following way:
+ *  `Symbol("mysym")`.
+ *
+ *  @author  Martin Odersky, Iulian Dragos
+ *  @since   1.7
+ */
+final class Symbol private (val name: String) extends Serializable {
+  /** Converts this symbol to a string.
+   */
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+// Modified to use Scala.js specific cache
+object Symbol extends JSUniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class JSUniquenessCache[V]
+{
+  private val cache = js.Dictionary.empty[V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}
+
+/** This is private so it won't appear in the library API, but
+  * abstracted to offer some hope of reusability.  */
+/* DELETED for Scala.js
+private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
+{
+
+  import java.lang.ref.WeakReference
+  import java.util.WeakHashMap
+  import java.util.concurrent.locks.ReentrantReadWriteLock
+
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
+
+  protected def valueFromKey(k: K): V
+  protected def keyFromValue(v: V): Option[K]
+
+  def apply(name: K): V = {
+    def cached(): V = {
+      rlock.lock
+      try {
+        val reference = map get name
+        if (reference == null) null
+        else reference.get  // will be null if we were gc-ed
+      }
+      finally rlock.unlock
+    }
+    def updateCache(): V = {
+      wlock.lock
+      try {
+        val res = cached()
+        if (res != null) res
+        else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
+          map remove name
+          val sym = valueFromKey(name)
+          map.put(name, new WeakReference(sym))
+          sym
+        }
+      }
+      finally wlock.unlock
+    }
+
+    val res = cached()
+    if (res == null) updateCache()
+    else res
+  }
+  def unapply(other: V): Option[K] = keyFromValue(other)
+}
+*/

--- a/scalalib/overrides-2.13/scala/Symbol.scala
+++ b/scalalib/overrides-2.13/scala/Symbol.scala
@@ -29,7 +29,7 @@ import scala.scalajs.js
 final class Symbol private (val name: String) extends Serializable {
   /** Converts this symbol to a string.
    */
-  override def toString(): String = "'" + name
+  override def toString(): String = "Symbol(" + name + ")"
 
   @throws(classOf[java.io.ObjectStreamException])
   private def readResolve(): Any = Symbol.apply(name)

--- a/scalalib/overrides-2.13/scala/Symbol.scala
+++ b/scalalib/overrides-2.13/scala/Symbol.scala
@@ -1,0 +1,113 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.scalajs.js
+
+/** This class provides a simple way to get unique objects for equal strings.
+ *  Since symbols are interned, they can be compared using reference equality.
+ *  Instances of `Symbol` can be created easily with Scala's built-in quote
+ *  mechanism.
+ *
+ *  For instance, the Scala term `'mysym` will
+ *  invoke the constructor of the `Symbol` class in the following way:
+ *  `Symbol("mysym")`.
+ *
+ *  @author  Martin Odersky, Iulian Dragos
+ *  @since   1.7
+ */
+final class Symbol private (val name: String) extends Serializable {
+  /** Converts this symbol to a string.
+   */
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+// Modified to use Scala.js specific cache
+object Symbol extends JSUniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class JSUniquenessCache[V]
+{
+  private val cache = js.Dictionary.empty[V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}
+
+/** This is private so it won't appear in the library API, but
+  * abstracted to offer some hope of reusability.  */
+/* DELETED for Scala.js
+private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
+{
+
+  import java.lang.ref.WeakReference
+  import java.util.WeakHashMap
+  import java.util.concurrent.locks.ReentrantReadWriteLock
+
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
+
+  protected def valueFromKey(k: K): V
+  protected def keyFromValue(v: V): Option[K]
+
+  def apply(name: K): V = {
+    def cached(): V = {
+      rlock.lock
+      try {
+        val reference = map get name
+        if (reference == null) null
+        else reference.get  // will be null if we were gc-ed
+      }
+      finally rlock.unlock
+    }
+    def updateCache(): V = {
+      wlock.lock
+      try {
+        val res = cached()
+        if (res != null) res
+        else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
+          map remove name
+          val sym = valueFromKey(name)
+          map.put(name, new WeakReference(sym))
+          sym
+        }
+      }
+      finally wlock.unlock
+    }
+
+    val res = cached()
+    if (res == null) updateCache()
+    else res
+  }
+  def unapply(other: V): Option[K] = keyFromValue(other)
+}
+*/

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
@@ -15,6 +15,8 @@ package org.scalajs.testsuite.scalalib
 import org.junit.Test
 import org.junit.Assert._
 
+import org.scalajs.testsuite.utils.Platform.scalaVersion
+
 class SymbolTest {
 
   @Test def should_ensure_unique_identity(): Unit = {
@@ -52,12 +54,31 @@ class SymbolTest {
   @Test def should_support_toString(): Unit = {
     val scalajs = 'ScalaJS
 
-    assertEquals("'ScalaJS", scalajs.toString)
-    assertEquals("'$", Symbol("$").toString)
-    assertEquals("'$$", '$$.toString)
-    assertEquals("'-", '-.toString)
-    assertEquals("'*", '*.toString)
-    assertEquals("''", Symbol("'").toString)
-    assertEquals("'\"", Symbol("\"").toString)
+    val toStringUsesQuoteSyntax = {
+      scalaVersion.startsWith("2.10.") ||
+      scalaVersion.startsWith("2.11.") ||
+      scalaVersion.startsWith("2.12.") ||
+      scalaVersion == "2.13.0" ||
+      scalaVersion == "2.13.1" ||
+      scalaVersion == "2.13.2"
+    }
+
+    if (toStringUsesQuoteSyntax) {
+      assertEquals("'ScalaJS", scalajs.toString)
+      assertEquals("'$", Symbol("$").toString)
+      assertEquals("'$$", '$$.toString)
+      assertEquals("'-", '-.toString)
+      assertEquals("'*", '*.toString)
+      assertEquals("''", Symbol("'").toString)
+      assertEquals("'\"", Symbol("\"").toString)
+    } else {
+      assertEquals("Symbol(ScalaJS)", scalajs.toString)
+      assertEquals("Symbol($)", Symbol("$").toString)
+      assertEquals("Symbol($$)", '$$.toString)
+      assertEquals("Symbol(-)", '-.toString)
+      assertEquals("Symbol(*)", '*.toString)
+      assertEquals("Symbol(')", Symbol("'").toString)
+      assertEquals("Symbol(\")", Symbol("\"").toString)
+    }
   }
 }


### PR DESCRIPTION
The upstream commit https://github.com/scala/scala/commit/904e3a5d2b9616b9c533d77d0c51652b138e8659 changed `scala.Symbol.toString()`. This change breaks `testSuiteJVM/test`, since we are testing for the old `toString()`.

In this commit, we adapt the test for 2.13.3+, and consequently our implementation in the override for `scala/Symbol.scala`.

---

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.3-bin-43b70d4
> testSuiteJVM/test
> testSuite/test
> compiler/test
```