### PR TITLE
Restrict type of JSON.stringify.space and improve doc

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.1.2-SNAPSHOT",
+    current = "1.2.0-SNAPSHOT",
     binaryEmitted = "1.1"
 )
 

--- a/library/src/main/scala/scala/scalajs/js/JSON.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSON.scala
@@ -72,15 +72,22 @@ object JSON extends js.Object {
    * @param replacer If a function, transforms values and properties encountered
    *                 while stringifying; if an array, specifies the set of
    *                 properties included in objects in the final string.
-   * @param space Causes the resulting string to be pretty-printed.
+   * @param space A String or Int that's used to insert white space into the
+   *              output JSON string for readability purposes. If this is an
+   *              Int, it indicates the number of space characters to use as
+   *              white space; this number is capped at 10; values less than 1
+   *              indicate that no space should be used. If this is a String,
+   *              the string (or the first 10 characters of the string, if it's
+   *              longer than that) is used as white space. If this parameter is
+   *              not provided (or is null), no white space is used.
    *
    * MDN
    */
   // scalastyle:on line.size.limit
   def stringify(value: js.Any,
       replacer: js.Function2[String, js.Any, js.Any] = ???,
-      space: js.Any = ???): String = js.native
+      space: Int | String = ???): String = js.native
   def stringify(value: js.Any, replacer: js.Array[Any]): String = js.native
   def stringify(value: js.Any, replacer: js.Array[Any],
-      space: js.Any): String = js.native
+      space: Int | String): String = js.native
 }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -23,6 +23,11 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+      // Native types, not an issue.
+      exclude[IncompatibleMethTypeProblem](
+          "scala.scalajs.js.JSON.stringify"),
+      exclude[IncompatibleResultTypeProblem](
+          "scala.scalajs.js.JSON.stringify$default$3"),
   )
 
   val TestInterface = Seq(


### PR DESCRIPTION
This is a potentially source incompatible change. It is binary compatible, since native types do not appear at the binary level.