### PR TITLE
Fix #4195: Clear the state of `LinkedHashMap` upon `clear()`.

### DIFF
--- a/javalib/src/main/scala/java/util/LinkedHashMap.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashMap.scala
@@ -93,6 +93,17 @@ class LinkedHashMap[K, V](initialCapacity: Int, loadFactor: Float,
       younger.older = older
   }
 
+  override def clear(): Unit = {
+    super.clear()
+
+    /* #4195 HashMap.clear() won't call `nodeWasRemoved` for every node, which
+     * would be inefficient, so `eldest` and `yougest` are not automatically
+     * updated. We must explicitly set them to `null` here.
+     */
+    eldest = null
+    youngest = null
+  }
+
   protected def removeEldestEntry(eldest: Map.Entry[K, V]): Boolean = false
 
   private[util] override def nodeIterator(): ju.Iterator[HashMap.Node[K, V]] =

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -314,9 +314,18 @@ trait MapTest {
     mp.put("TWO", "two")
     assertEquals(2, mp.size())
     mp.clear()
+
+    // Test the content size
     assertEquals(0, mp.size())
+
+    // Test the hash table
     assertNull(mp.get("ONE"))
     assertNull(mp.get("TWO"))
+
+    // Test the iterators (different from the hash table for LinkedHashMap)
+    assertFalse(mp.entrySet().iterator().hasNext())
+    assertFalse(mp.keySet().iterator().hasNext())
+    assertFalse(mp.values().iterator().hasNext())
 
     // can be reused after clear()
     mp.put("TWO", "value 2")


### PR DESCRIPTION
For most operations, we rely on the hooks like `nodeWasAdded` to update `eldest` and `youngest`. However that does not work for `clear()`, because `HashMap.clear()` takes shortcuts and does not call `nodeWasRemoved` for every node.

We now override `clear()` in `LinkedHashMap` to explicitly null out `eldest` and `youngest`.