### PR TITLE
Fix #4117: Allow to export abstract JS classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -154,7 +154,7 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
     } else if (!sym.isStatic) {
       err("You may not export a nested " +
           (if (isMod) "object" else s"class. $createFactoryInOuterClassHint"))
-    } else if (sym.isAbstractClass) {
+    } else if (sym.isAbstractClass && !isJSAny(sym)) {
       err("You may not export an abstract class")
     } else if (!isMod && !hasAnyNonPrivateCtor) {
       /* This test is only relevant for JS classes but doesn't hurt for Scala

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -449,9 +449,6 @@ class JSExportTest extends DirectTest with TestHelpers {
       @JSExportTopLevel("B")
       def this() = this(5)
     }
-
-    @JSExportTopLevel("C")
-    abstract class C extends js.Object
     """ hasErrors
     """
       |newSource1.scala:3: error: You may not export an abstract class
@@ -460,9 +457,6 @@ class JSExportTest extends DirectTest with TestHelpers {
       |newSource1.scala:7: error: You may not export an abstract class
       |      @JSExportTopLevel("B")
       |       ^
-      |newSource1.scala:11: error: You may not export an abstract class
-      |    @JSExportTopLevel("C")
-      |     ^
     """
 
   }


### PR DESCRIPTION
There was no reason to forbid this, and in fact the entire pipeline was already prepared to deal with it.