### PR TITLE
Streamline classVar definitions

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -11,6 +11,10 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
+      // private[emitter], not an issue.
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.backend.emitter.ClassEmitter.org$scalajs$linker$backend$emitter$ClassEmitter$$classVarDef$default$5"),
+
       // private[linker], not an issue.
       exclude[MissingClassProblem]("org.scalajs.linker.NodeFS$FS$"),
 


### PR DESCRIPTION
We remove classVarDefGeneric and replace it with methods to create
specific types of definitions.

Note that this will now emit default method definitions as function
definitions in ES6. Previously they were emitted as lets. Presumably
this is an oversight.

Further, there is a minor regression in the position of the name of
a js.ClassDef: Previously it was at the position of the class name,
now it is at the position of the class definition itself. This
unlikely matters.