### PR TITLE
Separate usage of "b" and "c" fields

### DIFF
--- a/javalanglib/src/main/scala/java/lang/StackTrace.scala
+++ b/javalanglib/src/main/scala/java/lang/StackTrace.scala
@@ -167,7 +167,9 @@ private[lang] object StackTrace {
    *  {{{
    *    new \$c_<encoded class name>
    *    \$c_<encoded class name>.prototype.<encoded method name>
+   *    \$b_<encoded class name>.prototype.<encoded method name>
    *    \$c_<encoded class name>.<encoded method name>
+   *    \$b_<encoded class name>.<encoded method name>
    *    \$s_<encoded class name>__<encoded method name>
    *    \$f_<encoded class name>__<encoded method name>
    *    \$m_<encoded module name>
@@ -187,17 +189,17 @@ private[lang] object StackTrace {
    *    javalanglib.
    */
   private def extractClassMethod(functionName: String): js.Array[String] = {
-    val PatC = """^(?:Object\.|\[object Object\]\.)?\$c_([^\.]+)(?:\.prototype)?\.([^\.]+)$""".re
+    val PatBC = """^(?:Object\.|\[object Object\]\.)?\$[bc]_([^\.]+)(?:\.prototype)?\.([^\.]+)$""".re
     val PatS = """^(?:Object\.|\[object Object\]\.)?\$(?:ps?|s|f)_((?:_[^_]|[^_])+)__([^\.]+)$""".re
     val PatCT = """^(?:Object\.|\[object Object\]\.)?\$ct_((?:_[^_]|[^_])+)__([^\.]*)$""".re
     val PatN = """^new (?:Object\.|\[object Object\]\.)?\$c_([^\.]+)$""".re
     val PatM = """^(?:Object\.|\[object Object\]\.)?\$m_([^\.]+)$""".re
 
-    val matchC = PatC.exec(functionName)
-    val matchCOrS = if (matchC ne null) matchC else PatS.exec(functionName)
-    if (matchCOrS ne null) {
-      js.Array[String](decodeClassName(undefOrForceGet(matchCOrS(1))),
-          decodeMethodName(undefOrForceGet(matchCOrS(2))))
+    val matchBC = PatBC.exec(functionName)
+    val matchBCOrS = if (matchBC ne null) matchBC else PatS.exec(functionName)
+    if (matchBCOrS ne null) {
+      js.Array[String](decodeClassName(undefOrForceGet(matchBCOrS(1))),
+          decodeMethodName(undefOrForceGet(matchBCOrS(2))))
     } else {
       val matchCT = PatCT.exec(functionName)
       val matchCTOrN = if (matchCT ne null) matchCT else PatN.exec(functionName)

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -197,20 +197,27 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
         node.addChildToFront(rhs)
         new Node(Token.VAR, node)
 
-      case ClassDef(className, parentClass, members) =>
-        val membersBlock = new Node(Token.CLASS_MEMBERS)
-        for (member <- members)
-          membersBlock.addChildToBack(transformClassMember(member))
-        new Node(
-            Token.CLASS,
-            className.fold(new Node(Token.EMPTY))(transformName(_)),
-            parentClass.fold(new Node(Token.EMPTY))(transformExpr(_)),
-            membersBlock)
+      case classDef: ClassDef =>
+        transformClassDef(classDef)
 
       case _ =>
         // We just assume it is an expression
         new Node(Token.EXPR_RESULT, transformExpr(tree))
     }
+  }
+
+  private def transformClassDef(classDef: ClassDef)(
+      implicit pos: Position): Node = {
+    val ClassDef(className, parentClass, members) = classDef
+
+    val membersBlock = new Node(Token.CLASS_MEMBERS)
+    for (member <- members)
+      membersBlock.addChildToBack(transformClassMember(member))
+    new Node(
+        Token.CLASS,
+        className.fold(new Node(Token.EMPTY))(transformName(_)),
+        parentClass.fold(new Node(Token.EMPTY))(transformExpr(_)),
+        membersBlock)
   }
 
   private def transformClassMember(member: Tree): Node = {
@@ -393,6 +400,9 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
         node
       case FunctionDef(name, args, body) =>
         genFunction(name.name, args, body)
+
+      case classDef: ClassDef =>
+        transformClassDef(classDef)
 
       case Spread(items) =>
         new Node(Token.ITER_SPREAD, transformExpr(items))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -1583,17 +1583,6 @@ private[emitter] object CoreJSLib {
     private def genIsScalaJSObjectOrNull(obj: VarRef): Tree =
       genIsScalaJSObject(obj) || (obj === Null())
 
-    private def assignES5ClassMembers(classRef: Tree, members: List[MethodDef]): Tree = {
-      val stats = for {
-        MethodDef(static, name, args, body) <- members
-      } yield {
-        val target = if (static) classRef else classRef.prototype
-        genPropSelect(target, name) := Function(arrow = false, args, body)
-      }
-
-      Block(stats)
-    }
-
     private def varRef(name: String): VarRef = VarRef(Ident(name))
 
     private def const(ref: VarRef, rhs: Tree): LocalDef =

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -368,13 +368,4 @@ private[emitter] final class SJSGen(
 
   def envModuleFieldIdent(module: String)(implicit pos: Position): Ident =
     fileLevelVarIdent("i", genModuleName(module), OriginalName(module))
-
-  def genPropSelect(qual: Tree, item: PropertyName)(
-      implicit pos: Position): Tree = {
-    item match {
-      case item: Ident         => DotSelect(qual, item)
-      case item: StringLiteral => genBracketSelect(qual, item)
-      case ComputedName(tree)  => genBracketSelect(qual, tree)
-    }
-  }
 }


### PR DESCRIPTION
"c" is now only used for Scala classes.
"b" is now only used for JS classes ("a" is the accessor).

Since we now generate ES6 classes in expression position, we adjust
ClosureAstTransformer to support this.