### PR TITLE
WiP Remove the dependency from linker-interface on scalajs-ir.

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleInitializer.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleInitializer.scala
@@ -12,9 +12,6 @@
 
 package org.scalajs.linker.interface
 
-import org.scalajs.ir.Names._
-import org.scalajs.ir.Types._
-
 import org.scalajs.linker.interface.unstable.ModuleInitializerImpl
 
 import Fingerprint.FingerprintBuilder
@@ -39,9 +36,6 @@ abstract class ModuleInitializer private[interface] () {
 object ModuleInitializer {
   import ModuleInitializerImpl._
 
-  private val ArrayOfStringTypeRef =
-    ArrayTypeRef(ClassRef(BoxedStringClass), 1)
-
   /** Makes a [[ModuleInitializer]] that calls a static zero-argument method
    *  returning `Unit` in a top-level `class`.
    *
@@ -52,8 +46,7 @@ object ModuleInitializer {
    */
   def mainMethod(className: String,
       mainMethodName: String): ModuleInitializer = {
-    VoidMainMethod(ClassName(className),
-        MethodName(mainMethodName, Nil, VoidRef))
+    VoidMainMethod(className, mainMethodName)
   }
 
   /** Makes a [[ModuleInitializer]] that calls a static method of a top-level
@@ -85,21 +78,7 @@ object ModuleInitializer {
    */
   def mainMethodWithArgs(className: String, mainMethodName: String,
       args: List[String]): ModuleInitializer = {
-    MainMethodWithArgs(ClassName(className),
-        MethodName(mainMethodName, ArrayOfStringTypeRef :: Nil, VoidRef),
-        args)
-  }
-
-  private implicit object MethodNameFingerprint
-      extends Fingerprint[MethodName] {
-
-    override def fingerprint(methodName: MethodName): String =
-      methodName.nameString
-  }
-
-  private implicit object ClassNameFingerprint extends Fingerprint[ClassName] {
-    override def fingerprint(className: ClassName): String =
-      className.nameString
+    MainMethodWithArgs(className, mainMethodName, args)
   }
 
   private implicit object ModuleInitializerFingerprint

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/IRContainerImpl.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/IRContainerImpl.scala
@@ -16,7 +16,6 @@ import scala.concurrent._
 
 import java.io.IOException
 
-import org.scalajs.ir
 import org.scalajs.linker.interface.{IRContainer, IRFile}
 
 /** A virtual file containing Scala.js IR.

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/IRFileImpl.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/IRFileImpl.scala
@@ -14,10 +14,6 @@ package org.scalajs.linker.interface.unstable
 
 import scala.concurrent._
 
-import java.io.IOException
-
-import org.scalajs.ir
-
 import org.scalajs.linker.interface.IRFile
 
 /** A virtual Scala.js IR file.
@@ -44,25 +40,15 @@ abstract class IRFileImpl(
   private[interface] final def impl: IRFileImpl = this
 
   /** Entry points information for this file. */
-  def entryPointsInfo(implicit ec: ExecutionContext): Future[ir.EntryPointsInfo]
+  def entryPointsInfo(implicit ec: ExecutionContext): Future[IRFileImpl.EntryPointsInfo]
 
   /** IR Tree of this file. */
-  def tree(implicit ec: ExecutionContext): Future[ir.Trees.ClassDef]
+  def tree(implicit ec: ExecutionContext): Future[IRFileImpl.ClassDef]
 }
 
 object IRFileImpl {
+  type EntryPointsInfo
+  type ClassDef
+
   def fromIRFile(irFile: IRFile): IRFileImpl = irFile.impl
-
-  def withPathExceptionContext[A](path: String, future: Future[A])(
-      implicit ec: ExecutionContext): Future[A] = {
-    future.recover {
-      case e: ir.IRVersionNotSupportedException =>
-        throw new ir.IRVersionNotSupportedException(e.version, e.supported,
-            s"Failed to deserialize a file compiled with Scala.js ${e.version}" +
-            s" (supported up to: ${e.supported}): $path", e)
-
-      case e: Exception =>
-        throw new IOException(s"Failed to deserialize $path", e)
-    }
-  }
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/ModuleInitializerImpl.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/ModuleInitializerImpl.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.linker.interface.unstable
 
-import org.scalajs.ir.Names._
-
 import org.scalajs.linker.interface.ModuleInitializer
 
 /** A module initializer for a Scala.js application.
@@ -35,11 +33,11 @@ sealed abstract class ModuleInitializerImpl extends ModuleInitializer {
 object ModuleInitializerImpl {
   def fromModuleInitializer(mi: ModuleInitializer): ModuleInitializerImpl = mi.impl
 
-  final case class VoidMainMethod(className: ClassName,
-      encodedMainMethodName: MethodName)
+  final case class VoidMainMethod(className: String,
+      encodedMainMethodName: String)
       extends ModuleInitializerImpl
 
-  final case class MainMethodWithArgs(className: ClassName,
-      encodedMainMethodName: MethodName, args: List[String])
+  final case class MainMethodWithArgs(className: String,
+      encodedMainMethodName: String, args: List[String])
       extends ModuleInitializerImpl
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -1313,11 +1313,13 @@ private[emitter] final class ClassEmitter(jsGen: JSGen) {
 
     ModuleInitializerImpl.fromModuleInitializer(moduleInitializer) match {
       case VoidMainMethod(className, mainMethodName) =>
-        js.Apply(classVar("s", className, mainMethodName), Nil)
+        js.Apply(classVar("s", ClassName(className),
+            MethodName(mainMethodName, Nil, VoidRef)), Nil)
 
       case MainMethodWithArgs(className, mainMethodName, args) =>
         val stringArrayTypeRef = ArrayTypeRef(ClassRef(BoxedStringClass), 1)
-        js.Apply(classVar("s", className, mainMethodName),
+        js.Apply(classVar("s", ClassName(className),
+            MethodName(mainMethodName, stringArrayTypeRef :: Nil, VoidRef)),
             genArrayValue(stringArrayTypeRef, args.map(js.StringLiteral(_))) :: Nil)
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/ConcreteIRFileImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/ConcreteIRFileImpl.scala
@@ -1,0 +1,40 @@
+package org.scalajs.linker.standard
+
+import java.io.IOException
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import org.scalajs.ir.EntryPointsInfo
+import org.scalajs.ir.IRVersionNotSupportedException
+import org.scalajs.ir.Trees.ClassDef
+
+import org.scalajs.linker.interface.unstable.IRFileImpl
+
+object ConcreteIRFileImpl {
+  def fromIRFileImplEntryPointsInfo(
+      entryPointsInfo: IRFileImpl.EntryPointsInfo): EntryPointsInfo =
+    entryPointsInfo.asInstanceOf[EntryPointsInfo]
+
+  def fromIRFileImplClassDef(classDef: IRFileImpl.ClassDef): ClassDef =
+    classDef.asInstanceOf[ClassDef]
+
+  def toIRFileImplEntryPointsInfo(
+      entryPointsInfo: EntryPointsInfo): IRFileImpl.EntryPointsInfo =
+    entryPointsInfo.asInstanceOf[IRFileImpl.EntryPointsInfo]
+
+  def toIRFileImplClassDef(classDef: ClassDef): IRFileImpl.ClassDef =
+    classDef.asInstanceOf[IRFileImpl.ClassDef]
+
+  def withPathExceptionContext[A](path: String, future: Future[A])(
+      implicit ec: ExecutionContext): Future[A] = {
+    future.recover {
+      case e: IRVersionNotSupportedException =>
+        throw new IRVersionNotSupportedException(e.version, e.supported,
+            s"Failed to deserialize a file compiled with Scala.js ${e.version}" +
+            s" (supported up to: ${e.supported}): $path", e)
+
+      case e: Exception =>
+        throw new IOException(s"Failed to deserialize $path", e)
+    }
+  }
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/MemIRFile.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/MemIRFile.scala
@@ -21,22 +21,24 @@ import org.scalajs.ir
 import org.scalajs.linker.interface.IRFile
 import org.scalajs.linker.interface.unstable.IRFileImpl
 
+import ConcreteIRFileImpl._
+
 /** A simple in-memory virtual serialized Scala.js IR file. */
 final class MemIRFileImpl(
     path: String,
     version: Option[String],
     content: Array[Byte]
 ) extends IRFileImpl(path, version) {
-  def entryPointsInfo(implicit ec: ExecutionContext): Future[ir.EntryPointsInfo] =
-    withBuffer(ir.Serializers.deserializeEntryPointsInfo)
+  def entryPointsInfo(implicit ec: ExecutionContext): Future[IRFileImpl.EntryPointsInfo] =
+    withBuffer(buf => toIRFileImplEntryPointsInfo(ir.Serializers.deserializeEntryPointsInfo(buf)))
 
-  def tree(implicit ec: ExecutionContext): Future[ir.Trees.ClassDef] =
-    withBuffer(ir.Serializers.deserialize)
+  def tree(implicit ec: ExecutionContext): Future[IRFileImpl.ClassDef] =
+    withBuffer(buf => toIRFileImplClassDef(ir.Serializers.deserialize(buf)))
 
   @inline
   private def withBuffer[A](f: ByteBuffer => A)(
       implicit ec: ExecutionContext): Future[A] = {
     val result = Future(f(ByteBuffer.wrap(content)))
-    IRFileImpl.withPathExceptionContext(path, result)
+    withPathExceptionContext(path, result)
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardIRFileCache.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardIRFileCache.scala
@@ -21,9 +21,6 @@ import java.net.URI
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
 
-import org.scalajs.ir.EntryPointsInfo
-import org.scalajs.ir.Trees.ClassDef
-
 import org.scalajs.linker.interface._
 import org.scalajs.linker.interface.unstable._
 
@@ -216,15 +213,15 @@ final class StandardIRFileCache extends IRFileCacheImpl {
       implicit ec: ExecutionContext) extends IRFileImpl(_irFile.path, _irFile.version) {
 
     @volatile
-    private[this] var _tree: Future[ClassDef] = null
+    private[this] var _tree: Future[IRFileImpl.ClassDef] = null
 
     // Force reading of entry points since we'll definitely need them.
-    private[this] val _entryPointsInfo: Future[EntryPointsInfo] = _irFile.entryPointsInfo
+    private[this] val _entryPointsInfo: Future[IRFileImpl.EntryPointsInfo] = _irFile.entryPointsInfo
 
-    override def entryPointsInfo(implicit ec: ExecutionContext): Future[EntryPointsInfo] =
+    override def entryPointsInfo(implicit ec: ExecutionContext): Future[IRFileImpl.EntryPointsInfo] =
       _entryPointsInfo
 
-    override def tree(implicit ec: ExecutionContext): Future[ClassDef] = {
+    override def tree(implicit ec: ExecutionContext): Future[IRFileImpl.ClassDef] = {
       if (_tree == null) {
         synchronized {
           if (_tree == null) { // check again, race!

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
@@ -13,6 +13,7 @@
 package org.scalajs.linker.standard
 
 import org.scalajs.ir.Names._
+import org.scalajs.ir.Types._
 
 import org.scalajs.linker.interface.ModuleInitializer
 import org.scalajs.linker.interface.unstable.ModuleInitializerImpl
@@ -130,6 +131,9 @@ object SymbolRequirement {
     case object NoRequirement extends SymbolRequirement
   }
 
+  private val ArrayOfStringTypeRef =
+    ArrayTypeRef(ClassRef(BoxedStringClass), 1)
+
   private[linker] def fromModuleInitializer(
       entryPoints: Seq[ModuleInitializer]): SymbolRequirement = {
     import ModuleInitializerImpl._
@@ -138,10 +142,12 @@ object SymbolRequirement {
     val requirements = for (entryPoint <- entryPoints) yield {
       ModuleInitializerImpl.fromModuleInitializer(entryPoint) match {
         case VoidMainMethod(className, mainMethodName) =>
-          factory.callStaticMethod(className, mainMethodName)
+          factory.callStaticMethod(ClassName(className),
+              MethodName(mainMethodName, Nil, VoidRef))
 
         case MainMethodWithArgs(className, mainMethodName, _) =>
-          factory.callStaticMethod(className, mainMethodName) ++
+          factory.callStaticMethod(ClassName(className),
+              MethodName(mainMethodName, ArrayOfStringTypeRef :: Nil, VoidRef)) ++
           factory.classData(BoxedStringClass)
       }
     }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/MemClassDefIRFile.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/MemClassDefIRFile.scala
@@ -19,15 +19,16 @@ import org.scalajs.ir.Trees.ClassDef
 
 import org.scalajs.linker.interface.IRFile
 import org.scalajs.linker.interface.unstable.IRFileImpl
+import org.scalajs.linker.standard.ConcreteIRFileImpl._
 
 private final class MemClassDefIRFile(classDef: ClassDef)
     extends IRFileImpl("mem://" + classDef.name.name + ".sjsir", None) {
 
-  def tree(implicit ec: ExecutionContext): Future[ClassDef] =
-    Future(classDef)
+  def tree(implicit ec: ExecutionContext): Future[IRFileImpl.ClassDef] =
+    Future(toIRFileImplClassDef(classDef))
 
-  def entryPointsInfo(implicit ec: ExecutionContext): Future[EntryPointsInfo] =
-    tree.map(EntryPointsInfo.forClassDef)
+  def entryPointsInfo(implicit ec: ExecutionContext): Future[IRFileImpl.EntryPointsInfo] =
+    Future(toIRFileImplEntryPointsInfo(EntryPointsInfo.forClassDef(classDef)))
 }
 
 object MemClassDefIRFile {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -691,7 +691,7 @@ object Build {
           "org.scala-js" %% "scalajs-logging" % "1.1.1",
           "com.novocode" % "junit-interface" % "0.11" % "test",
       ),
-  ).dependsOn(irProject)
+  )
 
   lazy val linkerInterfaceJS: MultiScalaProject = MultiScalaProject(
       id = "linkerInterfaceJS", base = file("linker-interface/js")
@@ -736,7 +736,7 @@ object Build {
         fileSet.toSeq.filter(_.getPath().endsWith(".scala"))
       }.taskValue,
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      library, irProjectJS, jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test",
+      library, jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test",
   )
 
   lazy val linkerPrivateLibrary: Project = (project in file("linker-private-library")).enablePlugins(

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSCrossVersion.scala
@@ -14,10 +14,8 @@ package org.scalajs.sbtplugin
 
 import sbt._
 
-import org.scalajs.ir.ScalaJSVersions
-
 object ScalaJSCrossVersion {
-  private val sjsPrefix = "sjs" + ScalaJSVersions.binaryCross + "_"
+  private val sjsPrefix = "sjs1_"
 
   val binary: CrossVersion =
     CrossVersion.binaryWith(prefix = sjsPrefix, suffix = "")

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -17,8 +17,6 @@ import scala.language.implicitConversions
 import sbt._
 import sbt.Keys._
 
-import org.scalajs.ir.ScalaJSVersions
-
 import org.scalajs.linker.interface._
 
 import org.scalajs.jsenv.{Input, JSEnv}
@@ -31,7 +29,7 @@ object ScalaJSPlugin extends AutoPlugin {
     import KeyRanks._
 
     /** The current version of the Scala.js sbt plugin and tool chain. */
-    val scalaJSVersion = ScalaJSVersions.current
+    val scalaJSVersion = "1.1.1-SNAPSHOT"
 
     /** Declares [[sbt.Tags.Tag Tag]]s which may be used to limit the
      *  concurrency of build tasks.


### PR DESCRIPTION
And since sbt-scalajs only depends on linker-interface, this transitively removes the dependency from sbt-scalajs on scalajs-ir as well.