### PR TITLE
Implement locale-sensitivity in `java.util.Formatter`.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/_String.scala
+++ b/javalanglib/src/main/scala/java/lang/_String.scala
@@ -324,15 +324,16 @@ final class _String private () // scalastyle:ignore
 
   /* toLowerCase() and toUpperCase()
    *
-   * The overloads without an explicit locale use the default locale, which
-   * is English by specification. They are implemented by direct delegation to
-   * ECMAScript's `toLowerCase()` and `toUpperCase()`, which are specified as
-   * locale-insensitive. This is correct because those two operations are
-   * equivalent for English and for locale-insensitive. In fact, only
-   * Lithuanian (lt), Turkish (tr) and Azeri (az) have different behaviors than
-   * locale-insensitive.
+   * The overloads without an explicit locale use the default locale, which is
+   * the root locale by specification. They are implemented by direct
+   * delegation to ECMAScript's `toLowerCase()` and `toUpperCase()`, which are
+   * specified as locale-insensitive, therefore equivalent to the root locale.
    *
-   * The overloads with a `Locale` specificially test for those three languages
+   * It turns out virtually every locale behaves in the same way as the root
+   * locale for default case algorithms. Only Lithuanian (lt), Turkish (tr)
+   * and Azeri (az) have different behaviors.
+   *
+   * The overloads with a `Locale` specifically test for those three languages
    * and delegate to dedicated methods to handle them. Those methods start by
    * handling their respective special cases, then delegate to the locale-
    * insensitive version. The special cases are specified in the Unicode

--- a/javalib-ext-dummies/src/main/scala/java/text/DecimalFormat.scala
+++ b/javalib-ext-dummies/src/main/scala/java/text/DecimalFormat.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.text
+
+import java.util.Locale
+
+class DecimalFormat(locale: Locale) extends NumberFormat {
+  def getGroupingSize(): Int = 3
+}

--- a/javalib-ext-dummies/src/main/scala/java/text/DecimalFormatSymbols.scala
+++ b/javalib-ext-dummies/src/main/scala/java/text/DecimalFormatSymbols.scala
@@ -1,0 +1,61 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.text
+
+import java.util.Locale
+
+/** Dummy implementation of `DecimalFormatSymbols`.
+ *
+ *  It is even worse than most other dummies, in the sense that it
+ *  special-cases the locales that we use in our tests (`FormatterTestEx`).
+ *  It is incorrect for most locales.
+ */
+class DecimalFormatSymbols(locale: Locale) extends NumberFormat {
+  def getZeroDigit(): Char = {
+    locale.getLanguage() match {
+      case "hi" =>
+        locale.getCountry() match {
+          case "IN" => '\u0966' // '०' DEVANAGARI DIGIT ZERO
+          case _    => unsupported()
+        }
+      case "" | "en" | "fr" =>
+        '0'
+      case _ =>
+        unsupported()
+    }
+  }
+
+  def getGroupingSeparator(): Char = {
+    locale.getLanguage() match {
+      case "fr"             => '\u00A0' // NO-BREAK SPACE
+      case "" | "en" | "hi" => ','
+      case _                => unsupported()
+    }
+  }
+
+  def getDecimalSeparator(): Char = {
+    locale.getLanguage() match {
+      case "fr"             => ','
+      case "" | "en" | "hi" => '.'
+      case _                => unsupported()
+    }
+  }
+
+  private def unsupported(): Nothing =
+    throw new Error(s"Unsupported locale '$locale' in DecimalFormatSymbols")
+}
+
+object DecimalFormatSymbols {
+  def getInstance(locale: Locale): DecimalFormatSymbols =
+    new DecimalFormatSymbols(locale)
+}

--- a/javalib-ext-dummies/src/main/scala/java/text/Format.scala
+++ b/javalib-ext-dummies/src/main/scala/java/text/Format.scala
@@ -1,0 +1,16 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.text
+
+abstract class Format protected ()
+    extends AnyRef with java.io.Serializable with java.lang.Cloneable

--- a/javalib-ext-dummies/src/main/scala/java/text/NumberFormat.scala
+++ b/javalib-ext-dummies/src/main/scala/java/text/NumberFormat.scala
@@ -1,0 +1,22 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.text
+
+import java.util.Locale
+
+abstract class NumberFormat protected () extends Format
+
+object NumberFormat {
+  def getNumberInstance(inLocale: Locale): NumberFormat =
+    new DecimalFormat(inLocale)
+}

--- a/javalib-ext-dummies/src/main/scala/java/util/Locale.scala
+++ b/javalib-ext-dummies/src/main/scala/java/util/Locale.scala
@@ -12,10 +12,39 @@
 
 package java.util
 
-final class Locale private (languageRaw: String)
+final class Locale(languageRaw: String, countryRaw: String)
     extends AnyRef with java.lang.Cloneable with java.io.Serializable {
+
+  def this(languageRaw: String) = this(languageRaw, "")
 
   private[this] val language: String = languageRaw.toLowerCase()
 
+  private[this] val country: String = countryRaw.toUpperCase()
+
   def getLanguage(): String = language
+
+  def getCountry(): String = country
+
+  override def toString(): String = {
+    if (country == "") language
+    else language + "_" + country
+  }
+
+  override def hashCode(): Int =
+    language.## ^ country.##
+
+  override def equals(that: Any): Boolean = that match {
+    case that: Locale =>
+      this.getLanguage() == that.getLanguage() &&
+      this.getCountry() == that.getCountry()
+    case _ =>
+      false
+  }
+}
+
+object Locale {
+  val ROOT: Locale = new Locale("", "")
+
+  // By specification, the default locale in Scala.js is always `ROOT`.
+  def getDefault(): Locale = ROOT
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1897,14 +1897,14 @@ object Build {
       testSuiteCommonSettings(isJSTest = false),
       name := "Scala.js test suite on JVM",
 
-      /* Scala.js always assumes en-US, UTF-8 and NL as line separator by
+      /* Scala.js always assumes Locale.ROOT, UTF-8 and NL as line separator by
        * default. Since some of our tests rely on these defaults (notably to
        * test them), we have to force the same values on the JVM.
        */
       fork in Test := true,
       javaOptions in Test ++= Seq(
           "-Dfile.encoding=UTF-8",
-          "-Duser.country=US", "-Duser.language=en",
+          "-Duser.country=", "-Duser.language=",
           "-Dline.separator=\n"
       ),
 
@@ -1993,14 +1993,14 @@ object Build {
       testSuiteExCommonSettings(isJSTest = false),
       name := "Scala.js test suite ex on JVM",
 
-      /* Scala.js always assumes en-US, UTF-8 and NL as line separator by
+      /* Scala.js always assumes Locale.ROOT, UTF-8 and NL as line separator by
        * default. Since some of our tests rely on these defaults (notably to
        * test them), we have to force the same values on the JVM.
        */
       fork in Test := true,
       javaOptions in Test ++= Seq(
           "-Dfile.encoding=UTF-8",
-          "-Duser.country=US", "-Duser.language=en",
+          "-Duser.country=", "-Duser.language=",
           "-Dline.separator=\n"
       ),
 

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTestEx.scala
@@ -1,0 +1,94 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util
+
+import java.util.{Formatter, Locale}
+
+import org.junit.Test
+import org.junit.Assert._
+
+/** Additional tests for java.lang.String that require `java.util.Locale`
+ *  as well as classes in `java.text.*`.
+ */
+class FormatterTestEx {
+
+  /* Note: there is no test for a grouping size != 3, because I (sjrd) could
+   * not find any locale for which it would be different from 3.
+   */
+
+  val French = new Locale("fr")           // decimal sep ','  grouping sep '\u00A0'
+  val HindiIndia = new Locale("hi", "IN") // non-ASCII digits
+  val Turkish = new Locale("tr")          // special uppercase behavior
+
+  def assertF(locale: Locale, expected: String, format: String, args: Any*): Unit = {
+    // Locale passed as constructor parameter
+    val fmt1 = new Formatter(locale)
+    val res1 = fmt1.format(format, args.asInstanceOf[Seq[AnyRef]]: _*).toString()
+    fmt1.close()
+    assertEquals(expected, res1)
+
+    // Locale passed as argument to `format`
+    val fmt2 = new Formatter()
+    val res2 = fmt2.format(locale, format, args.asInstanceOf[Seq[AnyRef]]: _*).toString()
+    fmt2.close()
+    assertEquals(expected, res2)
+  }
+
+  @Test def testLocale(): Unit = {
+    assertEquals(Locale.ROOT, new Formatter().locale())
+
+    assertSame(Locale.ROOT, new Formatter(Locale.ROOT).locale())
+    assertSame(French, new Formatter(French).locale())
+    assertSame(null, new Formatter(null: Locale).locale())
+
+    // Calling `format` with an explicit locale does not change the `locale()`
+    val formatter = new Formatter(French)
+    formatter.format(HindiIndia, "")
+    assertSame(French, formatter.locale())
+  }
+
+  @Test def testFormatFrench(): Unit = {
+    // U+00A0 NO-BREAK SPACE
+    assertF(French, "1\u00A0234\u00A0567", "%,d", 1234567)
+    assertF(French, "1\u00A0234\u00A0567,89", "%,.2f", 1234567.89)
+    assertF(French, "0012", "%04d", 12)
+  }
+
+  @Test def testFormatHindiIndia(): Unit = {
+    // U+0966 DEVANAGARI DIGIT ZERO through U+096F DEVANAGARI DIGIT NINE
+    assertF(HindiIndia, "१,२३४,५६७", "%,d", 1234567)
+    assertF(HindiIndia, "१,२३४,५६७.८९", "%,.2f", 1234567.89)
+    assertF(HindiIndia, "००१२", "%04d", 12)
+
+    assertF(HindiIndia, "0x0012", "%#06x", 0x12)
+    assertF(HindiIndia, "0X0012", "%#06X", 0x12)
+    assertF(HindiIndia, "000014", "%#06o", 12)
+  }
+
+  @Test def testFormatTurkish(): Unit = {
+    // Uppercasing does not follow the locale
+    assertF(Turkish, "TITLE", "%S", "title")
+    assertF(Turkish, "INFINITY", "%E", Double.PositiveInfinity)
+  }
+
+  @Test def testFormatNullLocale(): Unit = {
+    assertF(null, "1,234,567", "%,d", 1234567)
+    assertF(null, "1,234,567.89", "%,.2f", 1234567.89)
+    assertF(null, "0012", "%04d", 12)
+
+    assertF(null, "0x0012", "%#06x", 0x12)
+    assertF(null, "0X0012", "%#06X", 0x12)
+    assertF(null, "000014", "%#06o", 12)
+  }
+
+}

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LocaleTest.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LocaleTest.scala
@@ -26,6 +26,12 @@ import org.scalajs.testsuite.utils.AssertThrows._
  *  cause tests to "fail to fail" if they are not respected.
  */
 class LocaleTest {
+  @Test def testDefaultLocaleIsRoot(): Unit = {
+    assertEquals(Locale.ROOT, Locale.getDefault())
+    assertEquals("", Locale.ROOT.getLanguage())
+    assertEquals("", Locale.ROOT.getCountry())
+  }
+
   @Test def testLanguageIsNormalizedLowerCase(): Unit = {
     /* Our implementations of `String.toLowerCase(locale: Locale)` and
      * `String.toUpperCase(locale: Locale)` assume that the result of


### PR DESCRIPTION
Since the core does not provide `java.util.Locale` nor `java.text.*`, the new methods are only available for users if they use a third-party extension that provides those.

We use dummies in `javalib-ext-dummies` to test our implementation.