### PR TITLE
Always have an entry point in sbt tests

### DIFF
--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/build.sbt
@@ -2,4 +2,4 @@ scalaVersion := "2.12.12"
 
 enablePlugins(ScalaJSPlugin)
 
-scalaJSUseMainModuleInitializer := false
+scalaJSUseMainModuleInitializer := true

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/test
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/test
@@ -3,7 +3,7 @@ $ copy-file Main.scala.first Main.scala
 $ copy-file target/scala-2.12/change-config-and-source-fastopt.js target/scala-2.12/output-1.js
 
 # When the linker config and source both change, re-running fastOptJS should re-link:
-> set scalaJSUseMainModuleInitializer := true
+> set scalaJSLinkerConfig ~= (_.withOptimizer(false))
 $ copy-file Main.scala.second Main.scala
 > fastOptJS
 -$ must-mirror target/scala-2.12/change-config-and-source-fastopt.js target/scala-2.12/output-1.js

--- a/sbt-plugin/src/sbt-test/incremental/change-config/build.sbt
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/build.sbt
@@ -2,4 +2,4 @@ scalaVersion := "2.12.12"
 
 enablePlugins(ScalaJSPlugin)
 
-scalaJSUseMainModuleInitializer := false
+scalaJSUseMainModuleInitializer := true

--- a/sbt-plugin/src/sbt-test/incremental/change-config/test
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/test
@@ -2,7 +2,7 @@
 $ copy-file target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-1.js
 
 # When the linker config changes, re-running fastOptJS should re-link:
-> set scalaJSUseMainModuleInitializer := true
+> set scalaJSLinkerConfig ~= (_.withOptimizer(false))
 > fastOptJS
 -$ must-mirror target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-1.js
 $ newer target/scala-2.12/change-config-fastopt.js target/scala-2.12/output-1.js

--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/build.sbt
@@ -8,3 +8,4 @@ disablePlugins(sbt.plugins.IvyPlugin)
 
 lazy val `my-project` = project
   .enablePlugins(ScalaJSPlugin)
+  .settings(scalaJSUseMainModuleInitializer := true)

--- a/sbt-plugin/src/sbt-test/linker/non-existent-classpath/Main.scala
+++ b/sbt-plugin/src/sbt-test/linker/non-existent-classpath/Main.scala
@@ -1,0 +1,5 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def main(args: Array[String]): Unit = println("Hello World")
+}

--- a/sbt-plugin/src/sbt-test/linker/non-existent-classpath/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/non-existent-classpath/build.sbt
@@ -6,3 +6,5 @@ enablePlugins(ScalaJSPlugin)
 // Test that non-existent classpath entries are allowed - #2198
 fullClasspath in Compile += baseDirectory.value /
   "non-existent-directory-please-dont-ever-create-this"
+
+scalaJSUseMainModuleInitializer := true


### PR DESCRIPTION
Not having an entry point at all is a valid use case for the linker,
but it is a corner case. This surfaces in module splitting, where we
will not be able to cover this case in a fully backwards compatible
manner (the linker will not produce anything at all in this case).

We bring the sbt tests (that do not test this corner case) in line
with a more normal use case to ease that transition.