### PR TITLE
Fix #4151: Report a somewhat helpful message for back-end exceptions.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -418,6 +418,14 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         for (tree <- clDefs) {
           genIRFile(cunit, tree)
         }
+      } catch {
+        // Handle exceptions in exactly the same way as the JVM backend
+        case ex: InterruptedException =>
+          throw ex
+        case ex: Throwable =>
+          if (settings.debug)
+            ex.printStackTrace()
+          globalError(s"Error while emitting ${cunit.source}\n${ex.getMessage}")
       } finally {
         lazilyGeneratedAnonClasses.clear()
         generatedStaticForwarderClasses.clear()

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/DiverseErrorsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/DiverseErrorsTest.scala
@@ -299,4 +299,23 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
 
   }
 
+  @Test
+  def veryLongStringLiteral(): Unit = {
+    // Create a string whose length is greater than 65,635 bytes
+    val len = 70000
+    val charArray = new Array[Char](len)
+    java.util.Arrays.fill(charArray, 'A')
+    val veryLongString = new String(charArray)
+
+    s"""
+    object Foo {
+      val bar: String = "$veryLongString"
+    }
+    """ hasErrors
+    """
+      |error: Error while emitting newSource1.scala
+      |encoded string too long: 70000 bytes
+    """
+  }
+
 }


### PR DESCRIPTION
This implements exactly the same last resort mechanism as the JVM for back-end crashes. In particular, it applies for string literals that are too long to be serialized (in JVM bytecode or in SJSIR).

Arguably, this should be caught earlier as a nice front-end compile error, but that is not a job for Scala.js.