### PR TITLE
Remove an abstract def that shadows a concrete def in SetTest.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
@@ -204,6 +204,4 @@ trait SetTest extends CollectionTest {
 
 trait SetFactory extends CollectionFactory {
   def empty[E: ClassTag]: ju.Set[E]
-
-  def allowsNullElement: Boolean
 }


### PR DESCRIPTION
The abstract def SetFactory.allowsNullElement shadowed the concrete def of the same name in CollectionFactory. This is not allowed in Dotty anymore:
https://github.com/lampepfl/dotty/issues/4770

Since this is not necessary in our tests, there is no point in leaving that abstract def.