### PR TITLE
Enable j.u.Objects#requireNonNull with message Supplier argument

### DIFF
--- a/javalib/src/main/scala/java/util/Objects.scala
+++ b/javalib/src/main/scala/java/util/Objects.scala
@@ -12,6 +12,8 @@
 
 package java.util
 
+import java.util.function.Supplier
+
 import scala.reflect.ClassTag
 
 object Objects {
@@ -82,9 +84,8 @@ object Objects {
   def nonNull(obj: Any): Boolean =
     obj != null
 
-  // Requires the implementation of java.util.function
-  // @inline
-  // def requireNonNull[T](obj: T, messageSupplier: Supplier[String]): T =
-  //   if (obj == null) throw new NullPointerException(messageSupplier.get())
-  //   else obj
+  @inline
+  def requireNonNull[T](obj: T, messageSupplier: Supplier[String]): T =
+    if (obj == null) throw new NullPointerException(messageSupplier.get())
+    else obj
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ObjectsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ObjectsTest.scala
@@ -94,6 +94,27 @@ class ObjectsTest {
     assertEquals("abc", ju.Objects.requireNonNull("abc", ""))
   }
 
+  @Test def requireNonNullWithMsgSupplier(): Unit = {
+    val message = "All is well!"
+
+    val successSupplier = new ju.function.Supplier[String] {
+      def get(): String = message
+    }
+
+    val failureSupplier = new ju.function.Supplier[String] {
+      def get(): String = {
+        throw new AssertionError(
+            "Objects.requireNonNull() should not have called Supplier")
+      }
+    }
+
+    val e = expectThrows(classOf[NullPointerException],
+        ju.Objects.requireNonNull(null, successSupplier))
+    assertEquals(message, e.getMessage())
+
+    assertEquals("abc", ju.Objects.requireNonNull("abc", failureSupplier))
+  }
+
   @Test def isNull(): Unit = {
     assertTrue(ju.Objects.isNull(null))
     assertFalse(ju.Objects.isNull(new Object))


### PR DESCRIPTION
Enable j.u.Objects#requireNonNull with message Supplier argument

Now that we have j.u.f.Supplier, the comment had become obsolete.
We can now implement that method.