### PR TITLE
Adapt SymbolTest to Dotty & Scala2 common syntax

### DIFF
--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/SymbolTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/SymbolTestScala2.scala
@@ -1,0 +1,58 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.scalalib
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.testsuite.utils.Platform.scalaVersion
+
+class SymbolTestScala2 {
+
+  /**
+   * This is a Scala 2.x only test because:
+   * Dotty no longer supports symbol literal.
+   */
+  @Test def should_support_symbol_literal(): Unit = {
+    val scalajs = 'ScalaJS
+
+    assertEquals(Symbol("ScalaJS"), scalajs)
+    assertEquals(Symbol("$"), '$)
+    assertEquals(Symbol("$$"), '$$)
+    assertEquals(Symbol("-"), '-)
+    assertEquals(Symbol("*"), '*)
+  }
+
+  /**
+   * This test is similar to the one found in SymbolTest with the same name.
+   * But it uses symbol literals that are not supported on Dotty.
+   */
+  @Test def should_ensure_unique_identity(): Unit = {
+    def expectEqual(sym1: Symbol, sym2: Symbol): Unit = {
+      assertTrue(sym1 eq sym2)
+      assertEquals(sym2, sym1)
+      assertEquals(sym2.##, sym1.##)
+    }
+
+    expectEqual('ScalaJS, Symbol("ScalaJS"))
+    expectEqual('$, Symbol("$"))
+    expectEqual('-, Symbol("-"))
+
+    val `42` = Symbol("42")
+    val map = Map[Symbol, Any](Symbol("ScalaJS") -> "Scala.js", '$ -> 1.2, `42` -> 42)
+    assertEquals("Scala.js", map('ScalaJS))
+    assertEquals(1.2, map(Symbol("$")))
+    assertEquals(42, map(Symbol("42")))
+    assertEquals(42, map(`42`))
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
@@ -23,36 +23,38 @@ class SymbolTest {
     def expectEqual(sym1: Symbol, sym2: Symbol): Unit = {
       assertTrue(sym1 eq sym2)
       assertEquals(sym2, sym1)
-      assertEquals(sym2, sym1)
       assertEquals(sym2.##, sym1.##)
     }
 
-    expectEqual('ScalaJS, Symbol("ScalaJS"))
-    expectEqual('$, Symbol("$"))
-    expectEqual('-, Symbol("-"))
+    expectEqual(Symbol("ScalaJS"), Symbol("ScalaJS"))
+    expectEqual(Symbol("$"), Symbol("$"))
+    expectEqual(Symbol("-"), Symbol("-"))
+
+    val scalajs = Symbol("ScalaJS")
+    expectEqual(scalajs, Symbol("ScalaJS"))
 
     val `42` = Symbol("42")
-    val map = Map[Symbol, Any](Symbol("ScalaJS") -> "Scala.js", '$ -> 1.2, `42` -> 42)
-    assertEquals("Scala.js", map('ScalaJS))
+    val map = Map[Symbol, Any](Symbol("ScalaJS") -> "Scala.js", Symbol("$") -> 1.2, `42` -> 42)
+    assertEquals("Scala.js", map(Symbol("ScalaJS")))
     assertEquals(1.2, map(Symbol("$")))
     assertEquals(42, map(Symbol("42")))
     assertEquals(42, map(`42`))
   }
 
   @Test def should_support_name(): Unit = {
-    val scalajs = 'ScalaJS
+    val scalajs = Symbol("ScalaJS")
 
     assertEquals("ScalaJS", scalajs.name)
     assertEquals("$", Symbol("$").name)
-    assertEquals("$$", '$$.name)
-    assertEquals("-", '-.name)
-    assertEquals("*", '*.name)
+    assertEquals("$$", Symbol("$$").name)
+    assertEquals("-", Symbol("-").name)
+    assertEquals("*", Symbol("*").name)
     assertEquals("'", Symbol("'").name)
     assertEquals("\"", Symbol("\"").name)
   }
 
   @Test def should_support_toString(): Unit = {
-    val scalajs = 'ScalaJS
+    val scalajs = Symbol("ScalaJS")
 
     val toStringUsesQuoteSyntax = {
       scalaVersion.startsWith("2.10.") ||
@@ -66,17 +68,17 @@ class SymbolTest {
     if (toStringUsesQuoteSyntax) {
       assertEquals("'ScalaJS", scalajs.toString)
       assertEquals("'$", Symbol("$").toString)
-      assertEquals("'$$", '$$.toString)
-      assertEquals("'-", '-.toString)
-      assertEquals("'*", '*.toString)
+      assertEquals("'$$", Symbol("$$").toString)
+      assertEquals("'-", Symbol("-").toString)
+      assertEquals("'*", Symbol("*").toString)
       assertEquals("''", Symbol("'").toString)
       assertEquals("'\"", Symbol("\"").toString)
     } else {
       assertEquals("Symbol(ScalaJS)", scalajs.toString)
       assertEquals("Symbol($)", Symbol("$").toString)
-      assertEquals("Symbol($$)", '$$.toString)
-      assertEquals("Symbol(-)", '-.toString)
-      assertEquals("Symbol(*)", '*.toString)
+      assertEquals("Symbol($$)", Symbol("$$").toString)
+      assertEquals("Symbol(-)", Symbol("-").toString)
+      assertEquals("Symbol(*)", Symbol("*").toString)
       assertEquals("Symbol(')", Symbol("'").toString)
       assertEquals("Symbol(\")", Symbol("\"").toString)
     }


### PR DESCRIPTION
Dotty longer supported symbol literal.
Adapt SymbolTest to use application Symbol instead of symbol literal.
Add test cases using symbol literal on SymbolTestScala2.