### PR TITLE
Store isParentDataAccessed in LinkingUnit

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -33,6 +33,7 @@ trait Analysis {
   import Analysis._
 
   def classInfos: scala.collection.Map[ClassName, ClassInfo]
+  def isParentDataAccessed: Boolean
   def errors: scala.collection.Seq[Error]
 }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -59,6 +59,8 @@ private final class Analyzer(config: CommonPhaseConfig,
   def classInfos: scala.collection.Map[ClassName, Analysis.ClassInfo] =
     _loadedClassInfos
 
+  var isParentDataAccessed: Boolean = false
+
   def errors: scala.collection.Seq[Error] = _errors
 
   def computeReachability(): Future[Unit] = {
@@ -216,6 +218,8 @@ private final class Analyzer(config: CommonPhaseConfig,
         classClassInfo.flatMap(_.publicMethodInfos.get(getSuperclassMethodName))
       if getSuperclassMethodInfo.isReachable
     } {
+      isParentDataAccessed = true
+
       // calledFrom should always be nonEmpty if isReachable, but let's be robust
       implicit val from =
         getSuperclassMethodInfo.calledFrom.headOption.getOrElse(fromAnalyzer)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterNames.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterNames.scala
@@ -77,6 +77,5 @@ private[emitter] object EmitterNames {
   val floatValueMethodName = MethodName("floatValue", Nil, FloatRef)
   val doubleValueMethodName = MethodName("doubleValue", Nil, DoubleRef)
   val getNameMethodName = MethodName("getName", Nil, ClassRef(BoxedStringClass))
-  val getSuperclassMethodName = MethodName("getSuperclass", Nil, ClassRef(ClassClass))
 
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -125,7 +125,7 @@ final class BaseLinker(config: CommonPhaseConfig) {
       linkedClassDefs <- Future.traverse(analysis.classInfos.values)(assembleClass)
     } yield {
       new LinkingUnit(config.coreSpec, linkedClassDefs.toList,
-          moduleInitializers.toList)
+          moduleInitializers.toList, analysis.isParentDataAccessed)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -59,7 +59,8 @@ final class Refiner(config: CommonPhaseConfig) {
           refineClassDef(linkedClassesByName(info.className), info)
         }
 
-        new LinkingUnit(unit.coreSpec, linkedClassDefs.toList, unit.moduleInitializers)
+        new LinkingUnit(unit.coreSpec, linkedClassDefs.toList,
+            unit.moduleInitializers, analysis.isParentDataAccessed)
       }
 
       inputProvider.cleanAfterRun()

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -128,7 +128,8 @@ abstract class GenIncOptimizer private[optimizer] (config: CommonPhaseConfig) {
         linkedClass.optimized(methods = newMethods)
       }
 
-      new LinkingUnit(unit.coreSpec, newLinkedClasses, unit.moduleInitializers)
+      new LinkingUnit(unit.coreSpec, newLinkedClasses, unit.moduleInitializers,
+          unit.isParentDataAccessed)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkingUnit.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkingUnit.scala
@@ -17,5 +17,6 @@ import org.scalajs.linker.interface.ModuleInitializer
 final class LinkingUnit private[linker] (
     val coreSpec: CoreSpec,
     val classDefs: List[LinkedClass],
-    val moduleInitializers: List[ModuleInitializer]
+    val moduleInitializers: List[ModuleInitializer],
+    val isParentDataAccessed: Boolean
 )

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -9,6 +9,8 @@ object BinaryIncompatibilities {
 
   val Linker = Seq(
       // Breaking in the unstable API.
+      exclude[ReversedMissingMethodProblem](
+          "org.scalajs.linker.analyzer.Analysis.isParentDataAccessed"),
       exclude[IncompatibleResultTypeProblem](
           "org.scalajs.linker.backend.emitter.Emitter#Result.body"),
       exclude[IncompatibleMethTypeProblem](
@@ -96,6 +98,8 @@ object BinaryIncompatibilities {
       exclude[IncompatibleMethTypeProblem](
           "org.scalajs.linker.backend.emitter.Emitter#Result.this"),
       exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.backend.emitter.EmitterNames.getSuperclassMethodName"),
+      exclude[DirectMissingMethodProblem](
           "org.scalajs.linker.backend.emitter.VarGen.classVarIdent"),
       exclude[IncompatibleMethTypeProblem](
           "org.scalajs.linker.backend.emitter.VarGen.classVarIdent"),
@@ -108,6 +112,8 @@ object BinaryIncompatibilities {
 
       // private[linker], not an issue.
       exclude[MissingClassProblem]("org.scalajs.linker.NodeFS$FS$"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.standard.LinkingUnit.this"),
 
       // private, not an issue.
       exclude[MissingClassProblem](


### PR DESCRIPTION
It is linking information just like hasRuntimeTypeInfo. As such, we
should not recalculate it, but simply store it.