### PR TITLE
Fix #4171: Fix a missing condition in tryOptimizePatternMatch.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3969,7 +3969,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
         returnedTypes.reduce(constrainedLub(_, _, resultType))
       val returnCount = returnedTypes.size - 1
 
-      tryOptimizePatternMatch(oldLabelName, refinedType,
+      tryOptimizePatternMatch(oldLabelName, newLabel, refinedType,
           returnCount, newBody) getOrElse {
         Labeled(LabelIdent(newLabel), refinedType, newBody)
       }
@@ -4040,8 +4040,8 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
    *  !!! There is quite of bit of code duplication with
    *      GenJSCode.genOptimizedMatchEndLabeled.
    */
-  def tryOptimizePatternMatch(oldLabelName: LabelName, refinedType: Type,
-      returnCount: Int, body: Tree): Option[Tree] = {
+  def tryOptimizePatternMatch(oldLabelName: LabelName, newLabelName: LabelName,
+      refinedType: Type, returnCount: Int, body: Tree): Option[Tree] = {
     // Heuristic for speed: only try to optimize labels likely named 'matchEnd...'
     val isMaybeMatchEndLabel = {
       val oldEncodedName = oldLabelName.encoded
@@ -4065,7 +4065,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
           if (revAlts.size == returnCount - 1) {
             def tryDropReturn(body: Tree): Option[Tree] = body match {
-              case BlockOrAlone(prep, Return(result, _)) =>
+              case BlockOrAlone(prep, Return(result, LabelIdent(`newLabelName`))) =>
                 val result1 =
                   if (refinedType == NoType) keepOnlySideEffects(result)
                   else result

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -17,9 +17,6 @@ import scala.concurrent._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.ir.ClassKind
-import org.scalajs.ir.EntryPointsInfo
-import org.scalajs.ir.Names._
 import org.scalajs.ir.Trees._
 
 import org.scalajs.logging._
@@ -28,12 +25,11 @@ import org.scalajs.junit.async._
 
 import org.scalajs.linker.interface._
 import org.scalajs.linker.testutils._
+import org.scalajs.linker.testutils.LinkingUtils._
 import org.scalajs.linker.testutils.TestIRBuilder._
 
 class LinkerTest {
   import scala.concurrent.ExecutionContext.Implicits.global
-
-  import LinkerTest._
 
   /** Makes sure that the minilib is sufficient to completely link a hello
    *  world.
@@ -88,20 +84,4 @@ class LinkerTest {
     (1 to 4).foldLeft(firstRun)((p, _) => callInFailedState(p))
   }
 
-}
-
-object LinkerTest {
-  def testLink(classDefs: Seq[ClassDef],
-      moduleInitializers: List[ModuleInitializer])(
-      implicit ec: ExecutionContext): Future[Unit] = {
-
-    val linker = StandardImpl.linker(StandardConfig())
-    val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
-    val output = LinkerOutput(MemOutputFile())
-
-    TestIRRepo.minilib.flatMap { stdLibFiles =>
-      linker.link(stdLibFiles ++ classDefsFiles, moduleInitializers,
-          output, new ScalaConsoleLogger(Level.Error))
-    }
-  }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
@@ -1,0 +1,38 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.testutils
+
+import scala.concurrent._
+
+import org.scalajs.ir.Trees.ClassDef
+
+import org.scalajs.logging._
+
+import org.scalajs.linker._
+import org.scalajs.linker.interface._
+
+object LinkingUtils {
+  def testLink(classDefs: Seq[ClassDef],
+      moduleInitializers: List[ModuleInitializer])(
+      implicit ec: ExecutionContext): Future[Unit] = {
+
+    val linker = StandardImpl.linker(StandardConfig())
+    val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
+    val output = LinkerOutput(MemOutputFile())
+
+    TestIRRepo.minilib.flatMap { stdLibFiles =>
+      linker.link(stdLibFiles ++ classDefsFiles, moduleInitializers,
+          output, new ScalaConsoleLogger(Level.Error))
+    }
+  }
+}


### PR DESCRIPTION
`tryOptimizePatternMatch` tries to identify `Return`s to a given `Labeled` block, and rearrange the code to get rid of both. It was too liberal in how it did so, as it recognized *any* `Return` in the expected positions. We now specifically verify that the `Return`s are for the particular `Labeled` block that we are optimizing.