### PR TITLE
Extract a few tests with Arrays of Null and Nothing as Scala 2.x-only.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -87,12 +87,6 @@ class RuntimeTypesTest {
     assertThrows(classOf[ClassCastException], "a".asInstanceOf[Null])
   }
 
-  @Test def scala_Null_classTag_of_scala_Null_should_contain_proper_Class_issue_297(): Unit = {
-    val tag = scala.reflect.classTag[Null]
-    assertTrue(tag.runtimeClass != null)
-    assertEquals("scala.runtime.Null$", tag.runtimeClass.getName)
-  }
-
   @Test def scala_Null_casts_to_scala_Null_should_succeed_on_null(): Unit = {
     null.asInstanceOf[Null]
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -70,18 +70,6 @@ class RuntimeTypesTest {
     test(null)
   }
 
-  @Test def scala_Nothing_Array_Nothing_should_be_allowed_to_exists_and_be_castable(): Unit = {
-    val arr = Array[Nothing]()
-    arr.asInstanceOf[Array[Nothing]]
-  }
-
-  @Test def scala_Nothing_Array_Array_Nothing_too(): Unit = {
-    val arr = Array[Array[Nothing]]()
-    arr.asInstanceOf[Array[Array[Nothing]]]
-    // This apparently works too... Dunno why
-    arr.asInstanceOf[Array[Nothing]]
-  }
-
   @Test def scala_Null_casts_to_scala_Null_should_fail_for_everything_else_but_null(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     assertThrows(classOf[ClassCastException], "a".asInstanceOf[Null])
@@ -89,18 +77,6 @@ class RuntimeTypesTest {
 
   @Test def scala_Null_casts_to_scala_Null_should_succeed_on_null(): Unit = {
     null.asInstanceOf[Null]
-  }
-
-  @Test def scala_Null_Array_Null_should_be_allowed_to_exist_and_be_castable(): Unit = {
-    val arr = Array.fill[Null](5)(null)
-    arr.asInstanceOf[Array[Null]]
-  }
-
-  @Test def scala_Null_Array_Array_Null_too(): Unit = {
-    val arr = Array.fill[Null](5,5)(null)
-    arr.asInstanceOf[Array[Array[Null]]]
-    // This apparently works too... Dunno why
-    arr.asInstanceOf[Array[Null]]
   }
 
   @Test def scala_Arrays_of_JS_types(): Unit = {

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/RuntimeTypesTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/RuntimeTypesTestScala2.scala
@@ -1,0 +1,50 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.compiler
+
+import org.junit.Test
+
+class RuntimeTypesTestScala2 {
+
+  /* The following tests are Scala 2.x only because `Array[Null]` and
+   * `Array[Nothing]` are not officially supported in Scala 3. As of this
+   * writing, they *can* be made to work by actively avoiding the `ClassTag`s,
+   * but they might break at any point in the future.
+   */
+
+  @Test def scala_Nothing_Array_Nothing_should_be_allowed_to_exists_and_be_castable(): Unit = {
+    val arr = Array[Nothing]()
+    arr.asInstanceOf[Array[Nothing]]
+  }
+
+  @Test def scala_Nothing_Array_Array_Nothing_too(): Unit = {
+    val arr = Array[Array[Nothing]]()
+    arr.asInstanceOf[Array[Array[Nothing]]]
+    // This apparently works too... Dunno why
+    arr.asInstanceOf[Array[Nothing]]
+  }
+
+  @Test def scala_Null_Array_Null_should_be_allowed_to_exist_and_be_castable(): Unit = {
+    val arr = Array.fill[Null](5)(null)
+    arr.asInstanceOf[Array[Null]]
+  }
+
+  @Test def scala_Null_Array_Array_Null_too(): Unit = {
+    // Was `val arr = Array.fill[Null](5, 5)(null)` but that crashes on the JVM
+    val arr = new Array[Array[Null]](5)
+    arr.asInstanceOf[Array[Array[Null]]]
+    // This apparently works too... Dunno why
+    arr.asInstanceOf[Array[Null]]
+  }
+
+}

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ClassTagTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ClassTagTestScala2.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.scalalib
 import scala.reflect._
 
 import org.junit.Test
-import org.junit.Assert.assertSame
+import org.junit.Assert._
 
 class ClassTagTestScala2 {
 
@@ -44,5 +44,16 @@ class ClassTagTestScala2 {
     // The same happens on the JVM
     assertSame(classOf[Array[scala.runtime.Nothing$]], classTag[Array[Nothing]].runtimeClass)
     assertSame(classOf[Array[scala.runtime.Null$]], classTag[Array[Null]].runtimeClass)
+  }
+
+  /**
+   * This is a Scala 2.x only test because:
+   * Dotty does not have [[ClassTag]] instances for [[Nothing]] or for [[Null]].
+   * @see [[https://github.com/lampepfl/dotty/issues/1730]]
+   */
+  @Test def scala_Null_classTag_of_scala_Null_should_contain_proper_Class_issue_297(): Unit = {
+    val tag = classTag[Null]
+    assertTrue(tag.runtimeClass != null)
+    assertEquals("scala.runtime.Null$", tag.runtimeClass.getName)
   }
 }


### PR DESCRIPTION
As of this writing, the tests that were moved *can* be made to work by actively avoiding the `ClassTag`s, but they might break at any point in the future, because the status of `Array[Null]` and `Array[Nothing]` themselves in Scala 3 is up in the air.