### PR TITLE
Port two new internal methods of `ClassTag` from upstream.

### DIFF
--- a/scalalib/overrides-2.13/scala/reflect/ClassTag.scala
+++ b/scalalib/overrides-2.13/scala/reflect/ClassTag.scala
@@ -15,6 +15,9 @@ package reflect
 
 import java.lang.{ Class => jClass }
 
+import scala.collection.mutable
+import scala.runtime.BoxedUnit
+
 /**
  *
  * A `ClassTag[T]` stores the erased class of a given type `T`, accessible via the `runtimeClass`
@@ -46,6 +49,22 @@ import java.lang.{ Class => jClass }
  */
 @scala.annotation.implicitNotFound(msg = "No ClassTag available for ${T}")
 trait ClassTag[T] extends ClassManifestDeprecatedApis[T] with Equals with Serializable {
+
+  /* Scala.js deviation: emptyArray and emptyWrappedArray are
+   * `@transient lazy val`s on the JVM, but we make them `def`s. On the JVM,
+   * instances of `ClassTag` are cached, so that makes sense. On JS, however,
+   * `ClassTag`s are usually stack-allocated instead, hence the lazy vals
+   * contribute more useless code than actual caching. `def`s are more
+   * appropriate.
+   */
+  private[scala] def emptyArray: Array[T] = {
+    val componentType =
+      if (runtimeClass eq classOf[Void]) classOf[BoxedUnit] else runtimeClass
+    java.lang.reflect.Array.newInstance(componentType, 0).asInstanceOf[Array[T]]
+  }
+  private[scala] def emptyWrappedArray: mutable.WrappedArray[T] =
+    mutable.WrappedArray.make[T](emptyArray)
+
   // please, don't add any APIs here, like it was with `newWrappedArray` and `newArrayBuilder`
   // class tags, and all tags in general, should be as minimalistic as possible
 


### PR DESCRIPTION
This is a port of the changes to `ClassTag` in https://github.com/scala/scala/commit/31d6481b8a1322bd1ecfa6d68c49f6c03ab42f19

Although that commit has not reached the 2.13.x branch, we also apply the changes to the 2.13.x overrides to be future-proof.

---

This fixes the nightly build on 2.12.x. Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.12.13-bin-490e3e3
> testSuite2_12/test
```