### PR TITLE
Remove unused temp variable in java.util.Random

### DIFF
--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -58,8 +58,6 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
 
     // seed = (seed * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1)
 
-    val twoPow24 = (1 << 24).toDouble
-
     val oldSeedHi = seedHi
     val oldSeedLo = seedLo
 


### PR DESCRIPTION
It seems that `twoPow24` is never used.

Several places uses `1 << 24` directly, but I think it is fine since Scala(.js) can convolve such values at compile-time.