### PR TITLE
Introduce the distinction between static and class initializers.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -489,7 +489,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           reflectInit.toList ::: staticModuleInit.toList
         if (staticInitializerStats.nonEmpty) {
           List(genStaticConstructorWithStats(
-              ir.Names.ClassInitializerName, // temp: emulate codegen of 1.1.x
+              ir.Names.StaticInitializerName,
               js.Block(staticInitializerStats)))
         } else {
           Nil

--- a/ir/src/main/scala/org/scalajs/ir/EntryPointsInfo.scala
+++ b/ir/src/main/scala/org/scalajs/ir/EntryPointsInfo.scala
@@ -27,6 +27,7 @@ object EntryPointsInfo {
       classDef.memberDefs.exists {
         case m: MethodDef =>
           m.flags.namespace == MemberNamespace.StaticConstructor
+            // && m.methodName.isStaticInitializer // Temp: emulate 1.1.x codegen
         case _ =>
           false
       }

--- a/ir/src/main/scala/org/scalajs/ir/EntryPointsInfo.scala
+++ b/ir/src/main/scala/org/scalajs/ir/EntryPointsInfo.scala
@@ -26,8 +26,8 @@ object EntryPointsInfo {
       classDef.topLevelExportDefs.nonEmpty ||
       classDef.memberDefs.exists {
         case m: MethodDef =>
-          m.flags.namespace == MemberNamespace.StaticConstructor
-            // && m.methodName.isStaticInitializer // Temp: emulate 1.1.x codegen
+          m.flags.namespace == MemberNamespace.StaticConstructor &&
+          m.methodName.isStaticInitializer
         case _ =>
           false
       }

--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -18,7 +18,7 @@ import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
     current = "1.2.0-SNAPSHOT",
-    binaryEmitted = "1.1"
+    binaryEmitted = "1.2-SNAPSHOT"
 )
 
 /** Helper class to allow for testing of logic. */

--- a/ir/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1187,7 +1187,8 @@ object Serializers {
              * rewrite it as a static initializers instead (`<stinit>`).
              */
             val name0 = readMethodIdent()
-            if (name0.name == ClassInitializerName &&
+            if (hacks.use11 &&
+                name0.name == ClassInitializerName &&
                 !ownerKind.isJSType) {
               MethodIdent(StaticInitializerName)(name0.pos)
             } else {
@@ -1577,6 +1578,8 @@ object Serializers {
   /** Hacks for backwards compatible deserializing. */
   private final class Hacks(sourceVersion: String) {
     val use10: Boolean = sourceVersion == "1.0"
+
+    val use11: Boolean = use10 || sourceVersion == "1.1"
   }
 
   /** Names needed for hacks. */

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -855,11 +855,9 @@ private final class Analyzer(config: CommonPhaseConfig,
       implicit val from = FromExports
 
       // Static initializer
-      if (!isJSType) {
-        tryLookupStaticLikeMethod(MemberNamespace.StaticConstructor,
-            StaticInitializerName).foreach {
-          _.reachStatic()(fromAnalyzer)
-        }
+      tryLookupStaticLikeMethod(MemberNamespace.StaticConstructor,
+          StaticInitializerName).foreach {
+        _.reachStatic()(fromAnalyzer)
       }
 
       // Top-level exports
@@ -926,7 +924,7 @@ private final class Analyzer(config: CommonPhaseConfig,
           if (isJSClass) {
             superClass.foreach(_.instantiated())
             tryLookupStaticLikeMethod(MemberNamespace.StaticConstructor,
-                StaticInitializerName).foreach {
+                ClassInitializerName).foreach {
               staticInit => staticInit.reachStatic()
             }
           } else {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -483,11 +483,7 @@ final class Emitter(config: Emitter.Config) {
 
     // Static initialization
 
-    val staticInitialization = if (linkedClass.kind.isJSType) {
-      Nil
-    } else {
-      classEmitter.genStaticInitialization(linkedClass)
-    }
+    val staticInitialization = classEmitter.genStaticInitialization(linkedClass)
 
     // Top-level exports
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -60,7 +60,11 @@ final class LinkedClass(
 
   val hasEntryPoint: Boolean = {
     topLevelExports.nonEmpty ||
-    methods.exists(_.value.flags.namespace == MemberNamespace.StaticConstructor)
+    methods.exists { m =>
+      val methodDef = m.value
+      methodDef.flags.namespace == MemberNamespace.StaticConstructor &&
+      methodDef.methodName.isStaticInitializer
+    }
   }
 
   def fullName: String = className.nameString

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -5,6 +5,15 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val IR = Seq(
+      // private, not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.ir.Serializers#Deserializer.readMemberDef"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.ir.Serializers#Deserializer.readMemberDefs"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.ir.Serializers#Deserializer.readTopLevelExportDef"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.ir.Serializers#Deserializer.readTopLevelExportDefs"),
   )
 
   val Linker = Seq(


### PR DESCRIPTION
Previously, a unique concept of static initializer was used for two different purposes:

* In Scala classes, code that is executed when initializing the module, which is always reachable.
* In JS classes, code that is executed when the class value is created, which happens lazily the first time it is accessed.

We now separate those two behaviors in two different concepts:

* Static initializers are executed when initializing the module, and are always reachable. They are valid in all kinds of classes.
* Class initializers are only valid for JS classes, and are executed when the class is created.

The encoded name `<clinit>`, which was used for all static initializers before, is now used for class initializers. To preserve backward binary compatibility, a deserialization hack turns class initializers found in Scala classes back into static initializers.

In this commit, the compiler always emits *class initializers*, to emulate the behavior of 1.1.x, and the deserialization is always applied.