### PR TITLE
Use captures instead of ctor params for anon JS class captures.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -840,9 +840,6 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
     }
 
     private case class ExportedSymbol(sym: Symbol) extends Exported {
-      private val isAnonJSClassConstructor =
-        sym.isClassConstructor && sym.owner.isAnonymousClass && isJSType(sym.owner)
-
       val isLiftedJSConstructor =
         sym.isClassConstructor && isNestedJSClass(sym.owner)
 
@@ -863,7 +860,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
           }
         }
 
-        if (!isLiftedJSConstructor && !isAnonJSClassConstructor) {
+        if (!isLiftedJSConstructor) {
           /* Easy case: all params are formal params, and we only need to
            * travel back before uncurry to handle repeated params, or before
            * posterasure for other params.
@@ -908,16 +905,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
             allParamsNow.splitAt(startOfRealParams)
           val captureParamsBack = restOfParamsNow.drop(formalParams.size)
 
-          if (isAnonJSClassConstructor) {
-            /* For an anonymous JS class constructor, we put the capture
-             * parameters back as formal parameters.
-             */
-            val allFormalParams =
-              captureParamsFront ::: formalParams ::: captureParamsBack
-            (allFormalParams.toIndexedSeq, Nil, Nil)
-          } else {
-            (formalParams.toIndexedSeq, captureParamsFront, captureParamsBack)
-          }
+          (formalParams.toIndexedSeq, captureParamsFront, captureParamsBack)
         }
       }
 


### PR DESCRIPTION
The logic in `GenJSExports.ExportedSymbol` has always separated "lifted" JS constructors from normal methods and Scala constructors (the latter are, by construction, never lifted at that point). For lifted constructors, it separates the original parameters from the captures, so that orignal parameters become formal parameters of the JS constructor function, while capture parameters become JS class captures.

However, before this commit, it put all parameters back together as regular parameters if the class was an anonymous JS class. The logic in `genAnonJSClass` reassigned those parameters based on the actual arguments inserted by lambdalift in the `new` invocation. Effectively, this dance treated those parameters as class captures, but with an extra indirection of going through constructor parameters.

In this commit, we remove this special case in `ExportedSymbol`, and treat all lifted JS constructors in the same way. `genAnonJSClass` now passes the actual arguments inserted by lambdalift as the actual values for the JS class captures thus produced.

Overall, the end result is basically the same, modulo some boxing and unboxing which happened with the previous scheme, which the optimizer would take care of. The new translation is however cleaner.

---

(backporting the translation scheme I implemented in dotty)