### PR TITLE
Fix #4061: Report a linking error on export of non-JS ident in a Script.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -162,6 +162,11 @@ object Analysis {
   final case class NotAModule(info: ClassInfo, from: From) extends Error
   final case class MissingMethod(info: MethodInfo, from: From) extends Error
   final case class ConflictingDefaultMethods(infos: List[MethodInfo], from: From) extends Error
+
+  final case class InvalidTopLevelExportInScript(name: String, info: ClassInfo) extends Error {
+    def from: From = FromExports
+  }
+
   final case class ConflictingTopLevelExport(name: String, infos: List[ClassInfo]) extends Error {
     def from: From = FromExports
   }
@@ -201,6 +206,11 @@ object Analysis {
         s"Referring to non-existent method ${info.fullDisplayName}"
       case ConflictingDefaultMethods(infos, _) =>
         s"Conflicting default methods: ${infos.map(_.fullDisplayName).mkString(" ")}"
+      case InvalidTopLevelExportInScript(name, info) =>
+        s"Invalid top level export for name '$name' in class " +
+        s"${info.displayName} when emitting a Script (NoModule) because it " +
+        "is not a valid JavaScript identifier " +
+        "(did you want to emit a module instead?)"
       case ConflictingTopLevelExport(name, infos) =>
         s"Conflicting top level export for name $name involving " +
         infos.map(_.displayName).mkString(", ")


### PR DESCRIPTION
When emitting a Script (`NoModule`), we cannot export on the top-level under a name that is not a valid JavaScript identifier. Such exports must be emitted as `var`s or `let`s, which is only possible for valid JS identifiers.

Previously, attempts at such invalid exports would silently result in invalid .js code, producing a `SyntaxError` at run-time. In this commit, we preemptively report a linking error instead (as a thrown `LinkingException`).

It can be argued that we might want fallback behaviors for these cases, as discussed in #4061. However, this commit is a definitive improvement over the status quo, and leaves the door open for fallbacks in the future, if they prove desirable/necessary.