### PR TITLE
Add explicit `()` to calls to `jsIterator()`.

### DIFF
--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
@@ -72,7 +72,7 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
   }
 
   def iterator: scala.collection.Iterator[(K, V)] =
-    underlying.jsIterator.toIterator.map(kv => (kv._1, kv._2))
+    underlying.jsIterator().toIterator.map(kv => (kv._1, kv._2))
 
   @inline
   override def keys: scala.collection.Iterable[K] =

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedSet.scala
@@ -65,7 +65,7 @@ final class WrappedSet[T](private val underlying: js.Set[T])
   override def iterableFactory: IterableFactory[WrappedSet] = WrappedSet
 
   override def iterator: scala.collection.Iterator[T] =
-    underlying.jsIterator.toIterator
+    underlying.jsIterator().toIterator
 
   override def empty: WrappedSet[T] =
     new WrappedSet(js.Set.empty[T])
@@ -98,4 +98,3 @@ object WrappedSet extends IterableFactory[WrappedSet] {
       new js.WrappedSet(set)
   }
 }
-

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -60,7 +60,7 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
   }
 
   def iterator: scala.collection.Iterator[(K, V)] =
-    underlying.jsIterator.toIterator.map(kv => (kv._1, kv._2))
+    underlying.jsIterator().toIterator.map(kv => (kv._1, kv._2))
 
   @inline
   override def keys: scala.collection.Iterable[K] =

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedSet.scala
@@ -59,7 +59,7 @@ final class WrappedSet[T](private val underlying: js.Set[T])
   }
 
   def iterator: scala.collection.Iterator[T] =
-    underlying.jsIterator.toIterator
+    underlying.jsIterator().toIterator
 
   override def empty: js.WrappedSet[T] =
     new js.WrappedSet(js.Set.empty[T])


### PR DESCRIPTION
This fixes the build on 2.13.3+, where they are necessary not to get (fatal) warnings.

---

Of course, that wouldn't have happened in the first place if our build and CI were using 2.13.3 (#4157)...