### PR TITLE
Add an IDE stub for `emitter.PrivateLibHolder` in the linkerJS.

### DIFF
--- a/linker/js/src/main/scala-ide-stubs/org/scalajs/linker/backend/emitter/PrivateLibHolder.scala
+++ b/linker/js/src/main/scala-ide-stubs/org/scalajs/linker/backend/emitter/PrivateLibHolder.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.emitter
+
+import org.scalajs.linker.interface.IRFile
+
+object PrivateLibHolder {
+  val files: Seq[IRFile] = Nil
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -810,48 +810,53 @@ object Build {
   ).zippedSettings("library")(
       commonLinkerSettings _
   ).settings(
-      sourceGenerators in Compile += Def.task {
-        val dir = (sourceManaged in Compile).value
-        val privateLibProducts = (products in (linkerPrivateLibrary, Compile)).value
+      if (isGeneratingForIDE) {
+        unmanagedSourceDirectories in Compile +=
+          baseDirectory.value.getParentFile.getParentFile / "js/src/main/scala-ide-stubs"
+      } else {
+        sourceGenerators in Compile += Def.task {
+          val dir = (sourceManaged in Compile).value
+          val privateLibProducts = (products in (linkerPrivateLibrary, Compile)).value
 
-        val content = {
-          val namesAndContents = for {
-            f <- (privateLibProducts ** "*.sjsir").get
-          } yield {
-            val bytes = IO.readBytes(f)
-            val base64 = java.util.Base64.getEncoder().encodeToString(bytes)
-            s""""${f.getName}" -> "$base64""""
+          val content = {
+            val namesAndContents = for {
+              f <- (privateLibProducts ** "*.sjsir").get
+            } yield {
+              val bytes = IO.readBytes(f)
+              val base64 = java.util.Base64.getEncoder().encodeToString(bytes)
+              s""""${f.getName}" -> "$base64""""
+            }
+
+            s"""
+            |package org.scalajs.linker.backend.emitter
+            |
+            |import org.scalajs.linker.interface.IRFile
+            |import org.scalajs.linker.standard.MemIRFileImpl
+            |
+            |object PrivateLibHolder {
+            |  private val namesAndContents = Seq(
+            |    ${namesAndContents.mkString(",\n    ")}
+            |  )
+            |
+            |  val files: Seq[IRFile] = {
+            |    for ((name, contentBase64) <- namesAndContents) yield {
+            |      new MemIRFileImpl(
+            |          path = "org/scalajs/linker/runtime/" + name,
+            |          version = Some(""), // this indicates that the file never changes
+            |          content = java.util.Base64.getDecoder().decode(contentBase64)
+            |      )
+            |    }
+            |  }
+            |}
+            """.stripMargin
           }
 
-          s"""
-          |package org.scalajs.linker.backend.emitter
-          |
-          |import org.scalajs.linker.interface.IRFile
-          |import org.scalajs.linker.standard.MemIRFileImpl
-          |
-          |object PrivateLibHolder {
-          |  private val namesAndContents = Seq(
-          |    ${namesAndContents.mkString(",\n    ")}
-          |  )
-          |
-          |  val files: Seq[IRFile] = {
-          |    for ((name, contentBase64) <- namesAndContents) yield {
-          |      new MemIRFileImpl(
-          |          path = "org/scalajs/linker/runtime/" + name,
-          |          version = Some(""), // this indicates that the file never changes
-          |          content = java.util.Base64.getDecoder().decode(contentBase64)
-          |      )
-          |    }
-          |  }
-          |}
-          """.stripMargin
-        }
-
-        IO.createDirectory(dir)
-        val output = dir / "PrivateLibHolder.scala"
-        IO.write(output, content)
-        Seq(output)
-      }.taskValue,
+          IO.createDirectory(dir)
+          val output = dir / "PrivateLibHolder.scala"
+          IO.write(output, content)
+          Seq(output)
+        }.taskValue,
+      },
 
       scalaJSLinkerConfig in Test ~= (_.withModuleKind(ModuleKind.CommonJSModule))
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(


### PR DESCRIPTION
In the JVM version of `linker`, `PrivateLibHolder` is a normal source file, but in JS it is generated by the build. Depending on whether Metals chose to associate `Emitter.scala` to the JVM or JS project, we could get spurious compile errors in the IDE because it would not find `PrivateLibHolder` in the JS project.

We fix this by adding an IDE stub for `PrivateLibHolder` in the JS version of the linker, similarly to what we do for other generated sources.

---

I've been puzzled for a while that Metals would sometimes fail to compile the `linker` files, and sometimes not. I finally figured it out.