### PR TITLE
Use a js.Block as result from Emitter

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -31,10 +31,10 @@ import scala.annotation.tailrec
 import java.net.URI
 
 private[closure] object ClosureAstTransformer {
-  def transformScript(trees: List[Tree], featureSet: FeatureSet,
+  def transformScript(tree: Tree, featureSet: FeatureSet,
       relativizeBaseURI: Option[URI]): Node = {
     val transformer = new ClosureAstTransformer(featureSet, relativizeBaseURI)
-    transformer.transformScript(trees)
+    transformer.transformScript(tree)
   }
 }
 
@@ -42,7 +42,7 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
     relativizeBaseURI: Option[URI]) {
   private val dummySourceName = new java.net.URI("virtualfile:scala.js-ir")
 
-  def transformScript(trees: List[Tree]): Node = {
+  def transformScript(tree: Tree): Node = {
     /* Top-level `js.Block`s must be explicitly flattened here.
      * Our `js.Block`s do not have the same semantics as GCC's `BLOCK`s: GCC's
      * impose strict scoping for `let`s, `const`s and `class`es, while ours are
@@ -51,7 +51,7 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
      */
     val script = setNodePosition(new Node(Token.SCRIPT), NoPosition)
 
-    trees.foreach {
+    tree match {
       case Block(stats) =>
         transformBlockStats(stats)(NoPosition).foreach(script.addChildToBack(_))
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -104,8 +104,8 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
     }
   }
 
-  private def buildModule(trees: List[js.Tree]): JSModule = {
-    val root = ClosureAstTransformer.transformScript(trees,
+  private def buildModule(tree: js.Tree): JSModule = {
+    val root = ClosureAstTransformer.transformScript(tree,
         languageMode.toFeatureSet(), config.relativizeSourceMapBase)
 
     val module = new JSModule("Scala.js")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -63,7 +63,7 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
           val printer = new Printers.JSTreePrinter(writer)
           writer.write(emitterResult.header)
           writer.write("'use strict';\n")
-          emitterResult.body.foreach(printer.printTopLevelTree _)
+          printer.printTopLevelTree(emitterResult.body)
           writer.write(emitterResult.footer)
         }
 
@@ -82,7 +82,7 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
           writer.write("'use strict';\n")
           sourceMapWriter.nextLine()
 
-          emitterResult.body.foreach(printer.printTopLevelTree _)
+          printer.printTopLevelTree(emitterResult.body)
 
           writer.write(emitterResult.footer)
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,6 +8,16 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
+      // Breaking in the unstable API.
+      exclude[IncompatibleResultTypeProblem](
+          "org.scalajs.linker.backend.emitter.Emitter#Result.body"),
+      exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.linker.backend.javascript.Trees#Block.apply"),
+
+      // private[closure], not an issue.
+      exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.linker.backend.closure.ClosureAstTransformer.transformScript"),
+
       // private[emitter], not an issue.
       exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.emitter.ClassEmitter.org$scalajs$linker$backend$emitter$ClassEmitter$$classVarDef$default$4"),
@@ -83,6 +93,8 @@ object BinaryIncompatibilities {
           "org.scalajs.linker.backend.emitter.JSGen.useBigIntForLongs"),
       exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.emitter.JSGen.varGen"),
+      exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.linker.backend.emitter.Emitter#Result.this"),
       exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.emitter.VarGen.classVarIdent"),
       exclude[IncompatibleMethTypeProblem](


### PR DESCRIPTION
js.Blocks are a specialized way of returning a list of trees. As such,
using List[js.Tree] as a way to return multiple trees is inconsistent.