### PR TITLE
Simplify OutputFile's API

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/OutputFileImpl.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/OutputFileImpl.scala
@@ -21,37 +21,9 @@ import org.scalajs.linker.interface.LinkerOutput
 abstract class OutputFileImpl extends LinkerOutput.File {
   final private[interface] def impl: OutputFileImpl = this
 
-  def newChannel()(implicit ec: ExecutionContext): Future[OutputFileImpl.Channel]
-
-  def writeFull(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit] = {
-    newChannel().flatMap { chan =>
-      def writeLoop(): Future[Unit] = {
-        if (buf.hasRemaining()) chan.write(buf).flatMap(_ => writeLoop())
-        else Future.successful(())
-      }
-
-      finallyWith(writeLoop(), chan.close())
-    }
-  }
-
-  private def finallyWith(v: Future[Unit], f: => Future[Unit])(
-      implicit ec: ExecutionContext): Future[Unit] = {
-    v.map[Option[Throwable]](_ => None)
-      .recover { case t => Some(t) }
-      .flatMap {
-        case None => f
-
-        case Some(vt) =>
-          f.transform(_ => throw vt, ft => { ft.addSuppressed(vt); ft })
-      }
-  }
+  def writeFull(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit]
 }
 
 object OutputFileImpl {
   def fromOutputFile(f: LinkerOutput.File): OutputFileImpl = f.impl
-
-  trait Channel {
-    def write(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit]
-    def close()(implicit ec: ExecutionContext): Future[Unit]
-  }
 }

--- a/linker/js/src/main/scala/org/scalajs/linker/NodeFS.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/NodeFS.scala
@@ -65,10 +65,9 @@ private[linker] object NodeFS {
   def read(fd: Int, buffer: TypedArray[_, _], offset: Int, length: Int, position: Int,
       callback: CB[Int]): Unit = js.native
 
-  @JSImport("fs", "write")
+  @JSImport("fs", "writeFile")
   @js.native
-  def write(fd: Int, buffer: TypedArray[_, _], offset: Int, length: Int,
-      position: js.UndefOr[Int], callback: CB[Int]): Unit = js.native
+  def writeFile(path: String, data: TypedArray[_, _], callback: CB[Unit]): Unit = js.native
 
   @JSImport("fs", "readdir")
   @js.native

--- a/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputFile.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputFile.scala
@@ -28,83 +28,71 @@ object PathOutputFile {
 
   def atomic(path: Path): LinkerOutput.File = new AtomicPathOutputFileImpl(path)
 
-  import OutputFileImpl.Channel
-
   private final class PathOutputFileImpl(path: Path) extends OutputFileImpl {
-    def newChannel()(implicit ec: ExecutionContext): Future[Channel] =
-      Future(blocking(new PathChannel(path)))
+    def writeFull(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit] =
+      writeFullImpl(path, buf)
   }
 
   private final class AtomicPathOutputFileImpl(path: Path) extends OutputFileImpl {
-    def newChannel()(implicit ec: ExecutionContext): Future[Channel] =
-      Future(blocking(newAtomicChannel(path)))
-  }
-
-  private def newAtomicChannel(path: Path): Channel = {
-    val tmpFile =
-      Files.createTempFile(path.getParent(), ".tmp-" + path.getFileName(), ".tmp")
-
-    try {
-      val chan = new PathChannel(tmpFile)
-      new AtomicChannel(path, tmpFile, chan)
-    } catch {
-      case t: Throwable =>
-        Files.deleteIfExists(tmpFile)
-        throw t
-    }
-  }
-
-  private final class AtomicChannel(baseFile: Path, tmpFile: Path, chan: Channel) extends Channel {
-    def write(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit] = chan.write(buf)
-
-    def close()(implicit ec: ExecutionContext): Future[Unit] = {
-      chan.close()
-        .map(_ => blocking(move()))
-        .finallyWith(Future(blocking(Files.deleteIfExists(tmpFile))))
-    }
-
-    private def move(): Unit = {
-      try {
-        // Try atomic move.
-        Files.move(tmpFile, baseFile, StandardCopyOption.ATOMIC_MOVE)
-      } catch {
-        case _: IOException =>
-          /* We need to catch all exceptions, because it is platform dependent:
-           * - whether ATOMIC_MOVE overrides an existing file or not,
-           * - it throws a FileAlreadyExistsException in this case.
-           *
-           * If the atomic move fails, we fall back to a normal copy & delete.
-           */
-          Files.copy(tmpFile, baseFile, StandardCopyOption.REPLACE_EXISTING)
+    def writeFull(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit] = {
+      Future(blocking(Files.createTempFile(
+          path.getParent(), ".tmp-" + path.getFileName(), ".tmp"))).flatMap { tmpFile =>
+        writeFullImpl(tmpFile, buf)
+          .flatMap(_ => Future(blocking(move(tmpFile, path))))
+          .finallyWith(Future(blocking(Files.deleteIfExists(tmpFile))))
       }
     }
   }
 
-  private final class PathChannel(path: Path) extends Channel {
+  private def writeFullImpl(path: Path, buf: ByteBuffer)(
+      implicit ec: ExecutionContext): Future[Unit] = {
     import StandardOpenOption._
 
-    private[this] var _pos = 0L
-
-    private[this] val chan =
-      AsynchronousFileChannel.open(path, WRITE, CREATE, TRUNCATE_EXISTING)
-
-    def write(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit] = {
-      val promise = Promise[Unit]()
-      chan.write(buf, _pos, promise, Handler)
-      promise.future
+    Future(blocking(AsynchronousFileChannel.open(
+        path, WRITE, CREATE, TRUNCATE_EXISTING))).flatMap { chan =>
+      writeToChannel(chan, buf)
+        .finallyWith(Future(blocking(chan.close())))
     }
+  }
 
-    def close()(implicit ec: ExecutionContext): Future[Unit] =
-      Future(blocking(chan.close()))
+  private def writeToChannel(chan: AsynchronousFileChannel, buf: ByteBuffer): Future[Unit] = {
+    val promise = Promise[Unit]()
 
-    private object Handler extends CompletionHandler[Integer, Promise[Unit]]{
-      def completed(written: Integer, promise: Promise[Unit]): Unit = {
-        _pos += written
-        promise.success(())
+    var pos = 0
+
+    def writeLoop(): Unit =
+      chan.write(buf, pos, (), Handler)
+
+    object Handler extends CompletionHandler[Integer, Unit]{
+      def completed(written: Integer, unit: Unit): Unit = {
+        pos += written
+        if (buf.hasRemaining())
+          writeLoop()
+        else
+          promise.success(())
       }
 
-      def failed(exc: Throwable, promise: Promise[Unit]): Unit =
+      def failed(exc: Throwable, unit: Unit): Unit =
         promise.failure(exc)
+    }
+
+    writeLoop()
+    promise.future
+  }
+
+  private def move(from: Path, to: Path): Unit = {
+    try {
+      // Try atomic move.
+      Files.move(from, to, StandardCopyOption.ATOMIC_MOVE)
+    } catch {
+      case _: IOException =>
+        /* We need to catch all exceptions, because it is platform dependent:
+         * - whether ATOMIC_MOVE overrides an existing file or not,
+         * - it throws a FileAlreadyExistsException in this case.
+         *
+         * If the atomic move fails, we fall back to a normal copy & delete.
+         */
+        Files.copy(from, to, StandardCopyOption.REPLACE_EXISTING)
     }
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/MemOutputFile.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/MemOutputFile.scala
@@ -41,35 +41,11 @@ object MemOutputFile {
       _content
     }
 
-    def newChannel()(implicit ec: ExecutionContext): Future[OutputFileImpl.Channel] =
-      Future.successful(new Channel)
-
-    override def writeFull(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit] = {
+    def writeFull(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit] = {
       val c = new Array[Byte](buf.remaining())
       buf.get(c)
       _content = c
       Future.successful(())
-    }
-
-    private class Channel extends OutputFileImpl.Channel {
-      private val out = new ByteArrayOutputStream
-
-      def write(buf: ByteBuffer)(implicit ec: ExecutionContext): Future[Unit] = Future {
-        val promise = Promise[Unit]()
-        if (buf.hasArray()) {
-          out.write(buf.array(), buf.arrayOffset() + buf.position(), buf.remaining())
-          buf.position(buf.limit())
-        } else {
-          val c = new Array[Byte](buf.remaining())
-          buf.get(c)
-          out.write(c)
-        }
-      }
-
-      def close()(implicit ec: ExecutionContext): Future[Unit] = {
-        _content = out.toByteArray
-        Future.successful(())
-      }
     }
   }
 }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -24,9 +24,33 @@ object BinaryIncompatibilities {
       exclude[ProblemRef]("org.scalajs.linker.analyzer.*"),
       exclude[ProblemRef]("org.scalajs.linker.backend.*"),
       exclude[ProblemRef]("org.scalajs.linker.frontend.*"),
+
+      // private, not an issue.
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.MemOutputFile#MemFileImpl.newChannel"),
+      exclude[MissingClassProblem](
+          "org.scalajs.linker.MemOutputFile$MemFileImpl$Channel"),
+      exclude[MissingClassProblem](
+          "org.scalajs.linker.PathOutputFile$AtomicChannel"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.PathOutputFile#AtomicPathOutputFileImpl.newChannel"),
+      exclude[MissingClassProblem](
+          "org.scalajs.linker.PathOutputFile$PathChannel"),
+      exclude[MissingClassProblem](
+          "org.scalajs.linker.PathOutputFile$PathChannel$Handler$"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.PathOutputFile#PathOutputFileImpl.newChannel"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.NodeFS.write"),
+      exclude[DirectMissingMethodProblem](
+          "org.scalajs.linker.NodeOutputFile#NodeOutputFileImpl.newChannel"),
+      exclude[MissingClassProblem](
+          "org.scalajs.linker.NodeOutputFile$NodeOutputChannel"),
   )
 
   val LinkerInterface = Seq(
+      // Breaking in stable API. OK in Minor version.
+      exclude[ProblemRef]("org.scalajs.linker.interface.unstable.*"),
   )
 
   val SbtPlugin = Seq(


### PR DESCRIPTION
Nothing in the linker was using the ability to write in a chunked
fashion (and it's unlikely we will in the near future). Since this is
part of the unstable API, we can always add this ability later.