### PR TITLE
#4143: Pseudo-union type inference with type aliases and js.undefined

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,8 +17,8 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.2.0-SNAPSHOT",
-    binaryEmitted = "1.2-SNAPSHOT"
+    current = "1.1.2",
+    binaryEmitted = "1.1"
 )
 
 /** Helper class to allow for testing of logic. */

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
@@ -182,6 +182,32 @@ class UnionTypeTest {
     assertEquals(a, a: js.UndefOr[js.UndefOr[Int] | Object | String])
     assertEquals(a, a: js.UndefOr[js.UndefOr[Object] | String | Int])
     assertEquals(a, a: js.UndefOr[js.UndefOr[Object] | Object | String])
+
+    // Test with type aliases.
+    // Using a type alias hides the @uncheckedVariance annotation of `js.UndefOr`,
+    // which forces the use of an implicit conversion.
+    type Foo = Int
+    type FooOpt = js.UndefOr[Foo]
+    val foo: js.UndefOr[Foo] = js.undefined
+    val foo2: js.UndefOr[Foo] = 1
+    val fooOpt: FooOpt = js.undefined
+    val fooOpt2: FooOpt = 1
+
+    // More complex tests with type aliases on multiple levels
+    type ANumber = (Float | Int) | Double
+    trait Element
+    type Node = (Null | ANumber) | Element
+    type NodeOpt = js.UndefOr[Node]
+    val node: Node = 1
+    val undefOrNode: js.UndefOr[Node] = node
+    val undefOrNode2: js.UndefOr[Node] = js.undefined
+    val undefOrNodeOpt: NodeOpt = node.merge // Merge necessary here
+    val undefOrNodeOpt2: NodeOpt = js.undefined
+    assertEquals(1, node)
+    assertEquals(1, undefOrNode)
+    assertEquals((), undefOrNode2)
+    assertEquals(1, undefOrNodeOpt)
+    assertEquals((), undefOrNodeOpt2)
   }
 
   @Test def covariant_type_constructor(): Unit = {


### PR DESCRIPTION
This PR fixes #4143, an issue with type inference for pseudo-union types `scala.scalajs.js.|` when `Nothing` is the first type parameter. This is especially useful when infering for `js.undefined` (see #4143).

Since Scala 3 will include proper union types, I've limited the changes to the strict minimum to allow `js.undefined` to work with type aliases like it did in Scala.js 0.6.x. 

This is my first contribution to Scala.js, so there are probably issues with this PR. Feel free to point them out! 