### PR TITLE
Make j.u.HashMap loadFactor constructor follow Java 8 description.

### DIFF
--- a/javalib/src/main/scala/java/util/HashMap.scala
+++ b/javalib/src/main/scala/java/util/HashMap.scala
@@ -19,7 +19,7 @@ import java.util.function.BiConsumer
 
 import ScalaOps._
 
-class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
+class HashMap[K, V](initialCapacity: Int, loadFactor: Float)
     extends AbstractMap[K, V] with Serializable with Cloneable {
   self =>
 
@@ -27,7 +27,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
 
   if (initialCapacity < 0)
     throw new IllegalArgumentException("initialCapacity < 0")
-  if (loadFactor <= 0.0)
+  if (loadFactor <= 0.0f)
     throw new IllegalArgumentException("loadFactor <= 0.0")
 
   def this() =
@@ -381,7 +381,7 @@ class HashMap[K, V](initialCapacity: Int, loadFactor: Double)
     Math.min(Integer.highestOneBit(Math.max(capacity - 1, 4)) * 2, 1 << 30)
 
   @inline private[this] def newThreshold(size: Int): Int =
-    (size.toDouble * loadFactor).toInt
+    (size.toDouble * loadFactor.toDouble).toInt
 
   // Iterators
 

--- a/javalib/src/main/scala/java/util/NullRejectingHashMap.scala
+++ b/javalib/src/main/scala/java/util/NullRejectingHashMap.scala
@@ -19,7 +19,7 @@ package java.util
  *  their specifications.
  */
 private[util] class NullRejectingHashMap[K, V](
-    initialCapacity: Int, loadFactor: Double)
+    initialCapacity: Int, loadFactor: Float)
     extends HashMap[K, V](initialCapacity, loadFactor) {
 
   def this() =

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashMapTest.scala
@@ -16,8 +16,17 @@ import java.{util => ju}
 
 import scala.reflect.ClassTag
 
+import org.junit.Test
+import org.junit.Assert.assertNotNull
+
 class HashMapTest extends MapTest {
   def factory: HashMapFactory = new HashMapFactory
+
+  @Test def testConstructorWithLoadFactorArg(): Unit = {
+    // Test constructor has correct binary signature for calling from user code
+    // and direct use links.
+    new ju.HashMap[Int,String](10, 0.5f)
+  }
 }
 
 class HashMapFactory extends AbstractMapFactory {


### PR DESCRIPTION
This PR changes j.u.HashMap to follow the the Java 8 documentation for [HashMap](https://docs.oracle.com/javase/8/docs/api/java/util/HashMap.html). The loadFactor constructor argument as is described as float.

The type of loadFactor in the private class NullRejectingHashMap, which extends HashMap,
was changed to match.