### PR TITLE
Syntax change to make it compatible with dotty

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
@@ -193,7 +193,7 @@ class ArrayBuilderTest {
 
   @Test def Unit_normal_case_inline(): Unit = {
     val b = ArrayBuilder.make[Unit]
-    b += ()
+    b += (())
     val a = b.result()
 
     assertSame(classOf[Array[Unit]], a.getClass)
@@ -204,7 +204,7 @@ class ArrayBuilderTest {
 
   @Test def Unit_normal_case_noinline(): Unit = {
     val b = makeNoInline[Unit]
-    b += ()
+    b += (())
     val a = b.result()
 
     assertSame(classOf[Array[Unit]], a.getClass)


### PR DESCRIPTION
The test ArrayBuilderTest does not compile on Dotty but the change is not related with ScalaJs
@smarter mentioned that dotty is stricter about auto-tupling
https://gitter.im/lampepfl/dotty?at=5ede2cb6a91f120a6cee7c6f

Minor change on code syntax so the test can be enable:
https://github.com/lampepfl/dotty/blob/ff7673c1aed82cdc7293ddd71f43d2176160eb9a/project/Build.scala#L1061