### PR TITLE
Fix #4086: Expose `object`s and `class`es in top-level JS objects.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitInnerJS.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ExplicitInnerJS.scala
@@ -43,6 +43,38 @@ import scala.collection.mutable
  *
  *  These fields will be read by code generated in `ExplicitLocalJS`.
  *
+ *  A `\$jsclass` field is also generated for classes declared inside *static
+ *  JS objects*. Indeed, even though those classes have a unique, globally
+ *  accessible class value, that class value needs to be *exposed* as a field
+ *  of the enclosing object. In those cases, the rhs of the field is a direct
+ *  call to `runtime.constructorOf[classOf[Inner]]`.
+ *
+ *  Finally, for *modules* declared inside static JS objects, we generate an
+ *  explicit exposed getter as well. For non-static objects, scalac already
+ *  generates a getter with the `@ExposedJSMember` annotation, so we do not
+ *  need to do anything. But for static objects, it doesn't, so we have to do
+ *  it ourselves here.
+ *
+ *  To illustrate the two above paragraphs, for the following input:
+ *  {{{
+ *  object Outer extends js.Object {
+ *    class InnerClass extends ParentJSClass
+ *    object InnerObject extends SomeOtherJSClass
+ *  }
+ *  }}}
+ *  this phase will generate
+ *  {{{
+ *  object Outer extends js.Object {
+ *    ...
+ *
+ *    @ExposedJSMember @JSName("InnerClass")
+ *    val InnerClass\$jsclass: AnyRef = runtime.constructorOf(classOf[InnerClass])
+ *
+ *    @ExposedJSMember @JSName("InnerObject")
+ *    def InnerObject\$jsobject: AnyRef = InnerObject
+ *  }
+ *  }}}
+ *
  *  Note that this field must also be added to outer classes and traits coming
  *  from separate compilation, therefore this phase is an `InfoTransform`.
  *  Since the `transformInfo` also applies to classes defined in the current
@@ -93,10 +125,19 @@ abstract class ExplicitInnerJS[G <: Global with Singleton](val global: G)
 
   /** Is the given symbol an owner for which this transformation applies?
    *
-   *  This applies if it is not a static owner.
+   *  This applies if either or both of the following are true:
+   *  - It is not a static owner, or
+   *  - It is a non-native JS object.
+   *
+   *  The latter is necessary for #4086.
    */
-  private def isApplicableOwner(sym: Symbol): Boolean =
-    !sym.isStaticOwner
+  private def isApplicableOwner(sym: Symbol): Boolean = {
+    !sym.isStaticOwner || (
+        sym.isModuleClass &&
+        sym.hasAnnotation(JSTypeAnnot) &&
+        !sym.hasAnnotation(JSNativeAnnotation)
+    )
+  }
 
   /** Is the given symbol a JS class (that is not a trait nor an object)? */
   private def isJSClass(sym: Symbol): Boolean = {
@@ -105,6 +146,13 @@ abstract class ExplicitInnerJS[G <: Global with Singleton](val global: G)
     sym.hasAnnotation(JSTypeAnnot)
   }
 
+  /** Is the given symbol a Module that should be exposed? */
+  private def isExposedModule(sym: Symbol): Boolean =
+    sym.isModule && sym.hasAnnotation(ExposedJSMemberAnnot)
+
+  private def jsobjectGetterNameFor(moduleSym: Symbol): TermName =
+    moduleSym.name.append("$jsobject").toTermName
+
   /** Transforms the info of types to add the `Inner\$jsclass` fields.
    *
    *  This method was inspired by `ExplicitOuter.transformInfo`.
@@ -112,23 +160,32 @@ abstract class ExplicitInnerJS[G <: Global with Singleton](val global: G)
   def transformInfo(sym: Symbol, tp: Type): Type = tp match {
     case ClassInfoType(parents, decls, clazz) if !clazz.isJava && isApplicableOwner(clazz) =>
       val innerJSClasses = decls.filter(isJSClass)
-      if (innerJSClasses.isEmpty) {
+
+      val innerObjectsForAdHocExposed =
+        if (!clazz.isStaticOwner) Nil // those receive a module accessor from scalac
+        else decls.filter(isExposedModule).toList
+
+      if (innerJSClasses.isEmpty && innerObjectsForAdHocExposed.isEmpty) {
         tp
       } else {
+        def addAnnots(sym: Symbol, symForName: Symbol): Unit = {
+          symForName.getAnnotation(JSNameAnnotation).fold {
+            sym.addAnnotation(JSNameAnnotation,
+                Literal(Constant(jsInterop.defaultJSNameOf(symForName))))
+          } { annot =>
+            sym.addAnnotation(annot)
+          }
+          sym.addAnnotation(ExposedJSMemberAnnot)
+        }
+
         val clazzIsJSClass = clazz.hasAnnotation(JSTypeAnnot)
 
         val decls1 = decls.cloneScope
+
         for (innerJSClass <- innerJSClasses) {
           def addAnnotsIfInJSClass(sym: Symbol): Unit = {
-            if (clazzIsJSClass) {
-              innerJSClass.getAnnotation(JSNameAnnotation).fold {
-                sym.addAnnotation(JSNameAnnotation,
-                    Literal(Constant(jsInterop.defaultJSNameOf(innerJSClass))))
-              } { annot =>
-                sym.addAnnotation(annot)
-              }
-              sym.addAnnotation(ExposedJSMemberAnnot)
-            }
+            if (clazzIsJSClass)
+              addAnnots(sym, innerJSClass)
           }
 
           val accessorName: TermName =
@@ -152,6 +209,20 @@ abstract class ExplicitInnerJS[G <: Global with Singleton](val global: G)
             decls1.enter(field)
           }
         }
+
+        // #4086 Create exposed getters for exposed objects in static JS objects
+        for (innerObject <- innerObjectsForAdHocExposed) {
+          assert(clazzIsJSClass && clazz.isModuleClass && clazz.isStatic,
+              s"trying to ad-hoc expose objects in non-JS static object")
+
+          val getterName = jsobjectGetterNameFor(innerObject)
+          val getterFlags = Flags.SYNTHETIC | Flags.ARTIFACT | Flags.STABLE
+          val getter = clazz.newMethod(getterName, innerObject.pos, getterFlags)
+          getter.setInfo(NullaryMethodType(AnyRefTpe))
+          addAnnots(getter, innerObject)
+          decls1.enter(getter)
+        }
+
         ClassInfoType(parents, decls1, clazz)
       }
 
@@ -182,19 +253,26 @@ abstract class ExplicitInnerJS[G <: Global with Singleton](val global: G)
           atOwner(tree, currentOwner) {
             for (decl <- decls) {
               val declSym = decl.symbol
-              if ((declSym ne null) && isJSClass(declSym)) {
+              if (declSym eq null) {
+                // not a member def, do nothing
+              } else if (isJSClass(declSym)) {
                 val jsclassAccessor = jsclassAccessorFor(declSym)
 
                 val rhs = if (currentOwner.hasAnnotation(JSNativeAnnotation)) {
                   gen.mkAttributedRef(JSPackage_native)
                 } else {
                   val clazzValue = gen.mkClassOf(declSym.tpe_*)
-                  val parentTpe =
-                    extractSuperTpeFromImpl(decl.asInstanceOf[ClassDef].impl)
-                  val superClassCtor = gen.mkNullaryCall(
-                      JSPackage_constructorOf, List(parentTpe))
-                  gen.mkMethodCall(Runtime_createInnerJSClass,
-                      List(clazzValue, superClassCtor))
+                  if (currentOwner.isStaticOwner) {
+                    // #4086
+                    gen.mkMethodCall(Runtime_constructorOf, List(clazzValue))
+                  } else {
+                    val parentTpe =
+                      extractSuperTpeFromImpl(decl.asInstanceOf[ClassDef].impl)
+                    val superClassCtor = gen.mkNullaryCall(
+                        JSPackage_constructorOf, List(parentTpe))
+                    gen.mkMethodCall(Runtime_createInnerJSClass,
+                        List(clazzValue, superClassCtor))
+                  }
                 }
 
                 if (!currentOwner.isTrait || !traitValsHoldTheirGetterSymbol) {
@@ -207,6 +285,18 @@ abstract class ExplicitInnerJS[G <: Global with Singleton](val global: G)
                   }
                 } else {
                   newDecls += localTyper.typedValDef(ValDef(jsclassAccessor, rhs))
+                }
+              } else if (currentOwner.isStaticOwner) {
+                // #4086
+                val maybeModuleSym =
+                  if (declSym.isModuleClass) declSym.module // Necessary for Scala 2.11
+                  else declSym
+                if (isExposedModule(maybeModuleSym)) {
+                  val getter =
+                    currentOwner.info.member(jsobjectGetterNameFor(maybeModuleSym))
+                  newDecls += localTyper.typedDefDef {
+                    DefDef(getter, gen.mkAttributedRef(maybeModuleSym))
+                  }
                 }
               }
 


### PR DESCRIPTION
`object`s (resp. `class`es) in top-level objects are static, and therefore do not receive getters from scalac (resp. the inner JS class treatment of `ExplicitInnerJS`). This is problematic if the enclosing top-level object is a JS object, as it prevents JavaScript code from accessing those objects and classes as members of the top-level object.

To fix this issue, we extend the `ExplicitInnerJS` phase to:

* Apply the existing transformation of JS classes if they are in a static JS object (with an rhs for the field which is just `js.constructorOf[Inner.C]`).
* Create exposed getters for objects (Scala and JS) if they are in a static JS object.