### PR TITLE
Fix #4148: Do not erase a regular class with a static forwarder class.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
@@ -46,6 +46,12 @@ trait CompatComponent {
     object originalOwner {
       def getOrElse(sym: Symbol, orElse: => Symbol): Symbol = infiniteLoop()
     }
+
+    // Added in Scala 2.13.2 for configurable warnings
+    object runReporting {
+      def warning(pos: Position, msg: String, cat: Any, site: Symbol): Unit =
+        reporter.warning(pos, msg)
+    }
   }
 
   private implicit final class FlagsCompat(self: Flags.type) {
@@ -103,6 +109,26 @@ trait CompatComponent {
 
   implicit class BTypesCompat(bTypes: genBCode.bTypes.type) {
     def initializeCoreBTypes(): Unit = ()
+  }
+
+  // WarningCategory was added in Scala 2.13.2 for configurable warnings
+
+  object WarningCategoryCompat {
+    object Reporting {
+      object WarningCategory {
+        val Other: Any = null
+      }
+    }
+  }
+
+  // Of type Reporting.WarningCategory.type, but we cannot explicit write it
+  val WarningCategory = {
+    import WarningCategoryCompat._
+
+    {
+      import scala.tools.nsc._
+      Reporting.WarningCategory
+    }
   }
 }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -844,6 +844,14 @@ class RegressionTest {
     assertEquals(0, set.size())
   }
 
+  @Test def nestedObjectsAndClassesWhoseNamesDifferOnlyInCase_issue_4148(): Unit = {
+    // These tests mostly assert that all four objects and classes link
+    assertEquals(1, bug4148ObjectBeforeClass.checkValue)
+    assertEquals(2, new Bug4148ObjectBeforeClass().checkValue)
+    assertEquals(3, new Bug4148ObjectAfterClass().checkValue)
+    assertEquals(4, bug4148ObjectAfterClass.checkValue)
+  }
+
 }
 
 object RegressionTest {
@@ -905,5 +913,25 @@ object RegressionTest {
 
   object `class` { // scalastyle:ignore
     def foo(x: Int): Int = x + 1
+  }
+
+  /* #4148: The objects and classes here intentionally have names that differ
+   * only in case, and are intentionally defined in a specific order.
+   */
+
+  object bug4148ObjectBeforeClass {
+    def checkValue: Int = 1
+  }
+
+  class Bug4148ObjectBeforeClass {
+    def checkValue: Int = 2
+  }
+
+  class Bug4148ObjectAfterClass {
+    def checkValue: Int = 3
+  }
+
+  object bug4148ObjectAfterClass {
+    def checkValue: Int = 4
   }
 }


### PR DESCRIPTION
This is only relevant for case insensitive file systems. On such file systems, a static nested object could generate a static forwarder class whose name differed from a regular class' name only in case, therefore erasing the latter on case insensitive file systems.

We now avoid emitting static forwarder classes for objects if they would clash with a regular class on a case insensitive file system.