### PR TITLE
Fix a Dotty incompatibility in BigIntTest.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/BigIntTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/BigIntTest.scala
@@ -46,14 +46,14 @@ class BigIntTest {
     val bi = js.BigInt("42123456789123456789")
     assertEquals(bi.toString(), "42123456789123456789")
 
-    val currency = bi
+    val result = bi
       .toLocaleString("de-DE", new js.BigInt.ToLocaleStringOptions {
         style = "currency"
         currency = "EUR"
       })
 
     // The exact return value is not specified. Just check the type.
-    assertTrue(js.typeOf(currency) == "string")
+    assertTrue(js.typeOf(result) == "string")
   }
 
   @Test def valueOf(): Unit = {


### PR DESCRIPTION
Dotty considers that an identifier that is both inherited from a super class and available in the enclosing scope is an ambiguous reference.

We had one such case in `BigIntTest`, which is fix by renaming a local variable with a better name.