### PR TITLE
Implement String.repeat(Int) for JDK 11+

### DIFF
--- a/javalanglib/src/main/scala/java/lang/_String.scala
+++ b/javalanglib/src/main/scala/java/lang/_String.scala
@@ -308,6 +308,26 @@ final class _String private () // scalastyle:ignore
     regionMatches(false, toffset, other, ooffset, len)
   }
 
+  def repeat(count: Int): String = {
+    if (count < 0) {
+      throw new IllegalArgumentException
+    } else if (thisString == "" || count == 0) {
+      ""
+    } else if (thisString.length > (Int.MaxValue / count)) {
+      throw new OutOfMemoryError
+    } else {
+      var str = thisString
+      val resultLength = thisString.length * count
+      var remainingIters = 31 - Integer.numberOfLeadingZeros(count)
+      while (remainingIters > 0) {
+        str += str
+        remainingIters -= 1
+      }
+      str += str.jsSubstring(0, resultLength - str.length)
+      str
+    }
+  }
+
   @inline
   def replace(oldChar: Char, newChar: Char): String =
     replace(oldChar.toString, newChar.toString)

--- a/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/lang/StringTestOnJDK11.scala
+++ b/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/lang/StringTestOnJDK11.scala
@@ -1,0 +1,41 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang
+
+import java.nio.charset.Charset
+
+import scala.language.implicitConversions
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform._
+
+class StringTestOnJDK11 {
+  @Test def repeat(): Unit = {
+    assertThrows(classOf[IllegalArgumentException], "".repeat(-1))
+    assertTrue("".repeat(0) == "")
+    assertTrue("".repeat(1) == "")
+    assertTrue("".repeat(100) == "")
+
+    val str = "a_"
+    assertThrows(classOf[IllegalArgumentException], str.repeat(-1))
+    assertTrue(str.repeat(0) == "")
+    assertTrue(str.repeat(1) == "a_")
+    assertTrue(str.repeat(3) == "a_a_a_")
+    assertTrue(str.repeat(10) == List.fill(10)(str).mkString(""))
+    assertTrue(str.repeat(100) == List.fill(100)(str).mkString(""))
+    assertTrue(str.repeat(1000) == List.fill(1000)(str).mkString(""))
+  }
+}


### PR DESCRIPTION
This PR implements [`java.lang.String.repeat(Int)`](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/lang/String.html#repeat(int)), added in JDK 11, for Scala.js 1.x

Algorithm is based on [the polyfill from MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat), which is public domain.