### PR TITLE
Fix the IDE import with more `addScalaJSCompilerOption`.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -135,7 +135,7 @@ object MyScalaJSPlugin extends AutoPlugin {
 }
 
 object Build {
-  import MyScalaJSPlugin.{addScalaJSCompilerOption, isGeneratingForIDE}
+  import MyScalaJSPlugin.{addScalaJSCompilerOption, addScalaJSCompilerOptionInConfig, isGeneratingForIDE}
 
   val bintrayProjectName = settingKey[String](
       "Project name on Bintray")
@@ -1027,7 +1027,7 @@ object Build {
        */
       scalacOptions += "-Yno-predef",
       // We implement JDK classes, so we emit static forwarders for all static objects
-      scalacOptions += "-P:scalajs:genStaticForwardersForNonTopLevelObjects",
+      addScalaJSCompilerOption("genStaticForwardersForNonTopLevelObjects"),
 
       resourceGenerators in Compile += Def.task {
         val output = (resourceManaged in Compile).value / "java/lang/Object.sjsir"
@@ -1062,7 +1062,7 @@ object Build {
        */
       scalacOptions += "-Yno-predef",
       // We implement JDK classes, so we emit static forwarders for all static objects
-      scalacOptions += "-P:scalajs:genStaticForwardersForNonTopLevelObjects",
+      addScalaJSCompilerOption("genStaticForwardersForNonTopLevelObjects"),
 
       headerSources in Compile ~= { srcs =>
         srcs.filter { src =>
@@ -1710,7 +1710,7 @@ object Build {
             moduleKind == ModuleKind.ESModule) // this is an approximation that works for now
       },
 
-      scalacOptions in Test += "-P:scalajs:genStaticForwardersForNonTopLevelObjects",
+      addScalaJSCompilerOptionInConfig(Test, "genStaticForwardersForNonTopLevelObjects"),
 
       scalaJSLinkerConfig ~= { _.withSemantics(TestSuiteLinkerOptions.semantics _) },
       scalaJSModuleInitializers in Test ++= TestSuiteLinkerOptions.moduleInitializers,


### PR DESCRIPTION
In 3c3b10061eeb3a807f063892d888df0e6be8236b, we added the compiler option `-P:scalajs:genStaticForwardersForNonTopLevelObjects` to some projects. However, that option should not be enabled when importing the build into an IDE, like other Scala.js-specific options.

In this commit, we use the existing `addScalaJSCompilerOption` mechanism to fix this issue.