### PR TITLE
Fix #4243: Set scalaJSLinkerOutputDirectory suffixes to -fastopt/-opt

### DIFF
--- a/ci/checksizes.sh
+++ b/ci/checksizes.sh
@@ -20,8 +20,8 @@ case $FULLVER in
     ;;
 esac
 
-REVERSI_PREOPT="$BASEDIR/examples/reversi/.$VER/target/scala-$VER/reversi-dev/main.js"
-REVERSI_OPT="$BASEDIR/examples/reversi/.$VER/target/scala-$VER/reversi-prod/main.js"
+REVERSI_PREOPT="$BASEDIR/examples/reversi/.$VER/target/scala-$VER/reversi-fastopt/main.js"
+REVERSI_OPT="$BASEDIR/examples/reversi/.$VER/target/scala-$VER/reversi-opt/main.js"
 
 REVERSI_PREOPT_SIZE=$(stat '-c%s' "$REVERSI_PREOPT")
 REVERSI_OPT_SIZE=$(stat '-c%s' "$REVERSI_OPT")

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -396,11 +396,11 @@ private[sbtplugin] object ScalaJSPluginInternal {
 
       scalaJSLinkerOutputDirectory in fastLinkJS :=
         ((crossTarget in fastLinkJS).value /
-            ((moduleName in fastLinkJS).value + "-dev")),
+            ((moduleName in fastLinkJS).value + "-fastopt")),
 
       scalaJSLinkerOutputDirectory in fullLinkJS :=
         ((crossTarget in fullLinkJS).value /
-            ((moduleName in fullLinkJS).value + "-prod")),
+            ((moduleName in fullLinkJS).value + "-opt")),
 
       artifactPath in fastOptJS :=
         ((crossTarget in fastOptJS).value /

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/test
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/test
@@ -1,16 +1,16 @@
 $ copy-file Main.scala.first Main.scala
 > fastLinkJS
-$ copy-file target/scala-2.12/change-config-and-source-dev/main.js target/scala-2.12/output-1.js
+$ copy-file target/scala-2.12/change-config-and-source-fastopt/main.js target/scala-2.12/output-1.js
 
 # When the linker config and source both change, re-running fastLinkJS should re-link:
 > set scalaJSLinkerConfig ~= (_.withOptimizer(false))
 $ copy-file Main.scala.second Main.scala
 > fastLinkJS
--$ must-mirror target/scala-2.12/change-config-and-source-dev/main.js target/scala-2.12/output-1.js
-$ newer target/scala-2.12/change-config-and-source-dev/main.js target/scala-2.12/output-1.js
-$ copy-file target/scala-2.12/change-config-and-source-dev/main.js target/scala-2.12/output-2.js
+-$ must-mirror target/scala-2.12/change-config-and-source-fastopt/main.js target/scala-2.12/output-1.js
+$ newer target/scala-2.12/change-config-and-source-fastopt/main.js target/scala-2.12/output-1.js
+$ copy-file target/scala-2.12/change-config-and-source-fastopt/main.js target/scala-2.12/output-2.js
 
 # However, this re-linking should not happen more than once:
 > fastLinkJS
-$ must-mirror target/scala-2.12/change-config-and-source-dev/main.js target/scala-2.12/output-2.js
--$ newer target/scala-2.12/change-config-and-source-dev/main.js target/scala-2.12/output-2.js
+$ must-mirror target/scala-2.12/change-config-and-source-fastopt/main.js target/scala-2.12/output-2.js
+-$ newer target/scala-2.12/change-config-and-source-fastopt/main.js target/scala-2.12/output-2.js

--- a/sbt-plugin/src/sbt-test/incremental/change-config/test
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/test
@@ -1,14 +1,14 @@
 > fastLinkJS
-$ copy-file target/scala-2.12/change-config-dev/main.js target/scala-2.12/output-1.js
+$ copy-file target/scala-2.12/change-config-fastopt/main.js target/scala-2.12/output-1.js
 
 # When the linker config changes, re-running fastLinkJS should re-link:
 > set scalaJSLinkerConfig ~= (_.withOptimizer(false))
 > fastLinkJS
--$ must-mirror target/scala-2.12/change-config-dev/main.js target/scala-2.12/output-1.js
-$ newer target/scala-2.12/change-config-dev/main.js target/scala-2.12/output-1.js
-$ copy-file target/scala-2.12/change-config-dev/main.js target/scala-2.12/output-2.js
+-$ must-mirror target/scala-2.12/change-config-fastopt/main.js target/scala-2.12/output-1.js
+$ newer target/scala-2.12/change-config-fastopt/main.js target/scala-2.12/output-1.js
+$ copy-file target/scala-2.12/change-config-fastopt/main.js target/scala-2.12/output-2.js
 
 # However, this re-linking should not happen more than once:
 > fastLinkJS
-$ must-mirror target/scala-2.12/change-config-dev/main.js target/scala-2.12/output-2.js
--$ newer target/scala-2.12/change-config-dev/main.js target/scala-2.12/output-2.js
+$ must-mirror target/scala-2.12/change-config-fastopt/main.js target/scala-2.12/output-2.js
+-$ newer target/scala-2.12/change-config-fastopt/main.js target/scala-2.12/output-2.js


### PR DESCRIPTION
This was forgotten in 225a052ab6df3cda9da0f6eee993b3bb8dd674d5 after the tasks were renamed during review.