### PR TITLE
Fix #4034: Encode -x as -1.0 * x instead of 0.0 - x.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/core/compiler/GenJSCode.scala
@@ -3515,9 +3515,9 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                 case jstpe.LongType =>
                   js.BinaryOp(js.BinaryOp.Long_-, js.LongLiteral(0), source)
                 case jstpe.FloatType =>
-                  js.BinaryOp(js.BinaryOp.Float_-, js.FloatLiteral(0.0f), source)
+                  js.BinaryOp(js.BinaryOp.Float_*, js.FloatLiteral(-1.0f), source)
                 case jstpe.DoubleType =>
-                  js.BinaryOp(js.BinaryOp.Double_-, js.DoubleLiteral(0), source)
+                  js.BinaryOp(js.BinaryOp.Double_*, js.DoubleLiteral(-1.0), source)
               }
             case NOT =>
               (resultType: @unchecked) match {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -14,8 +14,14 @@ package org.scalajs.testsuite.compiler
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.Platform.executingInRhino
 
 class FloatTest {
+  final def assertExactEquals(expected: Float, actual: Float): Unit =
+    assertTrue(s"expected: $expected; actual: $actual", expected.equals(actual))
+
   @Test
   def `toInt`(): Unit = {
     @inline
@@ -100,5 +106,51 @@ class FloatTest {
     assertTrue(test_not_>=(5, NaN))
     assertTrue(test_not_>=(NaN, NaN))
     assertFalse(test_not_>=(0.0f, -0.0f))
+  }
+
+  @Test
+  def negate_issue4034(): Unit = {
+    @noinline
+    def testNoInline(expected: Float, x: Float): Unit = {
+      assertExactEquals(expected, -x)
+      assertExactEquals(expected, -1.0f * x)
+    }
+
+    @inline
+    def test(expected: Float, x: Float): Unit = {
+      testNoInline(expected, x)
+      assertExactEquals(expected, -x)
+      assertExactEquals(expected, -1f * x)
+    }
+
+    test(-0.0f, 0.0f)
+    test(0.0f, -0.0f)
+    test(Float.NaN, Float.NaN)
+    test(Float.NegativeInfinity, Float.PositiveInfinity)
+    test(Float.PositiveInfinity, Float.NegativeInfinity)
+
+    test(-1.5f, 1.5f)
+    test(567.89f, -567.89f)
+  }
+
+  @Test
+  def noWrongSimplifications(): Unit = {
+    assumeFalse("Rhino does not execute these operations correctly",
+        executingInRhino)
+
+    @noinline
+    def hide(x: Float): Float = x
+
+    @inline
+    def negate(x: Float): Float = -x
+
+    assertExactEquals(0.8f, (hide(0.1f) + 0.3f) + 0.4f)
+    assertExactEquals(0.8000001f, 0.1f + (0.3f + hide(0.4f)))
+
+    assertExactEquals(0.0f, 0.0f + hide(-0.0f))
+    assertExactEquals(0.0f, 0.0f - hide(0.0f))
+
+    assertExactEquals(0.0f, negate(negate(hide(0.0f))))
+    assertExactEquals(-0.0f, negate(negate(hide(-0.0f))))
   }
 }

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
@@ -1884,22 +1884,22 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
             case Int_>>  => js.BinaryOp(JSBinaryOp.>>, newLhs, newRhs)
 
             case Float_+ => genFround(js.BinaryOp(JSBinaryOp.+, newLhs, newRhs))
-            case Float_- =>
+            case Float_- => genFround(js.BinaryOp(JSBinaryOp.-, newLhs, newRhs))
+            case Float_* =>
               genFround(lhs match {
-                case DoubleLiteral(0.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
-                case _                  => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+                case FloatLiteral(-1.0f) => js.UnaryOp(JSUnaryOp.-, newRhs)
+                case _                   => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
               })
-            case Float_* => genFround(js.BinaryOp(JSBinaryOp.*, newLhs, newRhs))
             case Float_/ => genFround(js.BinaryOp(JSBinaryOp./, newLhs, newRhs))
             case Float_% => genFround(js.BinaryOp(JSBinaryOp.%, newLhs, newRhs))
 
             case Double_+ => js.BinaryOp(JSBinaryOp.+, newLhs, newRhs)
-            case Double_- =>
+            case Double_- => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+            case Double_* =>
               lhs match {
-                case DoubleLiteral(0.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
-                case _                  => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+                case DoubleLiteral(-1.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
+                case _                   => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
               }
-            case Double_* => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
             case Double_/ => js.BinaryOp(JSBinaryOp./, newLhs, newRhs)
             case Double_% => js.BinaryOp(JSBinaryOp.%, newLhs, newRhs)
 

--- a/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
+++ b/tools/shared/src/main/scala/org/scalajs/core/tools/linker/frontend/optimizer/OptimizerCore.scala
@@ -3451,40 +3451,6 @@ private[optimizer] abstract class OptimizerCore(
           case _ => default
         }
 
-      case Float_+ =>
-        (lhs, rhs) match {
-          case (PreTransLit(FloatLiteral(0)), _) =>
-            rhs
-          case (_, PreTransLit(FloatLiteral(_))) =>
-            foldBinaryOp(Float_+, rhs, lhs)
-
-          case (PreTransLit(FloatLiteral(x)),
-              PreTransBinaryOp(innerOp @ (Float_+ | Float_-),
-                  PreTransLit(FloatLiteral(y)), z)) =>
-            foldBinaryOp(innerOp, PreTransLit(FloatLiteral(x + y)), z)
-
-          case _ => default
-        }
-
-      case Float_- =>
-        (lhs, rhs) match {
-          case (_, PreTransLit(FloatLiteral(r))) =>
-            foldBinaryOp(Float_+, lhs, PreTransLit(FloatLiteral(-r)))
-
-          case (PreTransLit(FloatLiteral(x)),
-              PreTransBinaryOp(Float_+, PreTransLit(FloatLiteral(y)), z)) =>
-            foldBinaryOp(Float_-, PreTransLit(FloatLiteral(x - y)), z)
-          case (PreTransLit(FloatLiteral(x)),
-              PreTransBinaryOp(Float_-, PreTransLit(FloatLiteral(y)), z)) =>
-            foldBinaryOp(Float_+, PreTransLit(FloatLiteral(x - y)), z)
-
-          case (_, PreTransBinaryOp(BinaryOp.Float_-,
-              PreTransLit(FloatLiteral(0)), x)) =>
-            foldBinaryOp(Float_+, lhs, x)
-
-          case _ => default
-        }
-
       case Float_* =>
         (lhs, rhs) match {
           case (_, PreTransLit(FloatLiteral(_))) =>
@@ -3492,8 +3458,9 @@ private[optimizer] abstract class OptimizerCore(
 
           case (PreTransLit(FloatLiteral(1)), _) =>
             rhs
-          case (PreTransLit(FloatLiteral(-1)), _) =>
-            foldBinaryOp(Float_-, PreTransLit(FloatLiteral(0)), rhs)
+          case (PreTransLit(FloatLiteral(-1)),
+              PreTransBinaryOp(Float_*, PreTransLit(FloatLiteral(-1)), z)) =>
+            z
 
           case _ => default
         }
@@ -3503,48 +3470,13 @@ private[optimizer] abstract class OptimizerCore(
           case (_, PreTransLit(FloatLiteral(1))) =>
             lhs
           case (_, PreTransLit(FloatLiteral(-1))) =>
-            foldBinaryOp(Float_-, PreTransLit(FloatLiteral(0)), lhs)
+            foldBinaryOp(Float_*, PreTransLit(FloatLiteral(-1)), lhs)
 
           case _ => default
         }
 
       case Float_% =>
         (lhs, rhs) match {
-          case _ => default
-        }
-
-      case Double_+ =>
-        (lhs, rhs) match {
-          case (PreTransLit(NumberLiteral(0)), _) =>
-            rhs
-          case (_, PreTransLit(NumberLiteral(_))) =>
-            foldBinaryOp(Double_+, rhs, lhs)
-
-          case (PreTransLit(NumberLiteral(x)),
-              PreTransBinaryOp(innerOp @ (Double_+ | Double_-),
-                  PreTransLit(NumberLiteral(y)), z)) =>
-            foldBinaryOp(innerOp, PreTransLit(DoubleLiteral(x + y)), z)
-
-          case _ => default
-        }
-
-      case Double_- =>
-        (lhs, rhs) match {
-          case (_, PreTransLit(NumberLiteral(r))) =>
-            foldBinaryOp(Double_+, lhs, PreTransLit(DoubleLiteral(-r)))
-
-          case (PreTransLit(NumberLiteral(x)),
-              PreTransBinaryOp(Double_+, PreTransLit(NumberLiteral(y)), z)) =>
-            foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(x - y)), z)
-
-          case (PreTransLit(NumberLiteral(x)),
-              PreTransBinaryOp(Double_-, PreTransLit(NumberLiteral(y)), z)) =>
-            foldBinaryOp(Double_+, PreTransLit(DoubleLiteral(x - y)), z)
-
-          case (_, PreTransBinaryOp(BinaryOp.Double_-,
-              PreTransLit(NumberLiteral(0)), x)) =>
-            foldBinaryOp(Double_+, lhs, x)
-
           case _ => default
         }
 
@@ -3555,8 +3487,9 @@ private[optimizer] abstract class OptimizerCore(
 
           case (PreTransLit(NumberLiteral(1)), _) =>
             rhs
-          case (PreTransLit(NumberLiteral(-1)), _) =>
-            foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(0)), rhs)
+          case (PreTransLit(NumberLiteral(-1)),
+              PreTransBinaryOp(Double_*, PreTransLit(NumberLiteral(-1)), z)) =>
+            z
 
           case _ => default
         }
@@ -3566,7 +3499,7 @@ private[optimizer] abstract class OptimizerCore(
           case (_, PreTransLit(NumberLiteral(1))) =>
             lhs
           case (_, PreTransLit(NumberLiteral(-1))) =>
-            foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(0)), lhs)
+            foldBinaryOp(Double_*, PreTransLit(DoubleLiteral(-1)), lhs)
 
           case _ => default
         }


### PR DESCRIPTION
The result of `-x` is not the same as `0.0 - x` when `x` is `0.0`: it is -0.0 instead of +0.0. Therefore, encoding `-x` as `0.0 - x` was incorrect, as well as link-time optimizations that interpreted `0.0 - x` as `-x`.

We now encode `-x` as `-1.0 * x` instead, which always give the correct result. We adapt the rules in the optimizer and in the emitter to recognize `-1.0 * x` as `-x`, instead of `0.0 - x`.

In addition, we remove some wrong simplifications in the optimizer, that were assuming that `+` is associative for doubles, whereas it is not.

All of the above also applies to floats.

Only code compiled with the newer version of the compiler will be fixed.

**Attention!** Code doing `-x` in source code and compiled with an earlier version of the compiler will be *broken* by this change, since it was encoded as `0.0 - x` in the IR, which used to be emitted as `-x` (fixing the wrong encoding) and now emitted as `0.0 - x` (which is correct given the IR, but incorrect given the original source code). An alternative would be to add a deserialization hack to deserialize `0.0 - x` as `-1.0 * x`.