### PR TITLE
Fix #4061: Report a linking error on export of non-JS ident in a Script.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -287,7 +287,7 @@ final class Emitter(config: Emitter.Config) {
                   logger.error(
                       s"$displayName.${nativeMember.name.name.displayName} " +
                       s"needs to be imported from module '$module' but " +
-                      "module support is disabled")
+                      "module support is disabled.")
                   importsFound = true
 
                 case _ =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -411,6 +411,16 @@ object Trees {
       true
       // scalastyle:on return
     }
+
+    /** Tests whether a string is a valid export name in a Script.
+     *
+     *  This is true iff it is a valid export name in general, as tested by
+     *  [[isValidExportName]], *and* it is a valid name for a global variable,
+     *  as tested by
+     *  [[org.scalajs.ir.Trees.JSGlobalRef.isValidJSGlobalRefName]].
+     */
+    def isValidExportNameInScript(name: String): Boolean =
+      isValidExportName(name) && ir.Trees.JSGlobalRef.isValidJSGlobalRefName(name)
   }
 
   /** `import` statement, except namespace import.

--- a/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker
+
+import scala.concurrent._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.ir.ClassKind
+import org.scalajs.ir.EntryPointsInfo
+import org.scalajs.ir.Names._
+import org.scalajs.ir.Trees._
+
+import org.scalajs.logging._
+
+import org.scalajs.junit.async._
+
+import org.scalajs.linker.interface._
+import org.scalajs.linker.testutils._
+import org.scalajs.linker.testutils.TestIRBuilder._
+
+class EmitterTest {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  @Test
+  def testLinkingErrorForImportInScript(): AsyncResult = await {
+    val nativeMemberName = m("nativeMember", Nil, O)
+
+    val classDefs = Seq(
+        classDef(
+            "Imported",
+            kind = ClassKind.NativeJSModuleClass,
+            superClass = Some(ObjectClass),
+            jsNativeLoadSpec = Some(JSNativeLoadSpec.Import("foo.js", List("Foo")))
+        ),
+        classDef(
+            "WithImportMember",
+            kind = ClassKind.ModuleClass,
+            superClass = Some(ObjectClass),
+            memberDefs = List(
+                JSNativeMemberDef(EMF.withNamespace(MemberNamespace.PublicStatic),
+                    nativeMemberName,
+                    JSNativeLoadSpec.Import("bar.js", List("Bar")))
+            )
+        ),
+        mainTestClassDef(Block(
+            consoleLog(LoadJSModule("Imported")),
+            consoleLog(SelectJSNativeMember("WithImportMember", nativeMemberName))
+        ))
+    )
+
+    val linkResult = LinkingUtils.expectFailure(LinkingUtils.linkAndEmit(
+        classDefs,
+        MainTestModuleInitializers,
+        StandardConfig().withModuleKind(ModuleKind.NoModule)))
+
+    for (result <- linkResult) yield {
+      val exception = result.exception
+      assertTrue(
+          exception.getMessage(),
+          exception.getMessage().startsWith(
+              "There were module imports without fallback to global " +
+              "variables, but module support is disabled."))
+
+      val log = result.log
+      log.assertContainsLogLine(
+          "Imported needs to be imported from module 'foo.js' but module " +
+          "support is disabled.")
+      log.assertContainsLogLine(
+          "WithImportMember.nativeMember()java.lang.Object needs to be " +
+          "imported from module 'bar.js' but module support is disabled.")
+    }
+  }
+}

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -95,13 +95,7 @@ object LinkerTest {
       moduleInitializers: List[ModuleInitializer])(
       implicit ec: ExecutionContext): Future[Unit] = {
 
-    val linker = StandardImpl.linker(StandardConfig())
-    val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
-    val output = LinkerOutput(MemOutputFile())
-
-    TestIRRepo.minilib.flatMap { stdLibFiles =>
-      linker.link(stdLibFiles ++ classDefsFiles, moduleInitializers,
-          output, new ScalaConsoleLogger(Level.Error))
-    }
+    LinkingUtils.expectSuccess(LinkingUtils.linkAndEmit(
+        classDefs, moduleInitializers, StandardConfig()))
   }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/FailedLinkingResult.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/FailedLinkingResult.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.testutils
+
+import org.scalajs.linker.interface.LinkingException
+
+final class FailedLinkingResult(
+    val exception: LinkingException,
+    val log: TestLogger)

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
@@ -1,0 +1,135 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.testutils
+
+import scala.concurrent._
+
+import org.scalajs.ir.Trees.ClassDef
+
+import org.scalajs.logging._
+
+import org.scalajs.linker._
+import org.scalajs.linker.interface._
+import org.scalajs.linker.standard._
+
+object LinkingUtils {
+
+  def expectSuccess[A](link: Logger => Future[A])(
+      implicit ec: ExecutionContext): Future[A] = {
+    link(new ScalaConsoleLogger(Level.Error))
+  }
+
+  def expectFailure(link: Logger => Future[Unit])(
+      implicit ec: ExecutionContext): Future[FailedLinkingResult] = {
+
+    val logger = new TestLogger()
+
+    // We cannot use `transform` because of 2.11.
+    link(logger).failed.recoverWith {
+      case _: NoSuchElementException =>
+        Future.failed(new AssertionError("Linking did not fail"))
+    }.map { exception =>
+      exception match {
+        case exception: LinkingException =>
+          new FailedLinkingResult(exception, logger)
+        case _ =>
+          throw new AssertionError("Expected LinkingException but got " + exception)
+      }
+    }
+  }
+
+  def linkOnly(classDefs: Seq[ClassDef],
+      moduleInitializers: List[ModuleInitializer],
+      config: StandardConfig,
+      stdlib: Future[Seq[IRFile]] = TestIRRepo.minilib)(
+      implicit ec: ExecutionContext): Logger => Future[Unit] = { logger =>
+
+    val linkerFrontend = StandardLinkerFrontend(config.withCheckIR(true))
+    val noSymbolRequirements = SymbolRequirement.factory("linker test").none()
+
+    withLibAndClassDefFiles(stdlib, classDefs) { irFiles =>
+      linkerFrontend.link(irFiles, moduleInitializers, noSymbolRequirements,
+          logger)
+    }.map(_ => ())
+  }
+
+  private final class StoreLinkingUnitLinkerBackend(
+      originalBackend: LinkerBackend)
+      extends LinkerBackend {
+
+    @volatile
+    private var _linkingUnit: LinkingUnit = _
+
+    val coreSpec: CoreSpec = originalBackend.coreSpec
+
+    val symbolRequirements: SymbolRequirement = originalBackend.symbolRequirements
+
+    override def injectedIRFiles: Seq[IRFile] = originalBackend.injectedIRFiles
+
+    def emit(unit: LinkingUnit, output: LinkerOutput, logger: Logger)(
+        implicit ec: ExecutionContext): Future[Unit] = {
+      _linkingUnit = unit
+      Future.successful(())
+    }
+
+    def linkingUnit: LinkingUnit = {
+      if (_linkingUnit == null)
+        throw new IllegalStateException("Cannot access linkingUnit before emit is called")
+      _linkingUnit
+    }
+  }
+
+  def linkToLinkingUnit(classDefs: Seq[ClassDef],
+      moduleInitializers: List[ModuleInitializer],
+      config: StandardConfig,
+      stdlib: Future[Seq[IRFile]] = TestIRRepo.minilib)(
+      implicit ec: ExecutionContext): Logger => Future[LinkingUnit] = { logger =>
+
+    val configWithCheckIR = config.withCheckIR(true)
+    val frontend = StandardLinkerFrontend(configWithCheckIR)
+    val backend = new StoreLinkingUnitLinkerBackend(
+        StandardLinkerBackend(configWithCheckIR))
+    val linker = StandardLinkerImpl(frontend, backend)
+    val output = LinkerOutput(MemOutputFile())
+
+    withLibAndClassDefFiles(stdlib, classDefs) { irFiles =>
+      linker.link(irFiles, moduleInitializers, output, logger)
+    }.map { _ =>
+      backend.linkingUnit
+    }
+  }
+
+  def linkAndEmit(classDefs: Seq[ClassDef],
+      moduleInitializers: List[ModuleInitializer],
+      config: StandardConfig,
+      stdlib: Future[Seq[IRFile]] = TestIRRepo.minilib)(
+      implicit ec: ExecutionContext): Logger => Future[Unit] = { logger =>
+
+    val linker = StandardImpl.linker(config.withCheckIR(true))
+    val output = LinkerOutput(MemOutputFile())
+
+    withLibAndClassDefFiles(stdlib, classDefs) { irFiles =>
+      linker.link(irFiles, moduleInitializers, output, logger)
+    }
+  }
+
+  private def withLibAndClassDefFiles[A](
+      stdlib: Future[Seq[IRFile]], classDefs: Seq[ClassDef])(
+      f: Seq[IRFile] => Future[A])(
+      implicit ec: ExecutionContext): Future[A] = {
+    stdlib.flatMap { stdLibFiles =>
+      f(stdLibFiles ++ classDefs.map(MemClassDefIRFile(_)))
+    }
+  }
+
+}

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestLogger.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestLogger.scala
@@ -1,0 +1,42 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.testutils
+
+import scala.collection.mutable
+
+import org.scalajs.logging._
+
+import org.junit.Assert._
+
+final class TestLogger extends Logger {
+  private val logLines = mutable.ListBuffer.empty[String]
+
+  def log(level: Level, message: => String): Unit = {
+    if (level == Level.Error)
+      logLines += message
+  }
+
+  def trace(t: => Throwable): Unit =
+    logLines += t.toString()
+
+  def assertContainsLogLine(expected: String): Unit = {
+    if (!containsLogLine(expected))
+      fail(s"expected a log line containing '$expected', but got\n$show")
+  }
+
+  def containsLogLine(expected: String): Boolean =
+    logLines.exists(_.contains(expected))
+
+  def show: String =
+    logLines.mkString("  ", "\n  ", "")
+}


### PR DESCRIPTION
When emitting a Script (`NoModule`), we cannot export on the top-level under a name that is not a valid JavaScript identifier. Such exports must be emitted as `var`s or `let`s, which is only possible for valid JS identifiers.

Previously, attempts at such invalid exports would silently result in invalid .js code, producing a `SyntaxError` at run-time. In this commit, we preemptively report a linking error instead (as a thrown `LinkingException`).

It can be argued that we might want fallback behaviors for these cases, as discussed in #4061. However, this commit is a definitive improvement over the status quo, and leaves the door open for fallbacks in the future, if they prove desirable/necessary.