### PR TITLE
Split TopLevelExportDefs away from LinkedClass

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -166,11 +166,11 @@ object Analysis {
   final case class MissingJSNativeMember(info: ClassInfo, name: MethodName, from: From) extends Error
   final case class ConflictingDefaultMethods(infos: List[MethodInfo], from: From) extends Error
 
-  final case class InvalidTopLevelExportInScript(name: String, info: ClassInfo) extends Error {
+  final case class InvalidTopLevelExportInScript(name: String, info: ClassName) extends Error {
     def from: From = FromExports
   }
 
-  final case class ConflictingTopLevelExport(name: String, infos: List[ClassInfo]) extends Error {
+  final case class ConflictingTopLevelExport(name: String, infos: List[ClassName]) extends Error {
     def from: From = FromExports
   }
 
@@ -218,12 +218,12 @@ object Analysis {
         s"Conflicting default methods: ${infos.map(_.fullDisplayName).mkString(" ")}"
       case InvalidTopLevelExportInScript(name, info) =>
         s"Invalid top level export for name '$name' in class " +
-        s"${info.displayName} when emitting a Script (NoModule) because it " +
+        s"${info.nameString} when emitting a Script (NoModule) because it " +
         "is not a valid JavaScript identifier " +
         "(did you want to emit a module instead?)"
       case ConflictingTopLevelExport(name, infos) =>
         s"Conflicting top level export for name $name involving " +
-        infos.map(_.displayName).mkString(", ")
+        infos.map(_.nameString).mkString(", ")
       case ImportWithoutModuleSupport(module, info, None, _) =>
         s"${info.displayName} needs to be imported from module " +
         s"'$module' but module support is disabled"

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -1161,21 +1161,21 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       yield js.Block(exports)(tree.pos)
   }
 
-  def genTopLevelExports(tree: LinkedClass)(
+  def genTopLevelExports(topLevelExports: List[LinkedTopLevelExport])(
       implicit globalKnowledge: GlobalKnowledge): WithGlobals[List[js.Tree]] = {
-    val exportsWithGlobals = tree.topLevelExports.map { topLevelExport =>
-      implicit val pos = topLevelExport.pos
+    val exportsWithGlobals = topLevelExports.map { topLevelExport =>
+      implicit val pos = topLevelExport.tree.pos
 
-      topLevelExport match {
+      topLevelExport.tree match {
         case TopLevelJSClassExportDef(exportName) =>
           genConstValueExportDef(
-              exportName, genNonNativeJSClassConstructor(tree.name.name))
+              exportName, genNonNativeJSClassConstructor(topLevelExport.owningClass))
         case TopLevelModuleExportDef(exportName) =>
-          genConstValueExportDef(exportName, genLoadModule(tree.name.name))
+          genConstValueExportDef(exportName, genLoadModule(topLevelExport.owningClass))
         case e: TopLevelMethodExportDef =>
           genTopLevelMethodExportDef(e)
         case e: TopLevelFieldExportDef =>
-          genTopLevelFieldExportDef(tree.className, e)
+          genTopLevelFieldExportDef(topLevelExport.owningClass, e)
       }
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -41,6 +41,8 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
    */
   def update(linkingUnit: LinkingUnit): Boolean = {
     val hasInlineableInit = computeHasInlineableInit(linkingUnit)
+    val staticFieldMirrors =
+      computeStaticFieldMirrors(linkingUnit.topLevelExports)
 
     var objectClass: LinkedClass = null
     var classClass: Option[LinkedClass] = None
@@ -50,12 +52,15 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
     for (linkedClass <- linkingUnit.classDefs) {
       val className = linkedClass.className
       val thisClassHasInlineableInit = hasInlineableInit(className)
+      val thisClassStaticFieldMirrors =
+        staticFieldMirrors.getOrElse(className, Map.empty)
+
       classes.get(className).fold[Unit] {
         // new class
         classes.put(className,
-            new Class(linkedClass, thisClassHasInlineableInit))
+            new Class(linkedClass, thisClassHasInlineableInit, thisClassStaticFieldMirrors))
       } { existingCls =>
-        existingCls.update(linkedClass, thisClassHasInlineableInit)
+        existingCls.update(linkedClass, thisClassHasInlineableInit, thisClassStaticFieldMirrors)
       }
 
       linkedClass.className match {
@@ -120,6 +125,28 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
       .toSet
   }
 
+  private def computeStaticFieldMirrors(
+      topLevelExports: List[LinkedTopLevelExport]): Map[ClassName, Map[FieldName, List[String]]] = {
+    if (config.moduleKind != ModuleKind.NoModule) {
+      Map.empty
+    } else {
+      var result = Map.empty[ClassName, Map[FieldName, List[String]]]
+      for (export <- topLevelExports) {
+        export.tree match {
+          case TopLevelFieldExportDef(exportName, FieldIdent(fieldName)) =>
+            val className = export.owningClass
+            val mirrors = result.getOrElse(className, Map.empty)
+            val newExportNames = exportName :: mirrors.getOrElse(fieldName, Nil)
+            val newMirrors = mirrors.updated(fieldName, newExportNames)
+            result = result.updated(className, newMirrors)
+
+          case _ =>
+        }
+      }
+      result
+    }
+  }
+
   abstract class KnowledgeAccessor extends GlobalKnowledge with Invalidatable {
     /* In theory, a KnowledgeAccessor should *contain* a GlobalKnowledge, not
      * *be* a GlobalKnowledge. We organize it that way to reduce memory
@@ -172,7 +199,8 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
   }
 
   private class Class(initClass: LinkedClass,
-      initHasInlineableInit: Boolean)
+      initHasInlineableInit: Boolean,
+      initStaticFieldMirrors: Map[FieldName, List[String]])
       extends Unregisterable {
 
     private val className = initClass.className
@@ -187,7 +215,7 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
     private var jsNativeMemberLoadSpecs = computeJSNativeMemberLoadSpecs(initClass)
     private var superClass = computeSuperClass(initClass)
     private var fieldDefs = computeFieldDefs(initClass)
-    private var staticFieldMirrors = computeStaticFieldMirrors(initClass)
+    private var staticFieldMirrors = initStaticFieldMirrors
 
     private val isInterfaceAskers = mutable.Set.empty[Invalidatable]
     private val hasInlineableInitAskers = mutable.Set.empty[Invalidatable]
@@ -199,7 +227,8 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
     private val fieldDefsAskers = mutable.Set.empty[Invalidatable]
     private val staticFieldMirrorsAskers = mutable.Set.empty[Invalidatable]
 
-    def update(linkedClass: LinkedClass, newHasInlineableInit: Boolean): Unit = {
+    def update(linkedClass: LinkedClass, newHasInlineableInit: Boolean,
+        newStaticFieldMirrors: Map[FieldName, List[String]]): Unit = {
       isAlive = true
 
       val newIsInterface = computeIsInterface(linkedClass)
@@ -249,7 +278,6 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
         invalidateAskers(fieldDefsAskers)
       }
 
-      val newStaticFieldMirrors = computeStaticFieldMirrors(linkedClass)
       if (newStaticFieldMirrors != staticFieldMirrors) {
         staticFieldMirrors = newStaticFieldMirrors
         invalidateAskers(staticFieldMirrorsAskers)
@@ -285,26 +313,6 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
 
     private def computeFieldDefs(linkedClass: LinkedClass): List[AnyFieldDef] =
       linkedClass.fields
-
-    private def computeStaticFieldMirrors(
-        linkedClass: LinkedClass): Map[FieldName, List[String]] = {
-      if (config.moduleKind != ModuleKind.NoModule ||
-          linkedClass.topLevelExports.isEmpty) {
-        // Fast path
-        Map.empty
-      } else {
-        val result = mutable.Map.empty[FieldName, List[String]]
-        for (export <- linkedClass.topLevelExports) {
-          export match {
-            case TopLevelFieldExportDef(exportName, FieldIdent(fieldName)) =>
-              result(fieldName) = exportName :: result.getOrElse(fieldName, Nil)
-            case _ =>
-              ()
-          }
-        }
-        result.toMap
-      }
-    }
 
     def testAndResetIsAlive(): Boolean = {
       val result = isAlive

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -82,8 +82,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
             ClassKind.NativeJSModuleClass =>
           if (classDef.fields.nonEmpty ||
               classDef.methods.exists(!_.value.flags.namespace.isStatic) ||
-              classDef.exportedMembers.nonEmpty ||
-              classDef.topLevelExports.nonEmpty) {
+              classDef.exportedMembers.nonEmpty) {
             val kind =
               if (classDef.kind == ClassKind.AbstractJSType) "Abstract"
               else "Native"
@@ -94,6 +93,25 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
           checkScalaClassDef(classDef)
       }
     }
+
+    for (topLevelExport <- unit.topLevelExports) {
+      val owningClass = topLevelExport.owningClass
+
+      topLevelExport.tree match {
+        case tree: TopLevelJSClassExportDef =>
+          checkTopLevelJSClassExportDef(tree, owningClass)
+
+        case tree: TopLevelModuleExportDef =>
+          checkTopLevelModuleExportDef(tree, owningClass)
+
+        case tree: TopLevelMethodExportDef =>
+          checkTopLevelMethodExportDef(tree)
+
+        case tree: TopLevelFieldExportDef =>
+          checkTopLevelFieldExportDef(tree, owningClass)
+      }
+    }
+
     errorCount
   }
 
@@ -254,46 +272,23 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
           reportError("Module class must have a parameterless constructor")
       }
 
+      val checkedClass = classes(classDef.name.name)
+
       // Check exported members
       for (member <- classDef.exportedMembers) {
         implicit val ctx = ErrorContext(member.value)
 
         member.value match {
           case m: JSMethodDef =>
-            checkExportedMethodDef(m, classDef, isTopLevel = false)
+            checkExportedMethodDef(m, checkedClass)
 
           case p: JSPropertyDef =>
-            checkExportedPropertyDef(p, classDef)
+            checkExportedPropertyDef(p, checkedClass)
 
           // Anything else is illegal
           case _ =>
             reportError("Illegal exported class member of type " +
                 member.value.getClass.getName)
-        }
-      }
-
-      // Check top-level exports
-      for (tree <- classDef.topLevelExports) {
-        implicit val ctx = ErrorContext(tree)
-
-        tree match {
-          case tree: TopLevelJSClassExportDef =>
-            checkTopLevelJSClassExportDef(tree, classDef)
-
-          case tree: TopLevelModuleExportDef =>
-            checkTopLevelModuleExportDef(tree, classDef)
-
-          case TopLevelMethodExportDef(methodDef) =>
-            checkExportedMethodDef(methodDef, classDef, isTopLevel = true)
-
-          case TopLevelFieldExportDef(_, field) =>
-            lookupClass(classDef.name.name).lookupStaticField(field.name).fold {
-              reportError(i"Cannot export non-existent static field '$field'")
-            } { checkedField =>
-              val tpe = checkedField.tpe
-              if (tpe != AnyType)
-                reportError(i"Cannot export field '$field' of type $tpe")
-            }
         }
       }
     } else {
@@ -306,7 +301,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
       if (classDef.fields.nonEmpty)
         reportError(i"$kindStr may not have fields")
 
-      if (classDef.exportedMembers.nonEmpty || classDef.topLevelExports.nonEmpty)
+      if (classDef.exportedMembers.nonEmpty)
         reportError(i"$kindStr may not have exports")
     }
 
@@ -411,7 +406,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
   }
 
   private def checkExportedMethodDef(methodDef: JSMethodDef,
-      classDef: LinkedClass, isTopLevel: Boolean): Unit = withPerMethodState {
+      clazz: CheckedClass): Unit = withPerMethodState {
     val JSMethodDef(flags, pName, params,  body) = methodDef
     implicit val ctx = ErrorContext(methodDef)
 
@@ -422,18 +417,15 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
     if (flags.namespace.isPrivate)
       reportError("An exported method cannot be private")
 
-    if (!isTopLevel && !classDef.kind.isAnyNonNativeClass) {
+    if (!clazz.kind.isAnyNonNativeClass) {
       reportError(i"Exported method def can only appear in a class")
       return
     }
 
-    if (!isTopLevel && static && classDef.kind != ClassKind.JSClass)
+    if (static && clazz.kind != ClassKind.JSClass)
       reportError("Exported method def in non-JS class cannot be static")
 
-    if (isTopLevel && !static)
-      reportError("Top level export must be static")
-
-    checkExportedPropertyName(pName, classDef, isTopLevel)
+    checkExportedPropertyName(pName, clazz)
     checkJSParamDefs(params)
 
     def isJSConstructor = {
@@ -443,22 +435,22 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
       })
     }
 
-    if (classDef.kind.isJSClass && isJSConstructor) {
-      checkJSClassConstructor(methodDef, classDef)
+    if (clazz.kind.isJSClass && isJSConstructor) {
+      checkJSClassConstructor(methodDef, clazz)
     } else {
       val thisType = {
         if (static) NoType
-        else if (classDef.kind.isJSClass) AnyType
-        else ClassType(classDef.name.name)
+        else if (clazz.kind.isJSClass) AnyType
+        else ClassType(clazz.name)
       }
 
-      val bodyEnv = Env.fromSignature(thisType, classDef.jsClassCaptures, params)
+      val bodyEnv = Env.fromSignature(thisType, clazz.jsClassCaptures, params)
       typecheckExpect(body, bodyEnv, AnyType)
     }
   }
 
   private def checkJSClassConstructor(methodDef: JSMethodDef,
-      classDef: LinkedClass): Unit = {
+      clazz: CheckedClass): Unit = {
     val JSMethodDef(static, _, params, body) = methodDef
     implicit val ctx = ErrorContext(methodDef)
 
@@ -480,7 +472,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
         (JSSuperConstructorCall(Nil)(methodDef.pos), Nil)
     }
 
-    val initialEnv = Env.fromSignature(NoType, classDef.jsClassCaptures,
+    val initialEnv = Env.fromSignature(NoType, clazz.jsClassCaptures,
         params, isConstructor = true)
 
     val preparedEnv = prepStats.foldLeft(initialEnv) { (prevEnv, stat) =>
@@ -495,7 +487,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
   }
 
   private def checkExportedPropertyDef(propDef: JSPropertyDef,
-      classDef: LinkedClass): Unit = withPerMethodState {
+      clazz: CheckedClass): Unit = withPerMethodState {
     val JSPropertyDef(flags, pName, getterBody, setterArgAndBody) = propDef
     implicit val ctx = ErrorContext(propDef)
 
@@ -506,20 +498,20 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
     if (flags.namespace.isPrivate)
       reportError("An exported property def cannot be private")
 
-    if (!classDef.kind.isAnyNonNativeClass) {
+    if (!clazz.kind.isAnyNonNativeClass) {
       reportError(i"Exported property def can only appear in a class")
       return
     }
 
-    checkExportedPropertyName(pName, classDef, isTopLevel = false)
+    checkExportedPropertyName(pName, clazz)
 
     val thisType =
       if (static) NoType
-      else if (classDef.kind.isJSClass) AnyType
-      else ClassType(classDef.name.name)
+      else if (clazz.kind.isJSClass) AnyType
+      else ClassType(clazz.name)
 
     getterBody.foreach { getterBody =>
-      val getterBodyEnv = Env.fromSignature(thisType, classDef.jsClassCaptures, Nil)
+      val getterBodyEnv = Env.fromSignature(thisType, clazz.jsClassCaptures, Nil)
       typecheckExpect(getterBody, getterBodyEnv, AnyType)
     }
 
@@ -531,43 +523,92 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
       if (setterArg.rest)
         reportError(i"Rest parameter ${setterArg.name} is illegal in setter")
 
-      val setterBodyEnv = Env.fromSignature(thisType, classDef.jsClassCaptures,
+      val setterBodyEnv = Env.fromSignature(thisType, clazz.jsClassCaptures,
           List(setterArg))
       typecheckStat(setterBody, setterBodyEnv)
     }
   }
 
-  private def checkExportedPropertyName(propName: Tree,
-      classDef: LinkedClass, isTopLevel: Boolean)(
+  private def checkExportedPropertyName(propName: Tree, clazz: CheckedClass)(
       implicit ctx: ErrorContext): Unit = {
     propName match {
       case StringLiteral(name) =>
-        if (!classDef.kind.isJSClass && name.contains("__"))
+        if (!clazz.kind.isJSClass && name.contains("__"))
           reportError("Exported method def name cannot contain __")
 
       case _ =>
-        if (isTopLevel || !classDef.kind.isJSClass)
+        if (!clazz.kind.isJSClass)
           reportError("Only JS classes may contain members with computed names")
         typecheckExpect(propName, Env.empty, AnyType)
     }
   }
 
   private def checkTopLevelJSClassExportDef(
-      classExportDef: TopLevelJSClassExportDef, classDef: LinkedClass): Unit = {
+      classExportDef: TopLevelJSClassExportDef, owningClass: ClassName): Unit = {
     implicit val ctx = ErrorContext(classExportDef)
 
-    if (classDef.kind != ClassKind.JSClass)
+    val clazz = lookupClass(owningClass)
+
+    if (clazz.kind != ClassKind.JSClass)
       reportError(i"Exported JS class def can only appear in a JS class")
   }
 
   private def checkTopLevelModuleExportDef(
       topLevelModuleDef: TopLevelModuleExportDef,
-      classDef: LinkedClass): Unit = {
+      owningClass: ClassName): Unit = {
     implicit val ctx = ErrorContext(topLevelModuleDef)
 
-    if (!classDef.kind.hasModuleAccessor) {
+    val clazz = lookupClass(owningClass)
+
+    if (!clazz.kind.hasModuleAccessor) {
       reportError(
           "Top-level module export def can only appear in a module class")
+    }
+  }
+
+  private def checkTopLevelMethodExportDef(
+      topLevelMethodExportDef: TopLevelMethodExportDef): Unit = withPerMethodState {
+
+    val JSMethodDef(flags, pName, params,  body) = topLevelMethodExportDef.methodDef
+    implicit val ctx = ErrorContext(topLevelMethodExportDef.methodDef)
+
+    if (flags.isMutable)
+      reportError("Top level export method cannot have the flag Mutable")
+    if (flags.namespace != MemberNamespace.PublicStatic)
+      reportError("Top level export must be public and static")
+
+    pName match {
+      case StringLiteral(name) => // ok
+
+      case _ =>
+        reportError("Top level exports may not have computed names")
+    }
+
+    checkJSParamDefs(params)
+
+    val bodyEnv = Env.fromSignature(NoType, None, params)
+    typecheckExpect(body, bodyEnv, AnyType)
+  }
+
+  private def checkTopLevelFieldExportDef(
+      topLevelFieldExportDef: TopLevelFieldExportDef,
+      owningClass: ClassName): Unit = {
+    implicit val ctx = ErrorContext(topLevelFieldExportDef)
+
+    val clazz = lookupClass(owningClass)
+
+    if (!clazz.kind.isAnyNonNativeClass) {
+      reportError("non-native classes may not have field exports")
+    }
+
+    val field = topLevelFieldExportDef.field
+
+    clazz.lookupStaticField(field.name).fold {
+      reportError(i"Cannot export non-existent static field '$field'")
+    } { checkedField =>
+      val tpe = checkedField.tpe
+      if (tpe != AnyType)
+        reportError(i"Cannot export field '$field' of type $tpe")
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/GenIncOptimizer.scala
@@ -128,7 +128,8 @@ abstract class GenIncOptimizer private[optimizer] (config: CommonPhaseConfig) {
         linkedClass.optimized(methods = newMethods)
       }
 
-      new LinkingUnit(unit.coreSpec, newLinkedClasses, unit.moduleInitializers)
+      new LinkingUnit(unit.coreSpec, newLinkedClasses, unit.topLevelExports,
+          unit.moduleInitializers)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -45,7 +45,6 @@ final class LinkedClass(
     val methods: List[Versioned[MethodDef]],
     val exportedMembers: List[Versioned[JSMethodPropDef]],
     val jsNativeMembers: List[JSNativeMemberDef],
-    val topLevelExports: List[TopLevelExportDef],
     val optimizerHints: OptimizerHints,
     val pos: Position,
 
@@ -58,8 +57,7 @@ final class LinkedClass(
 
   def className: ClassName = name.name
 
-  val hasEntryPoint: Boolean = {
-    topLevelExports.nonEmpty ||
+  val hasStaticInitializer: Boolean = {
     methods.exists { m =>
       val methodDef = m.value
       methodDef.flags.namespace == MemberNamespace.StaticConstructor &&
@@ -107,7 +105,6 @@ final class LinkedClass(
       methods: List[Versioned[MethodDef]] = this.methods,
       exportedMembers: List[Versioned[JSMethodPropDef]] = this.exportedMembers,
       jsNativeMembers: List[JSNativeMemberDef] = this.jsNativeMembers,
-      topLevelExports: List[TopLevelExportDef] = this.topLevelExports,
       optimizerHints: OptimizerHints = this.optimizerHints,
       pos: Position = this.pos,
       ancestors: List[ClassName] = this.ancestors,
@@ -127,7 +124,6 @@ final class LinkedClass(
         methods,
         exportedMembers,
         jsNativeMembers,
-        topLevelExports,
         optimizerHints,
         pos,
         ancestors,

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedTopLevelExport.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedTopLevelExport.scala
@@ -12,11 +12,14 @@
 
 package org.scalajs.linker.standard
 
-import org.scalajs.linker.interface.ModuleInitializer
+import scala.collection.mutable
 
-final class LinkingUnit private[linker] (
-    val coreSpec: CoreSpec,
-    val classDefs: List[LinkedClass],
-    val topLevelExports: List[LinkedTopLevelExport],
-    val moduleInitializers: List[ModuleInitializer]
-)
+import org.scalajs.ir.Trees.TopLevelExportDef
+import org.scalajs.ir.Names.ClassName
+
+final class LinkedTopLevelExport(
+    val owningClass: ClassName,
+    val tree: TopLevelExportDef
+) {
+  def exportName: String = tree.topLevelExportName
+}

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -408,7 +408,7 @@ class AnalyzerTest {
         config = StandardConfig().withModuleKind(ModuleKind.NoModule))
 
     val scriptResult = assertContainsError("InvalidTopLevelExportInScript(foo, A)", scriptAnalysis) {
-      case InvalidTopLevelExportInScript("default", ClsInfo("A")) =>
+      case InvalidTopLevelExportInScript("default", ClsName("A")) =>
         true
     }
 
@@ -436,9 +436,9 @@ class AnalyzerTest {
     val analysis = computeAnalysis(classDefs)
 
     assertContainsError("ConflictingTopLevelExport(foo, A, B)", analysis) {
-      case ConflictingTopLevelExport("foo", List(ClsInfo("A"), ClsInfo("B"))) =>
+      case ConflictingTopLevelExport("foo", List(ClsName("A"), ClsName("B"))) =>
         true
-      case ConflictingTopLevelExport("foo", List(ClsInfo("B"), ClsInfo("A"))) =>
+      case ConflictingTopLevelExport("foo", List(ClsName("B"), ClsName("A"))) =>
         true
     }
   }
@@ -732,5 +732,10 @@ object AnalyzerTest {
   object MethInfo {
     def unapply(methodInfo: Analysis.MethodInfo): Some[(String, String)] =
       Some((methodInfo.owner.className.nameString, methodInfo.methodName.nameString))
+  }
+
+  object ClsName {
+    def unapply(className: ClassName): Some[String] =
+      Some(className.nameString)
   }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -81,7 +81,7 @@ class AnalyzerTest {
     val analysis = computeAnalysis(classDefs, reqsFactory.classData("A"))
 
     assertContainsError("CycleInInheritanceChain(A, B)", analysis) {
-      case CycleInInheritanceChain(List(AClass, BClass), `fromAnalyzer`) => true
+      case CycleInInheritanceChain(List(ClsName("A"), ClsName("B")), `fromAnalyzer`) => true
     }
   }
 
@@ -95,7 +95,7 @@ class AnalyzerTest {
     val analysis = computeAnalysis(classDefs, reqsFactory.classData("A"))
 
     assertContainsError("CycleInInheritanceChain(A, B)", analysis) {
-      case CycleInInheritanceChain(List(AClass, BClass), `fromAnalyzer`) => true
+      case CycleInInheritanceChain(List(ClsName("A"), ClsName("B")), `fromAnalyzer`) => true
     }
   }
 
@@ -113,8 +113,8 @@ class AnalyzerTest {
 
     val analysis = computeAnalysis(classDefs, reqsFactory.classData("A"))
 
-    assertContainsError("CycleInInheritanceChain(B, C, D)", analysis) {
-      case CycleInInheritanceChain(List(CClass, DClass, EClass), `fromAnalyzer`) => true
+    assertContainsError("CycleInInheritanceChain(C, D, E)", analysis) {
+      case CycleInInheritanceChain(List(ClsName("C"), ClsName("D"), ClsName("E")), `fromAnalyzer`) => true
     }
   }
 
@@ -643,12 +643,6 @@ object AnalyzerTest {
 
   private val fromAnalyzer = FromCore("analyzer")
   private val fromUnitTest = FromCore("unit test")
-
-  private val AClass = ClassName("A")
-  private val BClass = ClassName("B")
-  private val CClass = ClassName("C")
-  private val DClass = ClassName("D")
-  private val EClass = ClassName("E")
 
   private def validParentForKind(kind: ClassKind): Option[ClassName] = {
     import ClassKind._

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/IRAssertions.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/IRAssertions.scala
@@ -89,8 +89,6 @@ object IRAssertions {
             traverseMemberDef(memberDef.value)
           for (memberDef <- node.exportedMembers)
             traverseMemberDef(memberDef.value)
-          for (topLevelExportDef <- node.topLevelExports)
-            traverseTopLevelExportDef(topLevelExportDef)
         }
       }
     }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -17,8 +17,13 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
+      // Breaking in stable API. OK in Minor version.
+      exclude[ProblemRef]("org.scalajs.linker.standard.*"),
+
       // Breaking in unstable packages
       exclude[ProblemRef]("org.scalajs.linker.analyzer.*"),
+      exclude[ProblemRef]("org.scalajs.linker.backend.*"),
+      exclude[ProblemRef]("org.scalajs.linker.frontend.*"),
   )
 
   val LinkerInterface = Seq(


### PR DESCRIPTION
Side-effects for TopLevelMethodExportDefs in IRChecker:
- Allow them on all class kinds.
- Allow names containing `__` for non JS classes.
- Disallow references to JS class captures (this was a bug).