### PR TITLE
Add ModuleKind as an attribute to linked Scala.js files

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1664,6 +1664,7 @@ object Build {
         } ((cpFiles :+ linkerModule).toSet)
 
         Attributed.blank(out)
+          .put(scalaJSModuleKind, ModuleKind.NoModule)
       },
 
       compile := (compile in Test).value,

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -245,6 +245,10 @@ object ScalaJSPlugin extends AutoPlugin {
         "Source map file attached to an Attributed .js file.",
         BSetting)
 
+    val scalaJSModuleKind = AttributeKey[ModuleKind]("scalaJSModuleKind",
+        "ModuleKind attached to an Attributed .js file.",
+        BSetting)
+
     val scalaJSTestHTMLArtifactDirectory = SettingKey[File]("scalaJSTestHTMLArtifactDirectory",
         "Directory for artifacts produced by testHtml.",
         BSetting)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -176,11 +176,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
          */
         val moduleKind = (scalaJSLinkerConfig in key).value.moduleKind
 
-        Def.task {
-          val log = s.log
-          val realFiles = irInfo.get(scalaJSSourceFiles).get
-          val ir = irInfo.data
-
+        val configChanged = {
           def moduleInitializersChanged = (scalaJSModuleInitializersFingerprints in key)
             .previous
             .exists(_ != (scalaJSModuleInitializersFingerprints in key).value)
@@ -189,7 +185,14 @@ private[sbtplugin] object ScalaJSPluginInternal {
             .previous
             .exists(_ != (scalaJSLinkerConfigFingerprint in key).value)
 
-          val configChanged = moduleInitializersChanged || linkerConfigChanged
+          moduleInitializersChanged || linkerConfigChanged
+        }
+
+        Def.task {
+          val log = s.log
+          val realFiles = irInfo.get(scalaJSSourceFiles).get
+          val ir = irInfo.data
+
           if (configChanged && output.exists()) {
             output.delete() // triggers re-linking through FileFunction.cached
           }


### PR DESCRIPTION
Thanks to this, we do not need to "peek-back" as far when assembling the
jsEnvInput. That in turn allows us to properly deal with different
module kinds in different configurations.

The re-use of the ModuleKind type is somewhat a shortcut, but I think
that is acceptable for the sake of consistency / brievity.