### PR TITLE
FF ONLY Merge 0.6.x into master, May 14

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -3985,9 +3985,9 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                 case jstpe.LongType =>
                   js.BinaryOp(js.BinaryOp.Long_-, js.LongLiteral(0), src)
                 case jstpe.FloatType =>
-                  js.BinaryOp(js.BinaryOp.Float_-, js.FloatLiteral(0.0f), src)
+                  js.BinaryOp(js.BinaryOp.Float_*, js.FloatLiteral(-1.0f), src)
                 case jstpe.DoubleType =>
-                  js.BinaryOp(js.BinaryOp.Double_-, js.DoubleLiteral(0), src)
+                  js.BinaryOp(js.BinaryOp.Double_*, js.DoubleLiteral(-1.0), src)
               }
             case NOT =>
               (opType: @unchecked) match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2355,22 +2355,22 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                 genLongMethodApply(newLhs, LongImpl.>=, newRhs)
 
             case Float_+ => genFround(js.BinaryOp(JSBinaryOp.+, newLhs, newRhs))
-            case Float_- =>
+            case Float_- => genFround(js.BinaryOp(JSBinaryOp.-, newLhs, newRhs))
+            case Float_* =>
               genFround(lhs match {
-                case DoubleLiteral(0.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
-                case _                  => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+                case FloatLiteral(-1.0f) => js.UnaryOp(JSUnaryOp.-, newRhs)
+                case _                   => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
               })
-            case Float_* => genFround(js.BinaryOp(JSBinaryOp.*, newLhs, newRhs))
             case Float_/ => genFround(js.BinaryOp(JSBinaryOp./, newLhs, newRhs))
             case Float_% => genFround(js.BinaryOp(JSBinaryOp.%, newLhs, newRhs))
 
             case Double_+ => js.BinaryOp(JSBinaryOp.+, newLhs, newRhs)
-            case Double_- =>
+            case Double_- => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+            case Double_* =>
               lhs match {
-                case DoubleLiteral(0.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
-                case _                  => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+                case DoubleLiteral(-1.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
+                case _                   => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
               }
-            case Double_* => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
             case Double_/ => js.BinaryOp(JSBinaryOp./, newLhs, newRhs)
             case Double_% => js.BinaryOp(JSBinaryOp.%, newLhs, newRhs)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3663,40 +3663,6 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case _ => default
         }
 
-      case Float_+ =>
-        (lhs, rhs) match {
-          case (PreTransLit(FloatLiteral(0)), _) =>
-            rhs
-          case (_, PreTransLit(FloatLiteral(_))) =>
-            foldBinaryOp(Float_+, rhs, lhs)
-
-          case (PreTransLit(FloatLiteral(x)),
-              PreTransBinaryOp(innerOp @ (Float_+ | Float_-),
-                  PreTransLit(FloatLiteral(y)), z)) =>
-            foldBinaryOp(innerOp, PreTransLit(FloatLiteral(x + y)), z)
-
-          case _ => default
-        }
-
-      case Float_- =>
-        (lhs, rhs) match {
-          case (_, PreTransLit(FloatLiteral(r))) =>
-            foldBinaryOp(Float_+, lhs, PreTransLit(FloatLiteral(-r)))
-
-          case (PreTransLit(FloatLiteral(x)),
-              PreTransBinaryOp(Float_+, PreTransLit(FloatLiteral(y)), z)) =>
-            foldBinaryOp(Float_-, PreTransLit(FloatLiteral(x - y)), z)
-          case (PreTransLit(FloatLiteral(x)),
-              PreTransBinaryOp(Float_-, PreTransLit(FloatLiteral(y)), z)) =>
-            foldBinaryOp(Float_+, PreTransLit(FloatLiteral(x - y)), z)
-
-          case (_, PreTransBinaryOp(BinaryOp.Float_-,
-              PreTransLit(FloatLiteral(0)), x)) =>
-            foldBinaryOp(Float_+, lhs, x)
-
-          case _ => default
-        }
-
       case Float_* =>
         (lhs, rhs) match {
           case (_, PreTransLit(FloatLiteral(_))) =>
@@ -3704,8 +3670,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
           case (PreTransLit(FloatLiteral(1)), _) =>
             rhs
-          case (PreTransLit(FloatLiteral(-1)), _) =>
-            foldBinaryOp(Float_-, PreTransLit(FloatLiteral(0)), rhs)
+          case (PreTransLit(FloatLiteral(-1)),
+              PreTransBinaryOp(Float_*, PreTransLit(FloatLiteral(-1)), z)) =>
+            z
 
           case _ => default
         }
@@ -3715,48 +3682,13 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case (_, PreTransLit(FloatLiteral(1))) =>
             lhs
           case (_, PreTransLit(FloatLiteral(-1))) =>
-            foldBinaryOp(Float_-, PreTransLit(FloatLiteral(0)), lhs)
+            foldBinaryOp(Float_*, PreTransLit(FloatLiteral(-1)), lhs)
 
           case _ => default
         }
 
       case Float_% =>
         (lhs, rhs) match {
-          case _ => default
-        }
-
-      case Double_+ =>
-        (lhs, rhs) match {
-          case (PreTransLit(DoubleLiteral(0)), _) =>
-            rhs
-          case (_, PreTransLit(DoubleLiteral(_))) =>
-            foldBinaryOp(Double_+, rhs, lhs)
-
-          case (PreTransLit(DoubleLiteral(x)),
-              PreTransBinaryOp(innerOp @ (Double_+ | Double_-),
-                  PreTransLit(DoubleLiteral(y)), z)) =>
-            foldBinaryOp(innerOp, PreTransLit(DoubleLiteral(x + y)), z)
-
-          case _ => default
-        }
-
-      case Double_- =>
-        (lhs, rhs) match {
-          case (_, PreTransLit(DoubleLiteral(r))) =>
-            foldBinaryOp(Double_+, lhs, PreTransLit(DoubleLiteral(-r)))
-
-          case (PreTransLit(DoubleLiteral(x)),
-              PreTransBinaryOp(Double_+, PreTransLit(DoubleLiteral(y)), z)) =>
-            foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(x - y)), z)
-
-          case (PreTransLit(DoubleLiteral(x)),
-              PreTransBinaryOp(Double_-, PreTransLit(DoubleLiteral(y)), z)) =>
-            foldBinaryOp(Double_+, PreTransLit(DoubleLiteral(x - y)), z)
-
-          case (_, PreTransBinaryOp(BinaryOp.Double_-,
-              PreTransLit(DoubleLiteral(0)), x)) =>
-            foldBinaryOp(Double_+, lhs, x)
-
           case _ => default
         }
 
@@ -3767,8 +3699,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
           case (PreTransLit(DoubleLiteral(1)), _) =>
             rhs
-          case (PreTransLit(DoubleLiteral(-1)), _) =>
-            foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(0)), rhs)
+          case (PreTransLit(DoubleLiteral(-1)),
+              PreTransBinaryOp(Double_*, PreTransLit(DoubleLiteral(-1)), z)) =>
+            z
 
           case _ => default
         }
@@ -3778,7 +3711,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case (_, PreTransLit(DoubleLiteral(1))) =>
             lhs
           case (_, PreTransLit(DoubleLiteral(-1))) =>
-            foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(0)), lhs)
+            foldBinaryOp(Double_*, PreTransLit(DoubleLiteral(-1)), lhs)
 
           case _ => default
         }

--- a/scalalib/overrides-2.13.0/scala/Symbol.scala
+++ b/scalalib/overrides-2.13.0/scala/Symbol.scala
@@ -1,0 +1,113 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.scalajs.js
+
+/** This class provides a simple way to get unique objects for equal strings.
+ *  Since symbols are interned, they can be compared using reference equality.
+ *  Instances of `Symbol` can be created easily with Scala's built-in quote
+ *  mechanism.
+ *
+ *  For instance, the Scala term `'mysym` will
+ *  invoke the constructor of the `Symbol` class in the following way:
+ *  `Symbol("mysym")`.
+ *
+ *  @author  Martin Odersky, Iulian Dragos
+ *  @since   1.7
+ */
+final class Symbol private (val name: String) extends Serializable {
+  /** Converts this symbol to a string.
+   */
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+// Modified to use Scala.js specific cache
+object Symbol extends JSUniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class JSUniquenessCache[V]
+{
+  private val cache = js.Dictionary.empty[V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}
+
+/** This is private so it won't appear in the library API, but
+  * abstracted to offer some hope of reusability.  */
+/* DELETED for Scala.js
+private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
+{
+
+  import java.lang.ref.WeakReference
+  import java.util.WeakHashMap
+  import java.util.concurrent.locks.ReentrantReadWriteLock
+
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
+
+  protected def valueFromKey(k: K): V
+  protected def keyFromValue(v: V): Option[K]
+
+  def apply(name: K): V = {
+    def cached(): V = {
+      rlock.lock
+      try {
+        val reference = map get name
+        if (reference == null) null
+        else reference.get  // will be null if we were gc-ed
+      }
+      finally rlock.unlock
+    }
+    def updateCache(): V = {
+      wlock.lock
+      try {
+        val res = cached()
+        if (res != null) res
+        else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
+          map remove name
+          val sym = valueFromKey(name)
+          map.put(name, new WeakReference(sym))
+          sym
+        }
+      }
+      finally wlock.unlock
+    }
+
+    val res = cached()
+    if (res == null) updateCache()
+    else res
+  }
+  def unapply(other: V): Option[K] = keyFromValue(other)
+}
+*/

--- a/scalalib/overrides-2.13.1/scala/Symbol.scala
+++ b/scalalib/overrides-2.13.1/scala/Symbol.scala
@@ -1,0 +1,113 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.scalajs.js
+
+/** This class provides a simple way to get unique objects for equal strings.
+ *  Since symbols are interned, they can be compared using reference equality.
+ *  Instances of `Symbol` can be created easily with Scala's built-in quote
+ *  mechanism.
+ *
+ *  For instance, the Scala term `'mysym` will
+ *  invoke the constructor of the `Symbol` class in the following way:
+ *  `Symbol("mysym")`.
+ *
+ *  @author  Martin Odersky, Iulian Dragos
+ *  @since   1.7
+ */
+final class Symbol private (val name: String) extends Serializable {
+  /** Converts this symbol to a string.
+   */
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+// Modified to use Scala.js specific cache
+object Symbol extends JSUniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class JSUniquenessCache[V]
+{
+  private val cache = js.Dictionary.empty[V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}
+
+/** This is private so it won't appear in the library API, but
+  * abstracted to offer some hope of reusability.  */
+/* DELETED for Scala.js
+private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
+{
+
+  import java.lang.ref.WeakReference
+  import java.util.WeakHashMap
+  import java.util.concurrent.locks.ReentrantReadWriteLock
+
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
+
+  protected def valueFromKey(k: K): V
+  protected def keyFromValue(v: V): Option[K]
+
+  def apply(name: K): V = {
+    def cached(): V = {
+      rlock.lock
+      try {
+        val reference = map get name
+        if (reference == null) null
+        else reference.get  // will be null if we were gc-ed
+      }
+      finally rlock.unlock
+    }
+    def updateCache(): V = {
+      wlock.lock
+      try {
+        val res = cached()
+        if (res != null) res
+        else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
+          map remove name
+          val sym = valueFromKey(name)
+          map.put(name, new WeakReference(sym))
+          sym
+        }
+      }
+      finally wlock.unlock
+    }
+
+    val res = cached()
+    if (res == null) updateCache()
+    else res
+  }
+  def unapply(other: V): Option[K] = keyFromValue(other)
+}
+*/

--- a/scalalib/overrides-2.13.2/scala/Symbol.scala
+++ b/scalalib/overrides-2.13.2/scala/Symbol.scala
@@ -1,0 +1,113 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.scalajs.js
+
+/** This class provides a simple way to get unique objects for equal strings.
+ *  Since symbols are interned, they can be compared using reference equality.
+ *  Instances of `Symbol` can be created easily with Scala's built-in quote
+ *  mechanism.
+ *
+ *  For instance, the Scala term `'mysym` will
+ *  invoke the constructor of the `Symbol` class in the following way:
+ *  `Symbol("mysym")`.
+ *
+ *  @author  Martin Odersky, Iulian Dragos
+ *  @since   1.7
+ */
+final class Symbol private (val name: String) extends Serializable {
+  /** Converts this symbol to a string.
+   */
+  override def toString(): String = "'" + name
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+// Modified to use Scala.js specific cache
+object Symbol extends JSUniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class JSUniquenessCache[V]
+{
+  private val cache = js.Dictionary.empty[V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}
+
+/** This is private so it won't appear in the library API, but
+  * abstracted to offer some hope of reusability.  */
+/* DELETED for Scala.js
+private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
+{
+
+  import java.lang.ref.WeakReference
+  import java.util.WeakHashMap
+  import java.util.concurrent.locks.ReentrantReadWriteLock
+
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
+
+  protected def valueFromKey(k: K): V
+  protected def keyFromValue(v: V): Option[K]
+
+  def apply(name: K): V = {
+    def cached(): V = {
+      rlock.lock
+      try {
+        val reference = map get name
+        if (reference == null) null
+        else reference.get  // will be null if we were gc-ed
+      }
+      finally rlock.unlock
+    }
+    def updateCache(): V = {
+      wlock.lock
+      try {
+        val res = cached()
+        if (res != null) res
+        else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
+          map remove name
+          val sym = valueFromKey(name)
+          map.put(name, new WeakReference(sym))
+          sym
+        }
+      }
+      finally wlock.unlock
+    }
+
+    val res = cached()
+    if (res == null) updateCache()
+    else res
+  }
+  def unapply(other: V): Option[K] = keyFromValue(other)
+}
+*/

--- a/scalalib/overrides-2.13/scala/Symbol.scala
+++ b/scalalib/overrides-2.13/scala/Symbol.scala
@@ -1,0 +1,113 @@
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala
+
+import scala.scalajs.js
+
+/** This class provides a simple way to get unique objects for equal strings.
+ *  Since symbols are interned, they can be compared using reference equality.
+ *  Instances of `Symbol` can be created easily with Scala's built-in quote
+ *  mechanism.
+ *
+ *  For instance, the Scala term `'mysym` will
+ *  invoke the constructor of the `Symbol` class in the following way:
+ *  `Symbol("mysym")`.
+ *
+ *  @author  Martin Odersky, Iulian Dragos
+ *  @since   1.7
+ */
+final class Symbol private (val name: String) extends Serializable {
+  /** Converts this symbol to a string.
+   */
+  override def toString(): String = "Symbol(" + name + ")"
+
+  @throws(classOf[java.io.ObjectStreamException])
+  private def readResolve(): Any = Symbol.apply(name)
+  override def hashCode = name.hashCode()
+  override def equals(other: Any) = this eq other.asInstanceOf[AnyRef]
+}
+
+// Modified to use Scala.js specific cache
+object Symbol extends JSUniquenessCache[Symbol] {
+  override def apply(name: String): Symbol = super.apply(name)
+  protected def valueFromKey(name: String): Symbol = new Symbol(name)
+  protected def keyFromValue(sym: Symbol): Option[String] = Some(sym.name)
+}
+
+private[scala] abstract class JSUniquenessCache[V]
+{
+  private val cache = js.Dictionary.empty[V]
+
+  protected def valueFromKey(k: String): V
+  protected def keyFromValue(v: V): Option[String]
+
+  def apply(name: String): V =
+    cache.getOrElseUpdate(name, valueFromKey(name))
+
+  def unapply(other: V): Option[String] = keyFromValue(other)
+}
+
+/** This is private so it won't appear in the library API, but
+  * abstracted to offer some hope of reusability.  */
+/* DELETED for Scala.js
+private[scala] abstract class UniquenessCache[K >: js.String, V >: Null]
+{
+
+  import java.lang.ref.WeakReference
+  import java.util.WeakHashMap
+  import java.util.concurrent.locks.ReentrantReadWriteLock
+
+  private[this] val rwl = new ReentrantReadWriteLock()
+  private[this] val rlock = rwl.readLock
+  private[this] val wlock = rwl.writeLock
+  private[this] val map = new WeakHashMap[K, WeakReference[V]]
+
+  protected def valueFromKey(k: K): V
+  protected def keyFromValue(v: V): Option[K]
+
+  def apply(name: K): V = {
+    def cached(): V = {
+      rlock.lock
+      try {
+        val reference = map get name
+        if (reference == null) null
+        else reference.get  // will be null if we were gc-ed
+      }
+      finally rlock.unlock
+    }
+    def updateCache(): V = {
+      wlock.lock
+      try {
+        val res = cached()
+        if (res != null) res
+        else {
+          // If we don't remove the old String key from the map, we can
+          // wind up with one String as the key and a different String as
+          // the name field in the Symbol, which can lead to surprising GC
+          // behavior and duplicate Symbols. See scala/bug#6706.
+          map remove name
+          val sym = valueFromKey(name)
+          map.put(name, new WeakReference(sym))
+          sym
+        }
+      }
+      finally wlock.unlock
+    }
+
+    val res = cached()
+    if (res == null) updateCache()
+    else res
+  }
+  def unapply(other: V): Option[K] = keyFromValue(other)
+}
+*/

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -16,6 +16,9 @@ import org.junit.Test
 import org.junit.Assert._
 
 class DoubleTest {
+  final def assertExactEquals(expected: Double, actual: Double): Unit =
+    assertTrue(s"expected: $expected; actual: $actual", expected.equals(actual))
+
   @Test
   def `toInt`(): Unit = {
     @inline
@@ -101,5 +104,48 @@ class DoubleTest {
     assertTrue(test_not_>=(5, NaN))
     assertTrue(test_not_>=(NaN, NaN))
     assertFalse(test_not_>=(0.0, -0.0))
+  }
+
+  @Test
+  def negate_issue4034(): Unit = {
+    @noinline
+    def testNoInline(expected: Double, x: Double): Unit = {
+      assertExactEquals(expected, -x)
+      assertExactEquals(expected, -1.0 * x)
+    }
+
+    @inline
+    def test(expected: Double, x: Double): Unit = {
+      testNoInline(expected, x)
+      assertExactEquals(expected, -x)
+      assertExactEquals(expected, -1.0 * x)
+    }
+
+    test(-0.0, 0.0)
+    test(0.0, -0.0)
+    test(Double.NaN, Double.NaN)
+    test(Double.NegativeInfinity, Double.PositiveInfinity)
+    test(Double.PositiveInfinity, Double.NegativeInfinity)
+
+    test(-1.5, 1.5)
+    test(567.89, -567.89)
+  }
+
+  @Test
+  def noWrongSimplifications(): Unit = {
+    @noinline
+    def hide(x: Double): Double = x
+
+    @inline
+    def negate(x: Double): Double = -x
+
+    assertExactEquals(0.6000000000000001, (hide(0.1) + 0.2) + 0.3)
+    assertExactEquals(0.6, 0.1 + (0.2 + hide(0.3)))
+
+    assertExactEquals(0.0, 0.0 + hide(-0.0))
+    assertExactEquals(0.0, 0.0 - hide(0.0))
+
+    assertExactEquals(0.0, negate(negate(hide(0.0))))
+    assertExactEquals(-0.0, negate(negate(hide(-0.0))))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -15,7 +15,12 @@ package org.scalajs.testsuite.compiler
 import org.junit.Test
 import org.junit.Assert._
 
+import org.scalajs.testsuite.utils.Platform.hasStrictFloats
+
 class FloatTest {
+  final def assertExactEquals(expected: Float, actual: Float): Unit =
+    assertTrue(s"expected: $expected; actual: $actual", expected.equals(actual))
+
   @Test
   def `toInt`(): Unit = {
     @inline
@@ -100,5 +105,50 @@ class FloatTest {
     assertTrue(test_not_>=(5, NaN))
     assertTrue(test_not_>=(NaN, NaN))
     assertFalse(test_not_>=(0.0f, -0.0f))
+  }
+
+  @Test
+  def negate_issue4034(): Unit = {
+    @noinline
+    def testNoInline(expected: Float, x: Float): Unit = {
+      assertExactEquals(expected, -x)
+      assertExactEquals(expected, -1.0f * x)
+    }
+
+    @inline
+    def test(expected: Float, x: Float): Unit = {
+      testNoInline(expected, x)
+      assertExactEquals(expected, -x)
+      assertExactEquals(expected, -1f * x)
+    }
+
+    test(-0.0f, 0.0f)
+    test(0.0f, -0.0f)
+    test(Float.NaN, Float.NaN)
+    test(Float.NegativeInfinity, Float.PositiveInfinity)
+    test(Float.PositiveInfinity, Float.NegativeInfinity)
+
+    test(-1.5f, 1.5f)
+    test(567.89f, -567.89f)
+  }
+
+  @Test
+  def noWrongSimplifications(): Unit = {
+    @noinline
+    def hide(x: Float): Float = x
+
+    @inline
+    def negate(x: Float): Float = -x
+
+    if (hasStrictFloats) {
+      assertExactEquals(0.8f, (hide(0.1f) + 0.3f) + 0.4f)
+      assertExactEquals(0.8000001f, 0.1f + (0.3f + hide(0.4f)))
+    }
+
+    assertExactEquals(0.0f, 0.0f + hide(-0.0f))
+    assertExactEquals(0.0f, 0.0f - hide(0.0f))
+
+    assertExactEquals(0.0f, negate(negate(hide(0.0f))))
+    assertExactEquals(-0.0f, negate(negate(hide(-0.0f))))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
@@ -15,6 +15,8 @@ package org.scalajs.testsuite.scalalib
 import org.junit.Test
 import org.junit.Assert._
 
+import org.scalajs.testsuite.utils.Platform.scalaVersion
+
 class SymbolTest {
 
   @Test def should_ensure_unique_identity(): Unit = {
@@ -52,12 +54,31 @@ class SymbolTest {
   @Test def should_support_toString(): Unit = {
     val scalajs = 'ScalaJS
 
-    assertEquals("'ScalaJS", scalajs.toString)
-    assertEquals("'$", Symbol("$").toString)
-    assertEquals("'$$", '$$.toString)
-    assertEquals("'-", '-.toString)
-    assertEquals("'*", '*.toString)
-    assertEquals("''", Symbol("'").toString)
-    assertEquals("'\"", Symbol("\"").toString)
+    val toStringUsesQuoteSyntax = {
+      scalaVersion.startsWith("2.10.") ||
+      scalaVersion.startsWith("2.11.") ||
+      scalaVersion.startsWith("2.12.") ||
+      scalaVersion == "2.13.0" ||
+      scalaVersion == "2.13.1" ||
+      scalaVersion == "2.13.2"
+    }
+
+    if (toStringUsesQuoteSyntax) {
+      assertEquals("'ScalaJS", scalajs.toString)
+      assertEquals("'$", Symbol("$").toString)
+      assertEquals("'$$", '$$.toString)
+      assertEquals("'-", '-.toString)
+      assertEquals("'*", '*.toString)
+      assertEquals("''", Symbol("'").toString)
+      assertEquals("'\"", Symbol("\"").toString)
+    } else {
+      assertEquals("Symbol(ScalaJS)", scalajs.toString)
+      assertEquals("Symbol($)", Symbol("$").toString)
+      assertEquals("Symbol($$)", '$$.toString)
+      assertEquals("Symbol(-)", '-.toString)
+      assertEquals("Symbol(*)", '*.toString)
+      assertEquals("Symbol(')", Symbol("'").toString)
+      assertEquals("Symbol(\")", Symbol("\"").toString)
+    }
   }
 }


### PR DESCRIPTION
```
$ git checkout -b merge-0.6.x-into-master-may-14
Switched to a new branch 'merge-0.6.x-into-master-may-14'
```
```
$ export mb=$(git merge-base scalajs/0.6.x scalajs/master)
```
```
$ git log --graph --oneline --decorate $mb..scalajs/0.6.x | cat
* 01a8c8090 (scalajs/0.6.x, origin/0.6.x) Towards 0.6.34.
* db0899064 (tag: v0.6.33) Version 0.6.33.
*   ad064987c Merge pull request #4040 from sjrd/fix-double-negate-zero
|\
| * 40e323acc Fix #4034: Encode -x as -1.0 * x instead of 0.0 - x.
* |   b9bd9cf74 Merge pull request #4039 from sjrd/fix-symbol-tostring
|\ \
| |/
|/|
| * 0b6356707 Fix #4038: Update Symbol.toString() to match 2.13.3+.
| * 411847dab Copy the override for Symbol.scala to 2.13/ and 2.13.{0-2}/.
* ce84c646a Merge pull request #4036 from sjrd/fix-react-development-mode-in-jsdom
* f4ecc8930 [no-master] Fix #3458: Hack around React's dev mode error triggering hack.
```
```
$ git merge -s ours ce84c646a
Merge made by the 'ours' strategy.
```
```
$ git show
commit f7179340c999c62c5bf93ab6ece7236d35a3a70e (HEAD -> merge-0.6.x-into-master-may-14)
Merge: 1761f94ee ce84c646a
Author: Sébastien Doeraene <sjrdoeraene@gmail.com>
Date:   Thu May 14 10:40:43 2020 +0200

    Skip the no-master commit f4ecc8930.

```
```
$ git merge --no-commit scalajs/0.6.x
CONFLICT (modify/delete): tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala left in tree.
Auto-merging project/Build.scala
CONFLICT (content): Merge conflict in project/Build.scala
Auto-merging linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
CONFLICT (content): Merge conflict in linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
CONFLICT (modify/delete): ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala deleted in HEAD and modified in scalajs/0.6.x. Version scalajs/0.6.x of ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala left in tree.
Auto-merging compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
CONFLICT (content): Merge conflict in compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
Automatic merge failed; fix conflicts and then commit the result.
```
```
$ git st
UU compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
DU ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
UU linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
UU project/Build.scala
A  scalalib/overrides-2.13.0/scala/Symbol.scala
A  scalalib/overrides-2.13.1/scala/Symbol.scala
A  scalalib/overrides-2.13.2/scala/Symbol.scala
A  scalalib/overrides-2.13/scala/Symbol.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
M  test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
DU tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
```
```
$ git rm -f ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala
rm 'ir/src/main/scala/org/scalajs/core/ir/ScalaJSVersions.scala'
```
Transfer the changes in `tools/.../FunctionEmitter.scala` to `linker/.../FunctionEmitter.scala`.
```
$ git rm -f tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala
rm 'tools/shared/src/main/scala/org/scalajs/core/tools/linker/backend/emitter/FunctionEmitter.scala'
```
Fix other conflicts, make things compile and tests pass.
```diff
$ git diff | cat
diff --cc compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
index dec0dfa75,9da812c6a..000000000
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@@ -3971,33 -3504,30 +3971,33 @@@ abstract class GenJSCode[G <: Global wi

        sources match {
          // Unary operation
 -        case List(source) =>
 +        case List(src_in) =>
 +          val opType = toIRType(resultTpe)
 +          val src = adaptPrimitive(src_in, opType)
 +
            (code match {
              case POS =>
 -              source
 +              src
              case NEG =>
 -              (resultType: @unchecked) match {
 +              (opType: @unchecked) match {
                  case jstpe.IntType =>
 -                  js.BinaryOp(js.BinaryOp.Int_-, js.IntLiteral(0), source)
 +                  js.BinaryOp(js.BinaryOp.Int_-, js.IntLiteral(0), src)
                  case jstpe.LongType =>
 -                  js.BinaryOp(js.BinaryOp.Long_-, js.LongLiteral(0), source)
 +                  js.BinaryOp(js.BinaryOp.Long_-, js.LongLiteral(0), src)
                  case jstpe.FloatType =>
-                   js.BinaryOp(js.BinaryOp.Float_-, js.FloatLiteral(0.0f), src)
 -                  js.BinaryOp(js.BinaryOp.Float_*, js.FloatLiteral(-1.0f), source)
++                  js.BinaryOp(js.BinaryOp.Float_*, js.FloatLiteral(-1.0f), src)
                  case jstpe.DoubleType =>
-                   js.BinaryOp(js.BinaryOp.Double_-, js.DoubleLiteral(0), src)
 -                  js.BinaryOp(js.BinaryOp.Double_*, js.DoubleLiteral(-1.0), source)
++                  js.BinaryOp(js.BinaryOp.Double_*, js.DoubleLiteral(-1.0), src)
                }
              case NOT =>
 -              (resultType: @unchecked) match {
 +              (opType: @unchecked) match {
                  case jstpe.IntType =>
 -                  js.BinaryOp(js.BinaryOp.Int_^, js.IntLiteral(-1), source)
 +                  js.BinaryOp(js.BinaryOp.Int_^, js.IntLiteral(-1), src)
                  case jstpe.LongType =>
 -                  js.BinaryOp(js.BinaryOp.Long_^, js.LongLiteral(-1), source)
 +                  js.BinaryOp(js.BinaryOp.Long_^, js.LongLiteral(-1), src)
                }
              case ZNOT =>
 -              js.UnaryOp(js.UnaryOp.Boolean_!, source)
 +              js.UnaryOp(js.UnaryOp.Boolean_!, src)
              case _ =>
                abort("Unknown unary operation code: " + code)
            })
diff --cc linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
index af70f665c,a70642cc5..000000000
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@@ -3725,60 -3480,26 +3692,26 @@@ private[optimizer] abstract class Optim
            case _ => default
          }

-       case Double_+ =>
-         (lhs, rhs) match {
-           case (PreTransLit(DoubleLiteral(0)), _) =>
-             rhs
-           case (_, PreTransLit(DoubleLiteral(_))) =>
-             foldBinaryOp(Double_+, rhs, lhs)
-
-           case (PreTransLit(DoubleLiteral(x)),
-               PreTransBinaryOp(innerOp @ (Double_+ | Double_-),
-                   PreTransLit(DoubleLiteral(y)), z)) =>
-             foldBinaryOp(innerOp, PreTransLit(DoubleLiteral(x + y)), z)
-
-           case _ => default
-         }
-
-       case Double_- =>
-         (lhs, rhs) match {
-           case (_, PreTransLit(DoubleLiteral(r))) =>
-             foldBinaryOp(Double_+, lhs, PreTransLit(DoubleLiteral(-r)))
-
-           case (PreTransLit(DoubleLiteral(x)),
-               PreTransBinaryOp(Double_+, PreTransLit(DoubleLiteral(y)), z)) =>
-             foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(x - y)), z)
-
-           case (PreTransLit(DoubleLiteral(x)),
-               PreTransBinaryOp(Double_-, PreTransLit(DoubleLiteral(y)), z)) =>
-             foldBinaryOp(Double_+, PreTransLit(DoubleLiteral(x - y)), z)
-
-           case (_, PreTransBinaryOp(BinaryOp.Double_-,
-               PreTransLit(DoubleLiteral(0)), x)) =>
-             foldBinaryOp(Double_+, lhs, x)
-
-           case _ => default
-         }
-
        case Double_* =>
          (lhs, rhs) match {
 -          case (_, PreTransLit(NumberLiteral(_))) =>
 +          case (_, PreTransLit(DoubleLiteral(_))) =>
              foldBinaryOp(Double_*, rhs, lhs)

 -          case (PreTransLit(NumberLiteral(1)), _) =>
 +          case (PreTransLit(DoubleLiteral(1)), _) =>
              rhs
-           case (PreTransLit(DoubleLiteral(-1)), _) =>
-             foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(0)), rhs)
 -          case (PreTransLit(NumberLiteral(-1)),
 -              PreTransBinaryOp(Double_*, PreTransLit(NumberLiteral(-1)), z)) =>
++          case (PreTransLit(DoubleLiteral(-1)),
++              PreTransBinaryOp(Double_*, PreTransLit(DoubleLiteral(-1)), z)) =>
+             z

            case _ => default
          }

        case Double_/ =>
          (lhs, rhs) match {
 -          case (_, PreTransLit(NumberLiteral(1))) =>
 +          case (_, PreTransLit(DoubleLiteral(1))) =>
              lhs
 -          case (_, PreTransLit(NumberLiteral(-1))) =>
 +          case (_, PreTransLit(DoubleLiteral(-1))) =>
-             foldBinaryOp(Double_-, PreTransLit(DoubleLiteral(0)), lhs)
+             foldBinaryOp(Double_*, PreTransLit(DoubleLiteral(-1)), lhs)

            case _ => default
          }
diff --cc project/Build.scala
index a150a87d4,a22761408..000000000
--- a/project/Build.scala
+++ b/project/Build.scala
diff --git a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
index 12a8a8c39..bc78903ef 100644
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2355,22 +2355,22 @@ private[emitter] class FunctionEmitter(jsGen: JSGen) {
                 genLongMethodApply(newLhs, LongImpl.>=, newRhs)

             case Float_+ => genFround(js.BinaryOp(JSBinaryOp.+, newLhs, newRhs))
-            case Float_- =>
+            case Float_- => genFround(js.BinaryOp(JSBinaryOp.-, newLhs, newRhs))
+            case Float_* =>
               genFround(lhs match {
-                case DoubleLiteral(0.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
-                case _                  => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+                case FloatLiteral(-1.0f) => js.UnaryOp(JSUnaryOp.-, newRhs)
+                case _                   => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
               })
-            case Float_* => genFround(js.BinaryOp(JSBinaryOp.*, newLhs, newRhs))
             case Float_/ => genFround(js.BinaryOp(JSBinaryOp./, newLhs, newRhs))
             case Float_% => genFround(js.BinaryOp(JSBinaryOp.%, newLhs, newRhs))

             case Double_+ => js.BinaryOp(JSBinaryOp.+, newLhs, newRhs)
-            case Double_- =>
+            case Double_- => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+            case Double_* =>
               lhs match {
-                case DoubleLiteral(0.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
-                case _                  => js.BinaryOp(JSBinaryOp.-, newLhs, newRhs)
+                case DoubleLiteral(-1.0) => js.UnaryOp(JSUnaryOp.-, newRhs)
+                case _                   => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
               }
-            case Double_* => js.BinaryOp(JSBinaryOp.*, newLhs, newRhs)
             case Double_/ => js.BinaryOp(JSBinaryOp./, newLhs, newRhs)
             case Double_% => js.BinaryOp(JSBinaryOp.%, newLhs, newRhs)

diff --git a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
index e1bb999f7..132a5245d 100644
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -14,9 +14,6 @@ package org.scalajs.testsuite.compiler

 import org.junit.Test
 import org.junit.Assert._
-import org.junit.Assume._
-
-import org.scalajs.testsuite.utils.Platform.executingInRhino

 class DoubleTest {
   final def assertExactEquals(expected: Double, actual: Double): Unit =
@@ -136,9 +133,6 @@ class DoubleTest {

   @Test
   def noWrongSimplifications(): Unit = {
-    assumeFalse("Rhino does not execute these operations correctly",
-        executingInRhino)
-
     @noinline
     def hide(x: Double): Double = x

diff --git a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
index 80d2201a6..39600ec74 100644
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -14,9 +14,6 @@ package org.scalajs.testsuite.compiler

 import org.junit.Test
 import org.junit.Assert._
-import org.junit.Assume._
-
-import org.scalajs.testsuite.utils.Platform.executingInRhino

 class FloatTest {
   final def assertExactEquals(expected: Float, actual: Float): Unit =
@@ -135,9 +132,6 @@ class FloatTest {

   @Test
   def noWrongSimplifications(): Unit = {
-    assumeFalse("Rhino does not execute these operations correctly",
-        executingInRhino)
-
     @noinline
     def hide(x: Float): Float = x

```
```
$ git add -u
```
```
$ git commit
[merge-0.6.x-into-master-may-14 041225880] Merge '0.6.x' into 'master'.
```