### PR TITLE
Support ESModules in testHTML

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -244,6 +244,10 @@ object ScalaJSPlugin extends AutoPlugin {
     val scalaJSSourceMap = AttributeKey[File]("scalaJSSourceMap",
         "Source map file attached to an Attributed .js file.",
         BSetting)
+
+    val scalaJSTestHTMLArtifactDirectory = SettingKey[File]("scalaJSTestHTMLArtifactDirectory",
+        "Directory for artifacts produced by testHtml.",
+        BSetting)
   }
 
   import autoImport._


### PR DESCRIPTION
As a side effect, we avoid tmp files and relativize all paths. This is
to make it easier to serve the HTML page through a webserver.