### PR TITLE
Fix #4089: Do not `addAnnotation` on `NoSymbol`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -1203,8 +1203,11 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
         sym.addAnnotation(ExposedJSMemberAnnot)
         /* For accessors, the field being accessed must also be exposed,
          * although it is private.
+         *
+         * #4089 Don't do this if `sym.accessed == NoSymbol`. This happens in
+         * 2.12+, where fields are created later than this phase.
          */
-        if (sym.isAccessor)
+        if (sym.isAccessor && sym.accessed != NoSymbol)
           sym.accessed.addAnnotation(ExposedJSMemberAnnot)
       }
     }


### PR DESCRIPTION
We were blindly doing `sym.accessed.addAnnotation()` in one spot, without first checking that `sym.accessed != NoSymbol`. This was wrong in Scala 2.12+ because fields are created later than the `PrepJSInterop` phase, leading to adding an annotation on `NoSymbol`.

---

I manually checked that this fixes the overcompilation reported in the original ticket https://github.com/sbt/zinc/issues/718, after having upgrade the reproduction to 1.1.1-SNAPSHOT (and reproducing the overcompilation on the latest master).

/cc @retronym