### PR TITLE
Split test case from RegressionTest to scala 2.x

### DIFF
--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/RegressionTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/RegressionTestScala2.scala
@@ -1,0 +1,30 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.compiler
+
+import org.junit.Test
+import org.junit.Assert.assertEquals
+
+class RegressionTestTestScala2 {
+
+  /**
+   * This is a Scala 2.x only test because:
+   * The extension method any2stringadd (the `+` in `x + "check"`)
+   * was deprecated in 2.13.0 and Dotty no longer has the method.
+   */
+  @Test def String_concatenation_with_null_issue_26(): Unit = {
+    val x: Object = null
+    assertEquals("nullcheck", x + "check")
+  }
+
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -73,11 +73,6 @@ class RegressionTest {
     assertEquals(39, strQuotes.charAt(1).toInt)
   }
 
-  @Test def String_concatenation_with_null_issue_26(): Unit = {
-    val x: Object = null
-    assertEquals("nullcheck", x + "check")
-  }
-
   @Test def should_emit_static_calls_when_forwarding_to_another_constructor_issue_66(): Unit = {
     new Bug66B("", "")
   }


### PR DESCRIPTION
The extension method any2stringadd was deprecated in 2.13.0.
Dotty no longer has that method.