### PR TITLE
Fix #4244: Patch source map links in the output of {fast,full}OptJS

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Linker.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Linker.scala
@@ -16,13 +16,11 @@ import scala.collection.mutable
 import scala.concurrent._
 
 import java.io.IOException
-import java.net.URI
 import java.nio.ByteBuffer
-import java.nio.charset.StandardCharsets
 
 import org.scalajs.logging.Logger
 
-import org.scalajs.linker.interface.unstable.{OutputDirectoryImpl, OutputFileImpl}
+import org.scalajs.linker.interface.unstable.OutputDirectoryImpl
 
 /** A Scala.js linker, with its most abstract API.
  *
@@ -43,190 +41,27 @@ abstract class Linker private[interface] () {
       moduleInitializers: Seq[ModuleInitializer],
       output: LinkerOutput, logger: Logger)(
       implicit ec: ExecutionContext): Future[Unit] = {
-    /* Backwards compatibility implementation for pre 1.3.0 link method.
-     *
-     * The major interface change in 1.3.0 is that the linker (and not the
-     * caller) determines the set of files to be written. As a consequence, the
-     * post 1.3.0 API does not offer as much control over cross-file references
-     * (i.e. source map links): it is based on patterns rather than simply
-     * asking the caller to verbatim provide the URI to reference in each file.
-     *
-     * To provide a backwards compatible interface, we do the following post-run
-     * processing:
-     *
-     * - Match and copy the produced set of files (in the OutputDirectory) to
-     *   the files provided by the caller (in LinkerOutput).
-     * - Replace the pattern generated cross-file references with the ones
-     *   provided by the caller. This is necessary as a post-processing step,
-     *   because of the reduced flexibility of the 1.3.0 API: we cannot express
-     *   all legacy requests in the new API.
-     */
 
     val outDir = new Linker.MemOutputDirectory()
 
-    link(irFiles, moduleInitializers, outDir, logger).flatMap { report =>
-      val (jsFileContent, optSourceMapContent) =
-        Linker.retrieveOutputFiles(report, outDir)
-
-      val hasSourceMap =
-        optSourceMapContent.isDefined && output.sourceMap.isDefined
-
-      import StandardCharsets.UTF_8
-
-      val jsFileWrite = {
-        val content = new String(jsFileContent, UTF_8)
-        val patched = Linker.patchJSFileContent(content,
-            output.sourceMapURI.filter(_ => hasSourceMap))
-
-        OutputFileImpl.fromOutputFile(output.jsFile)
-          .writeFull(ByteBuffer.wrap(patched.getBytes(UTF_8)))
+    link(irFiles, moduleInitializers, outDir, logger)
+      .flatMap(ReportToLinkerOutputAdapter.convert(_, outDir, output))
+      .recover {
+        case e: ReportToLinkerOutputAdapter.UnsupportedLinkerOutputException =>
+          throw new LinkingException(
+              "The linker produced a result not supported by the pre v1.3.0 " +
+              "legacy API. Call the overload taking an OutputDirectory " +
+              "instead. " + e.getMessage(), e)
       }
-
-      val sourceMapWrite = for {
-        sourceMapContent <- optSourceMapContent
-        sourceMapFile <- output.sourceMap
-      } yield {
-        val content = new String(sourceMapContent, UTF_8)
-        val patched = Linker.patchSourceMapContent(content, output.jsFileURI)
-
-        OutputFileImpl.fromOutputFile(sourceMapFile)
-          .writeFull(ByteBuffer.wrap(patched.getBytes(UTF_8)))
-      }
-
-      Future.sequence(List(jsFileWrite) ++ sourceMapWrite).map(_ => ())
-    }
   }
 }
 
 private object Linker {
-  private val sourceMapRe = """(?m)^//# sourceMappingURL=.*$""".r
-
-  /* It is somewhat acceptable to parse the JSON field "file" with a Regex
-   * because:
-   *
-   * - Source maps do not contain nested objects.
-   * - The file URI should not contain '"', because URI.toASCIIString (which is
-   *   used by the StandardLinker) never returns them.
-   *
-   * So as a legacy mechanism, this is OK-ish. It keeps us from having to build
-   * the infrastructure to parse JSON cross platform.
-   */
-  private val fileFieldRe = """(?m)([,{])\s*"file"\s*:\s*".*"\s*([,}])""".r
-
-  /** Retrieve the linker JS file and an optional source map */
-  private def retrieveOutputFiles(report: Report,
-      outDir: MemOutputDirectory): (Array[Byte], Option[Array[Byte]]) = {
-    val module = {
-      if (report.publicModules.size != 1) {
-        throw new LinkingException(
-            "Linking did not return exactly one public module, but the legacy " +
-            "`link` method was called. Call the overload taking an " +
-            s"OutputDirectory instead. Full report:\n$report")
-      }
-
-      report.publicModules.head
-    }
-
-    val expectedFiles = Set(module.jsFileName) ++ module.sourceMapName
-    val foundFiles = outDir.content.keySet
-
-    if (foundFiles != expectedFiles) {
-      if (expectedFiles.subsetOf(foundFiles)) {
-        throw new LinkingException(
-            "Linking produced more than a single JS file (and source map) but " +
-            "the legacy `link` method was called. Call the overload taking " +
-            "an OutputDirectory instead. " +
-            s"Expected files:\n$expectedFiles\nProduced files:\n$foundFiles")
-      } else {
-        throw new LinkingException(
-            "Linking did not produce the files mentioned in the report. " +
-            "This is a bug in the linker." +
-            s"Expected files:\n$expectedFiles\nProduced files:\n$foundFiles")
-      }
-    }
-
-    val jsFileContent = outDir.content(module.jsFileName)
-    val sourceMapContent = module.sourceMapName.map(outDir.content(_))
-
-    (jsFileContent, sourceMapContent)
-  }
-
-  /** Patches the JS file content to have the provided source map link (or none)
-   *
-   *  Looks for a line of the form `//# sourceMappingURL=.*` and replaces the
-   *  URL with the provided `sourceMapURI`. In case `sourceMapURI` is None, the
-   *  line is replaced with an empty line.
-   */
-  private def patchJSFileContent(content: String,
-      sourceMapURI: Option[URI]): String = {
-
-    val newLine =
-      sourceMapURI.map(u => s"//# sourceMappingURL=${u.toASCIIString}")
-
-    sourceMapRe.findFirstMatchIn(content).fold {
-      content + newLine.fold("")("\n" + _ + "\n")
-    } { reMatch =>
-      val res = new StringBuilder
-
-      res.append(reMatch.before)
-
-      /* If there is no source map link, keep an empty line to not break a
-       * potential (unlinked) source map
-       */
-      newLine.foreach(res.append(_))
-
-      res.append(reMatch.after)
-
-      res.toString()
-    }
-  }
-
-  /** Patches the source map content to have the provided JS file link (or none).
-   *
-   *  Looks for a `"file":` key in the top-level source map JSON object and
-   *  replaces it's value with `jsFileURI`. In case `jsFileURI` is None, it
-   *  removes the key from the object.
-   */
-  private def patchSourceMapContent(content: String,
-      jsFileURI: Option[URI]): String = {
-
-    // No need for quoting: toASCIIString never returns '"'
-    val newField =
-      jsFileURI.map(u => s""""file": "${u.toASCIIString}"""")
-
-    fileFieldRe.findFirstMatchIn(content).fold {
-      newField.fold(content) { field =>
-        val Array(pre, post) = content.split("\\{", 1)
-        pre + field + "," + post
-      }
-    } { reMatch =>
-      val res = new StringBuilder
-
-      res.append(reMatch.before)
-
-      newField match {
-        case None =>
-          if (reMatch.group(1) == "{")
-            res.append('{')
-          if (reMatch.group(2) == "}")
-            res.append('}')
-        case Some(field) =>
-          res.append(reMatch.group(1))
-          res.append(field)
-          res.append(reMatch.group(2))
-      }
-
-      res.append(reMatch.after)
-
-      res.toString()
-    }
-  }
-
   /* Basically a copy of MemOutputDirectory in `linker`, but we can't use is
    * here because we are in the interface which cannot depend on the linker.
    */
   private final class MemOutputDirectory extends OutputDirectoryImpl {
-    val content: mutable.Map[String, Array[Byte]] = mutable.Map.empty
+    private val content: mutable.Map[String, Array[Byte]] = mutable.Map.empty
 
     def writeFull(name: String, buf: ByteBuffer)(
         implicit ec: ExecutionContext): Future[Unit] = synchronized {
@@ -234,6 +69,11 @@ private object Linker {
       buf.get(c)
       content(name) = c
       Future.successful(())
+    }
+
+    def readFull(name: String)(
+        implicit ec: ExecutionContext): Future[ByteBuffer] = synchronized {
+      Future.successful(ByteBuffer.wrap(content(name)))
     }
 
     def listFiles()(implicit ec: ExecutionContext): Future[List[String]] = synchronized {

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ReportToLinkerOutputAdapter.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ReportToLinkerOutputAdapter.scala
@@ -1,0 +1,215 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import scala.concurrent._
+
+import java.net.URI
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.scalajs.logging.Logger
+
+import org.scalajs.linker.interface.unstable.{OutputDirectoryImpl, OutputFileImpl}
+
+/** Backwards compatibility implementation for pre 1.3.0 link method.
+ *
+ *  The major interface change in 1.3.0 is that the linker (and not the
+ *  caller) determines the set of files to be written. As a consequence, the
+ *  post 1.3.0 API does not offer as much control over cross-file references
+ *  (i.e. source map links): it is based on patterns rather than simply
+ *  asking the caller to verbatim provide the URI to reference in each file.
+ *
+ *  To provide a backwards compatible interface, we do the following post-run
+ *  processing:
+ *
+ *  - Match and copy the produced set of files (in the OutputDirectory) to
+ *    the files provided by the caller (in LinkerOutput).
+ *  - Replace the pattern generated cross-file references with the ones
+ *    provided by the caller. This is necessary as a post-processing step,
+ *    because of the reduced flexibility of the 1.3.0 API: we cannot express
+ *    all legacy requests in the new API.
+  */
+@deprecated("Part of legacy API.", "1.3.0")
+object ReportToLinkerOutputAdapter {
+  final class UnsupportedLinkerOutputException private[ReportToLinkerOutputAdapter] (
+      message: String) extends IllegalArgumentException(message)
+
+  def convert(report: Report, outputDirectory: OutputDirectory,
+      legacyOutput: LinkerOutput)(
+      implicit ec: ExecutionContext): Future[Unit] = {
+    retrieveOutputFiles(report, outputDirectory).flatMap {
+      case (jsFileContent, optSourceMapContent) =>
+        val hasSourceMap =
+          optSourceMapContent.isDefined && legacyOutput.sourceMap.isDefined
+
+        val jsFileWrite = {
+          val content = UTF_8.decode(jsFileContent).toString()
+          val patched = patchJSFileContent(content,
+              legacyOutput.sourceMapURI.filter(_ => hasSourceMap))
+
+          OutputFileImpl.fromOutputFile(legacyOutput.jsFile)
+            .writeFull(ByteBuffer.wrap(patched.getBytes(UTF_8)))
+        }
+
+        val sourceMapWrite = for {
+          sourceMapContent <- optSourceMapContent
+          sourceMapFile <- legacyOutput.sourceMap
+        } yield {
+          val content = UTF_8.decode(sourceMapContent).toString()
+          val patched = patchSourceMapContent(content, legacyOutput.jsFileURI)
+
+          OutputFileImpl.fromOutputFile(sourceMapFile)
+            .writeFull(ByteBuffer.wrap(patched.getBytes(UTF_8)))
+        }
+
+        Future.sequence(List(jsFileWrite) ++ sourceMapWrite).map(_ => ())
+    }
+  }
+
+  /** Retrieve the linker JS file and an optional source map */
+  private def retrieveOutputFiles(report: Report,
+      outputDirectory: OutputDirectory)(
+      implicit ec: ExecutionContext): Future[(ByteBuffer, Option[ByteBuffer])] = {
+    val outDirImpl = OutputDirectoryImpl.fromOutputDirectory(outputDirectory)
+
+    val module = {
+      if (report.publicModules.size != 1) {
+        throw new UnsupportedLinkerOutputException(
+            "Linking did not return exactly one public module. Full report:\n" +
+            report)
+      }
+
+      report.publicModules.head
+    }
+
+    val checkFiles = for {
+      foundFilesList <- outDirImpl.listFiles()
+    } yield {
+      val foundFiles = foundFilesList.toSet
+      val expectedFiles = Set(module.jsFileName) ++ module.sourceMapName
+
+      if (foundFiles != expectedFiles) {
+        if (expectedFiles.subsetOf(foundFiles)) {
+          throw new UnsupportedLinkerOutputException(
+              "Linking produced more than a single JS file (and source map). " +
+              s"Expected files:\n$expectedFiles\nProduced files:\n$foundFiles")
+        } else {
+          throw new AssertionError(
+              "Linking did not produce the files mentioned in the report. " +
+              "This is a bug in the linker. " +
+              s"Expected files:\n$expectedFiles\nProduced files:\n$foundFiles")
+        }
+      }
+    }
+
+    for {
+      _ <- checkFiles
+      jsFileContent <- outDirImpl.readFull(module.jsFileName)
+      sourceMapContent <- Future.traverse(module.sourceMapName.toList)(outDirImpl.readFull(_))
+    } yield {
+      (jsFileContent, sourceMapContent.headOption)
+    }
+  }
+
+  private val sourceMapRe = """(?m)^//# sourceMappingURL=.*$""".r
+
+  /** Patches the JS file content to have the provided source map link (or none)
+   *
+   *  Looks for a line of the form `//# sourceMappingURL=.*` and replaces the
+   *  URL with the provided `sourceMapURI`. In case `sourceMapURI` is None, the
+   *  line is replaced with an empty line.
+   */
+  private def patchJSFileContent(content: String,
+      sourceMapURI: Option[URI]): String = {
+
+    val newLine =
+      sourceMapURI.map(u => s"//# sourceMappingURL=${u.toASCIIString}")
+
+    sourceMapRe.findFirstMatchIn(content).fold {
+      content + newLine.fold("")("\n" + _ + "\n")
+    } { reMatch =>
+      val res = new StringBuilder
+
+      res.append(reMatch.before)
+
+      /* If there is no source map link, keep an empty line to not break a
+       * potential (unlinked) source map
+       */
+      newLine.foreach(res.append(_))
+
+      res.append(reMatch.after)
+
+      res.toString()
+    }
+  }
+
+  /* It is somewhat acceptable to parse the JSON field "file" with a Regex
+   * because:
+   *
+   * - Source maps do not contain nested objects.
+   * - The file URI should not contain '"', because URI.toASCIIString (which is
+   *   used by the StandardLinker) never returns them.
+   *
+   * So as a legacy mechanism, this is OK-ish. It keeps us from having to build
+   * the infrastructure to parse JSON cross platform.
+   */
+  private val fileFieldRe = """(?m)([,{])\s*"file"\s*:\s*".*"\s*([,}])""".r
+
+  /** Patches the source map content to have the provided JS file link (or none).
+   *
+   *  Looks for a `"file":` key in the top-level source map JSON object and
+   *  replaces it's value with `jsFileURI`. In case `jsFileURI` is None, it
+   *  removes the key from the object.
+   */
+  private def patchSourceMapContent(content: String,
+      jsFileURI: Option[URI]): String = {
+
+    // No need for quoting: toASCIIString never returns '"'
+    val newField =
+      jsFileURI.map(u => s""""file": "${u.toASCIIString}"""")
+
+    fileFieldRe.findFirstMatchIn(content).fold {
+      newField.fold(content) { field =>
+        content.split("\\{", 2) match {
+          case Array(pre, post) =>
+            pre + "{" + field + "," + post
+
+          case _ =>
+            throw new IllegalArgumentException(
+                s"source map file does not seem to contain a JSON object: $content")
+        }
+      }
+    } { reMatch =>
+      val res = new StringBuilder
+
+      res.append(reMatch.before)
+
+      newField match {
+        case None =>
+          if (reMatch.group(1) == "{")
+            res.append('{')
+          if (reMatch.group(2) == "}")
+            res.append('}')
+        case Some(field) =>
+          res.append(reMatch.group(1))
+          res.append(field)
+          res.append(reMatch.group(2))
+      }
+
+      res.append(reMatch.after)
+
+      res.toString()
+    }
+  }
+}

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/OutputDirectoryImpl.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/OutputDirectoryImpl.scala
@@ -30,6 +30,10 @@ abstract class OutputDirectoryImpl extends OutputDirectory {
   def writeFull(name: String, buf: ByteBuffer)(
       implicit ec: ExecutionContext): Future[Unit]
 
+  /** Fully read the given file into a new ByteBuffer. */
+  def readFull(name: String)(
+      implicit ec: ExecutionContext): Future[ByteBuffer]
+
   /** Lists all the files in the directory. */
   def listFiles()(implicit ec: ExecutionContext): Future[List[String]]
 

--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/ReportToLinkerOutputAdapterTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/ReportToLinkerOutputAdapterTest.scala
@@ -1,0 +1,226 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import scala.collection.mutable
+import scala.concurrent._
+
+import java.net.URI
+import java.nio.ByteBuffer
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.junit.async._
+
+import org.scalajs.linker.interface.unstable._
+
+@deprecated("Mark deprecated to silence warnings", "never/always")
+class ReportToLinkerOutputAdapterTest {
+  import ReportToLinkerOutputAdapterTest._
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  private val dummyReport = new ReportImpl(List(
+      new ReportImpl.ModuleImpl(
+          moduleID = "dummy",
+          jsFileName = "main.js",
+          sourceMapName = Some("main.js.map"),
+          moduleKind = ModuleKind.NoModule
+      )
+  ))
+
+  @Test
+  def testReplaceLinks(): AsyncResult = await {
+    val writeOut = new WriteOnlyOutputDirectory()
+
+    val legacyOutput = LinkerOutput(new OutputFileImpl("js", writeOut))
+      .withSourceMap(new OutputFileImpl("sm", writeOut))
+      .withSourceMapURI(new URI("http://example.org/my-source-map-uri"))
+      .withJSFileURI(new URI("http://example.org/my-js-file-uri"))
+
+    val readOut = new ReadOnlyOutputDirectory(
+        "main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin,
+        "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+
+    for {
+      _ <- ReportToLinkerOutputAdapter.convert(dummyReport, readOut, legacyOutput)
+    } yield {
+      assertEquals(writeOut.content.size, 2)
+
+      assertEquals(raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=http://example.org/my-source-map-uri
+          |// some other comment
+          |""".stripMargin,
+          writeOut.content("js"))
+      assertEquals(raw"""{"file": "http://example.org/my-js-file-uri",
+          |  "other key": 1
+          |}""".stripMargin,
+          writeOut.content("sm"))
+    }
+  }
+
+  @Test
+  def testAddLinks(): AsyncResult = await {
+    val writeOut = new WriteOnlyOutputDirectory()
+
+    val legacyOutput = LinkerOutput(new OutputFileImpl("js", writeOut))
+      .withSourceMap(new OutputFileImpl("sm", writeOut))
+      .withSourceMapURI(new URI("http://example.org/my-source-map-uri"))
+      .withJSFileURI(new URI("http://example.org/my-js-file-uri"))
+
+    val readOut = new ReadOnlyOutputDirectory(
+        "main.js" -> raw"""
+          |console.log("hello");
+          |""".stripMargin,
+        "main.js.map" -> raw"""{
+          |  "other key": 1
+          |}""".stripMargin)
+
+    for {
+      _ <- ReportToLinkerOutputAdapter.convert(dummyReport, readOut, legacyOutput)
+    } yield {
+      assertEquals(writeOut.content.size, 2)
+
+      assertEquals(raw"""
+          |console.log("hello");
+          |
+          |//# sourceMappingURL=http://example.org/my-source-map-uri
+          |""".stripMargin,
+          writeOut.content("js"))
+      assertEquals(raw"""{"file": "http://example.org/my-js-file-uri",
+          |  "other key": 1
+          |}""".stripMargin,
+          writeOut.content("sm"))
+    }
+  }
+
+  @Test
+  def testRemoveLinks(): AsyncResult = await {
+    val writeOut = new WriteOnlyOutputDirectory()
+
+    val legacyOutput = LinkerOutput(new OutputFileImpl("js", writeOut))
+      .withSourceMap(new OutputFileImpl("sm", writeOut))
+
+    val readOut = new ReadOnlyOutputDirectory(
+        "main.js" -> raw"""
+          |console.log("hello");
+          |//# sourceMappingURL=main.js.map
+          |// some other comment
+          |""".stripMargin,
+        "main.js.map" -> raw"""{
+          |  "file": "main.js",
+          |  "other key": 1
+          |}""".stripMargin)
+
+    for {
+      _ <- ReportToLinkerOutputAdapter.convert(dummyReport, readOut, legacyOutput)
+    } yield {
+      assertEquals(writeOut.content.size, 2)
+
+      assertEquals(raw"""
+          |console.log("hello");
+          |
+          |// some other comment
+          |""".stripMargin,
+          writeOut.content("js"))
+      assertEquals(raw"""{
+          |  "other key": 1
+          |}""".stripMargin,
+          writeOut.content("sm"))
+    }
+  }
+
+  @Test
+  def testNoLinks(): AsyncResult = await {
+    val writeOut = new WriteOnlyOutputDirectory()
+
+    val legacyOutput = LinkerOutput(new OutputFileImpl("js", writeOut))
+      .withSourceMap(new OutputFileImpl("sm", writeOut))
+
+    val readOut = new ReadOnlyOutputDirectory(
+        "main.js" -> raw"""
+          |console.log("hello");
+          |""".stripMargin,
+        "main.js.map" -> raw"""{
+          |  "other key": 1
+          |}""".stripMargin)
+
+    for {
+      _ <- ReportToLinkerOutputAdapter.convert(dummyReport, readOut, legacyOutput)
+    } yield {
+      assertEquals(writeOut.content.size, 2)
+
+      assertEquals(raw"""
+          |console.log("hello");
+          |""".stripMargin,
+          writeOut.content("js"))
+      assertEquals(raw"""{
+          |  "other key": 1
+          |}""".stripMargin,
+          writeOut.content("sm"))
+    }
+  }
+}
+
+object ReportToLinkerOutputAdapterTest {
+  private class ReadOnlyOutputDirectory(fileContents: Map[String, String])
+      extends OutputDirectoryImpl {
+    def this(fileContents: (String, String)*) = this(fileContents.toMap)
+
+    def writeFull(name: String, buf: ByteBuffer)(
+        implicit ec: ExecutionContext): Future[Unit] = {
+      throw new AssertionError("should not be called")
+    }
+
+    def readFull(name: String)(
+        implicit ec: ExecutionContext): Future[ByteBuffer] = {
+      Future.successful(ByteBuffer.wrap(fileContents(name).getBytes(UTF_8)))
+    }
+
+    def listFiles()(implicit ec: ExecutionContext): Future[List[String]] =
+      Future.successful(fileContents.keys.toList)
+
+    def delete(name: String)(implicit ec: ExecutionContext): Future[Unit] =
+      throw new AssertionError("should not be called")
+  }
+
+  private class WriteOnlyOutputDirectory extends OutputDirectoryImpl {
+    val content: mutable.Map[String, String] = mutable.Map.empty
+
+    def writeFull(name: String, buf: ByteBuffer)(
+        implicit ec: ExecutionContext): Future[Unit] = {
+      content(name) = UTF_8.decode(buf).toString()
+      Future.successful(())
+    }
+
+    def readFull(name: String)(
+        implicit ec: ExecutionContext): Future[ByteBuffer] = {
+      throw new AssertionError("should not be called")
+    }
+
+    def listFiles()(implicit ec: ExecutionContext): Future[List[String]] =
+      throw new AssertionError("should not be called")
+
+    def delete(name: String)(implicit ec: ExecutionContext): Future[Unit] =
+      throw new AssertionError("should not be called")
+  }
+}

--- a/linker/js/src/main/scala/org/scalajs/linker/NodeOutputDirectory.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/NodeOutputDirectory.scala
@@ -15,6 +15,7 @@ package org.scalajs.linker
 import scala.concurrent._
 
 import scala.scalajs.js
+import scala.scalajs.js.typedarray._
 import scala.scalajs.js.typedarray.TypedArrayBufferOps._
 
 import java.nio.ByteBuffer
@@ -42,6 +43,13 @@ object NodeOutputDirectory {
       }
 
       cbFuture[Unit](NodeFS.writeFile(path, data, _))
+    }
+
+    def readFull(name: String)(
+        implicit ec: ExecutionContext): Future[ByteBuffer] = {
+      cbFuture[Uint8Array](NodeFS.readFile(name, _)).map { ta =>
+        TypedArrayBuffer.wrap(ta.buffer, ta.byteOffset, ta.byteLength)
+      }
     }
 
     def listFiles()(implicit ec: ExecutionContext): Future[List[String]] =

--- a/linker/jvm/src/test/scala/org/scalajs/linker/PathOutputDirectoryTest.scala
+++ b/linker/jvm/src/test/scala/org/scalajs/linker/PathOutputDirectoryTest.scala
@@ -54,4 +54,23 @@ class PathOutputDirectoryTest {
       assertEquals(lastModifiedBefore, lastModifiedAfter)
     }
   }
+
+  @Test
+  def readFull(): AsyncResult = await {
+    val dir = Jimfs.newFileSystem().getPath("/tmp")
+    Files.createDirectory(dir)
+
+    val fileName = "file.js"
+    val filePath = dir.resolve(fileName)
+
+    Files.write(filePath, dummyContent)
+
+    val readOp = OutputDirectoryImpl
+      .fromOutputDirectory(PathOutputDirectory(dir))
+      .readFull(fileName)
+
+    readOp.map { buf =>
+      assertEquals(ByteBuffer.wrap(dummyContent), buf)
+    }
+  }
 }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -57,13 +57,11 @@ object BinaryIncompatibilities {
 
   val SbtPlugin = Seq(
       // Changes in LinkerImpl, which is declared that we can break it.
-      exclude[DirectMissingMethodProblem](
-          "org.scalajs.sbtplugin.LinkerImpl.outputFile"),
       exclude[ReversedMissingMethodProblem](
           "org.scalajs.sbtplugin.LinkerImpl.outputDirectory"),
-      exclude[DirectMissingMethodProblem](
+      exclude[FinalMethodProblem](
           "org.scalajs.sbtplugin.LinkerImpl#Reflect.outputFile"),
-      exclude[DirectMissingMethodProblem](
+      exclude[FinalMethodProblem](
           "org.scalajs.sbtplugin.LinkerImpl#Forwarding.outputFile"),
   )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -727,7 +727,7 @@ object Build {
           "org.scala-js" %% "scalajs-logging" % "1.1.1",
           "com.novocode" % "junit-interface" % "0.11" % "test",
       ),
-  ).dependsOn(irProject)
+  ).dependsOn(irProject, jUnitAsyncJVM % "test")
 
   lazy val linkerInterfaceJS: MultiScalaProject = MultiScalaProject(
       id = "linkerInterfaceJS", base = file("linker-interface/js")

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LinkerImpl.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LinkerImpl.scala
@@ -20,6 +20,7 @@ import java.net.URLClassLoader
 import java.nio.file.Path
 
 import org.scalajs.linker.interface._
+import org.scalajs.linker.interface.unstable.OutputFileImpl
 
 /** Abstract implementation of a linker as needed by the sbt plugin.
  *
@@ -38,6 +39,10 @@ trait LinkerImpl {
       implicit ec: ExecutionContext): Future[(Seq[IRContainer], Seq[Path])]
 
   def outputDirectory(path: Path): OutputDirectory
+
+  @deprecated("Use outputDirectory instead", "1.3.0")
+  final def outputFile(path: Path): LinkerOutput.File =
+    new OutputFileImpl(path.getFileName().toString(), outputDirectory(path.getParent()))
 }
 
 /** Factory methods and concrete implementations of `LinkerImpl`.


### PR DESCRIPTION
As a bonus, this allows us to quite easily test more cases. It is left as an exercise to the reader to spot the bug that got fixed on the way.