### PR TITLE
Upgrade GCC to v20200719

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -804,7 +804,7 @@ object Build {
     commonLinkerSettings _
   ).settings(
       libraryDependencies ++= Seq(
-          "com.google.javascript" % "closure-compiler" % "v20200614",
+          "com.google.javascript" % "closure-compiler" % "v20200719",
           "com.novocode" % "junit-interface" % "0.9" % "test"
       ) ++ (
           parallelCollectionsDependencies(scalaVersion.value)


### PR DESCRIPTION
Following #4109: If we remove the workaround to #4098
(42dd238b510db0ae955a713911f7b2db50691021), GCC will now OOM instead
of throwing an IllegalStateException. This happens even without the
specially introduced test case.