### PR TITLE
Add .jvmopts and .sbtopts to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ bin/
 /.metals/
 /project/**/metals.sbt
 /.vscode/
+
+# User specific
+/.jvmopts
+/.sbtopts


### PR DESCRIPTION
Allows users to have `.jvmopts` and `.sbtopts` settings without permenantly having them in unstaged, state.