### PR TITLE
Add j.l.Character.to{Lower,Upper}Case(codePoint: Int)/toTitleCase

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -12,7 +12,7 @@
 
 package java.lang
 
-import scala.annotation.tailrec
+import scala.annotation.{tailrec, switch}
 import scala.scalajs.js
 
 import java.util.{ArrayList, Arrays, HashMap}
@@ -507,7 +507,38 @@ object Character {
     }
   }
 
-  //def toTitleCase(c: scala.Char): scala.Char
+  def toTitleCase(ch: scala.Char): scala.Char = toTitleCase(ch.toInt).toChar
+
+/*
+def format(codePoint: Int): String = "0x%04x".format(codePoint)
+
+for (cp <- 0 to Character.MAX_CODE_POINT) {
+  val titleCaseCP: Int = Character.toTitleCase(cp)
+  val upperCaseCP: Int = Character.toUpperCase(cp)
+
+  if (titleCaseCP != upperCaseCP) {
+    println(s"    case ${format(cp)} => ${format(titleCaseCP)}")
+  }
+}
+*/
+  def toTitleCase(codePoint: scala.Int): scala.Int = {
+    (codePoint: @switch) match {
+      case 0x01c4 => 0x01c5
+      case 0x01c5 => 0x01c5
+      case 0x01c6 => 0x01c5
+      case 0x01c7 => 0x01c8
+      case 0x01c8 => 0x01c8
+      case 0x01c9 => 0x01c8
+      case 0x01ca => 0x01cb
+      case 0x01cb => 0x01cb
+      case 0x01cc => 0x01cb
+      case 0x01f1 => 0x01f2
+      case 0x01f2 => 0x01f2
+      case 0x01f3 => 0x01f2
+      case _      => toUpperCase(codePoint)
+    }
+  }
+
   //def getNumericValue(c: scala.Char): Int
 
   /* Misc */

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -461,8 +461,52 @@ object Character {
   //def getDirectionality(c: scala.Char): scala.Byte
 
   /* Conversions */
-  def toUpperCase(c: scala.Char): scala.Char = c.toString.toUpperCase().charAt(0)
-  def toLowerCase(c: scala.Char): scala.Char = c.toString.toLowerCase().charAt(0)
+  def toUpperCase(ch: Char): Char = toUpperCase(ch.toInt).toChar
+
+  def toUpperCase(codePoint: scala.Int): scala.Int = {
+    codePoint match {
+      case 0x1fb3 | 0x1fc3 | 0x1ff3 =>
+        (codePoint + 0x0009)
+      case _ if codePoint >= 0x1f80 && codePoint <= 0x1faf =>
+        (codePoint | 0x0008)
+      case _ =>
+        val upperChars = _String.fromCodePoint(codePoint).toUpperCase()
+        upperChars.length match {
+          case 1 =>
+            upperChars.charAt(0).toInt
+          case 2 =>
+            val high = upperChars.charAt(0)
+            val low = upperChars.charAt(1)
+            if (isSurrogatePair(high, low))
+              toCodePoint(high, low)
+            else
+              codePoint
+          case _ =>
+            codePoint
+        }
+    }
+  }
+
+  def toLowerCase(ch: scala.Char): scala.Char = toLowerCase(ch.toInt).toChar
+
+  def toLowerCase(codePoint: scala.Int): scala.Int = {
+    val lowerChars = _String.fromCodePoint(codePoint).toLowerCase()
+
+    lowerChars.length match {
+      case 1 =>
+        lowerChars.charAt(0).toInt
+      case 2 =>
+        val high = lowerChars.charAt(0)
+        val low = lowerChars.charAt(1)
+        if (isSurrogatePair(high, low))
+          toCodePoint(high, low)
+        else
+          codePoint
+      case _ =>
+        codePoint
+    }
+  }
+
   //def toTitleCase(c: scala.Char): scala.Char
   //def getNumericValue(c: scala.Char): Int
 

--- a/javalanglib/src/main/scala/java/lang/_String.scala
+++ b/javalanglib/src/main/scala/java/lang/_String.scala
@@ -762,7 +762,7 @@ object _String { // scalastyle:ignore
 
   // Helpers
 
-  private def fromCodePoint(codePoint: Int): String = {
+  private[lang] def fromCodePoint(codePoint: Int): String = {
     if ((codePoint & ~Character.MAX_VALUE) == 0) {
       NativeJSString.fromCharCode(codePoint)
     } else if (codePoint < 0 || codePoint > Character.MAX_CODE_POINT) {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
@@ -635,6 +635,195 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0xfb17, Character.toUpperCase(0xfb17)) // ﬗ => ﬗ
   }
 
+  @Test def toTitleCase_compare_char_and_codepoint(): Unit = {
+    for (ch <- Character.MIN_VALUE to Character.MAX_VALUE)
+      assertEquals(Character.toTitleCase(ch), Character.toTitleCase(ch.toInt).toChar)
+  }
+
+  @Test def toTitleCase_CodePoint_special_cases(): Unit = {
+    assertEquals(0x1fbc, Character.toTitleCase(0x1fb3))
+    assertEquals(0x1fcc, Character.toTitleCase(0x1fc3))
+    assertEquals(0x1ffc, Character.toTitleCase(0x1ff3))
+
+    assertEquals(0x1f88, Character.toTitleCase(0x1f80))
+    assertEquals(0x1f89, Character.toTitleCase(0x1f81))
+    assertEquals(0x1f8a, Character.toTitleCase(0x1f82))
+    assertEquals(0x1f8b, Character.toTitleCase(0x1f83))
+    assertEquals(0x1f8c, Character.toTitleCase(0x1f84))
+    assertEquals(0x1f8d, Character.toTitleCase(0x1f85))
+    assertEquals(0x1f8e, Character.toTitleCase(0x1f86))
+    assertEquals(0x1f8f, Character.toTitleCase(0x1f87))
+    assertEquals(0x1f88, Character.toTitleCase(0x1f88))
+    assertEquals(0x1f89, Character.toTitleCase(0x1f89))
+    assertEquals(0x1f8a, Character.toTitleCase(0x1f8a))
+    assertEquals(0x1f8b, Character.toTitleCase(0x1f8b))
+    assertEquals(0x1f8c, Character.toTitleCase(0x1f8c))
+    assertEquals(0x1f8d, Character.toTitleCase(0x1f8d))
+    assertEquals(0x1f8e, Character.toTitleCase(0x1f8e))
+    assertEquals(0x1f8f, Character.toTitleCase(0x1f8f))
+    assertEquals(0x1f98, Character.toTitleCase(0x1f90))
+    assertEquals(0x1f99, Character.toTitleCase(0x1f91))
+    assertEquals(0x1f9a, Character.toTitleCase(0x1f92))
+    assertEquals(0x1f9b, Character.toTitleCase(0x1f93))
+    assertEquals(0x1f9c, Character.toTitleCase(0x1f94))
+    assertEquals(0x1f9d, Character.toTitleCase(0x1f95))
+    assertEquals(0x1f9e, Character.toTitleCase(0x1f96))
+    assertEquals(0x1f9f, Character.toTitleCase(0x1f97))
+    assertEquals(0x1f98, Character.toTitleCase(0x1f98))
+    assertEquals(0x1f99, Character.toTitleCase(0x1f99))
+    assertEquals(0x1f9a, Character.toTitleCase(0x1f9a))
+    assertEquals(0x1f9b, Character.toTitleCase(0x1f9b))
+    assertEquals(0x1f9c, Character.toTitleCase(0x1f9c))
+    assertEquals(0x1f9d, Character.toTitleCase(0x1f9d))
+    assertEquals(0x1f9e, Character.toTitleCase(0x1f9e))
+    assertEquals(0x1f9f, Character.toTitleCase(0x1f9f))
+    assertEquals(0x1fa8, Character.toTitleCase(0x1fa0))
+    assertEquals(0x1fa9, Character.toTitleCase(0x1fa1))
+    assertEquals(0x1faa, Character.toTitleCase(0x1fa2))
+    assertEquals(0x1fab, Character.toTitleCase(0x1fa3))
+    assertEquals(0x1fac, Character.toTitleCase(0x1fa4))
+    assertEquals(0x1fad, Character.toTitleCase(0x1fa5))
+    assertEquals(0x1fae, Character.toTitleCase(0x1fa6))
+    assertEquals(0x1faf, Character.toTitleCase(0x1fa7))
+    assertEquals(0x1fa8, Character.toTitleCase(0x1fa8))
+    assertEquals(0x1fa9, Character.toTitleCase(0x1fa9))
+    assertEquals(0x1faa, Character.toTitleCase(0x1faa))
+    assertEquals(0x1fab, Character.toTitleCase(0x1fab))
+    assertEquals(0x1fac, Character.toTitleCase(0x1fac))
+    assertEquals(0x1fad, Character.toTitleCase(0x1fad))
+    assertEquals(0x1fae, Character.toTitleCase(0x1fae))
+    assertEquals(0x1faf, Character.toTitleCase(0x1faf))
+  }
+
+/*
+def format(codePoint: Int): String = "0x%04x".format(codePoint)
+
+for (cp <- 0 to Character.MAX_CODE_POINT) {
+  val cpStr: String = new String(Array(cp), 0, 1)
+  val titleCP: Int = Character.toTitleCase(cp)
+  val titleCPStr: String = new String(Array(titleCP), 0, 1)
+
+  if (cpStr.toUpperCase() != titleCPStr)
+    println(s"    assertEquals(${format(titleCP)}, Character.toTitleCase(${format(cp)})) // $cpStr => $titleCPStr")
+}
+*/
+  @Test def toTitleCase_CodePoint_StringUpperCase_diff_CharacterTitleCase(): Unit = {
+    assertEquals(0x00df, Character.toTitleCase(0x00df)) // ß => ß
+    assertEquals(0x0149, Character.toTitleCase(0x0149)) // ŉ => ŉ
+    assertEquals(0x01c5, Character.toTitleCase(0x01c4)) // Ǆ => ǅ
+    assertEquals(0x01c5, Character.toTitleCase(0x01c5)) // ǅ => ǅ
+    assertEquals(0x01c5, Character.toTitleCase(0x01c6)) // ǆ => ǅ
+    assertEquals(0x01c8, Character.toTitleCase(0x01c7)) // Ǉ => ǈ
+    assertEquals(0x01c8, Character.toTitleCase(0x01c8)) // ǈ => ǈ
+    assertEquals(0x01c8, Character.toTitleCase(0x01c9)) // ǉ => ǈ
+    assertEquals(0x01cb, Character.toTitleCase(0x01ca)) // Ǌ => ǋ
+    assertEquals(0x01cb, Character.toTitleCase(0x01cb)) // ǋ => ǋ
+    assertEquals(0x01cb, Character.toTitleCase(0x01cc)) // ǌ => ǋ
+    assertEquals(0x01f0, Character.toTitleCase(0x01f0)) // ǰ => ǰ
+    assertEquals(0x01f2, Character.toTitleCase(0x01f1)) // Ǳ => ǲ
+    assertEquals(0x01f2, Character.toTitleCase(0x01f2)) // ǲ => ǲ
+    assertEquals(0x01f2, Character.toTitleCase(0x01f3)) // ǳ => ǲ
+    assertEquals(0x0390, Character.toTitleCase(0x0390)) // ΐ => ΐ
+    assertEquals(0x03b0, Character.toTitleCase(0x03b0)) // ΰ => ΰ
+    assertEquals(0x0587, Character.toTitleCase(0x0587)) // և => և
+    assertEquals(0x1e96, Character.toTitleCase(0x1e96)) // ẖ => ẖ
+    assertEquals(0x1e97, Character.toTitleCase(0x1e97)) // ẗ => ẗ
+    assertEquals(0x1e98, Character.toTitleCase(0x1e98)) // ẘ => ẘ
+    assertEquals(0x1e99, Character.toTitleCase(0x1e99)) // ẙ => ẙ
+    assertEquals(0x1e9a, Character.toTitleCase(0x1e9a)) // ẚ => ẚ
+    assertEquals(0x1f50, Character.toTitleCase(0x1f50)) // ὐ => ὐ
+    assertEquals(0x1f52, Character.toTitleCase(0x1f52)) // ὒ => ὒ
+    assertEquals(0x1f54, Character.toTitleCase(0x1f54)) // ὔ => ὔ
+    assertEquals(0x1f56, Character.toTitleCase(0x1f56)) // ὖ => ὖ
+    assertEquals(0x1f88, Character.toTitleCase(0x1f80)) // ᾀ => ᾈ
+    assertEquals(0x1f89, Character.toTitleCase(0x1f81)) // ᾁ => ᾉ
+    assertEquals(0x1f8a, Character.toTitleCase(0x1f82)) // ᾂ => ᾊ
+    assertEquals(0x1f8b, Character.toTitleCase(0x1f83)) // ᾃ => ᾋ
+    assertEquals(0x1f8c, Character.toTitleCase(0x1f84)) // ᾄ => ᾌ
+    assertEquals(0x1f8d, Character.toTitleCase(0x1f85)) // ᾅ => ᾍ
+    assertEquals(0x1f8e, Character.toTitleCase(0x1f86)) // ᾆ => ᾎ
+    assertEquals(0x1f8f, Character.toTitleCase(0x1f87)) // ᾇ => ᾏ
+    assertEquals(0x1f88, Character.toTitleCase(0x1f88)) // ᾈ => ᾈ
+    assertEquals(0x1f89, Character.toTitleCase(0x1f89)) // ᾉ => ᾉ
+    assertEquals(0x1f8a, Character.toTitleCase(0x1f8a)) // ᾊ => ᾊ
+    assertEquals(0x1f8b, Character.toTitleCase(0x1f8b)) // ᾋ => ᾋ
+    assertEquals(0x1f8c, Character.toTitleCase(0x1f8c)) // ᾌ => ᾌ
+    assertEquals(0x1f8d, Character.toTitleCase(0x1f8d)) // ᾍ => ᾍ
+    assertEquals(0x1f8e, Character.toTitleCase(0x1f8e)) // ᾎ => ᾎ
+    assertEquals(0x1f8f, Character.toTitleCase(0x1f8f)) // ᾏ => ᾏ
+    assertEquals(0x1f98, Character.toTitleCase(0x1f90)) // ᾐ => ᾘ
+    assertEquals(0x1f99, Character.toTitleCase(0x1f91)) // ᾑ => ᾙ
+    assertEquals(0x1f9a, Character.toTitleCase(0x1f92)) // ᾒ => ᾚ
+    assertEquals(0x1f9b, Character.toTitleCase(0x1f93)) // ᾓ => ᾛ
+    assertEquals(0x1f9c, Character.toTitleCase(0x1f94)) // ᾔ => ᾜ
+    assertEquals(0x1f9d, Character.toTitleCase(0x1f95)) // ᾕ => ᾝ
+    assertEquals(0x1f9e, Character.toTitleCase(0x1f96)) // ᾖ => ᾞ
+    assertEquals(0x1f9f, Character.toTitleCase(0x1f97)) // ᾗ => ᾟ
+    assertEquals(0x1f98, Character.toTitleCase(0x1f98)) // ᾘ => ᾘ
+    assertEquals(0x1f99, Character.toTitleCase(0x1f99)) // ᾙ => ᾙ
+    assertEquals(0x1f9a, Character.toTitleCase(0x1f9a)) // ᾚ => ᾚ
+    assertEquals(0x1f9b, Character.toTitleCase(0x1f9b)) // ᾛ => ᾛ
+    assertEquals(0x1f9c, Character.toTitleCase(0x1f9c)) // ᾜ => ᾜ
+    assertEquals(0x1f9d, Character.toTitleCase(0x1f9d)) // ᾝ => ᾝ
+    assertEquals(0x1f9e, Character.toTitleCase(0x1f9e)) // ᾞ => ᾞ
+    assertEquals(0x1f9f, Character.toTitleCase(0x1f9f)) // ᾟ => ᾟ
+    assertEquals(0x1fa8, Character.toTitleCase(0x1fa0)) // ᾠ => ᾨ
+    assertEquals(0x1fa9, Character.toTitleCase(0x1fa1)) // ᾡ => ᾩ
+    assertEquals(0x1faa, Character.toTitleCase(0x1fa2)) // ᾢ => ᾪ
+    assertEquals(0x1fab, Character.toTitleCase(0x1fa3)) // ᾣ => ᾫ
+    assertEquals(0x1fac, Character.toTitleCase(0x1fa4)) // ᾤ => ᾬ
+    assertEquals(0x1fad, Character.toTitleCase(0x1fa5)) // ᾥ => ᾭ
+    assertEquals(0x1fae, Character.toTitleCase(0x1fa6)) // ᾦ => ᾮ
+    assertEquals(0x1faf, Character.toTitleCase(0x1fa7)) // ᾧ => ᾯ
+    assertEquals(0x1fa8, Character.toTitleCase(0x1fa8)) // ᾨ => ᾨ
+    assertEquals(0x1fa9, Character.toTitleCase(0x1fa9)) // ᾩ => ᾩ
+    assertEquals(0x1faa, Character.toTitleCase(0x1faa)) // ᾪ => ᾪ
+    assertEquals(0x1fab, Character.toTitleCase(0x1fab)) // ᾫ => ᾫ
+    assertEquals(0x1fac, Character.toTitleCase(0x1fac)) // ᾬ => ᾬ
+    assertEquals(0x1fad, Character.toTitleCase(0x1fad)) // ᾭ => ᾭ
+    assertEquals(0x1fae, Character.toTitleCase(0x1fae)) // ᾮ => ᾮ
+    assertEquals(0x1faf, Character.toTitleCase(0x1faf)) // ᾯ => ᾯ
+    assertEquals(0x1fb2, Character.toTitleCase(0x1fb2)) // ᾲ => ᾲ
+    assertEquals(0x1fbc, Character.toTitleCase(0x1fb3)) // ᾳ => ᾼ
+    assertEquals(0x1fb4, Character.toTitleCase(0x1fb4)) // ᾴ => ᾴ
+    assertEquals(0x1fb6, Character.toTitleCase(0x1fb6)) // ᾶ => ᾶ
+    assertEquals(0x1fb7, Character.toTitleCase(0x1fb7)) // ᾷ => ᾷ
+    assertEquals(0x1fbc, Character.toTitleCase(0x1fbc)) // ᾼ => ᾼ
+    assertEquals(0x1fc2, Character.toTitleCase(0x1fc2)) // ῂ => ῂ
+    assertEquals(0x1fcc, Character.toTitleCase(0x1fc3)) // ῃ => ῌ
+    assertEquals(0x1fc4, Character.toTitleCase(0x1fc4)) // ῄ => ῄ
+    assertEquals(0x1fc6, Character.toTitleCase(0x1fc6)) // ῆ => ῆ
+    assertEquals(0x1fc7, Character.toTitleCase(0x1fc7)) // ῇ => ῇ
+    assertEquals(0x1fcc, Character.toTitleCase(0x1fcc)) // ῌ => ῌ
+    assertEquals(0x1fd2, Character.toTitleCase(0x1fd2)) // ῒ => ῒ
+    assertEquals(0x1fd3, Character.toTitleCase(0x1fd3)) // ΐ => ΐ
+    assertEquals(0x1fd6, Character.toTitleCase(0x1fd6)) // ῖ => ῖ
+    assertEquals(0x1fd7, Character.toTitleCase(0x1fd7)) // ῗ => ῗ
+    assertEquals(0x1fe2, Character.toTitleCase(0x1fe2)) // ῢ => ῢ
+    assertEquals(0x1fe3, Character.toTitleCase(0x1fe3)) // ΰ => ΰ
+    assertEquals(0x1fe4, Character.toTitleCase(0x1fe4)) // ῤ => ῤ
+    assertEquals(0x1fe6, Character.toTitleCase(0x1fe6)) // ῦ => ῦ
+    assertEquals(0x1fe7, Character.toTitleCase(0x1fe7)) // ῧ => ῧ
+    assertEquals(0x1ff2, Character.toTitleCase(0x1ff2)) // ῲ => ῲ
+    assertEquals(0x1ffc, Character.toTitleCase(0x1ff3)) // ῳ => ῼ
+    assertEquals(0x1ff4, Character.toTitleCase(0x1ff4)) // ῴ => ῴ
+    assertEquals(0x1ff6, Character.toTitleCase(0x1ff6)) // ῶ => ῶ
+    assertEquals(0x1ff7, Character.toTitleCase(0x1ff7)) // ῷ => ῷ
+    assertEquals(0x1ffc, Character.toTitleCase(0x1ffc)) // ῼ => ῼ
+    assertEquals(0xfb00, Character.toTitleCase(0xfb00)) // ﬀ => ﬀ
+    assertEquals(0xfb01, Character.toTitleCase(0xfb01)) // ﬁ => ﬁ
+    assertEquals(0xfb02, Character.toTitleCase(0xfb02)) // ﬂ => ﬂ
+    assertEquals(0xfb03, Character.toTitleCase(0xfb03)) // ﬃ => ﬃ
+    assertEquals(0xfb04, Character.toTitleCase(0xfb04)) // ﬄ => ﬄ
+    assertEquals(0xfb05, Character.toTitleCase(0xfb05)) // ﬅ => ﬅ
+    assertEquals(0xfb06, Character.toTitleCase(0xfb06)) // ﬆ => ﬆ
+    assertEquals(0xfb13, Character.toTitleCase(0xfb13)) // ﬓ => ﬓ
+    assertEquals(0xfb14, Character.toTitleCase(0xfb14)) // ﬔ => ﬔ
+    assertEquals(0xfb15, Character.toTitleCase(0xfb15)) // ﬕ => ﬕ
+    assertEquals(0xfb16, Character.toTitleCase(0xfb16)) // ﬖ => ﬖ
+    assertEquals(0xfb17, Character.toTitleCase(0xfb17)) // ﬗ => ﬗ
+  }
+
   @Test def codePointCount_String(): Unit = {
     val s: String =
       "abc\uD834\uDF06de\uD834\uDF06fgh\uD834ij\uDF06\uD834kl\uDF06"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
@@ -383,6 +383,258 @@ class CharacterTest {
     assertFalse(Character.isDigit('\uFBFC'))
   }
 
+  @Test def toLowerCase_compare_char_and_codepoint(): Unit = {
+    for (ch <- Character.MIN_VALUE to Character.MAX_VALUE)
+      assertEquals(Character.toLowerCase(ch), Character.toLowerCase(ch.toInt).toChar)
+  }
+
+  @Test def toLowerCase_Int(): Unit = {
+    // ASCII, not a letter
+    assertEquals(0x000a, Character.toLowerCase(0x000a)) // '\n' => '\n'
+    assertEquals(0x0037, Character.toLowerCase(0x0037)) // '7' => '7'
+    assertEquals(0xff3b, Character.toLowerCase(0xff3b)) // ［ => ［
+
+    // ASCII, letters
+    assertEquals(0x0061, Character.toLowerCase(0x0041)) // A => a
+    assertEquals(0x0066, Character.toLowerCase(0x0046)) // F => f
+    assertEquals(0x007a, Character.toLowerCase(0x005a)) // Z => z
+    assertEquals(0x03b2, Character.toLowerCase(0x0392)) // Β => β
+    assertEquals(0x03bc, Character.toLowerCase(0x039c)) // Μ => μ
+    assertEquals(0x0101, Character.toLowerCase(0x0100)) // Ā => ā
+    assertEquals(0x0103, Character.toLowerCase(0x0102)) // Ă => ă
+    assertEquals(0x012f, Character.toLowerCase(0x012e)) // Į => į
+    assertEquals(0xff41, Character.toLowerCase(0xff21)) // Ａ => ａ
+    assertEquals(0xff5a, Character.toLowerCase(0xff3a)) // Ｚ => ｚ
+
+    // ASCII, letters, no change
+    assertEquals(0x0061, Character.toLowerCase(0x0061)) // a => a
+    assertEquals(0x0066, Character.toLowerCase(0x0066)) // f => f
+    assertEquals(0x007a, Character.toLowerCase(0x007a)) // z => z
+    assertEquals(0x0101, Character.toLowerCase(0x0101)) // ā => ā
+
+    // BMP, letters & titlecase
+    assertEquals(0x10428, Character.toLowerCase(0x10400)) // 𐐨 => 𐐀
+    assertEquals(0x10429, Character.toLowerCase(0x10401)) // 𐐁 => 𐐩
+    assertEquals(0x1044e, Character.toLowerCase(0x10426)) // 𐐦 => 𐑎
+    assertEquals(0x1044f, Character.toLowerCase(0x10427)) // 𐐧 => 𐑏
+
+    // BMP, no change
+    assertEquals(0xffff, Character.toLowerCase(0xffff)) // ￿ => ￿
+    assertEquals(0x10000, Character.toLowerCase(0x10000)) // 𐀀 => 𐀀
+    assertEquals(0x10001, Character.toLowerCase(0x10001)) // 𐀁 => 𐀁
+    assertEquals(0x10fffe, Character.toLowerCase(0x10fffe)) // 􏿾 => 􏿾
+    assertEquals(0x10ffff, Character.toLowerCase(0x10ffff)) // 􏿿 => 􏿿
+  }
+
+  @Test def toUpperCase_compare_char_and_codepoint(): Unit = {
+    for (ch <- Character.MIN_VALUE to Character.MAX_VALUE)
+      assertEquals(Character.toUpperCase(ch), Character.toUpperCase(ch.toInt).toChar)
+  }
+
+  @Test def toUpperCase_Int(): Unit = {
+    // ASCII, not a letter
+    assertEquals(0x000a, Character.toUpperCase(0x000a)) // '\n' => '\n'
+    assertEquals(0x0037, Character.toUpperCase(0x0037)) // '7' => '7'
+    assertEquals(0xff3b, Character.toUpperCase(0xff3b)) // ［ => ［
+
+    // ASCII, letters
+    assertEquals(0x0041, Character.toUpperCase(0x0061)) // a => A
+    assertEquals(0x0046, Character.toUpperCase(0x0066)) // f => F
+    assertEquals(0x005a, Character.toUpperCase(0x007a)) // z => Z
+    assertEquals(0x0392, Character.toUpperCase(0x03D0)) // β => Β
+    assertEquals(0x039C, Character.toUpperCase(0x00B5)) // μ => Μ
+
+    // ASCII, letters, no change
+    assertEquals(0x0041, Character.toUpperCase(0x0041)) // A => A
+    assertEquals(0x0046, Character.toUpperCase(0x0046)) // F => F
+    assertEquals(0x005a, Character.toUpperCase(0x005a)) // Z => Z
+
+    // BMP, letters & titlecase
+    assertEquals(0x10400, Character.toUpperCase(0x10428)) // 𐐨 => 𐐀
+    assertEquals(0x10401, Character.toUpperCase(0x10429)) // 𐐩 => 𐐁
+    assertEquals(0x10426, Character.toUpperCase(0x1044e)) // 𐑎 => 𐐦
+    assertEquals(0x10427, Character.toUpperCase(0x1044f)) // 𐑏 => 𐐧
+
+    // BMP, no change
+    assertEquals(0xffff, Character.toUpperCase(0xffff)) // ￿ => ￿
+    assertEquals(0x10000, Character.toUpperCase(0x10000)) // 𐀀 => 𐀀
+    assertEquals(0x10001, Character.toUpperCase(0x10001)) // 𐀁 => 𐀁
+    assertEquals(0x10fffe, Character.toUpperCase(0x10fffe)) // 􏿾 => 􏿾
+    assertEquals(0x10ffff, Character.toUpperCase(0x10ffff)) // 􏿿 => 􏿿
+  }
+
+  @Test def toUpperCase_CodePoint_special_cases(): Unit = {
+    assertEquals(0x1fbc, Character.toUpperCase(0x1fb3))
+    assertEquals(0x1fcc, Character.toUpperCase(0x1fc3))
+    assertEquals(0x1ffc, Character.toUpperCase(0x1ff3))
+
+    assertEquals(0x1f88, Character.toUpperCase(0x1f80))
+    assertEquals(0x1f89, Character.toUpperCase(0x1f81))
+    assertEquals(0x1f8a, Character.toUpperCase(0x1f82))
+    assertEquals(0x1f8b, Character.toUpperCase(0x1f83))
+    assertEquals(0x1f8c, Character.toUpperCase(0x1f84))
+    assertEquals(0x1f8d, Character.toUpperCase(0x1f85))
+    assertEquals(0x1f8e, Character.toUpperCase(0x1f86))
+    assertEquals(0x1f8f, Character.toUpperCase(0x1f87))
+    assertEquals(0x1f88, Character.toUpperCase(0x1f88))
+    assertEquals(0x1f89, Character.toUpperCase(0x1f89))
+    assertEquals(0x1f8a, Character.toUpperCase(0x1f8a))
+    assertEquals(0x1f8b, Character.toUpperCase(0x1f8b))
+    assertEquals(0x1f8c, Character.toUpperCase(0x1f8c))
+    assertEquals(0x1f8d, Character.toUpperCase(0x1f8d))
+    assertEquals(0x1f8e, Character.toUpperCase(0x1f8e))
+    assertEquals(0x1f8f, Character.toUpperCase(0x1f8f))
+    assertEquals(0x1f98, Character.toUpperCase(0x1f90))
+    assertEquals(0x1f99, Character.toUpperCase(0x1f91))
+    assertEquals(0x1f9a, Character.toUpperCase(0x1f92))
+    assertEquals(0x1f9b, Character.toUpperCase(0x1f93))
+    assertEquals(0x1f9c, Character.toUpperCase(0x1f94))
+    assertEquals(0x1f9d, Character.toUpperCase(0x1f95))
+    assertEquals(0x1f9e, Character.toUpperCase(0x1f96))
+    assertEquals(0x1f9f, Character.toUpperCase(0x1f97))
+    assertEquals(0x1f98, Character.toUpperCase(0x1f98))
+    assertEquals(0x1f99, Character.toUpperCase(0x1f99))
+    assertEquals(0x1f9a, Character.toUpperCase(0x1f9a))
+    assertEquals(0x1f9b, Character.toUpperCase(0x1f9b))
+    assertEquals(0x1f9c, Character.toUpperCase(0x1f9c))
+    assertEquals(0x1f9d, Character.toUpperCase(0x1f9d))
+    assertEquals(0x1f9e, Character.toUpperCase(0x1f9e))
+    assertEquals(0x1f9f, Character.toUpperCase(0x1f9f))
+    assertEquals(0x1fa8, Character.toUpperCase(0x1fa0))
+    assertEquals(0x1fa9, Character.toUpperCase(0x1fa1))
+    assertEquals(0x1faa, Character.toUpperCase(0x1fa2))
+    assertEquals(0x1fab, Character.toUpperCase(0x1fa3))
+    assertEquals(0x1fac, Character.toUpperCase(0x1fa4))
+    assertEquals(0x1fad, Character.toUpperCase(0x1fa5))
+    assertEquals(0x1fae, Character.toUpperCase(0x1fa6))
+    assertEquals(0x1faf, Character.toUpperCase(0x1fa7))
+    assertEquals(0x1fa8, Character.toUpperCase(0x1fa8))
+    assertEquals(0x1fa9, Character.toUpperCase(0x1fa9))
+    assertEquals(0x1faa, Character.toUpperCase(0x1faa))
+    assertEquals(0x1fab, Character.toUpperCase(0x1fab))
+    assertEquals(0x1fac, Character.toUpperCase(0x1fac))
+    assertEquals(0x1fad, Character.toUpperCase(0x1fad))
+    assertEquals(0x1fae, Character.toUpperCase(0x1fae))
+    assertEquals(0x1faf, Character.toUpperCase(0x1faf))
+  }
+
+/*
+def format(codePoint: Int): String = "0x%04x".format(codePoint)
+
+for (cp <- 0 to Character.MAX_CODE_POINT) {
+  val cpStr: String = new String(Array(cp), 0, 1)
+  val upperCP: Int = Character.toUpperCase(cp)
+  val upperCPStr: String = new String(Array(upperCP), 0, 1)
+
+  if (cpStr.toUpperCase() != upperCPStr)
+    println(s"    assertEquals(${format(upperCP)}, Character.toUpperCase(${format(cp)})) // $cpStr => $upperCPStr")
+}
+*/
+  @Test def toUpperCase_CodePoint_StringUpperCase_diff_CharacterUpperCase(): Unit = {
+    assertEquals(0x00df, Character.toUpperCase(0x00df)) // ß => ß
+    assertEquals(0x0149, Character.toUpperCase(0x0149)) // ŉ => ŉ
+    assertEquals(0x01f0, Character.toUpperCase(0x01f0)) // ǰ => ǰ
+    assertEquals(0x0390, Character.toUpperCase(0x0390)) // ΐ => ΐ
+    assertEquals(0x03b0, Character.toUpperCase(0x03b0)) // ΰ => ΰ
+    assertEquals(0x0587, Character.toUpperCase(0x0587)) // և => և
+    assertEquals(0x1e96, Character.toUpperCase(0x1e96)) // ẖ => ẖ
+    assertEquals(0x1e97, Character.toUpperCase(0x1e97)) // ẗ => ẗ
+    assertEquals(0x1e98, Character.toUpperCase(0x1e98)) // ẘ => ẘ
+    assertEquals(0x1e99, Character.toUpperCase(0x1e99)) // ẙ => ẙ
+    assertEquals(0x1e9a, Character.toUpperCase(0x1e9a)) // ẚ => ẚ
+    assertEquals(0x1f50, Character.toUpperCase(0x1f50)) // ὐ => ὐ
+    assertEquals(0x1f52, Character.toUpperCase(0x1f52)) // ὒ => ὒ
+    assertEquals(0x1f54, Character.toUpperCase(0x1f54)) // ὔ => ὔ
+    assertEquals(0x1f56, Character.toUpperCase(0x1f56)) // ὖ => ὖ
+    assertEquals(0x1f88, Character.toUpperCase(0x1f80)) // ᾀ => ᾈ
+    assertEquals(0x1f89, Character.toUpperCase(0x1f81)) // ᾁ => ᾉ
+    assertEquals(0x1f8a, Character.toUpperCase(0x1f82)) // ᾂ => ᾊ
+    assertEquals(0x1f8b, Character.toUpperCase(0x1f83)) // ᾃ => ᾋ
+    assertEquals(0x1f8c, Character.toUpperCase(0x1f84)) // ᾄ => ᾌ
+    assertEquals(0x1f8d, Character.toUpperCase(0x1f85)) // ᾅ => ᾍ
+    assertEquals(0x1f8e, Character.toUpperCase(0x1f86)) // ᾆ => ᾎ
+    assertEquals(0x1f8f, Character.toUpperCase(0x1f87)) // ᾇ => ᾏ
+    assertEquals(0x1f88, Character.toUpperCase(0x1f88)) // ᾈ => ᾈ
+    assertEquals(0x1f89, Character.toUpperCase(0x1f89)) // ᾉ => ᾉ
+    assertEquals(0x1f8a, Character.toUpperCase(0x1f8a)) // ᾊ => ᾊ
+    assertEquals(0x1f8b, Character.toUpperCase(0x1f8b)) // ᾋ => ᾋ
+    assertEquals(0x1f8c, Character.toUpperCase(0x1f8c)) // ᾌ => ᾌ
+    assertEquals(0x1f8d, Character.toUpperCase(0x1f8d)) // ᾍ => ᾍ
+    assertEquals(0x1f8e, Character.toUpperCase(0x1f8e)) // ᾎ => ᾎ
+    assertEquals(0x1f8f, Character.toUpperCase(0x1f8f)) // ᾏ => ᾏ
+    assertEquals(0x1f98, Character.toUpperCase(0x1f90)) // ᾐ => ᾘ
+    assertEquals(0x1f99, Character.toUpperCase(0x1f91)) // ᾑ => ᾙ
+    assertEquals(0x1f9a, Character.toUpperCase(0x1f92)) // ᾒ => ᾚ
+    assertEquals(0x1f9b, Character.toUpperCase(0x1f93)) // ᾓ => ᾛ
+    assertEquals(0x1f9c, Character.toUpperCase(0x1f94)) // ᾔ => ᾜ
+    assertEquals(0x1f9d, Character.toUpperCase(0x1f95)) // ᾕ => ᾝ
+    assertEquals(0x1f9e, Character.toUpperCase(0x1f96)) // ᾖ => ᾞ
+    assertEquals(0x1f9f, Character.toUpperCase(0x1f97)) // ᾗ => ᾟ
+    assertEquals(0x1f98, Character.toUpperCase(0x1f98)) // ᾘ => ᾘ
+    assertEquals(0x1f99, Character.toUpperCase(0x1f99)) // ᾙ => ᾙ
+    assertEquals(0x1f9a, Character.toUpperCase(0x1f9a)) // ᾚ => ᾚ
+    assertEquals(0x1f9b, Character.toUpperCase(0x1f9b)) // ᾛ => ᾛ
+    assertEquals(0x1f9c, Character.toUpperCase(0x1f9c)) // ᾜ => ᾜ
+    assertEquals(0x1f9d, Character.toUpperCase(0x1f9d)) // ᾝ => ᾝ
+    assertEquals(0x1f9e, Character.toUpperCase(0x1f9e)) // ᾞ => ᾞ
+    assertEquals(0x1f9f, Character.toUpperCase(0x1f9f)) // ᾟ => ᾟ
+    assertEquals(0x1fa8, Character.toUpperCase(0x1fa0)) // ᾠ => ᾨ
+    assertEquals(0x1fa9, Character.toUpperCase(0x1fa1)) // ᾡ => ᾩ
+    assertEquals(0x1faa, Character.toUpperCase(0x1fa2)) // ᾢ => ᾪ
+    assertEquals(0x1fab, Character.toUpperCase(0x1fa3)) // ᾣ => ᾫ
+    assertEquals(0x1fac, Character.toUpperCase(0x1fa4)) // ᾤ => ᾬ
+    assertEquals(0x1fad, Character.toUpperCase(0x1fa5)) // ᾥ => ᾭ
+    assertEquals(0x1fae, Character.toUpperCase(0x1fa6)) // ᾦ => ᾮ
+    assertEquals(0x1faf, Character.toUpperCase(0x1fa7)) // ᾧ => ᾯ
+    assertEquals(0x1fa8, Character.toUpperCase(0x1fa8)) // ᾨ => ᾨ
+    assertEquals(0x1fa9, Character.toUpperCase(0x1fa9)) // ᾩ => ᾩ
+    assertEquals(0x1faa, Character.toUpperCase(0x1faa)) // ᾪ => ᾪ
+    assertEquals(0x1fab, Character.toUpperCase(0x1fab)) // ᾫ => ᾫ
+    assertEquals(0x1fac, Character.toUpperCase(0x1fac)) // ᾬ => ᾬ
+    assertEquals(0x1fad, Character.toUpperCase(0x1fad)) // ᾭ => ᾭ
+    assertEquals(0x1fae, Character.toUpperCase(0x1fae)) // ᾮ => ᾮ
+    assertEquals(0x1faf, Character.toUpperCase(0x1faf)) // ᾯ => ᾯ
+    assertEquals(0x1fb2, Character.toUpperCase(0x1fb2)) // ᾲ => ᾲ
+    assertEquals(0x1fbc, Character.toUpperCase(0x1fb3)) // ᾳ => ᾼ
+    assertEquals(0x1fb4, Character.toUpperCase(0x1fb4)) // ᾴ => ᾴ
+    assertEquals(0x1fb6, Character.toUpperCase(0x1fb6)) // ᾶ => ᾶ
+    assertEquals(0x1fb7, Character.toUpperCase(0x1fb7)) // ᾷ => ᾷ
+    assertEquals(0x1fbc, Character.toUpperCase(0x1fbc)) // ᾼ => ᾼ
+    assertEquals(0x1fc2, Character.toUpperCase(0x1fc2)) // ῂ => ῂ
+    assertEquals(0x1fcc, Character.toUpperCase(0x1fc3)) // ῃ => ῌ
+    assertEquals(0x1fc4, Character.toUpperCase(0x1fc4)) // ῄ => ῄ
+    assertEquals(0x1fc6, Character.toUpperCase(0x1fc6)) // ῆ => ῆ
+    assertEquals(0x1fc7, Character.toUpperCase(0x1fc7)) // ῇ => ῇ
+    assertEquals(0x1fcc, Character.toUpperCase(0x1fcc)) // ῌ => ῌ
+    assertEquals(0x1fd2, Character.toUpperCase(0x1fd2)) // ῒ => ῒ
+    assertEquals(0x1fd3, Character.toUpperCase(0x1fd3)) // ΐ => ΐ
+    assertEquals(0x1fd6, Character.toUpperCase(0x1fd6)) // ῖ => ῖ
+    assertEquals(0x1fd7, Character.toUpperCase(0x1fd7)) // ῗ => ῗ
+    assertEquals(0x1fe2, Character.toUpperCase(0x1fe2)) // ῢ => ῢ
+    assertEquals(0x1fe3, Character.toUpperCase(0x1fe3)) // ΰ => ΰ
+    assertEquals(0x1fe4, Character.toUpperCase(0x1fe4)) // ῤ => ῤ
+    assertEquals(0x1fe6, Character.toUpperCase(0x1fe6)) // ῦ => ῦ
+    assertEquals(0x1fe7, Character.toUpperCase(0x1fe7)) // ῧ => ῧ
+    assertEquals(0x1ff2, Character.toUpperCase(0x1ff2)) // ῲ => ῲ
+    assertEquals(0x1ffc, Character.toUpperCase(0x1ff3)) // ῳ => ῼ
+    assertEquals(0x1ff4, Character.toUpperCase(0x1ff4)) // ῴ => ῴ
+    assertEquals(0x1ff6, Character.toUpperCase(0x1ff6)) // ῶ => ῶ
+    assertEquals(0x1ff7, Character.toUpperCase(0x1ff7)) // ῷ => ῷ
+    assertEquals(0x1ffc, Character.toUpperCase(0x1ffc)) // ῼ => ῼ
+    assertEquals(0xfb00, Character.toUpperCase(0xfb00)) // ﬀ => ﬀ
+    assertEquals(0xfb01, Character.toUpperCase(0xfb01)) // ﬁ => ﬁ
+    assertEquals(0xfb02, Character.toUpperCase(0xfb02)) // ﬂ => ﬂ
+    assertEquals(0xfb03, Character.toUpperCase(0xfb03)) // ﬃ => ﬃ
+    assertEquals(0xfb04, Character.toUpperCase(0xfb04)) // ﬄ => ﬄ
+    assertEquals(0xfb05, Character.toUpperCase(0xfb05)) // ﬅ => ﬅ
+    assertEquals(0xfb06, Character.toUpperCase(0xfb06)) // ﬆ => ﬆ
+    assertEquals(0xfb13, Character.toUpperCase(0xfb13)) // ﬓ => ﬓ
+    assertEquals(0xfb14, Character.toUpperCase(0xfb14)) // ﬔ => ﬔ
+    assertEquals(0xfb15, Character.toUpperCase(0xfb15)) // ﬕ => ﬕ
+    assertEquals(0xfb16, Character.toUpperCase(0xfb16)) // ﬖ => ﬖ
+    assertEquals(0xfb17, Character.toUpperCase(0xfb17)) // ﬗ => ﬗ
+  }
+
   @Test def codePointCount_String(): Unit = {
     val s: String =
       "abc\uD834\uDF06de\uD834\uDF06fgh\uD834ij\uDF06\uD834kl\uDF06"


### PR DESCRIPTION
Addresses: https://github.com/scala-js/scala-js/issues/4206 & https://github.com/scala-js/scala-js/issues/4208

Also fixes minor edge case in `Character.toUpperCase(ch: Char)`

TODO:
- [x] Add a test character that expands into a multiple-codepoint via Strinig.toUpperCase/toLowerCase 

> Then I'm not sure what we should do with results that span more than one code point. It's not necessarily just `length > 2`; it's also possible that this happens with `length == 2` if the two Chars are not a surrogate pair. We need to carefully check the spec for that.

### Javadoc


	public static int toUpperCase(int codePoint)
    
	Converts the character (Unicode code point) argument to uppercase using case mapping information from the UnicodeData file.
	Note that Character.isUpperCase(Character.toUpperCase(codePoint)) does not always return true for some ranges of characters, particularly those that are symbols or ideographs.
	
	In general, String.toUpperCase() should be used to map characters to uppercase. String case mapping methods have several benefits over Character case mapping methods. String case mapping methods can perform locale-sensitive mappings, context-sensitive mappings, and 1:M character mappings, whereas the Character case mapping methods cannot.
	
	Parameters:
	codePoint - the character (Unicode code point) to be converted.
	Returns:
	the uppercase equivalent of the character, if any; otherwise, the character itself.
	Since:
	1.5
	See Also:
	isUpperCase(int), String.toUpperCase()

### Implementation notes

`Character.isSurrogatePair` can be used to verify length == 2, and only return the codePoint if they are a pair, otherwise the original codePoint is suppose to be returned