### PR TITLE
Fix #4148: Do not emit static forwarders for non-top-level objects by default.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
@@ -46,6 +46,12 @@ trait CompatComponent {
     object originalOwner {
       def getOrElse(sym: Symbol, orElse: => Symbol): Symbol = infiniteLoop()
     }
+
+    // Added in Scala 2.13.2 for configurable warnings
+    object runReporting {
+      def warning(pos: Position, msg: String, cat: Any, site: Symbol): Unit =
+        reporter.warning(pos, msg)
+    }
   }
 
   private implicit final class FlagsCompat(self: Flags.type) {
@@ -103,6 +109,26 @@ trait CompatComponent {
 
   implicit class BTypesCompat(bTypes: genBCode.bTypes.type) {
     def initializeCoreBTypes(): Unit = ()
+  }
+
+  // WarningCategory was added in Scala 2.13.2 for configurable warnings
+
+  object WarningCategoryCompat {
+    object Reporting {
+      object WarningCategory {
+        val Other: Any = null
+      }
+    }
+  }
+
+  // Of type Reporting.WarningCategory.type, but we cannot explicit write it
+  val WarningCategory = {
+    import WarningCategoryCompat._
+
+    {
+      import scala.tools.nsc._
+      Reporting.WarningCategory
+    }
   }
 }
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -217,6 +217,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
 
     private val lazilyGeneratedAnonClasses = mutable.Map.empty[Symbol, ClassDef]
     private val generatedClasses = ListBuffer.empty[js.ClassDef]
+    private val generatedStaticForwarderClasses = ListBuffer.empty[(Symbol, js.ClassDef)]
 
     private def consumeLazilyGeneratedAnonClass(sym: Symbol): ClassDef = {
       /* If we are trying to generate an method as JSFunction, we cannot
@@ -364,7 +365,54 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           }
         }
 
-        val clDefs = generatedClasses.toList
+        val clDefs = if (generatedStaticForwarderClasses.isEmpty) {
+          /* Fast path, applicable under -Xno-forwarders, as well as when all
+           * the `object`s of a compilation unit have a companion class.
+           */
+          generatedClasses.toList
+        } else {
+          val regularClasses = generatedClasses.toList
+
+          /* #4148 Add generated static forwarder classes, except those that
+           * would collide with regular classes on case insensitive file
+           * systems.
+           */
+
+          /* I could not find any reference anywhere about what locale is used
+           * by case insensitive file systems to compare case-insensitively.
+           * In doubt, force the English locale, which is probably going to do
+           * the right thing in virtually all cases (especially if users stick
+           * to ASCII class names), and it has the merit of being deterministic,
+           * as opposed to using the OS' default locale.
+           * The JVM backend performs a similar test to emit a warning for
+           * conflicting top-level classes. However, it uses `toLowerCase()`
+           * without argument, which is not deterministic.
+           */
+          def caseInsensitiveNameOf(classDef: js.ClassDef): String =
+            classDef.name.name.nameString.toLowerCase(java.util.Locale.ENGLISH)
+
+          val generatedCaseInsensitiveNames =
+            regularClasses.map(caseInsensitiveNameOf).toSet
+          val staticForwarderClasses = generatedStaticForwarderClasses.toList
+            .withFilter { case (site, classDef) =>
+              if (!generatedCaseInsensitiveNames.contains(caseInsensitiveNameOf(classDef))) {
+                true
+              } else {
+                global.runReporting.warning(
+                    site.pos,
+                    s"Not generating the static forwarders of ${classDef.name.name.nameString} " +
+                    "because its name differs only in case from the name of another class or " +
+                    "trait in this compilation unit.",
+                    WarningCategory.Other,
+                    site)
+                false
+              }
+            }
+            .map(_._2)
+
+          regularClasses ::: staticForwarderClasses
+        }
+
         generatedJSAST(clDefs)
 
         for (tree <- clDefs) {
@@ -372,6 +420,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         }
       } finally {
         lazilyGeneratedAnonClasses.clear()
+        generatedStaticForwarderClasses.clear()
         generatedClasses.clear()
         pos2irPosCache.clear()
       }
@@ -523,7 +572,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                   forwarders,
                   Nil
               )(js.OptimizerHints.empty)
-              generatedClasses += forwardersClassDef
+              generatedStaticForwarderClasses += sym -> forwardersClassDef
             }
           }
           allMemberDefsExceptStaticForwarders

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSOptions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSOptions.scala
@@ -26,6 +26,14 @@ trait ScalaJSOptions {
    *  If false, bad calls to classOf will cause an error. */
   def fixClassOf: Boolean
 
+  /** Should static forwarders be emitted for non-top-level objects.
+   *
+   *  Scala/JVM does not do that. Since Scala.js 1.2.0, we do not do it by
+   *  default either, but this option can be used to opt in. This is necessary
+   *  for implementations of JDK classes.
+   */
+  def genStaticForwardersForNonTopLevelObjects: Boolean
+
   /** which source locations in source maps should be relativized (or where
    *  should they be mapped to)? */
   def sourceURIMaps: List[URIMap]

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
@@ -55,6 +55,7 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
   object scalaJSOpts extends ScalaJSOptions {
     import ScalaJSOptions.URIMap
     var fixClassOf: Boolean = false
+    var genStaticForwardersForNonTopLevelObjects: Boolean = false
     lazy val sourceURIMaps: List[URIMap] = {
       if (_sourceURIMaps.nonEmpty)
         _sourceURIMaps.reverse
@@ -118,6 +119,8 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
     for (option <- options) {
       if (option == "fixClassOf") {
         fixClassOf = true
+      } else if (option == "genStaticForwardersForNonTopLevelObjects") {
+        genStaticForwardersForNonTopLevelObjects = true
       } else if (option.startsWith("mapSourceURI:")) {
         val uris = option.stripPrefix("mapSourceURI:").split("->")
 
@@ -170,6 +173,10 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
       |     - strips away the prefix FROM_URI (if it matches)
       |     - optionally prefixes the TO_URI, where stripping has been performed
       |     - any number of occurrences are allowed. Processing is done on a first match basis.
+      |  -P:$name:genStaticForwardersForNonTopLevelObjects
+      |     Generate static forwarders for non-top-level objects.
+      |     This option should be used by codebases that implement JDK classes.
+      |     When used together with -Xno-forwarders, this option has no effect.
       |  -P:$name:fixClassOf
       |     Repair calls to Predef.classOf that reach Scala.js.
       |     WARNING: This is a tremendous hack! Expect ugly errors if you use this option.

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -13,7 +13,7 @@
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._
-import org.scalajs.nscplugin.test.util.VersionDependentMessages.methodSig
+import org.scalajs.nscplugin.test.util.VersionDependentUtils.methodSig
 
 import org.junit.Assume._
 import org.junit.Test

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
@@ -13,7 +13,7 @@
 package org.scalajs.nscplugin.test
 
 import org.scalajs.nscplugin.test.util._
-import org.scalajs.nscplugin.test.util.VersionDependentMessages.methodSig
+import org.scalajs.nscplugin.test.util.VersionDependentUtils.methodSig
 
 import org.junit.Test
 import org.junit.Ignore

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/StaticForwardersWarningsAllObjectsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/StaticForwardersWarningsAllObjectsTest.scala
@@ -1,0 +1,64 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.nscplugin.test
+
+import org.scalajs.nscplugin.test.util._
+import org.scalajs.nscplugin.test.util.VersionDependentUtils.scalaSupportsNoWarn
+
+import org.junit.Assume._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+class StaticForwardersWarningsAllObjectsTest extends DirectTest with TestHelpers {
+
+  override def extraArgs: List[String] =
+    super.extraArgs ::: List("-P:scalajs:genStaticForwardersForNonTopLevelObjects")
+
+  @Test
+  def warnWhenAvoidingStaticForwardersForNonTopLevelObject: Unit = {
+    """
+    object Enclosing {
+      class A
+
+      object a {
+        def foo(x: Int): Int = x + 1
+      }
+    }
+    """ hasWarns
+    """
+      |newSource1.scala:5: warning: Not generating the static forwarders of Enclosing$a because its name differs only in case from the name of another class or trait in this compilation unit.
+      |      object a {
+      |             ^
+    """
+  }
+
+  @Test
+  def noWarnIfSelectivelyDisabled: Unit = {
+    assumeTrue(scalaSupportsNoWarn)
+
+    """
+    import scala.annotation.nowarn
+
+    object Enclosing {
+      class A
+
+      @nowarn("cat=other")
+      object a {
+        def foo(x: Int): Int = x + 1
+      }
+    }
+    """.hasNoWarns()
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/StaticForwardersWarningsTopLevelOnlyTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/StaticForwardersWarningsTopLevelOnlyTest.scala
@@ -1,0 +1,88 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.nscplugin.test
+
+import org.scalajs.nscplugin.test.util._
+import org.scalajs.nscplugin.test.util.VersionDependentUtils._
+
+import org.junit.Assume._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+class StaticForwardersWarningsTopLevelOnlyTest extends DirectTest with TestHelpers {
+
+  @Test
+  def warnWhenAvoidingStaticForwardersForTopLevelObject: Unit = {
+    val jvmBackendIssuesWarningOfItsOwn = {
+      !scalaVersion.startsWith("2.11.") &&
+      scalaVersion != "2.12.1" &&
+      scalaVersion != "2.12.2" &&
+      scalaVersion != "2.12.3" &&
+      scalaVersion != "2.12.4"
+    }
+    val jvmBackendMessage = if (!jvmBackendIssuesWarningOfItsOwn) {
+      ""
+    } else {
+      """
+        |newSource1.scala:4: warning: Generated class a differs only in case from A.
+        |  Such classes will overwrite one another on case-insensitive filesystems.
+        |    object a {
+        |           ^
+      """
+    }
+
+    """
+    class A
+
+    object a {
+      def foo(x: Int): Int = x + 1
+    }
+    """ hasWarns
+    s"""
+      |newSource1.scala:4: warning: Not generating the static forwarders of a because its name differs only in case from the name of another class or trait in this compilation unit.
+      |    object a {
+      |           ^$jvmBackendMessage
+    """
+  }
+
+  @Test
+  def noWarnIfSelectivelyDisabled: Unit = {
+    assumeTrue(scalaSupportsNoWarn)
+
+    """
+    import scala.annotation.nowarn
+
+    class A
+
+    @nowarn("cat=other")
+    object a {
+      def foo(x: Int): Int = x + 1
+    }
+    """.hasNoWarns()
+  }
+
+  @Test
+  def noWarnForNonTopLevelObject: Unit = {
+    """
+    object Enclosing {
+      class A
+
+      object a {
+        def foo(x: Int): Int = x + 1
+      }
+    }
+    """.hasNoWarns()
+  }
+
+}

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/VersionDependentUtils.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/VersionDependentUtils.scala
@@ -12,11 +12,21 @@
 
 package org.scalajs.nscplugin.test.util
 
-object VersionDependentMessages {
-  private val scalaVersion = scala.util.Properties.versionNumberString
+object VersionDependentUtils {
+  val scalaVersion = scala.util.Properties.versionNumberString
+
+  /** Does the current Scala version support the `@nowarn` annotation? */
+  val scalaSupportsNoWarn = {
+    !scalaVersion.startsWith("2.11.") &&
+    !scalaVersion.startsWith("2.12.") &&
+    scalaVersion != "2.13.0" &&
+    scalaVersion != "2.13.1"
+  }
 
   private val usesColonInMethodSig = {
-    !scalaVersion.startsWith("2.10.") &&
+    /* Yes, this is the same test as in scalaSupportsNoWarn, but that's
+     * completely coincidental, so we have a copy.
+     */
     !scalaVersion.startsWith("2.11.") &&
     !scalaVersion.startsWith("2.12.") &&
     scalaVersion != "2.13.0" &&

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1026,6 +1026,8 @@ object Build {
        * flag prevents these mistakes from happening.
        */
       scalacOptions += "-Yno-predef",
+      // We implement JDK classes, so we emit static forwarders for all static objects
+      scalacOptions += "-P:scalajs:genStaticForwardersForNonTopLevelObjects",
 
       resourceGenerators in Compile += Def.task {
         val output = (resourceManaged in Compile).value / "java/lang/Object.sjsir"
@@ -1059,6 +1061,8 @@ object Build {
        * we rely on the Scala library.
        */
       scalacOptions += "-Yno-predef",
+      // We implement JDK classes, so we emit static forwarders for all static objects
+      scalacOptions += "-P:scalajs:genStaticForwardersForNonTopLevelObjects",
 
       headerSources in Compile ~= { srcs =>
         srcs.filter { src =>
@@ -1705,6 +1709,8 @@ object Build {
         includeIf(testDir / "require-dynamic-import",
             moduleKind == ModuleKind.ESModule) // this is an approximation that works for now
       },
+
+      scalacOptions in Test += "-P:scalajs:genStaticForwardersForNonTopLevelObjects",
 
       scalaJSLinkerConfig ~= { _.withSemantics(TestSuiteLinkerOptions.semantics _) },
       scalaJSModuleInitializers in Test ++= TestSuiteLinkerOptions.moduleInitializers,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -844,6 +844,14 @@ class RegressionTest {
     assertEquals(0, set.size())
   }
 
+  @Test def nestedObjectsAndClassesWhoseNamesDifferOnlyInCase_issue_4148(): Unit = {
+    // These tests mostly assert that all four objects and classes link
+    assertEquals(1, staticForwardersAvoidanceObjectBeforeClass.checkValue)
+    assertEquals(2, new StaticForwardersAvoidanceObjectBeforeClass().checkValue)
+    assertEquals(3, new StaticForwardersAvoidanceObjectAfterClass().checkValue)
+    assertEquals(4, staticForwardersAvoidanceObjectAfterClass.checkValue)
+  }
+
 }
 
 object RegressionTest {
@@ -905,5 +913,31 @@ object RegressionTest {
 
   object `class` { // scalastyle:ignore
     def foo(x: Int): Int = x + 1
+  }
+
+  /* The objects and classes here intentionally have names that differ only in
+   * case, and are intentionally defined in a specific order. This is required
+   * to properly test the fix for #4148 (static forwarders can overwrite
+   * companion classes with a name that differs only in case on
+   * case-insensitive file systems). Depending on the order of which comes
+   * first or second, different strategies can fail, so we test both. For
+   * example, prior to the fix, #4148 would only manifest itself when the
+   * object was declared *after* the class, but not before.
+   */
+
+  object staticForwardersAvoidanceObjectBeforeClass {
+    def checkValue: Int = 1
+  }
+
+  class StaticForwardersAvoidanceObjectBeforeClass {
+    def checkValue: Int = 2
+  }
+
+  class StaticForwardersAvoidanceObjectAfterClass {
+    def checkValue: Int = 3
+  }
+
+  object staticForwardersAvoidanceObjectAfterClass {
+    def checkValue: Int = 4
   }
 }


### PR DESCRIPTION
Alternative to #4149.

---

### Fix #4148: Do not emit static forwarders for non-top-level objects by default.

Scala/JVM does not emit static forwarders for non-top-level objects. The reason we do it in Scala.js is for implementations of JDK classes that contain static methods in inner static classes (#3950). However, this causes issues with existing Scala projects that have non-top-level `object`s and `class`es with names differing only in case.

In this commit, we now only emit static forwarders for top-level objects by default, and add an opt-in option to emit them for non-top-level objects, which should be used by implementations of JDK classes.

---

### Do not erase a regular class with a static forwarder class.

This is only relevant for case insensitive file systems. On such file systems, a static nested object could generate a static forwarder class whose name differed from a regular class' name only in case, therefore erasing the latter on case insensitive file systems.

We now avoid emitting static forwarder classes for objects if they would clash with a regular class on a case insensitive file system.

When doing so, we emit a warning. On Scala 2.13.2+, the warning can be silenced with `@nowarn("other")` on the object, or `-Wconf:cat=other:s` in the scalac options.

For top-level objects, the warning is similar to a warning already emitted by the JVM back-end. For non-top-level objects, it only happens in Scala.js, and only when they are emitted due to the opt-in option.

This commit complements its parent in fixing #4148 for good, as now that issue won't present itself even when we opt in for static forwards of non-top-level objects. We therefore add a test for that issue, which we could not do before because the test suite as a whole requires the opt-in for other reasons.