### PR TITLE
Fix #4105: Type the matchEnd block of switches as NoType in statement pos.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -3496,7 +3496,9 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
        */
       val genSelector = genExpr(selector)
 
-      val resultType = toIRType(tree.tpe)
+      val resultType =
+        if (isStat) jstpe.NoType
+        else toIRType(tree.tpe)
 
       val defaultLabelSym = cases.collectFirst {
         case CaseDef(Ident(nme.WILDCARD), EmptyTree,


### PR DESCRIPTION
In statement position, we were always emitting `return@matchEnd (void 0)` in switches with guards, even though the type of the `matchEnd` would receive the declared type of the scalac `Match` node. This would cause a mismatch if the `Match` had a non-`Unit` type in statement position.

We fix this by forcing the type of the `matchEnd` label (and inner `If` nodes) to be `NoType` when the entire `Match` node is in statement position.