### PR TITLE
Add an entry point in linker/concurrent-linker-use test

### DIFF
--- a/sbt-plugin/src/sbt-test/linker/concurrent-linker-use/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/concurrent-linker-use/build.sbt
@@ -15,6 +15,8 @@ scalaVersion := "2.12.12"
 
 enablePlugins(ScalaJSPlugin)
 
+scalaJSUseMainModuleInitializer := true
+
 /* This hopefully exposes concurrent uses of the linker. If it fails/gets
  * flaky, there is a bug somewhere - #2202
  */


### PR DESCRIPTION
This should have been part of 49509f783a387229e159f94128d88f854f0e2fad
but I forgot it.