### PR TITLE
Add conversion from Date to Instant and vice versa.

### DIFF
--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -12,6 +12,7 @@
 
 package java.util
 
+import java.time.Instant
 import scalajs.js
 
 class Date private (private val date: js.Date) extends Object
@@ -118,6 +119,9 @@ class Date private (private val date: js.Date) extends Object
       pad0(date.getUTCSeconds().toInt) +" GMT"
   }
 
+  /* Calling this requires java.time so it's not tested in this repository. */
+  def toInstant(): Instant = Instant.ofEpochMilli(getTime())
+
   @Deprecated
   def toLocaleString(): String = {
     "" + date.getDate().toInt + "-" + Months(date.getMonth().toInt) + "-" +
@@ -149,6 +153,9 @@ object Date {
     val str = "" + i
     if (str.length < 2) "0" + str else str
   }
+
+  /* Calling this requires java.time so it's not tested in this repository. */
+  def from(instant: Instant): Date = new Date(instant.toEpochMilli())
 
   @Deprecated
   def UTC(year: Int, month: Int, date: Int,

--- a/library/src/main/scala/scala/scalajs/js/Date.scala
+++ b/library/src/main/scala/scala/scalajs/js/Date.scala
@@ -50,6 +50,13 @@ class Date extends js.Object {
 
   override def valueOf(): Double = js.native
 
+  /**
+   * Returns the numeric value of the specified date as the number of
+   * milliseconds since January 1, 1970, 00:00:00 UTC.
+   * (Negative values are returned for prior times).
+   *
+   * MDN
+   */
   def getTime(): Double = js.native
 
   /**


### PR DESCRIPTION
This is a proposal to add conversion methods to and from `java.time.Instant` to `java.util.Date` and vice versa to the javalib. They can be useful in conjunction with `java.time` implementations like [scala-js-java-time](https://github.com/scala-js/scala-js-java-time) or [scala-java-time](https://github.com/cquiroz/scala-java-time).

It's based on my question on Gitter a few week ago:

> Is there a way to "patch" existing Scala.js implementations of Java standard library classes somehow?
> 
> My issue is that I'm running into linking errors because a method from a third party dependency calls `java.util.Date.from(instant: Instant)` and `toInstant()` on `Date`.
> ```
> Referring to non-existent method static java.util.Date.from(java.time.Instant)java.util.Date
> ```
> 
> I guess these methods aren't part of the Scala.js port of `java.util.Date` due to `java.time` not being part of core Scala.js. But once I add a`java.time` implementation like `scala-java-time` to my project it would be interesting to have them available.
> 
> Any ideas how to achieve this or is the only way to change the call site?

And the answer from @sjrd:

> @sbrunk There's no way in user space. The only way would be to implement `from` (and probably `toInstant`) in the javalib of Scala.js core (with the usual clean room requirement). The problem is that it would not be testable, so it would have to be "clearly correct" for it to even be considered. We have precedent, but very rare.

Because we obviously can't test these methods in core Scala.js, I started writing some tests in scala-js-java-time against my locally published scala.js build. Doing that I could observe a behaviour that I hadn't expected:

```scala
assertEquals(Instant.ofEpochMilli(8640000000000000L), new Date(8640000000000000L).toInstant()) // OK
assertEquals(Instant.ofEpochMilli(8640000000000001L), new Date(8640000000000001L).toInstant()) // OK on JVM, but not on JS
```
On JS, the `Date` is `0`:
```
[error] Test org.scalajs.testsuite.javalib.time.InstantTest.fromDate failed: java.lang.AssertionError: expected:<+275760-09-13T00:00:00.001Z> but was:<1970-01-01T00:00:00Z>, took 0.006999808 sec
```

`js.Date` objects have a valid time range of ±8.64E15 as defined in [ECMAScript Time Values and Time Range](https://www.ecma-international.org/ecma-262/5.1/#sec-15.9.1.1). `js.Date` objects given a value outside of that range are an *invalid date* and calling getTime() on such an instance returns `NaN`.

Since the `java.util.Date` implementation of Scala.js is based on a `js.Date` internally, instantiating `Date` with a value `> 8640000000000000L` (or `< -8640000000000000L` will result in the backing `js.Date` instance being `NaN`. That in turn results in the `java.util.Date` instance being 0 (the Unix Epoch), because `getTime()` converts `NaN` to a `Long` and `Double.NaN.toLong == 0`.

https://github.com/scala-js/scala-js/blob/a4e7c455c29448de48c394865217a22dbd7a1a4a/javalib/src/main/scala/java/util/Date.scala#L85

So we get

`x <= 8640000000000000L // OK`
`x >  8640000000000000L   // getTime() always returns 0`

Analogous for negative values.

When we now add the conversion from `Instant` to the mix, we get the following behaviour in JS which is a bit surprising from a user perspective:

```scala
println(Date.from(Instant.ofEpochMilli(8640000000000000L)).getTime)             // 8640000000000000
println(Date.from(Instant.ofEpochMilli(8640000000000001L)).getTime)             // 0
println(Date.from(Instant.ofEpochMilli(Long.MaxValue)).getTime)                 // still 0
println(Date.from(Instant.ofEpochMilli(Long.MaxValue).plusMillis(193)).getTime) // java.lang.ArithmeticException: Long overflow
println(Date.from(Instant.MAX))                                                 // java.lang.ArithmeticException: Long overflow
```

On the JVM `java.util.Date` seems to be backed by a `Long` so it works as expected:
```scala
println(Date.from(Instant.ofEpochMilli(8640000000000000L)).getTime)           // 8640000000000000
println(Date.from(Instant.ofEpochMilli(8640000000000001L)).getTime)           // 8640000000000001
println(Date.from(Instant.ofEpochMilli(Long.MaxValue)).getTime)               // 9223372036854775807
println(Date.from(Instant.ofEpochMilli(Long.MaxValue).plusMillis(1)).getTime) // java.lang.ArithmeticException: Long overflow
println(Date.from(Instant.MAX))                                               // java.lang.ArithmeticException: Long overflow
```

I'm not sure if there's something to be done about it. `new Date(date: Long)` on the JVM obviously doesn't need to throw an exception. From a user perspective though, because the semantics is different on JS, I'd argue that it could make sense to throw an `IllegalArgumentException` on the `Date` constructor if the timestamp is out of range.
