### PR TITLE
Avoid Option(null) from UndefOrOps#toOption

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/UndefOrOps.scala
@@ -229,7 +229,7 @@ final class UndefOrOps[A] private[js] (private val self: js.UndefOr[A])
    *  if this $option is nonempty, [[scala.None None]] otherwise.
    */
   @inline final def toOption: Option[A] =
-    if (isEmpty) None else Some(this.forceGet)
+    if (isEmpty) None else Option(this.forceGet)
 }
 
 object UndefOrOps {


### PR DESCRIPTION
The `UndefOrOps#toOption` method may return `Option(null)` which is unlikely what users expect, now, it returns `None` instead.