### PR TITLE
[no-master] Deactivate the weekly build.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,8 +1,9 @@
 // If not a PR, this is a long-lived branch, which should have a nightly build
 def triggers = []
 if (!env.CHANGE_ID) {
+  // Deactivated now that the 0.6.x branch is frozen
   // This is the 0.6.x series: run weekly on Saturday
-  triggers << cron('H H(0-2) * * 6')
+  //triggers << cron('H H(0-2) * * 6')
 }
 
 // Setup properties of this job definition


### PR DESCRIPTION
Following #4045, the 0.6.x branch is now frozen. There is no point in wasting resources testing it weekly.

The last PR for 0.6.x.