### PR TITLE
Create a Scala 2 only test folder

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1580,7 +1580,7 @@ object Build {
         val isScalaAtLeast212 = !scalaV.startsWith("2.11.")
 
         List(sharedTestDir / "scala", sharedTestDir / "require-jdk7",
-            sharedTestDir / "require-jdk8") ++
+            sharedTestDir / "require-jdk8", sharedTestDir / "require-scala2") ++
         includeIf(testDir / "require-2.12", isJSTest && isScalaAtLeast212)
       },
 

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ArrayBuilderTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ArrayBuilderTestScala2.scala
@@ -1,0 +1,50 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.scalalib
+
+import scala.reflect.ClassTag
+import scala.collection.mutable.ArrayBuilder
+
+import org.junit.Test
+import org.junit.Assert.assertSame
+
+class ArrayBuilderTestScala2 {
+
+  @inline
+  def makeNoInline[T](implicit ct: ClassTag[T]): ArrayBuilder[T] = {
+    /* The dance in this method is to be source compatible with the old and
+     * new collections. In the new collections, ArrayBuilder.make[T] doesn't
+     * take an explicit () parameter list, but it does in the old collections.
+     */
+
+    @noinline def ctNoInline = ct
+
+    {
+      implicit val ct = ctNoInline
+      ArrayBuilder.make[T]
+    }
+  }
+
+  /**
+   * This is a Scala 2.x only test because:
+   * Dotty does not have [[ClassTag]] instances for [[Nothing]] or for [[Null]].
+   * @see [[https://github.com/lampepfl/dotty/issues/1730]]
+   */
+  @Test def Nothing_and_Null(): Unit = {
+    assertSame(classOf[Array[Nothing]], ArrayBuilder.make[Nothing].result().getClass)
+    assertSame(classOf[Array[Null]], ArrayBuilder.make[Null].result().getClass)
+
+    assertSame(classOf[Array[Nothing]], makeNoInline[Nothing].result().getClass)
+    assertSame(classOf[Array[Null]], makeNoInline[Null].result().getClass)
+  }
+}

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ClassTagTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ClassTagTestScala2.scala
@@ -1,0 +1,48 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.scalalib
+
+import scala.reflect._
+
+import org.junit.Test
+import org.junit.Assert.assertSame
+
+class ClassTagTestScala2 {
+
+  /**
+   * This is a Scala 2.x only test because:
+   * Dotty does not have [[ClassTag]] instances for [[Nothing]] or for [[Null]].
+   * @see [[https://github.com/lampepfl/dotty/issues/1730]]
+   */
+  @Test def apply_should_get_the_existing_instances_for_predefined_ClassTags(): Unit = {
+    assertSame(ClassTag.Nothing, classTag[Nothing])
+    assertSame(ClassTag.Null, classTag[Null])
+  }
+
+  /**
+   * This is a Scala 2.x only test because:
+   * Dotty does not have [[ClassTag]] instances for [[Nothing]] or for [[Null]].
+   * The [[Array]] needs the [[ClassTag]] for the parameterized type.
+   * @see [[https://github.com/lampepfl/dotty/issues/1730]]
+   */
+  @Test def runtimeClass(): Unit = {
+    assertSame(classOf[Array[_]], classTag[Array[_]].runtimeClass)
+    assertSame(classOf[Array[_ <: AnyRef]], classTag[Array[_ <: AnyRef]].runtimeClass)
+    assertSame(classOf[Array[_ <: Seq[_]]], classTag[Array[_ <: Seq[_]]].runtimeClass)
+
+    // Weird, those two return Array[s.r.Nothing$] instead of Array[Object]
+    // The same happens on the JVM
+    assertSame(classOf[Array[scala.runtime.Nothing$]], classTag[Array[Nothing]].runtimeClass)
+    assertSame(classOf[Array[scala.runtime.Null$]], classTag[Array[Null]].runtimeClass)
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
@@ -273,14 +273,6 @@ class ArrayBuilderTest {
     assertEquals(null, erase(a(0)))
   }
 
-  @Test def Nothing_and_Null(): Unit = {
-    assertSame(classOf[Array[Nothing]], ArrayBuilder.make[Nothing].result().getClass)
-    assertSame(classOf[Array[Null]], ArrayBuilder.make[Null].result().getClass)
-
-    assertSame(classOf[Array[Nothing]], makeNoInline[Nothing].result().getClass)
-    assertSame(classOf[Array[Null]], makeNoInline[Null].result().getClass)
-  }
-
   @Test def addAll(): Unit = {
     assumeFalse("Needs at least Scala 2.13",
         scalaVersion.startsWith("2.11.") ||

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
@@ -51,8 +51,6 @@ class ClassTagTest {
     assertSame(ClassTag.Object, classTag[Object])
     assertSame(ClassTag.AnyVal, classTag[AnyVal])
     assertSame(ClassTag.AnyRef, classTag[AnyRef])
-    assertSame(ClassTag.Nothing, classTag[Nothing])
-    assertSame(ClassTag.Null, classTag[Null])
   }
 
   @Test def runtimeClass(): Unit = {
@@ -76,18 +74,10 @@ class ClassTagTest {
     assertSame(classOf[Integer], classTag[Integer].runtimeClass)
     assertSame(classOf[Seq[_]], classTag[Seq[_]].runtimeClass)
 
-    assertSame(classOf[Array[_]], classTag[Array[_]].runtimeClass)
     assertSame(classOf[Array[Object]], classTag[Array[Object]].runtimeClass)
-    assertSame(classOf[Array[_ <: AnyRef]], classTag[Array[_ <: AnyRef]].runtimeClass)
     assertSame(classOf[Array[String]], classTag[Array[String]].runtimeClass)
-    assertSame(classOf[Array[_ <: Seq[_]]], classTag[Array[_ <: Seq[_]]].runtimeClass)
     assertSame(classOf[Array[Int]], classTag[Array[Int]].runtimeClass)
     assertSame(classOf[Array[Unit]], classTag[Array[Unit]].runtimeClass)
-
-    // Weird, those two return Array[s.r.Nothing$] instead of Array[Object]
-    // The same happens on the JVM
-    assertSame(classOf[Array[scala.runtime.Nothing$]], classTag[Array[Nothing]].runtimeClass)
-    assertSame(classOf[Array[scala.runtime.Null$]], classTag[Array[Null]].runtimeClass)
 
     assertSame(classOf[String], ClassTag(classOf[String]).runtimeClass)
     assertSame(classOf[Integer], ClassTag(classOf[Integer]).runtimeClass)


### PR DESCRIPTION
The goal is to support the difference between scala 2.x and dotty:
Move check 'Nothing_and_Null' from ArrayBuilderTest to a new test ArrayBuilderTestScala2
'Nothing_and_Null' require implicit instance for ClassTag[Nothing] and ClassTag[Null] at does not exists on Dotty