### PR TITLE
Remove unused topLevelExports OneTimeCache

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -697,7 +697,6 @@ object Emitter {
     val setTypeData = new OneTimeCache[js.Tree]
     val moduleAccessor = new OneTimeCache[js.Tree]
     val staticFields = new OneTimeCache[List[js.Tree]]
-    val topLevelExports = new OneTimeCache[WithGlobals[List[js.Tree]]]
   }
 
   private final class GeneratedClass(


### PR DESCRIPTION
This was an oversight in 8d10150500747bde7b521a4fbe6f28bee469ea9c.