### PR TITLE
Fix #4098: Avoid `let`/`const` when building the ASTs for GCC.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -837,6 +837,13 @@ class RegressionTest {
     assertEquals(6, `class`.foo(5))
   }
 
+  @Test def gcc_crash_with_let_const_issue_4098(): Unit = {
+    val set = new java.util.HashSet[String]()
+    set.remove("")
+    set.remove("1") // only if remove is called twice
+    assertEquals(0, set.size())
+  }
+
 }
 
 object RegressionTest {


### PR DESCRIPTION
We now use `var`s instead, which do not expose the issue.

This is a workaround for an unknown root cause. We should properly fix this in the future.