### PR TITLE
Add explicit conversions required on JDK13+

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
@@ -159,7 +159,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
 
       buf.order(ByteOrder.BIG_ENDIAN)
       val charBuf1 = buf.asCharBuffer()
-      charBuf1.put(1, 0x7e7f)
+      charBuf1.put(1, 0x7e7f.toChar)
       assertEquals(0x7e, buf.get(3))
       assertEquals(0x7f, buf.get(4))
       assertEquals(0, charBuf1.position())
@@ -170,7 +170,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
 
       buf.order(ByteOrder.LITTLE_ENDIAN)
       val charBuf2 = buf.asCharBuffer()
-      charBuf2.put(1, 0x7e7f)
+      charBuf2.put(1, 0x7e7f.toChar)
       assertEquals(0x7f, buf.get(3))
       assertEquals(0x7e, buf.get(4))
       assertEquals(0, charBuf2.position())
@@ -183,7 +183,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
       buf.limit(8).position(1)
 
       val charBuf1 = buf.asReadOnlyBuffer().asCharBuffer()
-      expectThrows(classOf[ReadOnlyBufferException], charBuf1.put(1, 0x7e7f))
+      expectThrows(classOf[ReadOnlyBufferException], charBuf1.put(1, 0x7e7f.toChar))
     }
   }
 
@@ -313,7 +313,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
 
       buf.order(ByteOrder.BIG_ENDIAN)
       val shortBuf1 = buf.asShortBuffer()
-      shortBuf1.put(1, 0x7e7f)
+      shortBuf1.put(1, 0x7e7f.toShort)
       assertEquals(0x7e, buf.get(3))
       assertEquals(0x7f, buf.get(4))
       assertEquals(0, shortBuf1.position())
@@ -324,7 +324,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
 
       buf.order(ByteOrder.LITTLE_ENDIAN)
       val shortBuf2 = buf.asShortBuffer()
-      shortBuf2.put(1, 0x7e7f)
+      shortBuf2.put(1, 0x7e7f.toShort)
       assertEquals(0x7f, buf.get(3))
       assertEquals(0x7e, buf.get(4))
       assertEquals(0, shortBuf2.position())
@@ -337,7 +337,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
       buf.limit(8).position(1)
 
       val shortBuf1 = buf.asReadOnlyBuffer().asShortBuffer()
-      expectThrows(classOf[ReadOnlyBufferException], shortBuf1.put(1, 0x7e7f))
+      expectThrows(classOf[ReadOnlyBufferException], shortBuf1.put(1, 0x7e7f.toShort))
     }
   }
 


### PR DESCRIPTION
jdk13 introduced a new methods for `CharBuffer` and `ShortBuffer` that brokes building with errors like:
```
[error] test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala:162:16: overloaded method value put with alternatives:
[error]   (x$1: Int,x$2: Array[Char])java.nio.CharBuffer <and>
[error]   (x$1: Int,x$2: Char)java.nio.CharBuffer
[error]  cannot be applied to (Int, Int)
[error]         charBuf1.put(1, 0x7e7f)
```
and
```
[error] test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala:316:17: overloaded method value put with alternatives:
[error]   (x$1: Int,x$2: Array[Short])java.nio.ShortBuffer <and>
[error]   (x$1: Int,x$2: Short)java.nio.ShortBuffer
[error]  cannot be applied to (Int, Int)
[error]         shortBuf1.put(1, 0x7e7f)
```

anyway, a few lines bellow the same tests are doint the same trick with `.toChar` and `.toShort` to same value.

Let make it here to allow build scala-native by jdk13+

This is backport from Scala-Native: https://github.com/scala-native/scala-native/pull/1939