### PR TITLE
Change JUnit test names to toggle case and update names

### DIFF
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/DiverseErrorsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/DiverseErrorsTest.scala
@@ -24,7 +24,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
     """
 
   @Test
-  def noIsInstanceOnJS: Unit = {
+  def noIsInstanceOnJS(): Unit = {
 
     """
     @js.native
@@ -44,7 +44,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
   }
 
   @Test
-  def jsConstructorOfErrors: Unit = {
+  def jsConstructorOfErrors(): Unit = {
 
     """
     class ScalaClass
@@ -131,7 +131,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
   }
 
   @Test
-  def jsConstructorTagErrors: Unit = {
+  def jsConstructorTagErrors(): Unit = {
 
     """
     class ScalaClass
@@ -218,7 +218,7 @@ class DiverseErrorsTest extends DirectTest with TestHelpers  {
   }
 
   @Test
-  def runtimeConstructorOfErrors: Unit = {
+  def runtimeConstructorOfErrors(): Unit = {
 
     """
     import scala.scalajs.runtime

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/EnumerationInteropTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 class EnumerationInteropTest extends DirectTest with TestHelpers {
 
   @Test
-  def warnIfUnableToTransformValue: Unit = {
+  def warnIfUnableToTransformValue(): Unit = {
 
     """
     class A extends Enumeration {
@@ -49,7 +49,7 @@ class EnumerationInteropTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def warnIfNoNameVal: Unit = {
+  def warnIfNoNameVal(): Unit = {
 
     """
     class A extends Enumeration {
@@ -73,7 +73,7 @@ class EnumerationInteropTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def warnIfNullValue: Unit = {
+  def warnIfNullValue(): Unit = {
 
     """
     class A extends Enumeration {
@@ -97,7 +97,7 @@ class EnumerationInteropTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def warnIfNullNewVal: Unit = {
+  def warnIfNullNewVal(): Unit = {
 
     """
     class A extends Enumeration {
@@ -121,7 +121,7 @@ class EnumerationInteropTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def warnIfExtNoNameVal: Unit = {
+  def warnIfExtNoNameVal(): Unit = {
 
     """
     class A extends Enumeration {
@@ -145,7 +145,7 @@ class EnumerationInteropTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def warnIfExtNullNameVal: Unit = {
+  def warnIfExtNullNameVal(): Unit = {
 
     """
     class A extends Enumeration {

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/InternalAnnotationsTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/InternalAnnotationsTest.scala
@@ -24,17 +24,17 @@ class InternalAnnotationsTest extends DirectTest with TestHelpers {
     "import scala.scalajs.js, js.annotation._, js.annotation.internal._"
 
   @Test
-  def exposedJSMember: Unit = {
+  def exposedJSMember(): Unit = {
     test("ExposedJSMember")
   }
 
   @Test
-  def jsType: Unit = {
+  def jsType(): Unit = {
     test("JSType")
   }
 
   @Test
-  def jsOptional: Unit = {
+  def jsOptional(): Unit = {
     test("JSOptional")
   }
 

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSDynamicLiteralTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSDynamicLiteralTest.scala
@@ -24,7 +24,7 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
     """
 
   @Test
-  def callApplyOnly: Unit = {
+  def callApplyOnly(): Unit = {
 
     // selectDynamic (with any name)
     expr"""
@@ -61,7 +61,7 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def goodTypesOnly: Unit = {
+  def goodTypesOnly(): Unit = {
 
     // Bad value type (applyDynamic)
     """
@@ -113,7 +113,7 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noNonLiteralMethodName: Unit = {
+  def noNonLiteralMethodName(): Unit = {
 
     // applyDynamicNamed
     """
@@ -144,7 +144,7 @@ class JSDynamicLiteralTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def keyDuplicationWarning: Unit = {
+  def keyDuplicationWarning(): Unit = {
     // detects duplicate named keys
     expr"""
     lit(a = "1", b = "2", a = "3")

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportASTTest.scala
@@ -22,7 +22,7 @@ import org.scalajs.ir.{Trees => js}
 class JSExportASTTest extends JSASTTest {
 
   @Test
-  def inheritExportMethods: Unit = {
+  def inheritExportMethods(): Unit = {
     """
     import scala.scalajs.js.annotation.JSExport
 

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -30,7 +30,7 @@ class JSExportTest extends DirectTest with TestHelpers {
     """
 
   @Test
-  def warnOnDuplicateExport: Unit = {
+  def warnOnDuplicateExport(): Unit = {
     """
     class A {
       @JSExport
@@ -101,7 +101,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noWarnOnUniqueExplicitName: Unit = {
+  def noWarnOnUniqueExplicitName(): Unit = {
     """
     class A {
       @JSExport("a")
@@ -112,7 +112,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noJSExportClass: Unit = {
+  def noJSExportClass(): Unit = {
     """
     @JSExport
     class A
@@ -131,7 +131,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noJSExportObject: Unit = {
+  def noJSExportObject(): Unit = {
     """
     @JSExport
     object A
@@ -150,7 +150,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noDoubleUnderscoreExport: Unit = {
+  def noDoubleUnderscoreExport(): Unit = {
     """
     class A {
       @JSExport(name = "__")
@@ -171,7 +171,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def doubleUnderscoreOKInTopLevelExport: Unit = {
+  def doubleUnderscoreOKInTopLevelExport(): Unit = {
     """
     @JSExportTopLevel("__A")
     class A
@@ -190,7 +190,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noConflictingExport: Unit = {
+  def noConflictingExport(): Unit = {
     """
     class Confl {
       @JSExport("value")
@@ -314,7 +314,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportLocal: Unit = {
+  def noExportLocal(): Unit = {
     // Local class
     """
     class A {
@@ -405,7 +405,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noMiddleVarArg: Unit = {
+  def noMiddleVarArg(): Unit = {
 
     """
     class A {
@@ -422,7 +422,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noMiddleDefaultParam: Unit = {
+  def noMiddleDefaultParam(): Unit = {
 
     """
     class A {
@@ -439,7 +439,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportAbstractClass: Unit = {
+  def noExportAbstractClass(): Unit = {
 
     """
     @JSExportTopLevel("A")
@@ -462,7 +462,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noJSExportOnTrait: Unit = {
+  def noJSExportOnTrait(): Unit = {
 
     """
     @JSExport
@@ -490,7 +490,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportNonPublicClassOrObject: Unit = {
+  def noExportNonPublicClassOrObject(): Unit = {
 
     """
     @JSExportTopLevel("A")
@@ -551,7 +551,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportNonPublicMember: Unit = {
+  def noExportNonPublicMember(): Unit = {
 
     """
     class A {
@@ -574,7 +574,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportNestedClass: Unit = {
+  def noExportNestedClass(): Unit = {
 
     """
     class A {
@@ -633,7 +633,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noNestedExportObject: Unit = {
+  def noNestedExportObject(): Unit = {
 
     """
     object A {
@@ -656,7 +656,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelNestedObject: Unit = {
+  def noExportTopLevelNestedObject(): Unit = {
 
     """
     class A {
@@ -679,7 +679,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportJSNative: Unit = {
+  def noExportJSNative(): Unit = {
 
     """
     import scala.scalajs.js
@@ -731,7 +731,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportJSMember: Unit = {
+  def noExportJSMember(): Unit = {
 
     """
     import scala.scalajs.js
@@ -766,7 +766,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noBadSetterType: Unit = {
+  def noBadSetterType(): Unit = {
 
     // Bad param list
     """
@@ -823,7 +823,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noBadToStringExport: Unit = {
+  def noBadToStringExport(): Unit = {
 
     """
     class A {
@@ -840,7 +840,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noBadNameExportAll: Unit = {
+  def noBadNameExportAll(): Unit = {
 
     """
     @JSExportAll
@@ -861,7 +861,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noConflictingMethodAndProperty: Unit = {
+  def noConflictingMethodAndProperty(): Unit = {
 
     // Basic case
     """
@@ -906,7 +906,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def gracefulDoubleDefaultFail: Unit = {
+  def gracefulDoubleDefaultFail(): Unit = {
     // This used to blow up (i.e. not just fail), because PrepJSExports asked
     // for the symbol of the default parameter getter of [[y]], and asserted its
     // not overloaded. Since the Scala compiler only fails later on this, the
@@ -926,7 +926,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noNonLiteralExportNames: Unit = {
+  def noNonLiteralExportNames(): Unit = {
 
     """
     object A {
@@ -950,7 +950,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noNonLiteralModuleID: Unit = {
+  def noNonLiteralModuleID(): Unit = {
 
     """
     object A {
@@ -974,7 +974,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportImplicitApply: Unit = {
+  def noExportImplicitApply(): Unit = {
 
     """
     class A {
@@ -1024,7 +1024,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def exportObjectAsToString: Unit = {
+  def exportObjectAsToString(): Unit = {
 
     """
     @JSExportTopLevel("toString")
@@ -1040,7 +1040,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelTrait: Unit = {
+  def noExportTopLevelTrait(): Unit = {
     """
     @JSExportTopLevel("foo")
     trait A
@@ -1077,7 +1077,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelLazyVal: Unit = {
+  def noExportTopLevelLazyVal(): Unit = {
     """
     object A {
       @JSExportTopLevel("foo")
@@ -1092,7 +1092,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelInvalidJSIdentifier: Unit = {
+  def noExportTopLevelInvalidJSIdentifier(): Unit = {
     """
     @JSExportTopLevel("not-a-valid-JS-identifier-1")
     object A
@@ -1137,7 +1137,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelNamespaced: Unit = {
+  def noExportTopLevelNamespaced(): Unit = {
     """
     @JSExportTopLevel("namespaced.export1")
     object A
@@ -1172,7 +1172,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelGetter: Unit = {
+  def noExportTopLevelGetter(): Unit = {
     """
     object A {
       @JSExportTopLevel("foo")
@@ -1187,7 +1187,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelSetter: Unit = {
+  def noExportTopLevelSetter(): Unit = {
     """
     object A {
       @JSExportTopLevel("foo")
@@ -1202,7 +1202,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelFieldsWithSameName: Unit = {
+  def noExportTopLevelFieldsWithSameName(): Unit = {
     """
     object A {
       @JSExportTopLevel("foo")
@@ -1220,7 +1220,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelFieldsAndMethodsWithSameName: Unit = {
+  def noExportTopLevelFieldsAndMethodsWithSameName(): Unit = {
     """
     object A {
       @JSExportTopLevel("foo")
@@ -1253,7 +1253,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelNonStatic: Unit = {
+  def noExportTopLevelNonStatic(): Unit = {
     """
     class A {
       @JSExportTopLevel("foo")
@@ -1330,7 +1330,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelLocal: Unit = {
+  def noExportTopLevelLocal(): Unit = {
     // Local class
     """
     class A {
@@ -1375,7 +1375,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportTopLevelJSModule: Unit = {
+  def noExportTopLevelJSModule(): Unit = {
     """
     object A extends js.Object {
       @JSExportTopLevel("foo")
@@ -1390,7 +1390,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticModule: Unit = {
+  def noExportStaticModule(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1407,7 +1407,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticTrait: Unit = {
+  def noExportStaticTrait(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1424,7 +1424,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticClass: Unit = {
+  def noExportStaticClass(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1457,7 +1457,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticValTwice: Unit = {
+  def noExportStaticValTwice(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1475,7 +1475,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticVarTwice: Unit = {
+  def noExportStaticVarTwice(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1493,7 +1493,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticLazyVal: Unit = {
+  def noExportStaticLazyVal(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1510,7 +1510,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportValAsStaticAndTopLevel: Unit = {
+  def noExportValAsStaticAndTopLevel(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1528,7 +1528,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportVarAsStaticAndTopLevel: Unit = {
+  def noExportVarAsStaticAndTopLevel(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1546,7 +1546,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportSetterWithBadSetterType: Unit = {
+  def noExportSetterWithBadSetterType(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1563,7 +1563,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticCollapsingMethods: Unit = {
+  def noExportStaticCollapsingMethods(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1585,7 +1585,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticCollapsingGetters: Unit = {
+  def noExportStaticCollapsingGetters(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1605,7 +1605,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticCollapsingSetters: Unit = {
+  def noExportStaticCollapsingSetters(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1627,7 +1627,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticFieldsWithSameName: Unit = {
+  def noExportStaticFieldsWithSameName(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1647,7 +1647,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticFieldsAndMethodsWithSameName: Unit = {
+  def noExportStaticFieldsAndMethodsWithSameName(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1684,7 +1684,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticFieldsAndPropertiesWithSameName: Unit = {
+  def noExportStaticFieldsAndPropertiesWithSameName(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1721,7 +1721,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticPropertiesAndMethodsWithSameName: Unit = {
+  def noExportStaticPropertiesAndMethodsWithSameName(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1758,7 +1758,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticNonStatic: Unit = {
+  def noExportStaticNonStatic(): Unit = {
     """
     class A {
       class StaticContainer extends js.Object
@@ -1777,7 +1777,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticInJSModule: Unit = {
+  def noExportStaticInJSModule(): Unit = {
     """
     class StaticContainer extends js.Object
 
@@ -1810,7 +1810,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticIfWrongCompanionType: Unit = {
+  def noExportStaticIfWrongCompanionType(): Unit = {
     """
     class StaticContainer
 
@@ -1857,7 +1857,7 @@ class JSExportTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noExportStaticFieldAfterStatOrNonStaticField: Unit = {
+  def noExportStaticFieldAfterStatOrNonStaticField(): Unit = {
     for {
       offendingDecl <- Seq(
           "val a: Int = 1",

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSGlobalScopeTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSGlobalScopeTest.scala
@@ -63,7 +63,7 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def canAccessLegitMembers: Unit = {
+  def canAccessLegitMembers(): Unit = {
     s"""
     object Main {
       def main(): Unit = {
@@ -84,7 +84,7 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def noLoadGlobalValue: Unit = {
+  def noLoadGlobalValue(): Unit = {
     s"""
     object Main {
       def main(): Unit = {
@@ -106,7 +106,7 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def rejectInvalidJSIdentifiers: Unit = {
+  def rejectInvalidJSIdentifiers(): Unit = {
     s"""
     object Main {
       def main(): Unit = {
@@ -165,7 +165,7 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def rejectInvalidJSIdentifiersInNestedObjectClass: Unit = {
+  def rejectInvalidJSIdentifiersInNestedObjectClass(): Unit = {
     """
     @js.native
     @JSGlobalScope
@@ -203,7 +203,7 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def rejectJSOperators: Unit = {
+  def rejectJSOperators(): Unit = {
     """
     object Main {
       def main(): Unit = {
@@ -235,7 +235,7 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def rejectApply: Unit = {
+  def rejectApply(): Unit = {
     """
     object Main {
       def main(): Unit = {
@@ -266,7 +266,7 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def rejectDynamicNames: Unit = {
+  def rejectDynamicNames(): Unit = {
     s"""
     object Main {
       def dynName: String = "foo"
@@ -327,7 +327,7 @@ class JSGlobalScopeTest extends DirectTest with TestHelpers {
   }
 
   @Test
-  def rejectAllReservedIdentifiers: Unit = {
+  def rejectAllReservedIdentifiers(): Unit = {
     val reservedIdentifiers = List(
         "arguments", "break", "case", "catch", "class", "const", "continue",
         "debugger", "default", "delete", "do", "else", "enum", "export",

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSInteropTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSInteropTest.scala
@@ -46,8 +46,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     }
   }
 
-  @Test
-  def warnJSPackageObjectDeprecated: Unit = {
+  @Test def warnJSPackageObjectDeprecated: Unit = {
 
     s"""
     package object jspackage extends js.Object
@@ -60,8 +59,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSNameAnnotOnNonJSNative: Unit = {
+  @Test def noJSNameAnnotOnNonJSNative: Unit = {
 
     for {
       obj <- Seq("class", "trait", "object")
@@ -149,8 +147,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def okJSNameOnNestedObjects: Unit = {
+  @Test def okJSNameOnNestedObjects: Unit = {
 
     """
     class A extends js.Object {
@@ -182,8 +179,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSGlobalAnnotOnNonJSNative: Unit = {
+  @Test def noJSGlobalAnnotOnNonJSNative: Unit = {
 
     for {
       obj <- Seq("class", "trait", "object")
@@ -263,8 +259,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSImportAnnotOnNonJSNative: Unit = {
+  @Test def noJSImportAnnotOnNonJSNative: Unit = {
 
     for {
       obj <- Seq("class", "trait", "object")
@@ -396,8 +391,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSGlobalScopeAnnotOnNonJSNative: Unit = {
+  @Test def noJSGlobalScopeAnnotOnNonJSNative: Unit = {
 
     """
     @JSGlobalScope
@@ -420,8 +414,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
 
   }
-  @Test
-  def noJSNameAnnotOnClass: Unit = {
+  @Test def noJSNameAnnotOnClass: Unit = {
     """
     @js.native
     @JSName("Foo")
@@ -447,8 +440,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noJSNameAnnotOnObject: Unit = {
+  @Test def noJSNameAnnotOnObject: Unit = {
     """
     @js.native
     @JSName("Foo")
@@ -464,8 +456,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noJSNameAnnotOnTrait: Unit = {
+  @Test def noJSNameAnnotOnTrait: Unit = {
 
     s"""
     object Sym {
@@ -494,8 +485,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSNameAnnotOnNativeValDef: Unit = {
+  @Test def noJSNameAnnotOnNativeValDef: Unit = {
 
     s"""
     object Sym {
@@ -569,8 +559,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSGlobalAnnotOnTrait: Unit = {
+  @Test def noJSGlobalAnnotOnTrait: Unit = {
 
     s"""
     @js.native
@@ -596,8 +585,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSImportAnnotOnTrait: Unit = {
+  @Test def noJSImportAnnotOnTrait: Unit = {
 
     s"""
     @js.native
@@ -746,8 +734,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     }
   }
 
-  @Test
-  def noJSNativeAnnotWithoutJSAny: Unit = {
+  @Test def noJSNativeAnnotWithoutJSAny: Unit = {
 
     // With the correct amount of native load spec annotations
     """
@@ -821,8 +808,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noInnerScalaClassTraitObjectInJSNative: Unit = {
+  @Test def noInnerScalaClassTraitObjectInJSNative: Unit = {
 
     for {
       outer <- Seq("class", "trait")
@@ -846,8 +832,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noInnerNonNativeJSClassTraitObjectInJSNative: Unit = {
+  @Test def noInnerNonNativeJSClassTraitObjectInJSNative: Unit = {
 
     for {
       outer <- Seq("class", "trait")
@@ -871,8 +856,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noScalaStuffInsideNativeJSObject: Unit = {
+  @Test def noScalaStuffInsideNativeJSObject: Unit = {
 
     for {
       inner <- Seq("class", "trait", "object")
@@ -893,8 +877,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNonSyntheticCompanionInsideNativeJSObject: Unit = {
+  @Test def noNonSyntheticCompanionInsideNativeJSObject: Unit = {
 
     // See #1891: The default parameter generates a synthetic companion object
     // The synthetic companion should be allowed, but it may not be explicit
@@ -919,8 +902,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNonNativeJSTypesInsideNativeJSObject: Unit = {
+  @Test def noNonNativeJSTypesInsideNativeJSObject: Unit = {
 
     for {
       inner <- Seq("class", "object")
@@ -941,8 +923,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def jsNativeValDefsMustHaveJSNativeRHS: Unit = {
+  @Test def jsNativeValDefsHaveJSNativeRHS: Unit = {
     """
     object Container {
       @js.native @JSGlobal("a")
@@ -968,8 +949,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noJSBracketAccessOnJSNativeValDefs: Unit = {
+  @Test def noJSBracketAccessOnJSNativeValDefs: Unit = {
     """
     object Container {
       @js.native @JSGlobal("a")
@@ -998,8 +978,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noJSBracketCallOnJSNativeValDefs: Unit = {
+  @Test def noJSBracketCallOnJSNativeValDefs: Unit = {
     """
     object Container {
       @js.native @JSGlobal("a")
@@ -1028,8 +1007,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noJSNativeValDefsInJSObjects: Unit = {
+  @Test def noJSNativeValDefsInJSObjects: Unit = {
     """
     object A {
       val sym = js.Symbol("foo")
@@ -1173,8 +1151,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noJSNativeSetters: Unit = {
+  @Test def noJSNativeSetters: Unit = {
     """
     object Container {
       @js.native @JSGlobal("foo")
@@ -1203,8 +1180,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noJSNativeVars: Unit = {
+  @Test def noJSNativeVars: Unit = {
     """
     object Container {
       @js.native @JSGlobal("foo")
@@ -1218,8 +1194,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noJSNativeLazyVals: Unit = {
+  @Test def noJSNativeLazyVals: Unit = {
     """
     object Container {
       @js.native @JSGlobal("foo")
@@ -1233,8 +1208,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def jsNativeValDefsCannotImplementAbstractMethod: Unit = {
+  @Test def jsNativeValDefsCannotImplementAbstractMethod: Unit = {
     """
     abstract class Parent {
       val a: Int
@@ -1266,8 +1240,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def jsNativeValDefsCannotOverrideConcreteMethod: Unit = {
+  @Test def jsNativeValDefsCannotOverrideConcreteMethod: Unit = {
     """
     class Parent {
       val a: Int = 1
@@ -1299,8 +1272,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noBadSetters: Unit = {
+  @Test def noBadSetters: Unit = {
 
     """
     @js.native
@@ -1329,8 +1301,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noBadBracketAccess: Unit = {
+  @Test def noBadBracketAccess: Unit = {
 
     """
     @js.native
@@ -1396,8 +1367,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noBadBracketCall: Unit = {
+  @Test def noBadBracketCall: Unit = {
 
     """
     @js.native
@@ -1433,8 +1403,8 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test // #4284
-  def noBracketCallAndJSName: Unit = {
+  // #4284
+  @Test def noBracketCallAndJSName: Unit = {
     """
     @js.native
     @JSGlobal
@@ -1451,8 +1421,8 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test // #4284
-  def noBracketAccessAndBracketCall: Unit = {
+  // #4284
+  @Test def noBracketAccessAndBracketCall: Unit = {
     """
     @js.native
     @JSGlobal
@@ -1469,8 +1439,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noBadBinaryOp: Unit = {
+  @Test def noBadBinaryOp: Unit = {
     """
     @js.native
     @JSGlobal
@@ -1485,8 +1454,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def onlyJSTraits: Unit = {
+  @Test def onlyJSTraits: Unit = {
 
     """
     trait A
@@ -1514,8 +1482,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noCaseClassObject: Unit = {
+  @Test def noCaseClassObject: Unit = {
 
     """
     @js.native
@@ -1559,8 +1526,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNativeJSNestedInScalaClassTrait: Unit = {
+  @Test def noNativeJSNestedInScalaClassTrait: Unit = {
 
     val outers = List("class", "trait")
     val inners = List("trait", "class", "object")
@@ -1590,8 +1556,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNativeJSNestedInNonNativeJS: Unit = {
+  @Test def noNativeJSNestedInNonNativeJS: Unit = {
 
     val outers = List("class", "trait", "object")
     val inners = List("class", "trait", "object")
@@ -1621,8 +1586,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noLocalJSNative: Unit = {
+  @Test def noLocalJSNative: Unit = {
     """
     object A {
       def a = {
@@ -1680,8 +1644,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noNativeInJSAny: Unit = {
+  @Test def noNativeInJSAny: Unit = {
 
     """
     @js.native
@@ -1699,8 +1662,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def checkJSAnyBody: Unit = {
+  @Test def checkJSAnyBody: Unit = {
 
     """
     @js.native
@@ -1721,8 +1683,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noWarnJSAnyDeferred: Unit = {
+  @Test def noWarnJSAnyDeferred: Unit = {
 
     """
     @js.native
@@ -1743,8 +1704,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noCallSecondaryCtor: Unit = {
+  @Test def noCallSecondaryCtor: Unit = {
 
     """
     @js.native
@@ -1762,8 +1722,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noPrivateMemberInNative: Unit = {
+  @Test def noPrivateMemberInNative: Unit = {
 
     """
     @js.native
@@ -1814,8 +1773,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noPrivateConstructorInNative: Unit = {
+  @Test def noPrivateConstructorInNative: Unit = {
 
     """
     @js.native
@@ -1847,8 +1805,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noUseJsNative: Unit = {
+  @Test def noUseJsNative: Unit = {
 
     """
     class A {
@@ -1863,8 +1820,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def warnNothingInNativeJS: Unit = {
+  @Test def warnNothingInNativeJS: Unit = {
 
     """
     @js.native
@@ -1885,8 +1841,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def nativeClassMustHaveLoadingSpec: Unit = {
+  @Test def nativeClassHasLoadingSpec: Unit = {
     """
     @js.native
     class A extends js.Object
@@ -1904,8 +1859,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def nativeObjectMustHaveLoadingSpec: Unit = {
+  @Test def nativeObjectHasLoadingSpec: Unit = {
     """
     @js.native
     object A extends js.Object
@@ -1917,8 +1871,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noNativeClassObjectWithoutExplicitNameInsideScalaObject: Unit = {
+  @Test def noNativeClassObjectWithoutExplicitNameInsideScalaObject: Unit = {
 
     """
     object A {
@@ -2099,8 +2052,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNonLiteralJSName: Unit = {
+  @Test def noNonLiteralJSName: Unit = {
 
     """
     import js.annotation.JSName
@@ -2127,8 +2079,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNonStaticStableJSNameSymbol: Unit = {
+  @Test def noNonStaticStableJSNameSymbol: Unit = {
 
     """
     import js.annotation.JSName
@@ -2170,8 +2121,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noSelfReferenceJSNameSymbol: Unit = {
+  @Test def noSelfReferenceJSNameSymbol: Unit = {
 
     """
     object A extends js.Object {
@@ -2201,8 +2151,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSGlobalOnMembersOfClassesAndTraits: Unit = {
+  @Test def noJSGlobalOnMembersOfClassesAndTraits: Unit = {
 
     for (outer <- Seq("class", "trait")) {
       s"""
@@ -2259,8 +2208,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSGlobalOnMembersOfObjects: Unit = {
+  @Test def noJSGlobalOnMembersOfObjects: Unit = {
 
     s"""
     @js.native @JSGlobal
@@ -2315,8 +2263,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSImportOnMembersOfClassesAndTraits: Unit = {
+  @Test def noJSImportOnMembersOfClassesAndTraits: Unit = {
 
     for {
       outer <- Seq("class", "trait")
@@ -2362,8 +2309,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noJSImportOnMembersOfObjects: Unit = {
+  @Test def noJSImportOnMembersOfObjects: Unit = {
 
     for {
       fallbackStr <- Seq("", ", globalFallback = \"Foo\"")
@@ -2408,8 +2354,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNonLiteralJSGlobal: Unit = {
+  @Test def noNonLiteralJSGlobal: Unit = {
 
     """
     object A {
@@ -2435,8 +2380,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNonJSIdentifierJSGlobal: Unit = {
+  @Test def noNonJSIdentifierJSGlobal: Unit = {
 
     """
     @js.native
@@ -2519,8 +2463,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noNonLiteralJSImport: Unit = {
+  @Test def noNonLiteralJSImport: Unit = {
 
     // Without global fallback
 
@@ -2731,8 +2674,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noApplyProperty: Unit = {
+  @Test def noApplyProperty: Unit = {
 
     // def apply
 
@@ -2808,8 +2750,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
 
   }
 
-  @Test
-  def noAbstractLocalJSClass: Unit = {
+  @Test def noAbstractLocalJSClass: Unit = {
     """
     object Enclosing {
       def method(): Unit = {
@@ -2824,8 +2765,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noLoadJSConstructorOfUnstableRef: Unit = {
+  @Test def noLoadJSConstructorOfUnstableRef: Unit = {
     """
     class Enclosing {
       class InnerJSClass extends js.Object
@@ -2887,8 +2827,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """.fails()
   }
 
-  @Test
-  def noJSSymbolNameOnNestedNativeClassesAndObjects: Unit = {
+  @Test def noJSSymbolNameOnNestedNativeClassesAndObjects: Unit = {
     for {
       kind <- Seq("class", "object")
     } {
@@ -2913,8 +2852,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     }
   }
 
-  @Test
-  def noBracketCallOrBracketAccessOnJSClasses: Unit = {
+  @Test def noBracketCallOrBracketAccessOnJSClasses: Unit = {
     // native
     """
     @js.native
@@ -2996,8 +2934,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noDuplicateJSNameAnnotOnMember: Unit = {
+  @Test def noDuplicateJSNameAnnotOnMember: Unit = {
     for {
       kind <- Seq("class", "object", "trait")
     } {
@@ -3022,8 +2959,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     }
   }
 
-  @Test
-  def nonNativeJSTypesNameOverrideErrors: Unit = {
+  @Test def nonNativeJSTypesNameOverrideErrors: Unit = {
     """
     abstract class A extends js.Object {
       def bar(): Int
@@ -3365,8 +3301,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def nonNativeJSTypesJSNameWithSymbolOverrideErrors: Unit = {
+  @Test def nonNativeJSTypesJSNameWithSymbolOverrideErrors: Unit = {
     """
     object Syms {
       val sym1 = js.Symbol()
@@ -3806,8 +3741,8 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test // #4282
-  def jsTypesSpecialCallingConventionOverrideErrors: Unit = {
+  // #4282
+  @Test def jsTypesSpecialCallingConventionOverrideErrors: Unit = {
     // name "apply" vs function application
     """
     @js.native
@@ -3946,8 +3881,7 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """.succeeds()
   }
 
-  @Test
-  def noDefaultConstructorArgsIfModuleIsJSNative: Unit = {
+  @Test def noDefaultConstructorArgsIfModuleIsJSNative: Unit = {
     """
     class A(x: Int = 1) extends js.Object
 
@@ -3975,8 +3909,8 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test // #2547
-  def noDefaultOverrideCrash: Unit = {
+  // #2547
+  @Test def noDefaultOverrideCrash: Unit = {
     """
     @js.native
     @JSGlobal
@@ -4014,8 +3948,8 @@ class JSInteropTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test // # 3969
-  def overrideEqualsHashCode: Unit = {
+  // # 3969
+  @Test def overrideEqualsHashCode: Unit = {
     for {
       obj <- List("class", "object")
     } {

--- a/examples/testing/src/test/scala/CollectionTest.scala
+++ b/examples/testing/src/test/scala/CollectionTest.scala
@@ -2,8 +2,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class CollectionTest {
-  @Test
-  def array_map_and_filter_ints(): Unit = {
+  @Test def arrayMapAndFilterInts(): Unit = {
     val array = Array(5, 7, 2, 6, -30, 33, 66, 76, 75, 0)
     val result = array.filter(_.toInt % 3 != 0).map(x => x*x)
     assertArrayEquals(Array(25, 49, 4, 76*76), result)

--- a/examples/testing/src/test/scala/DOMExistanceTest.scala
+++ b/examples/testing/src/test/scala/DOMExistanceTest.scala
@@ -6,19 +6,16 @@ import org.junit.Assert._
 
 class DOMExistenceTest {
 
-  @Test
-  def should_initialize_document(): Unit = {
+  @Test def initializeDocument(): Unit = {
     assertFalse(js.isUndefined(global.document))
     assertEquals("#document", global.document.nodeName)
   }
 
-  @Test
-  def should_initialize_document_body(): Unit = {
+  @Test def initializeDocumentBody(): Unit = {
     assertFalse(js.isUndefined(global.document.body))
   }
 
-  @Test
-  def should_initialize_windod(): Unit = {
+  @Test def initializeWindow(): Unit = {
     assertFalse(js.isUndefined(global.window))
   }
 }

--- a/examples/testing/src/test/scala/ElementCreatorTest.scala
+++ b/examples/testing/src/test/scala/ElementCreatorTest.scala
@@ -6,8 +6,7 @@ import org.junit.Assert._
 
 class ElementCreatorTest {
 
-  @Test
-  def element_creator_create_an_element_in_body(): Unit = {
+  @Test def elementCreatorCreateAnElementInBody(): Unit = {
     // Create the element
     ElementCreator.create()
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LinkerTest.scala
@@ -79,8 +79,7 @@ class LinkerTest {
   /** This test exposes a problem where a linker in error state is called
    *  multiple times and ends up thinking it is being used concurrently.
    */
-  @Test
-  def clean_linking_state(): AsyncResult = await {
+  @Test def cleanLinkingState(): AsyncResult = await {
     class DummyException extends Exception
 
     val badSeq = new IndexedSeq[IRFile] {

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -121,7 +121,7 @@ class OptimizerTest {
 
   /** Never inline the `clone()` method of arrays. */
   @Test
-  def testCloneOnArrayNotInlined_issue3778(): AsyncResult = await {
+  def testCloneOnArrayNotInlined_Issue3778(): AsyncResult = await {
     testCloneOnArrayNotInlinedGeneric(List(
         // @inline override def clone(): AnyRef = witness()
         MethodDef(EMF, cloneMethodName, NON, Nil, AnyType, Some {
@@ -134,7 +134,7 @@ class OptimizerTest {
    *  reachable `clone()` method is `Object.clone()`.
    */
   @Test
-  def testCloneOnArrayNotInlined_issue3778_onlyObjectClone(): AsyncResult = await {
+  def testCloneOnArrayNotInlinedObjectCloneOnly_Issue3778(): AsyncResult = await {
     testCloneOnArrayNotInlinedGeneric(Nil)
   }
 
@@ -142,7 +142,7 @@ class OptimizerTest {
    *  and another `clone()` method are reachable.
    */
   @Test
-  def testCloneOnArrayNotInlined_issue3778_ObjectCloneAndAnotherClone(): AsyncResult = await {
+  def testCloneOnArrayNotInlinedObjectCloneAndAnotherClone_Issue3778(): AsyncResult = await {
     testCloneOnArrayNotInlinedGeneric(List(
         // @inline override def clone(): AnyRef = witness()
         MethodDef(EMF, cloneMethodName, NON, Nil, AnyType, Some {
@@ -172,7 +172,7 @@ class OptimizerTest {
   }
 
   @Test
-  def testOptimizerDoesNotEliminateRequiredStaticField_issue4021(): AsyncResult = await {
+  def testOptimizerDoesNotEliminateRequiredStaticField_Issue4021(): AsyncResult = await {
     val StringType = ClassType(BoxedStringClass)
     val fooGetter = m("foo", Nil, T)
     val classDefs = Seq(
@@ -209,7 +209,7 @@ class OptimizerTest {
   }
 
   @Test
-  def testOptimizerDoesNotEliminateRequiredLabeledBlockEmittedByDotty_issue4171(): AsyncResult = await {
+  def testOptimizerDoesNotEliminateRequiredLabeledBlockEmittedByDotty_Issue4171(): AsyncResult = await {
     /* For the following source code:
      *
      * (null: Any) match {

--- a/sbt-plugin/src/sbt-test/cross-version/2.11/src/test/scala/sbttest/LibTest.scala
+++ b/sbt-plugin/src/sbt-test/cross-version/2.11/src/test/scala/sbttest/LibTest.scala
@@ -4,12 +4,12 @@ import org.junit.Test
 import org.junit.Assert._
 
 class LibTest {
-  @Test def dummy_library_should_provide_foo(): Unit = {
+  @Test def dummyLibraryHasFoo(): Unit = {
     assertEquals("foo", Lib.foo(""))
     assertEquals("afoo", Lib.foo("a"))
   }
 
-  @Test def dummy_library_should_provide_sq(): Unit = {
+  @Test def dummyLibraryHasSq(): Unit = {
     assertEquals(0, Lib.sq(0))
     assertEquals(100, Lib.sq(10))
   }

--- a/sbt-plugin/src/sbt-test/cross-version/2.13/src/test/scala/sbttest/LibTest.scala
+++ b/sbt-plugin/src/sbt-test/cross-version/2.13/src/test/scala/sbttest/LibTest.scala
@@ -4,12 +4,12 @@ import org.junit.Test
 import org.junit.Assert._
 
 class LibTest {
-  @Test def dummy_library_should_provide_foo(): Unit = {
+  @Test def dummyLibraryHasFoo(): Unit = {
     assertEquals("foo", Lib.foo(""))
     assertEquals("afoo", Lib.foo("a"))
   }
 
-  @Test def dummy_library_should_provide_sq(): Unit = {
+  @Test def dummyLibraryHasSq(): Unit = {
     assertEquals(0, Lib.sq(0))
     assertEquals(100, Lib.sq(10))
   }

--- a/test-suite-ex/js/src/test/scala/org/scalajs/testsuite/jsinterop/GlobalScopeTestEx.scala
+++ b/test-suite-ex/js/src/test/scala/org/scalajs/testsuite/jsinterop/GlobalScopeTestEx.scala
@@ -30,7 +30,7 @@ import org.scalajs.testsuite.utils.Platform._
 class GlobalScopeTestEx {
   import GlobalScopeTestEx._
 
-  @Test def access_dangerous_global_ref(): Unit = {
+  @Test def accessDangerousGlobalRef(): Unit = {
     assumeTrue("Assuming execution in Node.js", executingInNodeJS)
 
     nodejs_runInThisContext("""
@@ -49,14 +49,14 @@ class GlobalScopeTestEx {
     assertEquals("yet a bit more evil", GlobalScope.`$h_O`)
   }
 
-  @Test def can_still_create_an_array(): Unit = {
+  @Test def canStillCreateAnArray(): Unit = {
     val a = new Array[Int](3)
     a(1) = 42
     assertEquals(42, a(1))
     assertSame(classOf[Array[Int]], a.getClass)
   }
 
-  @Test def access_global_ref_that_serves_as_this_in_default_methods_issue2972(): Unit = {
+  @Test def accessGlobalRefThatServesAsThisInDefaultMethods_Issue2972(): Unit = {
     js.eval("""var $thiz = "evil thiz";""");
 
     trait Foo {

--- a/test-suite-ex/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTestEx.scala
+++ b/test-suite-ex/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTestEx.scala
@@ -26,7 +26,7 @@ import scala.scalajs.js.annotation._
  */
 class NonNativeJSTypeTestEx {
 
-  @Test def constructor_property_on_the_prototype_issue_1963(): Unit = {
+  @Test def constructorPropertyOnThePrototype_Issue1963(): Unit = {
     class ParentClass extends js.Object
 
     class ChildClass extends ParentClass

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/compiler/InternalNameClashesTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/compiler/InternalNameClashesTestEx.scala
@@ -46,7 +46,7 @@ class InternalNameClashesTestEx {
     assertEquals(1021, foo.test(6))
   }
 
-  @Test def testLocalClashWithTempVar_issue2971(): Unit = {
+  @Test def testLocalClashWithTempVar_Issue2971(): Unit = {
     @noinline def initValue: Int = 5
 
     @noinline def sum(x: Int, y: Int): Int = x + y

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTestEx.scala
@@ -25,7 +25,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
  */
 class ObjectTestEx {
 
-  @Test def clone_issue_2010(): Unit = {
+  @Test def clone_Issue2010(): Unit = {
     class NotCloneable extends Object {
       override def clone(): NotCloneable =
         super.clone().asInstanceOf[NotCloneable]

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTestEx.scala
@@ -53,7 +53,7 @@ class StringTestEx {
         "IÍÌĨİ".toLowerCase(Lithuanian))
   }
 
-  @Test def testToLowerCaseWithLocale_CornerCasesFor_Lithuanian(): Unit = {
+  @Test def testToLowerCaseWithLocaleCornerCasesForLithuanian(): Unit = {
     // All the characters with an unconditional special translation
     assertEquals("i\u0307\u0300 i\u0307\u0300a\u033D",
         "\u00CC \u00CCA\u033D".toLowerCase(Lithuanian))
@@ -83,7 +83,7 @@ class StringTestEx {
         "I\uD804\uDC00\u033D".toLowerCase(Lithuanian)) // 11000
   }
 
-  @Test def testToLowerCaseWithLocale_CornerCasesFor_TurkishAndAzeri(): Unit = {
+  @Test def testToLowerCaseWithLocaleCornerCasesForTurkishAndAzeri(): Unit = {
     // Can put another combining mark between I and 0307, as long as its class is not Above
     assertEquals("i\u0315",
         "I\u0315\u0307".toLowerCase(Turkish))
@@ -122,7 +122,7 @@ class StringTestEx {
         "iíìĩı i\u0307\u0301i\u0307\u0300i\u0307\u0303i\u0307".toUpperCase(Lithuanian))
   }
 
-  @Test def testToUpperCaseWithLocale_CornerCasesFor_Lithuanian(): Unit = {
+  @Test def testToUpperCaseWithLocaleCornerCasesForLithuanian(): Unit = {
     // More characters with the Soft_Dotted property
     assertEquals("J\u0301J\u0300J\u0303J",
         "j\u0307\u0301j\u0307\u0300j\u0307\u0303j\u0307".toUpperCase(Lithuanian))

--- a/test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/ArraySAMTest.scala
+++ b/test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/ArraySAMTest.scala
@@ -20,12 +20,12 @@ import org.scalajs.testsuite.utils.JSAssert._
 class ArraySAMTest {
   import ArraySAMTest._
 
-  @Test def should_provide_jsMap(): Unit = {
+  @Test def jsMap(): Unit = {
     assertJSArrayEquals(js.Array(2, 3, 1, 2),
         js.Array("Sc", "ala", ".", "js").jsMap(_.length))
   }
 
-  @Test def should_provide_jsFilter(): Unit = {
+  @Test def jsFilter(): Unit = {
     assertJSArrayEquals(js.Array(56, -20, 86),
         js.Array(56, 30, -20, 33, 54, 86).jsFilter(_ % 3 != 0))
   }

--- a/test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/SAMJSTest.scala
+++ b/test-suite/js/src/test/require-sam/org/scalajs/testsuite/jsinterop/SAMJSTest.scala
@@ -19,7 +19,7 @@ class SAMJSTest {
 
   import SAMJSTest._
 
-  @Test def samNestedInAnonJSClass_issue3264(): Unit = {
+  @Test def samNestedInAnonJSClass_Issue3264(): Unit = {
     val outer = new SAMInAnonJSClass_ParentJSClass {
       def foo(x: Int): Int = {
         val innerSAM: SAMInAnonJSClass_MySAM = _ * 2

--- a/test-suite/js/src/test/require-scala2/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTestScala2.scala
+++ b/test-suite/js/src/test/require-scala2/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTestScala2.scala
@@ -22,7 +22,7 @@ class NonNativeJSTypeTestScala2 {
   import NonNativeJSTypeTestScala2._
 
   /** Complements NonNativeJSTypeTest.default_values_for_fields(). */
-  @Test def default_values_for_fields(): Unit = {
+  @Test def defaultValuesForFields(): Unit = {
     val obj = new DefaultFieldValues
 
     /* Value class fields are initialized to null, instead of a boxed

--- a/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
+++ b/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
@@ -259,7 +259,7 @@ class ArrayOpsCollectionEraDependentTest {
         js.Array(), array.filterInPlace(_ < 0))
   }
 
-  @Test def to_T_issue_843(): Unit = {
+  @Test def toT_Issue843(): Unit = {
     val array = js.Array(1, 2, 1, 3, 1, 10, 9)
     val list = array.to(List)
     assertArrayEquals(array.toArray, list.toArray)

--- a/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
+++ b/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 
 class WrappedArrayToTest {
 
-  @Test def to_T(): Unit = {
+  @Test def toT(): Unit = {
     val seq: collection.Seq[Int] = js.Array(1, 2, 1, 3, 1, 10, 9)
     val list = seq.to(List)
     assertEquals(List(1, 2, 1, 3, 1, 10, 9), list)

--- a/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
+++ b/test-suite/js/src/test/scala-new-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 
 class WrappedDictionaryToTest {
 
-  @Test def to_T(): Unit = {
+  @Test def toT(): Unit = {
     val dict = js.Dictionary("a" -> "a", "b" -> 6, "e" -> js.undefined)
     val list = dict.to(List)
     assertEquals(3, list.size)

--- a/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
+++ b/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/ArrayOpsCollectionEraDependentTest.scala
@@ -59,7 +59,7 @@ class ArrayOpsCollectionEraDependentTest {
     assertEquals(List(3, 4, 5, 6, 3, 4), seq.toList)
   }
 
-  @Test def to_T_issue_843(): Unit = {
+  @Test def toT_Issue843(): Unit = {
     val array = js.Array(1, 2, 1, 3, 1, 10, 9)
     val list = array.to[List]
     assertArrayEquals(array.toArray, list.toArray)

--- a/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
+++ b/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedArrayToTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 
 class WrappedArrayToTest {
 
-  @Test def to_T(): Unit = {
+  @Test def toT(): Unit = {
     val seq: collection.Seq[Int] = js.Array(1, 2, 1, 3, 1, 10, 9)
     val list = seq.to[List]
     assertEquals(List(1, 2, 1, 3, 1, 10, 9), list)

--- a/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
+++ b/test-suite/js/src/test/scala-old-collections/org/scalajs/testsuite/library/WrappedDictionaryToTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 
 class WrappedDictionaryToTest {
 
-  @Test def to_T(): Unit = {
+  @Test def toT(): Unit = {
     val dict = js.Dictionary("a" -> "a", "b" -> 6, "e" -> js.undefined)
     val list = dict.to[List]
     assertEquals(3, list.size)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/BooleanJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/BooleanJSTest.scala
@@ -18,8 +18,7 @@ import org.junit.Assert._
 import scala.scalajs.js
 
 class BooleanJSTest {
-  @Test
-  def `primitive_operations_on_booleans_should_return_boolean`(): Unit = {
+  @Test def primitiveOperationsOnBooleansReturnBoolean(): Unit = {
     // FIXME: these tests are completely useless:
     // they're constant-folded by scalac. We're not at all testing those
     // operations are the IR level, nor, a fortiori, at the JS level

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
@@ -24,7 +24,7 @@ class FloatJSTest {
   @noinline def froundNotInlined(x: Double): Float =
     x.toFloat
 
-  @Test def fround_for_special_values(): Unit = {
+  @Test def froundForSpecialValues(): Unit = {
     assertTrue(froundNotInlined(Double.NaN).isNaN)
     assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(0.0).toDouble, 0.0)
     assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-0.0).toDouble, 0.0)
@@ -32,17 +32,17 @@ class FloatJSTest {
     assertEquals(Float.NegativeInfinity, froundNotInlined(Double.NegativeInfinity), 0.0)
   }
 
-  @Test def fround_overflows(): Unit = {
+  @Test def froundOverflows(): Unit = {
     assertEquals(Double.PositiveInfinity, froundNotInlined(1e200), 0.0)
     assertEquals(Double.NegativeInfinity, froundNotInlined(-1e200), 0.0)
   }
 
-  @Test def fround_underflows(): Unit = {
+  @Test def froundUnderflows(): Unit = {
     assertEquals(Double.PositiveInfinity, 1 / froundNotInlined(1e-300).toDouble, 0.0)
     assertEquals(Double.NegativeInfinity, 1 / froundNotInlined(-1e-300).toDouble, 0.0)
   }
 
-  @Test def fround_normal_cases(): Unit = {
+  @Test def froundNormalCases(): Unit = {
     def test(input: Double, expected: Double): Unit =
       assertEquals(expected, input.toFloat.toDouble, 0.0)
 
@@ -74,7 +74,7 @@ class FloatJSTest {
     test(1.973497969450596E-21, 1.973498047135062E-21)
   }
 
-  @Test def Int_should_be_cast_to_Float_when_comparing_to_Float_issue_1878(): Unit = {
+  @Test def intWidenedToFloatWhenComparingToFloat_Issue1878(): Unit = {
     val intMax: Int = Int.MaxValue
     val float: Float = (Int.MaxValue - 1).toFloat
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
@@ -21,7 +21,7 @@ import org.scalajs.testsuite.utils.Platform._
 
 class InstanceTestsHijackedBoxedClassesTest {
 
-  @Test def should_support_isInstanceOf_positive(): Unit = {
+  @Test def isInstanceOfPositive(): Unit = {
     assertTrue(((): Any).isInstanceOf[Unit])
     assertTrue((false: Any).isInstanceOf[Boolean])
     assertTrue(('a': Any).isInstanceOf[Char])
@@ -48,7 +48,7 @@ class InstanceTestsHijackedBoxedClassesTest {
     assertTrue((-0.0: Any).isInstanceOf[Float])
   }
 
-  @Test def should_support_isInstanceOf_negative(): Unit = {
+  @Test def isInstanceOfNegative(): Unit = {
     assertFalse((12345: Any).isInstanceOf[Unit])
     assertFalse((12345: Any).isInstanceOf[Boolean])
     assertFalse((12345: Any).isInstanceOf[Char])
@@ -62,12 +62,12 @@ class InstanceTestsHijackedBoxedClassesTest {
     assertFalse((-0.0: Any).isInstanceOf[Int])
   }
 
-  @Test def isInstanceOf_Float_with_strict_floats(): Unit = {
+  @Test def isInstanceOfFloatWithStrictFloats(): Unit = {
     assumeTrue("Assumed strict floats", hasStrictFloats)
     assertFalse((1.2: Any).isInstanceOf[Float])
   }
 
-  @Test def isInstanceOf_Float_with_non_strict_floats(): Unit = {
+  @Test def isInstanceOfFloatWithNonStrictFloats(): Unit = {
     assumeFalse("Assumed strict floats", hasStrictFloats)
     assertTrue((1.2: Any).isInstanceOf[Float])
 
@@ -112,7 +112,7 @@ class InstanceTestsHijackedBoxedClassesTest {
     test(true, new CustomNumber)
   }
 
-  @Test def should_support_asInstanceOf_positive(): Unit = {
+  @Test def asInstanceOfPositive(): Unit = {
     def swallow(x: Any): Unit = ()
     swallow(((): Any).asInstanceOf[Unit])
     swallow((false: Any).asInstanceOf[Boolean])
@@ -127,7 +127,7 @@ class InstanceTestsHijackedBoxedClassesTest {
       (12345: Any).asInstanceOf[Unit]
   }
 
-  @Test def should_support_asInstanceOf_negative(): Unit = {
+  @Test def asInstanceOfNegative(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     if (scalaVersion.startsWith("2.11."))
       assertThrows(classOf[Exception], (12345: Any).asInstanceOf[Unit])
@@ -143,18 +143,18 @@ class InstanceTestsHijackedBoxedClassesTest {
     assertThrows(classOf[Exception], (-0.0: Any).asInstanceOf[Int])
   }
 
-  @Test def asInstanceOf_Float_with_strict_floats(): Unit = {
+  @Test def asInstanceOfFloatWithStrictFloats(): Unit = {
     assumeTrue("Assumed strict floats", hasStrictFloats)
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     assertThrows(classOf[Exception], (1.2: Any).asInstanceOf[Float])
   }
 
-  @Test def asInstanceOf_Float_with_non_strict_floats(): Unit = {
+  @Test def asInstanceOfFloatWithNonStrictFloats(): Unit = {
     assumeFalse("Assumed strict floats", hasStrictFloats)
     assertEquals(1.2, (1.2: Any).asInstanceOf[Float], 0.0)
   }
 
-  @Test def should_support_isInstanceOf_via_java_lang_Class_positive(): Unit = {
+  @Test def isInstanceOfViaJavaLangClassPositive(): Unit = {
     def test(x: Any, clazz: Class[_]): Unit =
       assertTrue(clazz.isInstance(x))
 
@@ -173,7 +173,7 @@ class InstanceTestsHijackedBoxedClassesTest {
     test(-0.0, classOf[java.lang.Double])
   }
 
-  @Test def should_support_isInstanceOf_via_java_lang_Class_negative(): Unit = {
+  @Test def isInstanceOfViaJavaLangClassNegative(): Unit = {
     def test(x: Any, clazz: Class[_]): Unit =
       assertFalse(clazz.isInstance(x))
 
@@ -190,12 +190,12 @@ class InstanceTestsHijackedBoxedClassesTest {
     test(-0.0, classOf[java.lang.Integer])
   }
 
-  @Test def classOf_Float_isInstance_with_strict_floats(): Unit = {
+  @Test def classOfFloatIsInstanceWithStrictFloats(): Unit = {
     assumeTrue("Assumed strict floats", hasStrictFloats)
     assertFalse(classOf[java.lang.Float].isInstance(1.2))
   }
 
-  @Test def classOf_Float_isInstance_with_non_strict_floats(): Unit = {
+  @Test def classOfFloatIsInstanceWithNonStrictFloats(): Unit = {
     assumeFalse("Assumed strict floats", hasStrictFloats)
     assertTrue(classOf[java.lang.Float].isInstance(1.2))
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/IntJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/IntJSTest.scala
@@ -33,7 +33,7 @@ class IntJSTest {
   final val AlmostMinVal = Int.MinValue + 43
   final val AlmostMaxVal = Int.MaxValue - 36
 
-  @Test def `should_support_%`(): Unit = {
+  @Test def remainder(): Unit = {
     def test(a: Int, b: Int, expected: Int): Unit =
       assertEquals(expected, a % b)
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -41,7 +41,7 @@ class InteroperabilityTest {
     assertArrayEquals(expected, jsArray2Array(actual.asInstanceOf[js.Array[Any]]))
   }
 
-  @Test def should_support_backquotes_to_escape_Scala_fields(): Unit = {
+  @Test def backquotesToEscapeScalaFields(): Unit = {
     val obj = js.eval("""
       var interoperabilityTestFieldEscape = {
         def: 0,
@@ -56,7 +56,7 @@ class InteroperabilityTest {
     assertEquals(42, obj.`val`(42))
   }
 
-  @Test def should_support_atJSName_to_specify_the_JavaScript_name_for_fields(): Unit = {
+  @Test def testJSNameToSpecifyTheJavaScriptNameForFields(): Unit = {
     val obj = js.eval("""
       var interoperabilityTestJSName = {
         def: 42,
@@ -69,7 +69,7 @@ class InteroperabilityTest {
     assertEquals(7357, obj.value(7357))
   }
 
-  @Test def should_translate_explicit_getter_and_setter_names_to_field_access(): Unit = {
+  @Test def explicitGetterAndSetterNamesToFieldAccess(): Unit = {
     val obj = js.eval("""
       var interoperabilityTestProperty = { a: 1 };
       interoperabilityTestProperty;
@@ -80,7 +80,7 @@ class InteroperabilityTest {
     assertEquals(100, obj.a)
   }
 
-  @Test def should_support_atJSName_together_with_field_access(): Unit = {
+  @Test def testJSNameTogetherWithFieldAccess(): Unit = {
     val obj = js.eval("""
       var interoperabilityTestProperty = { b: 1 };
       interoperabilityTestProperty;
@@ -92,7 +92,7 @@ class InteroperabilityTest {
     assertEquals(100, obj.b)
   }
 
-  @Test def should_support_atJSBracketAccess_to_specify_access_using_square_bracket_subscription(): Unit = {
+  @Test def testJSBracketAccessToSpecifyAccessUsingSquareBracketSubscription(): Unit = {
     val obj = js.eval("""
       var interoperabilityTestJSBracketAccess = [ 0, 1, 7357 ];
       interoperabilityTestJSBracketAccess;
@@ -103,7 +103,7 @@ class InteroperabilityTest {
     assertEquals(42, obj(2))
   }
 
-  @Test def should_allow_instanciation_of_JS_classes_inheriting_from_js_Object(): Unit = {
+  @Test def instantiationOfJSClassesInheritingFromJSObject(): Unit = {
     js.eval("""
       var InteroperabilityTestInherit = {
         Pattern: function(x) {
@@ -124,7 +124,7 @@ class InteroperabilityTest {
     assertEquals("Scala.js", obj.getConstructorParam())
   }
 
-  @Test def should_acces_top_level_JS_objects_via_Scala_objects_inheriting_from_js_Object(): Unit = {
+  @Test def accessTopLevelJSObjectsViaScalaObjectsInheritingFromJSObject(): Unit = {
     js.eval("""
       var InteroperabilityTestTopLevelObject = function(value) {
         return {
@@ -143,7 +143,7 @@ class InteroperabilityTest {
     assertEquals(7357, obj.valueAsInt())
   }
 
-  @Test def should_access_native_JS_classes_and_objects_nested_in_JS_objects(): Unit = {
+  @Test def accessNativeJSClassesAndObjectsNestedInJSObjects(): Unit = {
     js.eval("""
       var InteroperabilityTestContainerObject = {
         ContainedClass: function(x) {
@@ -239,7 +239,7 @@ class InteroperabilityTest {
     assertEquals("abc def 10", obj6.foo("def "))
   }
 
-  @Test def should_access_native_JS_classes_and_objects_nested_in_atJSNamed_JS_objects(): Unit = {
+  @Test def accessNativeJSClassesAndObjectsNestedInAtJSNamedJSObjects(): Unit = {
     js.eval("""
       var InteroperabilityTestContainerObjectRenamed = {
         ContainedClass: function(x) {
@@ -273,7 +273,7 @@ class InteroperabilityTest {
     assertEquals(4242, obj4.x)
   }
 
-  @Test def should_allow_to_call_JS_methods_with_variadic_parameters(): Unit = {
+  @Test def callJSMethodsWithVariadicParameters(): Unit = {
     val obj = js.eval("""
       var obj = {
         foo: function() {
@@ -301,7 +301,7 @@ class InteroperabilityTest {
     assertArrayEquals(Array("plop", 42, 51), stat.foo(elems: _*))
   }
 
-  @Test def call_polytype_nullary_method_issue_2445(): Unit = {
+  @Test def callPolytypeNullaryMethod_Issue2445(): Unit = {
     val obj = js.eval("""
       var obj = {
         emptyArray: []
@@ -329,7 +329,7 @@ class InteroperabilityTest {
     assertEquals(0, c.length)
   }
 
-  @Test def should_allow_to_call_JS_constructors_with_variadic_parameters(): Unit = {
+  @Test def callJSConstructorsWithVariadicParameters(): Unit = {
     import js.Dynamic.{newInstance => jsnew}
 
     js.eval("""
@@ -361,7 +361,7 @@ class InteroperabilityTest {
     assertArrayEquals(Array("plop", 42, 51), new C(elems: _*).args)
   }
 
-  @Test def should_acces_top_level_JS_objects_via_Scala_object_with_annot_JSGlobalScope(): Unit = {
+  @Test def accessTopLevelJSObjectsViaScalaObjectWithAnnotJSGlobalScope(): Unit = {
     js.eval("""
       var interoperabilityTestGlobalScopeValue = "7357";
       var interoperabilityTestGlobalScopeValueAsInt = function() {
@@ -391,7 +391,7 @@ class InteroperabilityTest {
     assertEquals(654, obj.bar)
   }
 
-  @Test def should_access_top_level_JS_vars_and_functions_via_Scala_object_with_native_vals_and_defs(): Unit = {
+  @Test def accessTopLevelJSVarsAndFunctionsViaScalaObjectWithNativeValsAndDefs(): Unit = {
     js.eval("""
       var interoperabilityTestGlobalValDefConstant = 654321;
       var interoperabilityTestGlobalValDefVariable = 7357;
@@ -420,7 +420,7 @@ class InteroperabilityTest {
     assertEquals(126, Global.interoperabilityTestGlobalValDefFunction(3))
   }
 
-  @Test def should_access_top_level_JS_vars_and_functions_via_package_object_with_native_vals_and_defs(): Unit = {
+  @Test def accessTopLevelJSVarsAndFunctionsViaPackageObjectWithNativeValsAndDefs(): Unit = {
     js.eval("""
       var interoperabilityTestGlobalValDefConstantInPackageObject = 654321;
       var interoperabilityTestGlobalValDefVariableInPackageObject = 7357;
@@ -450,7 +450,7 @@ class InteroperabilityTest {
   }
 
 
-  @Test def should_protect_receiver_of_JS_apply_if_its_a_select_issue_804(): Unit = {
+  @Test def protectReceiverOfJSApplyIfItsSelect_Issue804(): Unit = {
     val obj = js.eval("""
       var interoperabilityTestJSFunctionFieldApply = {
         toString: function() { return "bad" },
@@ -471,7 +471,7 @@ class InteroperabilityTest {
     new InScalaSelect(check).test()
   }
 
-  @Test def should_properly_handle_default_parameters(): Unit = {
+  @Test def handleDefaultParameters(): Unit = {
     val obj = js.eval("""
       var interoperabilityTestDefaultParam = {
         fun: function() { return arguments; }
@@ -509,7 +509,7 @@ class InteroperabilityTest {
     assertEquals(5, obj.multi(2)()(5)("1"))
   }
 
-  @Test def should_properly_handle_default_parameters_for_constructors_issue_791(): Unit = {
+  @Test def defaultParametersForConstructors_Issue791(): Unit = {
     js.eval("""
       var InteroperabilityTestCtor = function(x,y) {
         this.values = Array(x || 6, y || 8)
@@ -522,7 +522,7 @@ class InteroperabilityTest {
     assertArrayEquals(Array(10, 2), new InteroperabilityTestCtor(10, 2).values)
   }
 
-  @Test def should_allow_constructor_params_that_are_vals_vars_in_facades_issue_1277(): Unit = {
+  @Test def constructorParamsThatAreValsVarsInFacades_Issue1277(): Unit = {
     js.eval("""
         var InteroparabilityCtorInlineValue = function(x,y) {
           this.x = x;
@@ -541,7 +541,7 @@ class InteroperabilityTest {
     assertEquals(100, obj.y)
   }
 
-  @Test def should_unbox_Chars_received_from_calling_a_JS_interop_method(): Unit = {
+  @Test def unboxCharsReceivedFromCallingJSInteropMethod(): Unit = {
     val obj = js.eval("""
       var obj = {
         anyAsChar: function(x) { return x; }
@@ -558,7 +558,7 @@ class InteroperabilityTest {
     assertTrue('e' == c)
   }
 
-  @Test def should_box_Chars_given_to_a_JS_interop_method(): Unit = {
+  @Test def boxCharsGivenToJSInteropMethod(): Unit = {
     val obj = js.eval("""
       var obj = {
         charAsAny: function(c) { return c; }
@@ -571,7 +571,7 @@ class InteroperabilityTest {
     assertEquals('x', any)
   }
 
-  @Test def should_unbox_value_classes_received_from_calling_a_JS_interop_method(): Unit = {
+  @Test def unboxValueClassReceivedFromCallingJSInteropMethod(): Unit = {
     val obj = js.eval("""
       var obj = {
         test: function(vc) { return vc; }
@@ -583,7 +583,7 @@ class InteroperabilityTest {
     assertEquals(5, r.i)
   }
 
-  @Test def should_box_value_classes_given_to_a_JS_interop_method(): Unit = {
+  @Test def boxValueClassesGivenToJSInteropMethod(): Unit = {
     val obj = js.eval("""
       var obj = {
         stringOf: function(vc) { return vc.toString(); }
@@ -595,7 +595,7 @@ class InteroperabilityTest {
     assertEquals("SomeValueClass(7)", obj.stringOf(vc))
   }
 
-  @Test def should_not_unbox_values_received_from_JS_method_in_statement_position(): Unit = {
+  @Test def doNotUnboxValuesReceivedFromJSMethodInStatementPosition(): Unit = {
     /* To test this, we verify that a purposefully ill-typed facade does not
      * throw a ClassCastException when called in statement position.
      */
@@ -610,7 +610,7 @@ class InteroperabilityTest {
       assertThrows(classOf[Exception], obj.test()) // in expression position, should throw
   }
 
-  @Test def should_asInstanceOf_values_received_from_calling_a_JS_interop_method(): Unit = {
+  @Test def asInstanceOfValuesReceivedFromCallingJSInteropMethod(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     val obj = js.eval("""
       var obj = {
@@ -636,7 +636,7 @@ class InteroperabilityTest {
     obj.testAny() // should not throw
   }
 
-  @Test def should_access_global_scope_for_object(): Unit = {
+  @Test def accessGlobalScopeForObject(): Unit = {
     assumeTrue("Assuming execution in Node.js", executingInNodeJS)
 
     nodejs_runInThisContext("""
@@ -649,7 +649,7 @@ class InteroperabilityTest {
     assertEquals(42, InteroperabilityTestConstObject.x)
   }
 
-  @Test def should_access_global_scope_for_class(): Unit = {
+  @Test def accessGlobalScopeForClass(): Unit = {
     assumeTrue("Assuming execution in Node.js", executingInNodeJS)
 
     nodejs_runInThisContext("""
@@ -666,7 +666,7 @@ class InteroperabilityTest {
     assertEquals(5, obj.x)
   }
 
-  @Test def should_access_global_scope_for_JSGlobalScope_members(): Unit = {
+  @Test def accessGlobalScopeForJSGlobalScopeMembers(): Unit = {
     assumeTrue("Assuming execution in Node.js", executingInNodeJS)
 
     nodejs_runInThisContext("""

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/LongJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/LongJSTest.scala
@@ -23,12 +23,12 @@ import org.scalajs.testsuite.utils.Platform._
 
 /** Tests the re-patching of native longs */
 class LongJSTest {
-  @Test def `should_convert_to_js.Any`(): Unit = {
+  @Test def longToJSAny(): Unit = {
     val x = 5: js.Any
     assertEquals(x, 5L: js.Any)
   }
 
-  @Test def should_correctly_implement_asInstanceOf_Longs_negative(): Unit = {
+  @Test def asInstanceOfIntWithLongAnyThrows(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
     val dyn: Any = 5L

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ModuleInitTest.scala
@@ -21,7 +21,7 @@ import org.scalajs.testsuite.utils.Platform._
 class ModuleInitTest {
   import ModuleInitTest._
 
-  @Test def should_only_execute_module_initializers_once(): Unit = {
+  @Test def executeModuleInitializersOnce(): Unit = {
     assumeTrue("Assumed compliant Module", hasCompliantModuleInit)
     val x = A.Y
     val y = A.cs.head

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -26,21 +26,21 @@ class OptimizerTest {
 
   // Inlineable classes
 
-  @Test def must_update_fields_of_this_in_the_computation_of_other_fields_issue_1153(): Unit = {
+  @Test def updateFieldsOfThisInTheComputationOfOtherFields_Issue1153(): Unit = {
     val foo = new InlineClassDependentFields(5)
     assertEquals(5, foo.x)
     assertTrue(foo.b)
     assertEquals(11, foo.y)
   }
 
-  @Test def must_not_break_code_that_assigns_this_to_a_field(): Unit = {
+  @Test def assignThisToField(): Unit = {
     val foo = new InlineClassThisAlias(5)
     assertEquals(5, foo.z)
   }
 
   // Optimizer regression tests
 
-  @Test def `must_not_break_*_(-1)_for_Int_issue_1453`(): Unit = {
+  @Test def timesNegativeOneForInt_Issue1453(): Unit = {
     @noinline
     def start0: Int = (() => 10) ()
 
@@ -51,7 +51,7 @@ class OptimizerTest {
     assertEquals(2, lastElement)
   }
 
-  @Test def `must_not_break_*_(-1)_for_Float_and_Double_issue_1478`(): Unit = {
+  @Test def timesNegativeOneForFloatAndDouble_Issue1478(): Unit = {
     @noinline
     def a: Float = (() => 5.0f) ()
     assertEquals(-5.0f, a * -1.0f, 0.0)
@@ -61,7 +61,7 @@ class OptimizerTest {
     assertEquals(-7.0, b * -1.0, 0.0)
   }
 
-  @Test def must_not_break_foreach_on_downward_Range_issue_1453(): Unit = {
+  @Test def foreachOnDownwardRange_Issue1453(): Unit = {
     @noinline
     def start0: Int = (() => 10) ()
 
@@ -74,7 +74,7 @@ class OptimizerTest {
     assertArrayEquals(Array(10, 9, 8, 7, 6, 5, 4, 3, 2), elements.toArray)
   }
 
-  @Test def must_not_break_classOf_T_eqeq_classOf_U_issue_1658(): Unit = {
+  @Test def classOfTEqEqClassOfU_Issue1658(): Unit = {
     assertEquals(classOf[String], classOf[String])
     assertEquals(classOf[Int], classOf[Int])
     assertEquals(classOf[Array[Int]], classOf[Array[Int]])
@@ -88,7 +88,7 @@ class OptimizerTest {
     assertFalse(classOf[Array[Array[Object]]] == classOf[Array[Object]])
   }
 
-  @Test def side_effect_discard_in_eliminated_binding_issue_2467(): Unit = {
+  @Test def sideEffectDiscardInEliminatedBinding_Issue2467(): Unit = {
     val b = Array.newBuilder[AnyRef]
     def mockPrintln(x: Any): Unit =
       b += ("" + x)
@@ -102,7 +102,7 @@ class OptimizerTest {
         b.result())
   }
 
-  @Test def must_not_break_bitset_oreq_issue_2523(): Unit = {
+  @Test def testBitsetOrEq_Issue2523(): Unit = {
     import scala.collection.mutable.BitSet
 
     val b0 = BitSet(5, 6)
@@ -123,7 +123,7 @@ class OptimizerTest {
     assertEquals("BitSet(5, 6, 7)", b0.toString)
   }
 
-  @Test def must_not_eliminate_break_to_label_within_finally_block_issue2689(): Unit = {
+  @Test def keepBreakToLabelWithinFinallyBlock_Issue2689(): Unit = {
     // scalastyle:off return
     val logs = js.Array[String]()
 
@@ -158,7 +158,7 @@ class OptimizerTest {
 
   // === constant folding
 
-  @Test def constant_folding_===(): Unit = {
+  @Test def constantFoldingEqEqEq(): Unit = {
     @inline def test(expectEq: Boolean, lhs: Any, rhs: Any): Unit = {
       assertEquals(expectEq,
           lhs.asInstanceOf[AnyRef] eq rhs.asInstanceOf[AnyRef])
@@ -194,7 +194,7 @@ class OptimizerTest {
     test(usingBigIntForLongs, 5L, 5L)
   }
 
-  @Test def constant_folding_==(): Unit = {
+  @Test def constantFoldingEqEq(): Unit = {
     @inline def testChar(expectEq: Boolean, lhs: Char, rhs: Char): Unit = {
       assertEquals(expectEq, lhs == rhs)
       assertEquals(!expectEq, lhs != rhs)
@@ -230,72 +230,72 @@ class OptimizerTest {
 
   // +[string] constant folding
 
-  @Test def must_not_break_when_folding_two_constant_strings(): Unit = {
+  @Test def foldingTwoConstantStrings(): Unit = {
     @inline def str: String = "I am "
     assertEquals("I am constant", str + "constant")
   }
 
-  @Test def must_not_break_when_folding_the_empty_string_when_associated_with_a_string(): Unit = {
+  @Test def foldingTheEmptyStringWithString(): Unit = {
     @noinline def str: String = "hello"
     assertEquals("hello", str + "")
     assertEquals("hello", "" + str)
   }
 
-  @Test def `must_not_break_when_folding_1.4f_and_a_stringLit`(): Unit = {
+  @Test def folding1Point4fAndString(): Unit = {
     assertEquals("1.399999976158142hello", 1.4f + "hello")
     assertEquals("hello1.399999976158142", "hello" + 1.4f)
   }
 
-  @Test def must_not_break_when_folding_cascading_+[string](): Unit = {
+  @Test def foldingCascadingPlusString(): Unit = {
     @noinline def str: String = "awesome! 10/10"
     assertEquals("Scala.js is awesome! 10/10", "Scala.js" + (" is " + str))
     assertEquals("awesome! 10/10 is Scala.js", (str + " is ") + "Scala.js")
   }
 
-  @Test def must_not_break_when_folding_a_chain_of_+[string](): Unit = {
+  @Test def foldingChainOfPlusString(): Unit = {
     @inline def b: String = "b"
     @inline def d: String = "d"
     @inline def f: String = "f"
     assertEquals("abcdefg", "a" + b + "c" + d + "e" + f + "g")
   }
 
-  @Test def must_not_break_when_folding_integer_in_double_and_stringLit(): Unit = {
+  @Test def foldingDouble1Point0AndString(): Unit = {
     assertEquals("1hello", 1.0 + "hello")
     assertEquals("hello1", "hello" + 1.0)
   }
 
-  @Test def must_not_break_when_folding_zero_and_stringLit(): Unit = {
+  @Test def foldingZeroAndString(): Unit = {
     assertEquals("0hello", 0.0 + "hello")
     assertEquals("hello0", "hello" + 0.0)
     assertEquals("0hello", -0.0 + "hello")
     assertEquals("hello0", "hello" + (-0.0))
   }
 
-  @Test def must_not_break_when_folding_Infinities_and_stringLit(): Unit = {
+  @Test def foldingInfinitiesAndString(): Unit = {
     assertEquals("Infinityhello", Double.PositiveInfinity + "hello")
     assertEquals("helloInfinity", "hello" + Double.PositiveInfinity)
     assertEquals("-Infinityhello", Double.NegativeInfinity + "hello")
     assertEquals("hello-Infinity", "hello" + Double.NegativeInfinity)
   }
 
-  @Test def must_not_break_when_folding_NaN_and_stringLit(): Unit = {
+  @Test def foldingNaNAndString(): Unit = {
     assertEquals("NaNhello", Double.NaN + "hello")
     assertEquals("helloNaN", "hello" + Double.NaN)
   }
 
-  @Test def must_not_break_when_folding_double_with_decimal_and_stringLit(): Unit = {
+  @Test def foldingDoubleWithDecimalAndString(): Unit = {
     assumeFalse("Assumed not executing in FullOpt", isInFullOpt)
     assertEquals("1.2323919403474454e+21hello", 1.2323919403474454E21 + "hello")
     assertEquals("hello1.2323919403474454e+21", "hello" + 1.2323919403474454E21)
   }
 
-  @Test def must_not_break_when_folding_double_that_JVM_would_print_in_scientific_notation_and_stringLit(): Unit = {
+  @Test def foldingDoubleThatJVMWouldPrintInScientificNotationAndString(): Unit = {
     assumeFalse("Assumed not executing in FullOpt", isInFullOpt)
     assertEquals("123456789012345hello", 123456789012345d + "hello")
     assertEquals("hello123456789012345", "hello" + 123456789012345d)
   }
 
-  @Test def must_not_break_when_folding_doubles_to_String(): Unit = {
+  @Test def foldingDoublesToString(): Unit = {
     assumeFalse("Assumed not executing in FullOpt", isInFullOpt)
     @noinline def toStringNoInline(v: Double): String = v.toString
     @inline def test(v: Double): Unit =
@@ -405,36 +405,36 @@ class OptimizerTest {
     test(607681513323520000000.0)
   }
 
-  @Test def must_not_break_when_folding_long_and_stringLit(): Unit = {
+  @Test def foldingLongAndString(): Unit = {
     assertEquals("1hello", 1L + "hello")
     assertEquals("hello1", "hello" + 1L)
   }
 
-  @Test def must_not_break_when_folding_integer_and_stringLit(): Unit = {
+  @Test def foldingIntegerAndString(): Unit = {
     assertEquals("42hello", 42 + "hello")
     assertEquals("hello42", "hello" + 42)
   }
 
-  @Test def must_not_break_when_folding_boolean_and_stringLit(): Unit = {
+  @Test def foldingBooleanAndString(): Unit = {
     assertEquals("false is not true", "false is not " + true)
   }
 
-  @Test def must_not_break_when_folding_unit_and_stringLit(): Unit = {
+  @Test def foldingUnitAndString(): Unit = {
     assertEquals("undefined is undefined", "undefined is " +())
   }
 
-  @Test def must_not_break_when_folding_null_and_stringLit(): Unit = {
+  @Test def foldingNullAndString(): Unit = {
     assertEquals("Damien is not null", "Damien is not " + null)
   }
 
-  @Test def must_not_break_when_folding_char_and_stringLit(): Unit = {
+  @Test def foldingCharAndString(): Unit = {
     assertEquals("Scala.js", 'S' + "cala.js")
     assertEquals("Scala.js", "Scala.j" + 's')
   }
 
   // Virtualization of JSArrayConstr
 
-  @Test def must_not_break_virtualized_jsarrayconstr(): Unit = {
+  @Test def virtualizedJSArrayConstr(): Unit = {
     @noinline def b = 42
 
     val a = js.Array[Any]("hello", b)
@@ -446,7 +446,7 @@ class OptimizerTest {
     assertEquals(js.undefined, a(2))
   }
 
-  @Test def must_not_break_escaped_jsarrayconstr(): Unit = {
+  @Test def escapedJSArrayConstr(): Unit = {
     @noinline def escape[A](a: A): A = a
 
     val a = js.Array[Any]("hello", 42)
@@ -460,7 +460,7 @@ class OptimizerTest {
     assertEquals(2, escape(a).length)
   }
 
-  @Test def must_not_break_modified_jsarrayconstr(): Unit = {
+  @Test def modifiedJSArrayConstr(): Unit = {
     @noinline def escape[A](a: A): A = a
 
     val a = js.Array[Any]("hello", 42)
@@ -476,7 +476,7 @@ class OptimizerTest {
     assertEquals("bar", a(0))
   }
 
-  @Test def must_not_break_virtualized_jsarrayconstr_in_spread(): Unit = {
+  @Test def virtualizedJSArrayConstrInSpread(): Unit = {
     class Foo extends js.Object {
       def check(a: Int, b: String, rest: Any*): Unit = {
         assertEquals(5, a)
@@ -492,7 +492,7 @@ class OptimizerTest {
     foo.check(5, "foobar", a.toIndexedSeq: _*)
   }
 
-  @Test def must_not_break_virtualized_tuple(): Unit = {
+  @Test def virtualizedTuple(): Unit = {
     @noinline def b = 42
 
     val a = js.Tuple2("hello", b)
@@ -501,7 +501,7 @@ class OptimizerTest {
     assertEquals(42, a._2)
   }
 
-  @Test def must_not_break_escaped_tuple(): Unit = {
+  @Test def escapedTuple(): Unit = {
     @noinline def escape[A](a: A): A = a
 
     val a = js.Tuple2("hello", 42)
@@ -514,7 +514,7 @@ class OptimizerTest {
 
   // Bug #3415
 
-  @Test def infinite_recursion_inlining_issue3415_original(): Unit = {
+  @Test def infiniteRecursionInlining_Issue3415(): Unit = {
     assumeTrue("linking only", false)
     doWhile1("foo")(f => f(true))
   }
@@ -529,7 +529,7 @@ class OptimizerTest {
     }
   }
 
-  @Test def infinite_recursion_inlining_issue3415_minimized(): Unit = {
+  @Test def infiniteRecursionInliningPlaceholder_Issue3415(): Unit = {
     assumeTrue("linking only", false)
     doWhile(???)
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -38,7 +38,7 @@ class ReflectionTest {
     case _ => false
   }
 
-  @Test def java_lang_Class_getName_under_normal_circumstances(): Unit = {
+  @Test def javaLangClassGetNameUnderNormalCircumstances(): Unit = {
     @noinline
     def testNoInline(expected: String, cls: Class[_]): Unit =
       assertEquals(expected, cls.getName())
@@ -52,12 +52,12 @@ class ReflectionTest {
     test("scala.Some", classOf[scala.Some[_]])
   }
 
-  @Test def should_append_$_to_class_name_of_objects(): Unit = {
+  @Test def appendDollarSignToClassNameOfObjects(): Unit = {
     assertEquals("org.scalajs.testsuite.compiler.ReflectionTest$TestObject$",
       TestObject.getClass.getName)
   }
 
-  @Test def java_lang_Class_getName_renamed_through_semantics(): Unit = {
+  @Test def javaLangClassGetNameRenamedThroughSemantics(): Unit = {
     @noinline
     def testNoInline(expected: String, cls: Class[_]): Unit =
       assertEquals(expected, cls.getName())
@@ -77,7 +77,7 @@ class ReflectionTest {
         classOf[OtherPrefixRenamedTestClass])
   }
 
-  @Test def java_lang_Object_getClass_getName_renamed_through_semantics(): Unit = {
+  @Test def javaLangObjectGetClassGetNameRenamedThroughSemantics(): Unit = {
     // x.getClass().getName() is subject to optimizations
 
     @noinline
@@ -105,7 +105,7 @@ class ReflectionTest {
         new OtherPrefixRenamedTestClass)
   }
 
-  @Test def should_support_isInstance(): Unit = {
+  @Test def isInstance(): Unit = {
     class A
     class B extends A
     val b = new B
@@ -126,7 +126,7 @@ class ReflectionTest {
     assertTrue(classOf[Cloneable].isInstance(new Array[String](1)))
   }
 
-  @Test def isInstance_for_JS_class(): Unit = {
+  @Test def isInstanceForJSClass(): Unit = {
     js.eval("""var ReflectionTestJSClass = (function() {})""")
 
     val obj = new ReflectionTestJSClass
@@ -145,7 +145,7 @@ class ReflectionTest {
     assertFalse(implicitClassTagTest[ReflectionTestJSClass](other))
   }
 
-  @Test def isInstance_for_JS_traits_should_fail(): Unit = {
+  @Test def isInstanceForJSTraitsThrows(): Unit = {
     assertThrows(classOf[Exception], classOf[ReflectionTestJSTrait].isInstance(5))
 
     val ct = classTag[ReflectionTestJSTrait]
@@ -154,7 +154,7 @@ class ReflectionTest {
     assertThrows(classOf[Exception], implicitClassTagTest[ReflectionTestJSTrait](new AnyRef))
   }
 
-  @Test def getClass_for_normal_types(): Unit = {
+  @Test def getClassForNormalTypes(): Unit = {
     class Foo {
       def bar(): Class[_] = super.getClass()
     }
@@ -163,7 +163,7 @@ class ReflectionTest {
     assertSame(foo.bar(), classOf[Foo])
   }
 
-  @Test def getClass_for_anti_boxed_primitive_types(): Unit = {
+  @Test def getClassForAntiBoxedPrimitiveTypes(): Unit = {
     implicit def classAsAny(c: java.lang.Class[_]): js.Any =
       c.asInstanceOf[js.Any]
     assertEquals(classOf[java.lang.Boolean], (false: Any).getClass)
@@ -177,7 +177,7 @@ class ReflectionTest {
     assertEquals(classOf[scala.runtime.BoxedUnit], ((): Any).getClass)
   }
 
-  @Test def getSuperclass_issue_1489(): Unit = {
+  @Test def getSuperclass_Issue1489(): Unit = {
     assertEquals(classOf[SomeParentClass], classOf[SomeChildClass].getSuperclass)
     assertNull(classOf[AnyRef].getSuperclass)
     assertEquals(classOf[AnyRef], classOf[String].getSuperclass)
@@ -187,7 +187,7 @@ class ReflectionTest {
       classOf[ChildClassWhoseDataIsAccessedDirectly].getSuperclass.getName)
   }
 
-  @Test def cast_positive(): Unit = {
+  @Test def castPositive(): Unit = {
     assertNull(classOf[String].cast(null))
     assertEquals("hello", classOf[String].cast("hello"))
     assertEquals(List(1, 2), classOf[Seq[_]].cast(List(1, 2)))
@@ -196,7 +196,7 @@ class ReflectionTest {
     classOf[Object].cast(js.Array(3, 4)) // should not throw
   }
 
-  @Test def cast_negative(): Unit = {
+  @Test def castNegative(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     assertThrows(classOf[Exception], classOf[String].cast(5))
     assertThrows(classOf[Exception], classOf[Seq[_]].cast(Some("foo")))

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RegressionJSTest.scala
@@ -21,7 +21,7 @@ import org.junit.Assert._
 class RegressionJSTest {
   import RegressionJSTest._
 
-  @Test def should_not_swallow_Unit_expressions_when_converting_to_js_Any_issue_83(): Unit = {
+  @Test def preserveUnitExpressionsWhenConvertingToJSAny_Issue83(): Unit = {
     var effectHappened = false
     def doEffect(): Unit = effectHappened = true
     def f(): js.Any = doEffect()
@@ -29,7 +29,7 @@ class RegressionJSTest {
     assertTrue(effectHappened)
   }
 
-  @Test def should_resolve_overloads_on_scala_Function_apply_when_converting_to_js_Function_issue_125(): Unit = {
+  @Test def resolveOverloadsOnScalaFunctionApplyWhenConvertingToJSFunction_Issue125(): Unit = {
     class Fct extends Function1[Int, Any] {
       def apply(n: Int): Int = n
     }
@@ -39,7 +39,7 @@ class RegressionJSTest {
     val thisFunction: js.ThisFunction = scalaFunction
   }
 
-  @Test def should_not_put_bad_flags_on_caseaccessor_export_forwarders_issue_1191(): Unit = {
+  @Test def badFlagsOnCaseaccessorExportForwarders_Issue1191(): Unit = {
     // This test used to choke patmat
 
     @JSExportAll
@@ -51,14 +51,14 @@ class RegressionJSTest {
     assertEquals(2, b)
   }
 
-  @Test def should_transform_js_dynamic_x_receiver_issue_2804(): Unit = {
+  @Test def transformJSDynamicXReceiver_Issue2804(): Unit = {
     class Foo extends js.Object
 
     assertTrue(js.isUndefined(js.constructorOf[Foo].x))
     assertTrue(js.isUndefined(js.constructorOf[Foo].y))
   }
 
-  @Test def super_mixin_call_in_2_12_issue_3013_ScalaOuter_JSInner(): Unit = {
+  @Test def superMixinCallIn212ScalaOuterJSInner_Issue3013(): Unit = {
     import Bug3013_ScalaOuter_JSInner._
 
     val b = new B
@@ -68,7 +68,7 @@ class RegressionJSTest {
     assertEquals("B", c.t3())
   }
 
-  @Test def emit_anon_JS_function_class_data_with_2_11_Xexperimental_issue_3222(): Unit = {
+  @Test def emitAnonJSFunctionClassDataWith211Xexperimental_Issue3222(): Unit = {
     val initSourceMapper: Option[js.Function1[Int, Int]] = None
     val sourceMapper: js.Function1[Int, Int] = {
       initSourceMapper.getOrElse {
@@ -78,7 +78,7 @@ class RegressionJSTest {
     assertEquals(4, sourceMapper(4))
   }
 
-  @Test def lambda_returning_object_literal_issue_3926(): Unit = {
+  @Test def lambdaReturningObjectLiteral_Issue3926(): Unit = {
     @noinline
     def f(): () => js.Dynamic =
       () => js.Dynamic.literal(foo = 5)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypesTest.scala
@@ -30,21 +30,21 @@ import scala.util.{ Try, Failure }
 class RuntimeTypesTest {
   import RuntimeTypesTest._
 
-  @Test def scala_Arrays_are_instances_of_Serializable_and_Cloneable_issue_2094(): Unit = {
+  @Test def scalaArraysAreInstancesOfSerializableAndCloneable_Issue2094(): Unit = {
     assertTrue((Array(3): Any).isInstanceOf[Serializable])
     assertTrue((Array(3): Any).isInstanceOf[Cloneable])
     assertTrue((Array("hello"): Any).isInstanceOf[Serializable])
     assertTrue((Array("hello"): Any).isInstanceOf[Cloneable])
   }
 
-  @Test def scala_Arrays_cast_to_Serializable_and_Cloneable_issue_2094(): Unit = {
+  @Test def scalaArraysCastToSerializableAndCloneable_Issue2094(): Unit = {
     (Array(3): Any).asInstanceOf[Serializable] // should not throw
     (Array(3): Any).asInstanceOf[Cloneable] // should not throw
     (Array("hello"): Any).asInstanceOf[Serializable] // should not throw
     (Array("hello"): Any).asInstanceOf[Cloneable] // should not throw
   }
 
-  @Test def scala_Nothing_casts_to_scala_Nothing_should_fail(): Unit = {
+  @Test def scalaNothingCastsToScalaNothingThrows(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
     def test(x: Any): Unit =
@@ -54,7 +54,7 @@ class RuntimeTypesTest {
     test(null)
   }
 
-  @Test def scala_Nothing_reflected_casts_to_scala_Nothing_should_fail(): Unit = {
+  @Test def scalaNothingReflectedCastsToScalaNothingThrows(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     def test(x: Any): Unit = {
       try {
@@ -70,16 +70,16 @@ class RuntimeTypesTest {
     test(null)
   }
 
-  @Test def scala_Null_casts_to_scala_Null_should_fail_for_everything_else_but_null(): Unit = {
+  @Test def scalaNullCastsToScalaNullThrowsForEverythingButNull(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     assertThrows(classOf[ClassCastException], "a".asInstanceOf[Null])
   }
 
-  @Test def scala_Null_casts_to_scala_Null_should_succeed_on_null(): Unit = {
+  @Test def scalaNullCastsToScalaNullWorksOnNull(): Unit = {
     null.asInstanceOf[Null]
   }
 
-  @Test def scala_Arrays_of_JS_types(): Unit = {
+  @Test def scalaArraysOfJSTypes(): Unit = {
     val arrayOfParentJSType = new Array[ParentJSType](0)
     val arrayOfJSInterface = new Array[SomeJSInterface](0)
     val arrayOfJSClass = new Array[SomeJSClass](0)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/UnitJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/UnitJSTest.scala
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class UnitJSTest {
-  @Test def `should_have_toString()`(): Unit = {
+  @Test def testToString(): Unit = {
     assertEquals(().toString(),  "undefined")
     assertEquals(((): Any).toString(),  "undefined")
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
@@ -23,12 +23,12 @@ import scala.scalajs.js
 
 class ObjectJSTest {
 
-  @Test def everything_but_null_should_be_an_Object(): Unit = {
+  @Test def everythingButNullIsAnObject(): Unit = {
     assertTrue((new js.Object: Any).isInstanceOf[Object])
     assertTrue((js.Array(5)  : Any).isInstanceOf[Object])
   }
 
-  @Test def everything_should_cast_to_Object_successfully_including_null(): Unit = {
+  @Test def everythingCanCastToObjectSuccessfullyIncludingNull(): Unit = {
     (new js.Object: Any).asInstanceOf[Object]
     (js.Array(5)  : Any).asInstanceOf[Object]
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementJSTest.scala
@@ -39,7 +39,7 @@ class StackTraceElementJSTest {
     assertEquals(5, getColumnNumber(ste))
   }
 
-  @Test def should_use_the_additional_columnNumber_field_in_its_toString(): Unit = {
+  @Test def additionalColumnNumberFieldInToString(): Unit = {
     val ste = new StackTraceElement("MyClass", "myMethod", "myFile.scala", 1)
     assertEquals("MyClass.myMethod(myFile.scala:1)", ste.toString)
     setColumnNumber(ste, 5)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferJSTest.scala
@@ -41,6 +41,6 @@ class StringBuilderJSTest {
   @Test def insert(): Unit =
     assertEquals("undefined", newBuilder.insert(0, js.undefined).toString)
 
-  @Test def should_allow_string_interpolation_to_survive_null_and_undefined(): Unit =
+  @Test def stringInterpolationSupportsNullAndUndefined(): Unit =
     assertEquals("undefined", s"${js.undefined}")
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -25,7 +25,7 @@ import org.junit.Assert._
 
 class SystemJSTest {
 
-  @Test def identityHashCode_should_survive_if_an_object_is_sealed(): Unit = {
+  @Test def identityHashCodeIsStableIfObjectIsSealed(): Unit = {
     /* This is mostly forward-checking that, should we have an implementation
      * that seals Scala.js objects, identityHashCode() survives.
      */
@@ -44,7 +44,7 @@ class SystemJSTest {
     assertEquals(x2FirstHash, x2.hashCode())
   }
 
-  @Test def identityHashCode_for_JS_objects(): Unit = {
+  @Test def identityHashCodeForJSObjects(): Unit = {
     if (assumingES6 || js.typeOf(js.Dynamic.global.WeakMap) != "undefined") {
       /* This test is more restrictive than the spec, but we know our
        * implementation will always pass the test.

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterJSTest.scala
@@ -21,14 +21,14 @@ import java.util.Formatter
 
 class FormatterJSTest {
 
-  @Test def `should_survive_undefined`(): Unit = {
+  @Test def formatUndefined(): Unit = {
     val fmt = new Formatter()
     val res = fmt.format("%s", js.undefined).toString()
     fmt.close()
     assertEquals("undefined", res)
   }
 
-  @Test def `should_allow_f_string_interpolation_to_survive_undefined`(): Unit = {
+  @Test def formatUndefinedWithInterpolator(): Unit = {
     assertEquals("undefined", f"${js.undefined}%s")
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
@@ -26,7 +26,7 @@ class ArrayTest {
 
   // scala.scalajs.js.Array
 
-  @Test def should_provide_implicit_conversion_from_js_Array_to_ArrayOps_String(): Unit = {
+  @Test def implicitConversionFromJSArrayToArrayOpsString(): Unit = {
     var propCount = 0
     var propString = ""
 
@@ -40,7 +40,7 @@ class ArrayTest {
     assertEquals("Scala.js", propString)
   }
 
-  @Test def should_provide_implicit_conversion_from_js_Array_to_ArrayOps_Int(): Unit = {
+  @Test def implicitConversionFromJSArrayToArrayOpsInt(): Unit = {
     var propCount = 0
     var propString = ""
 
@@ -54,7 +54,7 @@ class ArrayTest {
     assertEquals("7357", propString)
   }
 
-  @Test def should_provide_implicit_conversion_from_js_Array_to_ArrayOps_Char(): Unit = {
+  @Test def implicitConversionFromJSArrayToArrayOpsChar(): Unit = {
     var propCount = 0
     var propString = ""
 
@@ -68,7 +68,7 @@ class ArrayTest {
     assertEquals("Scala", propString)
   }
 
-  @Test def should_provide_implicit_conversion_from_js_Array_to_ArrayOps_value_class(): Unit = {
+  @Test def implicitConversionFromJSArrayToArrayOpsValueClass(): Unit = {
     var propCount = 0
     var propString = ""
 
@@ -84,7 +84,7 @@ class ArrayTest {
 
   // scala.scalajs.js.JSConverters.JSRichGenTraversableOnce
 
-  @Test def should_provide_toJSArray(): Unit = {
+  @Test def toJSArray(): Unit = {
     import js.JSConverters._
     assertJSArrayEquals(js.Array("foo", "bar"), List("foo", "bar").toJSArray)
     assertJSArrayEquals(js.Array(1, 2, 3), Iterator(1, 2, 3).toJSArray)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
@@ -82,7 +82,7 @@ class AsyncTest {
       "foreach"), res.toArray)
   }
 
-  @Test def scala_scalajs_concurrent_JSExecutionContext_queue(): Unit = {
+  @Test def scalaScalajsConcurrentJSExecutionContextQueue(): Unit = {
     assumeTrue("Assumed js.Dynamic.global.Promise is undefined",
         js.typeOf(js.Dynamic.global.Promise) == "undefined")
     TimeoutMock.withMockedTimeout { tick =>
@@ -92,7 +92,7 @@ class AsyncTest {
     }
   }
 
-  @Test def scala_scala_concurrent_ExecutionContext_global(): Unit = {
+  @Test def scalaScalaConcurrentExecutionContextGlobal(): Unit = {
     assumeTrue("Assumed js.Dynamic.global.Promise is undefined",
         js.typeOf(js.Dynamic.global.Promise) == "undefined")
     TimeoutMock.withMockedTimeout { tick =>
@@ -104,7 +104,7 @@ class AsyncTest {
     }
   }
 
-  @Test def scala_scalajs_concurrent_QueueExecutionContext(): Unit = {
+  @Test def scalaScalajsConcurrentQueueExecutionContext(): Unit = {
     TimeoutMock.withMockedTimeout { tick =>
       PromiseMock.withMockedPromiseIfExists { optProcessQueue =>
         implicit val executor = QueueExecutionContext()
@@ -116,7 +116,7 @@ class AsyncTest {
     }
   }
 
-  @Test def scala_scalajs_concurrent_QueueExecutionContext_timeouts(): Unit = {
+  @Test def scalaScalajsConcurrentQueueExecutionContextTimeouts(): Unit = {
     TimeoutMock.withMockedTimeout { tick =>
       implicit val executor = QueueExecutionContext.timeouts()
       queueExecOrderTests { () =>
@@ -125,7 +125,7 @@ class AsyncTest {
     }
   }
 
-  @Test def scala_scalajs_concurrent_QueueExecutionContext_promises(): Unit = {
+  @Test def scalaScalajsConcurrentQueueExecutionContextPromises(): Unit = {
     PromiseMock.withMockedPromise { processQueue =>
       implicit val executor = QueueExecutionContext.promises()
       queueExecOrderTests { () =>
@@ -134,25 +134,25 @@ class AsyncTest {
     }
   }
 
-  @Test def scala_concurrent_future_should_support_map(): AsyncResult = await {
+  @Test def scalaConcurrentFutureSupportsMap(): AsyncResult = await {
     import ExecutionContext.Implicits.global
     val f = Future(3).map(x => x*2)
     f.map(v => assertEquals(6, v))
   }
 
-  @Test def scala_concurrent_future_should_support_flatMap(): AsyncResult = await {
+  @Test def scalaConcurrentFutureSupportsFlatMap(): AsyncResult = await {
     import ExecutionContext.Implicits.global
     val f = Future(Future(3)).flatMap(x => x)
     f.map(v => assertEquals(3, v))
   }
 
-  @Test def scala_concurrent_future_should_support_sequence(): AsyncResult = await {
+  @Test def scalaConcurrentFutureSupportsSequence(): AsyncResult = await {
     import ExecutionContext.Implicits.global
     val f = Future.sequence(Seq(Future(3), Future(5)))
     f.map(v => assertEquals(Seq(3, 5), v))
   }
 
-  @Test def JSPromiseToFuture_basic_case(): Unit = {
+  @Test def jsPromiseToFutureBasicCase(): Unit = {
     PromiseMock.withMockedPromise { processQueue =>
       implicit val ec = QueueExecutionContext.promises()
 
@@ -177,7 +177,7 @@ class AsyncTest {
     }
   }
 
-  @Test def scala_concurrent_FutureToJSPromise_basic_case(): Unit = {
+  @Test def scalaConcurrentFutureToJSPromiseBasicCase(): Unit = {
     PromiseMock.withMockedPromise { processQueue =>
       implicit val ec = QueueExecutionContext.promises()
 
@@ -199,7 +199,7 @@ class AsyncTest {
     }
   }
 
-  @Test def scala_concurrent_FutureToJSPromise_thenable_case(): Unit = {
+  @Test def scalaConcurrentFutureToJSPromiseThenableCase(): Unit = {
     PromiseMock.withMockedPromise { processQueue =>
       implicit val ec = QueueExecutionContext.promises()
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
@@ -26,12 +26,12 @@ class DictionaryTest {
 
   // scala.scalajs.js.Dictionary
 
-  @Test def apply_should_throw_when_not_found(): Unit = {
+  @Test def applyThrowsWhenNotFound(): Unit = {
     val obj = js.Dictionary("foo" -> "bar")
     assertThrows(classOf[NoSuchElementException], obj("bar"))
   }
 
-  @Test def should_provide_get(): Unit = {
+  @Test def get(): Unit = {
     val obj = js.Dictionary.empty[Int]
     obj("hello") = 1
 
@@ -39,12 +39,12 @@ class DictionaryTest {
     assertFalse(obj.get("world").isDefined)
   }
 
-  @Test def `-=_should_ignore_deleting_a_non_existent_key`(): Unit = {
+  @Test def minusEqualsIgnoresNonExistentKey(): Unit = {
     val obj = js.Dictionary("a" -> "A")
     obj -= "b"
   }
 
-  @Test def should_provide_keys(): Unit = {
+  @Test def keys(): Unit = {
     val obj = js.Dictionary("a" -> "A", "b" -> "B")
     val keys = obj.keys.toList
     assertEquals(2, keys.size)
@@ -52,7 +52,7 @@ class DictionaryTest {
     assertTrue(keys.contains("b"))
   }
 
-  @Test def should_survive_the_key_hasOwnProperty_issue_1414(): Unit = {
+  @Test def keyHasOwnProperty_Issue1414(): Unit = {
     val obj = js.Dictionary.empty[Int]
     assertFalse(obj.contains("hasOwnProperty"))
     obj("hasOwnProperty") = 5
@@ -61,7 +61,7 @@ class DictionaryTest {
     assertFalse(obj.contains("hasOwnProperty"))
   }
 
-  @Test def should_provide_an_iterator(): Unit = {
+  @Test def iterator(): Unit = {
     val obj = js.Dictionary("foo" -> 5, "bar" -> 42, "babar" -> 0)
     var elems: List[(String, Int)] = Nil
     for ((prop, value) <- obj) {
@@ -75,7 +75,7 @@ class DictionaryTest {
 
   // scala.scalajs.js.JSConverters.JSRichGenMap
 
-  @Test def should_provide_toJSDictionary(): Unit = {
+  @Test def toJSDictionary(): Unit = {
     import js.JSConverters._
     val dict1 = Map("a" -> 1, "b" -> 2).toJSDictionary
     assertEquals(1, dict1("a"))
@@ -86,7 +86,7 @@ class DictionaryTest {
     assertEquals("bar", dict2("b"))
   }
 
-  @Test def should_provide_underlying_JSDictionary(): Unit = {
+  @Test def underlyingJSDictionary(): Unit = {
     val original = js.Dictionary("a" -> 1, "b" -> 2, "c" -> 3)
     val dict: js.Dictionary[Int] = original.filter(_._1 != "b")
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
@@ -35,7 +35,7 @@ class DynamicTest {
 
   // scala.scalajs.js.Dynamic
 
-  @Test def should_allow_instanciating_JS_classes_dynamically_issue_10(): Unit = {
+  @Test def evalJSClassesDynamically_Issue10(): Unit = {
     val DynamicTestClass = js.eval("""
         var DynamicTestClass = function(x) {
           this.x = x;
@@ -46,7 +46,7 @@ class DynamicTest {
     assertEquals("Scala.js", obj.x)
   }
 
-  @Test def should_allow_instantiating_JS_classes_dynamically_with_varargs_issue_708(): Unit = {
+  @Test def evalJSClassesDynamicallyWithVarargs_Issue708(): Unit = {
     val DynamicTestClassVarArgs = js.eval("""
         var DynamicTestClassVarArgs = function() {
           this.count = arguments.length;
@@ -85,7 +85,7 @@ class DynamicTest {
     assertTrue(obj3_elem2)
   }
 
-  @Test def should_provide_an_object_literal_construction(): Unit = {
+  @Test def objectLiteralConstruction(): Unit = {
     import js.Dynamic.{ literal => obj }
     val x = obj(foo = 3, bar = "foobar")
     val x_foo = x.foo
@@ -106,14 +106,14 @@ class DynamicTest {
     assertJSUndefined(obj_anything)
   }
 
-  @Test def object_literal_in_statement_position_issue_1627(): Unit = {
+  @Test def objectLiteralInStatementPosition_Issue1627(): Unit = {
     // Just make sure it does not cause a SyntaxError
     js.Dynamic.literal(foo = "bar")
     // and also test the case without param (different code path in Printers)
     js.Dynamic.literal()
   }
 
-  @Test def should_provide_object_literal_construction_with_dynamic_naming(): Unit = {
+  @Test def objectLiteralConstructionWithDynamicNaming(): Unit = {
     import js.Dynamic.{ literal => obj }
     val x = obj("foo" -> 3, "bar" -> "foobar")
     val x_foo = x.foo
@@ -139,7 +139,7 @@ class DynamicTest {
     assertEquals(1, count)
   }
 
-  @Test def should_preserve_evaluation_order_of_keys_and_values(): Unit = {
+  @Test def evaluationOrderOfKeysAndValues(): Unit = {
     import js.Dynamic.{ literal => obj }
 
     val orderCheck = Array.newBuilder[Int]
@@ -183,13 +183,13 @@ class DynamicTest {
     assertArrayEquals(Array(1, 2, 3, 4), orderCheck3.result())
   }
 
-  @Test def should_allow_to_create_an_empty_object_with_the_literal_syntax(): Unit = {
+  @Test def createAnEmptyObjectWithTheLiteralSyntax(): Unit = {
     import js.Dynamic.{ literal => obj }
     val x = obj()
     assertTrue(x.isInstanceOf[js.Object])
   }
 
-  @Test def should_properly_encode_object_literal_property_names(): Unit = {
+  @Test def encodeObjectLiteralPropertyNames(): Unit = {
     import js.Dynamic.{ literal => obj }
 
     val obj0 = obj("3-" -> 42)
@@ -233,7 +233,7 @@ class DynamicTest {
     }
   }
 
-  @Test def `should_accept_:__*_arguments_for_literal_construction_issue_1743`(): Unit = {
+  @Test def colonAsteriskArgumentsForLiteralConstruction_Issue1743(): Unit = {
     import js.Dynamic.literal
 
     val fields = Seq[(String, js.Any)]("foo" -> 42, "bar" -> "foobar")
@@ -257,7 +257,7 @@ class DynamicTest {
     assertEquals("foobar", y_bar)
   }
 
-  @Test def should_allow_object_literals_to_have_duplicate_keys_issue_1595(): Unit = {
+  @Test def objectLiteralsWithDuplicateKeys_Issue1595(): Unit = {
     import js.Dynamic.{literal => obj}
 
     // Basic functionality
@@ -285,7 +285,7 @@ class DynamicTest {
     test(obj(foo = 4, bar = 5, foo = 6))
   }
 
-  @Test def should_return_subclasses_of_js_Object_in_literal_construction_issue_783(): Unit = {
+  @Test def subclassesOfJSObjectInLiteralConstruction_Issue783(): Unit = {
     import js.Dynamic.{ literal => obj }
 
     val a: js.Object = obj(theValue = 1)
@@ -297,7 +297,7 @@ class DynamicTest {
     assertFalse(b.hasOwnProperty("noValue"))
   }
 
-  @Test def shouldNotListScalaDynamicAsSuperIntf(): Unit = {
+  @Test def scalaDynamicIsNotSuperIntf(): Unit = {
     /* We test the arrays of the classes, as it is the only reliable way to
      * ensure that interfaces listed in the IR are what they should be.
      */

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -72,7 +72,7 @@ class ExportsTest {
 
   // @JSExport
 
-  @Test def exports_for_methods_with_implicit_name(): Unit = {
+  @Test def exportsForMethodsWithImplicitName(): Unit = {
     class Foo {
       @JSExport
       def bar(): Int = 42
@@ -86,7 +86,7 @@ class ExportsTest {
     assertEquals(6, foo.double(3))
   }
 
-  @Test def exports_for_methods_with_explicit_name(): Unit = {
+  @Test def exportsForMethodsWithExplicitName(): Unit = {
     class Foo {
       @JSExport("theAnswer")
       def bar(): Int = 42
@@ -101,7 +101,7 @@ class ExportsTest {
     assertEquals(6, foo.doubleTheParam(3))
   }
 
-  @Test def exports_for_methods_with_constant_folded_name(): Unit = {
+  @Test def exportsForMethodsWithConstantFoldedName(): Unit = {
     class Foo {
       @JSExport(ExportNameHolder.methodName)
       def bar(): Int = 42
@@ -112,7 +112,7 @@ class ExportsTest {
     assertEquals(42, foo.myMethod())
   }
 
-  @Test def exports_for_methods_whose_encodedName_starts_with_dollar_issue_3219(): Unit = {
+  @Test def exportsForMethodsWhoseEncodedNameStartsWithDollar_Issue3219(): Unit = {
     class ExportsForMethodsWhoseEncodedNameStartsWithDollar {
       @JSExport("$a")
       def f(x: Int): Int = x + 1
@@ -136,7 +136,7 @@ class ExportsTest {
     assertEquals(9, fns.applyDynamic("plus")(5))
   }
 
-  @Test def exports_for_protected_methods(): Unit = {
+  @Test def exportsForProtectedMethods(): Unit = {
     class Foo {
       @JSExport
       protected def bar(): Int = 42
@@ -152,7 +152,7 @@ class ExportsTest {
     assertEquals(100, foo.foo())
   }
 
-  @Test def exports_for_properties_with_implicit_name(): Unit = {
+  @Test def exportsForPropertiesWithImplicitName(): Unit = {
     class Foo {
       private[this] var myY: String = "hello"
       @JSExport
@@ -180,7 +180,7 @@ class ExportsTest {
     assertEquals("world set get", foo.y)
   }
 
-  @Test def exports_for_properties_with_explicit_name(): Unit = {
+  @Test def exportsForPropertiesWithExplicitName(): Unit = {
     class Foo {
       private[this] var myY: String = "hello"
       @JSExport("answer")
@@ -209,7 +209,7 @@ class ExportsTest {
     assertEquals("world set get", foo.y)
   }
 
-  @Test def exports_for_properties_whose_encodedName_starts_with_dollar_issue_3219(): Unit = {
+  @Test def exportsForPropertiesWhoseEncodedNameStartsWithDollar_Issue3219(): Unit = {
     class ExportsForPropertiesWhoseEncodedNameStartsWithDollar {
       @JSExport("$a")
       def f: Int = 6
@@ -233,7 +233,7 @@ class ExportsTest {
     assertEquals(9, fns.selectDynamic("plus"))
   }
 
-  @Test def exports_for_protected_properties(): Unit = {
+  @Test def exportsForProtectedProperties(): Unit = {
     class Foo {
       @JSExport
       protected val x: Int = 42
@@ -246,7 +246,7 @@ class ExportsTest {
     assertEquals(43, foo.y)
   }
 
-  @Test def exports_for_abstract_properties_in_class_issue_2513(): Unit = {
+  @Test def exportsForAbstractPropertiesInClass_Issue2513(): Unit = {
     abstract class Foo {
       @JSExport
       val x: Int
@@ -266,7 +266,7 @@ class ExportsTest {
     assertEquals(7, bar.y)
   }
 
-  @Test def exports_for_abstract_properties_in_trait_issue_2513(): Unit = {
+  @Test def exportsForAbstractPropertiesInTrait_Issue2513(): Unit = {
     trait Foo {
       @JSExport
       val x: Int
@@ -286,7 +286,7 @@ class ExportsTest {
     assertEquals(7, bar.y)
   }
 
-  @Test def readonly_properties(): Unit = {
+  @Test def readonlyProperties(): Unit = {
     class Foo {
       @JSExport
       val foo: Int = 1
@@ -304,7 +304,7 @@ class ExportsTest {
     })
   }
 
-  @Test def properties_are_not_enumerable(): Unit = {
+  @Test def propertiesAreNotEnumerable(): Unit = {
     class Foo {
       @JSExport
       def myProp: Int = 1
@@ -314,7 +314,7 @@ class ExportsTest {
     assertFalse(js.Object.properties(x).contains("myProp"))
   }
 
-  @Test def overloaded_exports_for_methods(): Unit = {
+  @Test def overloadedExportsForMethods(): Unit = {
     class Foo {
       @JSExport("foobar")
       def foo(): Int = 42
@@ -328,7 +328,7 @@ class ExportsTest {
     assertEquals(6, foo.foobar(3))
   }
 
-  @Test def multiple_exports_for_the_same_method(): Unit = {
+  @Test def multipleExportsForTheSameMethod(): Unit = {
     class Foo {
       @JSExport
       @JSExport("b")
@@ -346,7 +346,7 @@ class ExportsTest {
     assertEquals(1, foo.c())
   }
 
-  @Test def should_inherit_exports_from_traits(): Unit = {
+  @Test def inheritExportsFromTraits(): Unit = {
     trait Foo {
       @JSExport
       def x: Int
@@ -375,7 +375,7 @@ class ExportsTest {
     assertEquals(6, bar.otherMethod(2))
   }
 
-  @Test def should_inherit_exports_from_traits_with_value_classes(): Unit = {
+  @Test def inheritExportsFromTraitsWithValueClasses(): Unit = {
     trait Foo {
       @JSExport
       def x: SomeValueClass = new SomeValueClass(5)
@@ -392,7 +392,7 @@ class ExportsTest {
     assertEquals(4, bar.method(vc.asInstanceOf[js.Any]))
   }
 
-  @Test def should_inherit_exports_from_traits_with_varargs_issue_3538(): Unit = {
+  @Test def inheritExportsFromTraitsWithVarargs_Issue3538(): Unit = {
     trait Foo {
       @JSExport
       def method(args: Int*): Int = args.sum
@@ -404,7 +404,7 @@ class ExportsTest {
     assertEquals(18, bar.method(5, 6, 7))
   }
 
-  @Test def overloading_with_inherited_exports(): Unit = {
+  @Test def overloadingWithInheritedExports(): Unit = {
     class A {
       @JSExport
       def foo(x: Int): Int = 2*x
@@ -421,7 +421,7 @@ class ExportsTest {
     assertEquals("Hello World", b.foo("World"))
   }
 
-  @Test def exports_for_generic_methods(): Unit = {
+  @Test def exportsForGenericMethods(): Unit = {
     class Foo {
       @JSExport
       def gen[T <: AnyRef](x: T): T = x
@@ -434,7 +434,7 @@ class ExportsTest {
     assertSame(x, foo.gen(x))
   }
 
-  @Test def exports_for_lambda_return_types(): Unit = {
+  @Test def exportsForLambdaReturnTypes(): Unit = {
     class Foo {
       @JSExport
       def lambda(x: Int): Int => Int = (y: Int) => x + y
@@ -448,7 +448,7 @@ class ExportsTest {
     assertEquals(9, lambda(4))
   }
 
-  @Test def exports_for_multi_parameter_lists(): Unit = {
+  @Test def exportsForMultiParameterLists(): Unit = {
     class Foo {
       @JSExport
       def multiParam(x: Int)(y: Int): Int = x + y
@@ -459,7 +459,7 @@ class ExportsTest {
     assertEquals(11, foo.multiParam(5,6))
   }
 
-  @Test def exports_for_default_arguments(): Unit = {
+  @Test def exportsForDefaultArguments(): Unit = {
     class Foo {
       @JSExport
       def defArg(x: Int = 1): Int = x
@@ -470,7 +470,7 @@ class ExportsTest {
     assertEquals(5, foo.defArg(5))
   }
 
-  @Test def exports_for_weird_stuff(): Unit = {
+  @Test def exportsForWeirdStuff(): Unit = {
     class UhOh {
       // Something no one should export
       @JSExport
@@ -481,7 +481,7 @@ class ExportsTest {
     assertEquals("function", js.typeOf(x.ahem))
   }
 
-  @Test def exports_with_value_class_return_types(): Unit = {
+  @Test def exportsWithValueClassReturnTypes(): Unit = {
     class Foo {
       @JSExport
       def vc(x: Int): SomeValueClass = new SomeValueClass(x)
@@ -497,7 +497,7 @@ class ExportsTest {
     assertTrue((result: Any) == (new SomeValueClass(5)))
   }
 
-  @Test def should_allow_exports_with_Any_as_return_type(): Unit = {
+  @Test def exportsWithAnyAsReturnType(): Unit = {
     class A
     class Foo {
       @JSExport
@@ -510,7 +510,7 @@ class ExportsTest {
     assertTrue((foo.foo(false): Any).isInstanceOf[A])
   }
 
-  @Test def boxed_value_classes_as_parameter(): Unit = {
+  @Test def boxedValueClassesAsParameter(): Unit = {
     class Foo {
       @JSExport
       def vc(x: SomeValueClass): Int = x.i
@@ -526,7 +526,7 @@ class ExportsTest {
     assertEquals(7, result)
   }
 
-  @Test def should_overload_on_boxed_value_classes_as_parameters(): Unit = {
+  @Test def overloadOnBoxedValueClassesAsParameters(): Unit = {
     class Foo {
       @JSExport
       def foo(x: String): Int = x.length
@@ -540,7 +540,7 @@ class ExportsTest {
     assertEquals(5, foo.foo("hello"))
   }
 
-  @Test def exports_for_overridden_methods_with_refined_return_type(): Unit = {
+  @Test def exportsForOverriddenMethodsWithRefinedReturnType(): Unit = {
     class A
     class B extends A
 
@@ -557,7 +557,7 @@ class ExportsTest {
     assertTrue((c2.x: Any).isInstanceOf[B])
   }
 
-  @Test def exports_for_methods_with_refined_types_as_return_type(): Unit = {
+  @Test def exportsForMethodsWithRefinedTypesAsReturnType(): Unit = {
     class A {
       @JSExport
       def foo(x: String): js.Object with js.Dynamic =
@@ -568,7 +568,7 @@ class ExportsTest {
     assertEquals(js.Dynamic.literal(arg = "hello").toMap, a.foo("hello").toMap)
   }
 
-  @Test def exports_for_polytype_nullary_method_issue_2445(): Unit = {
+  @Test def exportsForPolytypeNullaryMethod_Issue2445(): Unit = {
     class ExportPolyTypeNullaryMethod {
       @JSExport def emptyArray[T]: js.Array[T] = js.Array()
     }
@@ -579,7 +579,7 @@ class ExportsTest {
     assertEquals(0, a.length)
   }
 
-  @Test def exports_for_variable_argument_methods_issue_393(): Unit = {
+  @Test def exportsForVariableArgumentMethods_Issue393(): Unit = {
     class A {
       @JSExport
       def foo(i: String*): String = i.mkString("|")
@@ -592,7 +592,7 @@ class ExportsTest {
     assertEquals("a|b|c|d", a.foo("a", "b", "c", "d"))
   }
 
-  @Test def overload_in_view_of_difficult_repeated_parameter_lists(): Unit = {
+  @Test def overloadInViewOfDifficultRepeatedParameterLists(): Unit = {
     class A {
       @JSExport
       def foo(a: String, b: String, i: Int, c: String): Int = 1
@@ -616,7 +616,7 @@ class ExportsTest {
     assertEquals(100000, a.foo(1))
   }
 
-  @Test def exports_with_default_arguments(): Unit = {
+  @Test def exportsWithDefaultArguments(): Unit = {
     class A {
       var oneCount: Int = 0
       def one: Int = {
@@ -650,7 +650,7 @@ class ExportsTest {
     assertEquals(9, a.oneCount)
   }
 
-  @Test def overload_methods_in_presence_of_default_parameters(): Unit = {
+  @Test def overloadMethodsInPresenceOfDefaultParameters(): Unit = {
     class A {
       @JSExport
       def foo(a: Int)(b: Int = 5)(c: Int = 7): Int = 1000 + a + b + c
@@ -672,7 +672,7 @@ class ExportsTest {
 
   }
 
-  @Test def should_prefer_overloads_taking_a_Unit_over_methods_with_default_parameters(): Unit = {
+  @Test def preferOverloadsTakingUnitOverMethodsWithDefaultParameters(): Unit = {
     class A {
       @JSExport
       def foo(a: Int)(b: String = "asdf"): String = s"$a $b"
@@ -689,7 +689,7 @@ class ExportsTest {
 
   }
 
-  @Test def overload_methods_in_presence_of_default_parameters_and_repeated_parameters(): Unit = {
+  @Test def overloadMethodsInPresenceOfDefaultParametersAndRepeatedParameters(): Unit = {
     class A {
       @JSExport
       def foo(x: Int, y: Int = 1): Int = x + y
@@ -707,7 +707,7 @@ class ExportsTest {
 
   }
 
-  @Test def overload_exports_called_toString(): Unit = {
+  @Test def overloadExportsCalledToString(): Unit = {
     class A {
       override def toString(): String = "no arg"
       @JSExport
@@ -719,7 +719,7 @@ class ExportsTest {
     assertEquals("with arg: 1", a.applyDynamic("toString")(1))
   }
 
-  @Test def should_allow_to_explicitly_export_toString(): Unit = {
+  @Test def explicitExportToString(): Unit = {
     class A {
       @JSExport("toString")
       override def toString(): String = "called"
@@ -729,7 +729,7 @@ class ExportsTest {
     assertEquals("called", a.applyDynamic("toString")())
   }
 
-  @Test def box_repeated_parameter_lists_with_value_classes(): Unit = {
+  @Test def boxRepeatedParameterListsWithValueClasses(): Unit = {
     class A {
       @JSExport
       def foo(vcs: SomeValueClass*): Int = vcs.map(_.i).sum
@@ -742,7 +742,7 @@ class ExportsTest {
     assertEquals(3, a.foo(vc1.asInstanceOf[js.Any], vc2.asInstanceOf[js.Any]))
   }
 
-  @Test def toplevel_exports_for_objects(): Unit = {
+  @Test def toplevelExportsForObjects(): Unit = {
     val obj =
       if (isNoModule) global.TopLevelExportedObject
       else exportsNamespace.TopLevelExportedObject
@@ -751,7 +751,7 @@ class ExportsTest {
     assertEquals("witness", obj.witness)
   }
 
-  @Test def toplevel_exports_for_Scala_js_defined_JS_objects(): Unit = {
+  @Test def toplevelExportsForScalaJSDefinedJSObjects(): Unit = {
     val obj1 =
       if (isNoModule) global.SJSDefinedTopLevelExportedObject
       else exportsNamespace.SJSDefinedTopLevelExportedObject
@@ -762,7 +762,7 @@ class ExportsTest {
     assertSame(obj1, SJSDefinedExportedObject)
   }
 
-  @Test def toplevel_exports_for_nested_objects(): Unit = {
+  @Test def toplevelExportsForNestedObjects(): Unit = {
     val obj =
       if (isNoModule) global.NestedExportedObject
       else exportsNamespace.NestedExportedObject
@@ -771,7 +771,7 @@ class ExportsTest {
     assertSame(obj, ExportHolder.ExportedObject)
   }
 
-  @Test def exports_for_objects_with_constant_folded_name(): Unit = {
+  @Test def exportsForObjectsWithConstantFoldedName(): Unit = {
     val obj =
       if (isNoModule) global.ConstantFoldedObjectExport
       else exportsNamespace.ConstantFoldedObjectExport
@@ -780,7 +780,7 @@ class ExportsTest {
     assertEquals("witness", obj.witness)
   }
 
-  @Test def exports_for_protected_objects(): Unit = {
+  @Test def exportsForProtectedObjects(): Unit = {
     val obj =
       if (isNoModule) global.ProtectedExportedObject
       else exportsNamespace.ProtectedExportedObject
@@ -789,7 +789,7 @@ class ExportsTest {
     assertEquals("witness", obj.witness)
   }
 
-  @Test def toplevel_exports_for_classes(): Unit = {
+  @Test def toplevelExportsForClasses(): Unit = {
     val constr =
       if (isNoModule) global.TopLevelExportedClass
       else exportsNamespace.TopLevelExportedClass
@@ -799,7 +799,7 @@ class ExportsTest {
     assertEquals(5, obj.x)
   }
 
-  @Test def toplevel_exports_for_Scala_js_defined_JS_classes(): Unit = {
+  @Test def toplevelExportsForScalaJSDefinedJSClasses(): Unit = {
     val constr =
       if (isNoModule) global.SJSDefinedTopLevelExportedClass
       else exportsNamespace.SJSDefinedTopLevelExportedClass
@@ -812,7 +812,7 @@ class ExportsTest {
     assertSame(constr, js.constructorOf[SJSDefinedTopLevelExportedClass])
   }
 
-  @Test def toplevel_exports_for_abstract_JS_classes_issue4117(): Unit = {
+  @Test def toplevelExportsForAbstractJSClasses_Issue4117(): Unit = {
     val constr =
       if (isNoModule) global.TopLevelExportedAbstractJSClass
       else exportsNamespace.TopLevelExportedAbstractJSClass
@@ -857,7 +857,7 @@ class ExportsTest {
     assertEquals(33, obj.bar(6))
   }
 
-  @Test def toplevel_exports_for_nested_classes(): Unit = {
+  @Test def toplevelExportsForNestedClasses(): Unit = {
     val constr =
       if (isNoModule) global.NestedExportedClass
       else exportsNamespace.NestedExportedClass
@@ -867,7 +867,7 @@ class ExportsTest {
     assertTrue((obj: Any).isInstanceOf[ExportHolder.ExportedClass])
   }
 
-  @Test def toplevel_exports_for_nested_sjs_defined_classes(): Unit = {
+  @Test def toplevelExportsForNestedSjsDefinedClasses(): Unit = {
     val constr =
       if (isNoModule) global.NestedSJSDefinedExportedClass
       else exportsNamespace.NestedSJSDefinedExportedClass
@@ -877,7 +877,7 @@ class ExportsTest {
     assertTrue((obj: Any).isInstanceOf[ExportHolder.SJSDefinedExportedClass])
   }
 
-  @Test def exports_for_classes_with_constant_folded_name(): Unit = {
+  @Test def exportsForClassesWithConstantFoldedName(): Unit = {
     val constr =
       if (isNoModule) global.ConstantFoldedClassExport
       else exportsNamespace.ConstantFoldedClassExport
@@ -887,7 +887,7 @@ class ExportsTest {
     assertEquals(5, obj.x)
   }
 
-  @Test def exports_for_protected_classes(): Unit = {
+  @Test def exportsForProtectedClasses(): Unit = {
     val constr =
       if (isNoModule) global.ProtectedExportedClass
       else exportsNamespace.ProtectedExportedClass
@@ -897,7 +897,7 @@ class ExportsTest {
     assertEquals(5, obj.x)
   }
 
-  @Test def export_for_classes_with_repeated_parameters_in_ctor(): Unit = {
+  @Test def exportForClassesWithRepeatedParametersInCtor(): Unit = {
     val constr =
       if (isNoModule) global.ExportedVarArgClass
       else exportsNamespace.ExportedVarArgClass
@@ -908,7 +908,7 @@ class ExportsTest {
     assertEquals("Number: <5>|a", js.Dynamic.newInstance(constr)(5, "a").result)
   }
 
-  @Test def export_for_classes_with_default_parameters_in_ctor(): Unit = {
+  @Test def exportForClassesWithDefaultParametersInCtor(): Unit = {
     val constr =
       if (isNoModule) global.ExportedDefaultArgClass
       else exportsNamespace.ExportedDefaultArgClass
@@ -917,7 +917,7 @@ class ExportsTest {
     assertEquals(103, js.Dynamic.newInstance(constr)(1,2).result)
   }
 
-  @Test def disambiguate_overloads_involving_longs(): Unit = {
+  @Test def disambiguateOverloadsInvolvingLongs(): Unit = {
 
     class Foo {
       @JSExport
@@ -940,7 +940,7 @@ class ExportsTest {
     assertEquals(2, foo.foo(trueJsLong))
   }
 
-  @Test def should_return_boxed_Chars(): Unit = {
+  @Test def returnBoxedChars(): Unit = {
     class Foo {
       @JSExport
       def bar(x: Int): Char = x.toChar
@@ -957,7 +957,7 @@ class ExportsTest {
     assertTrue('A' == charAsAny.asInstanceOf[Char])
   }
 
-  @Test def should_take_boxed_Chars_as_parameter(): Unit = {
+  @Test def boxedCharsAsParameter(): Unit = {
     class Foo {
       @JSExport
       def bar(x: Char): Int = x.toInt
@@ -968,7 +968,7 @@ class ExportsTest {
     assertEquals('e'.toInt, foo.bar(eCharAsAny.asInstanceOf[js.Any]))
   }
 
-  @Test def should_be_able_to_disambiguate_an_Int_from_a_Char(): Unit = {
+  @Test def distinguishIntFromChar(): Unit = {
     class Foo {
       @JSExport
       def bar(x: Char): String = "char: "+x
@@ -984,7 +984,7 @@ class ExportsTest {
     assertEquals("int: 68", foo.bar(intAsAny.asInstanceOf[js.Any]))
   }
 
-  @Test def exporting_constructor_parameter_fields_issue_970(): Unit = {
+  @Test def exportingConstructorParameterFields_Issue970(): Unit = {
     class Foo(@JSExport val x: Int, @JSExport var y: Int)
 
     val foo = new Foo(5, 6).asInstanceOf[js.Dynamic]
@@ -994,7 +994,7 @@ class ExportsTest {
     assertEquals(7, foo.y)
   }
 
-  @Test def exporting_case_class_fields_issue_970(): Unit = {
+  @Test def exportingCaseClassFields_Issue970(): Unit = {
     case class Bar(@JSExport x: Int, @JSExport var y: Int)
 
     val bar = Bar(5, 6).asInstanceOf[js.Dynamic]
@@ -1004,7 +1004,7 @@ class ExportsTest {
     assertEquals(7, bar.y)
   }
 
-  @Test def exporting_lazy_values_issue_977(): Unit = {
+  @Test def exportingLazyValues_Issue977(): Unit = {
     class Foo {
       @JSExport
       lazy val x = 1
@@ -1013,7 +1013,7 @@ class ExportsTest {
     assertEquals(1, foo.x)
   }
 
-  @Test def exporting_all_members_of_a_class(): Unit = {
+  @Test def exportingAllMembersOfClass(): Unit = {
     @JSExportAll
     class Foo {
       val a = 1
@@ -1033,7 +1033,7 @@ class ExportsTest {
     assertEquals(3, foo.c)
   }
 
-  @Test def should_not_export_synthetic_members_with_atJSExportAll_issue_1195(): Unit = {
+  @Test def noExportOfSyntheticMembersWithJSExportAll_Issue1195(): Unit = {
     @JSExportAll
     case class Foo(x: Int)
 
@@ -1043,7 +1043,7 @@ class ExportsTest {
     assertJSUndefined(foo.copy)
   }
 
-  @Test def should_allow_mutliple_equivalent_JSExport_annotations(): Unit = {
+  @Test def multipleEquivalentJSExportAnnotations(): Unit = {
     class Foo {
       @JSExport
       @JSExport("a")
@@ -1057,7 +1057,7 @@ class ExportsTest {
     assertEquals(1, foo.b)
   }
 
-  @Test def null_for_arguments_of_primitive_value_type_issue_1719(): Unit = {
+  @Test def nullForArgumentsOfPrimitiveValueType_Issue1719(): Unit = {
     @JSExportAll
     class Foo {
       def doBool(x: Boolean): Unit = assertTrue((x: Any) == false) // scalastyle:ignore
@@ -1084,7 +1084,7 @@ class ExportsTest {
     foo.doUnit(null)
   }
 
-  @Test def should_reject_bad_values_for_arguments_of_primitive_value_type(): Unit = {
+  @Test def throwOnBadValuesForArgumentsOfPrimitiveValueType(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
     @JSExportAll
@@ -1136,7 +1136,7 @@ class ExportsTest {
     assertThrows(classOf[Exception], foo.doFloat("a"))
   }
 
-  @Test def should_reject_bad_values_for_arguments_of_value_class_type_issue_613(): Unit = {
+  @Test def throwOnBadValuesForArgumentsOfValueClassType_Issue613(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
     class Foo {
@@ -1152,7 +1152,7 @@ class ExportsTest {
     assertThrows(classOf[Exception], foo.doVC("a"))
   }
 
-  @Test def should_reject_bad_values_for_arguments_of_class_type(): Unit = {
+  @Test def throwOnBadValuesForArgumentsOfClassType(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
     class A
@@ -1172,7 +1172,7 @@ class ExportsTest {
 
   private abstract class JSAbstractClass extends js.Object
 
-  @Test def should_expose_public_members_of_new_js_Object_issue_1899(): Unit = {
+  @Test def exposePublicMembersOfNewJSObject_Issue1899(): Unit = {
 
     // Test that the bug is fixed for js.Any classes.
 
@@ -1282,7 +1282,7 @@ class ExportsTest {
 
   // @JSExportTopLevel
 
-  @Test def basic_top_level_export(): Unit = {
+  @Test def basicTopLevelExport(): Unit = {
     if (isNoModule) {
       assertEquals(1, global.TopLevelExport_basic())
     } else {
@@ -1290,7 +1290,7 @@ class ExportsTest {
     }
   }
 
-  @Test def overloaded_top_level_export(): Unit = {
+  @Test def overloadedTopLevelExport(): Unit = {
     if (isNoModule) {
       assertEquals("Hello World", global.TopLevelExport_overload("World"))
       assertEquals(2, global.TopLevelExport_overload(2))
@@ -1304,7 +1304,7 @@ class ExportsTest {
     }
   }
 
-  @Test def default_params_top_level_export_issue4052(): Unit = {
+  @Test def defaultParamsTopLevelExport_Issue4052(): Unit = {
     if (isNoModule) {
       assertEquals(7, global.TopLevelExport_defaultParams(6))
       assertEquals(11, global.TopLevelExport_defaultParams(6, 5))
@@ -1314,7 +1314,7 @@ class ExportsTest {
     }
   }
 
-  @Test def top_level_export_uses_unique_object(): Unit = {
+  @Test def topLevelExportUsesUniqueObject(): Unit = {
     if (isNoModule) {
       global.TopLevelExport_set(3)
       assertEquals(3, TopLevelExports.myVar)
@@ -1328,7 +1328,7 @@ class ExportsTest {
     }
   }
 
-  @Test def top_level_export_from_nested_object(): Unit = {
+  @Test def topLevelExportFromNestedObject(): Unit = {
     if (isNoModule)
       global.TopLevelExport_setNested(28)
     else
@@ -1336,7 +1336,7 @@ class ExportsTest {
     assertEquals(28, TopLevelExports.Nested.myVar)
   }
 
-  @Test def top_level_export_with_double_underscore(): Unit = {
+  @Test def topLevelExportWithDoubleUnderscore(): Unit = {
     if (isNoModule) {
       assertEquals(true, global.__topLevelExportWithDoubleUnderscore)
     } else {
@@ -1344,7 +1344,7 @@ class ExportsTest {
     }
   }
 
-  @Test def top_level_export_is_always_reachable(): Unit = {
+  @Test def topLevelExportIsAlwaysReachable(): Unit = {
     if (isNoModule) {
       assertEquals("Hello World", global.TopLevelExport_reachability())
     } else {
@@ -1354,7 +1354,7 @@ class ExportsTest {
 
   // @JSExportTopLevel fields
 
-  @Test def top_level_export_basic_field(): Unit = {
+  @Test def topLevelExportBasicField(): Unit = {
     if (isNoModule) {
       // Initialization
       assertEquals(5, global.TopLevelExport_basicVal)
@@ -1379,7 +1379,7 @@ class ExportsTest {
     TopLevelFieldExports.basicVar = "hello"
   }
 
-  @Test def top_level_export_field_twice(): Unit = {
+  @Test def topLevelExportFieldTwice(): Unit = {
     if (isNoModule) {
       // Initialization
       assertEquals(5, global.TopLevelExport_valExportedTwice1)
@@ -1408,7 +1408,7 @@ class ExportsTest {
     TopLevelFieldExports.varExportedTwice = "hello"
   }
 
-  @Test def top_level_export_write_val_var_causes_typeerror(): Unit = {
+  @Test def topLevelExportWriteValVarCausesTypeerror(): Unit = {
     assumeFalse("Unchecked in Script mode", isNoModule)
 
     assertThrows(classOf[js.JavaScriptException], {
@@ -1420,7 +1420,7 @@ class ExportsTest {
     })
   }
 
-  @Test def top_level_export_uninitialized_fields(): Unit = {
+  @Test def topLevelExportUninitializedFields(): Unit = {
     assertEquals(0, TopLevelFieldExports.uninitializedVarInt)
     assertEquals(0L, TopLevelFieldExports.uninitializedVarLong)
     assertEquals(null, TopLevelFieldExports.uninitializedVarString)
@@ -1439,7 +1439,7 @@ class ExportsTest {
     }
   }
 
-  @Test def top_level_export_field_is_always_reachable_and_initialized(): Unit = {
+  @Test def topLevelExportFieldIsAlwaysReachableAndInitialized(): Unit = {
     if (isNoModule) {
       assertEquals("Hello World", global.TopLevelExport_fieldreachability)
     } else {
@@ -1447,7 +1447,7 @@ class ExportsTest {
     }
   }
 
-  @Test def top_level_export_field_is_writable_accross_modules(): Unit = {
+  @Test def topLevelExportFieldIsWritableAccrossModules(): Unit = {
     /* We write to basicVar exported above from a different object to test writing
      * of static fields accross module boundaries (when module splitting is
      * enabled).

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
@@ -23,7 +23,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
 
 class FunctionTest {
 
-  @Test def should_support_call_with_expanded_arguments(): Unit = {
+  @Test def expandedArguments(): Unit = {
     val f = js.eval("""
         var f = function() { return arguments; }; f;
     """).asInstanceOf[js.Function]
@@ -34,7 +34,7 @@ class FunctionTest {
     assertFalse(res.contains("2"))
   }
 
-  @Test def `should_support_call_with_the_:_*_notation_to_expand_a_Seq`(): Unit = {
+  @Test def expandSeqWithUnderscoreAsteriskNotation(): Unit = {
     val f = js.eval("""
         var f = function() { return arguments; }; f;
     """).asInstanceOf[js.Function]

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
@@ -25,13 +25,13 @@ import org.junit.Test
 class JSExportStaticTest {
   // Methods
 
-  @Test def toplevel_basic_static_method_export(): Unit = {
+  @Test def toplevelBasicStaticMethodExport(): Unit = {
     val statics = js.constructorOf[TopLevelStaticExportMethods]
 
     assertEquals(1, statics.basic())
   }
 
-  @Test def toplevel_overloaded_static_method_export(): Unit = {
+  @Test def toplevelOverloadedStaticMethodExport(): Unit = {
     val statics = js.constructorOf[TopLevelStaticExportMethods]
 
     assertEquals("Hello World", statics.overload("World"))
@@ -40,13 +40,13 @@ class JSExportStaticTest {
     assertEquals(10, statics.overload(1, 2, 3, 4))
   }
 
-  @Test def toplevel_renamed_static_method_export(): Unit = {
+  @Test def toplevelRenamedStaticMethodExport(): Unit = {
     val statics = js.constructorOf[TopLevelStaticExportMethods]
 
     assertEquals(11, statics.renamed(8))
   }
 
-  @Test def toplevel_renamed_overloaded_static_method_export(): Unit = {
+  @Test def toplevelRenamedOverloadedStaticMethodExport(): Unit = {
     val statics = js.constructorOf[TopLevelStaticExportMethods]
 
     assertEquals("Hello World", statics.renamedOverload("World"))
@@ -55,13 +55,13 @@ class JSExportStaticTest {
     assertEquals(10, statics.renamedOverload(1, 2, 3, 4))
   }
 
-  @Test def toplevel_static_method_export_constructor(): Unit = {
+  @Test def toplevelStaticMethodExportConstructor(): Unit = {
     val statics = js.constructorOf[TopLevelStaticExportMethods]
 
     assertEquals(24, statics.constructor(12))
   }
 
-  @Test def toplevel_static_method_export_uses_unique_object(): Unit = {
+  @Test def toplevelStaticMethodExportUsesUniqueObject(): Unit = {
     val statics = js.constructorOf[TopLevelStaticExportMethods]
 
     statics.setMyVar(3)
@@ -70,7 +70,7 @@ class JSExportStaticTest {
     assertEquals(7, TopLevelStaticExportMethods.myVar)
   }
 
-  @Test def toplevel_static_method_export_also_exists_in_member(): Unit = {
+  @Test def toplevelStaticMethodExportAlsoExistsInMember(): Unit = {
     val statics = js.constructorOf[TopLevelStaticExportMethods]
     assertEquals(15, statics.alsoExistsAsMember(3))
 
@@ -78,13 +78,13 @@ class JSExportStaticTest {
     assertEquals(6, obj.alsoExistsAsMember(3))
   }
 
-  @Test def nested_basic_static_method_export(): Unit = {
+  @Test def nestedBasicStaticMethodExport(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportMethods]
 
     assertEquals(1, statics.basic())
   }
 
-  @Test def nested_overloaded_static_method_export(): Unit = {
+  @Test def nestedOverloadedStaticMethodExport(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportMethods]
 
     assertEquals("Hello World", statics.overload("World"))
@@ -93,13 +93,13 @@ class JSExportStaticTest {
     assertEquals(10, statics.overload(1, 2, 3, 4))
   }
 
-  @Test def nested_renamed_static_method_export(): Unit = {
+  @Test def nestedRenamedStaticMethodExport(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportMethods]
 
     assertEquals(11, statics.renamed(8))
   }
 
-  @Test def nested_renamed_overloaded_static_method_export(): Unit = {
+  @Test def nestedRenamedOverloadedStaticMethodExport(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportMethods]
 
     assertEquals("Hello World", statics.renamedOverload("World"))
@@ -108,13 +108,13 @@ class JSExportStaticTest {
     assertEquals(10, statics.renamedOverload(1, 2, 3, 4))
   }
 
-  @Test def nested_static_method_export_constructor(): Unit = {
+  @Test def nestedStaticMethodExportConstructor(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportMethods]
 
     assertEquals(24, statics.constructor(12))
   }
 
-  @Test def nested_static_method_export_uses_unique_object(): Unit = {
+  @Test def nestedStaticMethodExportUsesUniqueObject(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportMethods]
 
     statics.setMyVar(3)
@@ -123,7 +123,7 @@ class JSExportStaticTest {
     assertEquals(7, JSExportStaticTest.StaticExportMethods.myVar)
   }
 
-  @Test def nested_static_method_export_also_exists_in_member(): Unit = {
+  @Test def nestedStaticMethodExportAlsoExistsInMember(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportMethods]
     assertEquals(15, statics.alsoExistsAsMember(3))
 
@@ -133,13 +133,13 @@ class JSExportStaticTest {
 
   // Properties
 
-  @Test def basic_static_prop_readonly(): Unit = {
+  @Test def basicStaticPropReadonly(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
 
     assertEquals(1, statics.basicReadOnly)
   }
 
-  @Test def basic_static_prop_readwrite(): Unit = {
+  @Test def basicStaticPropReadwrite(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
 
     assertEquals(5, statics.basicReadWrite)
@@ -147,7 +147,7 @@ class JSExportStaticTest {
     assertEquals(15, statics.basicReadWrite)
   }
 
-  @Test def static_prop_set_wrong_type_throws_classcastexception(): Unit = {
+  @Test def staticPropSetWrongTypeThrowsClassCastException(): Unit = {
     assumeTrue("assuming compliant asInstanceOfs", hasCompliantAsInstanceOfs)
 
     val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
@@ -157,7 +157,7 @@ class JSExportStaticTest {
     })
   }
 
-  @Test def overloaded_static_prop_setter(): Unit = {
+  @Test def overloadedStaticPropSetter(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
 
     assertEquals("got: ", statics.overloadedSetter)
@@ -167,7 +167,7 @@ class JSExportStaticTest {
     assertEquals("got: foo10", statics.overloadedSetter)
   }
 
-  @Test def overloaded_static_prop_renamed(): Unit = {
+  @Test def overloadedStaticPropRenamed(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
 
     assertEquals(5, statics.renamed)
@@ -177,13 +177,13 @@ class JSExportStaticTest {
     assertEquals(21, statics.renamed)
   }
 
-  @Test def static_prop_constructor(): Unit = {
+  @Test def staticPropConstructor(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
 
     assertEquals(102, statics.constructor)
   }
 
-  @Test def static_prop_also_exists_in_member(): Unit = {
+  @Test def staticPropAlsoExistsInMember(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportProperties]
     assertEquals("also a member", statics.alsoExistsAsMember)
 
@@ -193,7 +193,7 @@ class JSExportStaticTest {
 
   // Fields
 
-  @Test def basic_field(): Unit = {
+  @Test def basicField(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportFields]
 
     // Initialization
@@ -215,7 +215,7 @@ class JSExportStaticTest {
     JSExportStaticTest.StaticExportFields.basicVar = "hello"
   }
 
-  @Test def read_tampered_var_causes_class_cast_exception(): Unit = {
+  @Test def readTamperedVarCausesClassCastException(): Unit = {
     assumeTrue("assuming compliant asInstanceOfs", hasCompliantAsInstanceOfs)
 
     val statics = js.constructorOf[JSExportStaticTest.StaticExportFields]
@@ -230,7 +230,7 @@ class JSExportStaticTest {
     JSExportStaticTest.StaticExportFields.basicVar = "hello"
   }
 
-  @Test def renamed_field(): Unit = {
+  @Test def renamedField(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportFields]
 
     // Initialization
@@ -253,7 +253,7 @@ class JSExportStaticTest {
     JSExportStaticTest.StaticExportFields.renamedBasicVar = "world"
   }
 
-  @Test def uninitialized_fields(): Unit = {
+  @Test def uninitializedFields(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportFields]
 
     assertEquals(0, JSExportStaticTest.StaticExportFields.uninitializedVarInt)
@@ -268,7 +268,7 @@ class JSExportStaticTest {
     assertEquals('\u0000', statics.uninitializedVarChar)
   }
 
-  @Test def field_also_exists_in_member(): Unit = {
+  @Test def fieldAlsoExistsInMember(): Unit = {
     val statics = js.constructorOf[JSExportStaticTest.StaticExportFields]
     assertEquals("hello", statics.alsoExistsAsMember)
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSNameTest.scala
@@ -21,41 +21,41 @@ import org.junit.Test
 class JSNameTest {
   import JSNameTest._
 
-  @Test def should_work_with_defs_that_are_properties(): Unit = {
+  @Test def defsThatAreProperties(): Unit = {
     val obj = js.Dynamic.literal(jsDef = 1).asInstanceOf[PropDefFacade]
     assertEquals(1, obj.internalDef)
   }
 
-  @Test def should_work_with_vals(): Unit = {
+  @Test def vals(): Unit = {
     val obj = js.Dynamic.literal(jsVal = "hi").asInstanceOf[PropValFacade]
     assertEquals("hi", obj.internalVal)
   }
 
-  @Test def should_work_with_vars(): Unit = {
+  @Test def vars(): Unit = {
     val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarFacade]
     assertEquals(0.1, obj.internalVar, 0.0)
     obj.internalVar = 0.2
     assertEquals(0.2, obj.internalVar, 0.0)
   }
 
-  @Test def should_work_with_defs_that_are_properties_in_Scala_js_defined_trait_issue_2197(): Unit = {
+  @Test def defsThatArePropertiesInScalaJSDefinedTrait_Issue2197(): Unit = {
     val obj = js.Dynamic.literal(jsDef = 1).asInstanceOf[PropDefSJSDefined]
     assertEquals(1, obj.internalDef)
   }
 
-  @Test def should_work_with_vals_in_Scala_js_defined_trait_issue_2197(): Unit = {
+  @Test def valsInScalaJSDefinedTrait_Issue2197(): Unit = {
     val obj = js.Dynamic.literal(jsVal = "hi").asInstanceOf[PropValSJSDefined]
     assertEquals("hi", obj.internalVal)
   }
 
-  @Test def should_work_with_vars_in_Scala_js_defined_trait_issue_2197(): Unit = {
+  @Test def varsInScalaJSDefinedTrait_Issue2197(): Unit = {
     val obj = js.Dynamic.literal(jsVar = 0.1).asInstanceOf[PropVarSJSDefined]
     assertEquals(0.1, obj.internalVar, 0.0)
     obj.internalVar = 0.2
     assertEquals(0.2, obj.internalVar, 0.0)
   }
 
-  @Test def should_allow_names_ending_in__=(): Unit = {
+  @Test def namesEndingInUnderscoreEquals(): Unit = {
     val d = js.Dynamic.literal("a_=" -> 1)
     val f = d.asInstanceOf[UndEqNamed]
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -23,7 +23,7 @@ class JSSymbolTest {
   import JSSymbolTest._
   import SJSDefinedWithSyms._
 
-  @Test def native_with_defs_that_are_properties(): Unit = {
+  @Test def nativeWithDefsThatAreProperties(): Unit = {
     val obj = mkObject(sym1 -> 1)
 
     assertEquals(1, obj.asInstanceOf[PropDefClass].internalDef)
@@ -31,7 +31,7 @@ class JSSymbolTest {
     assertEquals(1, selectSymbol(obj, sym1))
   }
 
-  @Test def sjsdefined_with_defs_that_are_properties(): Unit = {
+  @Test def sjsdefinedWithDefsThatAreProperties(): Unit = {
     val obj = new SJSDefinedPropDef
     assertEquals(456, obj.internalDef)
 
@@ -41,7 +41,7 @@ class JSSymbolTest {
     assertEquals(456, selectSymbol(obj, sym1))
   }
 
-  @Test def native_with_vals(): Unit = {
+  @Test def nativeWithVals(): Unit = {
     val obj = mkObject(sym1 -> "hi")
 
     assertEquals("hi", obj.asInstanceOf[PropValClass].internalVal)
@@ -49,7 +49,7 @@ class JSSymbolTest {
     assertEquals("hi", selectSymbol(obj, sym1))
   }
 
-  @Test def sjsdefined_with_vals(): Unit = {
+  @Test def sjsdefinedWithVals(): Unit = {
     val obj = new SJSDefinedPropVal
     assertEquals("hello", obj.internalVal)
 
@@ -59,7 +59,7 @@ class JSSymbolTest {
     assertEquals("hello", selectSymbol(obj, sym1))
   }
 
-  @Test def native_with_vars(): Unit = {
+  @Test def nativeWithVars(): Unit = {
     val obj0 = mkObject(sym1 -> 0.1).asInstanceOf[PropVarClass]
     assertEquals(0.1, obj0.internalVar, 0.0)
     obj0.internalVar = 0.2
@@ -76,7 +76,7 @@ class JSSymbolTest {
     assertEquals(8.2, selectSymbol(obj2, sym1))
   }
 
-  @Test def sjsdefined_with_vars(): Unit = {
+  @Test def sjsdefinedWithVars(): Unit = {
     val obj0 = new SJSDefinedPropVar
     assertEquals(1511.1989, obj0.internalVar, 0.0)
     obj0.internalVar = 0.2
@@ -93,7 +93,7 @@ class JSSymbolTest {
     assertEquals(8.2, selectSymbol(obj2, sym1))
   }
 
-  @Test def sjsdefined_with_inner_object(): Unit = {
+  @Test def sjsdefinedWithInnerObject(): Unit = {
     val obj0 = new SJSDefinedInnerObject
     assertEquals("object", js.typeOf(obj0.innerObject.asInstanceOf[js.Any]))
     assertEquals("SJSDefinedInnerObject.innerObject", obj0.innerObject.toString())
@@ -108,7 +108,7 @@ class JSSymbolTest {
         selectSymbol(obj1, sym1).toString())
   }
 
-  @Test def native_with_methods(): Unit = {
+  @Test def nativeWithMethods(): Unit = {
     val obj = mkObject(
         sym1 -> ((x: Int) => x + 2),
         sym2 -> ((x: String) => "Hello " + x)
@@ -124,7 +124,7 @@ class JSSymbolTest {
     assertEquals("Hello Moon", callSymbol(obj, sym2)("Moon"))
   }
 
-  @Test def sjsdefined_with_methods(): Unit = {
+  @Test def sjsdefinedWithMethods(): Unit = {
     val obj = new SJSDefinedMethod
     assertEquals(4, obj.foo(2))
     assertEquals("Hello World", obj.bar("World"))
@@ -137,7 +137,7 @@ class JSSymbolTest {
     assertEquals("Hello Moon", callSymbol(obj, sym2)("Moon"))
   }
 
-  @Test def native_with_overloaded_methods(): Unit = {
+  @Test def nativeWithOverloadedMethods(): Unit = {
     val obj = mkObject(
         sym1 -> ((x: Int) => x + 3),
         sym2 -> ((x: String) => "Hello " + x)
@@ -153,7 +153,7 @@ class JSSymbolTest {
     assertEquals("Hello Moon", callSymbol(obj, sym2)("Moon"))
   }
 
-  @Test def sjsdefined_with_overloaded_methods(): Unit = {
+  @Test def sjsdefinedWithOverloadedMethods(): Unit = {
     val obj = new SJSDefinedOverloadedMethod
     assertEquals(5, obj.foo(2))
     assertEquals("Hello World", obj.foo("World"))
@@ -166,7 +166,7 @@ class JSSymbolTest {
     assertEquals("Hello Moon", callSymbol(obj, sym2)("Moon"))
   }
 
-  @Test def native_with_overloaded_runtime_dispatch_methods(): Unit = {
+  @Test def nativeWithOverloadedRuntimeDispatchMethods(): Unit = {
     val obj = mkObject(
         sym1 -> { (x: Any) =>
           x match {
@@ -190,7 +190,7 @@ class JSSymbolTest {
     assertEquals("Hello Moon", callSymbol(obj, sym1)("Moon"))
   }
 
-  @Test def sjsdefined_with_overloaded_runtime_dispatch_methods(): Unit = {
+  @Test def sjsdefinedWithOverloadedRuntimeDispatchMethods(): Unit = {
     val obj = new SJSDefinedOverloadedRuntimeDispatchMethod
     assertEquals(5, obj.foo(2))
     assertEquals("Hello World", obj.foo("World"))
@@ -203,7 +203,7 @@ class JSSymbolTest {
     assertEquals("Hello Moon", callSymbol(obj, sym1)("Moon"))
   }
 
-  @Test def native_with_symbols_in_sjsdefined_object(): Unit = {
+  @Test def nativeWithSymbolsInSjsdefinedObject(): Unit = {
     val obj = mkObject(
         sym3 -> ((x: Int) => x + 2)
     )
@@ -216,7 +216,7 @@ class JSSymbolTest {
     assertEquals(65, callSymbol(obj, sym3)(63))
   }
 
-  @Test def sjsdefined_with_symbols_in_sjsdefined_object(): Unit = {
+  @Test def sjsdefinedWithSymbolsInSjsdefinedObject(): Unit = {
     val obj = new SJSDefinedWithSymsInSJSDefinedObject
     assertEquals(65, obj.symInSJSDefinedObject(63))
 
@@ -226,7 +226,7 @@ class JSSymbolTest {
     assertEquals(65, callSymbol(obj, sym3)(63))
   }
 
-  @Test def native_iterable(): Unit = {
+  @Test def nativeIterable(): Unit = {
     val obj = mkObject(
         js.Symbol.iterator -> (() => singletonIterator(653))
     )
@@ -241,7 +241,7 @@ class JSSymbolTest {
     assertArrayEquals(Array(653), content.result())
   }
 
-  @Test def sjsdefined_iterable(): Unit = {
+  @Test def sjsdefinedIterable(): Unit = {
     val obj = new SJSDefinedIterable
 
     assertArrayEquals(Array(532), iterableToArray(obj).toArray)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -27,7 +27,7 @@ class MiscInteropTest {
 
   // scala.scalajs.js.package
 
-  @Test def should_provide_an_equivalent_to_typeof_x(): Unit = {
+  @Test def equivalentToTypeOf(): Unit = {
     import js.typeOf
     assertEquals("number", typeOf(5))
     assertEquals("boolean", typeOf(false))
@@ -38,7 +38,7 @@ class MiscInteropTest {
     assertEquals("function", typeOf((() => 42): js.Function))
   }
 
-  @Test def testTypeofWithGlobalRefs_issue3822(): Unit = {
+  @Test def testTypeOfWithGlobalRefs_Issue3822(): Unit = {
     assumeFalse(
         "GCC wrongly optimizes this code, " +
         "see https://github.com/google/closure-compiler/issues/3498",
@@ -58,13 +58,13 @@ class MiscInteropTest {
         js.typeOf(nonExistentGlobalVarInline()))
   }
 
-  @Test def js_constructorOf_T_for_native_classes(): Unit = {
+  @Test def jsConstructorOfTForNativeClasses(): Unit = {
     assertSame(js.Dynamic.global.RegExp, js.constructorOf[js.RegExp])
     assertSame(js.Dynamic.global.Array, js.constructorOf[js.Array[_]])
     assertSame(js.Dynamic.global.Array, js.constructorOf[js.Array[Int]])
   }
 
-  @Test def js_constructorOf_T_for_Scala_js_defined_JS_classes(): Unit = {
+  @Test def jsConstructorOfTForScalaJSDefinedJSClasses(): Unit = {
     val concreteCtor = (new ConcreteJSClass).asInstanceOf[js.Dynamic].constructor
     val concreteProto = concreteCtor.prototype.asInstanceOf[js.Object]
     val abstractProto = js.Object.getPrototypeOf(concreteProto)
@@ -81,7 +81,7 @@ class MiscInteropTest {
     assertEquals(35, instance.x)
   }
 
-  @Test def js_constructorTag_T_for_native_classes(): Unit = {
+  @Test def jsConstructorTagTForNativeClasses(): Unit = {
     def test[T <: js.Any: js.ConstructorTag](expected: js.Dynamic): Unit =
       assertSame(expected, js.constructorTag[T].constructor)
 
@@ -90,7 +90,7 @@ class MiscInteropTest {
     test[js.Array[Int]](js.Dynamic.global.Array)
   }
 
-  @Test def js_constructorTag_T_for_Scala_js_defined_JS_classes(): Unit = {
+  @Test def jsConstructorTagTForScalaJSDefinedJSClasses(): Unit = {
     def test[T <: js.Any: js.ConstructorTag](expected: js.Dynamic): Unit =
       assertSame(expected, js.constructorTag[T].constructor)
 
@@ -133,14 +133,14 @@ class MiscInteropTest {
 
   // scala.scalajs.js.Object
 
-  @Test def should_provide_an_equivalent_to_p_in_o(): Unit = {
+  @Test def equivalentToPInO(): Unit = {
     val o = js.Dynamic.literal(foo = 5, bar = "foobar")
     assertTrue(js.Object.hasProperty(o, "foo"))
     assertFalse(js.Object.hasProperty(o, "foobar"))
     assertTrue(js.Object.hasProperty(o, "toString")) // in prototype
   }
 
-  @Test def should_respect_evaluation_order_for_hasProperty(): Unit = {
+  @Test def evaluationOrderForHasProperty(): Unit = {
     var indicator = 3
     def o(): js.Object = {
       indicator += 4
@@ -154,7 +154,7 @@ class MiscInteropTest {
     assertEquals(14, indicator)
   }
 
-  @Test def should_provide_equivalent_of_JS_for_in_loop_of_issue_13(): Unit = {
+  @Test def equivalentOfJSForInLoopOf_Issue13(): Unit = {
     val obj = js.eval("var dictionaryTest13 = { a: 'Scala.js', b: 7357 }; dictionaryTest13;")
     val dict = obj.asInstanceOf[js.Dictionary[js.Any]]
     var propCount = 0
@@ -169,7 +169,7 @@ class MiscInteropTest {
     assertEquals("Scala.js7357", propString)
   }
 
-  @Test def should_provide_equivalent_of_JS_for_in_loop2_of_issue_13(): Unit = {
+  @Test def equivalentOfJSForInLoop2Of_Issue13(): Unit = {
     val obj = js.eval("var arrayTest13 = [ 7, 3, 5, 7 ]; arrayTest13;")
     val array = obj.asInstanceOf[js.Dictionary[js.Any]]
     var propCount = 0
@@ -184,11 +184,11 @@ class MiscInteropTest {
     assertEquals("7357", propString)
   }
 
-  @Test def should_compile_js_undefined(): Unit = {
+  @Test def compileJSUndefined(): Unit = {
     assertThrows(classOf[Exception], js.undefined.asInstanceOf[js.Dynamic].toFixed())
   }
 
-  @Test def should_allow_to_define_direct_subtraits_of_js_Any(): Unit = {
+  @Test def defineDirectSubtraitsOfJSAny(): Unit = {
     val f = js.Dynamic.literal(
       foo = (x: Int) => x + 1
     ).asInstanceOf[DirectSubtraitOfJSAny]
@@ -196,7 +196,7 @@ class MiscInteropTest {
     assertEquals(6, f.foo(5))
   }
 
-  @Test def should_allow_to_define_direct_subclasses_of_js_Any(): Unit = {
+  @Test def defineDirectSubclassesOfJSAny(): Unit = {
     val f = js.Dynamic.literal(
       bar = (x: Int) => x + 2
     ).asInstanceOf[DirectSubclassOfJSAny]
@@ -206,13 +206,13 @@ class MiscInteropTest {
 
   // Global scope
 
-  @Test def canRead_undefined_inGlobalScope_issue3821(): Unit = {
+  @Test def canReadUndefinedInGlobalScope_Issue3821(): Unit = {
     assertEquals((), js.Dynamic.global.undefined)
   }
 
   // Emitted classes
 
-  @Test def should_have_a_meaningful_name_property(): Unit = {
+  @Test def meaningfulNameProperty(): Unit = {
     assumeFalse("Assumed not executing in FullOpt", isInFullOpt)
 
     def nameOf(obj: Any): js.Any =

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NestedJSClassTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NestedJSClassTest.scala
@@ -23,7 +23,7 @@ import org.junit.Test
 class NestedJSClassTest {
   import NestedJSClassTest._
 
-  @Test def innerJSClass_basics(): Unit = {
+  @Test def innerJSClassBasics(): Unit = {
     val container1 = new ScalaClassContainer("hello")
     val innerJSClass = container1.getInnerJSClass
     assertSame(innerJSClass, container1.getInnerJSClass)
@@ -56,7 +56,7 @@ class NestedJSClassTest {
     assertFalse(js.special.instanceof(inner3, innerJSClass))
   }
 
-  @Test def localJSClass_basics(): Unit = {
+  @Test def localJSClassBasics(): Unit = {
     val container1 = new ScalaClassContainer("hello")
     val localJSClass1 = container1.makeLocalJSClass("wide1")
     assertEquals("function", js.typeOf(localJSClass1))
@@ -82,7 +82,7 @@ class NestedJSClassTest {
     assertFalse(inner3.isInstanceOf[container1.InnerJSClass])
   }
 
-  @Test def innerJSClass_basicsInsideTrait(): Unit = {
+  @Test def innerJSClassBasicsInsideTrait(): Unit = {
     val container1 = new ScalaTraitContainerSubclass("hello")
     val innerJSClass = container1.getInnerJSClass
     assertSame(innerJSClass, container1.getInnerJSClass)
@@ -115,7 +115,7 @@ class NestedJSClassTest {
     assertFalse(js.special.instanceof(inner3, innerJSClass))
   }
 
-  @Test def localJSClass_basicsInsideTrait(): Unit = {
+  @Test def localJSClassBasicsInsideTrait(): Unit = {
     val container1 = new ScalaTraitContainerSubclass("hello")
     val localJSClass1 = container1.makeLocalJSClass("wide1")
     assertEquals("function", js.typeOf(localJSClass1))
@@ -141,7 +141,7 @@ class NestedJSClassTest {
     assertFalse(inner3.isInstanceOf[container1.InnerJSClass])
   }
 
-  @Test def innerJSObject_basics(): Unit = {
+  @Test def innerJSObjectBasics(): Unit = {
     val container1 = new ScalaClassContainerWithObject("hello")
     val inner1 = container1.InnerJSObject
     assertSame(inner1, container1.InnerJSObject)
@@ -162,7 +162,7 @@ class NestedJSClassTest {
     assertFalse(inner2.isInstanceOf[container1.InnerJSObject.type])
   }
 
-  @Test def localJSObject_basics(): Unit = {
+  @Test def localJSObjectBasics(): Unit = {
     val container1 = new ScalaClassContainerWithObject("hello")
     val inner1 = container1.makeLocalJSObject("world1")
 
@@ -338,7 +338,7 @@ class NestedJSClassTest {
     assertTrue(localJSObject.isInstanceOf[parentsContainer.GenericJSSuperClass[_, _]])
   }
 
-  @Test def innerJSClass_basicsInsideJSClass(): Unit = {
+  @Test def innerJSClassBasicsInsideJSClass(): Unit = {
     val container1 = new JSClassContainer("hello")
     val innerJSClass = container1.getInnerJSClass
     assertSame(innerJSClass, container1.getInnerJSClass)
@@ -375,7 +375,7 @@ class NestedJSClassTest {
     assertFalse(js.special.instanceof(inner3, innerJSClass))
   }
 
-  @Test def innerJSClass_accessibleFromJS_ifInsideJSClass(): Unit = {
+  @Test def innerJSClassAccessibleFromJSIfInsideJSClass(): Unit = {
     val container1 = new JSClassContainer("hello")
     val innerJSClass = container1.asInstanceOf[js.Dynamic].getInnerJSClass
     assertSame(innerJSClass, container1.getInnerJSClass)
@@ -402,7 +402,7 @@ class NestedJSClassTest {
     assertFalse(js.special.instanceof(inner3, innerJSClass))
   }
 
-  @Test def innerJSClassObject_accessibleFromJS_ifInsideTopJSObject_issue4086(): Unit = {
+  @Test def innerJSClassObjectAccessibleFromJSIfInsideTopJSObject_Issue4086(): Unit = {
     val container = NestedJSClassTest_TopLevelJSObject_Issue4086.asInstanceOf[js.Dynamic]
 
     assertEquals("object", js.typeOf(container.InnerScalaObject))
@@ -425,7 +425,7 @@ class NestedJSClassTest {
     assertEquals("InnerJSClass(5) of issue 4086", obj.toString())
   }
 
-  @Test def doublyNestedInnerObject_issue4114(): Unit = {
+  @Test def doublyNestedInnerObject_Issue4114(): Unit = {
     val outer1 = new DoublyNestedInnerObject_Issue4114().asInstanceOf[js.Dynamic]
     val outer2 = new DoublyNestedInnerObject_Issue4114().asInstanceOf[js.Dynamic]
 
@@ -436,7 +436,7 @@ class NestedJSClassTest {
     assertEquals(10, outer2.middle.inner.x)
   }
 
-  @Test def triplyNestedObject_issue4114(): Unit = {
+  @Test def triplyNestedObject_Issue4114(): Unit = {
     val obj = TriplyNestedObject_Issue4114.asInstanceOf[js.Dynamic]
 
     assertEquals("object", js.typeOf(obj.middle))
@@ -448,7 +448,7 @@ class NestedJSClassTest {
     assertEquals(10, obj.middle.inner.x)
   }
 
-  @Test def triplyNestedClassSuperDispatch_issue4114(): Unit = {
+  @Test def triplyNestedClassSuperDispatch_Issue4114(): Unit = {
     val x = new TriplyNestedClass_Issue4114().asInstanceOf[js.Dynamic]
     assertEquals(3, x.foo(3))
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
@@ -27,7 +27,7 @@ class NonNativeJSTypeTest {
   import org.scalajs.testsuite.jsinterop.{NonNativeJSTypeTestSeparateRun => SepRun}
   import NonNativeJSTypeTest._
 
-  @Test def minimal_definition(): Unit = {
+  @Test def minimalDefinition(): Unit = {
     val obj = new Minimal
     assertEquals("object", js.typeOf(obj))
     assertEquals(List[String](), js.Object.keys(obj).toList)
@@ -39,7 +39,7 @@ class NonNativeJSTypeTest {
     assertFalse((obj: Any).isInstanceOf[js.Error])
   }
 
-  @Test def minimal_static_object_with_lazy_initialization(): Unit = {
+  @Test def minimalStaticObjectWithLazyInitialization(): Unit = {
     assertEquals(0, staticNonNativeObjectInitCount)
     val obj = StaticNonNativeObject
     assertEquals(1, staticNonNativeObjectInitCount)
@@ -56,7 +56,7 @@ class NonNativeJSTypeTest {
     assertFalse((obj: Any).isInstanceOf[js.Error])
   }
 
-  @Test def simple_method(): Unit = {
+  @Test def simpleMethod(): Unit = {
     val obj = new SimpleMethod
     assertEquals(8, obj.foo(5))
     assertEquals("hello42", obj.bar("hello", 42))
@@ -66,7 +66,7 @@ class NonNativeJSTypeTest {
     assertEquals("hello42", dyn.bar("hello", 42))
   }
 
-  @Test def static_object_with_simple_method(): Unit = {
+  @Test def staticObjectWithSimpleMethod(): Unit = {
     val obj = StaticObjectSimpleMethod
     assertEquals(8, obj.foo(5))
     assertEquals("hello42", obj.bar("hello", 42))
@@ -76,7 +76,7 @@ class NonNativeJSTypeTest {
     assertEquals("hello42", dyn.bar("hello", 42))
   }
 
-  @Test def simple_field(): Unit = {
+  @Test def simpleField(): Unit = {
     val obj = new SimpleField
     assertEquals(List("x", "y"), js.Object.keys(obj).toList)
     assertEquals(5, obj.x)
@@ -98,7 +98,7 @@ class NonNativeJSTypeTest {
     assertEquals(94, dyn.sum())
   }
 
-  @Test def static_object_with_simple_field(): Unit = {
+  @Test def staticObjectWithSimpleField(): Unit = {
     val obj = StaticObjectSimpleField
     assertEquals(List("x", "y"), js.Object.keys(obj).toList)
     assertEquals(5, obj.x)
@@ -120,7 +120,7 @@ class NonNativeJSTypeTest {
     assertEquals(94, dyn.sum())
   }
 
-  @Test def simple_accessors(): Unit = {
+  @Test def simpleAccessors(): Unit = {
     val obj = new SimpleAccessors
     assertEquals(List("x"), js.Object.keys(obj).toList)
     assertEquals(1, obj.x)
@@ -143,7 +143,7 @@ class NonNativeJSTypeTest {
     assertEquals(10, dyn.readPlus1)
   }
 
-  @Test def simple_constructor(): Unit = {
+  @Test def simpleConstructor(): Unit = {
     val obj = new SimpleConstructor(5, 10)
     assertEquals(List("x", "y"), js.Object.keys(obj).toList)
     assertEquals(5, obj.x)
@@ -165,7 +165,7 @@ class NonNativeJSTypeTest {
     assertEquals(94, dyn.sum())
   }
 
-  @Test def simple_constructor_with_automatic_fields(): Unit = {
+  @Test def simpleConstructorWithAutomaticFields(): Unit = {
     val obj = new SimpleConstructorAutoFields(5, 10)
     assertEquals(List("x", "y"), js.Object.keys(obj).toList)
     assertEquals(5, obj.x)
@@ -187,7 +187,7 @@ class NonNativeJSTypeTest {
     assertEquals(94, dyn.sum())
   }
 
-  @Test def simple_constructor_with_param_accessors(): Unit = {
+  @Test def simpleConstructorWithParamAccessors(): Unit = {
     val obj = new SimpleConstructorParamAccessors(5, 10)
     assertNotEquals(Array("x", "y"), js.Object.keys(obj).toArray)
     assertEquals(15, obj.sum())
@@ -196,12 +196,12 @@ class NonNativeJSTypeTest {
     assertEquals(15, dyn.sum())
   }
 
-  @Test def constructor_with_param_name_clashes_issue_3933(): Unit = {
+  @Test def constructorWithParamNameClashes_Issue3933(): Unit = {
     val obj = new ConstructorWithParamNameClashes(1, 2, 3, 4, 5, 6)
     assertEquals(List(1, 2, 3, 4, 5, 6), obj.allArgs)
   }
 
-  @Test def default_values_for_fields(): Unit = {
+  @Test def defaultValuesForFields(): Unit = {
     val obj = new DefaultFieldValues
     assertEquals(0, obj.int)
     assertEquals(false, obj.bool)
@@ -215,7 +215,7 @@ class NonNativeJSTypeTest {
      */
   }
 
-  @Test def lazy_vals(): Unit = {
+  @Test def lazyVals(): Unit = {
     val obj1 = new LazyValFields()
     assertEquals(0, obj1.initCount)
     assertEquals(42, obj1.field)
@@ -250,7 +250,7 @@ class NonNativeJSTypeTest {
     assertEquals(1, obj3.initCount)
   }
 
-  @Test def override_lazy_vals(): Unit = {
+  @Test def overrideLazyVals(): Unit = {
     val obj1 = new OverrideLazyValFields()
     assertEquals(0, obj1.initCount)
     assertEquals(53, obj1.field)
@@ -278,11 +278,11 @@ class NonNativeJSTypeTest {
     assertEquals(1, obj2.initCount)
   }
 
-  @Test def nullingOutLazyValField_issue3422(): Unit = {
+  @Test def nullingOutLazyValField_Issue3422(): Unit = {
     assertEquals("foo", new NullingOutLazyValFieldBug3422("foo").str)
   }
 
-  @Test def simple_inherited_from_a_native_class(): Unit = {
+  @Test def simpleInheritedFromNativeClass(): Unit = {
     val obj = new SimpleInheritedFromNative(3, 5)
     assertEquals(3, obj.x)
     assertEquals(5, obj.y)
@@ -291,7 +291,7 @@ class NonNativeJSTypeTest {
     assertTrue(obj.isInstanceOf[NativeParentClass])
   }
 
-  @Test def double_underscore_in_member_names_issue_3784(): Unit = {
+  @Test def doubleUnderscoreInMemberNames_Issue3784(): Unit = {
     class DoubleUnderscoreInMemberNames extends js.Object {
       val x__y: String = "xy"
       def foo__bar(x: Int): Int = x + 1
@@ -304,7 +304,7 @@ class NonNativeJSTypeTest {
     assertEquals("babar", obj.ba__bar)
   }
 
-  @Test def lambda_inside_a_method_issue_2220(): Unit = {
+  @Test def lambdaInsideMethod_Issue2220(): Unit = {
     class LambdaInsideMethod extends js.Object {
       def foo(): Int = {
         List(1, 2, 3).map(_ * 2).sum
@@ -314,7 +314,7 @@ class NonNativeJSTypeTest {
     assertEquals(12, new LambdaInsideMethod().foo())
   }
 
-  @Test def nested_inside_a_Scala_class(): Unit = {
+  @Test def nestedInsideScalaClass(): Unit = {
     class OuterScalaClass(val x: Int) {
       class InnerJSClass(val y: Int) extends js.Object {
         def sum(z: Int): Int = x + y + z
@@ -327,7 +327,7 @@ class NonNativeJSTypeTest {
     assertEquals(20, obj.sum(11))
   }
 
-  @Test def nested_inside_a_Scala_js_defined_JS_class(): Unit = {
+  @Test def nestedInsideScalaJSDefinedJSClass(): Unit = {
     class OuterJSClass(val x: Int) extends js.Object {
       class InnerJSClass(val y: Int) extends js.Object {
         def sum(z: Int): Int = x + y + z
@@ -340,7 +340,7 @@ class NonNativeJSTypeTest {
     assertEquals(20, obj.sum(11))
   }
 
-  @Test def Scala_class_nested_inside_a_Scala_js_defined_JS_class(): Unit = {
+  @Test def scalaClassNestedInsideScalaJSDefinedJSClass(): Unit = {
     class OuterJSClass(val x: Int) extends js.Object {
       class InnerScalaClass(val y: Int) {
         def sum(z: Int): Int = x + y + z
@@ -353,7 +353,7 @@ class NonNativeJSTypeTest {
     assertEquals(20, obj.sum(11))
   }
 
-  @Test def Scala_object_nested_inside_a_Scala_js_defined_JS_class(): Unit = {
+  @Test def scalaObjectNestedInsideScalaJSDefinedJSClass(): Unit = {
     class Foo extends js.Object {
       var innerInitCount: Int = _
 
@@ -380,7 +380,7 @@ class NonNativeJSTypeTest {
   }
 
   // #2772
-  @Test def Scala_object_nested_inside_a_Scala_js_defined_JS_class_JSName(): Unit = {
+  @Test def scalaObjectNestedInsideScalaJSDefinedJSClassJSName(): Unit = {
     class Foo extends js.Object {
       var innerInitCount: Int = _
 
@@ -407,7 +407,7 @@ class NonNativeJSTypeTest {
     assertFalse((inner2: AnyRef) eq inner1)
   }
 
-  @Test def anonymous_class_with_captures(): Unit = {
+  @Test def anonymousClassWithCaptures(): Unit = {
     val x = (() => 5)()
     val obj = new js.Object {
       val y = 10
@@ -419,7 +419,7 @@ class NonNativeJSTypeTest {
     assertEquals(26, dyn.sum(11))
   }
 
-  @Test def anonymous_class_has_no_own_prototype(): Unit = {
+  @Test def anonymousClassHasNoOwnPrototype(): Unit = {
     val obj = new js.Object {
       val x = 1
     }
@@ -429,7 +429,7 @@ class NonNativeJSTypeTest {
         js.constructorOf[js.Object].prototype)
   }
 
-  @Test def local_class_has_own_prototype(): Unit = {
+  @Test def localClassHasOwnPrototype(): Unit = {
     class Local extends js.Object {
       val x = 1
     }
@@ -444,7 +444,7 @@ class NonNativeJSTypeTest {
     assertSame(prototype, js.constructorOf[Local].prototype)
   }
 
-  @Test def anonymous_class_non_trivial_supertype(): Unit = {
+  @Test def anonymousClassNonTrivialSupertype(): Unit = {
     val obj = new SimpleConstructor(1, 2) {
       val z = sum()
     }
@@ -452,7 +452,7 @@ class NonNativeJSTypeTest {
     assertEquals(3, obj.asInstanceOf[js.Dynamic].z)
   }
 
-  @Test def anonymous_class_using_own_method_in_ctor(): Unit = {
+  @Test def anonymousClassUsingOwnMethodInCtor(): Unit = {
     val obj = new js.Object {
       val y = inc(0)
       def inc(x: Int) = x + 1
@@ -461,7 +461,7 @@ class NonNativeJSTypeTest {
     assertEquals(1, obj.asInstanceOf[js.Dynamic].y)
   }
 
-  @Test def anonymous_class_uninitialized_fields(): Unit = {
+  @Test def anonymousClassUninitializedFields(): Unit = {
     val obj = new js.Object {
       var x: String = _
       var y: Int = _
@@ -471,7 +471,7 @@ class NonNativeJSTypeTest {
     assertEquals(0, obj.asInstanceOf[js.Dynamic].y)
   }
 
-  @Test def anonymous_class_field_init_order(): Unit = {
+  @Test def anonymousClassFieldInitOrder(): Unit = {
     val obj = new js.Object {
       val x = getY
       val y = "Hello World"
@@ -483,7 +483,7 @@ class NonNativeJSTypeTest {
     assertEquals("Hello World", obj.y)
   }
 
-  @Test def anonymous_class_dependent_fields(): Unit = {
+  @Test def anonymousClassDependentFields(): Unit = {
     val obj = new js.Object {
       val x = 1
       val y = x + 1
@@ -492,7 +492,7 @@ class NonNativeJSTypeTest {
     assertEquals(2, obj.asInstanceOf[js.Dynamic].y)
   }
 
-  @Test def anonymous_class_use_this_in_ctor(): Unit = {
+  @Test def anonymousClassUseThisInCtor(): Unit = {
     var obj0: js.Object = null
     val obj1 = new js.Object {
       obj0 = this
@@ -501,7 +501,7 @@ class NonNativeJSTypeTest {
     assertSame(obj0, obj1)
   }
 
-  @Test def nested_anonymous_classes(): Unit = {
+  @Test def nestedAnonymousClasses(): Unit = {
     val outer = new js.Object {
       private var _x = 1
       def x = _x
@@ -517,7 +517,7 @@ class NonNativeJSTypeTest {
     assertEquals(2, outer.x)
   }
 
-  @Test def nested_anonymous_classes_and_lambdas(): Unit = {
+  @Test def nestedAnonymousClassesAndLambdas(): Unit = {
     def call(f: Int => js.Any) = f(1)
 
     // Also check that f's capture is properly transformed.
@@ -528,7 +528,7 @@ class NonNativeJSTypeTest {
     assertEquals(1, call(x => x))
   }
 
-  @Test def anonymous_classes_private_fields_are_not_visible_issue2748(): Unit = {
+  @Test def anonymousClassesPrivateFieldsAreNotVisible_Issue2748(): Unit = {
     trait TheOuter extends js.Object {
       val id: String
       val paint: js.UndefOr[TheInner] = js.undefined
@@ -556,7 +556,7 @@ class NonNativeJSTypeTest {
         js.JSON.stringify(r0))
   }
 
-  @Test def local_object_is_lazy(): Unit = {
+  @Test def localObjectIsLazy(): Unit = {
     var initCount: Int = 0
 
     object Obj extends js.Object {
@@ -572,7 +572,7 @@ class NonNativeJSTypeTest {
     assertEquals(1, initCount)
   }
 
-  @Test def local_object_with_captures(): Unit = {
+  @Test def localObjectWithCaptures(): Unit = {
     val x = (() => 5)()
 
     object Obj extends js.Object {
@@ -588,7 +588,7 @@ class NonNativeJSTypeTest {
     assertEquals(26, dyn.sum(11))
   }
 
-  @Test def object_in_Scala_js_defined_JS_class(): Unit = {
+  @Test def objectInScalaJSDefinedJSClass(): Unit = {
     class Foo extends js.Object {
       var innerInitCount: Int = _
 
@@ -614,31 +614,31 @@ class NonNativeJSTypeTest {
     assertNotSame(inner1, inner2)
   }
 
-  @Test def local_defs_must_not_be_exposed(): Unit = {
-    class LocalDefsMustNotBeExposed extends js.Object {
+  @Test def localDefsAreNotExposed(): Unit = {
+    class LocalDefsAreNotExposed extends js.Object {
       def foo(): String = {
         def bar(): String = "hello"
         bar()
       }
     }
 
-    val obj = new LocalDefsMustNotBeExposed
+    val obj = new LocalDefsAreNotExposed
     assertFalse(js.Object.properties(obj).exists(_.contains("bar")))
   }
 
-  @Test def local_objects_must_not_be_exposed(): Unit = {
-    class LocalObjectsMustNotBeExposed extends js.Object {
+  @Test def localObjectsAreNotExposed(): Unit = {
+    class LocalObjectsAreNotExposed extends js.Object {
       def foo(): String = {
         object Bar
         Bar.toString()
       }
     }
 
-    val obj = new LocalObjectsMustNotBeExposed
+    val obj = new LocalObjectsAreNotExposed
     assertFalse(js.Object.properties(obj).exists(_.contains("Bar")))
   }
 
-  @Test def local_defs_with_captures_issue_1975(): Unit = {
+  @Test def localDefsWithCaptures_Issue1975(): Unit = {
     class LocalDefsWithCaptures extends js.Object {
       def foo(suffix: String): String = {
         def bar(): String = "hello " + suffix
@@ -650,7 +650,7 @@ class NonNativeJSTypeTest {
     assertEquals("hello world", obj.foo("world"))
   }
 
-  @Test def methods_with_explicit_name(): Unit = {
+  @Test def methodsWithExplicitName(): Unit = {
     class MethodsWithExplicitName extends js.Object {
       @JSName("theAnswer")
       def bar(): Int = 42
@@ -669,7 +669,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, dyn.doubleTheParam(3))
   }
 
-  @Test def methods_with_constant_folded_name(): Unit = {
+  @Test def methodsWithConstantFoldedName(): Unit = {
     class MethodsWithConstantFoldedName extends js.Object {
       @JSName(JSNameHolder.MethodName)
       def bar(): Int = 42
@@ -683,7 +683,7 @@ class NonNativeJSTypeTest {
     assertEquals(42, dyn.myMethod())
   }
 
-  @Test def protected_methods(): Unit = {
+  @Test def protectedMethods(): Unit = {
     class ProtectedMethods extends js.Object {
       protected def bar(): Int = 42
 
@@ -700,7 +700,7 @@ class NonNativeJSTypeTest {
     assertEquals(100, dyn.foo())
   }
 
-  @Test def readonly_properties(): Unit = {
+  @Test def readonlyProperties(): Unit = {
     // Named classes
     class Foo extends js.Object {
       def bar: Int = 1
@@ -721,7 +721,7 @@ class NonNativeJSTypeTest {
     })
   }
 
-  @Test def properties_are_not_enumerable(): Unit = {
+  @Test def propertiesAreNotEnumerable(): Unit = {
     // Named classes
     class Foo extends js.Object {
       def myProp: Int = 1
@@ -738,7 +738,7 @@ class NonNativeJSTypeTest {
     assertFalse(js.Object.properties(y).contains("myProp"))
   }
 
-  @Test def properties_are_configurable(): Unit = {
+  @Test def propertiesAreConfigurable(): Unit = {
     // Named classes
     class Foo extends js.Object {
       def myProp: Int = 1
@@ -763,7 +763,7 @@ class NonNativeJSTypeTest {
     assertFalse(y.hasOwnProperty("myProp"))
   }
 
-  @Test def properties_with_explicit_name(): Unit = {
+  @Test def propertiesWithExplicitName(): Unit = {
     class PropertiesWithExplicitName extends js.Object {
       private[this] var myY: String = "hello"
       @JSName("answer")
@@ -803,7 +803,7 @@ class NonNativeJSTypeTest {
     assertEquals("world set get", dyn.y)
   }
 
-  @Test def protected_properties(): Unit = {
+  @Test def protectedProperties(): Unit = {
     class ProtectedProperties extends js.Object {
       protected val x: Int = 42
       protected[testsuite] val y: Int = 43
@@ -817,7 +817,7 @@ class NonNativeJSTypeTest {
     assertEquals(43, dyn.y)
   }
 
-  @Test def simple_overloaded_methods(): Unit = {
+  @Test def simpleOverloadedMethods(): Unit = {
     class SimpleOverloadedMethods extends js.Object {
       def foo(): Int = 42
       def foo(x: Int): Int = x*2
@@ -833,7 +833,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, dyn.foo(3))
   }
 
-  @Test def simple_overloaded_methods_anon_js_class_issue_3054(): Unit = {
+  @Test def simpleOverloadedMethodsAnonJSClass_Issue3054(): Unit = {
     trait SimpleOverloadedMethodsAnonJSClass extends js.Object {
       def foo(): Int
       def foo(x: Int): Int
@@ -852,7 +852,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, dyn.foo(3))
   }
 
-  @Test def renamed_overloaded_methods(): Unit = {
+  @Test def renamedOverloadedMethods(): Unit = {
     class RenamedOverloadedMethods extends js.Object {
       @JSName("foobar")
       def foo(): Int = 42
@@ -870,7 +870,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, dyn.foobar(3))
   }
 
-  @Test def overloaded_methods_with_varargs(): Unit = {
+  @Test def overloadedMethodsWithVarargs(): Unit = {
     class OverloadedMethodsWithVarargs extends js.Object {
       def foo(x: Int): Int = x * 2
       def foo(strs: String*): Int = strs.foldLeft(0)(_ + _.length)
@@ -890,7 +890,7 @@ class NonNativeJSTypeTest {
     assertEquals(8, dyn.foo("bar", "babar"))
   }
 
-  @Test def overloaded_methods_with_varargs_anon_js_class_issue_3054(): Unit = {
+  @Test def overloadedMethodsWithVarargsAnonJSClass_Issue3054(): Unit = {
     trait OverloadedMethodsWithVarargsAnonJSClass extends js.Object {
       def foo(x: Int): Int
       def foo(strs: String*): Int
@@ -913,17 +913,17 @@ class NonNativeJSTypeTest {
     assertEquals(8, dyn.foo("bar", "babar"))
   }
 
-  @Test def overloaded_constructors_num_parameters_resolution(): Unit = {
+  @Test def overloadedConstructorsNumParametersResolution(): Unit = {
     assertEquals(1, new OverloadedConstructorParamNumber(1).foo)
     assertEquals(3, new OverloadedConstructorParamNumber(1, 2).foo)
   }
 
-  @Test def overloaded_constructors_parameter_type_resolution(): Unit = {
+  @Test def overloadedConstructorsParameterTypeResolution(): Unit = {
     assertEquals(1, new OverloadedConstructorParamType(1).foo)
     assertEquals(3, new OverloadedConstructorParamType("abc").foo)
   }
 
-  @Test def overloaded_constructors_with_captured_parameters(): Unit = {
+  @Test def overloadedConstructorsWithCapturedParameters(): Unit = {
     class OverloadedConstructorWithOuterContextOnly(val x: Int) extends js.Object {
       def this(y: String) = this(y.length)
     }
@@ -940,7 +940,7 @@ class NonNativeJSTypeTest {
     assertEquals(5, new OverloadedConstructorWithValCapture("abc").x)
   }
 
-  @Test def overloaded_constructors_with_super_class(): Unit = {
+  @Test def overloadedConstructorsWithSuperClass(): Unit = {
     class OverloadedConstructorSup(val x: Int) extends js.Object {
       def this(y: String) = this(y.length)
     }
@@ -955,7 +955,7 @@ class NonNativeJSTypeTest {
     assertEquals(12, new OverloadedConstructorSub("ab").x)
   }
 
-  @Test def overloaded_constructors_with_repeated_parameters(): Unit = {
+  @Test def overloadedConstructorsWithRepeatedParameters(): Unit = {
     class OverloadedConstructorWithRepeatedParameters(xs: Int*)
         extends js.Object {
       def this(y: String, ys: String*) = this(y.length +: ys.map(_.length): _*)
@@ -972,7 +972,7 @@ class NonNativeJSTypeTest {
     assertEquals(3, new OverloadedConstructorWithRepeatedParameters("a", "b", "c").sum)
   }
 
-  @Test def overloaded_constructors_complex_resolution(): Unit = {
+  @Test def overloadedConstructorsComplexResolution(): Unit = {
     val bazPrim = new OverloadedConstructorComplex(1, 2)
     assertEquals(1, bazPrim.foo)
     assertEquals(2, bazPrim.bar)
@@ -1018,7 +1018,7 @@ class NonNativeJSTypeTest {
     assertEquals(7, baz10.bar)
   }
 
-  @Test def polytype_nullary_method_issue_2445(): Unit = {
+  @Test def polytypeNullaryMethod_Issue2445(): Unit = {
     class PolyTypeNullaryMethod extends js.Object {
       def emptyArray[T]: js.Array[T] = js.Array()
     }
@@ -1034,7 +1034,7 @@ class NonNativeJSTypeTest {
     assertEquals(0, b.length)
   }
 
-  @Test def default_parameters(): Unit = {
+  @Test def defaultParameters(): Unit = {
     class DefaultParameters extends js.Object {
       def bar(x: Int, y: Int = 1): Int = x + y
       def dependent(x: Int)(y: Int = x + 1): Int = x + y
@@ -1073,7 +1073,7 @@ class NonNativeJSTypeTest {
     testDyn(DefaultParametersMod.asInstanceOf[js.Dynamic])
   }
 
-  @Test def override_default_parameters(): Unit = {
+  @Test def overrideDefaultParameters(): Unit = {
     class OverrideDefaultParametersParent extends js.Object {
       def bar(x: Int, y: Int = 1): Int = x + y
       def dependent(x: Int)(y: Int = x + 1): Int = x + y
@@ -1109,7 +1109,7 @@ class NonNativeJSTypeTest {
     assertEquals(24, dyn.dependent(8))
   }
 
-  @Test def override_method_with_default_parameters_without_new_default(): Unit = {
+  @Test def overrideMethodWithDefaultParametersWithoutNewDefault(): Unit = {
     class OverrideDefaultParametersWithoutDefaultParent extends js.Object {
       def bar(x: Int, y: Int = 1): Int = x + y
       def dependent(x: Int)(y: Int = x + 1): Int = x + y
@@ -1145,67 +1145,67 @@ class NonNativeJSTypeTest {
     assertEquals(-1, dyn.dependent(8))
   }
 
-  @Test def `constructors_with_default_parameters_(NonNative/-)`(): Unit = {
+  @Test def constructorsWithDefaultParametersNonNativeNone(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamJSNonNativeNone().foo)
     assertEquals(1, new ConstructorDefaultParamJSNonNativeNone(1).foo)
     assertEquals(5, new ConstructorDefaultParamJSNonNativeNone(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(NonNative/NonNative)`(): Unit = {
+  @Test def constructorsWithDefaultParametersNonNativeNonNative(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamJSNonNativeJSNonNative().foo)
     assertEquals(1, new ConstructorDefaultParamJSNonNativeJSNonNative(1).foo)
     assertEquals(5, new ConstructorDefaultParamJSNonNativeJSNonNative(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(NonNative/Scala)`(): Unit = {
+  @Test def constructorsWithDefaultParametersNonNativeScala(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamJSNonNativeScala().foo)
     assertEquals(1, new ConstructorDefaultParamJSNonNativeScala(1).foo)
     assertEquals(5, new ConstructorDefaultParamJSNonNativeScala(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(Scala/NonNative)`(): Unit = {
+  @Test def constructorsWithDefaultParametersScalaNonNative(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamScalaJSNonNative().foo)
     assertEquals(1, new ConstructorDefaultParamScalaJSNonNative(1).foo)
     assertEquals(5, new ConstructorDefaultParamScalaJSNonNative(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(Native/-)`(): Unit = {
+  @Test def constructorsWithDefaultParametersNativeNone(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamJSNativeNone().foo)
     assertEquals(1, new ConstructorDefaultParamJSNativeNone(1).foo)
     assertEquals(5, new ConstructorDefaultParamJSNativeNone(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(Native/Scala)`(): Unit = {
+  @Test def constructorsWithDefaultParametersNativeScala(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamJSNativeScala().foo)
     assertEquals(1, new ConstructorDefaultParamJSNativeScala(1).foo)
     assertEquals(5, new ConstructorDefaultParamJSNativeScala(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(Native/NonNative)`(): Unit = {
+  @Test def constructorsWithDefaultParametersNativeNonNative(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamJSNativeJSNonNative().foo)
     assertEquals(1, new ConstructorDefaultParamJSNativeJSNonNative(1).foo)
     assertEquals(5, new ConstructorDefaultParamJSNativeJSNonNative(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(Native/Native)`(): Unit = {
+  @Test def constructorsWithDefaultParametersNativeNative(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamJSNativeJSNative().foo)
     assertEquals(1, new ConstructorDefaultParamJSNativeJSNative(1).foo)
     assertEquals(5, new ConstructorDefaultParamJSNativeJSNative(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(Scala/Scala)`(): Unit = {
+  @Test def constructorsWithDefaultParametersScalaScala(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamScalaScala().foo)
     assertEquals(1, new ConstructorDefaultParamScalaScala(1).foo)
     assertEquals(5, new ConstructorDefaultParamScalaScala(5).foo)
   }
 
-  @Test def `constructors_with_default_parameters_(Scala/-)`(): Unit = {
+  @Test def constructorsWithDefaultParametersScalaNone(): Unit = {
     assertEquals(-1, new ConstructorDefaultParamScalaNone().foo)
     assertEquals(1, new ConstructorDefaultParamScalaNone(1).foo)
     assertEquals(5, new ConstructorDefaultParamScalaNone(5).foo)
   }
 
-  @Test def constructors_with_default_parameters_in_multi_param_lists(): Unit = {
+  @Test def constructorsWithDefaultParametersInMultiParamLists(): Unit = {
     val foo1 = new ConstructorDefaultParamMultiParamList(5)("foobar")
     assertEquals(5, foo1.default)
     assertEquals("foobar", foo1.title)
@@ -1217,7 +1217,7 @@ class NonNativeJSTypeTest {
     assertEquals("desc", foo2.description)
   }
 
-  @Test def constructors_with_default_parameters_in_multi_param_lists_and_overloading(): Unit = {
+  @Test def constructorsWithDefaultParametersInMultiParamListsAndOverloading(): Unit = {
     val foo1 = new ConstructorDefaultParamMultiParamListWithOverloading(5)(
         "foobar")
     assertEquals(5, foo1.default)
@@ -1241,7 +1241,7 @@ class NonNativeJSTypeTest {
     assertEquals(js.undefined, foo4.description)
   }
 
-  @Test def `call_super_constructor_with_:__*`(): Unit = {
+  @Test def callSuperConstructorWithColonAsterisk(): Unit = {
     class CallSuperCtorWithSpread(x: Int, y: Int, z: Int)
         extends NativeParentClassWithVarargs(x, Seq(y, z): _*)
 
@@ -1265,7 +1265,7 @@ class NonNativeJSTypeTest {
     assertJSArrayEquals(js.Array(8, 23), args)
   }
 
-  @Test def override_native_method(): Unit = {
+  @Test def overrideNativeMethod(): Unit = {
     class OverrideNativeMethod extends NativeParentClass(3) {
       override def foo(s: String): String = s + s + x
     }
@@ -1283,7 +1283,7 @@ class NonNativeJSTypeTest {
     assertEquals("hellohello3", dyn.foo("hello"))
   }
 
-  @Test def override_non_native_method(): Unit = {
+  @Test def overrideNonNativeMethod(): Unit = {
     class OverrideNonNativeMethod extends NonNativeParentClass(3) {
       override def foo(s: String): String = s + s + x
     }
@@ -1301,7 +1301,7 @@ class NonNativeJSTypeTest {
     assertEquals("hellohello3", dyn.foo("hello"))
   }
 
-  @Test def override_non_native_method_with_separate_compilation(): Unit = {
+  @Test def overrideNonNativeMethodWithSeparateCompilation(): Unit = {
     val foo = new SepRun.SimpleChildClass
     assertEquals(6, foo.foo(3))
 
@@ -1312,7 +1312,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, foo.foo(3))
   }
 
-  @Test def override_native_method_and_call_super(): Unit = {
+  @Test def overrideNativeMethodAndCallSuper(): Unit = {
     class OverrideNativeMethodSuperCall extends NativeParentClass(3) {
       override def foo(s: String): String = super.foo("bar") + s
     }
@@ -1330,7 +1330,7 @@ class NonNativeJSTypeTest {
     assertEquals("bar3hello", dyn.foo("hello"))
   }
 
-  @Test def override_non_native_method_and_call_super(): Unit = {
+  @Test def overrideNonNativeMethodAndCallSuper(): Unit = {
     class OverrideNonNativeMethodSuperCall extends NonNativeParentClass(3) {
       override def foo(s: String): String = super.foo("bar") + s
     }
@@ -1348,7 +1348,7 @@ class NonNativeJSTypeTest {
     assertEquals("bar3hello", dyn.foo("hello"))
   }
 
-  @Test def super_method_call_in_anon_JS_class_issue_3055(): Unit = {
+  @Test def superMethodCallInAnonJSClass_Issue3055(): Unit = {
     class Foo extends js.Object {
       def bar(msg: String): String = "super: " + msg
     }
@@ -1360,7 +1360,7 @@ class NonNativeJSTypeTest {
     assertEquals("super: foo: foobar", foo.bar("foobar"))
   }
 
-  @Test def override_native_val(): Unit = {
+  @Test def overrideNativeVal(): Unit = {
     class OverrideNativeVal extends NativeParentClass(3) {
       override val x: Int = 42
     }
@@ -1381,7 +1381,7 @@ class NonNativeJSTypeTest {
     assertEquals("hello42", dyn.foo("hello"))
   }
 
-  @Test def override_non_native_val(): Unit = {
+  @Test def overrideNonNativeVal(): Unit = {
     class OverrideNonNativeVal extends NonNativeParentClass(3) {
       override val x: Int = 42
     }
@@ -1402,7 +1402,7 @@ class NonNativeJSTypeTest {
     assertEquals("hello42", dyn.foo("hello"))
   }
 
-  @Test def override_native_getter(): Unit = {
+  @Test def overrideNativeGetter(): Unit = {
     class OverrideNativeGetter extends NativeParentClass(3) {
       override def bar: Int = x * 3
     }
@@ -1420,7 +1420,7 @@ class NonNativeJSTypeTest {
     assertEquals(9, dyn.bar)
   }
 
-  @Test def override_non_native_getter(): Unit = {
+  @Test def overrideNonNativeGetter(): Unit = {
     class OverrideNonNativeGetter extends NonNativeParentClass(3) {
       override def bar: Int = x * 3
     }
@@ -1438,7 +1438,7 @@ class NonNativeJSTypeTest {
     assertEquals(9, dyn.bar)
   }
 
-  @Test def override_native_getter_with_val(): Unit = {
+  @Test def overrideNativeGetterWithVal(): Unit = {
     class OverrideNativeGetterWithVal extends NativeParentClass(3) {
       override val bar: Int = 1
     }
@@ -1456,7 +1456,7 @@ class NonNativeJSTypeTest {
     assertEquals(1, dyn.bar)
   }
 
-  @Test def override_non_native_getter_with_val(): Unit = {
+  @Test def overrideNonNativeGetterWithVal(): Unit = {
     class OverrideNonNativeGetterWithVal extends NonNativeParentClass(3) {
       override val bar: Int = 1
     }
@@ -1474,7 +1474,7 @@ class NonNativeJSTypeTest {
     assertEquals(1, dyn.bar)
   }
 
-  @Test def override_getter_with_super(): Unit = {
+  @Test def overrideGetterWithSuper(): Unit = {
     class OverrideGetterSuperParent extends js.Object {
       def bar: Int = 43
     }
@@ -1492,7 +1492,7 @@ class NonNativeJSTypeTest {
     assertEquals(129, dyn.bar)
   }
 
-  @Test def override_setter_with_super(): Unit = {
+  @Test def overrideSetterWithSuper(): Unit = {
     class OverrideSetterSuperParent extends js.Object {
       var x: Int = 43
       def bar_=(v: Int): Unit = x = v
@@ -1514,7 +1514,7 @@ class NonNativeJSTypeTest {
     assertEquals(18, dyn.x)
   }
 
-  @Test def super_property_get_set_in_anon_JS_class_issue_3055(): Unit = {
+  @Test def superPropertyGetSetInAnonJSClass_Issue3055(): Unit = {
     class Foo extends js.Object {
       var x: Int = 1
       var lastSetValue: Int = 0
@@ -1538,7 +1538,7 @@ class NonNativeJSTypeTest {
     assertEquals(18, foo.bar)
   }
 
-  @Test def add_overload_in_subclass(): Unit = {
+  @Test def addOverloadInSubclass(): Unit = {
     class AddOverloadInSubclassParent extends js.Object {
       def bar(): Int = 53
     }
@@ -1555,7 +1555,7 @@ class NonNativeJSTypeTest {
     assertEquals(7, dyn.bar(5))
   }
 
-  @Test def add_setter_in_subclass(): Unit = {
+  @Test def addSetterInSubclass(): Unit = {
     class AddSetterInSubclassParent extends js.Object {
       var x: Int = 43
       def bar: Int = x
@@ -1575,7 +1575,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, dyn.bar)
   }
 
-  @Test def add_getter_in_subclass(): Unit = {
+  @Test def addGetterInSubclass(): Unit = {
     class AddGetterInSubclassParent extends js.Object {
       var x: Int = 43
       def bar_=(v: Int): Unit = x = v
@@ -1595,7 +1595,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, dyn.bar)
   }
 
-  @Test def overload_native_method(): Unit = {
+  @Test def overloadNativeMethod(): Unit = {
     class OverloadNativeMethod extends NativeParentClass(3) {
       def foo(s: String, y: Int): String = foo(s) + " " + y
     }
@@ -1612,7 +1612,7 @@ class NonNativeJSTypeTest {
     assertEquals("hello3 4", dyn.foo("hello", 4))
   }
 
-  @Test def overload_non_native_method(): Unit = {
+  @Test def overloadNonNativeMethod(): Unit = {
     class OverloadNonNativeMethod extends NonNativeParentClass(3) {
       def foo(s: String, y: Int): String = foo(s) + " " + y
     }
@@ -1629,7 +1629,7 @@ class NonNativeJSTypeTest {
     assertEquals("hello3 4", dyn.foo("hello", 4))
   }
 
-  @Test def overload_with_default_parameter(): Unit = {
+  @Test def overloadWithDefaultParameter(): Unit = {
     class OverloadDefaultParameter extends js.Object {
       def foo(x: Int): Int = x
       def foo(x: String = ""): String = x
@@ -1641,7 +1641,7 @@ class NonNativeJSTypeTest {
     assertEquals("hello", foo.foo("hello"))
   }
 
-  @Test def implement_a_simple_trait(): Unit = {
+  @Test def implementSimpleTrait(): Unit = {
     class ImplementSimpleTrait extends js.Object with SimpleTrait {
       def foo(x: Int): Int = x + 1
     }
@@ -1653,7 +1653,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, fooTrait.foo(5))
   }
 
-  @Test def implement_a_simple_trait_under_separate_compilation(): Unit = {
+  @Test def implementSimpleTraitUnderSeparateCompilation(): Unit = {
     class ImplementSimpleTraitSepRun extends js.Object with SepRun.SimpleTrait {
       def foo(x: Int): Int = x + 1
     }
@@ -1665,7 +1665,7 @@ class NonNativeJSTypeTest {
     assertEquals(6, fooTrait.foo(5))
   }
 
-  @Test def implement_a_trait_with_a_val(): Unit = {
+  @Test def implementTraitWithVal(): Unit = {
     trait TraitWithVal extends js.Object {
       val x: Int
     }
@@ -1681,7 +1681,7 @@ class NonNativeJSTypeTest {
     assertEquals(3, fooTrait.x)
   }
 
-  @Test def implement_a_trait_with_a_var(): Unit = {
+  @Test def implementTraitWithVar(): Unit = {
     trait TraitWithVar extends js.Object {
       var x: Int
     }
@@ -1702,7 +1702,7 @@ class NonNativeJSTypeTest {
     assertEquals(19, foo.x)
   }
 
-  @Test def implement_a_trait_extending_a_native_JS_class(): Unit = {
+  @Test def implementTraitExtendingNativeJSClass(): Unit = {
     trait TraitExtendsJSClass extends NativeParentClass {
       def foobar(x: Int): Int
     }
@@ -1716,7 +1716,7 @@ class NonNativeJSTypeTest {
     assertEquals(18, foo.foobar(6))
   }
 
-  @Test def implement_abstract_members_coming_from_a_native_JS_class(): Unit = {
+  @Test def implementAbstractMembersComingFromNativeJSClass(): Unit = {
     class ImplDeferredMembersFromJSParent
         extends NativeParentClassWithDeferred {
       val x: Int = 43
@@ -1742,7 +1742,7 @@ class NonNativeJSTypeTest {
     assertEquals(FooResult, dyn.foo(12))
   }
 
-  @Test def override_a_method_with_default_values_from_a_native_JS_class(): Unit = {
+  @Test def overrideMethodWithDefaultValuesFromNativeJSClass(): Unit = {
     class OverrideDefault extends NativeParentClass(7) {
       override def methodWithDefault(x: Int = 9): Int = x * 2
     }
@@ -1757,7 +1757,7 @@ class NonNativeJSTypeTest {
   }
 
   // #2603
-  @Test def default_values_in_non_exposed_methods(): Unit = {
+  @Test def defaultValuesInNonExposedMethods(): Unit = {
     class DefaultParameterss(val default: Int) extends js.Object {
       /* We don't use a constant default value to make sure it actually comes
        * from the default parameter accessors.
@@ -1777,7 +1777,7 @@ class NonNativeJSTypeTest {
   }
 
   // #3939
-  @Test def java_lang_object_method_names(): Unit = {
+  @Test def javaLangObjectMethodNames(): Unit = {
     class JavaLangObjectMethods extends js.Object {
       @JSName("clone")
       def myClone(): String = "myClone"

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PrimitivesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PrimitivesTest.scala
@@ -17,7 +17,7 @@ import org.junit.Test
 
 class PrimitivesTest {
 
-  @Test def should_convert_Java_boxed_types_to_js_Any(): Unit = {
+  @Test def javaBoxedTypesToJSAny(): Unit = {
     assertEquals(false, new java.lang.Boolean(false))
     assertNull(null: java.lang.Boolean)
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
@@ -74,7 +74,7 @@ class SpecialTest {
 
   // scala.scalajs.js.special.delete
 
-  @Test def should_provide_an_equivalent_of_the_JS_delete_keyword_issue_255(): Unit = {
+  @Test def equivalentOfTheJSDeleteKeyword_Issue255(): Unit = {
     val obj = js.Dynamic.literal(foo = 42, bar = "foobar")
 
     assertEquals(42, obj.foo)
@@ -84,7 +84,7 @@ class SpecialTest {
     assertEquals("foobar", obj.bar)
   }
 
-  @Test def should_behave_as_specified_when_deleting_a_non_configurable_property_issue_461_issue_679(): Unit = {
+  @Test def allowDeletingNonConfigurableProperty_Issue461_Issue679(): Unit = {
     val obj = js.Dynamic.literal()
     js.Object.defineProperty(obj, "nonconfig",
         js.Dynamic.literal(value = 4, writable = false).asInstanceOf[js.PropertyDescriptor])
@@ -93,12 +93,12 @@ class SpecialTest {
     assertEquals(4, obj.nonconfig)
   }
 
-  @Test def should_treat_delete_as_a_statement_issue_907(): Unit = {
+  @Test def deleteAsStatement_Issue907(): Unit = {
     val obj = js.Dynamic.literal(a = "A")
     js.special.delete(obj, "a")
   }
 
-  @Test def should_desugar_arguments_to_delete_statements_issue_908(): Unit = {
+  @Test def desugarArgumentsToDeleteStatements_Issue908(): Unit = {
     val kh = js.Dynamic.literal(key = "a").asInstanceOf[KeyHolder]
     val obj = js.Dynamic.literal(a = "A")
     def a[T](foo: String): T = obj.asInstanceOf[T]
@@ -107,7 +107,7 @@ class SpecialTest {
 
   // js.special.fileLevelThis
 
-  @Test def fileLevelThis_can_be_used_to_detect_the_global_object(): Unit = {
+  @Test def fileLevelThisCanBeUsedToDetectTheGlobalObject(): Unit = {
     assumeTrue(Platform.isNoModule)
     val globalObject = js.special.fileLevelThis.asInstanceOf[js.Dynamic]
 
@@ -116,7 +116,7 @@ class SpecialTest {
 
   // js.special.debugger
 
-  @Test def should_support_debugger_statements_through_the_whole_pipeline_issue_1402(): Unit = {
+  @Test def debuggerStatementsThroughTheWholePipeline_Issue1402(): Unit = {
     /* A function that hopefully persuades the optimizer not to optimize
      * we need a debugger statement that is unreachable, but not eliminated.
      */

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/StrangeNamedTests.scala
@@ -15,6 +15,8 @@ package org.scalajs.testsuite.jsinterop
 import org.junit.Test
 import org.scalajs.testsuite.junit.JUnitUtil
 
+// Strange named tests are part of the test
+
 class `1_TestName` { // scalastyle:ignore
   @Test def `a test with name 1_TestName`(): Unit = ()
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThisFunctionTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 
 class ThisFunctionTest {
 
-  @Test def should_provide_an_implicit_conversion_from_Scala_function_to_js_ThisFunction(): Unit = {
+  @Test def implicitConversionFromScalaFunctionToJSThisFunction(): Unit = {
     val g = js.eval("""
         var g = function(f, x) { return f.call(x, 42, x.foo); }; g;
     """).asInstanceOf[js.Function2[js.ThisFunction2[ // scalastyle:ignore
@@ -38,7 +38,7 @@ class ThisFunctionTest {
     assertEquals("foo42", g(f, obj))
   }
 
-  @Test def should_accept_a_lambda_where_a_js_ThisFunction_is_expected(): Unit = {
+  @Test def lambdaWhereJSThisFunctionIsExpected(): Unit = {
     val g = js.eval("""
         var g = function(f, x) { return f.call(x, 42, x.foo); }; g;
     """).asInstanceOf[js.Function2[js.ThisFunction2[ // scalastyle:ignore
@@ -57,7 +57,7 @@ class ThisFunctionTest {
     assertEquals("foo42", res)
   }
 
-  @Test def should_bind_the_first_argument_to_this_when_applying_js_ThisFunctionN(): Unit = {
+  @Test def bindTheFirstArgumentToThisWhenApplyingJSThisFunctionN(): Unit = {
     val g = js.eval("""
         var g = function(x) { return this.foo + ":" + x; }; g;
     """).asInstanceOf[js.ThisFunction1[js.Dynamic, Int, String]]
@@ -66,7 +66,7 @@ class ThisFunctionTest {
     assertEquals("foo:42", g(obj, 42))
   }
 
-  @Test def should_provide_an_implicit_conversion_from_js_ThisFunction_to_Scala_function(): Unit = {
+  @Test def implicitConversionFromJSThisFunctionToScalaFunction(): Unit = {
     val g = js.eval("""
         var g = function(x) { return this.foo + ":" + x; }; g;
     """).asInstanceOf[js.ThisFunction1[js.Dynamic, Int, String]]
@@ -76,7 +76,7 @@ class ThisFunctionTest {
     assertEquals("foo:42", f(obj, 42))
   }
 
-  @Test def thisFunction_in_trait_issue2643(): Unit = {
+  @Test def thisFunctionInTrait_Issue2643(): Unit = {
     trait TraitWithThisFunction {
       def create = {
         val f = { (passedThis: js.Dynamic) =>

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TupleTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TupleTest.scala
@@ -23,14 +23,14 @@ import org.scalajs.testsuite.utils.JSAssert._
 
 class TupleTest {
 
-  @Test def should_provide_an_equivalent_of_Scala_tuple(): Unit = {
+  @Test def equivalentOfScalaTuple(): Unit = {
     val obj = js.Tuple2(42, "foobar")
 
     assertEquals(42, obj._1)
     assertEquals("foobar", obj._2)
   }
 
-  @Test def should_unapply_JS_tuple_in_destructuring_use_case(): Unit = {
+  @Test def unapplyJSTupleInDestructuringUseCase(): Unit = {
     val obj = js.Tuple2(42, "foobar")
     val js.Tuple2(t1, t2) = obj
 
@@ -40,7 +40,7 @@ class TupleTest {
     assertEquals("foobar", t2IsString)
   }
 
-  @Test def should_unapply_JS_tuple_in_pattern_matching_position(): Unit = {
+  @Test def unapplyJSTupleInPatternMatchingPosition(): Unit = {
     val obj = js.Tuple2(42, "foobar")
     obj match {
       case js.Tuple2(2, _) =>
@@ -53,28 +53,28 @@ class TupleTest {
     }
   }
 
-  @Test def should_be_a_JS_array_instance(): Unit = {
+  @Test def testJSArrayInstance(): Unit = {
     val obj = js.Tuple2(42, "foobar")
 
     assertTrue((obj: Any).isInstanceOf[js.Array[_]])
     assertJSArrayEquals(js.Array(42, "foobar"), obj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_be_able_to_cast_from_a_JS_array_instance(): Unit = {
+  @Test def castFromJSArrayInstance(): Unit = {
     val obj = js.Array[Any](42, "foobar").asInstanceOf[js.Tuple2[Int, String]]
 
     assertEquals(42, obj._1)
     assertEquals("foobar", obj._2)
   }
 
-  @Test def should_convert_from_Scala_tuple(): Unit = {
+  @Test def convertFromScalaTuple(): Unit = {
     val obj: js.Tuple2[Int, String] = (42, "foobar")
 
     assertEquals(42, obj._1)
     assertEquals("foobar", obj._2)
   }
 
-  @Test def should_convert_to_Scala_tuple(): Unit = {
+  @Test def convertToScalaTuple(): Unit = {
     val obj: (Int, String) = js.Tuple2(42, "foobar")
 
     assertEquals(42, obj._1)
@@ -83,7 +83,7 @@ class TupleTest {
 
   // scalastyle:off line.size.limit
 
-  @Test def should_support_tuple_of_2(): Unit = {
+  @Test def testTuple2(): Unit = {
     val jsObj = js.Tuple2("1", 2)
     val scalaObj: (String, Int) = jsObj
     val t2IsInt: Int = js.Tuple2.unapply(jsObj).get._2
@@ -95,7 +95,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", 2), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_3(): Unit = {
+  @Test def testTuple3(): Unit = {
     val jsObj = js.Tuple3("1", "2", 3)
     val scalaObj: (String, String, Int) = jsObj
     val t3IsInt: Int = js.Tuple3.unapply(jsObj).get._3
@@ -107,7 +107,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", 3), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_4(): Unit = {
+  @Test def testTuple4(): Unit = {
     val jsObj = js.Tuple4("1", "2", "3", 4)
     val scalaObj: (String, String, String, Int) = jsObj
     val t4IsInt: Int = js.Tuple4.unapply(jsObj).get._4
@@ -119,7 +119,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", 4), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_5(): Unit = {
+  @Test def testTuple5(): Unit = {
     val jsObj = js.Tuple5("1", "2", "3", "4", 5)
     val scalaObj: (String, String, String, String, Int) = jsObj
     val t5IsInt: Int = js.Tuple5.unapply(jsObj).get._5
@@ -131,7 +131,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", 5), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_6(): Unit = {
+  @Test def testTuple6(): Unit = {
     val jsObj = js.Tuple6("1", "2", "3", "4", "5", 6)
     val scalaObj: (String, String, String, String, String, Int) = jsObj
     val t6IsInt: Int = js.Tuple6.unapply(jsObj).get._6
@@ -143,7 +143,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", 6), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_7(): Unit = {
+  @Test def testTuple7(): Unit = {
     val jsObj = js.Tuple7("1", "2", "3", "4", "5", "6", 7)
     val scalaObj: (String, String, String, String, String, String, Int) = jsObj
     val t7IsInt: Int = js.Tuple7.unapply(jsObj).get._7
@@ -155,7 +155,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", 7), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_8(): Unit = {
+  @Test def testTuple8(): Unit = {
     val jsObj = js.Tuple8("1", "2", "3", "4", "5", "6", "7", 8)
     val scalaObj: (String, String, String, String, String, String, String, Int) = jsObj
     val t8IsInt: Int = js.Tuple8.unapply(jsObj).get._8
@@ -167,7 +167,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", 8), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_9(): Unit = {
+  @Test def testTuple9(): Unit = {
     val jsObj = js.Tuple9("1", "2", "3", "4", "5", "6", "7", "8", 9)
     val scalaObj: (String, String, String, String, String, String, String, String, Int) = jsObj
     val t9IsInt: Int = js.Tuple9.unapply(jsObj).get._9
@@ -179,7 +179,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", 9), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_10(): Unit = {
+  @Test def testTuple10(): Unit = {
     val jsObj = js.Tuple10("1", "2", "3", "4", "5", "6", "7", "8", "9", 10)
     val scalaObj: (String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t10IsInt: Int = js.Tuple10.unapply(jsObj).get._10
@@ -191,7 +191,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", 10), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_11(): Unit = {
+  @Test def testTuple11(): Unit = {
     val jsObj = js.Tuple11("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", 11)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t11IsInt: Int = js.Tuple11.unapply(jsObj).get._11
@@ -203,7 +203,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", 11), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_12(): Unit = {
+  @Test def testTuple12(): Unit = {
     val jsObj = js.Tuple12("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", 12)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t12IsInt: Int = js.Tuple12.unapply(jsObj).get._12
@@ -215,7 +215,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", 12), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_13(): Unit = {
+  @Test def testTuple13(): Unit = {
     val jsObj = js.Tuple13("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", 13)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t13IsInt: Int = js.Tuple13.unapply(jsObj).get._13
@@ -227,7 +227,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", 13), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_14(): Unit = {
+  @Test def testTuple14(): Unit = {
     val jsObj = js.Tuple14("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", 14)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t14IsInt: Int = js.Tuple14.unapply(jsObj).get._14
@@ -239,7 +239,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", 14), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_15(): Unit = {
+  @Test def testTuple15(): Unit = {
     val jsObj = js.Tuple15("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", 15)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t15IsInt: Int = js.Tuple15.unapply(jsObj).get._15
@@ -251,7 +251,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", 15), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_16(): Unit = {
+  @Test def testTuple16(): Unit = {
     val jsObj = js.Tuple16("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", 16)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t16IsInt: Int = js.Tuple16.unapply(jsObj).get._16
@@ -263,7 +263,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", 16), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_17(): Unit = {
+  @Test def testTuple17(): Unit = {
     val jsObj = js.Tuple17("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", 17)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t17IsInt: Int = js.Tuple17.unapply(jsObj).get._17
@@ -275,7 +275,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", 17), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_18(): Unit = {
+  @Test def testTuple18(): Unit = {
     val jsObj = js.Tuple18("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", 18)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t18IsInt: Int = js.Tuple18.unapply(jsObj).get._18
@@ -287,7 +287,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", 18), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_19(): Unit = {
+  @Test def testTuple19(): Unit = {
     val jsObj = js.Tuple19("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", 19)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t19IsInt: Int = js.Tuple19.unapply(jsObj).get._19
@@ -299,7 +299,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", 19), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_20(): Unit = {
+  @Test def testTuple20(): Unit = {
     val jsObj = js.Tuple20("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", 20)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t20IsInt: Int = js.Tuple20.unapply(jsObj).get._20
@@ -311,7 +311,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", 20), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_21(): Unit = {
+  @Test def testTuple21(): Unit = {
     val jsObj = js.Tuple21("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", 21)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t21IsInt: Int = js.Tuple21.unapply(jsObj).get._21
@@ -322,7 +322,7 @@ class TupleTest {
     assertJSArrayEquals(js.Array("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", 21), jsObj.asInstanceOf[js.Array[Any]])
   }
 
-  @Test def should_support_tuple_of_22(): Unit = {
+  @Test def testTuple22(): Unit = {
     val jsObj = js.Tuple22("1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16", "17", "18", "19", "20", "21", 22)
     val scalaObj: (String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, String, Int) = jsObj
     val t22IsInt: Int = js.Tuple22.unapply(jsObj).get._22

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
@@ -27,7 +27,7 @@ class UndefOrTest {
 
   // scala.scalajs.js.UndefOr[A]
 
-  @Test def convert_A_to_js_UndefOr_A(): Unit = {
+  @Test def convertAToJSUndefOrA(): Unit = {
     val x: js.UndefOr[Int] = 42
     assertFalse(x.isEmpty)
     assertTrue(x.isDefined)
@@ -35,7 +35,7 @@ class UndefOrTest {
     assertEquals(42, x.get)
   }
 
-  @Test def convert_undefined_to_js_UndefOr_A(): Unit = {
+  @Test def convertUndefinedToJSUndefOrA(): Unit = {
     val x: js.UndefOr[Int] = js.undefined
     assertTrue(x.isEmpty)
     assertFalse(x.isDefined)
@@ -43,7 +43,7 @@ class UndefOrTest {
     assertThrows(classOf[NoSuchElementException], x.get)
   }
 
-  @Test def explicitly_convert_A_to_js_UndefOr_A(): Unit = {
+  @Test def explicitlyConvertAToJSUndefOrA(): Unit = {
     val x: js.UndefOr[Int] = js.defined(42)
     assertFalse(x.isEmpty)
     assertEquals(42, x.get)
@@ -53,7 +53,7 @@ class UndefOrTest {
     assertEquals(6, f.get(5))
   }
 
-  @Test def `convert_to_js_Any_when_A_<%_js_Any`(): Unit = {
+  @Test def convertToJSAnyWhenViewBoundToJSAny(): Unit = {
     val x: js.UndefOr[Int] = 42
     assertEquals(42, x)
 
@@ -158,7 +158,7 @@ class UndefOrTest {
     }))
   }
 
-  @Test def collect_should_call_guard_at_most_once(): Unit = {
+  @Test def collectCallsGuardAtMostOnce(): Unit = {
     var witness = 0
     def guard(x: String): Boolean = {
       witness += 1
@@ -186,7 +186,7 @@ class UndefOrTest {
     assertEquals(List.empty[String], none[String].toList)
   }
 
-  @Test def toLeft_and_toRight(): Unit = {
+  @Test def toLeftAndToRight(): Unit = {
     assertTrue(some("left").toLeft("right").isInstanceOf[Left[_, _]])
     assertTrue(none[String].toLeft("right").isInstanceOf[Right[_, _]])
     assertTrue(some("right").toRight("left").isInstanceOf[Right[_, _]])
@@ -202,7 +202,7 @@ class UndefOrTest {
 
   import js.JSConverters._
 
-  @Test def should_provide_orUndefined(): Unit = {
+  @Test def orUndefined(): Unit = {
     assertEquals("asdf", Some("asdf").orUndefined)
     assertJSUndefined((None: Option[String]).orUndefined)
     assertJSUndefined(None.orUndefined)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
@@ -952,7 +952,7 @@ class ArrayOpsTest {
         js.Array[Int]().reduceRight(_ + _))
   }
 
-  @Test def toList_issue_843(): Unit = {
+  @Test def toList_Issue843(): Unit = {
     val array = js.Array(1,2,1,3,1,10,9)
     val list = array.toList
     assertArrayEquals(array.toArray, list.toArray)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/BigIntTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/BigIntTest.scala
@@ -106,7 +106,7 @@ class BigIntTest {
     assertEquals(bitNot, js.BigInt("-43"))
   }
 
-  @Test def compare_with_bigint(): Unit = {
+  @Test def compareWithBigint(): Unit = {
     val n = js.BigInt("42")
     assertTrue(n == js.BigInt("42"))
     assertTrue(n != js.BigInt("43"))

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
@@ -55,7 +55,7 @@ class ObjectTest {
     assertFalse(js.Object.is(-0.0, +0.0))
   }
 
-  @Test def entries_from_object(): Unit = {
+  @Test def entriesFromObject(): Unit = {
     val obj = new js.Object {
       val a = 42
       val b = "foo"
@@ -72,7 +72,7 @@ class ObjectTest {
     assertEquals("foo", value2.asInstanceOf[String])
   }
 
-  @Test def entries_from_dictionary(): Unit = {
+  @Test def entriesFromDictionary(): Unit = {
     val dict = js.Dictionary[Int]("a" -> 42, "b" -> 0)
     val entries = js.Object.entries(dict)
     assertEquals(2, entries.length)
@@ -88,7 +88,7 @@ class ObjectTest {
     assertEquals(0, value2IsInt)
   }
 
-  @Test def fromEntries_array(): Unit = {
+  @Test def fromEntriesArray(): Unit = {
     // from Array
     val array = js.Array(js.Tuple2("a", 42), js.Tuple2("b", "foo"))
     val obj1 = js.Object.fromEntries(array)
@@ -96,7 +96,7 @@ class ObjectTest {
     assertEquals(obj1("b"), "foo")
   }
 
-  @Test def fromEntries_js_Map(): Unit = {
+  @Test def fromEntriesJSMap(): Unit = {
     assumeTrue("requires js.Map", Platform.jsMaps)
 
     val map = js.Map("a" -> 42, "b" -> "foo")

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
@@ -229,12 +229,12 @@ class ReflectTest {
     }
   }
 
-  @Test def testInnerObjectWithEnableReflectiveInstantiation_issue_3228(): Unit = {
+  @Test def testInnerObjectWithEnableReflectiveInstantiation_Issue3228(): Unit = {
     assertFalse(Reflect.lookupLoadableModuleClass(NameInnerObject).isDefined)
     assertFalse(Reflect.lookupInstantiatableClass(NameInnerObject).isDefined)
   }
 
-  @Test def testLocalClassWithReflectiveInstantiationInLambda_issue_3227(): Unit = {
+  @Test def testLocalClassWithReflectiveInstantiationInLambda_Issue3227(): Unit = {
     // Test that the presence of the following code does not prevent linking
     { () =>
       @EnableReflectiveInstantiation

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
@@ -49,7 +49,7 @@ class StackTraceTest {
     }
   }
 
-  @Test def decode_class_name_and_method_name(): Unit = {
+  @Test def decodeClassNameAndMethodName(): Unit = {
     assumeTrue("Assume Node.js", executingInNodeJS)
     assumeFalse("Assume fullopt-stage", isInFullOpt)
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
@@ -33,7 +33,7 @@ class UnionTypeTest {
 
   // js.| (postive)
 
-  @Test def left_and_right(): Unit = {
+  @Test def leftAndRight(): Unit = {
     val x1: Int | String = 4
     assertEquals(4, x1)
 
@@ -41,7 +41,7 @@ class UnionTypeTest {
     assertEquals("hello", x2)
   }
 
-  @Test def left_and_right_with_subtyping(): Unit = {
+  @Test def leftAndRightWithSubtyping(): Unit = {
     val list = List(1, 2, 3)
 
     val x1: Seq[Int] | CharSequence = list
@@ -52,7 +52,7 @@ class UnionTypeTest {
     assertEquals("hello", x2)
   }
 
-  @Test def three_types(): Unit = {
+  @Test def threeTypes(): Unit = {
     val x1: Int | String | Boolean = 3
     assertEquals(3, x1)
 
@@ -69,18 +69,18 @@ class UnionTypeTest {
     assertEquals("hello", x2)
   }
 
-  @Test def int_as_Double(): Unit = {
+  @Test def intAsDouble(): Unit = {
     val x1: Double | String = 3
     assertEquals(3, x1)
   }
 
-  @Test def swap_base_types(): Unit = {
+  @Test def swapBaseTypes(): Unit = {
     val x1: Int | String = 3
     val x2: String | Int = x1
     assertEquals(3, x2)
   }
 
-  @Test def permutations_for_3_base_types(): Unit = {
+  @Test def permutationsFor3BaseTypes(): Unit = {
     val x: Int | String | Boolean = 3
 
     val x1: Int | Boolean | String = x
@@ -96,7 +96,7 @@ class UnionTypeTest {
     assertEquals(3, x5)
   }
 
-  @Test def permutations_of_2_base_types_to_3_base_types(): Unit = {
+  @Test def permutationsOf2BaseTypesTo3BaseTypes(): Unit = {
     val x1: Int | String = 3
     val x2: Int | Boolean = false
     val x3: Boolean | String = "hello"
@@ -110,7 +110,7 @@ class UnionTypeTest {
     assertEquals("hello", y3)
   }
 
-  @Test def partial_upper_bound(): Unit = {
+  @Test def partialUpperBound(): Unit = {
     val x: Int | String | Boolean = "hello"
 
     val x1: AnyVal | String = x
@@ -142,7 +142,7 @@ class UnionTypeTest {
     assertEquals(Seq(3, 5), y4)
   }
 
-  @Test def js_UndefOr_A_or_B_inference(): Unit = {
+  @Test def jsUndefOrAOrBInference(): Unit = {
     val a: String = "hello"
 
     assertEquals(a, a: Int | String)
@@ -184,7 +184,7 @@ class UnionTypeTest {
     assertEquals(a, a: js.UndefOr[js.UndefOr[Object] | Object | String])
   }
 
-  @Test def covariant_type_constructor(): Unit = {
+  @Test def covariantTypeConstructor(): Unit = {
     val a: List[Int] = List(5)
 
     assertSame(a, a: List[Int | String])
@@ -195,7 +195,7 @@ class UnionTypeTest {
     assertSame(a, b: AnyVal | List[Int | String])
   }
 
-  @Test def contravariant_type_constructor(): Unit = {
+  @Test def contravariantTypeConstructor(): Unit = {
     val a: Consumer[CharSequence | Int] = new Consumer
 
     assertSame(a, a: Consumer[Int])
@@ -213,49 +213,49 @@ class UnionTypeTest {
    * not test them.
    */
 
-  @Test def neither_left_nor_right(): Unit = {
+  @Test def neitherLeftNorRight(): Unit = {
     typeError(
         "3: Boolean | String")
   }
 
-  @Test def none_of_three_types(): Unit = {
+  @Test def noneOfThreeTypes(): Unit = {
     typeError(
         "3: Boolean | String | List[Int]")
   }
 
-  @Test def wrong_type_parameter_on_left_or_right(): Unit = {
+  @Test def wrongTypeParameterOnLeftOrRight(): Unit = {
     typeError(
         "List(1, 2): List[String] | String")
     typeError(
         "List(1, 2): String | List[String]")
   }
 
-  @Test def left_of_OR_type_is_not_a_subtype_of_rhs(): Unit = {
+  @Test def leftOfOrTypeIsNotSubtypeOfRhs(): Unit = {
     typeError(
         "(1: Int | List[String]): String | List[String]")
   }
 
-  @Test def right_of_OR_type_is_not_a_subtype_of_rhs(): Unit = {
+  @Test def rightOfOrTypeIsNotSubtypeOfRhs(): Unit = {
     typeError(
         "(1: Int | List[String]): String | Int")
   }
 
-  @Test def merge_with_an_incorrect_subtype(): Unit = {
+  @Test def mergeWithAnIncorrectSubtype(): Unit = {
     typeError(
         "(List(1, 2): List[Int] | Set[Int]).merge: Seq[Int]")
   }
 
-  @Test def invariant_type_constructor(): Unit = {
+  @Test def invariantTypeConstructor(): Unit = {
     typeError(
         "(Array[Int]()): Array[Int | String]")
   }
 
-  @Test def covariant_type_constructor_in_contravariant_pos(): Unit = {
+  @Test def covariantTypeConstructorInContravariantPos(): Unit = {
     typeError(
         "(Nil: List[Int | String]): List[Int]")
   }
 
-  @Test def contravariant_type_constructor_in_covariant_pos(): Unit = {
+  @Test def contravariantTypeConstructorInCovariantPos(): Unit = {
     typeError(
         "(new Consumer[Int]): Consumer[Int | String]")
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedDictionaryTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedDictionaryTest.scala
@@ -34,7 +34,7 @@ class WrappedDictionaryTest {
     assertTrue(map.get("f") == None)
   }
 
-  @Test def `+=_and_-=`(): Unit = {
+  @Test def plusEqualAndMinusEqual(): Unit = {
     val dict = js.Dictionary[String]()
     val map: mutable.Map[String, String] = dict
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeJSTest.scala
@@ -19,7 +19,7 @@ import scala.scalajs.js
 
 class ScalaRunTimeJSTest {
 
-  @Test def ScalaRunTime_isArray_should_not_fail_with_JS_objects(): Unit = {
+  @Test def isArrayWorksWithJSObjects(): Unit = {
     def isScalaArray(x: Any): Boolean = {
       x match {
         case _: Array[_] => true

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArrayBufferTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/ArrayBufferTest.scala
@@ -29,14 +29,14 @@ class ArrayBufferTest {
     assertEquals(100, x.byteLength)
   }
 
-  @Test def slice_with_one_arg(): Unit = {
+  @Test def sliceWithOneArg(): Unit = {
     val x = new ArrayBuffer(100)
     val y = x.slice(10)
     assertEquals(90, y.byteLength)
 
   }
 
-  @Test def slice_with_two_args(): Unit = {
+  @Test def sliceWithTwoArgs(): Unit = {
     val x = new ArrayBuffer(100)
     val y = x.slice(10, 20)
     assertEquals(10, y.byteLength)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/DataViewTest.scala
@@ -24,7 +24,7 @@ object DataViewTest extends Requires.TypedArray
 
 class DataViewTest {
 
-  @Test def arrayBuffer_only_constructor(): Unit = {
+  @Test def arrayBufferOnlyConstructor(): Unit = {
     val buf = new ArrayBuffer(10)
     val view = new DataView(buf)
     assertTrue(view.isInstanceOf[DataView])
@@ -33,7 +33,7 @@ class DataViewTest {
     assertEquals(0, view.getInt8(0))
   }
 
-  @Test def arrayBuffer_and_offset_constructor(): Unit = {
+  @Test def arrayBufferAndOffsetConstructor(): Unit = {
     val buf = new ArrayBuffer(10)
     val view = new DataView(buf, 2)
     assertTrue(view.isInstanceOf[DataView])
@@ -42,7 +42,7 @@ class DataViewTest {
     assertEquals(0, view.getInt8(0))
   }
 
-  @Test def arrayBuffer_offset_and_length_constructor(): Unit = {
+  @Test def arrayBufferOffsetAndLengthConstructor(): Unit = {
     val buf = new ArrayBuffer(10)
     val view = new DataView(buf, 3, 2)
     assertTrue(view.isInstanceOf[DataView])
@@ -118,7 +118,7 @@ class DataViewTest {
     assertEquals(0x1A30B3FF, view.getInt32(1, true))
   }
 
-  @Test def getInt64_through_DataViewExt(): Unit = {
+  @Test def getInt64ThroughDataViewExt(): Unit = {
     val view = new DataView(new ArrayBuffer(9))
 
     view.setUint8(0, 0x01)
@@ -265,7 +265,7 @@ class DataViewTest {
     assertEquals(0x00, view.getUint8(7))
   }
 
-  @Test def setInt64_through_DataViewExt(): Unit = {
+  @Test def setInt64ThroughDataViewExt(): Unit = {
     val view = new DataView(new ArrayBuffer(16))
 
     view.setInt64(0, 0x01FFB3301A745CBDL, true)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayConversionTest.scala
@@ -27,7 +27,7 @@ class TypedArrayConversionTest {
 
   def sum(factor: Double): Double = (8 * 9 / 2 - 1) * factor
 
-  @Test def convert_an_Int8Array_to_a_scala_Array_Byte(): Unit = {
+  @Test def convertInt8ArrayToScalaArrayByte(): Unit = {
     val x = new Int8Array(data.map(_.toByte))
     val y = x.toArray
 
@@ -39,7 +39,7 @@ class TypedArrayConversionTest {
     assertEquals(sum(1), y.sum, 0.0)
   }
 
-  @Test def convert_an_Int16Array_to_a_scala_Array_Short(): Unit = {
+  @Test def convertInt16ArrayToScalaArrayShort(): Unit = {
     val x = new Int16Array(data.map(x => (100 * x).toShort))
     val y = x.toArray
 
@@ -51,7 +51,7 @@ class TypedArrayConversionTest {
     assertEquals(sum(100), y.sum, 0.0)
   }
 
-  @Test def convert_an_Uint16Array_to_a_scala_Array_Char(): Unit = {
+  @Test def convertUint16ArrayToScalaArrayChar(): Unit = {
     val data = js.Array(1, 2, 3, 4, 5, 6).map(x => 10000 * x)
     val sum = (6*7/2*10000).toChar
 
@@ -66,7 +66,7 @@ class TypedArrayConversionTest {
     assertEquals(sum, y.sum)
   }
 
-  @Test def convert_an_Int32Array_to_a_scala_Array_Int(): Unit = {
+  @Test def convertInt32ArrayToScalaArrayInt(): Unit = {
     val x = new Int32Array(data.map(x => 10000 * x))
     val y = x.toArray
 
@@ -78,7 +78,7 @@ class TypedArrayConversionTest {
     assertEquals(sum(10000), y.sum, 0.0)
   }
 
-  @Test def convert_a_Float32Array_to_a_scala_Array_Float(): Unit = {
+  @Test def convertFloat32ArrayToScalaArrayFloat(): Unit = {
     val x = new Float32Array(data.map(x => 0.2f * x.toFloat))
     val y = x.toArray
 
@@ -90,7 +90,7 @@ class TypedArrayConversionTest {
     assertEquals(sum(0.2), y.sum, 1E-6)
   }
 
-  @Test def convert_a_Float64Array_to_a_scala_Array_Double(): Unit = {
+  @Test def convertFloat64ArrayToScalaArrayDouble(): Unit = {
     val x = new Float64Array(data.map(x => 0.2 * x.toDouble))
     val y = x.toArray
 
@@ -102,7 +102,7 @@ class TypedArrayConversionTest {
     assertEquals(sum(0.2), y.sum, 0.0)
   }
 
-  @Test def convert_a_scala_Array_Byte__to_an_Int8Array(): Unit = {
+  @Test def convertScalaArrayByteToInt8Array(): Unit = {
     val x = (Byte.MinValue to Byte.MaxValue).map(_.toByte).toArray
     val y = x.toTypedArray
 
@@ -117,7 +117,7 @@ class TypedArrayConversionTest {
     assertEquals(Byte.MinValue, y(0))
   }
 
-  @Test def convert_a_scala_Array_Short__to_an_Int16Array(): Unit = {
+  @Test def convertScalaArrayShortToInt16Array(): Unit = {
     val x = ((Short.MinValue to (Short.MinValue + 1000)) ++
             ((Short.MaxValue - 1000) to Short.MaxValue)).map(_.toShort).toArray
     val y = x.toTypedArray
@@ -133,7 +133,7 @@ class TypedArrayConversionTest {
     assertEquals(Short.MinValue, y(0))
   }
 
-  @Test def convert_a_scala_Array_Char__to_an_Uint16Array(): Unit = {
+  @Test def convertScalaArrayCharToUint16Array(): Unit = {
     val x = ((Char.MaxValue - 1000) to Char.MaxValue).map(_.toChar).toArray
     val y = x.toTypedArray
 
@@ -148,7 +148,7 @@ class TypedArrayConversionTest {
     assertEquals(Char.MaxValue - 1000, y(0))
   }
 
-  @Test def convert_a_scala_Array_Int__to_an_Int32Array(): Unit = {
+  @Test def convertScalaArrayIntToInt32Array(): Unit = {
     val x = ((Int.MinValue to (Int.MinValue + 1000)) ++
             ((Int.MaxValue - 1000) to Int.MaxValue)).toArray
     val y = x.toTypedArray
@@ -164,7 +164,7 @@ class TypedArrayConversionTest {
     assertEquals(Int.MinValue, y(0))
   }
 
-  @Test def convert_a_scala_Array_Float__to_a_Float32Array(): Unit = {
+  @Test def convertScalaArrayFloatToFloat32Array(): Unit = {
     val x = Array[Float](1.0f, 2.0f, -2.3f, 5.3f)
     val y = x.toTypedArray
 
@@ -179,7 +179,7 @@ class TypedArrayConversionTest {
     assertEquals(1.0f, y(0), 0.0)
   }
 
-  @Test def convert_a_scala_Array_Double__to_a_Float64Array(): Unit = {
+  @Test def convertScalaArrayDoubleToFloat64Array(): Unit = {
     val x = Array[Double](1.0, 2.0, -2.3, 5.3)
     val y = x.toTypedArray
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/typedarray/TypedArrayTest.scala
@@ -41,39 +41,39 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
   def hasType(obj: Any): Boolean
   def intToV(n: Int): V
 
-  @Test def should_provide_a_factory_method_of(): Unit = {
+  @Test def factoryMethodOf(): Unit = {
     val x = ofFn(intToV(0), intToV(1), intToV(2))
     assertEquals(3, x.length)
     assertEquals(intToV(2), x(2))
   }
 
-  @Test def should_provide_a_factory_method_from(): Unit = {
+  @Test def factoryMethodFrom(): Unit = {
     val x = fromFn(js.Array(intToV(0), intToV(1), intToV(2)))
     assertEquals(3, x.length)
     assertEquals(intToV(2), x(2))
   }
 
-  @Test def should_provide_a_factory_method_from_with_mapping_function(): Unit = {
+  @Test def factoryMethodFromWithMappingFunction(): Unit = {
     val src = js.Array("", "a", "bc")
     val x = fromFn(src)((s: String) => intToV(s.length))
     assertEquals(3, x.length)
     assertEquals(intToV(2), x(2))
   }
 
-  @Test def should_provide_a_factory_method_from_with_mapping_function_and_thisArg(): Unit = {
+  @Test def factoryMethodFromWithMappingFunctionAndThisArg(): Unit = {
     val src = js.Array("", "a", "bc")
     val x = fromFn(src, 10)((thisArg: Int, s: String) => intToV(s.length * thisArg))
     assertEquals(3, x.length)
     assertEquals(intToV(20), x(2))
   }
 
-  @Test def should_allow_constructing_a_new_name_with_length(): Unit = {
+  @Test def constructNewTypedArrayWithLength(): Unit = {
     val x = lenCtor(10)
     assertTrue(hasType(x))
     assertEquals(10, x.length)
   }
 
-  @Test def should_allow_constructing_a_new_name_from_an_Int8Array(): Unit = {
+  @Test def constructNewTypedArrayFromTypedArray(): Unit = {
     val x = tarrCtor(tarr(js.Array(3, 7).map(intToV)))
     assertTrue(hasType(x))
     assertEquals(2, x.length)
@@ -82,7 +82,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(7), x(1))
   }
 
-  @Test def should_allow_constructing_a_new_name_from_a_js_Array(): Unit = {
+  @Test def constructNewTypedArrayFromJSArray(): Unit = {
     val x = itCtor(js.Array(5,6,7).map(intToV))
     assertTrue(hasType(x))
     assertEquals(3, x.length)
@@ -92,7 +92,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(7), x(2))
   }
 
-  @Test def should_allow_constructing_a_new_name_from_an_ArrayBuffer_1_arg(): Unit = {
+  @Test def constructNewTypedArrayFromArrayBuffer1Arg(): Unit = {
     val buf = itCtor(js.Array(5, 6, 7, 8).map(intToV)).buffer
     val x = bufCtor1(buf)
     assertTrue(hasType(x))
@@ -104,7 +104,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(8), x(3))
   }
 
-  @Test def should_allow_constructing_a_new_name_from_an_ArrayBuffer_2_args(): Unit = {
+  @Test def constructNewTypedArrayFromArrayBuffer2Args(): Unit = {
     val buf = itCtor(js.Array(5, 6, 7, 8).map(intToV)).buffer
     val x = bufCtor2(buf, bytesPerElement)
     assertTrue(hasType(x))
@@ -115,7 +115,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(8), x(2))
   }
 
-  @Test def should_allow_constructing_a_new_name_from_an_ArrayBuffer_3_args(): Unit = {
+  @Test def constructNewTypedArrayFromArrayBuffer3Args(): Unit = {
     val buf = itCtor(js.Array(5, 6, 7, 8).map(intToV)).buffer
     val x = bufCtor3(buf, bytesPerElement, 2)
     assertTrue(hasType(x))
@@ -125,17 +125,17 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(7), x(1))
   }
 
-  @Test def should_allow_retrieving_the_should_allow_retrieving_the(): Unit = {
+  @Test def length(): Unit = {
     val x = lenCtor(100)
     assertEquals(100, x.length)
   }
 
-  @Test def should_allow_retrieving_an_should_allow_retrieving_an(): Unit = {
+  @Test def apply(): Unit = {
     val x = itCtor(js.Array(5).map(intToV))
     assertEquals(intToV(5), x(0))
   }
 
-  @Test def should_allow_setting_an_should_allow_setting_an(): Unit = {
+  @Test def update(): Unit = {
     val x = lenCtor(2)
 
     x(0) = intToV(5)
@@ -145,12 +145,12 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(10), x(1))
   }
 
-  @Test def should_provide_should_provide(): Unit = {
+  @Test def get(): Unit = {
     val x = itCtor(js.Array(10).map(intToV))
     assertEquals(intToV(10), x.get(0))
   }
 
-  @Test def set_for_a_single_element(): Unit = {
+  @Test def setForSingleElement(): Unit = {
     val x = lenCtor(10)
     x.set(0, intToV(5))
     x.set(1, intToV(6))
@@ -160,7 +160,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(0), x(2))
   }
 
-  @Test def set_for_a_js_Array_with_one_arguments(): Unit = {
+  @Test def setJSArrayWithOneArguments(): Unit = {
     val x = lenCtor(10)
     x.set(js.Array(5,6,7).map(intToV))
     assertEquals(intToV(5), x(0))
@@ -171,7 +171,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(0), x(5))
   }
 
-  @Test def should_provide_set_for_a_js_Array_with_two_arguments(): Unit = {
+  @Test def setJSArrayWithTwoArguments(): Unit = {
     val x = lenCtor(10)
     x.set(js.Array(5,6,7).map(intToV), 2)
     assertEquals(intToV(0), x(0))
@@ -182,7 +182,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(0), x(5))
   }
 
-  @Test def should_provide_set_for_a_TypedArray_with_one_argument(): Unit = {
+  @Test def setTypedArrayWithOneArgument(): Unit = {
     val x = lenCtor(10)
     x.set(tarr(js.Array(5,6,7).map(intToV)))
     assertEquals(intToV(5), x(0))
@@ -193,7 +193,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(0), x(5))
   }
 
-  @Test def should_provide_set_for_a_TypedArray_with_two_arguments(): Unit = {
+  @Test def setTypedArrayWithTwoArguments(): Unit = {
     val x = lenCtor(10)
     x.set(tarr(js.Array(5,6,7).map(intToV)), 2)
     assertEquals(intToV(0), x(0))
@@ -204,7 +204,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(0), x(5))
   }
 
-  @Test def subarray_with_one_argument(): Unit = {
+  @Test def subarrayWithOneArgument(): Unit = {
     val x = itCtor(js.Array(1,2,3,4,5,6,7,8,9).map(intToV))
     val y = x.subarray(2)
 
@@ -216,7 +216,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(intToV(100), y(0))
   }
 
-  @Test def subarray_with_two_arguments(): Unit = {
+  @Test def subarrayWithTwoArguments(): Unit = {
     val x = itCtor(js.Array(1,2,3,4,5,6,7,8,9).map(intToV))
     val y = x.subarray(2, 4)
 
@@ -249,7 +249,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(bytesPerElement, y.byteOffset)
   }
 
-  @Test def is_iterable(): Unit = {
+  @Test def isIterable(): Unit = {
     assumeTrue("Assuming JavaScript symbols are supported",
         org.scalajs.testsuite.utils.Platform.jsSymbols)
 
@@ -263,7 +263,7 @@ trait TypedArrayTest[V, T <: TypedArray[V, T]] {
     assertEquals(iterable.toList, testData.map(intToV))
   }
 
-  @Test def from_iterable(): Unit = {
+  @Test def fromIterable(): Unit = {
     assumeTrue("Assuming JavaScript symbols are supported",
         org.scalajs.testsuite.utils.Platform.jsSymbols)
 

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/RegressionTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/RegressionTestScala2.scala
@@ -22,7 +22,7 @@ class RegressionTestTestScala2 {
    * The extension method any2stringadd (the `+` in `x + "check"`)
    * was deprecated in 2.13.0 and Dotty no longer has the method.
    */
-  @Test def String_concatenation_with_null_issue_26(): Unit = {
+  @Test def stringConcatenationWithNull_Issue26(): Unit = {
     val x: Object = null
     assertEquals("nullcheck", x + "check")
   }

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/RuntimeTypesTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/RuntimeTypesTestScala2.scala
@@ -22,24 +22,24 @@ class RuntimeTypesTestScala2 {
    * but they might break at any point in the future.
    */
 
-  @Test def scala_Nothing_Array_Nothing_should_be_allowed_to_exists_and_be_castable(): Unit = {
+  @Test def scalaNothingArrayNothingCanExistAndIsCastable(): Unit = {
     val arr = Array[Nothing]()
     arr.asInstanceOf[Array[Nothing]]
   }
 
-  @Test def scala_Nothing_Array_Array_Nothing_too(): Unit = {
+  @Test def scalaNothingArrayArrayNothingToo(): Unit = {
     val arr = Array[Array[Nothing]]()
     arr.asInstanceOf[Array[Array[Nothing]]]
     // This apparently works too... Dunno why
     arr.asInstanceOf[Array[Nothing]]
   }
 
-  @Test def scala_Null_Array_Null_should_be_allowed_to_exist_and_be_castable(): Unit = {
+  @Test def scalaNullArrayNullCanExistAndIsCastable(): Unit = {
     val arr = Array.fill[Null](5)(null)
     arr.asInstanceOf[Array[Null]]
   }
 
-  @Test def scala_Null_Array_Array_Null_too(): Unit = {
+  @Test def scalaNullArrayArrayNullToo(): Unit = {
     // Was `val arr = Array.fill[Null](5, 5)(null)` but that crashes on the JVM
     val arr = new Array[Array[Null]](5)
     arr.asInstanceOf[Array[Array[Null]]]

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ArrayBuilderTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ArrayBuilderTestScala2.scala
@@ -40,7 +40,7 @@ class ArrayBuilderTestScala2 {
    * Dotty does not have [[ClassTag]] instances for [[Nothing]] or for [[Null]].
    * @see [[https://github.com/lampepfl/dotty/issues/1730]]
    */
-  @Test def Nothing_and_Null(): Unit = {
+  @Test def nothingAndNull(): Unit = {
     assertSame(classOf[Array[Nothing]], ArrayBuilder.make[Nothing].result().getClass)
     assertSame(classOf[Array[Null]], ArrayBuilder.make[Null].result().getClass)
 

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ClassTagTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/ClassTagTestScala2.scala
@@ -24,7 +24,7 @@ class ClassTagTestScala2 {
    * Dotty does not have [[ClassTag]] instances for [[Nothing]] or for [[Null]].
    * @see [[https://github.com/lampepfl/dotty/issues/1730]]
    */
-  @Test def apply_should_get_the_existing_instances_for_predefined_ClassTags(): Unit = {
+  @Test def applyReturnsExistingInstancesForPredefinedClassTags(): Unit = {
     assertSame(ClassTag.Nothing, classTag[Nothing])
     assertSame(ClassTag.Null, classTag[Null])
   }
@@ -51,7 +51,7 @@ class ClassTagTestScala2 {
    * Dotty does not have [[ClassTag]] instances for [[Nothing]] or for [[Null]].
    * @see [[https://github.com/lampepfl/dotty/issues/1730]]
    */
-  @Test def scala_Null_classTag_of_scala_Null_should_contain_proper_Class_issue_297(): Unit = {
+  @Test def scalaNullClassTagOfScalaNullContainsProperClass_Issue297(): Unit = {
     val tag = classTag[Null]
     assertTrue(tag.runtimeClass != null)
     assertEquals("scala.runtime.Null$", tag.runtimeClass.getName)

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/SymbolTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/scalalib/SymbolTestScala2.scala
@@ -23,7 +23,7 @@ class SymbolTestScala2 {
    * This is a Scala 2.x only test because:
    * Dotty no longer supports symbol literal.
    */
-  @Test def should_support_symbol_literal(): Unit = {
+  @Test def symbolLiteral(): Unit = {
     val scalajs = 'ScalaJS
 
     assertEquals(Symbol("ScalaJS"), scalajs)
@@ -37,7 +37,7 @@ class SymbolTestScala2 {
    * This test is similar to the one found in SymbolTest with the same name.
    * But it uses symbol literals that are not supported on Dotty.
    */
-  @Test def should_ensure_unique_identity(): Unit = {
+  @Test def uniqueIdentity(): Unit = {
     def expectEqual(sym1: Symbol, sym2: Symbol): Unit = {
       assertTrue(sym1 eq sym2)
       assertEquals(sym2, sym1)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
@@ -46,7 +46,7 @@ class ArrayTest {
   }
 
   @Test
-  def arraySelectSideEffecting_issue_3848(): Unit = {
+  def arraySelectSideEffecting_Issue3848(): Unit = {
     assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
         hasCompliantArrayIndexOutOfBounds)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/BooleanTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/BooleanTest.scala
@@ -16,8 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class BooleanTest {
-  @Test
-  def `primitive_operations_on_booleans_should_return_correct_results`(): Unit = {
+  @Test def bitwiseAndOrXorOperators(): Unit = {
     assertFalse(false & false)
     assertFalse(false & true)
     assertFalse(true & false)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ByteTest.scala
@@ -17,8 +17,7 @@ import org.junit.Assert._
 
 class ByteTest {
 
-  @Test
-  def `should_always_be_in_their_range`(): Unit = {
+  @Test def toByteAndToCharAreInRange(): Unit = {
     def test(x: Int, y: Byte): Unit =
       assertEquals(y, x.toByte)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/CharTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/CharTest.scala
@@ -16,8 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class CharTest {
-  @Test
-  def `should_always_be_positive_when_coerced`(): Unit = {
+  @Test def toIntNegativeToPositive(): Unit = {
     assertEquals(-3.toByte.toChar.toInt, 65533)
     assertEquals(-100.toShort.toChar.toInt, 65436)
     assertEquals(-66000.toChar.toInt, 65072)
@@ -26,14 +25,12 @@ class CharTest {
     assertEquals(-7.9.toChar.toInt, 65529)
   }
 
-  @Test
-  def `should_overflow_when_coerced`(): Unit = {
+  @Test def toIntOverflow(): Unit = {
     assertEquals(347876543.toChar.toInt, 11455)
     assertEquals(34234567876543L.toChar.toInt, 57279)
   }
 
-  @Test
-  def `should_overflow_with_times`(): Unit = {
+  @Test def multiplyOverflow(): Unit = {
     def test(a: Char, b: Char, expected: Int): Unit =
       assertEquals(a * b, expected)
 
@@ -41,8 +38,7 @@ class CharTest {
     test(Char.MaxValue, Char.MaxValue, Char.MaxValue * Char.MaxValue)
   }
 
-  @Test
-  def do_not_box_several_times_in_a_block(): Unit = {
+  @Test def doNotBoxSeveralTimesInBlock(): Unit = {
     @noinline def test(x: Any): Unit =
       assertEquals('A', x)
 
@@ -52,8 +48,7 @@ class CharTest {
     }: Char)
   }
 
-  @Test
-  def do_not_box_several_times_in_an_if(): Unit = {
+  @Test def doNotBoxSeveralTimesInIf(): Unit = {
     @noinline def test(x: Any): Unit =
       assertEquals('A', x)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -53,7 +53,7 @@ class DoubleTest {
   }
 
   @Test
-  def noReverseComparisons_issue3575(): Unit = {
+  def noReverseComparisons_Issue3575(): Unit = {
     import Double.NaN
 
     @noinline def test_not_==(x: Double, y: Double): Boolean = !(x == y)
@@ -107,7 +107,7 @@ class DoubleTest {
   }
 
   @Test
-  def negate_issue4034(): Unit = {
+  def negate_Issue4034(): Unit = {
     @noinline
     def testNoInline(expected: Double, x: Double): Unit = {
       assertExactEquals(expected, -x)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -54,7 +54,7 @@ class FloatTest {
   }
 
   @Test
-  def noReverseComparisons_issue3575(): Unit = {
+  def noReverseComparisons_Issue3575(): Unit = {
     import Float.NaN
 
     @noinline def test_not_==(x: Float, y: Float): Boolean = !(x == y)
@@ -108,7 +108,7 @@ class FloatTest {
   }
 
   @Test
-  def negate_issue4034(): Unit = {
+  def negate_Issue4034(): Unit = {
     @noinline
     def testNoInline(expected: Float, x: Float): Unit = {
       assertExactEquals(expected, -x)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
@@ -30,7 +30,7 @@ import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 class IntTest {
   import IntTest._
 
-  @Test def `should_support_unary_minus`(): Unit = {
+  @Test def unaryMinus(): Unit = {
     def test(a: Int, expected: Int): Unit =
       assertEquals(expected, -a)
 
@@ -45,7 +45,7 @@ class IntTest {
     test(AlmostMaxVal, -AlmostMaxVal)
   }
 
-  @Test def `should_support_plus`(): Unit = {
+  @Test def plus(): Unit = {
     def test(a: Int, b: Int, expected: Int): Unit =
       assertEquals(expected, a + b)
 
@@ -60,7 +60,7 @@ class IntTest {
     test(AlmostMaxVal, 123, AlmostMaxVal + 123)
   }
 
-  @Test def `should_support_minus`(): Unit = {
+  @Test def minus(): Unit = {
     def test(a: Int, b: Int, expected: Int): Unit =
       assertEquals(expected, a - b)
 
@@ -75,7 +75,7 @@ class IntTest {
     test(AlmostMaxVal, -123, AlmostMaxVal + 123)
   }
 
-  @Test def `should_support_times`(): Unit = {
+  @Test def times(): Unit = {
     @inline def test(a: Int, b: Int, expected: Int): Unit = {
       @noinline def hideFromOptimizer(x: Int): Int = x
 
@@ -262,7 +262,7 @@ class IntTest {
     test(536870912, 20668, -2147483648)
   }
 
-  @Test def `should_support_division`(): Unit = {
+  @Test def division(): Unit = {
     def test(a: Int, b: Int, expected: Int): Unit =
       assertEquals(expected, a / b)
 
@@ -329,12 +329,12 @@ class IntTest {
     assertThrows(classOf[ArithmeticException], 5 % 0)
   }
 
-  @Test def `percent_should_never_produce_a_negative_0_#1984`(): Unit = {
+  @Test def remainderNegative0_Issue1984(): Unit = {
     @noinline def value: Int = -8
     assertEquals(0, value % 8)
   }
 
-  @Test def `should_support_shift_left`(): Unit = {
+  @Test def shiftLeft(): Unit = {
     def test(a: Int, b: Int, expected: Int): Unit =
       assertEquals(expected, a << b)
 
@@ -350,7 +350,7 @@ class IntTest {
     test(MaxVal, 1, MaxVal << 1)
   }
 
-  @Test def `should_support_shift_right`(): Unit = {
+  @Test def shiftRight(): Unit = {
     def test(a: Int, b: Int, expected: Int): Unit =
       assertEquals(expected, a >> b)
 
@@ -366,7 +366,7 @@ class IntTest {
     test(MaxVal, 1, MaxVal >> 1)
   }
 
-  @Test def `should_support_shift_right_sign_extend`(): Unit = {
+  @Test def shiftRightSignExtend(): Unit = {
     def test(a: Int, b: Int, expected: Int): Unit =
       assertEquals(expected, a >>> b)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -57,7 +57,7 @@ class LongTest {
 
   // Tests
 
-  @Test def sanity_of_equality_tests(): Unit = {
+  @Test def sanityOfEqualityTests(): Unit = {
     assertEquals(1958505087099L, lg(123, 456))
     assertEquals(528280977864L, lg(456, 123))
 
@@ -68,7 +68,7 @@ class LongTest {
     assertNotEquals(123L, lg(123, 456))
   }
 
-  @Test def equals_Any(): Unit = {
+  @Test def equalsAny(): Unit = {
     @inline def inlineCallEquals(lhs: Long, rhs: Any): Boolean =
       lhs.asInstanceOf[AnyRef].equals(rhs.asInstanceOf[AnyRef])
 
@@ -94,14 +94,14 @@ class LongTest {
     test(false, lg(-123, -456), lg(-123, 456))
   }
 
-  @Test def `should_correctly_handle_literals`(): Unit = {
+  @Test def literals(): Unit = {
     assertEquals(105L, 5L + 100L)
     assertEquals(2147483651L, 2147483649L + 2L)
     assertEquals(-8589934592L, -2147483648L * 4)
     assertEquals(-18014398509482040L, 4503599627370510L * (-4))
   }
 
-  @Test def `should_correctly_dispatch_unary_ops_on_Longs`(): Unit = {
+  @Test def unaryOps(): Unit = {
     val x = 10L
     assertEquals(-10L, -x)
     val y = 5L
@@ -110,13 +110,13 @@ class LongTest {
     assertEquals(-6L, ~y)
   }
 
-  @Test def `should_correctly_dispatch_binary_ops_on_Longs`(): Unit = {
+  @Test def binaryOps(): Unit = {
     assertEquals(25F, 5L * 5F, 0F)
     assertEquals(1F, 5L % 4F, 0F)
     assertEquals(20F, 5F * 4L, 0F)
   }
 
-  @Test def `should_support_shifts_with_Longs_#622`(): Unit = {
+  @Test def shifts_Issue622(): Unit = {
     def l(x: Long): Long = x
     def i(x: Int): Int = x
 
@@ -137,7 +137,7 @@ class LongTest {
     assertEquals(-5, i(-65) >> 4)
   }
 
-  @Test def `primitives_should_convert_to_Long`(): Unit = {
+  @Test def toLongConversions(): Unit = {
     // Byte
     assertEquals(112L, 112.toByte.toLong)
     // Short
@@ -154,7 +154,7 @@ class LongTest {
     assertEquals(100000L, 100000.6.toLong)
   }
 
-  @Test def `should_support_hashCode`(): Unit = {
+  @Test def testHashCodeLiterals(): Unit = {
     assertEquals(0, 0L.hashCode())
     assertEquals(55, 55L.hashCode())
     assertEquals(11, (-12L).hashCode())
@@ -167,7 +167,7 @@ class LongTest {
     assertEquals(-1689438124, 7632147899696541255L.hashCode())
   }
 
-  @Test def `should_support_hash_hash`(): Unit = {
+  @Test def hashHash(): Unit = {
     assertEquals(0, 0L.##)
     assertEquals(55, 55L.##)
     assertEquals(-12, (-12L).##)
@@ -181,7 +181,7 @@ class LongTest {
     assertEquals(-1689438124, 7632147899696541255L.##)
   }
 
-  @Test def `should_have_correct_hash_in_case_classes`(): Unit = {
+  @Test def hashHashInCaseClasses(): Unit = {
     if (scalaVersion.startsWith("2.11.") ||
         scalaVersion.startsWith("2.12.")) {
       assertEquals(-1669410282, HashTestBox(0L).##)
@@ -210,17 +210,17 @@ class LongTest {
     }
   }
 
-  @Test def `should_correctly_concat_to_string`(): Unit = {
+  @Test def concatWithString(): Unit = {
     val x = 20L
     assertEquals("asdf520hello", "asdf" + 5L + x + "hello")
     assertEquals("20hello", x + "hello")
   }
 
-  @Test def `string_should_convert_to_Long`(): Unit = {
+  @Test def stringToLong(): Unit = {
     assertEquals(45678901234567890L, "45678901234567890".toLong)
   }
 
-  @Test def `should_correctly_implement_is/asInstanceOf_Longs`(): Unit = {
+  @Test def asInstanceOf(): Unit = {
     val dyn:  Any  = 5L
     val stat: Long = 5L
 
@@ -237,14 +237,14 @@ class LongTest {
     assertFalse(dyn.isInstanceOf[Int])
   }
 
-  @Test def `should_correctly_compare_to_other_numeric_types`(): Unit = {
+  @Test def compareOtherNumericTypes(): Unit = {
     assertTrue(5L == 5)
     assertTrue(5 == 5L)
     assertTrue(4 != 5L)
     assertTrue('A' == 65L)
   }
 
-  @Test def hashCodeTest(): Unit = {
+  @Test def testHashCode(): Unit = {
     @inline def test(expected: Int, x: Long): Unit = {
       assertEquals(expected, x.hashCode())
       assertEquals(expected, hideFromOptimizer(x).hashCode())
@@ -609,7 +609,7 @@ class LongTest {
     test(8801656334077465992L, lg(2076251528, 2049295309))
   }
 
-  @Test def toFloat_strict(): Unit = {
+  @Test def toFloatStrict(): Unit = {
     assumeTrue("Assumed strict floats", hasStrictFloats)
 
     @inline def test(expected: Float, x: Long, epsilon: Float = 0.0f): Unit = {
@@ -863,7 +863,7 @@ class LongTest {
     test(lg(1839280888, -168388422), lg(-1645740821, -1967920957), 1)
   }
 
-  @Test def bitwise_not_~(): Unit = {
+  @Test def bitwiseNot(): Unit = {
     @inline def test(expected: Long, x: Long): Unit = {
       assertEquals(expected, ~x)
       assertEquals(expected, ~hideFromOptimizer(x))
@@ -921,7 +921,7 @@ class LongTest {
     test(lg(1382443514, -56307753), lg(-1382443515, 56307752))
   }
 
-  @Test def bitwise_or_|(): Unit = {
+  @Test def bitwiseOr(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x | y)
       assertEquals(expected, hideFromOptimizer(x) | y)
@@ -981,7 +981,7 @@ class LongTest {
     test(lg(-17107060, -35914117), lg(-402624124, -505696678), lg(-688199800, 2110291577))
   }
 
-  @Test def bitwise_and_&(): Unit = {
+  @Test def bitwiseAnd(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x & y)
       assertEquals(expected, hideFromOptimizer(x) & y)
@@ -1041,7 +1041,7 @@ class LongTest {
     test(lg(839516176, 671232089), lg(844761371, 1022505085), lg(1930384912, 688275291))
   }
 
-  @Test def bitwise_xor_^(): Unit = {
+  @Test def bitwiseXor(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x ^ y)
       assertEquals(expected, hideFromOptimizer(x) ^ y)
@@ -1101,7 +1101,7 @@ class LongTest {
     test(lg(857398449, 1711937081), lg(-1493347776, 1187436882), lg(-1779986703, 550293355))
   }
 
-  @Test def shift_left_<<(): Unit = {
+  @Test def shiftLeft(): Unit = {
     @inline def test(expected: Long, x: Long, y: Int): Unit = {
       assertEquals(expected, x << y)
       assertEquals(expected, hideFromOptimizer(x) << y)
@@ -1161,7 +1161,7 @@ class LongTest {
     test(lg(-1749421258, 1809275319), lg(-874710629, -1242845989), 484063041)
   }
 
-  @Test def shift_logical_right_>>>(): Unit = {
+  @Test def shiftLogicalRight(): Unit = {
     @inline def test(expected: Long, x: Long, y: Int): Unit = {
       assertEquals(expected, x >>> y)
       assertEquals(expected, hideFromOptimizer(x) >>> y)
@@ -1221,7 +1221,7 @@ class LongTest {
     test(lg(-5828381, 10), lg(-954198224, 369053217), 768150041)
   }
 
-  @Test def shift_arithmetic_right_>>(): Unit = {
+  @Test def shiftArithmeticRight(): Unit = {
     @inline def test(expected: Long, x: Long, y: Int): Unit = {
       assertEquals(expected, x >> y)
       assertEquals(expected, hideFromOptimizer(x) >> y)
@@ -1281,7 +1281,7 @@ class LongTest {
     test(lg(-104838948, -3), lg(-904956287, -543423347), -617227620)
   }
 
-  @Test def negate_-(): Unit = {
+  @Test def negate(): Unit = {
     @inline def test(expected: Long, x: Long): Unit = {
       assertEquals(expected, -x)
       assertEquals(expected, -hideFromOptimizer(x))
@@ -1346,7 +1346,7 @@ class LongTest {
     test(lg(2066446588, 688546120), lg(-2066446588, -688546121))
   }
 
-  @Test def plus_+(): Unit = {
+  @Test def plus(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x + y)
       assertEquals(expected, hideFromOptimizer(x) + y)
@@ -1406,7 +1406,7 @@ class LongTest {
     test(lg(-1393001322, 1362535802), lg(88305723, 1362535803), lg(-1481307045, -1))
   }
 
-  @Test def minus_-(): Unit = {
+  @Test def minus(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x - y)
       assertEquals(expected, hideFromOptimizer(x) - y)
@@ -1469,7 +1469,7 @@ class LongTest {
     test(lg(408960051, 967789979), lg(883147297, 967789979), lg(474187246, 0))
   }
 
-  @Test def times_*(): Unit = {
+  @Test def times(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x * y)
       assertEquals(expected, hideFromOptimizer(x) * y)
@@ -1682,7 +1682,7 @@ class LongTest {
     test(-3013501831155286016L, 4294967296L, -120218862620908531L)
   }
 
-  @Test def divide_/(): Unit = {
+  @Test def divide(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x / y)
       assertEquals(expected, hideFromOptimizer(x) / y)
@@ -2068,7 +2068,7 @@ class LongTest {
     assertThrows(classOf[ArithmeticException], 5L / 0L)
   }
 
-  @Test def modulo_%(): Unit = {
+  @Test def modulo(): Unit = {
     @inline def test(expected: Long, x: Long, y: Long): Unit = {
       assertEquals(expected, x % y)
       assertEquals(expected, hideFromOptimizer(x) % y)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/NameEncodingTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/NameEncodingTest.scala
@@ -17,7 +17,7 @@ import org.junit.Assert._
 
 class NameEncodingTest {
 
-  @Test def namesThatAreJSReservedWords_issue_153(): Unit = {
+  @Test def namesThatAreJSReservedWords_Issue153(): Unit = {
     // scalastyle:off class.name
 
     // Class name
@@ -44,7 +44,7 @@ class NameEncodingTest {
     // scalastyle:on class.name
   }
 
-  @Test def namesStartingWithDigit_issue_153(): Unit = {
+  @Test def namesStartingWithDigit_Issue153(): Unit = {
     // scalastyle:off class.name
 
     // Class name
@@ -102,7 +102,7 @@ class NameEncodingTest {
     assertEquals(5, obj.value)
   }
 
-  @Test def localEvalOrArguments_issue_743(): Unit = {
+  @Test def localEvalOrArguments_Issue743(): Unit = {
     val eval = 5
     assertEquals(5, eval)
     val arguments = "hello"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
@@ -26,7 +26,7 @@ import java.lang.{Float => JFloat, Double => JDouble}
 class ReflectiveCallTest {
   import ReflectiveCallTest._
 
-  @Test def should_allow_subtyping_in_return_types(): Unit = {
+  @Test def subtypingInReturnTypes(): Unit = {
     class A { def x: Int = 1 }
     class B extends A { override def x: Int = 2 }
 
@@ -39,7 +39,7 @@ class ReflectiveCallTest {
     assertEquals(2, f(Generator).x)
   }
 
-  @Test def should_allow_this_type_in_return_types(): Unit = {
+  @Test def thisTypeInReturnTypes(): Unit = {
     type ValueType = { def value: this.type }
     def f(x: ValueType): ValueType = x.value
 
@@ -51,7 +51,7 @@ class ReflectiveCallTest {
     assertEquals("StringValue(foo)", f(new StringValue("foo")).toString)
   }
 
-  @Test def should_allow_generic_return_types(): Unit = {
+  @Test def genericReturnTypes(): Unit = {
     case class Tata(name: String)
 
     object Rec {
@@ -64,7 +64,7 @@ class ReflectiveCallTest {
     assertEquals("Tata(iei)", m[Tata](Rec).toString)
   }
 
-  @Test def should_work_with_unary_methods_on_primitive_types(): Unit = {
+  @Test def unaryMethodsOnPrimitiveTypes(): Unit = {
     // scalastyle:off disallow.space.before.token
     def fInt(x: Any { def unary_- : Int }): Int = -x
     assertEquals(-1, fInt(1.toByte))
@@ -87,7 +87,7 @@ class ReflectiveCallTest {
     // scalastyle:on disallow.space.before.token
   }
 
-  @Test def should_work_with_binary_operators_on_primitive_types(): Unit = {
+  @Test def binaryOperatorsOnPrimitiveTypes(): Unit = {
     def fLong(x: Any { def +(x: Long): Long }): Long = x + 5L
     assertEquals(10L, fLong(5.toByte))
     assertEquals(15L, fLong(10.toShort))
@@ -118,7 +118,7 @@ class ReflectiveCallTest {
     assertTrue(fBoolean(true))
   }
 
-  @Test def should_work_with_equality_operators_on_primitive_types(): Unit = {
+  @Test def qualityOperatorsOnPrimitiveTypes(): Unit = {
     assumeFalse("Reflective call to == and != is broken on the JVM",
         Platform.executingInJVM)
 
@@ -163,7 +163,7 @@ class ReflectiveCallTest {
     assertFalse(fBoolN(false))
   }
 
-  @Test def should_work_with_compareTo_for_primitives(): Unit = {
+  @Test def compareToForPrimitives(): Unit = {
     def fCompareToBoolean(x: { def compareTo(y: java.lang.Boolean): Int }, y: Boolean): Int =
       x.compareTo(y)
     assertTrue(fCompareToBoolean(false, true) < 0)
@@ -197,7 +197,7 @@ class ReflectiveCallTest {
     assertTrue(fCompareToDouble(5.5, 6.5) < 0)
   }
 
-  @Test def should_work_with_concat_for_primitives(): Unit = {
+  @Test def concatForPrimitives(): Unit = {
     // See https://github.com/scala/bug/issues/10469
     assumeFalse("Reflective call prim.+(String) broken on the JVM",
         Platform.executingInJVM)
@@ -214,7 +214,7 @@ class ReflectiveCallTest {
     assertEquals("5.5foo", concat(5.5, "foo"))
   }
 
-  @Test def should_work_with_Arrays(): Unit = {
+  @Test def arrays(): Unit = {
     type UPD = { def update(i: Int, x: String): Unit }
     type APL = { def apply(i: Int): String }
     type LEN = { def length: Int }
@@ -235,7 +235,7 @@ class ReflectiveCallTest {
     assertEquals("foo", y(1))
   }
 
-  @Test def should_work_with_Arrays_of_primitive_values(): Unit = {
+  @Test def arraysOfPrimitiveValues(): Unit = {
     type UPD = { def update(i: Int, x: Int): Unit }
     type APL = { def apply(i: Int): Int}
     type LEN = { def length: Int }
@@ -256,7 +256,7 @@ class ReflectiveCallTest {
     assertEquals(2, y(1))
   }
 
-  @Test def should_work_with_Strings(): Unit = {
+  @Test def strings(): Unit = {
     def get(obj: { def codePointAt(str: Int): Int }): Int =
       obj.codePointAt(1)
     assertEquals('i'.toInt, get("Hi"))
@@ -273,7 +273,7 @@ class ReflectiveCallTest {
     assertTrue(compareToString("hello", "world") < 0)
   }
 
-  @Test def should_properly_generate_forwarders_for_inherited_methods(): Unit = {
+  @Test def forwardersForInheritedMethods(): Unit = {
     trait A {
       def foo: Int
     }
@@ -289,7 +289,7 @@ class ReflectiveCallTest {
     assertEquals(1, call(new C))
   }
 
-  @Test def should_be_bug_compatible_with_Scala_JVM_for_inherited_overloads(): Unit = {
+  @Test def bugCompatibleWithScalaJVMForInheritedOverloads(): Unit = {
     class Base {
       def foo(x: Option[Int]): String = "a"
     }
@@ -307,7 +307,7 @@ class ReflectiveCallTest {
     assertEquals(1, y.foo(Some("hello")))
   }
 
-  @Test def should_work_on_java_lang_Object_notify_notifyAll_issue_303(): Unit = {
+  @Test def javaLangObjectNotifyNotifyAll_Issue303(): Unit = {
     type ObjNotifyLike = Any {
       def notify(): Unit
       def notifyAll(): Unit
@@ -326,7 +326,7 @@ class ReflectiveCallTest {
     }
   }
 
-  @Test def should_work_on_java_lang_Object_clone_issue_303(): Unit = {
+  @Test def javaLangObjectClone_Issue303(): Unit = {
     type ObjCloneLike = Any { def clone(): AnyRef }
     def objCloneTest(obj: ObjCloneLike): AnyRef = obj.clone()
 
@@ -341,7 +341,7 @@ class ReflectiveCallTest {
     assertEquals(1, bClone.x)
   }
 
-  @Test def should_not_work_on_scala_AnyRef_eq_ne_synchronized_issue_2709(): Unit = {
+  @Test def scalaAnyRefEqNeSynchronized_Issue2709(): Unit = {
     // Bug compatible with Scala/JVM
 
     assumeFalse(
@@ -383,7 +383,7 @@ class ReflectiveCallTest {
     testWith(objSynchronizedTest(a1, "hello"))
   }
 
-  @Test def should_work_on_AnyVal_eq_ne_synchronized_issue_2709(): Unit = {
+  @Test def anyValEqNeSynchronized_Issue2709(): Unit = {
     type ObjWithAnyRefPrimitives = Any {
       def eq(that: AnyRef): Boolean
       def ne(that: AnyRef): Boolean
@@ -408,7 +408,7 @@ class ReflectiveCallTest {
     assertEquals("hellothere", objSynchronizedTest(a, "hello"))
   }
 
-  @Test def should_work_on_java_lang_Float_Double_isNaN_isInfinite(): Unit = {
+  @Test def javaLangFloatDoubleIsNaNIsInfinite(): Unit = {
     type FloatingNumberLike = Any {
       def isNaN(): Boolean
       def isInfinite(): Boolean
@@ -430,7 +430,7 @@ class ReflectiveCallTest {
     test(new JDouble(54.67), false, false)
   }
 
-  @Test def should_work_with_default_arguments_issue_390(): Unit = {
+  @Test def defaultArguments_Issue390(): Unit = {
     def pimpIt(a: Int) = new { // scalastyle:ignore
       def foo(b: Int, c: Int = 1): Int = a + b + c
     }
@@ -439,7 +439,7 @@ class ReflectiveCallTest {
     assertEquals(8, pimpIt(2).foo(2,4))
   }
 
-  @Test def should_unbox_all_types_of_arguments_issue_899(): Unit = {
+  @Test def unboxAllTypesOfArguments_Issue899(): Unit = {
     class Foo {
       def makeInt: Int = 5
       def testInt(x: Int): Unit = assertEquals(5, x)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -25,7 +25,7 @@ import org.scalajs.testsuite.utils.Platform
 class RegressionTest {
   import RegressionTest._
 
-  @Test def `Wrong_division_conversion_(7_/_2.0)_issue_18`(): Unit = {
+  @Test def wrongDivisionConversion7Divide2Pt0_Issue18(): Unit = {
     val div = 7 / 2.0
     assertEquals(3.5, div, 0.0)
     assertEquals("double", div.getClass.getName)
@@ -35,7 +35,7 @@ class RegressionTest {
     assertEquals("double", mod.getClass.getName)
   }
 
-  @Test def Abort_with_some_pattern_match_guards_issue_22(): Unit = {
+  @Test def abortWithSomePatternMatchGuards_Issue22(): Unit = {
     object PatternMatchGuards {
       def go(f: Int => Int): Int = f(1)
       def main(): Unit = {
@@ -47,7 +47,7 @@ class RegressionTest {
     // Nothing to check
   }
 
-  @Test def Bad_encoding_for_characters_spanning_2_UTF_16_chars_issue_23(): Unit = {
+  @Test def badEncodingForCharactersSpanning2UTF16Chars_Issue23(): Unit = {
     val str = "A∀\uD835\uDCAB"
     var s: String = ""
     for (c <- str) {
@@ -57,7 +57,7 @@ class RegressionTest {
     assertEquals("65 8704 55349 56491 ", s)
   }
 
-  @Test def characterEscapes_issue_3125(): Unit = {
+  @Test def characterEscapes_Issue3125(): Unit = {
     val str = {
       // The space at the end is intended. It is 0x20.
       "\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\u0009\u000a" +
@@ -73,23 +73,23 @@ class RegressionTest {
     assertEquals(39, strQuotes.charAt(1).toInt)
   }
 
-  @Test def should_emit_static_calls_when_forwarding_to_another_constructor_issue_66(): Unit = {
+  @Test def emitStaticCallsWhenForwardingToAnotherConstructor_Issue66(): Unit = {
     new Bug66B("", "")
   }
 
-  @Test def should_correctly_call_subSequence_on_non_string_CharSequences_issue_55(): Unit = {
+  @Test def callSubSequenceOnNonStringCharSequences_Issue55(): Unit = {
     val arr: CharSequence = java.nio.CharBuffer.wrap(Array('a', 'b', 'c', 'd'))
     val ss = arr.subSequence(2, 3)
     assertEquals(1, ss.length())
     assertEquals('c', ss.charAt(0))
   }
 
-  @Test def should_correctly_concat_primitive_values_to_strings_issue_113(): Unit = {
+  @Test def concatPrimitiveValuesToStrings_Issue113(): Unit = {
     assertEquals("4foo", 4 + "foo")
     assertEquals("afoo", 'a' + "foo")
   }
 
-  @Test def should_correctly_dispatch_calls_on_private_functions_issue_165(): Unit = {
+  @Test def dispatchCallsOnPrivateFunctions_Issue165(): Unit = {
     class A {
       private def x: Int = 1
       def value: Int = x
@@ -100,7 +100,7 @@ class RegressionTest {
     assertEquals(1, new B().value)
   }
 
-  @Test def should_support_class_literals_for_existential_value_types_issue_218(): Unit = {
+  @Test def classLiteralsForExistentialValueTypes_Issue218(): Unit = {
     import Platform.scalaVersion
 
     assumeFalse("Affected by https://github.com/scala/bug/issues/10551",
@@ -115,7 +115,7 @@ class RegressionTest {
         scala.reflect.classTag[Bug218Foo[_]].toString)
   }
 
-  @Test def should_support_Buffer_issue_268(): Unit = {
+  @Test def buffer_Issue268(): Unit = {
     val a = scala.collection.mutable.Buffer.empty[Int]
     a.insert(0, 0)
     a.remove(0)
@@ -125,7 +125,7 @@ class RegressionTest {
     assertEquals("1, 3, 5, 7, 9, 10, 8, 6, 4, 2, 0", a.mkString(", "))
   }
 
-  @Test def should_not_call_equals_when_comparing_with_a_literal_null_issue_362(): Unit = {
+  @Test def doNotCallEqualsWhenComparingWithLiteralNull_Issue362(): Unit = {
     // scalastyle:off equals.hash.code
     class A {
       override def equals(x: Any): Boolean = !(this == null)
@@ -141,7 +141,7 @@ class RegressionTest {
     assertEquals(x, y)
   }
 
-  @Test def should_unbox_null_to_the_zero_of_types_issue_674(): Unit = {
+  @Test def unboxNullToTheZeroOfTypes_Issue674(): Unit = {
     class Box[A] {
       var value: A = _
     }
@@ -187,7 +187,7 @@ class RegressionTest {
     assertEquals(null, ref)
   }
 
-  @Test def Param_defs_in_tailrec_methods_should_be_considered_mutable_issue_825(): Unit = {
+  @Test def paramDefsInTailrecMethodsAreMutable_Issue825(): Unit = {
     @tailrec
     def foo(x: Int, y: Int): Unit = {
       if (x < y) foo(y, x)
@@ -199,18 +199,18 @@ class RegressionTest {
     foo(2, 4)
   }
 
-  @Test def null_synchronized_should_throw_issue_874(): Unit = {
+  @Test def nullSynchronizedThrows_Issue874(): Unit = {
     assertThrows(classOf[NullPointerException], null.synchronized(5))
   }
 
-  @Test def x_synchronized_should_preserve_side_effects_of_x(): Unit = {
+  @Test def synchronizedXPreservesSideEffectsOfX(): Unit = {
     var c = 0
     def x: RegressionTest.this.type = { c += 1; this }
     assertEquals(5, x.synchronized(5))
     assertEquals(1, c)
   }
 
-  @Test def IR_checker_should_allow_Apply_Select_on_NullType_and_NothingType_issue_1123(): Unit = {
+  @Test def irCheckerAllowsApplySelectOnNullTypeAndNothingType_Issue1123(): Unit = {
     def giveMeANull(): Null = null
     assertThrows(classOf[Exception], (giveMeANull(): StringBuilder).append(5))
     assertThrows(classOf[Exception], (giveMeANull(): scala.runtime.IntRef).elem)
@@ -220,7 +220,7 @@ class RegressionTest {
     assertThrows(classOf[Exception], (giveMeANothing(): scala.runtime.IntRef).elem)
   }
 
-  @Test def IR_checker_must_not_check_field_existence_on_non_existent_classes(): Unit = {
+  @Test def irCheckerDoesNotCheckFieldExistenceOnNonExistentClasses(): Unit = {
     // In this test, Outer is not "needed at all"
 
     class Outer(x: Int) {
@@ -241,7 +241,7 @@ class RegressionTest {
     assertEquals(3, test(null))
   }
 
-  @Test def IR_checker_must_not_check_field_existence_on_classes_with_no_instance_issue_3060(): Unit = {
+  @Test def irCheckerDoesNotCheckFieldExistenceOnClassesWithNoInstance_Issue3060(): Unit = {
     // In this test, Outer is "needed at all", but does not have any instance
 
     class Outer(x: Int) {
@@ -265,7 +265,7 @@ class RegressionTest {
     assertEquals(3, test(null))
   }
 
-  @Test def IR_checker_must_not_check_method_signatures_on_classes_with_no_instance(): Unit = {
+  @Test def irCheckerDoesNotCheckMethodSignaturesOnClassesWithNoInstance(): Unit = {
     assumeTrue("linking only", false)
 
     class Foo // this class will be dropped by base linking
@@ -285,7 +285,7 @@ class RegressionTest {
     (??? : Bar).meth(null) // scalastyle:ignore
   }
 
-  @Test def should_properly_order_ctor_statements_when_inlining_issue_1369(): Unit = {
+  @Test def orderCtorStatementsWhenInlining_Issue1369(): Unit = {
     trait Bar {
       def x: Int
       var y = x + 1
@@ -299,7 +299,7 @@ class RegressionTest {
     assertEquals(2, obj.y)
   }
 
-  @Test def should_not_restrict_mutability_of_fields_issue_1021(): Unit = {
+  @Test def doNotRestrictMutabilityOfFields_Issue1021(): Unit = {
     class A {
       /* This var is referred to in the lambda passed to `foreach`. Therefore
        * it is altered in another compilation unit (even though it is
@@ -321,7 +321,7 @@ class RegressionTest {
     assertEquals(2, a.get)
   }
 
-  @Test def should_populate_desugar_environments_with_Closure_params_issue_1399(): Unit = {
+  @Test def populateDesugarEnvironmentsWithClosureParams_Issue1399(): Unit = {
     /* To query whether a field is mutable, the JSDesugar needs to first
      * unnest a statement block from an argument list, and then unnest the
      * parameter under test.
@@ -354,7 +354,7 @@ class RegressionTest {
     assertEquals("15", new Test().fct(1))
   }
 
-  @Test def should_not_cause_Closure_to_crash_with_Unexpected_variable_NaN_issue_1469(): Unit = {
+  @Test def doNotCauseClosureToCrashWithUnexpectedVariableNaN_Issue1469(): Unit = {
     /* Basically we want to make sure that a specialized bridge of Function1
      * taking and returning Double is emitted (and not dce'ed) for this
      * class F, which actually returns Unit.
@@ -390,7 +390,7 @@ class RegressionTest {
     f(5)
   }
 
-  @Test def switch_match_with_2_guards_for_the_same_value_issue_1589(): Unit = {
+  @Test def switchMatchWith2GuardsForTheSameValue_Issue1589(): Unit = {
     @noinline def genB(): Int = 0xE1
     val b = genB()
     val x = b >> 4 match {
@@ -402,7 +402,7 @@ class RegressionTest {
     assertEquals(5, x)
   }
 
-  @Test def switch_match_with_a_guard_and_a_result_type_of_BoxedUnit_issue_1955(): Unit = {
+  @Test def switchMatchWithGuardAndResultTypeOfBoxedUnit_Issue1955(): Unit = {
     val bug = new Bug1955
     bug.bug(2, true)
     assertEquals(0, bug.result)
@@ -411,7 +411,7 @@ class RegressionTest {
     assertThrows(classOf[MatchError], bug.bug(2, false))
   }
 
-  @Test def switch_match_with_a_guard_in_statement_pos_but_with_non_unit_branches_issue_4105(): Unit = {
+  @Test def switchMatchWithGuardInStatementPosButWithNonUnitBranches_Issue4105(): Unit = {
     def encodeString(string: String, isKey: Boolean): String = {
       val buffer = new java.lang.StringBuilder()
       val length = string.length
@@ -448,7 +448,7 @@ class RegressionTest {
     assertEquals("1\\t2\\n3\\f4\\r5\\\\6\\!7\\ 8a9", encodeString("1\t2\n3\f4\r5\\6!7 8a9", true))
   }
 
-  @Test def return_x_match_issue_2928_ints(): Unit = {
+  @Test def returnXMatchInt_Issue2928(): Unit = {
     // scalastyle:off return
 
     def testNonUnit(x: Int): Boolean = {
@@ -479,7 +479,7 @@ class RegressionTest {
     // scalastyle:on return
   }
 
-  @Test def return_x_match_issue_2928_strings(): Unit = {
+  @Test def returnXMatchString_Issue2928(): Unit = {
     // scalastyle:off return
 
     def testNonUnit(x: String): Boolean = {
@@ -510,7 +510,7 @@ class RegressionTest {
     // scalastyle:on return
   }
 
-  @Test def return_x_match_issue_2928_lists(): Unit = {
+  @Test def returnXMatchList_Issue2928(): Unit = {
     // scalastyle:off return
 
     def testNonUnit(x: List[String]): Boolean = {
@@ -545,7 +545,7 @@ class RegressionTest {
     // scalastyle:on return
   }
 
-  @Test def null_asInstanceOf_Unit_should_succeed_issue_1691(): Unit = {
+  @Test def nullAsInstanceOfUnitSucceeds_Issue1691(): Unit = {
     /* Avoid scalac's special treatment of `<literal null>.asInstanceOf[X]`.
      * It does have the benefit to test our constant-folder of that pattern,
      * once getNull() is inlined; and of our run-time implementation, when the
@@ -562,12 +562,12 @@ class RegressionTest {
     }
   }
 
-  @Test def lambda_parameter_with_a_dash_issue_1790(): Unit = {
+  @Test def lambdaParameterWithDash_Issue1790(): Unit = {
     val f = (`a-b`: Int) => `a-b` + 1
     assertEquals(6, f(5))
   }
 
-  @Test def nested_labeled_block_sort_circuit_returns_issue_2307(): Unit = {
+  @Test def nestedLabeledBlockSortCircuitReturns_Issue2307(): Unit = {
     class UnsafeCrud(i: Int) {
       def unsafeUpdate(l: List[Any], i: Int, f: Any => Any): (List[Any], Any) = {
         def loop(l: List[Any], i: Int, prefix: List[Any]): (List[Any], List[Any], Any) = {
@@ -689,7 +689,7 @@ class RegressionTest {
     assertTrue(f3A != f4B)
   }
 
-  @Test def isInstanceOf_must_not_call_toString_issue_2953(): Unit = {
+  @Test def isInstanceOfDoesNotCallToString_Issue2953(): Unit = {
     class C {
       override def toString(): String =
         throw new AssertionError("C.toString must not be called by isInstanceOf")
@@ -711,7 +711,7 @@ class RegressionTest {
     assertFalse("String", c.isInstanceOf[String])
   }
 
-  @Test def super_mixin_call_in_2_12_issue_3013(): Unit = {
+  @Test def superMixinCallIn212_Issue3013(): Unit = {
     assumeTrue(
         "Super mixin calls are broken in Scala/JVM 2.12.{0-2}",
         !Platform.executingInJVM ||
@@ -726,7 +726,7 @@ class RegressionTest {
     assertEquals("B", c.t3)
   }
 
-  @Test def tailrec_in_trait_with_self_type_scala_2_12_issue_3058(): Unit = {
+  @Test def tailrecInTraitWithSelfTypeScala212_Issue3058(): Unit = {
     trait Parent { this: Child =>
       @tailrec final def bar(i: Int, acc: Int): Int = {
         if (i <= count)
@@ -743,7 +743,7 @@ class RegressionTest {
     assertEquals(15, new Child().bar(1, 0))
   }
 
-  @Test def tailrec_in_class_with_self_type_scala_2_12_issue_3058(): Unit = {
+  @Test def tailrecInClassWithSelfTypeScala212_Issue3058(): Unit = {
     class Parent { this: Child =>
       @tailrec final def bar(i: Int, acc: Int): Int = {
         if (i <= count)
@@ -760,7 +760,7 @@ class RegressionTest {
     assertEquals(15, new Child().bar(1, 0))
   }
 
-  @Test def tailrec_in_trait_with_self_type_scala_2_12_issue_3267(): Unit = {
+  @Test def tailrecInTraitWithSelfTypeScala212_Issue3267(): Unit = {
     class Parser {
       def c(): Int = 65
     }
@@ -785,7 +785,7 @@ class RegressionTest {
     assertEquals(107, new ParserWithHelpers().rec(3))
   }
 
-  @Test def tailrec_in_class_with_self_type_scala_2_12_issue_3267(): Unit = {
+  @Test def tailrecInClassWithSelfTypeScala212_Issue3267(): Unit = {
     trait Parser {
       def c(): Int = 65
     }
@@ -810,7 +810,7 @@ class RegressionTest {
     assertEquals(107, new ParserWithHelpers().rec(3))
   }
 
-  @Test def adaptedIntToLongInMatch_issue_3281(): Unit = {
+  @Test def adaptedIntToLongInMatch_Issue3281(): Unit = {
     import Bug3281._
 
     val l: Any = 0 :: Nil
@@ -820,7 +820,7 @@ class RegressionTest {
     assertEquals(5L, r)
   }
 
-  @Test def polymorphicArrayApplyWithArrayOfArrayOfChar_issue_3338(): Unit = {
+  @Test def polymorphicArrayApplyWithArrayOfArrayOfChar_Issue3338(): Unit = {
     @inline
     def arrayGet[A](a: Array[A], i: Int): Any = a(i)
 
@@ -833,18 +833,18 @@ class RegressionTest {
     assertEquals('a', d)
   }
 
-  @Test def nested_object_named_class_issue_3888(): Unit = {
+  @Test def nestedObjectNamedClass_Issue3888(): Unit = {
     assertEquals(6, `class`.foo(5))
   }
 
-  @Test def gcc_crash_with_let_const_issue_4098(): Unit = {
+  @Test def gccCrashWithLetConst_Issue4098(): Unit = {
     val set = new java.util.HashSet[String]()
     set.remove("")
     set.remove("1") // only if remove is called twice
     assertEquals(0, set.size())
   }
 
-  @Test def nestedObjectsAndClassesWhoseNamesDifferOnlyInCase_issue_4148(): Unit = {
+  @Test def nestedObjectsAndClassesWhoseNamesDifferOnlyInCase_Issue4148(): Unit = {
     // These tests mostly assert that all four objects and classes link
     assertEquals(1, staticForwardersAvoidanceObjectBeforeClass.checkValue)
     assertEquals(2, new StaticForwardersAvoidanceObjectBeforeClass().checkValue)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ShortTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ShortTest.scala
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class ShortTest {
-  @Test def `should_always_be_in_their_range`(): Unit = {
+  @Test def toShort(): Unit = {
     def test(x: Int, y: Short): Unit =
       assertEquals(y, x.toShort)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/UnitTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/UnitTest.scala
@@ -16,17 +16,17 @@ import org.junit.Test
 import org.junit.Assert._
 
 class UnitTest {
-  @Test def `should_have_hashCode`(): Unit = {
+  @Test def testHashCode(): Unit = {
     assertEquals(0, ().hashCode())
     assertEquals(0, ((): Any).hashCode())
     assertEquals(0, ().##)
   }
 
-  @Test def `should_equal_itself`(): Unit = {
+  @Test def testEquals(): Unit = {
     assertTrue(().asInstanceOf[AnyRef].equals(().asInstanceOf[AnyRef]))
   }
 
-  @Test def `should_not_equal_other_values`(): Unit = {
+  @Test def testEqualsOtherValues(): Unit = {
     def testAgainst(v: Any): Unit = {
       assertFalse(().asInstanceOf[AnyRef].equals(v.asInstanceOf[AnyRef]))
     }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/AutoCloseableTest.scala
@@ -31,7 +31,7 @@ class AutoCloseableTest {
   }
 
   @Test
-  def byteArrayOutputStreamIsAnAutoCloseable_issue_3107(): Unit = {
+  def byteArrayOutputStreamIsAnAutoCloseable_Issue3107(): Unit = {
     val x = new java.io.ByteArrayOutputStream
     close(x)
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayInputStreamTest.scala
@@ -23,7 +23,7 @@ class ByteArrayInputStreamTest extends CommonStreamsTests {
   }
 
   @Test
-  def readWithZeroLengthReturnsMinus1AtEOF_issue_3913(): Unit = {
+  def readWithZeroLengthReturnsMinus1AtEof_Issue3913(): Unit = {
     /* Contrary to the spec in the base class InputStream, read(_, _, 0) must
      * return -1 if the stream is at the end of the buffer, instead of 0.
      */

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
@@ -21,7 +21,7 @@ import org.junit.Assert._
 
 class ByteArrayOutputStreamTest {
 
-  @Test def should_support_simple_write_int(): Unit = {
+  @Test def simpleWriteInt(): Unit = {
     val out = new ByteArrayOutputStream()
 
     for (i <- 0 to 9)
@@ -30,7 +30,7 @@ class ByteArrayOutputStreamTest {
     assertArrayEquals(Array[Byte](0, 1, 2, 3, 4, 5, 6, 7, 8, 9), out.toByteArray)
   }
 
-  @Test def should_support_simple_write_byte_array(): Unit = {
+  @Test def simpleWriteByteArray(): Unit = {
     val out = new ByteArrayOutputStream()
     val arr = Array[Byte](0, 1, 2, 3, 4, 5)
 
@@ -40,7 +40,7 @@ class ByteArrayOutputStreamTest {
     assertArrayEquals(Array[Byte](1, 2, 3, 4, 0, 1, 2, 3, 4, 5), out.toByteArray)
   }
 
-  @Test def should_support_write_byte_array_with_buffer_resize(): Unit = {
+  @Test def writeByteArrayWithBufferResize(): Unit = {
     val out = new ByteArrayOutputStream(16)
     val arr = Array[Byte](0, 1, 2, 3, 4, 5, 6, 7, 8, 9)
 
@@ -50,7 +50,7 @@ class ByteArrayOutputStreamTest {
     assertArrayEquals(arr ++ arr, out.toByteArray)
   }
 
-  @Test def should_support_toString_with_UTF8(): Unit = {
+  @Test def toStringWithUTF8(): Unit = {
     val buf = Array[Byte](72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100,
       46, -29, -127, -109, -29, -126, -109, -29, -127, -85, -29, -127, -95,
       -29, -127, -81, -26, -105, -91, -26, -100, -84, -24, -86, -98, -29,
@@ -63,7 +63,7 @@ class ByteArrayOutputStreamTest {
     assertEquals("Hello World.こんにちは日本語を読めますか。", out.toString)
   }
 
-  @Test def should_support_reset(): Unit = {
+  @Test def reset(): Unit = {
     val out = new ByteArrayOutputStream()
     for (i <- 0 to 9) out.write(i)
     out.reset()
@@ -72,7 +72,7 @@ class ByteArrayOutputStreamTest {
     assertArrayEquals(Array[Byte](0, 1, 2, 3, 4, 5, 6, 7, 8, 9), out.toByteArray)
   }
 
-  @Test def buf_field(): Unit = {
+  @Test def bufField(): Unit = {
     class ByteArrayOutputStreamWithBufAccess extends ByteArrayOutputStream {
       def getBuf(): Array[Byte] = buf
       def setBuf(b: Array[Byte]): Unit = buf = b
@@ -91,7 +91,7 @@ class ByteArrayOutputStreamTest {
     assertNotSame(newBuf, output)
   }
 
-  @Test def count_field(): Unit = {
+  @Test def countField(): Unit = {
     class ByteArrayOutputStreamWithCountAccess extends ByteArrayOutputStream {
       def getCount(): Int = count
       def setCount(c: Int): Unit = count = c

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayReaderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayReaderTest.scala
@@ -27,13 +27,13 @@ class CharArrayReaderTest {
       closeable.close()
   }
 
-  @Test def should_support_constructor_char_array(): Unit = {
+  @Test def ctorCharArray(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       assertTrue("Failed to create reader", cr.ready())
     }
   }
 
-  @Test def should_support_constructor_char_array_with_offset_and_length(): Unit = {
+  @Test def ctorCharArrayWithOffsetAndLength(): Unit = {
     // CharArrayReader for "Worl"
     withClose(new CharArrayReader(hw, 5, 4)) { cr =>
       assertTrue("Failed to create reader", cr.ready())
@@ -47,7 +47,7 @@ class CharArrayReaderTest {
     }
   }
 
-  @Test def should_support_constructor_char_array_with_offset_and_larger_length(): Unit = {
+  @Test def ctorCharArrayWithOffsetAndLargerLength(): Unit = {
     // CharArrayReader for "World"
     withClose(new CharArrayReader(hw, 5, 100)) { cr =>
       assertTrue("Failed to create reader", cr.ready())
@@ -61,20 +61,20 @@ class CharArrayReaderTest {
     }
   }
 
-  @Test def read_should_throw_IOException_after_close(): Unit = {
+  @Test def readThrowsIOExceptionAfterClose(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       cr.close()
       assertThrows(classOf[IOException], cr.read())
     }
   }
 
-  @Test def should_support_markSupported(): Unit = {
+  @Test def markSupported(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       assertTrue("markSupported returned false", cr.markSupported)
     }
   }
 
-  @Test def should_support_read_char(): Unit = {
+  @Test def readChar(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       assertEquals("Read returned incorrect char", 'H', cr.read())
     }
@@ -84,7 +84,7 @@ class CharArrayReaderTest {
     }
   }
 
-  @Test def should_support_read_char_array(): Unit = {
+  @Test def readCharArray(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       val c = new Array[Char](11)
       cr.read(c, 1, 10)
@@ -92,7 +92,7 @@ class CharArrayReaderTest {
     }
   }
 
-  @Test def ready_should_throw_IOException(): Unit = {
+  @Test def readyThrowsIOException(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       assertTrue("ready returned false", cr.ready())
       cr.skip(1000L)
@@ -108,7 +108,7 @@ class CharArrayReaderTest {
     }
   }
 
-  @Test def should_support_reset_after_mark(): Unit = {
+  @Test def resetAfterMark(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       cr.skip(5L)
       // Mark current position
@@ -120,7 +120,7 @@ class CharArrayReaderTest {
     }
   }
 
-  @Test def mark_limit_should_be_ignored(): Unit = {
+  @Test def markLimitMinusOneIgnored(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       cr.skip(5L)
       // Mark current position
@@ -135,25 +135,25 @@ class CharArrayReaderTest {
     }
   }
 
-  @Test def should_support_negative_skip(): Unit = {
+  @Test def skipNegative(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       assertEquals("Negative skip values should return zero", 0, cr.skip(-1L))
     }
   }
 
-  @Test def should_support_skip_zero(): Unit = {
+  @Test def skipZero(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       assertEquals("Zero skip value should return zero", 0, cr.skip(0L))
     }
   }
 
-  @Test def skip_should_return_array_size_when_greater(): Unit = {
+  @Test def skipReturnsArraySizeWhenGreater(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       assertEquals("Skip didn't return array size", 10L, cr.skip(1000L))
     }
   }
 
-  @Test def should_support_reset_from_offset_reader(): Unit = {
+  @Test def resetFromOffsetReader(): Unit = {
     val data = "offsetHello world!".toCharArray
     val offsetLength = 6
     val length = data.length - offsetLength
@@ -168,7 +168,7 @@ class CharArrayReaderTest {
     }
   }
 
-  @Test def should_support_skip(): Unit = {
+  @Test def skip(): Unit = {
     withClose(new CharArrayReader(hw)) { cr =>
       val skipped = cr.skip(5L)
       assertEquals("Failed to skip correct number of chars", 5L, skipped)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayWriterTest.scala
@@ -27,23 +27,23 @@ class CharArrayWriterTest {
       closeable.close()
   }
 
-  @Test def should_construct_with_correct_size_when_supplied(): Unit = {
+  @Test def ctorSize: Unit = {
     withClose(new CharArrayWriter(90)) { cw =>
       assertEquals(0, cw.size)
     }
   }
 
-  @Test def should_construct_with_exception(): Unit = {
+  @Test def ctorSizeNegativeThrows(): Unit = {
     assertThrows(classOf[IllegalArgumentException], new CharArrayWriter(-1))
   }
 
-  @Test def should_construct_with_correct_size_default(): Unit = {
+  @Test def ctorSizeDefault(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       assertEquals(0, cw.size)
     }
   }
 
-  @Test def should_support_close(): Unit = {
+  @Test def close(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.close()
       cw.close() // no-op
@@ -51,13 +51,13 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def should_support_flush(): Unit = {
+  @Test def flush(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.flush()
     }
   }
 
-  @Test def should_support_reset(): Unit = {
+  @Test def reset(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.write("HelloWorld", 5, 5)
       cw.reset()
@@ -67,7 +67,7 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def should_support_size(): Unit = {
+  @Test def size(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       assertEquals(0, cw.size)
       cw.write(hw, 5, 5)
@@ -75,21 +75,21 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def should_support_toCharArray(): Unit = {
+  @Test def toCharArray(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.write("HelloWorld", 0, 10)
       assertArrayEquals("HelloWorld".toCharArray, cw.toCharArray)
     }
   }
 
-  @Test def should_support_toString(): Unit = {
+  @Test def testToString(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.write("HelloWorld", 5, 5)
       assertEquals("World", cw.toString)
     }
   }
 
-  @Test def should_support_write_char_array(): Unit = {
+  @Test def writeSubArrayToCharArray(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.write(hw, 5, 5)
       assertEquals("World", cw.toString)
@@ -97,14 +97,14 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def write_should_throw_IndexOutOfBoundsException(): Unit = {
+  @Test def throwsIndexOutOfBoundsException(): Unit = {
     withClose(new CharArrayWriter) { obj =>
       assertThrows(classOf[IndexOutOfBoundsException],
           obj.write(Array[Char]('0'), 0, -1))
     }
   }
 
-  @Test def should_support_write_char(): Unit = {
+  @Test def writeChar(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.write('T')
       assertEquals("T", cw.toString)
@@ -112,7 +112,7 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def write_should_support_write_string(): Unit = {
+  @Test def writeString(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.write("HelloWorld", 5, 5)
       assertEquals("World", cw.toString)
@@ -120,7 +120,7 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def should_support_writeTo_StringWriter(): Unit = {
+  @Test def writeToStringWriter(): Unit = {
     withClose(new CharArrayWriter) { cw =>
       cw.write("HelloWorld", 0, 10)
       withClose(new StringWriter) { sw =>
@@ -130,7 +130,7 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def should_support_append_char(): Unit = {
+  @Test def appendChar(): Unit = {
     withClose(new CharArrayWriter(10)) { cw =>
       val testChar = ' '
       cw.append(testChar)
@@ -140,7 +140,7 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def should_support_append_CharSequence(): Unit = {
+  @Test def appendCharSequence(): Unit = {
     withClose(new CharArrayWriter(10)) { cw =>
       val testString: CharSequence = "My Test String"
       cw.append(testString)
@@ -150,7 +150,7 @@ class CharArrayWriterTest {
     }
   }
 
-  @Test def should_support_append_CharSequence_with_offset(): Unit = {
+  @Test def appendCharSequenceWithOffset(): Unit = {
     withClose(new CharArrayWriter(10)) { cw =>
       val testString: String = "My Test String"
       cw.append(testString, 1, 3)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
@@ -32,7 +32,7 @@ trait CommonStreamsTests {
   private implicit def seqToArray(seq: Seq[Int]): Array[Byte] =
     seq.toArray.map(_.toByte)
 
-  @Test def should_provide_read()(): Unit = {
+  @Test def read(): Unit = {
     val stream = newStream
 
     for (i <- 1 to length)
@@ -42,7 +42,7 @@ trait CommonStreamsTests {
       assertEquals(-1, stream.read())
   }
 
-  @Test def should_provide_read_from_buf(): Unit = {
+  @Test def testReadArrayByte(): Unit = {
     val stream = newStream
     val buf = new Array[Byte](10)
 
@@ -58,7 +58,7 @@ trait CommonStreamsTests {
     assertEquals(-1, stream.read())
   }
 
-  @Test def should_provide_full_argument_read(): Unit = {
+  @Test def readArrayByteIntInt(): Unit = {
     val stream = newStream
     val buf = new Array[Byte](20)
 
@@ -87,7 +87,7 @@ trait CommonStreamsTests {
 
   }
 
-  @Test def should_provide_available(): Unit = {
+  @Test def available(): Unit = {
     val stream = newStream
 
     def mySkip(n: Int) = for (_ <- 1 to n) assertNotEquals(stream.read(), -1)
@@ -104,7 +104,7 @@ trait CommonStreamsTests {
     check(0)
   }
 
-  @Test def should_provide_skip(): Unit = {
+  @Test def testSkip(): Unit = {
     val stream = newStream
 
     assertEquals(7L, stream.skip(7))
@@ -121,11 +121,11 @@ trait CommonStreamsTests {
     assertEquals(0L, stream.skip(30))
   }
 
-  @Test def should_return_true_from_markSupported(): Unit = {
+  @Test def markSupported(): Unit = {
     assertTrue(newStream.markSupported)
   }
 
-  @Test def should_provide_no_op_close(): Unit = {
+  @Test def close(): Unit = {
     val stream = newStream
 
     for (i <- 1 to length) {
@@ -134,7 +134,7 @@ trait CommonStreamsTests {
     }
   }
 
-  @Test def should_provide_mark_and_reset(): Unit = {
+  @Test def markAndReset(): Unit = {
     val stream = newStream
 
     def read(range: Range) = for (i <- range) assertEquals(i, stream.read())
@@ -160,7 +160,7 @@ trait CommonStreamsTests {
     assertEquals(-1, stream.read())
   }
 
-  @Test def should_return_positive_integers_when_calling_read(): Unit = {
+  @Test def readReturnsPositiveIntegers(): Unit = {
     val stream = mkStream(Seq(-1, -2, -3))
     assertEquals(255, stream.read())
     assertEquals(254, stream.read())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
@@ -28,7 +28,7 @@ trait DataInputStreamTest {
   private def newStream(data: Int*) =
     new DataInputStream(inFromBytes(data.map(_.toByte)))
 
-  @Test def should_provide_readBoolean(): Unit = {
+  @Test def readBoolean(): Unit = {
     val data = Seq(0x00, 0x01, 0xF1, 0x00, 0x01)
     val stream = newStream(data: _*)
 
@@ -38,7 +38,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readBoolean())
   }
 
-  @Test def should_provide_readByte(): Unit = {
+  @Test def readByte(): Unit = {
     val data = Seq(0x00, 0x01, 0xF1, 0x7D, 0x35)
     val stream = newStream(data: _*)
 
@@ -48,7 +48,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readBoolean())
   }
 
-  @Test def should_provide_readChar(): Unit = {
+  @Test def readChar(): Unit = {
     val stream = newStream(
       0x00, 0x48, // H
       0x00, 0xF6, // ö
@@ -73,7 +73,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readChar()) // Dangling + EOF
   }
 
-  @Test def should_provide_readDouble(): Unit = {
+  @Test def readDouble(): Unit = {
     val stream = newStream(
         0x3f, 0xe6, 0x66, 0x66, 0x66, 0x66, 0x66, 0x66,
         0x41, 0x15, 0x19, 0x20, 0x45, 0x8d, 0x9b, 0x5f,
@@ -97,7 +97,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readDouble())
   }
 
-  @Test def should_provide_readFloat(): Unit = {
+  @Test def readFloat(): Unit = {
     val stream = newStream(
         0xbf, 0x80, 0x00, 0x00,
         0x45, 0x8e, 0x9c, 0x83,
@@ -121,7 +121,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readFloat())
   }
 
-  @Test def should_provide_readInt(): Unit = {
+  @Test def readInt(): Unit = {
     val stream = newStream(
         0x00, 0x00, 0x00, 0x00,
         0x7f, 0xff, 0xff, 0xff,
@@ -143,7 +143,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readInt())
   }
 
-  @Test def should_provide_readLong(): Unit = {
+  @Test def readLong(): Unit = {
     val stream = newStream(
         0x00, 0x01, 0xf0, 0xec, 0x59, 0x0c, 0x70, 0x9a,
         0xff, 0xff, 0xff, 0xff, 0xfe, 0x10, 0xd5, 0x5e,
@@ -165,7 +165,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readLong())
   }
 
-  @Test def should_provide_readShort(): Unit = {
+  @Test def readShort(): Unit = {
     val stream = newStream(
         0x01, 0xc5,
         0xff, 0xd5,
@@ -189,7 +189,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readDouble())
   }
 
-  @Test def should_provide_readUnsignedByte(): Unit = {
+  @Test def readUnsignedByte(): Unit = {
     val data = Seq(0x00, 0x01, 0xF1, 0x7D, 0x35)
     val stream = newStream(data: _*)
 
@@ -199,7 +199,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readBoolean()) // EOF
   }
 
-  @Test def should_provide_readUnsignedShort(): Unit = {
+  @Test def readUnsignedShort(): Unit = {
     val stream = newStream(
         0xfe, 0x4c,
         0x00, 0x00,
@@ -223,7 +223,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readDouble())
   }
 
-  @Test def should_provide_readFully_1_arg_3_arg(): Unit = {
+  @Test def readFullyOneArgThreeArg(): Unit = {
     val stream = newStream(-100 to 99: _*)
     val buf = new Array[Byte](50)
 
@@ -249,7 +249,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[Exception], stream.readFully(buf))
   }
 
-  @Test def should_provide_readFully_for_bursty_streams(): Unit = {
+  @Test def readFullyForBurstyStreams(): Unit = {
     class BurstyStream(length: Int, burst: Int) extends InputStream {
       private var i: Int = 0
       def read(): Int = if (i < length) { i += 1; i } else -1
@@ -280,7 +280,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[EOFException], stream.readFully(buf))
   }
 
-  @Test def should_provide_readUTF(): Unit = {
+  @Test def readUTF(): Unit = {
     val stream = newStream(
         0x00, 0x10, 0x48, 0xc3, 0xb6, 0x6c, 0x6c, 0xc3,
         0xb6, 0x20, 0x57, 0xc4, 0x83, 0x72, 0xc8, 0xb4,
@@ -296,7 +296,7 @@ trait DataInputStreamTest {
     assertThrows(classOf[UTFDataFormatException], badStream.readUTF)
   }
 
-  @Test def readUTF_with_very_long_string(): Unit = {
+  @Test def readUTFWithVeryLongString(): Unit = {
     val length = 40000
     val inputBytes = new Array[Byte](2 + length)
     inputBytes(0) = (length >> 8).toByte
@@ -311,7 +311,7 @@ trait DataInputStreamTest {
     assertEquals(-1, stream.read())
   }
 
-  @Test def should_provide_readLine(): Unit = {
+  @Test def readLine(): Unit = {
     val stream = newStream(
         "Hello World\nUNIX\nWindows\r\nMac (old)\rStuff".map(_.toInt): _*)
 
@@ -323,7 +323,7 @@ trait DataInputStreamTest {
     assertEquals(null, stream.readLine())
   }
 
-  @Test def should_allow_marking_even_when_readLine_has_to_push_back(): Unit = {
+  @Test def markReadLinePushBack(): Unit = {
     assumeFalse("Not supported on JDK", executingInJVM)
 
     val stream = newStream(

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
@@ -39,7 +39,7 @@ class InputStreamTest extends CommonStreamsTests {
     override def markSupported(): Boolean = true
   }
 
-  @Test def should_provide_a_default_implementation_of_read_to_an_array(): Unit = {
+  @Test def readArrayByte(): Unit = {
     val stream = mkStream(1 to 200)
 
     val buf = new Array[Byte](50)
@@ -86,7 +86,7 @@ class InputStreamTest extends CommonStreamsTests {
         ((111 to 115) ++ (-95 to -56) ++ (-100 to -96)).toArray.map(_.toByte), buf)
   }
 
-  @Test def should_provide_a_default_implementation_of_skip(): Unit = {
+  @Test def skip(): Unit = {
     val stream = mkStream(1 to 10)
 
     assertEquals(5L, stream.skip(5))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
@@ -72,7 +72,7 @@ class OutputStreamWriterTest {
     assertArrayEquals(expected.map(_.toByte), bos.toByteArray)
   }
 
-  @Test def write_ASCII_repertoire(): Unit = {
+  @Test def writeASCIIRepertoire(): Unit = {
     // Pure ASCII
     testW(_.write('\n'), Array('\n'))
     testW(_.write("hello\n"), Array('h', 'e', 'l', 'l', 'o', '\n'))
@@ -81,7 +81,7 @@ class OutputStreamWriterTest {
     testW(_.write(Array('A', 'B', '\n', 'C'), 1, 2), Array('B', '\n'))
   }
 
-  @Test def write_Unicode_repertoire_without_surrogates(): Unit = {
+  @Test def writeUnicodeRepertoireWithoutSurrogates(): Unit = {
     testW(_.write('é'), Array(0xc3, 0xa9))
     testW(_.write("こんにちは"), Array(
         0xe3, 0x81, 0x93, 0xe3, 0x82, 0x93, 0xe3, 0x81, 0xab, 0xe3, 0x81, 0xa1, 0xe3, 0x81, 0xaf))
@@ -89,12 +89,12 @@ class OutputStreamWriterTest {
         0xce, 0xb7, 0xce, 0xbc, 0xce, 0xad, 0xcf, 0x81))
   }
 
-  @Test def write_surrogate_pairs(): Unit = {
+  @Test def writeSurrogatePairs(): Unit = {
     testW(_.write("\ud83d\udca9"), Array(0xf0, 0x9f, 0x92, 0xa9))
     testW(_.write("ab\ud83d\udca9cd", 1, 3), Array('b', 0xf0, 0x9f, 0x92, 0xa9))
   }
 
-  @Test def write_surrogate_pairs_spread_across_multiple_writes(): Unit = {
+  @Test def writeSurrogatePairsSpreadAcrossMultipleWrites(): Unit = {
     testW({ osw => osw.write('\ud83d'); osw.write('\udca9') },
         Array(0xf0, 0x9f, 0x92, 0xa9))
 
@@ -111,12 +111,12 @@ class OutputStreamWriterTest {
         Array('b', 0xf0, 0x9f, 0x92, 0xa9, 'c'))
   }
 
-  @Test def write_malformed_surrogates(): Unit = {
+  @Test def writeMalformedSurrogates(): Unit = {
     testW(_.write("\ud83da"), Array('?', 'a'))
     testW(_.write("\udca9"), Array('?'))
   }
 
-  @Test def write_malformed_surrogates_spread_across_multiple_writes(): Unit = {
+  @Test def writeMalformedSurrogatesSpreadAcrossMultipleWrites(): Unit = {
     testW({ osw => osw.write('\ud83d'); osw.write('a') },
         Array('?', 'a'))
 
@@ -127,7 +127,7 @@ class OutputStreamWriterTest {
         Array('a', 'b', '?', '?', 'c'))
   }
 
-  @Test def write_malformed_surrogates_at_end_of_input(): Unit = {
+  @Test def writeMalformedSurrogatesAtEndOfInput(): Unit = {
     testW({ osw => osw.write('\ud83d'); osw.close() },
         Array('?'), alreadyFlushed = true)
 
@@ -135,7 +135,7 @@ class OutputStreamWriterTest {
         Array('a', 'b', '?'), alreadyFlushed = true)
   }
 
-  @Test def constructor_throw_UnsupportedEncodingException_if_unsupported_charset_name_given(): Unit = {
+  @Test def constructorThrowUnsupportedEncodingExceptionIfUnsupportedCharsetNameGiven(): Unit = {
     val ex = expectThrows(classOf[UnsupportedEncodingException],
       new OutputStreamWriter(new ByteArrayOutputStream(), "UNSUPPORTED-CHARSET"))
     assertTrue("Cause should be null since constructor does not accept cause",

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintStreamTest.scala
@@ -65,7 +65,7 @@ class PrintStreamTest {
     assertArrayEquals(Array[Byte](1), bos.toByteArray)
   }
 
-  @Test def write_pass_the_bytes_through(): Unit = {
+  @Test def writePassTheBytesThrough(): Unit = {
     def test(body: PrintStream => Unit, expected: Array[Int],
         testFlushed: Boolean = false): Unit = {
       val (ps, bos) = newPrintStream(autoFlush = true)
@@ -111,7 +111,7 @@ class PrintStreamTest {
     test(_.print(null: AnyRef), "null")
   }
 
-  @Test def print_encodes_in_UTF_8(): Unit = {
+  @Test def printEncodesInUTF8(): Unit = {
     def test(body: PrintStream => Unit, expected: Array[Int]): Unit = {
       val (ps, bos) = newPrintStream(autoFlush = false)
       body(ps)
@@ -151,7 +151,7 @@ class PrintStreamTest {
     test({ osw => osw.print("ab\ud83d"); osw.close() }, Array('a', 'b', '?'))
   }
 
-  @Test def println_forwards_and_flushes_when_autoFlush_is_true(): Unit = {
+  @Test def printlnForwardsAndFlushesWhenAutoFlushIsTrue(): Unit = {
     testPrintlnForwards(_.println(), "\n", autoFlush = true)
     testPrintlnForwards(_.println(true), "true\n", autoFlush = true)
     testPrintlnForwards(_.println('Z'), "Z\n", autoFlush = true)
@@ -167,7 +167,7 @@ class PrintStreamTest {
     testPrintlnForwards(_.println(null: AnyRef), "null\n", autoFlush = true)
   }
 
-  @Test def println_forwards_does_not_flush_when_autoFlush_is_false(): Unit = {
+  @Test def printlnForwardsDoesNotFlushWhenAutoFlushIsFalse(): Unit = {
     testPrintlnForwards(_.println(), "\n", autoFlush = false)
     testPrintlnForwards(_.println(true), "true\n", autoFlush = false)
     testPrintlnForwards(_.println('Z'), "Z\n", autoFlush = false)
@@ -192,11 +192,11 @@ class PrintStreamTest {
     assertEquals(expected, bos.toString())
   }
 
-  @Test def printf_format_which_flushes_when_autoFlush_is_true(): Unit = {
+  @Test def printfFormatWhichFlushesWhenAutoFlushIsTrue(): Unit = {
     testPrintfFormat(_.printf("%04d", Int.box(5)), "0005", autoFlush = true)
     testPrintfFormat(_.format("%.5f", Double.box(Math.PI)), "3.14159", autoFlush = true)
   }
-  @Test def printf_format_which_flushes_when_autoFlush_is_false(): Unit = {
+  @Test def printfFormatWhichFlushesWhenAutoFlushIsFalse(): Unit = {
     testPrintfFormat(_.printf("%04d", Int.box(5)), "0005", autoFlush = false)
     testPrintfFormat(_.format("%.5f", Double.box(Math.PI)), "3.14159", autoFlush = false)
   }
@@ -230,7 +230,7 @@ class PrintStreamTest {
     test(_.append('\n'), "\n", testFlushed = true)
   }
 
-  @Test def traps_all_IOException_and_updates_checkError(): Unit = {
+  @Test def trapsAllIOExceptionAndUpdatesCheckError(): Unit = {
     def test(body: PrintStream => Unit): Unit = {
       val (ps, bos) = newPrintStream()
       bos.throwing = true
@@ -280,7 +280,7 @@ class PrintStreamTest {
     test(_.append('\n'))
   }
 
-  @Test def write_short_circuits_pending_high_surrogates_in_print(): Unit = {
+  @Test def writeShortCircuitsPendingHighSurrogatesInPrint(): Unit = {
     val (ps, bos) = newPrintStream()
     ps.print('A')
     assertArrayEquals(Array[Byte]('A'), bos.toByteArray)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintWriterTest.scala
@@ -69,7 +69,7 @@ class PrintWriterTest {
     assertEquals("begin", sw.toString())
   }
 
-  @Test def write_does_not_flush_even_with_new_line(): Unit = {
+  @Test def writeDoesNotFlushEvenWithNewLine(): Unit = {
     def test(body: PrintWriter => Unit, expected: String): Unit = {
       val (pw, sw) = newPrintWriter(autoFlush = true)
       body(pw)
@@ -85,7 +85,7 @@ class PrintWriterTest {
     test(_.write(Array('A', 'B', '\n', 'C'), 1, 2), "B\n")
   }
 
-  @Test def print_does_not_flush_even_with_new_line(): Unit = {
+  @Test def printDoesNotFlushEvenWithNewLine(): Unit = {
     def test(body: PrintWriter => Unit, expected: String): Unit = {
       val (pw, sw) = newPrintWriter(autoFlush = true)
       body(pw)
@@ -108,7 +108,7 @@ class PrintWriterTest {
     test(_.print(null: AnyRef), "null")
   }
 
-  @Test def println_forwards_and_flushes_when_autoFlush_is_true(): Unit = {
+  @Test def printlnForwardsAndFlushesWhenAutoFlushIsTrue(): Unit = {
     testPrintlnForward(_.println(), "\n", autoFlush = true)
     testPrintlnForward(_.println(true), "true\n", autoFlush = true)
     testPrintlnForward(_.println('Z'), "Z\n", autoFlush = true)
@@ -124,7 +124,7 @@ class PrintWriterTest {
     testPrintlnForward(_.println(null: AnyRef), "null\n", autoFlush = true)
   }
 
-  @Test def println_and_forwards_do_not_flush_when_autoFlush_is_false(): Unit = {
+  @Test def printlnAndForwardsDoNotFlushWhenAutoFlushIsFalse(): Unit = {
     testPrintlnForward(_.println(), "\n", autoFlush = false)
     testPrintlnForward(_.println(true), "true\n", autoFlush = false)
     testPrintlnForward(_.println('Z'), "Z\n", autoFlush = false)
@@ -150,12 +150,12 @@ class PrintWriterTest {
     assertEquals(expected, sw.toString())
   }
 
-  @Test def printf_and_format_which_flushes_when_autoFlush_is_true(): Unit = {
+  @Test def printfAndFormatWhichFlushesWhenAutoFlushIsTrue(): Unit = {
     testPrintfFormat(_.printf("%04d", Int.box(5)), "0005", autoFlush = true)
     testPrintfFormat(_.format("%.5f", Double.box(Math.PI)), "3.14159", autoFlush = true)
   }
 
-  @Test def printf_and_format_do_not_flush_when_autoFlush_is_false(): Unit = {
+  @Test def printfAndFormatDoNotFlushWhenAutoFlushIsFalse(): Unit = {
     testPrintfFormat(_.printf("%04d", Int.box(5)), "0005", autoFlush = false)
     testPrintfFormat(_.format("%.5f", Double.box(Math.PI)), "3.14159", autoFlush = false)
   }
@@ -170,7 +170,7 @@ class PrintWriterTest {
     assertEquals(expected, sw.toString())
   }
 
-  @Test def append_does_not_flush_even_with_new_line(): Unit = {
+  @Test def appendDoesNotFlushEvenWithNewLine(): Unit = {
     def test(body: PrintWriter => Unit, expected: String): Unit = {
       val (pw, sw) = newPrintWriter(autoFlush = true)
       body(pw)
@@ -187,7 +187,7 @@ class PrintWriterTest {
     test(_.append('\n'), "\n")
   }
 
-  @Test def traps_all_IOException_and_updates_checkError(): Unit = {
+  @Test def trapsAllIOExceptionAndUpdatesCheckError(): Unit = {
     def test(body: PrintWriter => Unit): Unit = {
       val (pw, sw) = newPrintWriter()
       sw.throwing = true

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -31,7 +31,7 @@ class ReaderTest {
     def close(): Unit = ()
   }
 
-  @Test def skip_should_always_skip_n_if_possible(): Unit = {
+  @Test def skipIntIfPossible(): Unit = {
     assertEquals(42, MyReader.skip(42))
     assertEquals(10000, MyReader.skip(10000)) // more than the 8192 batch size
   }
@@ -41,7 +41,7 @@ class StringReaderTest {
   val str = "asdf"
   def newReader: StringReader = new StringReader(str)
 
-  @Test def should_provide_read()(): Unit = {
+  @Test def read()(): Unit = {
     val r = newReader
 
     for (c <- str) {
@@ -51,7 +51,7 @@ class StringReaderTest {
     assertEquals(-1, r.read())
   }
 
-  @Test def should_provide_read_from_buffer_with_offset_and_length(): Unit = {
+  @Test def readArrayCharIntInt(): Unit = {
     val r = newReader
     val buf = new Array[Char](10)
 
@@ -60,7 +60,7 @@ class StringReaderTest {
     assertEquals(-1, r.read(buf, 2, 8)) // #1560
   }
 
-  @Test def should_provide_read_from_CharBuffer(): Unit = {
+  @Test def readCharBuffer(): Unit = {
     val r = newReader
     val buf0 = java.nio.CharBuffer.allocate(25)
     buf0.position(3)
@@ -75,7 +75,7 @@ class StringReaderTest {
         Array[Int](0, 0, 0, 0, 'a', 's', 'd', 'f'))
   }
 
-  @Test def should_provide_ready(): Unit = {
+  @Test def ready(): Unit = {
     val r = newReader
 
     for (c <- str) {
@@ -90,7 +90,7 @@ class StringReaderTest {
     expectThrows(classOf[IOException], r.ready())
   }
 
-  @Test def should_provide_mark_reset(): Unit = {
+  @Test def markReset(): Unit = {
     val r = newReader
     r.mark(str.length)
 
@@ -107,7 +107,7 @@ class StringReaderTest {
     assertEquals(-1, r.read())
   }
 
-  @Test def should_provide_skip(): Unit = {
+  @Test def skip(): Unit = {
     val r = newReader
 
     assertEquals('a': Int, r.read())
@@ -117,22 +117,22 @@ class StringReaderTest {
     assertEquals(-1, r.read())
   }
 
-  @Test def should_provide_close(): Unit = {
+  @Test def close(): Unit = {
     val r = newReader
 
     r.close()
     expectThrows(classOf[IOException], r.read())
   }
 
-  @Test def should_support_marking(): Unit = {
+  @Test def mark(): Unit = {
     assertTrue(newReader.markSupported)
   }
 
-  @Test def mark_should_throw_with_negative_lookahead(): Unit = {
+  @Test def markThrowsWithNegativeLookahead(): Unit = {
     expectThrows(classOf[IllegalArgumentException], newReader.mark(-10))
   }
 
-  @Test def skip_should_accept_negative_lookahead_as_lookback(): Unit = {
+  @Test def skipAcceptsNegativeLookaheadAsLookback(): Unit = {
     // StringReader.skip accepts negative lookahead
     val r = newReader
     assertEquals("already head", 0, r.skip(-1))
@@ -145,7 +145,7 @@ class StringReaderTest {
     assertEquals('s', r.read())
   }
 
-  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+  @Test def skipReturns0AfterReachingEnd(): Unit = {
     val r = newReader
     assertEquals(4, r.skip(100))
     assertEquals(-1, r.read())
@@ -196,7 +196,7 @@ class BufferedReaderTest {
     assertEquals(1, underlying.closeCount)
   }
 
-  @Test def should_provide_read(): Unit = {
+  @Test def read(): Unit = {
     val r = newReader
 
     for (c <- str) {
@@ -205,7 +205,7 @@ class BufferedReaderTest {
     assertEquals(-1, r.read())
   }
 
-  @Test def should_provide_read_from_buffer(): Unit = {
+  @Test def readArrayChar(): Unit = {
     var read = 0
     val r = newReader
     val buf = new Array[Char](15)
@@ -222,7 +222,7 @@ class BufferedReaderTest {
     }
   }
 
-  @Test def should_provide_read_frombuffer_with_offset(): Unit = {
+  @Test def readArrayCharIntInt(): Unit = {
     var read = 0
     val r = newReader
     val buf = new Array[Char](15)
@@ -240,7 +240,7 @@ class BufferedReaderTest {
     }
   }
 
-  @Test def should_provide_mark_and_reset(): Unit = {
+  @Test def markAndReset(): Unit = {
     val r = newReader
     assertEquals('l': Int, r.read())
 
@@ -258,7 +258,7 @@ class BufferedReaderTest {
     }
   }
 
-  @Test def should_provide_readLine(): Unit = {
+  @Test def readLine(): Unit = {
     val r = newReader
 
     assertEquals("line1", r.readLine())
@@ -269,13 +269,13 @@ class BufferedReaderTest {
     assertEquals(null, r.readLine())
   }
 
-  @Test def should_readLine_on_an_empty_stream(): Unit = {
+  @Test def readLineEmptyStream(): Unit = {
     val r = new BufferedReader(new StringReader(""))
 
     assertEquals(null, r.readLine())
   }
 
-  @Test def should_readline_with_empty_lines_only(): Unit = {
+  @Test def readLineEmptyLinesOnly(): Unit = {
     val r = new BufferedReader(new StringReader("\n\r\n\r\r\n"), 1)
 
     for (_ <- 1 to 4)
@@ -284,7 +284,7 @@ class BufferedReaderTest {
     assertEquals(null, r.readLine())
   }
 
-  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+  @Test def skipReturns0AfterReachingEnd(): Unit = {
     val r = newReader
     assertEquals(25, r.skip(100))
     assertEquals(-1, r.read())
@@ -293,18 +293,18 @@ class BufferedReaderTest {
     assertEquals(-1, r.read())
   }
 
-  @Test def should_support_marking(): Unit = {
+  @Test def markSupported(): Unit = {
     assertTrue(newReader.markSupported)
   }
 
-  @Test def mark_should_throw_with_negative_lookahead(): Unit = {
+  @Test def markThrowsWithNegativeLookahead(): Unit = {
     expectThrows(classOf[IllegalArgumentException], newReader.mark(-10))
   }
 }
 
 class InputStreamReaderTest {
 
-  @Test def should_read_UTF8(): Unit = {
+  @Test def readUTF8(): Unit = {
 
     val buf = Array[Byte](72, 101, 108, 108, 111, 32, 87, 111, 114, 108, 100,
         46, -29, -127, -109, -29, -126, -109, -29, -127, -85, -29, -127, -95,
@@ -335,7 +335,7 @@ class InputStreamReaderTest {
     assertEquals(-1, r.read())
   }
 
-  @Test def should_comply_with_read_after_eof_behaviour(): Unit = {
+  @Test def readEOFThrows(): Unit = {
     val data = "Lorem ipsum".getBytes()
     val streamReader = new InputStreamReader(new ByteArrayInputStream(data))
     val bytes = new Array[Char](11)
@@ -348,7 +348,7 @@ class InputStreamReaderTest {
     assertEquals(0, streamReader.read(new Array[Char](0)))
   }
 
-  @Test def skip_should_always_return_0_after_reaching_end(): Unit = {
+  @Test def skipReturns0AfterReachingEnd(): Unit = {
     val data = "Lorem ipsum".getBytes()
     val r = new InputStreamReader(new ByteArrayInputStream(data))
     assertTrue(r.skip(100) > 0)
@@ -358,7 +358,7 @@ class InputStreamReaderTest {
     assertEquals(-1, r.read())
   }
 
-  @Test def should_throw_IOException_since_mark_is_not_supported(): Unit = {
+  @Test def markThrowsNotSupported(): Unit = {
     val data = "Lorem ipsum".getBytes()
     val r = new InputStreamReader(new ByteArrayInputStream(data))
     expectThrows(classOf[IOException], r.mark(0))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ThrowablesTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.io
 import org.junit.Test
 
 class ThrowablesTest {
-  @Test def should_define_all_java_io_Errors_and_Exceptions(): Unit = {
+  @Test def allJavaIoErrorsAndExceptions(): Unit = {
     import java.io._
     new IOException("", new Exception())
     new EOFException("")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
@@ -39,7 +39,7 @@ class BooleanTest {
     assertEquals(0, compare(true, true))
   }
 
-  @Test def should_be_a_Comparable(): Unit = {
+  @Test def compareToAnyAny(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)
 
@@ -49,7 +49,7 @@ class BooleanTest {
     assertEquals(0, compare(true, true))
   }
 
-  @Test def should_parse_strings(): Unit = {
+  @Test def parseStringMethods(): Unit = {
     def test(s: String, v: Boolean): Unit = {
       assertEquals(v, JBoolean.parseBoolean(s))
       assertEquals(v, JBoolean.valueOf(s).booleanValue())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
@@ -23,7 +23,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
  */
 class ByteTest {
 
-  @Test def compareTo(): Unit = {
+  @Test def compareToJavaByte(): Unit = {
     def compare(x: Byte, y: Byte): Int =
       new JByte(x).compareTo(new JByte(y))
 
@@ -33,7 +33,7 @@ class ByteTest {
     assertEquals(0, compare(3.toByte, 3.toByte))
   }
 
-  @Test def should_be_a_Comparable(): Unit = {
+  @Test def compareTo(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)
 
@@ -43,7 +43,7 @@ class ByteTest {
     assertEquals(0, compare(3.toByte, 3.toByte))
   }
 
-  @Test def should_parse_strings(): Unit = {
+  @Test def parseString(): Unit = {
     def test(s: String, v: Byte): Unit = {
       assertEquals(v, JByte.parseByte(s))
       assertEquals(v, JByte.valueOf(s).byteValue())
@@ -57,7 +57,7 @@ class ByteTest {
     test("-100", -100)
   }
 
-  @Test def should_reject_invalid_strings_when_parsing(): Unit = {
+  @Test def parseStringInvalidThrows(): Unit = {
     def test(s: String): Unit = {
       expectThrows(classOf[NumberFormatException], JByte.parseByte(s))
       expectThrows(classOf[NumberFormatException], JByte.decode(s))
@@ -68,7 +68,7 @@ class ByteTest {
     test("200") // out of range
   }
 
-  @Test def should_parse_strings_in_base_16(): Unit = {
+  @Test def parseStringBase16(): Unit = {
     def test(s: String, v: Byte): Unit = {
       assertEquals(v, JByte.parseByte(s, 16))
       assertEquals(v, JByte.valueOf(s, 16).intValue())
@@ -85,7 +85,7 @@ class ByteTest {
     test("-9", -0x9)
   }
 
-  @Test def testDecodeBase8(): Unit = {
+  @Test def decodeStringBase8(): Unit = {
     def test(s: String, v: Byte): Unit = {
       assertEquals(v, JByte.decode(s))
     }
@@ -95,7 +95,7 @@ class ByteTest {
     test("-012", -10)
   }
 
-  @Test def testDecodeInvalid(): Unit = {
+  @Test def decodeInvalidThrows(): Unit = {
     def test(s: String): Unit =
       assertThrows(classOf[NumberFormatException], JByte.decode(s))
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
@@ -307,7 +307,7 @@ class CharacterTest {
     expectThrows(classOf[IllegalArgumentException], Character.toChars(Integer.MAX_VALUE))
   }
 
-  @Test def toChars_in_place(): Unit = {
+  @Test def toCharsInPlace(): Unit = {
     locally {
       val dst = new Array[Char](2)
       assertEquals(1, Character.toChars(0x61, dst, 0))
@@ -543,12 +543,12 @@ class CharacterTest {
     assertFalse(Character.isDigit('\uFBFC'))
   }
 
-  @Test def toLowerCase_compare_char_and_codepoint(): Unit = {
+  @Test def toLowerCaseCompareCharAndCodepoint(): Unit = {
     for (ch <- Character.MIN_VALUE to Character.MAX_VALUE)
       assertEquals(Character.toLowerCase(ch), Character.toLowerCase(ch.toInt).toChar)
   }
 
-  @Test def toLowerCase_Int(): Unit = {
+  @Test def toLowerCaseInt(): Unit = {
     // ASCII, not a letter
     assertEquals(0x000a, Character.toLowerCase(0x000a)) // '\n' => '\n'
     assertEquals(0x0037, Character.toLowerCase(0x0037)) // '7' => '7'
@@ -592,7 +592,7 @@ class CharacterTest {
    * This list happens to coincide with the code points tested in the following
    * test.
    */
-  @Test def toLowerCase_CodePoint_special_cases(): Unit = {
+  @Test def toLowerCaseCodePointSpecialCases(): Unit = {
     assertEquals(0x0069, Character.toLowerCase(0x0130))
   }
 
@@ -613,16 +613,16 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     println(s"    assertEquals(${format(lowerCP)}, Character.toLowerCase(${format(cp)})) // $cpStr => $lowerCPStr")
 }
   */
-  @Test def toLowerCase_CodePoint_StringLowerCase_diff_CharacterLowerCase(): Unit = {
+  @Test def toLowerCaseCodePointStringLowerCaseDiffCharacterLowerCase(): Unit = {
     assertEquals(0x0069, Character.toLowerCase(0x0130)) // İ => i
   }
 
-  @Test def toUpperCase_compare_char_and_codepoint(): Unit = {
+  @Test def toUpperCaseCompareCharAndCodepoint(): Unit = {
     for (ch <- Character.MIN_VALUE to Character.MAX_VALUE)
       assertEquals(Character.toUpperCase(ch), Character.toUpperCase(ch.toInt).toChar)
   }
 
-  @Test def toUpperCase_Int(): Unit = {
+  @Test def toUpperCaseInt(): Unit = {
     // ASCII, not a letter
     assertEquals(0x000a, Character.toUpperCase(0x000a)) // '\n' => '\n'
     assertEquals(0x0037, Character.toUpperCase(0x0037)) // '7' => '7'
@@ -657,7 +657,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
   /* Test all the code points that are specially handled in our implementation
    * of `toUpperCase(codePoint: Int)`.
    */
-  @Test def toUpperCase_CodePoint_special_cases(): Unit = {
+  @Test def toUpperCaseCodePointSpecialCases(): Unit = {
     assertEquals(0x1fbc, Character.toUpperCase(0x1fb3))
     assertEquals(0x1fcc, Character.toUpperCase(0x1fc3))
     assertEquals(0x1ffc, Character.toUpperCase(0x1ff3))
@@ -728,7 +728,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     println(s"    assertEquals(${format(upperCP)}, Character.toUpperCase(${format(cp)})) // $cpStr => $upperCPStr")
 }
   */
-  @Test def toUpperCase_CodePoint_StringUpperCase_diff_CharacterUpperCase(): Unit = {
+  @Test def toUpperCaseCodePointStringUpperCaseDiffCharacterUpperCase(): Unit = {
     assertEquals(0x00df, Character.toUpperCase(0x00df)) // ß => ß
     assertEquals(0x0149, Character.toUpperCase(0x0149)) // ŉ => ŉ
     assertEquals(0x01f0, Character.toUpperCase(0x01f0)) // ǰ => ǰ
@@ -833,12 +833,12 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0xfb17, Character.toUpperCase(0xfb17)) // ﬗ => ﬗ
   }
 
-  @Test def toTitleCase_compare_char_and_codepoint(): Unit = {
+  @Test def toTitleCaseCompareCharAndCodepoint(): Unit = {
     for (ch <- Character.MIN_VALUE to Character.MAX_VALUE)
       assertEquals(Character.toTitleCase(ch), Character.toTitleCase(ch.toInt).toChar)
   }
 
-  @Test def toTitleCase_CodePoint_special_cases(): Unit = {
+  @Test def toTitleCaseCodePointSpecialCases(): Unit = {
     assertEquals(0x1fbc, Character.toTitleCase(0x1fb3))
     assertEquals(0x1fcc, Character.toTitleCase(0x1fc3))
     assertEquals(0x1ffc, Character.toTitleCase(0x1ff3))
@@ -905,7 +905,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     println(s"    assertEquals(${format(titleCP)}, Character.toTitleCase(${format(cp)})) // $cpStr => $titleCPStr")
 }
 */
-  @Test def toTitleCase_CodePoint_StringUpperCase_diff_CharacterTitleCase(): Unit = {
+  @Test def toTitleCaseCodePointStringUpperCaseDiffCharacterTitleCase(): Unit = {
     assertEquals(0x00df, Character.toTitleCase(0x00df)) // ß => ß
     assertEquals(0x0149, Character.toTitleCase(0x0149)) // ŉ => ŉ
     assertEquals(0x01c5, Character.toTitleCase(0x01c4)) // Ǆ => ǅ
@@ -1022,7 +1022,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0xfb17, Character.toTitleCase(0xfb17)) // ﬗ => ﬗ
   }
 
-  @Test def codePointCount_String(): Unit = {
+  @Test def codePointCountString(): Unit = {
     val s: String =
       "abc\uD834\uDF06de\uD834\uDF06fgh\uD834ij\uDF06\uD834kl\uDF06"
 
@@ -1045,7 +1045,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     expectThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(s, 10, 30))
   }
 
-  @Test def codePointCount_CharSequence(): Unit = {
+  @Test def codePointCountCharSequence(): Unit = {
     import WrappedStringCharSequence.charSequence
 
     val cs: CharSequence =
@@ -1087,7 +1087,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0, compare('b', 'b'))
   }
 
-  @Test def should_be_a_Comparable(): Unit = {
+  @Test def compareToAnyAny(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)
 
@@ -2501,8 +2501,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertFalse(Character.isLetterOrDigit('\uFE4B'))
   }
 
-  @Test
-  def shouldProvideIsAlphabetic(): Unit = {
+  @Test def isAlphabetic(): Unit = {
     // 50 randomly chosen characters that produce true
     assertTrue(Character.isAlphabetic('\u04F8'))
     assertTrue(Character.isAlphabetic('\u05DB'))
@@ -2608,8 +2607,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertFalse(Character.isAlphabetic(993967))
   }
 
-  @Test
-  def shouldProvideIsIdeographic(): Unit = {
+  @Test def isIdeographic(): Unit = {
     // 50 randomly chosen characters that produce true
     assertTrue(Character.isIdeographic('\u388F'))
     assertTrue(Character.isIdeographic('\u4711'))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterUnicodeBlockTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterUnicodeBlockTest.scala
@@ -19,7 +19,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
 
 class CharacterUnicodeBlockTest {
 
-  @Test def forName_Normalizations(): Unit = {
+  @Test def forNameNormalizations(): Unit = {
     assertThrows(classOf[IllegalArgumentException], UnicodeBlock.forName("Surrogates-Area"))
     assertThrows(classOf[IllegalArgumentException], UnicodeBlock.forName("Surrogates Area"))
     assertThrows(classOf[IllegalArgumentException], UnicodeBlock.forName("SurrogatesArea"))
@@ -53,7 +53,7 @@ class CharacterUnicodeBlockTest {
         UnicodeBlock.forName("CJK Unified Ideographs Extension-A"))
   }
 
-  @Test def  forName_Historical(): Unit = {
+  @Test def  forNameHistorical(): Unit = {
     // scalastyle:off line.size.limit
     assertThrows(classOf[IllegalArgumentException], UnicodeBlock.forName("GREEK_AND_COPTIC"))
     assertEquals(UnicodeBlock.GREEK, UnicodeBlock.forName("Greek and Coptic"))
@@ -77,15 +77,15 @@ class CharacterUnicodeBlockTest {
     // scalastyle:on line.size.limit
   }
 
-  @Test def of_should_throw_IllegalArgumentException(): Unit = {
+  @Test def ofIntOutOfRangeThrowsIllegalArgumentException(): Unit = {
     assertThrows(classOf[IllegalArgumentException], UnicodeBlock.of(Character.MAX_CODE_POINT + 1))
   }
 
-  @Test def forName_should_throw_IllegalArgumentException(): Unit = {
+  @Test def forNameNotFoundThrowsIllegalArgumentException(): Unit = {
     assertThrows(classOf[IllegalArgumentException], UnicodeBlock.forName("INVALID_NAME"))
   }
 
-  @Test def of_Char(): Unit = {
+  @Test def ofChar(): Unit = {
     assertEquals(UnicodeBlock.BASIC_LATIN, UnicodeBlock.of(0x0000.toChar))
     assertEquals(UnicodeBlock.BASIC_LATIN, UnicodeBlock.of(0x007f.toChar))
     assertEquals(UnicodeBlock.MEETEI_MAYEK_EXTENSIONS, UnicodeBlock.of(0xaae0.toChar))
@@ -94,7 +94,7 @@ class CharacterUnicodeBlockTest {
     assertEquals(UnicodeBlock.SPECIALS, UnicodeBlock.of(0xffff.toChar))
   }
 
-  @Test def of_CodePoint(): Unit = {
+  @Test def ofCodePoint(): Unit = {
     assertEquals(UnicodeBlock.BASIC_LATIN, UnicodeBlock.of(0x0000))
     assertEquals(UnicodeBlock.BASIC_LATIN, UnicodeBlock.of(0x007f))
     assertEquals(UnicodeBlock.MEETEI_MAYEK_EXTENSIONS, UnicodeBlock.of(0xaae0))
@@ -111,7 +111,7 @@ class CharacterUnicodeBlockTest {
   }
 
 
-  @Test def forName_String(): Unit = {
+  @Test def forNameString(): Unit = {
     // scalastyle:off line.size.limit
     assertEquals(UnicodeBlock.BASIC_LATIN, UnicodeBlock.forName("BASIC_LATIN"))
     assertEquals(UnicodeBlock.BASIC_LATIN, UnicodeBlock.forName("Basic Latin"))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -25,7 +25,7 @@ import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class DoubleTest {
 
-  @Test def proper_equals(): Unit = {
+  @Test def properEquals(): Unit = {
     assertTrue(0.0.equals(0.0))
     assertTrue((-0.0).equals(-0.0))
     assertFalse(0.0.equals(-0.0))
@@ -61,7 +61,7 @@ class DoubleTest {
     }
   }
 
-  @Test def toString_with_integer_values_when_an_integer(): Unit = {
+  @Test def toStringWithIntegerValuesWhenAnInteger(): Unit = {
     if (executingInJVM) {
       assertEquals("0.0", 0.0.toString)
       assertEquals("-0.0", (-0.0).toString)
@@ -104,7 +104,7 @@ class DoubleTest {
     assertEquals("0x0.0000000000001p-1022", toHexString(Double.MinPositiveValue))
   }
 
-  @Test def should_parse_strings(): Unit = {
+  @Test def parseStringMethods(): Unit = {
     // scalastyle:off line.size.limit
 
     /* First, a selection of large categories for which test the combination of
@@ -321,7 +321,7 @@ class DoubleTest {
     // scalastyle:on line.size.limit
   }
 
-  @Test def should_reject_invalid_strings_when_parsing(): Unit = {
+  @Test def parseDoubleInvalidThrows(): Unit = {
     for (padding <- List("", "  ", (0 to 0x20).map(x => x.toChar).mkString)) {
       def pad(s: String): String = padding + s + padding
 
@@ -340,7 +340,7 @@ class DoubleTest {
     }
   }
 
-  @Test def compareTo(): Unit = {
+  @Test def compareToJavaDouble(): Unit = {
     def compare(x: Double, y: Double): Int =
       new JDouble(x).compareTo(new JDouble(y))
 
@@ -357,7 +357,7 @@ class DoubleTest {
     assertTrue(compare(0.0, -0.0) > 0)
   }
 
-  @Test def compareToConvertedFromInt_issue_3085(): Unit = {
+  @Test def compareToConvertedFromInt_Issue3085(): Unit = {
     @noinline
     def foo(x: Int): Unit =
       bar(x.toDouble)
@@ -375,7 +375,7 @@ class DoubleTest {
     foo(5)
   }
 
-  @Test def should_be_a_Comparable(): Unit = {
+  @Test def compareTo(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)
 
@@ -392,7 +392,7 @@ class DoubleTest {
     assertTrue(compare(0.0, -0.0) > 0)
   }
 
-  @Test def `isInfinite_- #515`(): Unit = {
+  @Test def isInfinite_Issue515(): Unit = {
     assertTrue(Double.PositiveInfinity.isInfinite)
     assertTrue(Double.NegativeInfinity.isInfinite)
     assertTrue((1.0/0).isInfinite)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -25,7 +25,7 @@ import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class FloatTest {
 
-  @Test def proper_equals(): Unit = {
+  @Test def properEquals(): Unit = {
     assertTrue(0.0f.equals(0.0f))
     assertTrue((-0.0f).equals(-0.0f))
     assertFalse(0.0f.equals(-0.0f))
@@ -60,7 +60,7 @@ class FloatTest {
     }
   }
 
-  @Test def toString_with_integer_values_when_an_integer(): Unit = {
+  @Test def toStringWithIntegerValuesWhenAnInteger(): Unit = {
     if (executingInJVM) {
       assertEquals("0.0", 0.0f.toString)
       assertEquals("-0.0", (-0.0f).toString)
@@ -107,7 +107,7 @@ class FloatTest {
     assertEquals("0x0.000002p-126", toHexString(Float.MinPositiveValue))
   }
 
-  @Test def should_parse_strings(): Unit = {
+  @Test def parseStringMethods(): Unit = {
     assertEquals(0.0f, "0.0".toFloat, 0.0f)
     assertTrue("NaN".toFloat.isNaN)
     assertTrue(Try("asdf".toFloat).isFailure)
@@ -133,7 +133,7 @@ class FloatTest {
     test("+.3f", 0.3f)
   }
 
-  @Test def should_reject_invalid_strings_when_parsing(): Unit = {
+  @Test def parseFloatInvalidThrows(): Unit = {
     def test(s: String): Unit =
       expectThrows(classOf[NumberFormatException], JFloat.parseFloat(s))
 
@@ -161,7 +161,7 @@ class FloatTest {
     assertTrue(compare(0.0f, -0.0f) > 0)
   }
 
-  @Test def should_be_a_Comparable(): Unit = {
+  @Test def compareToAnyAny(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)
 
@@ -178,7 +178,7 @@ class FloatTest {
     assertTrue(compare(0.0f, -0.0f) > 0)
   }
 
-  @Test def `isInfinite_- #515`(): Unit = {
+  @Test def isInfinite_Issue515(): Unit = {
     assertTrue(Float.PositiveInfinity.isInfinite)
     assertTrue(Float.NegativeInfinity.isInfinite)
     assertTrue((1f/0).isInfinite)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
@@ -467,7 +467,7 @@ class IntegerTest {
     assertEquals("17777777777", Integer.toOctalString(Int.MaxValue))
   }
 
-  @Test def compareTo(): Unit = {
+  @Test def compareToInteger(): Unit = {
     def compare(x: Int, y: Int): Int =
       new Integer(x).compareTo(new Integer(y))
 
@@ -477,7 +477,7 @@ class IntegerTest {
     assertEquals(0, compare(3, 3))
   }
 
-  @Test def should_be_a_Comparable(): Unit = {
+  @Test def compareTo(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)
 
@@ -487,7 +487,7 @@ class IntegerTest {
     assertEquals(0, compare(3, 3))
   }
 
-  @Test def should_parse_strings(): Unit = {
+  @Test def parseString(): Unit = {
     def test(s: String, v: Int, radix: Int = 10): Unit = {
       assertEquals(v, Integer.parseInt(s, radix))
       assertEquals(v, Integer.valueOf(s, radix).intValue())
@@ -519,7 +519,7 @@ class IntegerTest {
     test("\uff41\uff54", 389, 36)
   }
 
-  @Test def should_reject_invalid_strings_when_parsing(): Unit = {
+  @Test def parseStringInvalidThrows(): Unit = {
     def test(s: String, radix: Int = 10): Unit = {
       expectThrows(classOf[NumberFormatException], Integer.parseInt(s, radix))
       if (radix == 10 && s != null)
@@ -568,7 +568,7 @@ class IntegerTest {
     test("\uff41\uff54", 389, 36)
   }
 
-  @Test def parseUnsignedIntInvalid(): Unit = {
+  @Test def parseUnsignedIntInvalidThrows(): Unit = {
     def test(s: String, radix: Int = 10): Unit = {
       expectThrows(classOf[NumberFormatException],
           Integer.parseUnsignedInt(s, radix))
@@ -596,7 +596,7 @@ class IntegerTest {
     test("\ud804\udcf0")
   }
 
-  @Test def should_parse_strings_in_base_16(): Unit = {
+  @Test def parseStringBase16(): Unit = {
     def test(s: String, v: Int): Unit = {
       assertEquals(v, Integer.parseInt(s, 16))
       assertEquals(v, Integer.valueOf(s, 16).intValue())
@@ -613,7 +613,7 @@ class IntegerTest {
     test("-90000", -0x90000)
   }
 
-  @Test def testDecodeBase8(): Unit = {
+  @Test def decodeStringBase8(): Unit = {
     def test(s: String, v: Int): Unit = {
       assertEquals(v, Integer.decode(s))
     }
@@ -623,7 +623,7 @@ class IntegerTest {
     test("-012", -10)
   }
 
-  @Test def testDecodeInvalid(): Unit = {
+  @Test def decodeStringInvalidThrows(): Unit = {
     def test(s: String): Unit =
       assertThrows(classOf[NumberFormatException], Integer.decode(s))
 
@@ -673,7 +673,7 @@ class IntegerTest {
     assertEquals(Int.MinValue, Integer.lowestOneBit(Int.MinValue))
   }
 
-  @Test def toString_without_radix(): Unit = {
+  @Test def testToString(): Unit = {
     /* Spec ported from
      * https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/IntegerTest.java
      */
@@ -686,7 +686,7 @@ class IntegerTest {
     assertEquals("0", Integer.toString(0))
   }
 
-  @Test def toString_with_radix(): Unit = {
+  @Test def toStringRadix(): Unit = {
     /* Spec ported from
      * https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/IntegerTest.java
      */
@@ -704,7 +704,7 @@ class IntegerTest {
     assertEquals("-2147483648", Integer.toString(-2147483648, 10))
   }
 
-  @Test def parseUnsignedIntWithRadix(): Unit = {
+  @Test def parseUnsignedIntRadix(): Unit = {
     def test(s: String, v: Int, radix: Int = 10): Unit = {
       assertEquals(v, Integer.parseUnsignedInt(s, radix))
     }
@@ -722,7 +722,7 @@ class IntegerTest {
     test("4294967295", 0xFFFFFFFF)
   }
 
-  @Test def parseUnsignedIntWithRadixFailures(): Unit = {
+  @Test def parseUnsignedIntRadixInvalidThrows(): Unit = {
     def test(s: String, radix: Int = 10): Unit =
       expectThrows(classOf[NumberFormatException], Integer.parseUnsignedInt(s, radix))
 
@@ -805,7 +805,7 @@ class IntegerTest {
     assertThrows(classOf[ArithmeticException], Integer.remainderUnsigned(5, 0))
   }
 
-  @Test def toUnsignedString_without_radix(): Unit = {
+  @Test def toUnsignedString(): Unit = {
     assertEquals("0", Integer.toUnsignedString(0))
     assertEquals("12345", Integer.toUnsignedString(12345))
     assertEquals("242134", Integer.toUnsignedString(242134))
@@ -814,7 +814,7 @@ class IntegerTest {
     assertEquals("4000000000", Integer.toUnsignedString(0xEE6B2800))
   }
 
-  @Test def toUnsignedString_with_radix(): Unit = {
+  @Test def toUnsignedStringRadix(): Unit = {
     assertEquals("17777777777", Integer.toUnsignedString(2147483647, 8))
     assertEquals("7fffffff", Integer.toUnsignedString(2147483647, 16))
     assertEquals("1111111111111111111111111111111",

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
@@ -108,7 +108,7 @@ class LongTest {
     assertEquals(32, JLong.bitCount(-350003829229342837L))
   }
 
-  @Test def compareTo(): Unit = {
+  @Test def compareToJavaLong(): Unit = {
     def compare(x: Long, y: Long): Int =
       new JLong(x).compareTo(new JLong(y))
 
@@ -118,7 +118,7 @@ class LongTest {
     assertEquals(0, compare(3L, 3L))
   }
 
-  @Test def should_be_a_Comparable(): Unit = {
+  @Test def compareTo(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)
 
@@ -128,7 +128,7 @@ class LongTest {
     assertEquals(0, compare(3L, 3L))
   }
 
-  @Test def should_parse_strings(): Unit = {
+  @Test def parseString(): Unit = {
     def test(s: String, v: Long): Unit = {
       assertEquals(v, JLong.parseLong(s))
       assertEquals(v, JLong.valueOf(s).longValue())
@@ -153,7 +153,7 @@ class LongTest {
         9497394973L)
   }
 
-  @Test def should_reject_invalid_strings_when_parsing(): Unit = {
+  @Test def parseStringInvalidThrows(): Unit = {
     def test(s: String): Unit =
       expectThrows(classOf[NumberFormatException], JLong.parseLong(s))
 
@@ -162,7 +162,7 @@ class LongTest {
     test("")
   }
 
-  @Test def should_parse_strings_in_base_16(): Unit = {
+  @Test def parseStringBase16(): Unit = {
     def test(s: String, v: Long): Unit = {
       assertEquals(v, JLong.parseLong(s, 16))
       assertEquals(v, JLong.valueOf(s, 16).longValue())
@@ -184,7 +184,7 @@ class LongTest {
     test("\uff42\uff46\uff43\u19d9\u0f24\u0c6f\u1c47\ua6233", 51482236723L)
   }
 
-  @Test def should_parse_strings_in_bases_2_to_36(): Unit = {
+  @Test def parseStringBase2To36(): Unit = {
     def test(radix: Int, s: String, v: Long): Unit = {
       assertEquals(v, JLong.parseLong(s, radix))
       assertEquals(v, JLong.valueOf(s, radix).longValue())
@@ -205,7 +205,7 @@ class LongTest {
     }
   }
 
-  @Test def should_reject_parsing_strings_when_base_less_than_2_or_base_larger_than_36(): Unit = {
+  @Test def parseStringsBaseLessThanTwoOrBaseLargerThan36Throws(): Unit = {
     def test(s: String, radix: Int): Unit = {
       expectThrows(classOf[NumberFormatException], JLong.parseLong(s, radix))
       expectThrows(classOf[NumberFormatException], JLong.valueOf(s, radix).longValue())
@@ -224,7 +224,7 @@ class LongTest {
     test("-012", -10L)
   }
 
-  @Test def testDecodeInvalid(): Unit = {
+  @Test def decodeStringInvalidThrows(): Unit = {
     def test(s: String): Unit =
       assertThrows(classOf[NumberFormatException], JLong.decode(s))
 
@@ -251,7 +251,7 @@ class LongTest {
     test("-01000000000000000000001")
   }
 
-  @Test def toString_without_radix(): Unit = {
+  @Test def testToString(): Unit = {
     assertEquals("2147483647", Int.MaxValue.toLong.toString)
     assertEquals("-50", (-50L).toString)
     assertEquals("-1000000000", (-1000000000L).toString)
@@ -274,7 +274,7 @@ class LongTest {
     assertEquals("9223372036854775807", JLong.toString(JLong.MAX_VALUE))
   }
 
-  @Test def toString_with_radix(): Unit = {
+  @Test def toStringRadix(): Unit = {
     /* Ported from
      * https://github.com/gwtproject/gwt/blob/master/user/test/com/google/gwt/emultest/java/lang/JLongTest.java
      */
@@ -600,7 +600,7 @@ class LongTest {
     test("3w5e0eru6osu5", -1746501839363L, 36)
   }
 
-  @Test def parseUnsignedLong_failure_cases(): Unit = {
+  @Test def parseUnsignedLongFailureCases(): Unit = {
     def test(s: String, radix: Int = 10): Unit =
       expectThrows(classOf[NumberFormatException], JLong.parseUnsignedLong(s, radix))
 
@@ -627,7 +627,7 @@ class LongTest {
     test("3w5e11264sgsgvmqoijs34qsdf1ssfmlkjesl", 36)
   }
 
-  @Test def hashCode_test(): Unit = {
+  @Test def hashCodeTest(): Unit = {
     assertEquals(0, JLong.hashCode(0L))
     assertEquals(1, JLong.hashCode(1L))
     assertEquals(0, JLong.hashCode(-1L))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
@@ -121,7 +121,7 @@ class MathTest {
     assertTrue(Math.log10(Double.NegativeInfinity).isNaN)
   }
 
-  @Test def signum_for_Double(): Unit = {
+  @Test def signumForDouble(): Unit = {
     assertEquals(1.0, Math.signum(234394.2198273), 0.0)
     assertEquals(-1.0, Math.signum(-124937498.58), 0.0)
 
@@ -134,7 +134,7 @@ class MathTest {
     assertTrue(Math.signum(Double.NaN).isNaN)
   }
 
-  @Test def signum_for_Float(): Unit = {
+  @Test def signumForFloat(): Unit = {
     assertEquals(1.0f, Math.signum(234394.2198273f), 0.0f)
     assertEquals(-1.0f, Math.signum(-124937498.58f), 0.0f)
 
@@ -144,7 +144,7 @@ class MathTest {
     assertTrue(Math.signum(Float.NaN).isNaN)
   }
 
-  @Test def nextUp_for_Double(): Unit = {
+  @Test def nextUpForDouble(): Unit = {
     // Specials
     assertSameDouble(Double.MinPositiveValue, Math.nextUp(0.0))
     assertSameDouble(Double.MinPositiveValue, Math.nextUp(-0.0))
@@ -167,7 +167,7 @@ class MathTest {
     assertSameDouble(1.0000000000000002, Math.nextUp(1.0))
   }
 
-  @Test def nextUp_for_Float(): Unit = {
+  @Test def nextUpForFloat(): Unit = {
     // Specials
     assertSameFloat(Float.MinPositiveValue, Math.nextUp(0.0f))
     assertSameFloat(Float.MinPositiveValue, Math.nextUp(-0.0f))
@@ -189,7 +189,7 @@ class MathTest {
     assertSameFloat(1.0000001f, Math.nextUp(1.0f))
   }
 
-  @Test def nextAfter_for_Double(): Unit = {
+  @Test def nextAfterForDouble(): Unit = {
     assertSameDouble(Double.NaN, Math.nextAfter(Double.NaN, Double.NaN))
     assertSameDouble(Double.NaN, Math.nextAfter(1.0, Double.NaN))
     assertSameDouble(Double.NaN, Math.nextAfter(Double.NaN, 1.0))
@@ -222,7 +222,7 @@ class MathTest {
     assertSameDouble(0.9999999999999999, Math.nextAfter(1.0, 0.5))
   }
 
-  @Test def nextAfter_for_Float(): Unit = {
+  @Test def nextAfterForFloat(): Unit = {
     assertSameFloat(Float.NaN, Math.nextAfter(Float.NaN, Double.NaN))
     assertSameFloat(Float.NaN, Math.nextAfter(1.0f, Double.NaN))
     assertSameFloat(Float.NaN, Math.nextAfter(Float.NaN, 1.0))
@@ -255,7 +255,7 @@ class MathTest {
     assertSameFloat(0.99999994f, Math.nextAfter(1.0f, 0.5))
   }
 
-  @Test def ulp_for_Double(): Unit = {
+  @Test def ulpForDouble(): Unit = {
     assertEquals(4.440892098500626E-16, Math.ulp(3.4), 0.0)
     assertEquals(4.1718496795330275E93, Math.ulp(3.423E109), 0.0)
     assertEquals(Double.MinPositiveValue, Math.ulp(0.0), 0.0)
@@ -320,7 +320,7 @@ class MathTest {
     assertTrue(Math.tanh(Double.NaN).isNaN)
   }
 
-  @Test def rint_for_Double(): Unit = {
+  @Test def rintForDouble(): Unit = {
     import Math.rint
 
     def isPosZero(x: Double): Boolean =
@@ -641,7 +641,7 @@ class MathTest {
     assertThrows(classOf[ArithmeticException], Math.floorMod(5L, 0L))
   }
 
-  @Test def nextDown_for_Double(): Unit = {
+  @Test def nextDownForDouble(): Unit = {
     // Specials
     assertSameDouble(-Double.MinPositiveValue, Math.nextDown(0.0))
     assertSameDouble(-Double.MinPositiveValue, Math.nextDown(-0.0))
@@ -664,7 +664,7 @@ class MathTest {
     assertSameDouble(0.9999999999999999, Math.nextDown(1.0))
   }
 
-  @Test def nextDown_for_Float(): Unit = {
+  @Test def nextDownForFloat(): Unit = {
     // Specials
     assertSameFloat(-Float.MinPositiveValue, Math.nextDown(0.0f))
     assertSameFloat(-Float.MinPositiveValue, Math.nextDown(-0.0f))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
@@ -64,7 +64,7 @@ class ObjectTest {
     assertTrue(l.exists(_ == xy12)) // the workaround
   }
 
-  @Test def everything_but_null_should_be_an_Object(): Unit = {
+  @Test def isInstanceOfObjectExceptNull(): Unit = {
     assertTrue((()             : Any).isInstanceOf[Object])
     assertTrue((true           : Any).isInstanceOf[Object])
     assertTrue(('a'            : Any).isInstanceOf[Object])
@@ -81,11 +81,11 @@ class ObjectTest {
     assertTrue((Array(Nil)     : Any).isInstanceOf[Object])
   }
 
-  @Test def null_should_not_be_an_Object(): Unit = {
+  @Test def isInstanceOfObjectNull(): Unit = {
     assertFalse((null: Any).isInstanceOf[Object])
   }
 
-  @Test def everything_should_cast_to_Object_successfully_including_null(): Unit = {
+  @Test def asInstanceOfObjectAll(): Unit = {
     (()             : Any).asInstanceOf[Object]
     (true           : Any).asInstanceOf[Object]
     ('a'            : Any).asInstanceOf[Object]
@@ -103,7 +103,7 @@ class ObjectTest {
     (null           : Any).asInstanceOf[Object]
   }
 
-  @Test def cloneCtorSideEffects_issue_3192(): Unit = {
+  @Test def cloneCtorSideEffects_Issue3192(): Unit = {
     var ctorInvokeCount = 0
 
     // This class has an inlineable init

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
@@ -23,7 +23,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
  */
 class ShortTest {
 
-  @Test def compareTo(): Unit = {
+  @Test def compareToJavaShort(): Unit = {
     def compare(x: Short, y: Short): Int =
       new JShort(x).compareTo(new JShort(y))
 
@@ -33,7 +33,7 @@ class ShortTest {
     assertEquals(0, compare(3.toShort, 3.toShort))
   }
 
-  @Test def should_be_a_Comparable(): Unit = {
+  @Test def compareTo(): Unit = {
     def compare(x: Any, y: Any): Int =
       x.asInstanceOf[Comparable[Any]].compareTo(y)
 
@@ -43,7 +43,7 @@ class ShortTest {
     assertEquals(0, compare(3.toShort, 3.toShort))
   }
 
-  @Test def should_parse_strings(): Unit = {
+  @Test def parseString(): Unit = {
     def test(s: String, v: Short): Unit = {
       assertEquals(v, JShort.parseShort(s))
       assertEquals(v, JShort.valueOf(s).shortValue())
@@ -58,7 +58,7 @@ class ShortTest {
     test("30000", 30000)
   }
 
-  @Test def should_reject_invalid_strings_when_parsing(): Unit = {
+  @Test def parseStringInvalidThrows(): Unit = {
     def test(s: String): Unit = {
       expectThrows(classOf[NumberFormatException], JShort.parseShort(s))
       expectThrows(classOf[NumberFormatException], JShort.decode(s))
@@ -70,7 +70,7 @@ class ShortTest {
     test("-90000") // out of range
   }
 
-  @Test def should_parse_strings_in_base_16(): Unit = {
+  @Test def parseStringBase16(): Unit = {
     def test(s: String, v: Short): Unit = {
       assertEquals(v, JShort.parseShort(s, 16))
       assertEquals(v, JShort.valueOf(s, 16).intValue())
@@ -87,7 +87,7 @@ class ShortTest {
     test("-900", -0x900)
   }
 
-  @Test def testDecodeBase8(): Unit = {
+  @Test def decodeStringBase8(): Unit = {
     def test(s: String, v: Short): Unit = {
       assertEquals(v, JShort.decode(s))
     }
@@ -97,7 +97,7 @@ class ShortTest {
     test("-012", -10)
   }
 
-  @Test def testDecodeInvalid(): Unit = {
+  @Test def decodeStringInvalidThrows(): Unit = {
     def test(s: String): Unit =
       assertThrows(classOf[NumberFormatException], JShort.decode(s))
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StackTraceElementTest.scala
@@ -17,7 +17,7 @@ import org.junit.Test
 
 class StackTraceElementTest {
 
-  @Test def should_leave_toString_unmodified_if_columnNumber_is_not_specified(): Unit = {
+  @Test def toStringUnmodifiedIfColumnNumberIsNotSpecified(): Unit = {
     val st = new StackTraceElement("MyClass", "myMethod", "myFile.scala", 1)
     assertEquals("MyClass.myMethod(myFile.scala:1)", st.toString)
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
@@ -637,7 +637,7 @@ class StringBuilderTest {
     }
   }
 
-  @Test def should_allow_string_interpolation_to_survive_null_and_undefined(): Unit = {
+  @Test def stringInterpolationToSurviveNullAndUndefined(): Unit = {
     assertEquals("anullb", s"a${null}b")
 
     if (executingInJVM)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -24,7 +24,7 @@ import org.scalajs.testsuite.utils.Platform._
 
 class StringTest {
 
-  @Test def length_test(): Unit = {
+  @Test def lengthTest(): Unit = {
     assertEquals(8, "Scala.js".length)
     assertEquals(0, "".length)
   }
@@ -106,14 +106,14 @@ class StringTest {
     assertTrue("banana".endsWith("na"))
   }
 
-  @Test def indexOf_String(): Unit = {
+  @Test def indexOfString(): Unit = {
     assertEquals(6, "Scala.js".indexOf("js"))
     assertEquals(0, "Scala.js".indexOf("Scala.js"))
     assertEquals(1, "ananas".indexOf("na"))
     assertEquals(-1, "Scala.js".indexOf("Java"))
   }
 
-  @Test def indexOf_int(): Unit = {
+  @Test def indexOfInt(): Unit = {
     assertEquals(0, "abc\uD834\uDF06def\uD834\uDF06def".indexOf(0x61))
     assertEquals(3, "abc\uD834\uDF06def\uD834\uDF06def".indexOf(0x1D306))
     assertEquals(3, "abc\uD834\uDF06def\uD834\uDF06def".indexOf(0xD834))
@@ -121,14 +121,14 @@ class StringTest {
     assertEquals(5, "abc\uD834\uDF06def\uD834\uDF06def".indexOf(0x64))
   }
 
-  @Test def lastIndexOf_String(): Unit = {
+  @Test def lastIndexOfString(): Unit = {
     assertEquals(0, "Scala.js".lastIndexOf("Scala.js"))
     assertEquals(3, "ananas".lastIndexOf("na"))
     assertEquals(-1, "Scala.js".lastIndexOf("Java"))
     assertEquals(-1, "Negative index".lastIndexOf("N", -5))
   }
 
-  @Test def lastIndexOf_int(): Unit = {
+  @Test def lastIndexOfInt(): Unit = {
     assertEquals(0, "abc\uD834\uDF06def\uD834\uDF06def".lastIndexOf(0x61))
     assertEquals(8, "abc\uD834\uDF06def\uD834\uDF06def".lastIndexOf(0x1D306))
     assertEquals(8, "abc\uD834\uDF06def\uD834\uDF06def".lastIndexOf(0xD834))
@@ -283,7 +283,7 @@ class StringTest {
     }
   }
 
-  @Test def split_with_char_as_argument(): Unit = {
+  @Test def splitWithCharAsArgument(): Unit = {
     assertArrayEquals(Array[AnyRef]("Scala","js"), erased("Scala.js".split('.')))
     for (i <- 0 to 32) {
       val c = i.toChar
@@ -292,7 +292,7 @@ class StringTest {
     }
   }
 
-  @Test def `startsWith(prefix, toffset) - #1603`(): Unit = {
+  @Test def startsWithPrefixToffset_Issue1603(): Unit = {
     assertTrue("Scala.js".startsWith("ala", 2))
     assertTrue("Scala.js".startsWith("Scal", 0))
 
@@ -442,7 +442,7 @@ class StringTest {
     assertEquals("foo bar", "foo bar".trim())
   }
 
-  @Test def createFromLargeCharArray_issue2553(): Unit = {
+  @Test def createFromLargeCharArray_Issue2553(): Unit = {
     val largeCharArray =
       (1 to 100000).toArray.flatMap(_ => Array('a', 'b', 'c', 'd', 'e', 'f'))
     val str = new String(largeCharArray)
@@ -453,7 +453,7 @@ class StringTest {
       assertEquals(('a' + i % 6).toChar, str.charAt(i))
   }
 
-  @Test def createFromLargeCodePointArray_issue2553(): Unit = {
+  @Test def createFromLargeCodePointArray_Issue2553(): Unit = {
     val largeCodePointArray =
       (1 to 100000).toArray.flatMap(_ => Array[Int]('a', 'b', 'c', 'd', 'e', 'f'))
     val str = new String(largeCodePointArray, 0, largeCodePointArray.length)
@@ -464,7 +464,7 @@ class StringTest {
       assertEquals(('a' + i % 6).toChar, str.charAt(i))
   }
 
-  @Test def String_CASE_INSENSITIVE_ORDERING(): Unit = {
+  @Test def stringCaseInsensitiveOrdering(): Unit = {
     def compare(s1: String, s2: String): Int =
       String.CASE_INSENSITIVE_ORDER.compare(s1, s2)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -85,7 +85,7 @@ class SystemTest {
         chars.filter(_ != null).map(_.mkString).mkString)
   }
 
-  @Test def arraycopy_with_range_overlaps_for_the_same_array(): Unit = {
+  @Test def arraycopyWithRangeOverlapsForTheSameArray(): Unit = {
     val array = new Array[Int](10)
 
     for (i <- 1 to 6) {
@@ -165,7 +165,7 @@ class SystemTest {
     assertEquals(x2.hashCode(), System.identityHashCode(x2))
   }
 
-  @Test def identityHashCode_should_by_pass_hashCode(): Unit = {
+  @Test def identityHashCodeNotEqualHashCodeForList(): Unit = {
     val list1 = List(1, 3, 5)
     val list2 = List(1, 3, 5)
     assertEquals(list2, list1)
@@ -173,11 +173,11 @@ class SystemTest {
     assertNotEquals(System.identityHashCode(list1), System.identityHashCode(list2))
   }
 
-  @Test def identityHashCode_of_null(): Unit = {
+  @Test def identityHashCodeOfNull(): Unit = {
     assertEquals(0, System.identityHashCode(null))
   }
 
-  @Test def identityHashCode_of_values_implemented_as_JS_primitives(): Unit = {
+  @Test def identityHashCodeOfValuesImplementedAsJSPrimitives(): Unit = {
     if (!executingInJVM) {
       assertEquals("foo".hashCode(), System.identityHashCode("foo"))
       assertEquals("".hashCode(), System.identityHashCode(""))
@@ -201,13 +201,13 @@ class SystemTest {
       assertTrue(Set("\n", "\r", "\r\n").contains(lineSep))
   }
 
-  @Test def getenv_should_return_an_unmodifiable_map(): Unit = {
+  @Test def getenvReturnsUnmodifiableMap(): Unit = {
     assertTrue(System.getenv().isInstanceOf[java.util.Map[String, String]])
 
     expectThrows(classOf[Exception], System.getenv.put("", ""))
   }
 
-  @Test def getenv_should_link_and_does_not_throw(): Unit = {
+  @Test def getenvLinksAndDoesNotThrow(): Unit = {
     assertEquals(null, System.getenv(":${PATH}"))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThreadTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThreadTest.scala
@@ -19,7 +19,7 @@ import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class ThreadTest {
 
-  @Test def getName_and_setName(): Unit = {
+  @Test def getNameAndSetName(): Unit = {
     if (!executingInJVM) {
       val t = Thread.currentThread()
       assertEquals("main", t.getName) // default name of the main thread
@@ -33,7 +33,7 @@ class ThreadTest {
     }
   }
 
-  @Test def currentThread_getStackTrace(): Unit = {
+  @Test def currentThreadGetStackTrace(): Unit = {
     Thread.currentThread().getStackTrace()
   }
 
@@ -41,7 +41,7 @@ class ThreadTest {
     assertTrue(Thread.currentThread().getId > 0)
   }
 
-  @Test def interrupt_exist_and_the_status_is_properly_reflected(): Unit = {
+  @Test def interruptExistsAndTheStatusIsProperlyReflected(): Unit = {
     val t = Thread.currentThread()
     assertFalse(t.isInterrupted())
     assertFalse(Thread.interrupted())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
@@ -17,7 +17,7 @@ import org.junit.Assert._
 
 class ThrowablesTest {
 
-  @Test def should_define_all_java_lang_Errors_and_Exceptions(): Unit = {
+  @Test def allJavaLangErrorsAndExceptions(): Unit = {
     new ArithmeticException()
     new ArrayIndexOutOfBoundsException()
     new ArrayStoreException()
@@ -69,7 +69,7 @@ class ThrowablesTest {
     new VirtualMachineError() {}
   }
 
-  @Test def throwable_message_issue_2559(): Unit = {
+  @Test def throwableMessage_Issue2559(): Unit = {
     val t0 = new Throwable
     val t1 = new Throwable("foo")
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ref/ReferenceTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ref/ReferenceTest.scala
@@ -17,7 +17,7 @@ import org.junit.Assert._
 
 class ReferenceTest {
 
-  @Test def should_have_all_the_normal_operations(): Unit = {
+  @Test def normalOperations(): Unit = {
     val s = "string"
     val ref = new java.lang.ref.WeakReference(s)
     assertEquals(s, ref.get)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -213,7 +213,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result(1).scale(), remScale)
   }
 
-  @Test def testDivideAndRemainderMathContextDOWN(): Unit = {
+  @Test def testDivideAndRemainderMathContextDown(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 45
     val b = "134432345432345748766876876723342238476237823787879183470"
@@ -300,7 +300,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testDivideBigDecimalScaleMathContextDOWN(): Unit = {
+  @Test def testDivideBigDecimalScaleMathContextDown(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 15
     val b = "748766876876723342238476237823787879183470"
@@ -317,7 +317,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testDivideBigDecimalScaleMathContextFLOOR(): Unit = {
+  @Test def testDivideBigDecimalScaleMathContextFloor(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 15
     val b = "748766876876723342238476237823787879183470"
@@ -334,7 +334,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testDivideBigDecimalScaleMathContextHALF_DOWN(): Unit = {
+  @Test def testDivideBigDecimalScaleMathContextHalfDown(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 45
     val b = "134432345432345748766876876723342238476237823787879183470"
@@ -351,7 +351,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testDivideBigDecimalScaleMathContextHALF_EVEN(): Unit = {
+  @Test def testDivideBigDecimalScaleMathContextHalfEven(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 45
     val b = "134432345432345748766876876723342238476237823787879183470"
@@ -368,7 +368,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testDivideBigDecimalScaleMathContextHALF_UP(): Unit = {
+  @Test def testDivideBigDecimalScaleMathContextHalfUp(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 45
     val b = "134432345432345748766876876723342238476237823787879183470"
@@ -385,7 +385,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testDivideBigDecimalScaleMathContextUP(): Unit = {
+  @Test def testDivideBigDecimalScaleMathContextUp(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 15
     val b = "748766876876723342238476237823787879183470"
@@ -417,7 +417,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), newScale)
   }
 
-  @Test def testDivideBigDecimalScaleRoundingModeDOWN(): Unit = {
+  @Test def testDivideBigDecimalScaleRoundingModeDown(): Unit = {
     val a = "-37361671119238118911893939591735"
     val aScale = 10
     val b = "74723342238476237823787879183470"
@@ -432,7 +432,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), newScale)
   }
 
-  @Test def testDivideBigDecimalScaleRoundingModeFLOOR(): Unit = {
+  @Test def testDivideBigDecimalScaleRoundingModeFloor(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 100
     val b = "74723342238476237823787879183470"
@@ -447,7 +447,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), newScale)
   }
 
-  @Test def testDivideBigDecimalScaleRoundingModeHALF_DOWN(): Unit = {
+  @Test def testDivideBigDecimalScaleRoundingModeHalfDown(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 5
     val b = "74723342238476237823787879183470"
@@ -462,7 +462,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), newScale)
   }
 
-  @Test def testDivideBigDecimalScaleRoundingModeHALF_EVEN(): Unit = {
+  @Test def testDivideBigDecimalScaleRoundingModeHalfEven(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 5
     val b = "74723342238476237823787879183470"
@@ -477,7 +477,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), newScale)
   }
 
-  @Test def testDivideBigDecimalScaleRoundingModeHALF_UP(): Unit = {
+  @Test def testDivideBigDecimalScaleRoundingModeHalfUp(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = -51
     val b = "74723342238476237823787879183470"
@@ -509,7 +509,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), newScale)
   }
 
-  @Test def testDivideBigDecimalScale_issue2755(): Unit = {
+  @Test def testDivideBigDecimalScale_Issue2755(): Unit = {
     val a = new BigDecimal(2L)
     val b = new BigDecimal(1L)
     val r = a.divide(b, 1, RoundingMode.UNNECESSARY)
@@ -958,7 +958,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testDivideToIntegralValueMathContextDOWN(): Unit = {
+  @Test def testDivideToIntegralValueMathContextDown(): Unit = {
     val a = "3736186567876876578956958769675785435673453453653543654354365435675671119238118911893939591735"
     val aScale = 45
     val b = "134432345432345748766876876723342238476237823787879183470"
@@ -1002,7 +1002,7 @@ class  BigDecimalArithmeticTest {
     expectThrows(classOf[ArithmeticException], BigDecimal.ONE.divideToIntegralValue(BigDecimal.ZERO))
   }
 
-  @Test def testDivideToIntegralValue_on_floating_points__issue_1979(): Unit = {
+  @Test def testDivideToIntegralValueOnFloatingPoints_Issue1979(): Unit = {
     val one = new BigDecimal(1.0)
     val oneAndHalf = new BigDecimal(1.5)
     val a0 = new BigDecimal(3.0)
@@ -1124,7 +1124,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), cScale)
   }
 
-  @Test def testMultiplySmallOverflow_issue2587(): Unit = {
+  @Test def testMultiplySmallOverflow_Issue2587(): Unit = {
     val x = new BigDecimal(Int.MinValue)
     val y = new BigDecimal(Int.MinValue.toLong * 2L)
     val z = new BigDecimal("9223372036854775808")
@@ -1200,7 +1200,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testRemainderMathContextHALF_DOWN(): Unit = {
+  @Test def testRemainderMathContextHalfDown(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = -45
     val b = "134432345432345748766876876723342238476237823787879183470"
@@ -1217,7 +1217,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testRemainderMathContextHALF_UP(): Unit = {
+  @Test def testRemainderMathContextHalfUp(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 45
     val b = "134432345432345748766876876723342238476237823787879183470"
@@ -1234,7 +1234,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testRoundMathContextCEILING(): Unit = {
+  @Test def testRoundMathContextCeiling(): Unit = {
     var `val` = BigDecimal.valueOf(1.5)
     val result = `val`.round(new MathContext(1, RoundingMode.CEILING))
     assertEquals(result.toString, "2")
@@ -1251,7 +1251,7 @@ class  BigDecimalArithmeticTest {
       .round(new MathContext(1, RoundingMode.CEILING))
   }
 
-  @Test def testRoundMathContextHALF_DOWN(): Unit = {
+  @Test def testRoundMathContextHalfDown(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = -45
     val precision = 75
@@ -1265,7 +1265,7 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
-  @Test def testRoundMathContextHALF_UP(): Unit = {
+  @Test def testRoundMathContextHalfUp(): Unit = {
     val a = "3736186567876876578956958765675671119238118911893939591735"
     val aScale = 45
     val precision = 15

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
@@ -159,7 +159,7 @@ class BigDecimalConvertTest {
     test(-15L, 1)
   }
 
-  @Test def bigDecimal_9_223372E285625056_should_not_be_a_valid_long_issue_2314(): Unit = {
+  @Test def bigDecimal9Point223372E285625056IsNotValidLong_Issue2314(): Unit = {
     val num = new BigDecimal("9.223372E+285625056")
 
     // Sanity checks

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalTest.scala
@@ -21,158 +21,158 @@ class BigDecimalTest  {
 
   // java.lang.Math.BigDecimal Int/Long Constructors
 
-  @Test def `should accept 3 as aLong`(): Unit = {
+  @Test def valueOfLong3(): Unit = {
     val bd = BigDecimal.valueOf(3L)
     assertEquals(3, bd.intValue())
     assertTrue(bd.longValue == 3L)
   }
 
-  @Test def `should accept 999999999 as aLong`(): Unit = {
+  @Test def valueOfLong999999999(): Unit = {
     val bd = BigDecimal.valueOf(999999999L)
     assertEquals(999999999, bd.intValue())
     assertTrue(bd.longValue == 999999999L)
   }
 
-  @Test def `should accept 9999999999 as aLong`(): Unit = {
+  @Test def valueOfLong9999999999(): Unit = {
     val bd = BigDecimal.valueOf(9999999999L)
     assertTrue(bd.longValue == 9999999999L)
   }
 
-  @Test def `should accept -999999999 as aLong`(): Unit = {
+  @Test def valueOfLongNegative999999999(): Unit = {
     val bd = BigDecimal.valueOf(-999999999L)
     assertEquals(-999999999, bd.intValue())
     assertTrue(bd.longValue == -999999999L)
   }
 
-  @Test def `should accept -9999999999 as aLong`(): Unit = {
+  @Test def valueOfLongNegative9999999999(): Unit = {
     val bd = BigDecimal.valueOf(-9999999999L)
     assertTrue(bd.longValue == -9999999999L)
   }
 
-  @Test def `should accept 3 as a string`(): Unit = {
+  @Test def ctorString3(): Unit = {
     val bd = new BigDecimal("3")
     assertEquals(3, bd.intValue())
     assertTrue(bd.longValue == 3L)
   }
 
-  @Test def `should accept 99 as a string`(): Unit = {
+  @Test def ctorString99(): Unit = {
     val bd = new BigDecimal("99")
     assertEquals(99, bd.intValue())
     assertTrue(bd.longValue == 99L)
   }
 
-  @Test def `should accept 999999999 as string`(): Unit = {
+  @Test def ctorString999999999(): Unit = {
     val bd = new BigDecimal("999999999")
     assertEquals(999999999, bd.intValue())
     assertTrue(bd.longValue == 999999999L)
   }
 
-  @Test def `should accept 9999999999 as a string`(): Unit = {
+  @Test def ctorString9999999999(): Unit = {
     val bd = new BigDecimal("9999999999")
     assertTrue(bd.longValue == 9999999999L)
   }
 
-  @Test def `should accept -99 as a string`(): Unit = {
+  @Test def ctorStringNegative99(): Unit = {
     val bd = new BigDecimal("-99")
     assertEquals(-99, bd.intValue())
     assertTrue(bd.longValue == -99L)
   }
 
-  @Test def `should accept -999999999 as sting`(): Unit = {
+  @Test def ctorStringNegative999999999(): Unit = {
     val bd = new BigDecimal("-999999999")
     assertEquals(-999999999, bd.intValue())
     assertTrue(bd.longValue == -999999999L)
   }
 
-  @Test def `should accept -9999999999 as a string`(): Unit = {
+  @Test def ctorStringNegative9999999999(): Unit = {
     val bd = new BigDecimal("-9999999999")
     assertTrue(bd.longValue == -9999999999L)
   }
 
-  @Test def `should accept 9.9 as a string`(): Unit = {
+  @Test def ctorString9Point9(): Unit = {
     val bd = new BigDecimal("9.9")
     assertEquals("9.9", bd.toString)
     assertEquals(9.9, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept 99.99 as a string`(): Unit = {
+  @Test def ctorString99Point99(): Unit = {
     val bd = new BigDecimal("99.99")
     assertEquals(99.99, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept 999.999 as a string`(): Unit = {
+  @Test def ctorString999Point999(): Unit = {
     val bd = new BigDecimal("999.999")
     assertEquals(999.999, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept 9999.9999 as a string`(): Unit = {
+  @Test def ctorString9999Point9999(): Unit = {
     val bd = new BigDecimal("9999.9999")
     assertEquals(9999.9999, bd.doubleValue(), 0.0)
   }
 
   // java.lang.Math.BigDecimal double Constructors
 
-  @Test def `should accept 3.3 as a double`(): Unit = {
+  @Test def ctorDouble3Point3(): Unit = {
     val d = 3.3
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept 99.99 as a double`(): Unit = {
+  @Test def ctorDouble99Point99(): Unit = {
     val d = 99.99
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept 9999.9999 as a double`(): Unit = {
+  @Test def ctorDouble9999Point9999: Unit = {
     val d:Double = 9999.9999
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept 99999999.99999999 as a double`(): Unit = {
+  @Test def ctorDouble99999999Point99999999(): Unit = {
     val d = 99999999.99999999
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept 999999999.999999999 as a double`(): Unit = {
+  @Test def ctorDouble999999999Point999999999(): Unit = {
     val d = 999999999.999999999
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept 9999999999.9999999999 as a double`(): Unit = {
+  @Test def ctorDouble9999999999Point9999999999(): Unit = {
     val d = 9999999999.9999999999
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept -3.3 as a double`(): Unit = {
+  @Test def ctorDoubleNegative3Point3(): Unit = {
     val d = -3.3
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept -99.99 as a double`(): Unit = {
+  @Test def ctorDoubleNegative99Point99(): Unit = {
     val d = -99.99
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept -99999999.99999999 as a double`(): Unit = {
+  @Test def ctorDoubleNegative99999999Point99999999(): Unit = {
     val d = -99999999.99999999
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept -999999999.999999999 as a double`(): Unit = {
+  @Test def ctorDoubleNegative999999999Point999999999(): Unit = {
     val d = -999999999.999999999
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)
   }
 
-  @Test def `should accept -9999999999.9999999999 as a double`(): Unit = {
+  @Test def ctorDoubleNegative9999999999Point9999999999(): Unit = {
     val d = -9999999999.9999999999
     val bd = new BigDecimal(d)
     assertEquals(d, bd.doubleValue(), 0.0)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
@@ -493,7 +493,7 @@ class BigIntegerConstructorsTest {
     assertEquals(0, aNumber.signum())
   }
 
-  @Test def testConstructorStringRadix10Issue2228(): Unit = {
+  @Test def testConstructorStringRadix10_Issue2228(): Unit = {
     assumeFalse("Assumed not executing on JDK6", Platform.executingInJVMOnJDK6)
 
     val value = "+100000000"

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerHashCodeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerHashCodeTest.scala
@@ -38,7 +38,7 @@ class BigIntegerHashCodeTest {
     }
   }
 
-  @Test def hashCodeIssue2159(): Unit = {
+  @Test def hashCode_Issue2159(): Unit = {
     val a = 936417286865811553L
     val b = 1136802186495971562L
     val c = BigInteger.valueOf(a).add(BigInteger.valueOf(b))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
@@ -322,7 +322,7 @@ class BigIntegerMultiplyTest {
     assertEquals(1, result.signum())
   }
 
-  @Test def testPow31_issue_2045(): Unit = {
+  @Test def testPow31_Issue2045(): Unit = {
     assertEquals(BigInt("2147483648"), BigInt(2).pow(31))
     assertEquals(BigInt("1326443518324400147398656"), BigInt(6).pow(31))
     assertEquals(BigInt("10000000000000000000000000000000"), BigInt(10).pow(31))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
@@ -568,7 +568,7 @@ class BigIntegerOperateBitsTest {
     assertEquals(1, result.signum())
   }
 
-  @Test def testSetBitBug1331(): Unit = {
+  @Test def testSetBit_Issue1331(): Unit = {
     val result = BigInteger.valueOf(0L).setBit(191)
     assertEquals("3138550867693340381917894711603833208051177722232017256448", result.toString)
     assertEquals(1, result.signum())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerTest.scala
@@ -21,107 +21,107 @@ import org.junit.Assert._
 
 class BigIntegerTest {
 
-  @Test def `should accept 3 as a Byte Array`(): Unit = {
+  @Test def ctorArrayByte3(): Unit = {
     val bi = new BigInteger(Array[Byte](3))
     assertEquals(3, bi.intValue())
   }
 
-  @Test def `should accept 127 as a Byte Array`(): Unit = {
+  @Test def ctorArrayByte127(): Unit = {
     val bi = new BigInteger(Array[Byte](127))
     assertEquals(127, bi.intValue())
   }
 
-  @Test def `should accept 3 as aLong`(): Unit = {
+  @Test def valueOfLong3(): Unit = {
     val bi = BigInteger.valueOf(3L)
     assertEquals(3, bi.intValue())
     assertEquals(3L, bi.longValue())
   }
 
-  @Test def `should accept 999999999 as aLong`(): Unit = {
+  @Test def valueOfLong999999999(): Unit = {
     val bi = BigInteger.valueOf(999999999L)
     assertEquals(999999999, bi.intValue())
     assertEquals(999999999L, bi.longValue())
   }
 
-  @Test def `should accept 9999999999 as aLong`(): Unit = {
+  @Test def valueOfLong9999999999(): Unit = {
     val bi = BigInteger.valueOf(9999999999L)
     assertEquals(9999999999L, bi.longValue())
   }
 
-  @Test def `should accept -999999999 as aLong`(): Unit = {
+  @Test def valueOfLongNegative999999999(): Unit = {
     val bi = BigInteger.valueOf(-999999999L)
     assertEquals(-999999999, bi.intValue())
     assertEquals(-999999999L, bi.longValue())
   }
 
-  @Test def `should accept -9999999999 as aLong`(): Unit = {
+  @Test def valueOfLongNegative9999999999(): Unit = {
     val bi = BigInteger.valueOf(-9999999999L)
     assertEquals(-9999999999L, bi.longValue())
   }
 
-  @Test def `should accept 99 as a string`(): Unit = {
+  @Test def ctorString99(): Unit = {
     val bi = new BigInteger("99")
     assertEquals(99, bi.intValue())
     assertEquals(99L, bi.longValue())
   }
 
-  @Test def `should accept 999999999 as sting`(): Unit = {
+  @Test def ctorString999999999(): Unit = {
     val bi = new BigInteger("999999999")
     assertEquals(999999999, bi.intValue())
     assertEquals(999999999L, bi.longValue())
   }
 
-  @Test def `should accept 9999999999 as a string`(): Unit = {
+  @Test def ctorString9999999999(): Unit = {
     val bi = new BigInteger("9999999999")
     assertEquals(9999999999L, bi.longValue())
   }
 
-  @Test def `should accept -99 as a string`(): Unit = {
+  @Test def ctorStringNegative99(): Unit = {
     val bi = new BigInteger("-99")
     assertEquals(-99, bi.intValue())
     assertEquals(-99L, bi.longValue())
   }
 
-  @Test def `should accept -999999999 as sting`(): Unit = {
+  @Test def ctorStringNegative999999999(): Unit = {
     val bi = new BigInteger("-999999999")
     assertEquals(-999999999, bi.intValue())
     assertEquals(-999999999L, bi.longValue())
   }
 
-  @Test def `should accept -9999999999 as a string`(): Unit = {
+  @Test def ctorStringNegative9999999999(): Unit = {
     val bi = new BigInteger("-9999999999")
     assertEquals(-9999999999L, bi.longValue())
   }
 
-  @Test def `should intialise from byte array of Pos two's complement`(): Unit = {
+  @Test def ctorArrayBytePosTwosComplement(): Unit = {
     val eBytesSignum = Array[Byte](27, -15, 65, 39)
     val eBytes = Array[Byte](27, -15, 65, 39)
     val expSignum = new BigInteger(eBytesSignum)
     assertTrue(Arrays.equals(eBytes, expSignum.toByteArray))
   }
 
-  @Test def `should intialise from byte array of Neg two's complement`(): Unit = {
+  @Test def ctorArrayByteNegTwosComplement(): Unit = {
     val eBytesSignum = Array[Byte](-27, -15, 65, 39)
     val eBytes = Array[Byte](-27, -15, 65, 39)
     val expSignum = new BigInteger(eBytesSignum)
     assertTrue(Arrays.equals(eBytes, expSignum.toByteArray))
   }
 
-  @Test def `should intialise from Pos byte array with explicit sign`(): Unit = {
+  @Test def ctorArrayByteSign1PosTwosComplement(): Unit = {
     val eBytes = Array[Byte](27, -15, 65, 39)
     val eSign = 1
     val exp = new BigInteger(eSign, eBytes)
     assertTrue(Arrays.equals(eBytes, exp.toByteArray))
   }
 
-  @Test def `should intialise from Zero byte array with explicit sign`(): Unit = {
+  @Test def ctorIntArrayByteSign0Zeros(): Unit = {
     val eBytes = Array[Byte](0, 0, 0, 0)
     val eSign = 0
     val exp = new BigInteger(eSign, eBytes)
     assertTrue(Arrays.equals(Array[Byte](0), exp.toByteArray))
   }
 
-  @Test def `should intialise from Neg small byte array with explicit sign`(): Unit = {
+  @Test def ctorIntArrayByteSignNeg1(): Unit = {
     val eBytes = Array[Byte](27)
     val eSign = -1
     val eRes = Array[Byte](-27)
@@ -129,7 +129,7 @@ class BigIntegerTest {
     assertTrue(Arrays.equals(eRes, exp.toByteArray))
   }
 
-  @Test def `should intialise from Neg byte array with explicit sign`(): Unit = {
+  @Test def ctorIntArrayByteSignNeg1PosTwosComplement(): Unit = {
     val eBytes = Array[Byte](27, -15, 65, 39)
     val eSign = -1
     val eRes = Array[Byte](-28, 14, -66, -39)
@@ -137,7 +137,7 @@ class BigIntegerTest {
     assertTrue(Arrays.equals(eRes, exp.toByteArray))
   }
 
-  @Test def `should intialise both Pos byte arrays arrays the same`(): Unit = {
+  @Test def ctorArrayByteSign1CompareNoSignTwosComplement(): Unit = {
     val eBytes = Array[Byte](27, -15, 65, 39)
     val eSign = 1
     val exp = new BigInteger(eSign, eBytes)
@@ -150,7 +150,7 @@ class BigIntegerTest {
     assertTrue(Arrays.equals(exp.toByteArray, expSignum.toByteArray))
   }
 
-  @Test def `should intialise both Neg byte arrays arrays the same`(): Unit = {
+  @Test def ctorIntArrayByteCompareCtorArrayByte(): Unit = {
     val eBytes = Array[Byte](27, -15, 65, 39)
     val eSign = -1
     val eRes = Array[Byte](-28, 14, -66, -39)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
@@ -49,7 +49,7 @@ class URITest {
     assertEquals(isOpaque, uri.isOpaque())
   }
 
-  @Test def should_parse_vanilla_absolute_URIs(): Unit = {
+  @Test def absoluteURIs(): Unit = {
     expectURI(new URI("http://java.sun.com/j2se/1.3/"), true, false)(
         scheme = "http",
         host = "java.sun.com",
@@ -58,7 +58,7 @@ class URITest {
         schemeSpecificPart = "//java.sun.com/j2se/1.3/")()
   }
 
-  @Test def should_parse_absolute_URIs_with_empty_path(): Unit = {
+  @Test def absoluteURIsEmptyPath(): Unit = {
     expectURI(new URI("http://foo:bar"), true, false)(
         authority = "foo:bar",
         path = "",
@@ -66,7 +66,7 @@ class URITest {
         schemeSpecificPart = "//foo:bar")()
   }
 
-  @Test def should_parse_absolute_URIs_with_IPv6(): Unit = {
+  @Test def absoluteURIsIPv6(): Unit = {
     val uri = new URI("http://hans@[ffff::0:128.4.5.3]:345/~hans/")
     expectURI(uri, true, false)(
         scheme = "http",
@@ -78,21 +78,21 @@ class URITest {
         schemeSpecificPart = "//hans@[ffff::0:128.4.5.3]:345/~hans/")()
   }
 
-  @Test def should_parse_absolute_URIs_without_authority(): Unit = {
+  @Test def absolutURIsNoAuthority(): Unit = {
     expectURI(new URI("file:/~/calendar"), true, false)(
         scheme = "file",
         path = "/~/calendar",
         schemeSpecificPart = "/~/calendar")()
   }
 
-  @Test def should_parse_absolute_URIs_with_empty_authority(): Unit = {
+  @Test def absoluteURIsEmptyAuthority(): Unit = {
     expectURI(new URI("file:///~/calendar"), true, false)(
         scheme = "file",
         path = "/~/calendar",
         schemeSpecificPart = "///~/calendar")()
   }
 
-  @Test def should_parse_opaque_URIs(): Unit = {
+  @Test def opaqueURIs(): Unit = {
     expectURI(new URI("mailto:java-net@java.sun.com"), true, true)(
         scheme = "mailto",
         schemeSpecificPart = "java-net@java.sun.com")()
@@ -106,7 +106,7 @@ class URITest {
         schemeSpecificPart = "isbn:096139210x")()
   }
 
-  @Test def should_parse_relative_URIs(): Unit = {
+  @Test def relativeURIs(): Unit = {
     expectURI(new URI("docs/guide/collections/designfaq.html#28"), false, false)(
         path = "docs/guide/collections/designfaq.html",
         fragment = "28",
@@ -116,7 +116,7 @@ class URITest {
         schemeSpecificPart = "../../../demo/jfc/SwingSet2/src/SwingSet2.java")()
   }
 
-  @Test def should_parse_relative_URIs_with_IPv4(): Unit = {
+  @Test def relativeURIsIPv4(): Unit = {
     expectURI(new URI("//123.5.6.3:45/bar"), false, false)(
         authority = "123.5.6.3:45",
         host = "123.5.6.3",
@@ -125,14 +125,14 @@ class URITest {
         schemeSpecificPart = "//123.5.6.3:45/bar")()
   }
 
-  @Test def should_parse_relative_URIs_with_registry_based_authority(): Unit = {
+  @Test def relativeURIsRegistryBasedAuthority(): Unit = {
     expectURI(new URI("//foo:bar"), false, false)(
         authority = "foo:bar",
         path = "",
         schemeSpecificPart = "//foo:bar")()
   }
 
-  @Test def should_parse_relative_URIs_with_escapes(): Unit = {
+  @Test def relativeURIsWithEscapes(): Unit = {
     expectURI(new URI("//ma%5dx:secret@example.com:8000/foo"), false, false)(
         authority = "ma]x:secret@example.com:8000",
         userInfo = "ma]x:secret",
@@ -145,14 +145,14 @@ class URITest {
         rawSchemeSpecificPart = "//ma%5dx:secret@example.com:8000/foo")
   }
 
-  @Test def should_parse_relative_URIs_with_fragment_only(): Unit = {
+  @Test def relativeURIsFragmentOnly(): Unit = {
     expectURI(new URI("#foo"), false, false)(
         fragment = "foo",
         path = "",
         schemeSpecificPart = "")()
   }
 
-  @Test def should_parse_relative_URIs_with_query_and_fragment(): Unit = {
+  @Test def relativeURIsQueryAndFragment(): Unit = {
     expectURI(new URI("?query=1#foo"), false, false)(
         query = "query=1",
         fragment = "foo",
@@ -160,7 +160,7 @@ class URITest {
         schemeSpecificPart = "?query=1")()
   }
 
-  @Test def should_provide_compareTo(): Unit = {
+  @Test def compareTo(): Unit = {
     val x = new URI("http://example.com/asdf%6a")
     val y = new URI("http://example.com/asdf%6A")
     val z = new URI("http://example.com/asdfj")
@@ -182,7 +182,7 @@ class URITest {
     assertTrue(rel.compareTo(rel3) < 0)
   }
 
-  @Test def should_provide_equals(): Unit = {
+  @Test def testEquals(): Unit = {
     val x = new URI("http://example.com/asdf%6a")
     val y = new URI("http://example.com/asdf%6A")
     val z = new URI("http://example.com/asdfj")
@@ -195,7 +195,7 @@ class URITest {
     assertTrue(z == z)
   }
 
-  @Test def equals_and_hashCode_should_produces_same_result(): Unit = {
+  @Test def equalsHashCodeSame(): Unit = {
     val equalsPairs: Seq[(URI, URI)] = Seq(
       (new URI("http://example.com"), new URI("http://Example.CoM")),
       (new URI("http://Example.Com@example.com"), new URI("http://Example.Com@Example.Com")),
@@ -222,7 +222,7 @@ class URITest {
     }
   }
 
-  @Test def should_provide_normalize(): Unit = {
+  @Test def normalize(): Unit = {
     expectURI(new URI("http://example.com/../asef/../../").normalize, true, false)(
         scheme = "http",
         host = "example.com",
@@ -249,7 +249,7 @@ class URITest {
     assertTrue(x.normalize eq x)
   }
 
-  @Test def should_provide_resolve__JavaDoc_examples(): Unit = {
+  @Test def resolveJavaDocExamples(): Unit = {
     val base = "http://java.sun.com/j2se/1.3/"
     val relative1 = "docs/guide/collections/designfaq.html#28"
     val resolved1 =
@@ -264,7 +264,7 @@ class URITest {
     assertEquals("/a/", new URI("/a/").resolve("").toString)
   }
 
-  @Test def should_provide_resolve_RFC2396_examples(): Unit = {
+  @Test def resolveRFC2396Examples(): Unit = {
     val base = new URI("http://a/b/c/d;p?q")
     def resTest(ref: String, trg: String): Unit =
       assertEquals(trg, base.resolve(ref).toString)
@@ -315,7 +315,7 @@ class URITest {
     resTest("http:g", "http:g")
   }
 
-  @Test def should_provide_resolve_when_authority_is_empty__issue_2048(): Unit = {
+  @Test def resolveAuthorityEmpty_Issue2048(): Unit = {
     val base = new URI("http://foo/a")
     def resTest(ref: String, trg: String): Unit =
       assertEquals(trg, base.resolve(ref).toString)
@@ -325,7 +325,7 @@ class URITest {
     resTest("/b/../d", "http://foo/b/../d")
   }
 
-  @Test def should_provide_normalize__examples_derived_from_RFC_relativize(): Unit = {
+  @Test def normalizeExamplesDerivedFromRfcRelativize(): Unit = {
     expectURI(new URI("http://a/b/c/..").normalize, true, false)(
         scheme = "http",
         host = "a",
@@ -341,7 +341,7 @@ class URITest {
         schemeSpecificPart = "//a/b/c/")()
   }
 
-  @Test def should_provide_relativize(): Unit = {
+  @Test def relativize(): Unit = {
     val x = new URI("http://f%4Aoo@asdf/a")
     val y = new URI("http://fJoo@asdf/a/b/")
     val z = new URI("http://f%4aoo@asdf/a/b/")
@@ -364,7 +364,7 @@ class URITest {
     relTest("file:/c", "file:///c/d/", "d/")
   }
 
-  @Test def should_provide_hashCode(): Unit = {
+  @Test def testHashCode(): Unit = {
     assertEquals(new URI("http://example.com/asdf%6a").hashCode,
         new URI("http://example.com/asdf%6A").hashCode)
     assertEquals(new URI("http://example.com").hashCode(),
@@ -373,7 +373,7 @@ class URITest {
         new URI("http://Example.CoM/eXAMplE-cOm").hashCode())
   }
 
-  @Test def should_allow_non_ASCII_characters(): Unit = {
+  @Test def allowNonASCIICharacters(): Unit = {
     expectURI(new URI("http://cs.dbpedia.org/resource/Víno"), true, false)(
         scheme = "http",
         host = "cs.dbpedia.org",
@@ -382,7 +382,7 @@ class URITest {
         schemeSpecificPart = "//cs.dbpedia.org/resource/Víno")()
   }
 
-  @Test def should_decode_UTF_8(): Unit = {
+  @Test def decodeUTF8(): Unit = {
     expectURI(new URI("http://cs.dbpedia.org/resource/V%C3%ADno"), true, false)(
         scheme = "http",
         host = "cs.dbpedia.org",
@@ -399,7 +399,7 @@ class URITest {
         rawSchemeSpecificPart = "%e3%81%93a%e3%82%93%e3%81%AB%e3%81%a1%e3%81%af")
   }
 
-  @Test def should_support_toASCIIString(): Unit = {
+  @Test def toASCIIString(): Unit = {
     def cmp(base: String, encoded: String): Unit =
       assertEquals(encoded, new URI(base).toASCIIString())
 
@@ -411,7 +411,7 @@ class URITest {
         "foo://bar/%F0%90%83%B5/")
   }
 
-  @Test def should_replace_when_bad_surrogates_are_present(): Unit = {
+  @Test def replaceBadSurrogates(): Unit = {
     expectURI(new URI("http://booh/%E3a"), true, false)(
         scheme = "http",
         host = "booh",
@@ -452,21 +452,21 @@ class URITest {
         rawSchemeSpecificPart = "//booh/%E3%E3a")
   }
 
-  @Test def should_throw_on_bad_escape_sequences(): Unit = {
+  @Test def badEscapeSequenceThrows(): Unit = {
     expectThrows(classOf[URISyntaxException], new URI("http://booh/%E"))
     expectThrows(classOf[URISyntaxException], new URI("http://booh/%Ep"))
   }
 
-  @Test def should_accept_valid_ipv4(): Unit = {
+  @Test def validIPv4(): Unit = {
     assertEquals(new URI("http","000.001.01.0", "", "").getHost, "000.001.01.0")
   }
 
-  @Test def should_throw_on_ipv4_out_of_range(): Unit = {
+  @Test def invalidIPv4Throws(): Unit = {
     expectThrows(classOf[URISyntaxException], new URI("http","256.1.1.1", "", ""))
     expectThrows(classOf[URISyntaxException], new URI("http","123.45.67.890", "", ""))
   }
 
-  @Test def opaque_url_should_consider_ssp_on_equality(): Unit = {
+  @Test def opaqueUrlEqualityHandlesCase(): Unit = {
     assertTrue("scheme case-insensitive", new URI("MAILTO:john") == new URI("mailto:john"))
     assertTrue("SSP case-sensitive", new URI("mailto:john") != new URI("mailto:JOHN"))
     assertTrue(new URI("mailto:john") != new URI("MAILTO:jim"))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/security/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/security/ThrowablesTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.security
 import org.junit.Test
 
 class ThrowablesTest {
-  @Test def should_define_all_java_security_Errors_and_Exceptions(): Unit = {
+  @Test def allJavaSecurityErrorsAndExceptions(): Unit = {
     import java.security._
     new AccessControlException("", null)
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayDequeTest.scala
@@ -25,7 +25,7 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
 
   override def factory: ArrayDequeFactory = new ArrayDequeFactory
 
-  @Test def should_add_and_remove_head_and_last(): Unit = {
+  @Test def addRemovePeekFirstAndLastInt(): Unit = {
     val ad = factory.empty[Int]
 
     ad.addLast(1)
@@ -41,7 +41,7 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
     assertEquals(ad.peekLast(), 2)
   }
 
-  @Test def could_be_instantiated_with_a_prepopulated_Collection(): Unit = {
+  @Test def fromCollectionInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ad = factory.from[Int](l)
 
@@ -53,7 +53,7 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
     assertTrue(ad.isEmpty)
   }
 
-  @Test def should_add_multiple_element_in_one_operation(): Unit = {
+  @Test def addAllCollectionAndAddInt(): Unit = {
     val ad = factory.empty[Int]
 
     assertEquals(ad.size(), 0)
@@ -63,7 +63,7 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
     assertEquals(ad.size(), 6)
   }
 
-  @Test def should_retrieve_last_element(): Unit = {
+  @Test def addAndPollLastString(): Unit = {
     val adInt = factory.empty[Int]
 
     assertTrue(adInt.add(1000))
@@ -83,7 +83,7 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
     assertEquals(adDouble.pollLast(), -0.987, 0.0)
   }
 
-  @Test def should_perform_as_a_stack_with_push_and_pop(): Unit = {
+  @Test def pushAndPopString(): Unit = {
     val adInt = factory.empty[Int]
 
     adInt.push(1000)
@@ -109,7 +109,7 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
     assertTrue(adString.isEmpty())
   }
 
-  @Test def should_poll_and_peek_elements(): Unit = {
+  @Test def peekAndPollFirstAndLastString(): Unit = {
     val pq = factory.empty[String]
 
     assertTrue(pq.add("one"))
@@ -132,7 +132,7 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
     assertNull(pq.pollLast)
   }
 
-  @Test def should_remove_occurrences_of_provided_elements(): Unit = {
+  @Test def removeFirstAndLastOccurrenceString(): Unit = {
     val ad = factory.from[String](
         TrivialImmutableCollection("one", "two", "three", "two", "one"))
 
@@ -145,7 +145,7 @@ class ArrayDequeTest extends AbstractCollectionTest with DequeTest {
     assertTrue(ad.isEmpty)
   }
 
-  @Test def should_iterate_over_elements_in_both_directions(): Unit = {
+  @Test def iteratorDescendingIterator(): Unit = {
     val l = TrivialImmutableCollection("one", "two", "three")
     val ad = factory.from[String](l)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
@@ -22,7 +22,7 @@ class ArrayListTest extends AbstractListTest {
 
   override def factory: AbstractListFactory = new ArrayListFactory
 
-  @Test def `should_not_fail_with_pre-allocation_methods`(): Unit = {
+  @Test def ensureCapacity(): Unit = {
     // note that these methods become no ops in js
     val al = new ju.ArrayList[String]
     al.ensureCapacity(0)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
@@ -43,31 +43,31 @@ class ArraysTest {
     def compare(s1: String, s2: String): Int = s1.compareTo(s2)
   }
 
-  @Test def sort_Int(): Unit =
+  @Test def sortInt(): Unit =
     testSort[Int](_.toInt, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
 
-  @Test def sort_Long(): Unit =
+  @Test def sortLong(): Unit =
     testSort[Long](_.toLong, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
 
-  @Test def sort_Short(): Unit =
+  @Test def sortShort(): Unit =
     testSort[Short](_.toShort, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
 
-  @Test def sort_Byte(): Unit =
+  @Test def sortByte(): Unit =
     testSort[Byte](_.toByte, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
 
-  @Test def sort_Char(): Unit =
+  @Test def sortChar(): Unit =
     testSort[Char](_.toChar, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
 
-  @Test def sort_Float(): Unit =
+  @Test def sortFloat(): Unit =
     testSort[Float](_.toFloat, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
 
-  @Test def sort_Double(): Unit =
+  @Test def sortDouble(): Unit =
     testSort[Double](_.toDouble, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
 
-  @Test def sort_String(): Unit =
+  @Test def sortString(): Unit =
     testSort[AnyRef](_.toString, new Array(_), Arrays.sort(_), Arrays.sort(_, _, _))
 
-  @Test def sort_String_with_null_Comparator(): Unit =
+  @Test def sortStringWithNullComparator(): Unit =
     testSort[AnyRef](_.toString, new Array(_), Arrays.sort(_, null), Arrays.sort(_, _, _, null))
 
   private def testSort[T: ClassTag](elem: Int => T, newArray: Int => Array[T],
@@ -95,7 +95,7 @@ class ArraysTest {
     sort2(arr, 1, 1)
   }
 
-  @Test def sort_is_stable_issue_2400(): Unit = {
+  @Test def sortIsStable_Issue2400(): Unit = {
     case class N(i: Int)
 
     val cmp = new Comparator[N] {
@@ -162,7 +162,7 @@ class ArraysTest {
         Arrays.sort(array, 0, 5))
   }
 
-  @Test def fill_Boolean(): Unit = {
+  @Test def fillBoolean(): Unit = {
     val booleans = new Array[Boolean](6)
     Arrays.fill(booleans, false)
     assertArrayEquals(Array(false, false, false, false, false, false), booleans)
@@ -171,13 +171,13 @@ class ArraysTest {
     assertArrayEquals(Array(true, true, true, true, true, true), booleans)
   }
 
-  @Test def fill_Boolean_with_start_and_end_index(): Unit = {
+  @Test def fillBooleanWithStartAndEndIndex(): Unit = {
     val booleans = new Array[Boolean](6)
     Arrays.fill(booleans, 1, 4, true)
     assertArrayEquals(Array(false, true, true, true, false, false), booleans)
   }
 
-  @Test def fill_Byte(): Unit = {
+  @Test def fillByte(): Unit = {
     val bytes = new Array[Byte](6)
     Arrays.fill(bytes, 42.toByte)
     assertArrayEquals(Array[Byte](42, 42, 42, 42, 42, 42), bytes)
@@ -186,7 +186,7 @@ class ArraysTest {
     assertArrayEquals(Array[Byte](-1, -1, -1, -1, -1, -1), bytes)
   }
 
-  @Test def fill_Byte_with_start_and_end_index(): Unit = {
+  @Test def fillByteWithStartAndEndIndex(): Unit = {
     val bytes = new Array[Byte](6)
     Arrays.fill(bytes, 1, 4, 42.toByte)
     assertArrayEquals(Array[Byte](0, 42, 42, 42, 0, 0), bytes)
@@ -195,7 +195,7 @@ class ArraysTest {
     assertArrayEquals(Array[Byte](0, 42, -1, -1, -1, 0), bytes)
   }
 
-  @Test def fill_Short(): Unit = {
+  @Test def fillShort(): Unit = {
     val shorts = new Array[Short](6)
     Arrays.fill(shorts, 42.toShort)
     assertArrayEquals(Array[Short](42, 42, 42, 42, 42, 42), shorts)
@@ -204,7 +204,7 @@ class ArraysTest {
     assertArrayEquals(Array[Short](-1, -1, -1, -1, -1, -1), shorts)
   }
 
-  @Test def fill_Short_with_start_and_end_index(): Unit = {
+  @Test def fillShortWithStartAndEndIndex(): Unit = {
     val shorts = new Array[Short](6)
     Arrays.fill(shorts, 1, 4, 42.toShort)
     assertArrayEquals(Array[Short](0, 42, 42, 42, 0, 0), shorts)
@@ -213,7 +213,7 @@ class ArraysTest {
     assertArrayEquals(Array[Short](0, 42, -1, -1, -1, 0), shorts)
   }
 
-  @Test def fill_Int(): Unit = {
+  @Test def fillInt(): Unit = {
     val ints = new Array[Int](6)
     Arrays.fill(ints, 42)
     assertArrayEquals(Array(42, 42, 42, 42, 42, 42), ints)
@@ -222,7 +222,7 @@ class ArraysTest {
     assertArrayEquals(Array(-1, -1, -1, -1, -1, -1), ints)
   }
 
-  @Test def fill_Int_with_start_and_end_index(): Unit = {
+  @Test def fillIntWithStartAndEndIndex(): Unit = {
     val ints = new Array[Int](6)
     Arrays.fill(ints, 1, 4, 42)
     assertArrayEquals(Array(0, 42, 42, 42, 0, 0), ints)
@@ -231,7 +231,7 @@ class ArraysTest {
     assertArrayEquals(Array(0, 42, -1, -1, -1, 0), ints)
   }
 
-  @Test def fill_Long(): Unit = {
+  @Test def fillLong(): Unit = {
     val longs = new Array[Long](6)
     Arrays.fill(longs, 42L)
     assertArrayEquals(Array(42L, 42L, 42L, 42L, 42L, 42L), longs)
@@ -240,7 +240,7 @@ class ArraysTest {
     assertArrayEquals(Array(-1L, -1L, -1L, -1L, -1L, -1L), longs)
   }
 
-  @Test def fill_Long_with_start_and_end_index(): Unit = {
+  @Test def fillLongWithStartAndEndIndex(): Unit = {
     val longs = new Array[Long](6)
     Arrays.fill(longs, 1, 4, 42L)
     assertArrayEquals(Array(0L, 42L, 42L, 42L, 0L, 0L), longs)
@@ -249,7 +249,7 @@ class ArraysTest {
     assertArrayEquals(Array(0L, 42L, -1L, -1L, -1L, 0L), longs)
   }
 
-  @Test def fill_Float(): Unit = {
+  @Test def fillFloat(): Unit = {
     val floats = new Array[Float](6)
     Arrays.fill(floats, 42.0f)
     assertArrayEquals(Array(42.0f, 42.0f, 42.0f, 42.0f, 42.0f, 42.0f), floats)
@@ -258,7 +258,7 @@ class ArraysTest {
     assertArrayEquals(Array(-1.0f, -1.0f, -1.0f, -1.0f, -1.0f, -1.0f), floats)
   }
 
-  @Test def fill_Float_with_start_and_end_index(): Unit = {
+  @Test def fillFloatWithStartAndEndIndex(): Unit = {
     val floats = new Array[Float](6)
     Arrays.fill(floats, 1, 4, 42.0f)
     assertArrayEquals(Array(0.0f, 42.0f, 42.0f, 42.0f, 0.0f, 0.0f), floats)
@@ -267,7 +267,7 @@ class ArraysTest {
     assertArrayEquals(Array(0.0f, 42.0f, -1.0f, -1.0f, -1.0f, 0.0f), floats)
   }
 
-  @Test def fill_Double(): Unit = {
+  @Test def fillDouble(): Unit = {
     val doubles = new Array[Double](6)
     Arrays.fill(doubles, 42.0)
     assertArrayEquals(Array(42.0, 42.0, 42.0, 42.0, 42.0, 42.0), doubles)
@@ -276,7 +276,7 @@ class ArraysTest {
     assertArrayEquals(Array(-1.0, -1.0, -1.0, -1.0, -1.0, -1.0), doubles)
   }
 
-  @Test def fill_Double_with_start_and_end_index(): Unit = {
+  @Test def fillDoubleWithStartAndEndIndex(): Unit = {
     val doubles = new Array[Double](6)
     Arrays.fill(doubles, 1, 4, 42.0)
     assertArrayEquals(Array(0.0, 42.0, 42.0, 42.0, 0.0, 0.0), doubles)
@@ -285,7 +285,7 @@ class ArraysTest {
     assertArrayEquals(Array(0.0, 42.0, -1.0, -1.0, -1.0, 0.0), doubles)
   }
 
-    @Test def fill_AnyRef(): Unit = {
+    @Test def fillAnyRef(): Unit = {
     val array = new Array[AnyRef](6)
     Arrays.fill(array, "a")
     assertArrayEquals(Array[AnyRef]("a", "a", "a", "a", "a", "a"), array)
@@ -294,7 +294,7 @@ class ArraysTest {
     assertArrayEquals(Array[AnyRef]("b", "b", "b", "b", "b", "b"), array)
   }
 
-  @Test def fill_AnyRef_with_start_and_end_index(): Unit = {
+  @Test def fillAnyRefWithStartAndEndIndex(): Unit = {
     val bytes = new Array[AnyRef](6)
     Arrays.fill(bytes, 1, 4, "a")
     assertArrayEquals(Array[AnyRef](null, "a", "a", "a", null, null), bytes)
@@ -303,7 +303,7 @@ class ArraysTest {
     assertArrayEquals(Array[AnyRef](null, "a", "b", "b", "b", null), bytes)
   }
 
-  @Test def binarySearch_with_start_and_end_index_on_Long(): Unit = {
+  @Test def binarySearchWithStartAndEndIndexOnLong(): Unit = {
     val longs: Array[Long] = Array(1, 2, 3, 5, 6, 7)
     var ret = Arrays.binarySearch(longs, 0, 6, 5)
     assertEquals(3, ret)
@@ -318,7 +318,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_on_Long(): Unit = {
+  @Test def binarySearchOnLong(): Unit = {
     val longs: Array[Long] = Array(1, 2, 3, 5, 6, 7)
     var ret = Arrays.binarySearch(longs, 5)
     assertEquals(3, ret)
@@ -333,7 +333,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_with_start_and_end_index_on_Int(): Unit = {
+  @Test def binarySearchWithStartAndEndIndexOnInt(): Unit = {
     val ints: Array[Int] = Array(1, 2, 3, 5, 6, 7)
     var ret = Arrays.binarySearch(ints, 0, 6, 5)
     assertEquals(3, ret)
@@ -348,7 +348,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_on_Int(): Unit = {
+  @Test def binarySearchOnInt(): Unit = {
     val ints: Array[Int] = Array(1, 2, 3, 5, 6, 7)
     var ret = Arrays.binarySearch(ints, 5)
     assertEquals(3, ret)
@@ -363,7 +363,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_with_start_and_end_index_on_Short(): Unit = {
+  @Test def binarySearchWithStartAndEndIndexOnShort(): Unit = {
     val shorts: Array[Short] = Array(1, 2, 3, 5, 6, 7)
     var ret = Arrays.binarySearch(shorts, 0, 6, 5.toShort)
     assertEquals(3, ret)
@@ -378,7 +378,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_on_Short(): Unit = {
+  @Test def binarySearchOnShort(): Unit = {
     val shorts: Array[Short] = Array(1, 2, 3, 5, 6, 7)
     var ret = Arrays.binarySearch(shorts, 5.toShort)
     assertEquals(3, ret)
@@ -393,7 +393,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_with_start_and_end_index_on_Char(): Unit = {
+  @Test def binarySearchWithStartAndEndIndexOnChar(): Unit = {
     val chars: Array[Char] = Array('b', 'c', 'd', 'f', 'g', 'h')
     var ret = Arrays.binarySearch(chars, 0, 6, 'f')
     assertEquals(3, ret)
@@ -408,7 +408,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_on_Char(): Unit = {
+  @Test def binarySearchOnChar(): Unit = {
     val chars: Array[Char] = Array('b', 'c', 'd', 'f', 'g', 'h')
     var ret = Arrays.binarySearch(chars, 'f')
     assertEquals(3, ret)
@@ -423,7 +423,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_with_start_and_end_index_on_Double(): Unit = {
+  @Test def binarySearchWithStartAndEndIndexOnDouble(): Unit = {
     val doubles: Array[Double] = Array(0.1, 0.2, 0.3, 0.5, 0.6, 0.7)
     var ret = Arrays.binarySearch(doubles, 0, 6, 0.5)
     assertEquals(3, ret)
@@ -438,7 +438,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_on_Double(): Unit = {
+  @Test def binarySearchOnDouble(): Unit = {
     val doubles: Array[Double] = Array(0.1, 0.2, 0.3, 0.5, 0.6, 0.7)
     var ret = Arrays.binarySearch(doubles, 0.5)
     assertEquals(3, ret)
@@ -453,7 +453,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_with_start_and_end_index_on_Float(): Unit = {
+  @Test def binarySearchWithStartAndEndIndexOnFloat(): Unit = {
     val floats: Array[Float] = Array(0.1f, 0.2f, 0.3f, 0.5f, 0.6f, 0.7f)
     var ret = Arrays.binarySearch(floats, 0, 6, 0.5f)
     assertEquals(3, ret)
@@ -468,7 +468,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_on_Float(): Unit = {
+  @Test def binarySearchOnFloat(): Unit = {
     val floats: Array[Float] = Array(0.1f, 0.2f, 0.3f, 0.5f, 0.6f, 0.7f)
     var ret = Arrays.binarySearch(floats, 0.5f)
     assertEquals(3, ret)
@@ -483,7 +483,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_with_start_and_end_index_on_AnyRef(): Unit = {
+  @Test def binarySearchWithStartAndEndIndexOnAnyRef(): Unit = {
     val strings: Array[AnyRef] = Array("aa", "abc", "cc", "zz", "zzzs", "zzzt")
     var ret = Arrays.binarySearch(strings, 0, 6, "zz")
     assertEquals(3, ret)
@@ -498,7 +498,7 @@ class ArraysTest {
     assertEquals(-7, ret)
   }
 
-  @Test def binarySearch_on_AnyRef(): Unit = {
+  @Test def binarySearchOnAnyRef(): Unit = {
     val strings: Array[AnyRef] = Array("aa", "abc", "cc", "zz", "zzzs", "zzzt")
     var ret = Arrays.binarySearch(strings, "zz")
     assertEquals(3, ret)
@@ -539,55 +539,55 @@ class ArraysTest {
         Arrays.binarySearch(array, 0, 5, 2))
   }
 
-  @Test def copyOf_Int(): Unit = {
+  @Test def copyOfInt(): Unit = {
     val ints: Array[Int] = Array(1, 2, 3)
     val intscopy = Arrays.copyOf(ints, 5)
     assertArrayEquals(Array(1, 2, 3, 0, 0), intscopy)
   }
 
-  @Test def copyOf_Long(): Unit = {
+  @Test def copyOfLong(): Unit = {
     val longs: Array[Long] = Array(1, 2, 3)
     val longscopy = Arrays.copyOf(longs, 5)
     assertArrayEquals(Array[Long](1, 2, 3, 0, 0), longscopy)
   }
 
-  @Test def copyOf_Short(): Unit = {
+  @Test def copyOfShort(): Unit = {
     val shorts: Array[Short] = Array(1, 2, 3)
     val shortscopy = Arrays.copyOf(shorts, 5)
     assertArrayEquals(Array[Short](1, 2, 3, 0, 0), shortscopy)
   }
 
-  @Test def copyOf_Byte(): Unit = {
+  @Test def copyOfByte(): Unit = {
     val bytes: Array[Byte] = Array(42, 43, 44)
     val floatscopy = Arrays.copyOf(bytes, 5)
     assertArrayEquals(Array[Byte](42, 43, 44, 0, 0), floatscopy)
   }
 
-  @Test def copyOf_Char(): Unit = {
+  @Test def copyOfChar(): Unit = {
     val chars: Array[Char] = Array('a', 'b', '0')
     val charscopy = Arrays.copyOf(chars, 5)
     assertEquals(0.toChar, charscopy(4))
   }
 
-  @Test def copyOf_Double(): Unit = {
+  @Test def copyOfDouble(): Unit = {
     val doubles: Array[Double] = Array(0.1, 0.2, 0.3)
     val doublescopy = Arrays.copyOf(doubles, 5)
     assertArrayEquals(Array[Double](0.1, 0.2, 0.3, 0, 0), doublescopy)
   }
 
-  @Test def copyOf_Float(): Unit = {
+  @Test def copyOfFloat(): Unit = {
     val floats: Array[Float] = Array(0.1f, 0.2f, 0.3f)
     val floatscopy = Arrays.copyOf(floats, 5)
     assertArrayEquals(Array[Float](0.1f, 0.2f, 0.3f, 0f, 0f), floatscopy)
   }
 
-  @Test def copyOf_Boolean(): Unit = {
+  @Test def copyOfBoolean(): Unit = {
     val bools: Array[Boolean] = Array(false, true, false)
     val boolscopy = Arrays.copyOf(bools, 5)
     assertArrayEquals(Array[Boolean](false, true, false, false, false), boolscopy)
   }
 
-  @Test def copyOf_AnyRef(): Unit = {
+  @Test def copyOfAnyRef(): Unit = {
     val anyrefs: Array[AnyRef] = Array("a", "b", "c")
     val anyrefscopy = Arrays.copyOf(anyrefs, 5)
     assertEquals(classOf[Array[AnyRef]], anyrefscopy.getClass())
@@ -599,7 +599,7 @@ class ArraysTest {
     assertArrayEquals(Array[CharSequence]("a", "b"), sequencescopy)
   }
 
-  @Test def copyOf_AnyRef_with_change_of_type(): Unit = {
+  @Test def copyOfAnyRefWithChangeOfType(): Unit = {
     class A
     case class B(x: Int) extends A
 
@@ -609,7 +609,7 @@ class ArraysTest {
     assertArrayEquals(Array[A](B(1), B(2), B(3), null, null), bscopyAsA)
   }
 
-  @Test def copyOfRange_AnyRef(): Unit = {
+  @Test def copyOfRangeAnyRef(): Unit = {
     val anyrefs: Array[AnyRef] = Array("a", "b", "c", "d", "e")
     val anyrefscopy = Arrays.copyOfRange(anyrefs, 2, 4)
     assertEquals(classOf[Array[AnyRef]], anyrefscopy.getClass())
@@ -621,7 +621,7 @@ class ArraysTest {
     assertArrayEquals(Array[CharSequence]("b", "c", "d", "e"), sequencescopy)
   }
 
-  @Test def copyOfRange_AnyRef_with_change_of_type(): Unit = {
+  @Test def copyOfRangeAnyRefWithChangeOfType(): Unit = {
     class A
     case class B(x: Int) extends A
     val bs: Array[B] = Array(B(1), B(2), B(3), B(4), B(5))
@@ -630,7 +630,7 @@ class ArraysTest {
     assertArrayEquals(Array[A](B(3), B(4)), bscopyAsA)
   }
 
-  @Test def copyOfRange_AnyRef_ArrayIndexOutOfBoundsException(): Unit = {
+  @Test def copyOfRangeAnyRefArrayIndexOutOfBoundsException(): Unit = {
     assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
         hasCompliantArrayIndexOutOfBounds)
 
@@ -649,14 +649,14 @@ class ArraysTest {
     assertEquals(list.get(2), 3)
   }
 
-  @Test def hashCode_Boolean(): Unit = {
+  @Test def hashCodeBoolean(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[Boolean]))
     assertEquals(1, Arrays.hashCode(Array[Boolean]()))
     assertEquals(1268, Arrays.hashCode(Array[Boolean](false)))
     assertEquals(40359, Arrays.hashCode(Array[Boolean](true, false)))
   }
 
-  @Test def hashCode_Chars(): Unit = {
+  @Test def hashCodeChars(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[Char]))
     assertEquals(1, Arrays.hashCode(Array[Char]()))
     assertEquals(128, Arrays.hashCode(Array[Char]('a')))
@@ -665,7 +665,7 @@ class ArraysTest {
     assertEquals(88584920, Arrays.hashCode(Array[Char]('.', ' ', '\u4323', 'v', '~')))
   }
 
-  @Test def hashCode_Bytes(): Unit = {
+  @Test def hashCodeBytes(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[Byte]))
     assertEquals(1, Arrays.hashCode(Array[Byte]()))
     assertEquals(32, Arrays.hashCode(Array[Byte](1)))
@@ -674,7 +674,7 @@ class ArraysTest {
     assertEquals(30065878, Arrays.hashCode(Array[Byte](0, 45, 100, 1, 1)))
   }
 
-  @Test def hashCode_Shorts(): Unit = {
+  @Test def hashCodeShorts(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[Short]))
     assertEquals(1, Arrays.hashCode(Array[Short]()))
     assertEquals(32, Arrays.hashCode(Array[Short](1)))
@@ -683,7 +683,7 @@ class ArraysTest {
     assertEquals(30065878, Arrays.hashCode(Array[Short](0, 45, 100, 1, 1)))
   }
 
-  @Test def hashCode_Ints(): Unit = {
+  @Test def hashCodeInts(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[Int]))
     assertEquals(1, Arrays.hashCode(Array[Int]()))
     assertEquals(32, Arrays.hashCode(Array[Int](1)))
@@ -692,7 +692,7 @@ class ArraysTest {
     assertEquals(-1215441431, Arrays.hashCode(Array[Int](0, 45, 100, 1, 1, Int.MaxValue)))
   }
 
-  @Test def hashCode_Longs(): Unit = {
+  @Test def hashCodeLongs(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[Long]))
     assertEquals(1, Arrays.hashCode(Array[Long]()))
     assertEquals(32, Arrays.hashCode(Array[Long](1L)))
@@ -702,7 +702,7 @@ class ArraysTest {
     assertEquals(-1952288964, Arrays.hashCode(Array[Long](0L, 34573566354545L, 100L, 1L, 1L, Int.MaxValue)))
   }
 
-  @Test def hashCode_Floats(): Unit = {
+  @Test def hashCodeFloats(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[Float]))
     assertEquals(1, Arrays.hashCode(Array[Float]()))
     if (!executingInJVM) {
@@ -713,7 +713,7 @@ class ArraysTest {
     }
   }
 
-  @Test def hashCode_Doubles(): Unit = {
+  @Test def hashCodeDoubles(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[Double]))
     assertEquals(1, Arrays.hashCode(Array[Double]()))
     if (!executingInJVM) {
@@ -725,7 +725,7 @@ class ArraysTest {
     }
   }
 
-  @Test def hashCode_AnyRef(): Unit = {
+  @Test def hashCodeAnyRef(): Unit = {
     assertEquals(0, Arrays.hashCode(null: Array[AnyRef]))
     assertEquals(1, Arrays.hashCode(Array[AnyRef]()))
     assertEquals(961, Arrays.hashCode(Array[AnyRef](null, null)))
@@ -748,7 +748,7 @@ class ArraysTest {
     assertEquals(94, Arrays.deepHashCode(Array[AnyRef](Array[AnyRef](Array[AnyRef](1.asInstanceOf[AnyRef])))))
   }
 
-  @Test def equals_Booleans(): Unit = {
+  @Test def equalsBooleans(): Unit = {
     val a1 = Array(true, false)
 
     assertTrue(Arrays.equals(a1, a1))
@@ -761,7 +761,7 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array(false, true, false)))
   }
 
-  @Test def equals_Bytes(): Unit = {
+  @Test def equalsBytes(): Unit = {
     val a1 = Array[Byte](1, -7, 10)
 
     assertTrue(Arrays.equals(null: Array[Byte], null: Array[Byte]))
@@ -776,7 +776,7 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array[Byte](1, -7, 11, 20)))
   }
 
-  @Test def equals_Chars(): Unit = {
+  @Test def equalsChars(): Unit = {
     val a1 = Array[Char]('a', '0', '-')
 
     assertTrue(Arrays.equals(null: Array[Char], null: Array[Char]))
@@ -791,7 +791,7 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array[Char]('a', '0', '-', 'z')))
   }
 
-  @Test def equals_Shorts(): Unit = {
+  @Test def equalsShorts(): Unit = {
     val a1 = Array[Short](1, -7, 10)
 
     assertTrue(Arrays.equals(null: Array[Short], null: Array[Short]))
@@ -806,7 +806,7 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array[Short](1, -7, 11, 20)))
   }
 
-  @Test def equals_Ints(): Unit = {
+  @Test def equalsInts(): Unit = {
     val a1 = Array[Int](1, -7, 10)
 
     assertTrue(Arrays.equals(null: Array[Int], null: Array[Int]))
@@ -821,7 +821,7 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array[Int](1, -7, 11, 20)))
   }
 
-  @Test def equals_Longs(): Unit = {
+  @Test def equalsLongs(): Unit = {
     val a1 = Array[Long](1L, -7L, 10L)
 
     assertTrue(Arrays.equals(null: Array[Long], null: Array[Long]))
@@ -836,7 +836,7 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array[Long](1L, -7L, 11L, 20L)))
   }
 
-  @Test def equals_Floats(): Unit = {
+  @Test def equalsFloats(): Unit = {
     val a1 = Array[Float](1.1f, -7.4f, 10.0f)
 
     assertTrue(Arrays.equals(null: Array[Float], null: Array[Float]))
@@ -851,7 +851,7 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array[Float](1.1f, -7.4f, 10.0f, 20.0f)))
   }
 
-  @Test def equals_Doubles(): Unit = {
+  @Test def equalsDoubles(): Unit = {
     val a1 = Array[Double](1.1, -7.4, 10.0)
 
     assertTrue(Arrays.equals(null: Array[Double], null: Array[Double]))
@@ -866,7 +866,7 @@ class ArraysTest {
     assertFalse(Arrays.equals(a1, Array[Double](1.1, -7.4, 10.0, 20.0)))
   }
 
-  @Test def equals_AnyRefs(): Unit = {
+  @Test def equalsAnyRefs(): Unit = {
     // scalastyle:off equals.hash.code
     class A(private val x: Int) {
       override def equals(that: Any): Boolean = that match {
@@ -971,7 +971,7 @@ class ArraysTest {
         Array[AnyRef](Array[AnyRef](Array[AnyRef](2.asInstanceOf[AnyRef])))))
   }
 
-  @Test def toString_Long(): Unit = {
+  @Test def toStringLong(): Unit = {
     assertEquals("null", Arrays.toString(null: Array[Long]))
     assertEquals("[]", Arrays.toString(Array[Long]()))
     assertEquals("[0]", Arrays.toString(Array[Long](0L)))
@@ -981,7 +981,7 @@ class ArraysTest {
     assertEquals("[1, -2, 3, 9223372036854775807]", Arrays.toString(Array[Long](1L, -2L, 3L, Long.MaxValue)))
   }
 
-  @Test def toString_Int(): Unit = {
+  @Test def toStringInt(): Unit = {
     assertEquals("null", Arrays.toString(null: Array[Int]))
     assertEquals("[]", Arrays.toString(Array[Int]()))
     assertEquals("[0]", Arrays.toString(Array[Int](0)))
@@ -991,7 +991,7 @@ class ArraysTest {
     assertEquals("[1, -2, 3, 2147483647]", Arrays.toString(Array[Int](1, -2, 3, Int.MaxValue)))
   }
 
-  @Test def toString_Short(): Unit = {
+  @Test def toStringShort(): Unit = {
     assertEquals("null", Arrays.toString(null: Array[Short]))
     assertEquals("[]", Arrays.toString(Array[Short]()))
     assertEquals("[0]", Arrays.toString(Array[Short](0)))
@@ -1001,7 +1001,7 @@ class ArraysTest {
     assertEquals("[1, -2, 3, 32767]", Arrays.toString(Array[Short](1, -2, 3, Short.MaxValue)))
   }
 
-  @Test def toString_Byte(): Unit = {
+  @Test def toStringByte(): Unit = {
     assertEquals("null", Arrays.toString(null: Array[Byte]))
     assertEquals("[]", Arrays.toString(Array[Byte]()))
     assertEquals("[0]", Arrays.toString(Array[Byte](0)))
@@ -1011,7 +1011,7 @@ class ArraysTest {
     assertEquals("[1, -2, 3, 127]", Arrays.toString(Array[Byte](1, -2, 3, Byte.MaxValue)))
   }
 
-  @Test def toString_Boolean(): Unit = {
+  @Test def toStringBoolean(): Unit = {
     assertEquals("null", Arrays.toString(null: Array[Boolean]))
     assertEquals("[]", Arrays.toString(Array[Boolean]()))
     assertEquals("[true]", Arrays.toString(Array[Boolean](true)))
@@ -1020,7 +1020,7 @@ class ArraysTest {
     assertEquals("[true, true, false, false]", Arrays.toString(Array[Boolean](true, true, false, false)))
   }
 
-  @Test def toString_Float(): Unit = {
+  @Test def toStringFloat(): Unit = {
     assumeFalse("Assumes Float.toString JS semantics.", executingInJVM)
     assertEquals("null", Arrays.toString(null: Array[Float]))
     assertEquals("[]", Arrays.toString(Array[Float]()))
@@ -1031,7 +1031,7 @@ class ArraysTest {
     assertEquals("[1, -2, 3, 3.4028234663852886e+38]", Arrays.toString(Array[Float](1f, -2f, 3f, Float.MaxValue)))
   }
 
-  @Test def toString_Double(): Unit = {
+  @Test def toStringDouble(): Unit = {
     assumeFalse("Assumes Double.toString JS semantics.", executingInJVM)
     assertEquals("null", Arrays.toString(null: Array[Double]))
     assertEquals("[]", Arrays.toString(Array[Double]()))
@@ -1043,7 +1043,7 @@ class ArraysTest {
         Arrays.toString(Array[Double](1d, -2d, 3d, Double.MaxValue)))
   }
 
-  @Test def toString_AnyRef(): Unit = {
+  @Test def toStringAnyRef(): Unit = {
     class C(num: Int) {
       override def toString: String = s"C($num)"
     }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -29,7 +29,7 @@ trait CollectionTest extends IterableTest {
 
   def factory: CollectionFactory
 
-  @Test def shouldStoreStrings(): Unit = {
+  @Test def testWithString(): Unit = {
     val coll = factory.empty[String]
 
     assertEquals(0, coll.size())
@@ -49,7 +49,7 @@ trait CollectionTest extends IterableTest {
     assertTrue(coll.size() >= 1)
   }
 
-  @Test def shouldStoreIntegers(): Unit = {
+  @Test def testWithInt(): Unit = {
     val coll = factory.empty[Int]
 
     assertEquals(0, coll.size())
@@ -69,7 +69,7 @@ trait CollectionTest extends IterableTest {
     assertTrue(coll.size() >= 1)
   }
 
-  @Test def shouldStoreDoubles(): Unit = {
+  @Test def testWithDouble(): Unit = {
     val coll = factory.empty[Double]
 
     assertEquals(0, coll.size())
@@ -104,7 +104,7 @@ trait CollectionTest extends IterableTest {
     assertTrue(coll.contains(Double.NaN))
   }
 
-  @Test def shouldStoreCustomObjects(): Unit = {
+  @Test def testWithCustomClass(): Unit = {
     case class TestObj(num: Int) extends jl.Comparable[TestObj] {
       def compareTo(o: TestObj): Int =
         o.num.compareTo(num)
@@ -118,7 +118,7 @@ trait CollectionTest extends IterableTest {
     assertFalse(coll.contains(TestObj(200)))
   }
 
-  @Test def shouldRemoveStoredElements(): Unit = {
+  @Test def removeString(): Unit = {
     val coll = factory.empty[String]
 
     coll.add("one")
@@ -135,7 +135,7 @@ trait CollectionTest extends IterableTest {
     assertEquals(initialSize - 2, coll.size())
   }
 
-  @Test def shouldRemoveStoredElementsOnDoubleCornerCases(): Unit = {
+  @Test def removeDoubleCornerCases(): Unit = {
     val coll = factory.empty[Double]
 
     coll.add(1.234)
@@ -163,7 +163,7 @@ trait CollectionTest extends IterableTest {
     assertTrue(coll.isEmpty)
   }
 
-  @Test def shouldBeClearedWithOneOperation(): Unit = {
+  @Test def clear(): Unit = {
     val coll = factory.empty[String]
 
     coll.add("one")
@@ -173,7 +173,7 @@ trait CollectionTest extends IterableTest {
     assertEquals(0, coll.size)
   }
 
-  @Test def shouldCheckContainedPresence(): Unit = {
+  @Test def containsString(): Unit = {
     val coll = factory.empty[String]
 
     coll.add("one")
@@ -186,7 +186,7 @@ trait CollectionTest extends IterableTest {
     }
   }
 
-  @Test def shouldCheckContainedPresenceForDoubleCornerCases(): Unit = {
+  @Test def containsDoubleCornerCases(): Unit = {
     val coll = factory.empty[Double]
 
     coll.add(-0.0)
@@ -200,7 +200,7 @@ trait CollectionTest extends IterableTest {
     assertTrue(coll.contains(+0.0))
   }
 
-  @Test def shouldGiveProperIteratorOverElements(): Unit = {
+  @Test def iteratorString(): Unit = {
     val coll = factory.empty[String]
     coll.add("one")
     coll.add("two")
@@ -229,18 +229,18 @@ trait CollectionTest extends IterableTest {
     assertIteratorSameElementsAsSet(-45, 0, 12, 32, 42)(coll.iterator())
   }
 
-  @Test def toStringShouldConvertEmptyCollection(): Unit = {
+  @Test def toStringCollectionDoubleEmpty(): Unit = {
     val coll = factory.empty[Double]
     assertEquals("[]", coll.toString())
   }
 
-  @Test def toStringShouldConvertOneElementCollection(): Unit = {
+  @Test def toStringCollectionDoubleOneElement(): Unit = {
     val coll = factory.fromElements[Double](1.01)
     // JavaScript displays n.0 as n, so one trailing digit must be non-zero.
     assertEquals("[1.01]", coll.toString())
   }
 
-  @Test def toStringShouldUseCommaSpace(): Unit = {
+  @Test def toStringCollectionDoubleHasCommaSpace(): Unit = {
     // Choose Doubles which display the same in Java and Scala.js.
     // JavaScript displays n.0 as n, so one trailing digit must be non-zero.
     val elements = Seq(88.42, -23.36, 60.173)
@@ -258,7 +258,7 @@ trait CollectionTest extends IterableTest {
         expected.contains(result))
   }
 
-  @Test def toStringShouldHandleNullElements(): Unit = {
+  @Test def toStringCollectionAnyWithNull(): Unit = {
     if (factory.allowsNullElement) {
       val elements = Seq(-1, -2, null, -3)
 
@@ -272,7 +272,7 @@ trait CollectionTest extends IterableTest {
     }
   }
 
-  @Test def toStringInCustomClassShouldWork(): Unit = {
+  @Test def toStringCollectionCustomClass(): Unit = {
     case class Custom(name: String, id: Int) extends Ordered[Custom] {
       def compare(that: Custom): Int = this.id - that.id
     }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCollectionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCollectionsTest.scala
@@ -70,7 +70,7 @@ trait CollectionsOnCollectionsTest extends CollectionsTestBase {
     }
   }
 
-  @Test def min_on_comparables(): Unit = {
+  @Test def minOnComparables(): Unit = {
     def test[T <: AnyRef with Comparable[T]: ClassTag](toElem: Int => T): Unit =
       testMinMax1(factory, toElem, true)
 
@@ -79,7 +79,7 @@ trait CollectionsOnCollectionsTest extends CollectionsTestBase {
     test[jl.Double](_.toDouble)
   }
 
-  @Test def min_with_comparator(): Unit = {
+  @Test def minWithComparator(): Unit = {
     def test[T: ClassTag](toElem: Int => T, cmpFun: (T, T) => Int): Unit = {
       testMinMax2(factory, toElem, true, new Comparator[T] {
         override def compare(o1: T, o2: T): Int = cmpFun(o1, o2)
@@ -91,7 +91,7 @@ trait CollectionsOnCollectionsTest extends CollectionsTestBase {
     test[jl.Double](_.toDouble, (x: jl.Double, y: jl.Double) => x.compareTo(y))
   }
 
-  @Test def max_on_comparables(): Unit = {
+  @Test def maxOnComparables(): Unit = {
     def test[T <: AnyRef with Comparable[T]: ClassTag](toElem: Int => T): Unit =
       testMinMax1(factory, toElem, false)
 
@@ -100,7 +100,7 @@ trait CollectionsOnCollectionsTest extends CollectionsTestBase {
     test[jl.Double](_.toDouble)
   }
 
-  @Test def max_with_comparator(): Unit = {
+  @Test def maxWithComparator(): Unit = {
     def test[T: ClassTag](toElem: Int => T, cmpFun: (T, T) => Int): Unit = {
       testMinMax2(factory, toElem, false, new Comparator[T] {
         override def compare(o1: T, o2: T): Int = cmpFun(o1, o2)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
@@ -26,26 +26,26 @@ import scala.reflect.ClassTag
 object CollectionsOnListTest extends CollectionsTestBase {
 
   // Test: sort[T<:Comparable[T]](List[T])
-  def sort_on_comparables(factory: ListFactory): Unit = {
-    test_sort_on_comparables[CustomComparable](factory,
+  def sortOnComparables(factory: ListFactory): Unit = {
+    testSortOnComparables[CustomComparable](factory,
         new CustomComparable(_), false)
-    test_sort_on_comparables[jl.Integer](factory, jl.Integer.valueOf)
-    test_sort_on_comparables[jl.Long](factory, _.toLong)
-    test_sort_on_comparables[jl.Double](factory, _.toDouble)
+    testSortOnComparables[jl.Integer](factory, jl.Integer.valueOf)
+    testSortOnComparables[jl.Long](factory, _.toLong)
+    testSortOnComparables[jl.Double](factory, _.toDouble)
   }
 
   // Test: sort[T](List[T], Comparator[T])
-  def sort_with_comparator(factory: ListFactory): Unit = {
-    test_sort_with_comparator[CustomComparable](factory,
+  def sortWithComparator(factory: ListFactory): Unit = {
+    testSortWithComparator[CustomComparable](factory,
         new CustomComparable(_), (x, y) => x.compareTo(y), false)
-    test_sort_with_comparator[jl.Integer](factory, _.toInt, (x, y) => x.compareTo(y))
-    test_sort_with_comparator[jl.Long](factory, _.toLong,
+    testSortWithComparator[jl.Integer](factory, _.toInt, (x, y) => x.compareTo(y))
+    testSortWithComparator[jl.Long](factory, _.toLong,
         (x, y) => x.compareTo(y))
-    test_sort_with_comparator[jl.Double](factory, _.toDouble,
+    testSortWithComparator[jl.Double](factory, _.toDouble,
         (x, y) => x.compareTo(y))
   }
 
-  private def test_sort_on_comparables[T <: AnyRef with Comparable[T]: ClassTag](
+  private def testSortOnComparables[T <: AnyRef with Comparable[T]: ClassTag](
       factory: ListFactory, toElem: Int => T,
       absoluteOrder: Boolean = true): Unit = {
 
@@ -79,7 +79,7 @@ object CollectionsOnListTest extends CollectionsTestBase {
     }
   }
 
-  private def test_sort_with_comparator[T: ClassTag](factory: ListFactory, toElem: Int => T,
+  private def testSortWithComparator[T: ClassTag](factory: ListFactory, toElem: Int => T,
       cmpFun: (T, T) => Int, absoluteOrder: Boolean = true): Unit = {
 
     val list = factory.empty[T]
@@ -121,13 +121,13 @@ trait CollectionsOnListTest extends CollectionsOnCollectionsTest {
 
   def factory: ListFactory
 
-  @Test def sort_on_comparables(): Unit =
-    CollectionsOnListTest.sort_on_comparables(factory)
+  @Test def sortOnComparables(): Unit =
+    CollectionsOnListTest.sortOnComparables(factory)
 
-  @Test def sort_with_comparator(): Unit =
-    CollectionsOnListTest.sort_with_comparator(factory)
+  @Test def sortWithComparator(): Unit =
+    CollectionsOnListTest.sortWithComparator(factory)
 
-  @Test def binarySearch_on_comparables(): Unit = {
+  @Test def binarySearchOnComparables(): Unit = {
     // Test: binarySearch[T](list: List[Comparable[T]], T)
     def test[T <: AnyRef with Comparable[T]: ClassTag](toElem: Int => T): Unit = {
       val list = factory.fromElements[T](range.map(toElem).sorted: _*)
@@ -154,7 +154,7 @@ trait CollectionsOnListTest extends CollectionsOnCollectionsTest {
     test[jl.Double](_.toDouble)
   }
 
-  @Test def binarySearch_with_comparator(): Unit = {
+  @Test def binarySearchWithComparator(): Unit = {
     // Test: binarySearch[T](List[T], key: T, Comparator[T]))
     def test[T: ClassTag](toElem: Int => T, cmpFun: (T, T) => Int): Unit = {
       val cmp = new ju.Comparator[T] {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
@@ -238,7 +238,7 @@ class CollectionsTest extends CollectionsTestBase {
     test[Double](_.toDouble)
   }
 
-  @Test def reverseOrder_on_comparables(): Unit = {
+  @Test def reverseOrderOnComparables(): Unit = {
     def testNumerical[E](toElem: Int => E): Unit = {
       val rCmp = ju.Collections.reverseOrder[E]
       for (i <- range) {
@@ -270,7 +270,7 @@ class CollectionsTest extends CollectionsTestBase {
     assertTrue(rCmp.compare("aaa", "aa") < 0)
   }
 
-  @Test def reverseOrder_with_comparator(): Unit = {
+  @Test def reverseOrderWithComparator(): Unit = {
     val rCmp1 = new ju.Comparator[Int] {
       override def compare(o1: Int, o2: Int): Int = o2 - o1
     }
@@ -302,7 +302,7 @@ class CollectionsTest extends CollectionsTestBase {
     }
   }
 
-  @Test def reverseOrder_with_null_comparator(): Unit = {
+  @Test def reverseOrderWithNullComparator(): Unit = {
     // Essentially equivalent to reverseOrder_on_comparables
 
     def testNumerical[E](toElem: Int => E): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
@@ -156,7 +156,7 @@ class FormatterTest {
     assertEquals(conversion.toString, e.getConversion)
   }
 
-  @Test def `should_provide_b_conversion`(): Unit = {
+  @Test def formatB(): Unit = {
     assertF("false", "%b", null)
     assertF("true", "%b", true)
     assertF("false", "%b", false)
@@ -177,7 +177,7 @@ class FormatterTest {
     expectFormatFlagsConversionMismatch('b', "#+ 0,(", true)
   }
 
-  @Test def `should_provide_h_conversion`(): Unit = {
+  @Test def formatH(): Unit = {
     val x = new HelperClass
     assertF("f1e2a3", "%h", x)
     assertF("F1E2A3", "%H", x)
@@ -191,7 +191,7 @@ class FormatterTest {
     expectFormatFlagsConversionMismatch('h', "#+ 0,(", x)
   }
 
-  @Test def sConversionWithNonFormattable(): Unit = {
+  @Test def formatSWithNonFormattable(): Unit = {
     assertF("abcdef", "ab%sef", "cd")
     assertF("true", "%s", true)
     assertF("12345", "%s", 12345)
@@ -210,7 +210,7 @@ class FormatterTest {
         if (executingInJVMOnJDK6) "+ 0,(" else "#+ 0,(", "hello")
   }
 
-  @Test def sConversionWithFormattable(): Unit = {
+  @Test def formatSWithFormattable(): Unit = {
     import FormattableFlags._
 
     class FormattableClass extends Formattable {
@@ -254,7 +254,7 @@ class FormatterTest {
     x.expectNotCalled()
   }
 
-  @Test def `should_provide_c_conversion`(): Unit = {
+  @Test def formatC(): Unit = {
     assertF("a", "%c", 'a')
     assertF("A", "%C", 'A')
     assertF("A", "%c", 65)
@@ -273,7 +273,7 @@ class FormatterTest {
     assertEquals(0x123456, e.getCodePoint)
   }
 
-  @Test def `should_provide_d_conversion`(): Unit = {
+  @Test def formatD(): Unit = {
     assertF("5", "%d", 5)
     assertF("-5", "%d", -5)
     assertF("5", "%d", new BigInteger("5"))
@@ -333,7 +333,7 @@ class FormatterTest {
     expectIllegalFormatPrecision('d', 5)
   }
 
-  @Test def `should_provide_o_conversion`(): Unit = {
+  @Test def formatO(): Unit = {
     assertF("10", "%o", 8)
     assertF("52", "%o", new BigInteger("42"))
 
@@ -388,7 +388,7 @@ class FormatterTest {
     expectIllegalFormatPrecision('o', 5)
   }
 
-  @Test def `should_provide_x_conversion`(): Unit = {
+  @Test def formatX(): Unit = {
     assertF("d431", "%x", 54321)
     assertF("ffff2bcf", "%x", -54321)
     assertF("D431", "%X", 54321)
@@ -450,7 +450,7 @@ class FormatterTest {
     expectIllegalFormatPrecision('x', 5)
   }
 
-  @Test def `should_provide_e_conversion`(): Unit = {
+  @Test def formatE(): Unit = {
     assertF("1.000000e+03", "%e", 1000.0)
     assertF("1e+100", "%.0e", 1.2e100)
     assertF("0.000e+00", "%.3e", 0.0)
@@ -496,7 +496,7 @@ class FormatterTest {
     expectIllegalFormatFlags("% +e", "+ ", 5.5)
   }
 
-  @Test def `should_provide_g_conversion`(): Unit = {
+  @Test def formatG(): Unit = {
     assertF("5.00000e-05", "%g", 0.5e-4)
     assertF("-5.00000e-05", "%g", -0.5e-4)
     assertF("0.000300000", "%g", 3e-4)
@@ -556,7 +556,7 @@ class FormatterTest {
     expectIllegalFormatFlags("% +g", "+ ", 5.5)
   }
 
-  @Test def `should_provide_f_conversion`(): Unit = {
+  @Test def formatF(): Unit = {
     assertF("3.300000", "%f", 3.3)
     assertF("(04.6000)", "%0(9.4f", -4.6)
 
@@ -621,7 +621,7 @@ class FormatterTest {
     expectIllegalFormatFlags("% +f", "+ ", 5.5)
   }
 
-  @Test def `should_support_%%`(): Unit = {
+  @Test def formatPercentPercent(): Unit = {
     assertF("1%2", "%d%%%d", 1, 2)
 
     /* https://bugs.java.com/bugdatabase/view_bug.do?bug_id=JDK-8204229
@@ -636,7 +636,7 @@ class FormatterTest {
     expectIllegalFormatPrecision('%', null)
   }
 
-  @Test def `should_support_%n`(): Unit = {
+  @Test def formatPercentN(): Unit = {
     assertF("1\n2", "%d%n%d", 1, 2)
 
     expectIllegalFormatFlags("%0-,+< (#n", "-#+ 0,(<", null)
@@ -644,13 +644,13 @@ class FormatterTest {
     expectIllegalFormatWidth('n', null)
   }
 
-  @Test def should_allow_positional_arguments(): Unit = {
+  @Test def formatPositional(): Unit = {
     assertF("2 1", "%2$d %1$d", 1, 2)
     assertF("2 2 1", "%2$d %2$d %d", 1, 2)
     assertF("2 2 1", "%2$d %<d %d", 1, 2)
   }
 
-  @Test def unknownFormatConversion(): Unit = {
+  @Test def formatUnknown(): Unit = {
     // Correct format, unknown conversion
     expectUnknownFormatConversion("abc%udf", 'u')
     expectUnknownFormatConversion("abc%2$-(<034.12udf", 'u')
@@ -678,7 +678,7 @@ class FormatterTest {
     }
   }
 
-  @Test def indexTooLargeIsLikeUseLastIndex(): Unit = {
+  @Test def indexTooLargeUsesLastIndex(): Unit = {
     expectFormatterThrows(classOf[MissingFormatArgumentException],
         "%9876543210$d", 56, 78)
 
@@ -690,13 +690,13 @@ class FormatterTest {
     assertF("56 78", "%d %.9876543210d", 56, 78)
   }
 
-  @Test def should_fail_when_called_after_close(): Unit = {
+  @Test def closeThenUseThrows(): Unit = {
     val f = new Formatter()
     f.close()
     assertThrows(classOf[FormatterClosedException], f.toString())
   }
 
-  @Test def should_fail_with_bad_format_specifier(): Unit = {
+  @Test def formatBadFormatStringThrows(): Unit = {
     expectFormatterThrows(classOf[Exception], "hello world%")
     expectFormatterThrows(classOf[Exception], "%%%")
     expectFormatterThrows(classOf[Exception], "%q")
@@ -704,7 +704,7 @@ class FormatterTest {
     expectFormatterThrows(classOf[Exception], "%_f")
   }
 
-  @Test def should_fail_with_not_enough_arguments(): Unit = {
+  @Test def formatNotEnoughArgumentsThrows(): Unit = {
     expectFormatterThrows(classOf[MissingFormatArgumentException], "%f")
     expectFormatterThrows(classOf[MissingFormatArgumentException], "%d%d%d",
         1, 1)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashMapTest.scala
@@ -46,7 +46,7 @@ abstract class LinkedHashMapTest extends HashMapTest {
   val accessOrder = factory.accessOrder
   val withSizeLimit = factory.withSizeLimit
 
-  @Test def should_iterate_in_insertion_order_after_building(): Unit = {
+  @Test def iteratorOrder(): Unit = {
     val lhm = factory.empty[String, String]
     (0 until 100).foreach(key => lhm.put(key.toString(), s"elem $key"))
 
@@ -61,7 +61,7 @@ abstract class LinkedHashMapTest extends HashMapTest {
     assertSameEntriesOrdered(expected: _*)(lhm)
   }
 
-  @Test def should_iterate_in_the_same_order_after_removal_of_elements(): Unit = {
+  @Test def iteratorOrderAfterRemove(): Unit = {
     val lhm = factory.empty[String, String]
     (0 until 100).foreach(key => lhm.put(key.toString(), s"elem $key"))
 
@@ -75,7 +75,7 @@ abstract class LinkedHashMapTest extends HashMapTest {
     assertSameEntriesOrdered(expected: _*)(lhm)
   }
 
-  @Test def should_iterate_in_order_after_adding_elements(): Unit = {
+  @Test def iteratorOrderAfterPutPutIfAbsent(): Unit = {
     val lhm = factory.empty[String, String]
     (0 until 100).foreach(key => lhm.put(key.toString(), s"elem $key"))
 
@@ -111,7 +111,7 @@ abstract class LinkedHashMapTest extends HashMapTest {
     assertSameEntriesOrdered(expected: _*)(lhm)
   }
 
-  @Test def should_iterate_in_order_after_accessing_elements(): Unit = {
+  @Test def iteratorOrderAfterGet(): Unit = {
     val lhm = factory.empty[String, String]
     (0 until 100).foreach(key => lhm.put(key.toString(), s"elem $key"))
 
@@ -154,7 +154,7 @@ abstract class LinkedHashMapTest extends HashMapTest {
     assertSameEntriesOrdered(expected: _*)(lhm)
   }
 
-  @Test def testAccessOrderWithAllTheMethods(): Unit = {
+  @Test def iteratorOrderAfterUsingAllMethods(): Unit = {
     /* Relevant JavaDoc excerpt:
      *
      * > Invoking the put, putIfAbsent, get, getOrDefault, compute,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedHashSetTest.scala
@@ -23,7 +23,7 @@ class LinkedHashSetTest extends HashSetTest {
 
   override def factory: LinkedHashSetFactory = new LinkedHashSetFactory
 
-  @Test def should_iterate_over_elements_in_an_ordered_manner(): Unit = {
+  @Test def iterateInOrder(): Unit = {
     val hs = factory.empty[String]
 
     val l1 = TrivialImmutableCollection("ONE", "TWO", null)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedListTest.scala
@@ -25,7 +25,7 @@ class LinkedListTest extends AbstractListTest {
 
   override def factory: LinkedListFactory = new LinkedListFactory
 
-  @Test def add_and_remove_properly_in_head_and_last_positions(): Unit = {
+  @Test def addRemovePeekFirstAndLast(): Unit = {
     val ll = new LinkedList[Int]()
 
     ll.addLast(1)
@@ -41,7 +41,7 @@ class LinkedListTest extends AbstractListTest {
     assertEquals(2, ll.peekLast())
   }
 
-  @Test def could_be_instantiated_with_a_prepopulated_Collection(): Unit = {
+  @Test def ctorCollectionInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ll = new LinkedList[Int](l)
 
@@ -53,7 +53,7 @@ class LinkedListTest extends AbstractListTest {
     assertTrue(ll.isEmpty)
   }
 
-  @Test def should_add_multiple_element_in_one_operation(): Unit = {
+  @Test def addAllAndAdd(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ll = new LinkedList[Int]()
 
@@ -64,7 +64,7 @@ class LinkedListTest extends AbstractListTest {
     assertEquals(6, ll.size())
   }
 
-  @Test def `could_be_instantiated_with_a_prepopulated_Collection_-_LinkedListTest`(): Unit = {
+  @Test def poll(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ll = new LinkedList[Int](l)
 
@@ -76,7 +76,7 @@ class LinkedListTest extends AbstractListTest {
     assertTrue(ll.isEmpty)
   }
 
-  @Test def should_retrieve_the_last_element(): Unit = {
+  @Test def pollLast(): Unit = {
     val llInt = new LinkedList[Int]()
 
     assertTrue(llInt.add(1000))
@@ -96,7 +96,7 @@ class LinkedListTest extends AbstractListTest {
     assertEquals(-0.987, llDouble.pollLast(), 0.0)
   }
 
-  @Test def should_perform_as_a_stack_with_push_and_pop(): Unit = {
+  @Test def pushAndPop(): Unit = {
     val llInt = new LinkedList[Int]()
 
     llInt.push(1000)
@@ -122,7 +122,7 @@ class LinkedListTest extends AbstractListTest {
     assertTrue(llString.isEmpty())
   }
 
-  @Test def should_poll_and_peek_elements(): Unit = {
+  @Test def peekPollFirstAndLast(): Unit = {
     val pq = new LinkedList[String]()
 
     assertTrue(pq.add("one"))
@@ -145,7 +145,7 @@ class LinkedListTest extends AbstractListTest {
     assertNull(pq.pollLast)
   }
 
-  @Test def should_remove_occurrences_of_provided_elements(): Unit = {
+  @Test def removeFirstOccurrence(): Unit = {
     val l = TrivialImmutableCollection("one", "two", "three", "two", "one")
     val ll = new LinkedList[String](l)
 
@@ -160,7 +160,7 @@ class LinkedListTest extends AbstractListTest {
     assertTrue(ll.isEmpty)
   }
 
-  @Test def should_iterate_over_elements_in_both_directions(): Unit = {
+  @Test def iteratorAndDescendingIterator(): Unit = {
     val l = TrivialImmutableCollection("one", "two", "three")
     val ll = new LinkedList[String](l)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
@@ -28,7 +28,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
 
   def factory: ListFactory
 
-  @Test def shouldStoreStrings_List(): Unit = {
+  @Test def addStringGetIndex(): Unit = {
     val lst = factory.empty[String]
 
     assertEquals(0, lst.size())
@@ -44,7 +44,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     expectThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
-  @Test def shouldStoreIntegers_List(): Unit = {
+  @Test def addIntGetIndex(): Unit = {
     val lst = factory.empty[Int]
 
     lst.add(1)
@@ -59,7 +59,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     expectThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
-  @Test def shouldStoreDoubles_List(): Unit = {
+  @Test def addDoubleGetIndex(): Unit = {
     val lst = factory.empty[Double]
 
     lst.add(1.234)
@@ -83,7 +83,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     expectThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
-  @Test def shouldStoreCustomObjects_List(): Unit = {
+  @Test def addCustomObjectsGetIndex(): Unit = {
     case class TestObj(num: Int)
 
     val lst = factory.empty[TestObj]
@@ -96,7 +96,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     expectThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
-  @Test def shouldRemoveStoredElements_List(): Unit = {
+  @Test def removeStringRemoveIndex(): Unit = {
     val lst = factory.empty[String]
 
     lst.add("one")
@@ -115,7 +115,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     expectThrows(classOf[IndexOutOfBoundsException], lst.remove(lst.size))
   }
 
-  @Test def shouldRemoveStoredElementsOnDoubleCornerCases_List(): Unit = {
+  @Test def removeDoubleOnCornerCases(): Unit = {
     val al = factory.empty[Double]
 
     al.add(1.234)
@@ -143,7 +143,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertTrue(al.isEmpty)
   }
 
-  @Test def shouldBeClearedWithOneOperation_List(): Unit = {
+  @Test def clearList(): Unit = {
     val al = factory.empty[String]
 
     al.add("one")
@@ -153,7 +153,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals(0, al.size)
   }
 
-  @Test def shouldCheckContainedPresence_List(): Unit = {
+  @Test def containsStringList(): Unit = {
     val al = factory.empty[String]
 
     al.add("one")
@@ -162,7 +162,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertFalse(al.contains(null))
   }
 
-  @Test def shouldCheckContainedPresenceForDoubleCornerCases_List(): Unit = {
+  @Test def containedDoubleOnCornerCases(): Unit = {
     val al = factory.empty[Double]
 
     al.add(-0.0)
@@ -176,7 +176,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertTrue(al.contains(+0.0))
   }
 
-  @Test def shouldGiveAProperSetOperation(): Unit = {
+  @Test def setString(): Unit = {
     val al = factory.empty[String]
     al.add("one")
     al.add("two")
@@ -191,13 +191,13 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     expectThrows(classOf[IndexOutOfBoundsException], al.set(al.size, ""))
   }
 
-  @Test def shouldGiveProperIteratorOverElements_List(): Unit = {
+  @Test def iterator(): Unit = {
     val al = factory.empty[String]
     al.add("one")
     al.add("two")
     al.add("three")
 
-    val elements = al.iterator
+    val elements = al.iterator()
     assertTrue(elements.hasNext)
     assertEquals("one", elements.next())
     assertTrue(elements.hasNext)
@@ -207,13 +207,13 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertFalse(elements.hasNext)
   }
 
-  @Test def shouldGiveProperListIteratorOverElements(): Unit = {
+  @Test def listIterator(): Unit = {
     val lst = factory.empty[String]
     lst.add("one")
     lst.add("two")
     lst.add("three")
 
-    val elements = lst.listIterator
+    val elements = lst.listIterator()
     assertFalse(elements.hasPrevious)
     assertTrue(elements.hasNext)
     assertEquals("one", elements.next())
@@ -230,7 +230,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals("one", elements.previous())
   }
 
-  @Test def shouldAddElementsAtAGivenIndex(): Unit = {
+  @Test def addIndex(): Unit = {
     val al = factory.empty[String]
     al.add(0, "one") // ["one"]
     al.add(0, "two") // ["two", "one"]
@@ -244,7 +244,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     expectThrows(classOf[IndexOutOfBoundsException], al.add(al.size + 1, ""))
   }
 
-  @Test def shouldGiveTheFirstIndexOfAnElement(): Unit = {
+  @Test def indexOf(): Unit = {
     val al = factory.empty[String]
     al.add("one")
     al.add("two")
@@ -259,7 +259,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals(-1, al.indexOf("four"))
   }
 
-  @Test def shouldGiveTheLastIndexOfAnElement(): Unit = {
+  @Test def lastIndexOf(): Unit = {
     val al = factory.empty[String]
     al.add("one")
     al.add("two")
@@ -274,7 +274,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals(-1, al.lastIndexOf("four"))
   }
 
-  @Test def shouldGiveTheFirstOrLastIndexOfAnElementForDoubleCornerCases(): Unit = {
+  @Test def indexOfLastIndexOfDoubleCornerCases(): Unit = {
     val al = factory.empty[Double]
 
     al.add(-0.0)
@@ -293,9 +293,9 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals(5, al.lastIndexOf(Double.NaN))
   }
 
-  @Test def shouldGiveASublistBackedUpByTheOriginalList(): Unit = {
+  @Test def subListBackedByList(): Unit = {
     def testListIterator(list: ju.List[String], expected: Seq[String]): Unit = {
-      val iter = list.listIterator
+      val iter = list.listIterator()
       for (elem <- expected) {
         assertTrue(iter.hasNext)
         assertEquals(elem, iter.next())
@@ -380,7 +380,7 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     }
   }
 
-  @Test def shouldIterateAndModifyElementsWithAListIteratorIfAllowed(): Unit = {
+  @Test def iteratorSetRemoveIfAllowed(): Unit = {
     if (factory.allowsMutationThroughIterator) {
       val s = Seq("one", "two", "three")
       val ll = factory.empty[String]

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/NavigableSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/NavigableSetTest.scala
@@ -25,7 +25,7 @@ trait NavigableSetTest extends SetTest {
 
   def factory: NavigableSetFactory
 
-  @Test def `should_retrieve_ceiling(ordered)_elements`(): Unit = {
+  @Test def ceiling(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val nsInt = factory.empty[Int]
 
@@ -48,7 +48,7 @@ trait NavigableSetTest extends SetTest {
     assertNull(nsString.ceiling("z"))
   }
 
-  @Test def `should_retrieve_floor(ordered)_elements`(): Unit = {
+  @Test def floor(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val nsInt = factory.empty[Int]
 
@@ -71,7 +71,7 @@ trait NavigableSetTest extends SetTest {
     assertNull(nsString.floor("0"))
   }
 
-  @Test def `should_retrieve_higher(ordered)_elements`(): Unit = {
+  @Test def higher(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val nsInt = factory.empty[Int]
 
@@ -94,7 +94,7 @@ trait NavigableSetTest extends SetTest {
     assertEquals("a", nsString.higher("0"))
   }
 
-  @Test def `should_retrieve_lower(ordered)_elements`(): Unit = {
+  @Test def lower(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val nsInt = factory.empty[Int]
 
@@ -117,7 +117,7 @@ trait NavigableSetTest extends SetTest {
     assertNull(nsString.lower("0"))
   }
 
-  @Test def should_poll_first_and_last_elements(): Unit = {
+  @Test def pollFirstAndLast(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ns = factory.empty[Int]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
@@ -28,7 +28,7 @@ import org.scalajs.testsuite.utils.Platform.executingInJVM
 class PriorityQueueTest extends CollectionTest {
   def factory: PriorityQueueFactory = new PriorityQueueFactory
 
-  @Test def should_store_and_remove_ordered_integers(): Unit = {
+  @Test def addAndRemoveInt(): Unit = {
     val pq = new PriorityQueue[Int]()
 
     assertEquals(0, pq.size())
@@ -46,7 +46,7 @@ class PriorityQueueTest extends CollectionTest {
     assertFalse(pq.remove(222))
   }
 
-  @Test def should_store_and_remove_ordered_strings(): Unit = {
+  @Test def addAndRemoveString(): Unit = {
     val pq = new PriorityQueue[String]()
 
     assertEquals(0, pq.size())
@@ -65,7 +65,7 @@ class PriorityQueueTest extends CollectionTest {
     assertNull(pq.poll())
   }
 
-  @Test def should_store_objects_with_custom_comparables(): Unit = {
+  @Test def addAndRemoveObjectWithCustomComparator(): Unit = {
     case class Rect(x: Int, y: Int)
 
     val areaComp = new Comparator[Rect] {
@@ -104,7 +104,7 @@ class PriorityQueueTest extends CollectionTest {
     assertTrue(pq.poll() eq null)
   }
 
-  @Test def should_store_ordered_Double_even_in_corner_cases(): Unit = {
+  @Test def addAndRemoveDoubleCornerCases(): Unit = {
     val pq = new PriorityQueue[Double]()
 
     assertTrue(pq.add(1.0))
@@ -125,7 +125,7 @@ class PriorityQueueTest extends CollectionTest {
     assertTrue(pq.isEmpty)
   }
 
-  @Test def could_be_instantiated_with_a_prepopulated_Collection(): Unit = {
+  @Test def ctorCollectionInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val pq = new PriorityQueue[Int](l)
 
@@ -136,7 +136,7 @@ class PriorityQueueTest extends CollectionTest {
     assertTrue(pq.isEmpty)
   }
 
-  @Test def could_be_instantiated_with_a_prepopulated_PriorityQueue(): Unit = {
+  @Test def ctorPriorityQueueInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val pq1 = new PriorityQueue[Int](l)
     val pq2 = new PriorityQueue[Int](pq1)
@@ -150,7 +150,7 @@ class PriorityQueueTest extends CollectionTest {
     assertTrue(pq2.isEmpty)
   }
 
-  @Test def could_be_instantiated_with_a_prepopulated_SortedSet(): Unit = {
+  @Test def ctorSortedSetInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ss = new java.util.concurrent.ConcurrentSkipListSet[Int](l)
     val pq1 = new PriorityQueue[Int](l)
@@ -165,7 +165,7 @@ class PriorityQueueTest extends CollectionTest {
     assertTrue(pq2.isEmpty)
   }
 
-  @Test def should_be_cleared_in_a_single_operation(): Unit = {
+  @Test def testClear(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val pq = new PriorityQueue[Int](l)
 
@@ -174,7 +174,7 @@ class PriorityQueueTest extends CollectionTest {
     assertEquals(0, pq.size())
   }
 
-  @Test def should_add_multiple_elemnt_in_one_operation(): Unit = {
+  @Test def addAllCollectionIntAndAddInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val pq = new PriorityQueue[Int]()
 
@@ -185,7 +185,7 @@ class PriorityQueueTest extends CollectionTest {
     assertEquals(6, pq.size())
   }
 
-  @Test def should_check_contained_values_even_in_double_corner_cases(): Unit = {
+  @Test def containsDoubleCornerCasesPriorityQueue(): Unit = {
     val pq = new PriorityQueue[Double]()
 
     assertTrue(pq.add(11111.0))
@@ -220,7 +220,7 @@ class PriorityQueueTest extends CollectionTest {
     assertTrue(pq.contains(-0.0))
   }
 
-  @Test def should_retrieve_the_first_element(): Unit = {
+  @Test def pollIntStringDouble(): Unit = {
     val pqInt = new PriorityQueue[Int]()
 
     assertTrue(pqInt.add(1000))
@@ -240,7 +240,7 @@ class PriorityQueueTest extends CollectionTest {
     assertEquals(-0.987, pqDouble.poll(), 0.0)
   }
 
-  @Test def poll(): Unit = {
+  @Test def pollIntEntireQueue(): Unit = {
     val pq = newPriorityQueueWith0Until100()
 
     var nextExpected = 0
@@ -251,7 +251,7 @@ class PriorityQueueTest extends CollectionTest {
     assertEquals(100, nextExpected)
   }
 
-  @Test def removingAnArbitraryElementPreservesPriorities(): Unit = {
+  @Test def removePreservesPriorities(): Unit = {
     for (itemToRemove <- 0 until 100) {
       val pq = newPriorityQueueWith0Until100()
 
@@ -272,7 +272,7 @@ class PriorityQueueTest extends CollectionTest {
     }
   }
 
-  @Test def removingAnArbitraryElementWithAnIteratorPreservesPriorities(): Unit = {
+  @Test def iteratorRemovePreservesPriorities(): Unit = {
     for (itemToRemove <- 0 until 100) {
       val pq = newPriorityQueueWith0Until100()
 
@@ -315,7 +315,7 @@ class PriorityQueueTest extends CollectionTest {
    * the future.
    */
 
-  @Test def removingAnArbitraryElementWithAnIteratorPreservesPrioritiesCornerCase(): Unit = {
+  @Test def iteratorRemovePreservesPrioritiesIntCornerCase(): Unit = {
     /* This tests the specific scenario where `Iterator.remove()` causes the
      * array to be reordered in such a way that a) elements yet to be iterated
      * are moved before the iteration cursor, and b) elements already iteratoed
@@ -355,7 +355,7 @@ class PriorityQueueTest extends CollectionTest {
     assertFalse(iter.hasNext())
   }
 
-  @Test def removingAnArbitraryElementWithAnIteratorDoubleCornerCase(): Unit = {
+  @Test def iteratorRemoveDoubleCornerCase(): Unit = {
     /* This tests that when `Iterator.remove()` is supposed to remove a zero,
      * it does not accidentally remove a zero of the opposite sign.
      *
@@ -391,7 +391,7 @@ class PriorityQueueTest extends CollectionTest {
     assertFalse(iter.hasNext())
   }
 
-  @Test def removingAnArbitraryElementWithAnIteratorReferenceCornerCase(): Unit = {
+  @Test def iteratorRemoveCustomObjectCornerCase(): Unit = {
     /* This tests that when `Iterator.remove()` is supposed to remove an
      * object, it does not accidentally remove an other object that happens to
      * be `equals` to it (but with a different identity).

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/RandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/RandomTest.scala
@@ -21,7 +21,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
 
 class RandomTest {
 
-  @Test def should_produce_bits_according_to_spec_with_seed_10(): Unit = {
+  @Test def nextBitsSeed10(): Unit = {
     val random = new HackRandom(10)
 
     assertEquals(747, random.next(10))
@@ -31,7 +31,7 @@ class RandomTest {
     assertEquals(254270492, random.next(32))
   }
 
-  @Test def should_produce_bits_according_to_spec_with_seed_neg5(): Unit = {
+  @Test def nextBitsSeedNeg5(): Unit = {
     val random = new HackRandom(-5)
 
     assertEquals(275, random.next(10))
@@ -41,7 +41,7 @@ class RandomTest {
     assertEquals(1635930704, random.next(32))
   }
 
-  @Test def should_produce_bits_according_to_spec_withseedMaxLong(): Unit = {
+  @Test def nextBitsSeedMaxLong(): Unit = {
     val random = new HackRandom(Long.MaxValue)
 
     assertEquals(275, random.next(10))
@@ -51,7 +51,7 @@ class RandomTest {
     assertEquals(-1451336087, random.next(32))
   }
 
-  @Test def should_produce_bits_according_to_spec_withseedMinInt(): Unit = {
+  @Test def nextBitsSeedMinInt(): Unit = {
     val random = new HackRandom(Int.MinValue)
 
     assertEquals(388, random.next(10))
@@ -61,7 +61,7 @@ class RandomTest {
     assertEquals(-2140124682, random.next(32))
   }
 
-  @Test def should_allow_resetting_the_seed(): Unit = {
+  @Test def setSeed(): Unit = {
     val random = new HackRandom(11)
     assertEquals(747, random.next(10))
     assertEquals(1, random.next(1))
@@ -73,14 +73,14 @@ class RandomTest {
     assertEquals(27, random.next(6))
   }
 
-  @Test def should_reset_nextNextGaussian_when_setting_the_seed(): Unit = {
+  @Test def setSeedNextGaussian(): Unit = {
     val random = new Random(-1)
     assertEquals(1.7853314409882288, random.nextGaussian(), 0.0)
     random.setSeed(-1)
     assertEquals(1.7853314409882288, random.nextGaussian(), 0.0)
   }
 
-  @Test def should_correctly_implement_nextDouble(): Unit = {
+  @Test def nextDouble(): Unit = {
     val random = new Random(-45)
     assertEquals(0.27288421395636253, random.nextDouble(), 0.0)
     assertEquals(0.5523165360074201, random.nextDouble(), 0.0)
@@ -94,7 +94,7 @@ class RandomTest {
     assertEquals(0.7426529384056163, random.nextDouble(), 0.0)
   }
 
-  @Test def should_correctly_implement_nextBoolean(): Unit = {
+  @Test def nextBoolean(): Unit = {
     val random = new Random(4782934)
     assertFalse(random.nextBoolean())
     assertTrue(random.nextBoolean())
@@ -106,7 +106,7 @@ class RandomTest {
     assertFalse(random.nextBoolean())
   }
 
-  @Test def should_correctly_implement_nextInt(): Unit = {
+  @Test def nextInt(): Unit = {
     val random = new Random(-84638)
     assertEquals(-1217585344, random.nextInt())
     assertEquals(1665699216, random.nextInt())
@@ -120,7 +120,7 @@ class RandomTest {
     assertEquals(1397525728, random.nextInt())
   }
 
-  @Test def should_correctly_implement_nextInt_of_n(): Unit = {
+  @Test def nextIntInt(): Unit = {
     val random = new Random(7)
     assertEquals(32736, random.nextInt(76543))
     assertThrows(classOf[Exception], random.nextInt(0))
@@ -132,7 +132,7 @@ class RandomTest {
     assertEquals(8, random.nextInt(10))
   }
 
-  @Test def should_correctly_implement_nextInt_for_powers_of_2(): Unit = {
+  @Test def nextIntIntPowersOf2(): Unit = {
     val random = new Random(-56938)
 
     assertEquals(8, random.nextInt(32))
@@ -147,7 +147,7 @@ class RandomTest {
     assertEquals(31, random.nextInt(32))
   }
 
-  @Test def should_correctly_implement_nextLong(): Unit = {
+  @Test def nextLong(): Unit = {
     val random = new Random(205620432625028L)
     assertEquals(3710537363280377478L, random.nextLong())
     assertEquals(4121778334981170700L, random.nextLong())
@@ -161,7 +161,7 @@ class RandomTest {
     assertEquals(-1998975913933474L, random.nextLong())
   }
 
-  @Test def should_correctly_implement_nextFloat(): Unit = {
+  @Test def nextFloat(): Unit = {
     val random = new Random(-3920005825473L)
     assertEquals(0.059591234f, random.nextFloat(), 0.0f)
     assertEquals(0.7007871f, random.nextFloat(), 0.0f)
@@ -175,7 +175,7 @@ class RandomTest {
     assertEquals(0.06482434f, random.nextFloat(), 0.0f)
   }
 
-  @Test def should_correctly_implement_nextBytes(): Unit = {
+  @Test def nextBytes(): Unit = {
     val random = new Random(7399572013373333L)
 
     def test(exps: Int*): Unit = {
@@ -194,7 +194,7 @@ class RandomTest {
     test(57, -106, 42, -100, -47, -84, 67, -48, 45)
   }
 
-  @Test def should_correctly_implement_nextGaussian(): Unit = {
+  @Test def nextGaussian(): Unit = {
     val random = new Random(2446004)
     assertEquals(-0.5043346938630431, random.nextGaussian(), 0.0)
     assertEquals(-0.3250983270156675, random.nextGaussian(), 0.0)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
@@ -29,7 +29,7 @@ trait SetTest extends CollectionTest {
 
   def factory: SetFactory
 
-  @Test def shouldCheckSetSize(): Unit = {
+  @Test def size(): Unit = {
     val hs = factory.empty[String]
 
     assertEquals(0, hs.size())
@@ -39,7 +39,7 @@ trait SetTest extends CollectionTest {
     assertEquals(2, hs.size())
   }
 
-  @Test def shouldStoreIntegers_Set(): Unit = {
+  @Test def addInt(): Unit = {
     val hs = factory.empty[Int]
 
     assertTrue(hs.add(100))
@@ -48,7 +48,7 @@ trait SetTest extends CollectionTest {
     assertEquals(100, hs.iterator.next())
   }
 
-  @Test def shouldStoreObjectsWithSameHashCodeButDifferentTypes(): Unit = {
+  @Test def addAnyRefCustomObjectsWithSameHashCode(): Unit = {
     val hs = factory.empty[AnyRef]
     trait A extends Comparable[A] {
       def compareTo(o: A): Int = toString.compareTo(o.toString)
@@ -65,7 +65,7 @@ trait SetTest extends CollectionTest {
     assertEquals(2, hs.size())
   }
 
-  @Test def shouldStoreDoublesAlsoInCornerCases(): Unit = {
+  @Test def addDoubleCornerCases(): Unit = {
     val hs = factory.empty[Double]
 
     assertTrue(hs.add(11111.0))
@@ -100,7 +100,7 @@ trait SetTest extends CollectionTest {
     assertTrue(hs.contains(-0.0))
   }
 
-  @Test def shouldStoreCustomObjects_Set(): Unit = {
+  @Test def addCustomClass(): Unit = {
     case class TestObj(num: Int) extends jl.Comparable[TestObj] {
       override def compareTo(o: TestObj): Int = o.num - num
     }
@@ -113,7 +113,7 @@ trait SetTest extends CollectionTest {
     assertEquals(100, hs.iterator.next().num)
   }
 
-  @Test def shouldRemoveStoredElements_Set(): Unit = {
+  @Test def removeRemoveAllRetainAll(): Unit = {
     val hs = factory.empty[String]
 
     assertEquals(0, hs.size())
@@ -143,7 +143,7 @@ trait SetTest extends CollectionTest {
     assertFalse(hs.contains("TWO"))
   }
 
-  @Test def shouldBeClearedWithOneOperation_Set(): Unit = {
+  @Test def clearSet(): Unit = {
     val hs = factory.empty[String]
 
     assertTrue(hs.add("ONE"))
@@ -155,7 +155,7 @@ trait SetTest extends CollectionTest {
     assertTrue(hs.isEmpty)
   }
 
-  @Test def shouldCheckContainedElemsPresence(): Unit = {
+  @Test def contains(): Unit = {
     val hs = factory.empty[String]
 
     assertTrue(hs.add("ONE"))
@@ -170,7 +170,7 @@ trait SetTest extends CollectionTest {
     }
   }
 
-  @Test def shouldPutAWholeCollectionInto(): Unit = {
+  @Test def addAllCollectionStringSet(): Unit = {
     val hs = factory.empty[String]
 
     val l = TrivialImmutableCollection("ONE", "TWO", null)
@@ -186,7 +186,7 @@ trait SetTest extends CollectionTest {
     }
   }
 
-  @Test def shouldIterateOverElements(): Unit = {
+  @Test def iterator(): Unit = {
     val hs = factory.empty[String]
 
     val l = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedMapTest.scala
@@ -25,27 +25,27 @@ trait SortedMapTest extends MapTest {
 
   // TODO: implement tests (when we port the first SortedMap)
 
-  @Test def should_always_be_sorted(): Unit = {
+  @Test def sort(): Unit = {
 
   }
 
-  @Test def should_return_the_firstKey(): Unit = {
+  @Test def firstKey(): Unit = {
 
   }
 
-  @Test def should_return_the_lastKey(): Unit = {
+  @Test def lastKey(): Unit = {
 
   }
 
-  @Test def should_return_a_proper_headMap(): Unit = {
+  @Test def headMap(): Unit = {
 
   }
 
-  @Test def should_return_a_proper_tailMap(): Unit = {
+  @Test def tailMap(): Unit = {
 
   }
 
-  @Test def should_return_a_proper_subMap(): Unit = {
+  @Test def subMap(): Unit = {
 
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SortedSetTest.scala
@@ -23,7 +23,7 @@ trait SortedSetTest extends SetTest {
 
   def factory: SortedSetFactory
 
-  @Test def shouldRetrieveTheFirstElement(): Unit = {
+  @Test def first(): Unit = {
     val ssInt = factory.empty[Int]
 
     assertTrue(ssInt.add(1000))
@@ -43,7 +43,7 @@ trait SortedSetTest extends SetTest {
     assertEquals(-0.987, ssDouble.first, 0.0)
   }
 
-  @Test def shouldRetrieveTheLastElement(): Unit = {
+  @Test def last(): Unit = {
     val ssInt = factory.empty[Int]
 
     assertTrue(ssInt.add(1000))
@@ -65,7 +65,7 @@ trait SortedSetTest extends SetTest {
 
   val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
 
-  @Test def shouldReturnAProperHeadSet(): Unit = {
+  @Test def headSet(): Unit = {
     val ss = factory.empty[Int]
 
     ss.addAll(l)
@@ -89,7 +89,7 @@ trait SortedSetTest extends SetTest {
     assertTrue(ss.containsAll(TrivialImmutableCollection(4, 5)))
   }
 
-  @Test def shouldReturnAProperTailSet(): Unit = {
+  @Test def tailSet(): Unit = {
     val ss = factory.empty[Int]
 
     ss.addAll(l)
@@ -113,7 +113,7 @@ trait SortedSetTest extends SetTest {
     assertTrue(ss.containsAll(TrivialImmutableCollection(1, 2, 3)))
   }
 
-  @Test def shouldReturnAProperSubSet(): Unit = {
+  @Test def subSet(): Unit = {
     val ss = factory.empty[Int]
 
     ss.addAll(l)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SplittableRandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SplittableRandomTest.scala
@@ -21,7 +21,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
 
 class SplittableRandomTest {
 
-  @Test def should_correctly_implement_nextLong(): Unit = {
+  @Test def nextLong(): Unit = {
     val sr1 = new SplittableRandom(205620432625028L)
     assertEquals(-546649510716590878L, sr1.nextLong())
     assertEquals(5574037117696891406L, sr1.nextLong())
@@ -47,7 +47,7 @@ class SplittableRandomTest {
     assertEquals(-110482401893286265L, sr2.nextLong())
   }
 
-  @Test def should_correctly_implement_nextInt(): Unit = {
+  @Test def nextInt(): Unit = {
     val sr1 = new SplittableRandom(-84638)
     assertEquals(962946964, sr1.nextInt())
     assertEquals(1723227640, sr1.nextInt())
@@ -73,7 +73,7 @@ class SplittableRandomTest {
     assertEquals(-42114979, sr2.nextInt())
   }
 
-  @Test def should_correctly_implement_nextDouble(): Unit = {
+  @Test def nextDouble(): Unit = {
     val sr1 = new SplittableRandom(-45)
     assertEquals(0.8229662358649753, sr1.nextDouble(), 0.0)
     assertEquals(0.43324117570991283, sr1.nextDouble(), 0.0)
@@ -99,7 +99,7 @@ class SplittableRandomTest {
     assertEquals(0.6454709437764473, sr2.nextDouble(), 0.0)
   }
 
-  @Test def should_correctly_implement_nextBoolean(): Unit = {
+  @Test def nextBoolean(): Unit = {
     val sr1 = new SplittableRandom(4782934)
     assertFalse(sr1.nextBoolean())
     assertFalse(sr1.nextBoolean())
@@ -125,7 +125,7 @@ class SplittableRandomTest {
     assertTrue(sr2.nextBoolean())
   }
 
-  @Test def should_correctly_implement_split(): Unit = {
+  @Test def split(): Unit = {
     val sr1 = new SplittableRandom(205620432625028L).split()
     assertEquals(-2051870635339219700L, sr1.nextLong())
     assertEquals(-4512002368431042276L, sr1.nextLong())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/StringTokenizerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/StringTokenizerTest.scala
@@ -22,19 +22,19 @@ import org.scalajs.testsuite.utils.AssertThrows._
 class StringTokenizerTest {
   import StringTokenizerTest.assertTokenizerResult
 
-  @Test def constructor_with_delim(): Unit = {
+  @Test def ctorWithDelim(): Unit = {
     assertTokenizerResult("This", "is", "a", "test", "String") {
       new StringTokenizer(":This:is:a:test:String:", ":")
     }
   }
 
-  @Test def constructor_with_delim_with_returnDelims(): Unit = {
+  @Test def ctorWithDelimWithReturnDelims(): Unit = {
     assertTokenizerResult(":", "This", ":", "is", ":", "a", ":", "test", ":", "String", ":") {
       new StringTokenizer(":This:is:a:test:String:", ":", true)
     }
   }
 
-  @Test def default_delimiters_should_work(): Unit = {
+  @Test def defaultDelimiters(): Unit = {
     assertTokenizerResult("This", "is", "a", "test", "String") {
       new StringTokenizer(" This\tis\na\rtest\fString ")
     }
@@ -45,12 +45,12 @@ class StringTokenizerTest {
     assertEquals(5, st.countTokens())
   }
 
-  @Test def countTokens_with_returnDelims(): Unit = {
+  @Test def countTokensWithReturnDelims(): Unit = {
     val st = new StringTokenizer("This is a test String", " ", true)
     assertEquals(9, st.countTokens())
   }
 
-  @Test def empty_token_should_work(): Unit = {
+  @Test def ctorEmptyString(): Unit = {
     val st = new StringTokenizer("")
     assertFalse(st.hasMoreTokens())
     assertFalse(st.hasMoreElements())
@@ -58,7 +58,7 @@ class StringTokenizerTest {
     assertThrows(classOf[NoSuchElementException], st.nextElement())
   }
 
-  @Test def no_delimeter_string_should_work(): Unit = {
+  @Test def ctorNoDelimitersInString(): Unit = {
     assertTokenizerResult("ThisisatestString") {
       new StringTokenizer("ThisisatestString")
     }
@@ -68,7 +68,7 @@ class StringTokenizerTest {
     }
   }
 
-  @Test def nextToken_with_new_delim(): Unit = {
+  @Test def nextTokenWithNewDelim(): Unit = {
     val st = new StringTokenizer("ab;cd;:", ";")
     assertEquals("ab", st.nextToken())
     assertEquals("cd", st.nextToken())
@@ -77,13 +77,13 @@ class StringTokenizerTest {
     assertFalse("hasMoreTokens returned true", st.hasMoreTokens())
   }
 
-  @Test def consecutive_returnDelims_false(): Unit = {
+  @Test def consecutiveReturnDelimsFalse(): Unit = {
     assertTokenizerResult("This", "is", "a", "test", "String") {
       new StringTokenizer("::This::is::a::test::String::", ":")
     }
   }
 
-  @Test def consecutive_returnDelims_true(): Unit = {
+  @Test def consecutiveReturnDelimsTrue(): Unit = {
     assertTokenizerResult(":", ":", "This", ":", ":", "is",
         ":", ":", "a", ":", ":", "test", ":", ":", "String", ":", ":") {
       new StringTokenizer("::This::is::a::test::String::", ":", true)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ThrowablesTest.scala
@@ -16,7 +16,7 @@ import org.junit.Test
 
 class ThrowablesTest {
 
-  @Test def shouldDefineAllJavaUtilErrorsAndExceptions(): Unit = {
+  @Test def allJavaUtilErrorsAndExceptions(): Unit = {
     import java.util._
     new ServiceConfigurationError("")
     new ConcurrentModificationException()

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
@@ -31,7 +31,7 @@ import scala.reflect.ClassTag
 
 class TreeSetWithoutNullTest extends TreeSetTest(new TreeSetFactory) {
 
-  @Test def should_check_that_comparator_is_always_null(): Unit = {
+  @Test def comparatorNull(): Unit = {
     val ts1 = factory.empty[Int]
 
     assertNull(ts1.comparator())
@@ -43,7 +43,7 @@ class TreeSetWithoutNullTest extends TreeSetTest(new TreeSetFactory) {
 }
 
 class TreeSetWithNullTest extends TreeSetTest(new TreeSetWithNullFactory) {
-  @Test def should_check_that_comparator_is_never_null(): Unit = {
+  @Test def comparatorNotNull(): Unit = {
     val ts1 = factory.empty[Int]
 
     assertFalse(ts1.comparator() == null)
@@ -59,7 +59,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     with SortedSetTest
     with NavigableSetTest {
 
-  @Test def should_store_and_remove_ordered_integers(): Unit = {
+  @Test def addRemoveInt(): Unit = {
     val ts = factory.empty[Int]
 
     assertEquals(0, ts.size())
@@ -87,7 +87,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     }
   }
 
-  @Test def should_store_and_remove_ordered_strings(): Unit = {
+  @Test def addRemoveString(): Unit = {
     val ts = factory.empty[String]
 
     assertEquals(0, ts.size())
@@ -114,7 +114,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     }
   }
 
-  @Test def should_store_objects_with_custom_comparables(): Unit = {
+  @Test def addRemoveCustomComparator(): Unit = {
     case class Rect(x: Int, y: Int)
 
     val areaComp = new ju.Comparator[Rect] {
@@ -149,7 +149,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     assertTrue(ts.isEmpty)
   }
 
-  @Test def should_store_ordered_Double_even_in_corner_cases(): Unit = {
+  @Test def addRemoveDoubleCornerCases(): Unit = {
     val ts = factory.empty[Double]
 
     assertTrue(ts.add(1.0))
@@ -176,7 +176,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     assertTrue(ts.isEmpty)
   }
 
-  @Test def could_be_instantiated_with_a_prepopulated_Collection(): Unit = {
+  @Test def newFromCollectionInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ts = factory.newFrom(l)
 
@@ -188,7 +188,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     assertTrue(ts.isEmpty)
   }
 
-  @Test def should_be_cleared_in_a_single_operation(): Unit = {
+  @Test def clearTreeSet(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ts = factory.empty[Int]
 
@@ -199,7 +199,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     assertEquals(0, ts.size())
   }
 
-  @Test def should_add_multiple_element_in_one_operation(): Unit = {
+  @Test def addAllCollectionIntAndAddInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val ts = factory.empty[Int]
 
@@ -210,7 +210,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     assertEquals(6, ts.size())
   }
 
-  @Test def should_check_contained_values_even_in_double_corner_cases(): Unit = {
+  @Test def containsDoubleCornerCasesTreeSet(): Unit = {
     val ts = factory.empty[Double]
 
     assertTrue(ts.add(11111.0))
@@ -245,7 +245,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     assertTrue(ts.contains(-0.0))
   }
 
-  @Test def should_throws_exception_in_case_of_null_elements_and_default_ordering(): Unit = {
+  @Test def addNullOrNullNotSupportedThrows(): Unit = {
     val hs = factory.empty[String]
 
     assertTrue(hs.add("ONE"))
@@ -260,7 +260,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     }
   }
 
-  @Test def should_not_put_a_whole_Collection_with_null_elements_into(): Unit = {
+  @Test def addAllNullOrNullNotSupportedThrows(): Unit = {
     val l = TrivialImmutableCollection("ONE", "TWO", (null: String))
     val ts1 = factory.empty[String]
 
@@ -274,7 +274,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     }
   }
 
-  @Test def should_throw_exception_on_non_comparable_objects(): Unit = {
+  @Test def addNonComparableObjectThrows(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     assumeTrue("Assumed JDK8 implementation", !executingInJVMOnJDK6)
 
@@ -285,7 +285,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     expectThrows(classOf[ClassCastException], ts1.add(new TestObj(111)))
   }
 
-  @Test def should_throw_exceptions_on_access_outside_bound_on_views(): Unit = {
+  @Test def headSetTailSetSubSetThrowsOnAddElementOutOfBounds(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
     val l = TrivialImmutableCollection(2, 3, 6)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
@@ -30,7 +30,7 @@ class ConcurrentHashMapTest extends MapTest {
 
   def factory: ConcurrentHashMapFactory = new ConcurrentHashMapFactory
 
-  @Test def `should give proper Enumerator over elements`(): Unit = {
+  @Test def testEnumeration(): Unit = {
     val chm = factory.empty[String, String]
 
     chm.put("ONE", "one")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentLinkedQueueTest.scala
@@ -27,7 +27,7 @@ class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
 
   override def factory: ConcurrentLinkedQueueFactory = new ConcurrentLinkedQueueFactory
 
-  @Test def should_store_and_remove_ordered_integers(): Unit = {
+  @Test def addRemoveInt(): Unit = {
     val pq = factory.empty[Int]
 
     assertEquals(0, pq.size())
@@ -45,7 +45,7 @@ class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
     assertFalse(pq.remove(222))
   }
 
-  @Test def should_store_and_remove_strings(): Unit = {
+  @Test def addRemoveString(): Unit = {
     val pq = factory.empty[String]
 
     assertEquals(0, pq.size())
@@ -64,7 +64,7 @@ class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
     assertNull(pq.poll())
   }
 
-  @Test def should_store_Double_even_in_corner_cases(): Unit = {
+  @Test def addRemoveDoubleCornerCases(): Unit = {
     val pq = factory.empty[Double]
 
     assertTrue(pq.add(1.0))
@@ -85,7 +85,7 @@ class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
     assertTrue(pq.isEmpty)
   }
 
-  @Test def could_be_instantiated_with_a_prepopulated_Collection(): Unit = {
+  @Test def newFromCollectionInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val pq = factory.newFrom(l)
 
@@ -96,7 +96,7 @@ class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
     assertTrue(pq.isEmpty)
   }
 
-  @Test def should_be_cleared_in_a_single_operation(): Unit = {
+  @Test def clearConcurrentLinkQueue(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val pq = factory.newFrom(l)
 
@@ -105,7 +105,7 @@ class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
     assertEquals(0, pq.size())
   }
 
-  @Test def should_add_multiple_elemnt_in_one_operation(): Unit = {
+  @Test def addAll(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val pq = factory.empty[Int]
 
@@ -116,7 +116,7 @@ class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
     assertEquals(6, pq.size())
   }
 
-  @Test def should_check_contained_values_even_in_double_corner_cases(): Unit = {
+  @Test def containsDoubleCornerCasesConcurrentLinkedQueue(): Unit = {
     val pq = factory.empty[Double]
 
     assertTrue(pq.add(11111.0))
@@ -151,7 +151,7 @@ class ConcurrentLinkedQueueTest extends AbstractCollectionTest {
     assertTrue(pq.contains(-0.0))
   }
 
-  @Test def should_provide_a_weakly_consistent_iterator(): Unit = {
+  @Test def iteratorWeaklyConsistent(): Unit = {
     val queue = factory.empty[Int]
     queue.add(1)
     queue.add(2)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
@@ -32,7 +32,7 @@ class ConcurrentSkipListSetTest {
 
   def factory: ConcurrentSkipListSetFactory = new ConcurrentSkipListSetFactory
 
-  @Test def should_store_and_remove_ordered_integers(): Unit = {
+  @Test def addRemoveInt(): Unit = {
     val csls = factory.empty[Int]
 
     assertEquals(0, csls.size())
@@ -53,7 +53,7 @@ class ConcurrentSkipListSetTest {
     expectThrows(classOf[NoSuchElementException], csls.first)
   }
 
-  @Test def should_store_and_remove_ordered_strings(): Unit = {
+  @Test def adddRemoveString(): Unit = {
     val csls = factory.empty[String]
 
     assertEquals(0, csls.size())
@@ -73,7 +73,7 @@ class ConcurrentSkipListSetTest {
     assertTrue(csls.isEmpty)
   }
 
-  @Test def should_store_objects_with_custom_comparables(): Unit = {
+  @Test def addCustomObjectsWithComparator(): Unit = {
     case class Rect(x: Int, y: Int)
 
     val areaComp = new ju.Comparator[Rect] {
@@ -108,7 +108,7 @@ class ConcurrentSkipListSetTest {
     assertTrue(csls.isEmpty)
   }
 
-  @Test def should_store_ordered_Double_even_in_corner_cases(): Unit = {
+  @Test def addDoubleCornerCases(): Unit = {
     val csls = factory.empty[Double]
 
     assertTrue(csls.add(1.0))
@@ -135,7 +135,7 @@ class ConcurrentSkipListSetTest {
     assertTrue(csls.isEmpty)
   }
 
-  @Test def could_be_instantiated_with_a_prepopulated_Collection(): Unit = {
+  @Test def newFromCollectionInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val csls = factory.newFrom(l)
 
@@ -147,7 +147,7 @@ class ConcurrentSkipListSetTest {
     assertTrue(csls.isEmpty)
   }
 
-  @Test def should_be_cleared_in_a_single_operation(): Unit = {
+  @Test def clear(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val csls = factory.newFrom(l)
 
@@ -156,7 +156,7 @@ class ConcurrentSkipListSetTest {
     assertEquals(0, csls.size())
   }
 
-  @Test def should_add_multiple_elemnt_in_one_operation(): Unit = {
+  @Test def addAllCollectionInt(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val csls = factory.empty[Int]
 
@@ -167,7 +167,7 @@ class ConcurrentSkipListSetTest {
     assertEquals(6, csls.size())
   }
 
-  @Test def should_check_contained_values_even_in_double_corner_cases(): Unit = {
+  @Test def containsDoubleCornerCases(): Unit = {
     val csls = factory.empty[Double]
 
     assertTrue(csls.add(11111.0))
@@ -202,7 +202,7 @@ class ConcurrentSkipListSetTest {
     assertTrue(csls.contains(-0.0))
   }
 
-  @Test def `should_retrieve_the_first(ordered)_element`(): Unit = {
+  @Test def first(): Unit = {
     val cslsInt = factory.empty[Int]
 
     assertTrue(cslsInt.add(1000))
@@ -222,7 +222,7 @@ class ConcurrentSkipListSetTest {
     assertEquals(-0.987, cslsDouble.first, 0.0)
   }
 
-  @Test def `should_retrieve_the_last(ordered)_element`(): Unit = {
+  @Test def last(): Unit = {
     val cslsInt = factory.empty[Int]
 
     assertTrue(cslsInt.add(1000))
@@ -242,7 +242,7 @@ class ConcurrentSkipListSetTest {
     assertEquals(10000.987, cslsDouble.last, 0.0)
   }
 
-  @Test def `should_retrieve_ceiling(ordered)_elements`(): Unit = {
+  @Test def ceiling(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val cslsInt = new ConcurrentSkipListSet[Int](lInt)
 
@@ -261,7 +261,7 @@ class ConcurrentSkipListSetTest {
     assertNull(cslsString.ceiling("z"))
   }
 
-  @Test def `should_retrieve_floor(ordered)_elements`(): Unit = {
+  @Test def floor(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val cslsInt = new ConcurrentSkipListSet[Int](lInt)
 
@@ -280,7 +280,7 @@ class ConcurrentSkipListSetTest {
     assertNull(cslsString.floor("0"))
   }
 
-  @Test def `should_retrieve_higher(ordered)_elements`(): Unit = {
+  @Test def higher(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val cslsInt = new ConcurrentSkipListSet[Int](lInt)
 
@@ -299,7 +299,7 @@ class ConcurrentSkipListSetTest {
     assertEquals("a", cslsString.higher("0"))
   }
 
-  @Test def `should_retrieve_lower(ordered)_elements`(): Unit = {
+  @Test def lower(): Unit = {
     val lInt = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val cslsInt = new ConcurrentSkipListSet[Int](lInt)
 
@@ -318,7 +318,7 @@ class ConcurrentSkipListSetTest {
     assertNull(cslsString.lower("0"))
   }
 
-  @Test def should_poll_first_and_last_elements(): Unit = {
+  @Test def pollFirstAndLast(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val csls = new ConcurrentSkipListSet[Int](l)
 
@@ -332,7 +332,7 @@ class ConcurrentSkipListSetTest {
     assertTrue(csls.isEmpty())
   }
 
-  @Test def should_get_partial_views_that_are_backed_on_the_original_list(): Unit = {
+  @Test def headSetTailSetSubSetAreViews(): Unit = {
     val l = TrivialImmutableCollection(1, 5, 2, 3, 4)
     val csls = new ConcurrentSkipListSet[Int](l)
 
@@ -394,7 +394,7 @@ class ConcurrentSkipListSetTest {
     assertTrue(csls.containsAll(TrivialImmutableCollection(1, 4, 5)))
   }
 
-  @Test def should_throw_exception_on_non_comparable_objects(): Unit = {
+  @Test def addCustomClassNotComparableThrows(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
     assumeFalse("Ignored on JVM due to possible race condition", executingInJVM)
     // Behaviour based on JDK8 modulo (improbable) race conditions.

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/CopyOnWriteArrayListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/CopyOnWriteArrayListTest.scala
@@ -26,7 +26,7 @@ class CopyOnWriteArrayListTest extends ListTest {
 
   def factory: CopyOnWriteArrayListFactory = new CopyOnWriteArrayListFactory
 
-  @Test def should_implement_addIfAbsent(): Unit = {
+  @Test def addIfAbsent(): Unit = {
     val list = factory.empty[Int]
 
     assertTrue(list.addIfAbsent(0))
@@ -43,7 +43,7 @@ class CopyOnWriteArrayListTest extends ListTest {
     assertEquals(1, list.get(1))
   }
 
-  @Test def should_implement_addAllAbsent(): Unit = {
+  @Test def addAllAbsent(): Unit = {
     val list = factory.empty[Int]
 
     assertEquals(3, list.addAllAbsent(TrivialImmutableCollection((0 until 3): _*)))
@@ -73,7 +73,7 @@ class CopyOnWriteArrayListTest extends ListTest {
     assertEquals(42, list.get(10))
   }
 
-  @Test def should_implement_a_snapshot_iterator(): Unit = {
+  @Test def iteratorInt(): Unit = {
     val list = factory.empty[Int]
     list.addAll(TrivialImmutableCollection((0 to 10): _*))
 
@@ -90,7 +90,7 @@ class CopyOnWriteArrayListTest extends ListTest {
     assertFalse(iter2.hasNext)
   }
 
-  @Test def `should_have_accessible_array_constructor_-_#2023`(): Unit = {
+  @Test def newFromArray_Issue2023(): Unit = {
     def test[T <: AnyRef](arr: Array[T]): Unit = {
       val cowal1 = factory.newFrom(arr)
       assertEquals(arr.length, cowal1.size)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
@@ -23,7 +23,7 @@ import org.scalajs.testsuite.utils.Platform._
 
 class ThreadLocalRandomTest {
 
-  @Test def should_throw_exception_on_setSeed(): Unit = {
+  @Test def setSeedThrows(): Unit = {
     val tlr = ThreadLocalRandom.current()
 
     assertThrows(classOf[UnsupportedOperationException], tlr.setSeed(1))
@@ -42,7 +42,7 @@ class ThreadLocalRandomTest {
     }
   }
 
-  @Test def should_return_nextInt_that_fits_bounds(): Unit = {
+  @Test def nextIntIntInt(): Unit = {
     implicit val tlr = ThreadLocalRandom.current()
 
     checkIntBounds(Int.MinValue, Int.MaxValue)
@@ -157,7 +157,7 @@ class ThreadLocalRandomTest {
     assertTrue(next < bound)
   }
 
-  @Test def should_return_nextLong_under_a_bound(): Unit = {
+  @Test def nextLongLessThanBound(): Unit = {
     implicit val tlr = ThreadLocalRandom.current()
 
     checkLongUpperBound(Long.MaxValue)
@@ -280,7 +280,7 @@ class ThreadLocalRandomTest {
     }
   }
 
-  @Test def should_return_nextLong_that_fits_bounds(): Unit = {
+  @Test def nextLongLongLong(): Unit = {
     implicit val tlr = ThreadLocalRandom.current()
 
     checkLongBounds(Long.MinValue, Long.MaxValue)
@@ -397,7 +397,7 @@ class ThreadLocalRandomTest {
     assertTrue(next < bound)
   }
 
-  @Test def should_return_nextDouble_under_a_bound(): Unit = {
+  @Test def nextDoubleDouble(): Unit = {
     implicit val tlr = ThreadLocalRandom.current()
 
     checkDoubleUpperBound(Double.MaxValue)
@@ -520,7 +520,7 @@ class ThreadLocalRandomTest {
     }
   }
 
-  @Test def should_return_nextDouble_that_fits_bounds(): Unit = {
+  @Test def nextDoubleDoubleDouble(): Unit = {
     implicit val tlr = ThreadLocalRandom.current()
 
     checkDoubleBounds(Double.MinValue, Double.MaxValue)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
@@ -23,7 +23,7 @@ import org.scalajs.testsuite.utils.AssertThrows._
 
 class ReentrantLockTest {
 
-  @Test def should_lock_and_unlock(): Unit = {
+  @Test def lockAndUnlock(): Unit = {
     val lock = new ReentrantLock()
     assertFalse(lock.isLocked)
     lock.lock()
@@ -32,7 +32,7 @@ class ReentrantLockTest {
     assertFalse(lock.isLocked)
   }
 
-  @Test def properly_tryLock(): Unit = {
+  @Test def tryLock(): Unit = {
     val lock = new ReentrantLock()
     assertFalse(lock.isLocked)
     lock.tryLock()
@@ -47,7 +47,7 @@ class ReentrantLockTest {
     assertThrows(classOf[InterruptedException], lock.tryLock(1L, TimeUnit.SECONDS))
   }
 
-  @Test def properly_lockInterruptibly(): Unit = {
+  @Test def lockInterruptibly(): Unit = {
     val lock = new ReentrantLock()
     assertFalse(lock.isLocked)
     lock.lockInterruptibly()
@@ -58,14 +58,14 @@ class ReentrantLockTest {
     assertThrows(classOf[InterruptedException], lock.lockInterruptibly)
   }
 
-  @Test def check_if_is_held_by_current_Thread(): Unit = {
+  @Test def isHeldByCurrentThread(): Unit = {
     val lock = new ReentrantLock()
     assertFalse(lock.isHeldByCurrentThread())
     lock.lock()
     assertTrue(lock.isHeldByCurrentThread())
   }
 
-  @Test def should_be_created_with_a_fair_option(): Unit = {
+  @Test def isFair(): Unit = {
     val l1 = new ReentrantLock()
     assertFalse(l1.isFair)
     val l2 = new ReentrantLock(false)
@@ -74,7 +74,7 @@ class ReentrantLockTest {
     assertTrue(l3.isFair)
   }
 
-  @Test def should_count_properly_number_of_locks(): Unit = {
+  @Test def getHoldCount(): Unit = {
     val lock = new ReentrantLock()
     assertFalse(lock.isLocked)
     assertEquals(0, lock.getHoldCount())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/BiFunctionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/BiFunctionTest.scala
@@ -20,7 +20,7 @@ import org.junit.Test
 class BiFunctionTest {
   import BiFunctionTest._
 
-  @Test def create_and_apply(): Unit = {
+  @Test def createAndApply(): Unit = {
     assertEquals(3, addBiFunc(1, 2))
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/FunctionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/FunctionTest.scala
@@ -24,7 +24,7 @@ class FunctionTest {
     assertEquals(10, identityFunc(10))
   }
 
-  @Test def create_and_apply(): Unit = {
+  @Test def createAndApply(): Unit = {
     assertEquals(2, doubleFunc(1))
   }
 
@@ -38,7 +38,7 @@ class FunctionTest {
     assertEquals(22, incFunc.andThen(doubleFunc)(10))
   }
 
-  @Test def identity_compose_andThen(): Unit = {
+  @Test def identityComposeAndThen(): Unit = {
     // i.e. (self + 1) * 2
     val combined = identityFunc.andThen(doubleFunc).compose(incFunc)
     assertEquals(42, combined(20))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/UnaryOperatorTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/UnaryOperatorTest.scala
@@ -25,7 +25,7 @@ class UnaryOperatorTest {
     assertEquals("scala", unaryOperatorString.apply("scala"))
   }
 
-  @Test def create_and_apply(): Unit = {
+  @Test def createAndApply(): Unit = {
     val double: UnaryOperator[Int] = makeUnaryOperator(_ * 2)
     assertEquals(20, double.apply(10))
     assertEquals(20, double.apply(10))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -41,7 +41,7 @@ class RegexMatcherTest  {
     assertFalse(matcher.find())
   }
 
-  @Test def start_end_group_and_toMatchResult(): Unit = {
+  @Test def startEndGroupAndToMatchResult(): Unit = {
     val matcher = Pattern
       .compile("\\s(([A-Za-z]{5}(hum)?).js)\\s")
       .matcher("Write Scala.js everyday!")
@@ -53,7 +53,7 @@ class RegexMatcherTest  {
     )
   }
 
-  @Test def start_end_group_tricky_and_toMatchResult(): Unit = {
+  @Test def startEndGroupTrickyAndToMatchResult(): Unit = {
     val matcher = Pattern
       .compile("(Scala\\.js).*(Scala)$")
       .matcher("Scala.js is a Scalable javascript compiler based on Scala")
@@ -64,7 +64,7 @@ class RegexMatcherTest  {
     )
   }
 
-  @Test def start_end_group_matchnot_and_toMatchResult(): Unit = {
+  @Test def startEndGroupMatchnotAndToMatchResult(): Unit = {
     val matcher = Pattern
       .compile("(?!Scala\\.js)(Scala)")
       .matcher("There is a difference between Scala.js and Scala, but both are Scalable")
@@ -78,7 +78,7 @@ class RegexMatcherTest  {
     )
   }
 
-  @Test def start_end_group_multiple_and_toMatchResult(): Unit = {
+  @Test def startEndGroupMultipleAndToMatchResult(): Unit = {
     val matcher = Pattern
       .compile("(?=Scala\\.js is (nice|awesome))(Scala)\\.js")
       .matcher("Scala.js is nice, Scala.js is awesome")
@@ -94,7 +94,7 @@ class RegexMatcherTest  {
     )
   }
 
-  @Test def start_end_group_and_toMatchResult_with_inline_flags_issue3406(): Unit = {
+  @Test def startEndGroupAndToMatchResultWithInlineFlags_Issue3406(): Unit = {
     val matcher = Pattern
       .compile("(?i)(a).*(aa)")
       .matcher("bBaccAaD")
@@ -109,7 +109,7 @@ class RegexMatcherTest  {
         "(?i)(a)".r.findAllMatchIn("aA").map(_.matched).toList)
   }
 
-  @Test def start_end_group_with_region_issue4204(): Unit = {
+  @Test def startEndGroupWithRegion_Issue4204(): Unit = {
     val matcher = Pattern
       .compile("([a-z]+) ([a-z]+)(frobber)?")
       .matcher("This is only a test")
@@ -135,7 +135,7 @@ class RegexMatcherTest  {
     }
   }
 
-  @Test def parseRegex_test(): Unit = {
+  @Test def parseRegexTest(): Unit = {
     parseExpect("aa", "aa", 0 -> 2)
     parseExpect("a(a)", "aa", 0 -> 2, 1 -> 2)
     parseExpect("ABC(A(B))(C)", "ABCABC", 0 -> 6, 3 -> 5, 4 -> 5, 5 -> 6)
@@ -166,12 +166,12 @@ class RegexMatcherTest  {
     parseExpect("(?!(a))(b)", "b", 0 -> 1, -1 -> -1, 0 -> 1) // #3901
   }
 
-  @Test def parseRegex_backgroups_test(): Unit = {
+  @Test def parseRegexBackgroupsTest(): Unit = {
     parseExpect("bc(.c).c(\\1)", "bczcxczc", 0 -> 8, 2 -> 4, 6 -> 8)
     parseExpect("(bc(.c).c)(\\2)", "bczcxczc", 0 -> 8, 0 -> 6, 2 -> 4, 6 -> 8)
   }
 
-  @Test def parseRegex_disjunctions_test(): Unit = {
+  @Test def parseRegexDisjunctionsTest(): Unit = {
     parseExpect("a(b)|b(c)", "ab", 0 -> 2, 1 -> 2, -1 -> -1)
     parseExpect("a(b)|b(c)", "bc", 0 -> 2, -1 -> -1, 1 -> 2)
     if (!executingInJVM) {
@@ -218,7 +218,7 @@ class RegexMatcherTest  {
     assertFalse(matcher1.matches())
   }
 
-  @Test def several_matches_from_the_same_pattern_should_be_independent(): Unit = {
+  @Test def matchersFromTheSamePatternAreIndependent(): Unit = {
     val pattern = Pattern.compile("S[a-z]+")
     val matcher0 = pattern.matcher("Scalable")
     val matcher1 = pattern.matcher("Scalable")
@@ -243,7 +243,7 @@ class RegexMatcherTest  {
     assertTrue(matcher.find())
   }
 
-  @Test def reset_string(): Unit = {
+  @Test def resetString(): Unit = {
     val matcher = Pattern.compile("S[a-z]+").matcher("Scalable")
 
     assertTrue(matcher.matches())
@@ -352,7 +352,7 @@ class RegexMatcherTest  {
     assertEquals(20, matcher1.regionEnd)
   }
 
-  @Test def appendReplacement_and_appendTail(): Unit = {
+  @Test def appendReplacementAndAppendTail(): Unit = {
     // From the JavaDoc
     val matcher = Pattern.compile("cat").matcher("one cat two cats in the yard")
     val sb = new StringBuffer
@@ -383,7 +383,7 @@ class RegexMatcherTest  {
     assertEquals("zzzcatzzzdogzzz", matcher.replaceFirst("cat"))
   }
 
-  @Test def should_throw_exception_if_match_accessors_are_called_before_find(): Unit = {
+  @Test def usingMatchAccessorsBeforeFindThrows(): Unit = {
     def checkInvalidAccess(block: => Unit): Unit = {
       val exception: Throwable = try {
         block
@@ -412,7 +412,7 @@ class RegexMatcherTest  {
     checkInvalidAccess { matchResult.group(42) }
   }
 
-  @Test def should_correctly_handle_zero_length_matches(): Unit = {
+  @Test def zeroLengthMatches(): Unit = {
     val pat = Pattern.compile("a*?")
     val mat = pat.matcher("aaaaa")
     for (i <- 0 to 5) {
@@ -427,7 +427,7 @@ class RegexMatcherTest  {
     }
   }
 
-  @Test def should_support_in_pattern_flags_issue_997(): Unit = {
+  @Test def inPatternFlags_Issue997(): Unit = {
     val p0 = Pattern.compile("(?i)abc")
 
     assertNotEquals(0, p0.flags() & Pattern.CASE_INSENSITIVE)
@@ -451,7 +451,7 @@ class RegexMatcherTest  {
     assertFalse(m1.find())
   }
 
-  @Test def should_link_and_fail_on_group_of_String_issue_2381(): Unit = {
+  @Test def groupAndGroupName_Issue2381(): Unit = {
     val r = new Regex("a(b*)c", "Bee")
     val ms = r findAllIn "stuff abbbc more abc and so on"
     if (!executingInJVM)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
@@ -34,7 +34,7 @@ class RegexPatternTest {
     assertFalse(Pattern.matches("S[a-z]*", "Scala.js"))
   }
 
-  @Test def matches_with_flags(): Unit = {
+  @Test def matchesWithFlags(): Unit = {
     matches("scala.js", "Scala.js")
     matches("SCALA.JS", "Scala.js")
     matches("waz*up", "WAZZZZZZZZZZZUP")
@@ -99,7 +99,7 @@ class RegexPatternTest {
     }
   }
 
-  @Test def split_with_limit(): Unit = {
+  @Test def splitWithLimit(): Unit = {
     // Tests from JavaDoc
     splitWithLimit("boo:and:foo", ":", 2, Array("boo", "and:foo"))
     splitWithLimit("boo:and:foo", ":", 5, Array("boo", "and", "foo"))
@@ -152,7 +152,7 @@ class RegexPatternTest {
     assertEquals(flags2, pattern2.flags)
   }
 
-  @Test def pattern_and_toString(): Unit = {
+  @Test def patternAndToString(): Unit = {
     def checkPatternAndToString(regex: String): Unit = {
       val pattern0 = Pattern.compile(regex)
       assertEquals(regex, pattern0.pattern)
@@ -174,7 +174,7 @@ class RegexPatternTest {
     assertEquals("Scala$1&$2.js", splitNoQuote.mkString)
   }
 
-  @Test def compile_should_throw_for_invalid_patterns_issue_1718(): Unit = {
+  @Test def compileInvalidPatternThrows_Issue1718(): Unit = {
     assertThrows(classOf[Throwable], Pattern.compile("*"))
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
@@ -372,7 +372,7 @@ class JUnitAssertionsTest {
         ShallNotPass)
   }
 
-  @Test def testIfAssertsTest_issue_2252(): Unit = {
+  @Test def testIfAssertsTest_Issue2252(): Unit = {
     Try(testIfAsserts(())) match {
       case Success(_) => // As expected
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
@@ -99,7 +99,7 @@ abstract class BaseBufferTest {
     assertEquals(4, buf.position())
   }
 
-  @Test def mark_and_reset(): Unit = {
+  @Test def markAndReset(): Unit = {
     val buf = allocBuffer(10)
 
     // Initially, the mark should not be set
@@ -158,7 +158,7 @@ abstract class BaseBufferTest {
     expectThrows(classOf[InvalidMarkException], buf.reset())
   }
 
-  @Test def remaining_and_hasRemaining(): Unit = {
+  @Test def remainingAndHasRemaining(): Unit = {
     val buf = allocBuffer(3, 7, 10)
     assertEquals(7 - 3, buf.remaining())
 
@@ -181,7 +181,7 @@ abstract class BaseBufferTest {
     assertTrue(buf.hasRemaining())
   }
 
-  @Test def absolute_get(): Unit = {
+  @Test def absoluteGet(): Unit = {
     val buf = withContent(10, elemRange(0, 10): _*)
     assertEquals(elemFromInt(0), buf.get(0))
     assertEquals(0, buf.position())
@@ -195,7 +195,7 @@ abstract class BaseBufferTest {
     expectThrows(classOf[IndexOutOfBoundsException], buf.get(5))
   }
 
-  @Test def absolute_put(): Unit = {
+  @Test def absolutePut(): Unit = {
     val buf = allocBuffer(10)
     if (!createsReadOnly) {
       buf.put(5, 42)
@@ -220,7 +220,7 @@ abstract class BaseBufferTest {
     }
   }
 
-  @Test def relative_get(): Unit = {
+  @Test def relativeGet(): Unit = {
     val buf = withContent(10, elemRange(0, 10): _*)
     assertEquals(elemFromInt(0), buf.get())
     assertEquals(1, buf.position())
@@ -232,7 +232,7 @@ abstract class BaseBufferTest {
     expectThrows(classOf[BufferUnderflowException], buf.get())
   }
 
-  @Test def relative_put(): Unit = {
+  @Test def relativePut(): Unit = {
     val buf = allocBuffer(10)
     if (!createsReadOnly) {
       buf.put(5)
@@ -256,7 +256,7 @@ abstract class BaseBufferTest {
     }
   }
 
-  @Test def relative_bulk_get(): Unit = {
+  @Test def relativeBulkGet(): Unit = {
     val buf = withContent(10, elemRange(0, 10): _*)
     val a = new Array[ElementType](4)
     buf.get(a)
@@ -273,7 +273,7 @@ abstract class BaseBufferTest {
     assertArrayEquals(boxedElemsFromInt(0, 6, 7, 3), boxed(a))
   }
 
-  @Test def relative_bulk_put(): Unit = {
+  @Test def relativeBulkPut(): Unit = {
     val buf = allocBuffer(10)
     if (!createsReadOnly) {
       buf.put(Array[ElementType](6, 7, 12))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
@@ -34,7 +34,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(ByteOrder.BIG_ENDIAN, buf.order())
   }
 
-  @Test def relative_getChar(): Unit = {
+  @Test def relativeGetChar(): Unit = {
     val buf = withContent(10, elemRange(0x7b, 0x85): _*)
 
     buf.order(ByteOrder.BIG_ENDIAN)
@@ -50,7 +50,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[BufferUnderflowException], buf.getChar())
   }
 
-  @Test def relative_putChar(): Unit = {
+  @Test def relativePutChar(): Unit = {
     val buf = allocBuffer(10)
     if (!createsReadOnly) {
       buf.putChar(0x7b7c)
@@ -77,7 +77,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def absolute_getChar(): Unit = {
+  @Test def absoluteGetChar(): Unit = {
     val buf = withContent(10, elemRange(0x7b, 0x85): _*)
 
     buf.order(ByteOrder.BIG_ENDIAN)
@@ -93,7 +93,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[IndexOutOfBoundsException], buf.getChar(9))
   }
 
-  @Test def absolute_putChar(): Unit = {
+  @Test def absolutePutChar(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.putChar(2, 0x7b7c)
@@ -123,7 +123,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def asCharBuffer_Bytes_to_Chars(): Unit = {
+  @Test def asCharBufferBytesToChars(): Unit = {
     val buf = withContent(10, elemRange(0x7b, 0x85): _*)
     buf.limit(8).position(1)
 
@@ -152,7 +152,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(1, charBuf2.position())
   }
 
-  @Test def asCharBuffer_Chars_to_Bytes(): Unit = {
+  @Test def asCharBufferCharsToBytes(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.limit(8).position(1)
@@ -187,7 +187,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def relative_getShort(): Unit = {
+  @Test def relativeGetShort(): Unit = {
     val buf = withContent(10, elemRange(0x7b, 0x85): _*)
 
     buf.order(ByteOrder.BIG_ENDIAN)
@@ -203,7 +203,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[BufferUnderflowException], buf.getShort())
   }
 
-  @Test def relative_putShort(): Unit = {
+  @Test def relativePutShort(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.putShort(0x7b7c)
@@ -231,7 +231,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def absolute_getShort(): Unit = {
+  @Test def absoluteGetShort(): Unit = {
     val buf = withContent(10, elemRange(0x7b, 0x85): _*)
 
     buf.order(ByteOrder.BIG_ENDIAN)
@@ -247,7 +247,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[IndexOutOfBoundsException], buf.getShort(9))
   }
 
-  @Test def absolute_putShort(): Unit = {
+  @Test def absolutePutShort(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.putShort(2, 0x7b7c)
@@ -277,7 +277,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def asShortBuffer_Bytes_to_Shorts(): Unit = {
+  @Test def asShortBufferBytesToShorts(): Unit = {
     val buf = withContent(10, elemRange(0x7b, 0x85): _*)
     buf.limit(8).position(1)
 
@@ -306,7 +306,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(1, shortBuf2.position())
   }
 
-  @Test def asShortBuffer_Shorts_to_Bytes(): Unit = {
+  @Test def asShortBufferShortsToBytes(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.limit(8).position(1)
@@ -341,7 +341,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def relative_getInt(): Unit = {
+  @Test def relativeGetInt(): Unit = {
     val buf = withContent(10, elemRange(0x7b, 0x85): _*)
 
     buf.order(ByteOrder.BIG_ENDIAN)
@@ -356,7 +356,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[BufferUnderflowException], buf.getInt())
   }
 
-  @Test def relative_putInt(): Unit = {
+  @Test def relativePutInt(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.putInt(0x7b7c7d7e)
@@ -390,7 +390,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def absolute_getInt(): Unit = {
+  @Test def absoluteGetInt(): Unit = {
     val buf = withContent(10, elemRange(0x7b, 0x85): _*)
 
     buf.order(ByteOrder.BIG_ENDIAN)
@@ -406,7 +406,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[IndexOutOfBoundsException], buf.getInt(7))
   }
 
-  @Test def absolute_putInt(): Unit = {
+  @Test def absolutePutInt(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.putInt(2, 0x7b7c7d7e)
@@ -442,7 +442,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def asIntBuffer_Bytes_to_Ints(): Unit = {
+  @Test def asIntBufferBytesToInts(): Unit = {
     val buf = withContent(14, elemRange(0x7b, 0x89): _*)
     buf.limit(10).position(1)
 
@@ -471,7 +471,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(1, intBuf2.position())
   }
 
-  @Test def asIntBuffer_Ints_to_Bytes(): Unit = {
+  @Test def asIntBufferIntsToBytes(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(14)
       buf.limit(10).position(1)
@@ -514,7 +514,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def relative_getLong(): Unit = {
+  @Test def relativeGetLong(): Unit = {
     val buf = withContent(20, elemRange(0x76, 0x8a): _*)
 
     buf.order(ByteOrder.BIG_ENDIAN)
@@ -529,7 +529,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[BufferUnderflowException], buf.getLong())
   }
 
-  @Test def relative_putLong(): Unit = {
+  @Test def relativePutLong(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(20)
       buf.putLong(0x767778797a7b7c7dL)
@@ -575,7 +575,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def absolute_getLong(): Unit = {
+  @Test def absoluteGetLong(): Unit = {
     val buf = withContent(20, elemRange(0x76, 0x8a): _*)
 
     buf.order(ByteOrder.BIG_ENDIAN)
@@ -591,7 +591,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[IndexOutOfBoundsException], buf.getLong(15))
   }
 
-  @Test def absolute_putLong(): Unit = {
+  @Test def absolutePutLong(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(20)
       buf.putLong(2, 0x7b7c7d7e7f808182L)
@@ -639,7 +639,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def asLongBuffer_Bytes_to_Longs(): Unit = {
+  @Test def asLongBufferBytesToLongs(): Unit = {
     val buf = withContent(20, elemRange(0x76, 0x8a): _*)
     buf.limit(19).position(3)
 
@@ -668,7 +668,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(1, longBuf2.position())
   }
 
-  @Test def asLongBuffer_Longs_to_Bytes(): Unit = {
+  @Test def asLongBufferLongsToBytes(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(20)
       buf.limit(19).position(3)
@@ -727,7 +727,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def relative_getFloat(): Unit = {
+  @Test def relativeGetFloat(): Unit = {
     val buf = withContent(pos = 0, limit = 10, capacity = 10,
         0x40, 0x49, 0x0f, 0xd8.toByte, 0x43, 0x17, 0x30, 0x62, 0x4d, 0xab.toByte)
 
@@ -743,7 +743,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[BufferUnderflowException], buf.getFloat())
   }
 
-  @Test def relative_putFloat(): Unit = {
+  @Test def relativePutFloat(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.putFloat(3.141592f)
@@ -777,7 +777,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def absolute_getFloat(): Unit = {
+  @Test def absoluteGetFloat(): Unit = {
     val buf = withContent(pos = 0, limit = 10, capacity = 10,
         0x40, 0x49, 0x0f, 0xd8.toByte, 0x43, 0x17, 0x30, 0x62, 0x4d, 0xab.toByte)
 
@@ -793,7 +793,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[IndexOutOfBoundsException], buf.getFloat(7))
   }
 
-  @Test def absolute_putFloat(): Unit = {
+  @Test def absolutePutFloat(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(10)
       buf.putFloat(2, 3.141592f)
@@ -829,7 +829,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def asFloatBuffer_Bytes_to_Floats(): Unit = {
+  @Test def asFloatBufferBytesToFloats(): Unit = {
     val buf = withContent(pos = 0, limit = 12, capacity = 12,
         0x10, 0x23,
         0x40, 0x49, 0x0f, 0xd8.toByte, 0x62, 0x30, 0x17, 0x43,
@@ -861,7 +861,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(1, floatBuf2.position())
   }
 
-  @Test def asFloatBuffer_Floats_to_Bytes(): Unit = {
+  @Test def asFloatBufferFloatsToBytes(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(14)
       buf.limit(10).position(1)
@@ -904,7 +904,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def relative_getDouble(): Unit = {
+  @Test def relativeGetDouble(): Unit = {
     val buf = withContent(pos = 0, limit = 20, capacity = 20,
         0x40, 0x09, 0x21, 0xfb.toByte, 0x54, 0x44, 0x2d, 0x18,
         0x40, 0x97.toByte, 0x9c.toByte, 0xcb.toByte, 0xac.toByte, 0x71, 0x0c, 0xb3.toByte,
@@ -922,7 +922,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[BufferUnderflowException], buf.getDouble())
   }
 
-  @Test def relative_putDouble(): Unit = {
+  @Test def relativePutDouble(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(20)
       buf.putDouble(Math.PI)
@@ -968,7 +968,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def absolute_getDouble(): Unit = {
+  @Test def absoluteGetDouble(): Unit = {
     val buf = withContent(pos = 0, limit = 20, capacity = 20,
         0x40, 0x09, 0x21, 0xfb.toByte, 0x54, 0x44, 0x2d, 0x18,
         0x40, 0x97.toByte, 0x9c.toByte, 0xcb.toByte, 0xac.toByte, 0x71, 0x0c, 0xb3.toByte,
@@ -986,7 +986,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     expectThrows(classOf[IndexOutOfBoundsException], buf.getDouble(15))
   }
 
-  @Test def absolute_putDouble(): Unit = {
+  @Test def absolutePutDouble(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(20)
       buf.putDouble(2, Math.PI)
@@ -1034,7 +1034,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     }
   }
 
-  @Test def asDoubleBuffer_Bytes_to_Doubles(): Unit = {
+  @Test def asDoubleBufferBytesToDoubles(): Unit = {
     val buf = withContent(pos = 0, limit = 20, capacity = 20,
         0x20, 0xe8.toByte,
         0x40, 0x09, 0x21, 0xfb.toByte, 0x54, 0x44, 0x2d, 0x18,
@@ -1067,7 +1067,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(1, doubleBuf2.position())
   }
 
-  @Test def asDoubleBuffer_Doubles_to_Bytes(): Unit = {
+  @Test def asDoubleBufferDoublesToBytes(): Unit = {
     if (!createsReadOnly) {
       val buf = allocBuffer(20)
       buf.limit(19).position(3)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
@@ -65,7 +65,7 @@ class ArrayBuilderTest {
   @noinline def someBoolean: Boolean = false
   @noinline def someString: String = "world"
 
-  @Test def Int_normal_case_inline(): Unit = {
+  @Test def intNormalCaseInline(): Unit = {
     val b = ArrayBuilder.make[Int]
     b += 42
     b += someInt
@@ -78,7 +78,7 @@ class ArrayBuilderTest {
     assertEquals(53, erase(a(1)))
   }
 
-  @Test def Int_normal_case_noinline(): Unit = {
+  @Test def intNormalCaseNoinline(): Unit = {
     val b = makeNoInline[Int]
     b += 42
     b += someInt
@@ -91,7 +91,7 @@ class ArrayBuilderTest {
     assertEquals(53, erase(a(1)))
   }
 
-  @Test def Int_zeros_inline(): Unit = {
+  @Test def intZerosInline(): Unit = {
     val a = zerosInline[Int](3)
     assertSame(classOf[Array[Int]], a.getClass)
     assertEquals(3, a.length)
@@ -99,7 +99,7 @@ class ArrayBuilderTest {
     assertEquals(0, erase(a(0)))
   }
 
-  @Test def Int_zeros_noinline(): Unit = {
+  @Test def intZerosNoinline(): Unit = {
     val a = zerosNoInline[Int](3)
     assertSame(classOf[Array[Int]], a.getClass)
     assertEquals(3, a.length)
@@ -107,7 +107,7 @@ class ArrayBuilderTest {
     assertEquals(0, erase(a(0)))
   }
 
-  @Test def Char_normal_case_inline(): Unit = {
+  @Test def charNormalCaseInline(): Unit = {
     val b = ArrayBuilder.make[Char]
     b += 'A'
     b += someChar
@@ -120,7 +120,7 @@ class ArrayBuilderTest {
     assertEquals('S', erase(a(1)))
   }
 
-  @Test def Char_normal_case_noinline(): Unit = {
+  @Test def charNormalCaseNoinline(): Unit = {
     val b = makeNoInline[Char]
     b += 'A'
     b += someChar
@@ -133,7 +133,7 @@ class ArrayBuilderTest {
     assertEquals('S', erase(a(1)))
   }
 
-  @Test def Char_zeros_inline(): Unit = {
+  @Test def charZerosInline(): Unit = {
     val a = zerosInline[Char](3)
     assertSame(classOf[Array[Char]], a.getClass)
     assertEquals(3, a.length)
@@ -141,7 +141,7 @@ class ArrayBuilderTest {
     assertEquals('\u0000', erase(a(0)))
   }
 
-  @Test def Char_zeros_noinline(): Unit = {
+  @Test def charZerosNoinline(): Unit = {
     val a = zerosNoInline[Char](3)
     assertSame(classOf[Array[Char]], a.getClass)
     assertEquals(3, a.length)
@@ -149,7 +149,7 @@ class ArrayBuilderTest {
     assertEquals('\u0000', erase(a(0)))
   }
 
-  @Test def Boolean_normal_case_inline(): Unit = {
+  @Test def booleanNormalCaseInline(): Unit = {
     val b = ArrayBuilder.make[Boolean]
     b += true
     b += someBoolean
@@ -162,7 +162,7 @@ class ArrayBuilderTest {
     assertEquals(false, erase(a(1)))
   }
 
-  @Test def Boolean_normal_case_noinline(): Unit = {
+  @Test def booleanNormalCaseNoinline(): Unit = {
     val b = makeNoInline[Boolean]
     b += true
     b += someBoolean
@@ -175,7 +175,7 @@ class ArrayBuilderTest {
     assertEquals(false, erase(a(1)))
   }
 
-  @Test def Boolean_zeros_inline(): Unit = {
+  @Test def booleanZerosInline(): Unit = {
     val a = zerosInline[Boolean](3)
     assertSame(classOf[Array[Boolean]], a.getClass)
     assertEquals(3, a.length)
@@ -183,7 +183,7 @@ class ArrayBuilderTest {
     assertEquals(false, erase(a(0)))
   }
 
-  @Test def Boolean_zeros_noinline(): Unit = {
+  @Test def booleanZerosNoinline(): Unit = {
     val a = zerosNoInline[Boolean](3)
     assertSame(classOf[Array[Boolean]], a.getClass)
     assertEquals(3, a.length)
@@ -191,7 +191,7 @@ class ArrayBuilderTest {
     assertEquals(false, erase(a(0)))
   }
 
-  @Test def Unit_normal_case_inline(): Unit = {
+  @Test def unitNormalCaseInline(): Unit = {
     val b = ArrayBuilder.make[Unit]
     b += ()
     val a = b.result()
@@ -202,7 +202,7 @@ class ArrayBuilderTest {
     assertEquals((), erase(a(0)))
   }
 
-  @Test def Unit_normal_case_noinline(): Unit = {
+  @Test def unitNormalCaseNoinline(): Unit = {
     val b = makeNoInline[Unit]
     b += ()
     val a = b.result()
@@ -213,7 +213,7 @@ class ArrayBuilderTest {
     assertEquals((), erase(a(0)))
   }
 
-  @Test def Unit_zeros_inline(): Unit = {
+  @Test def unitZerosInline(): Unit = {
     val a = zerosInline[Unit](3)
     assertSame(classOf[Array[Unit]], a.getClass)
     assertEquals(3, a.length)
@@ -223,7 +223,7 @@ class ArrayBuilderTest {
     }
   }
 
-  @Test def Unit_zeros_noinline(): Unit = {
+  @Test def unitZerosNoinline(): Unit = {
     val a = zerosNoInline[Unit](3)
     assertSame(classOf[Array[Unit]], a.getClass)
     assertEquals(3, a.length)
@@ -233,7 +233,7 @@ class ArrayBuilderTest {
     }
   }
 
-  @Test def String_normal_case_inline(): Unit = {
+  @Test def stringNormalCaseInline(): Unit = {
     val b = ArrayBuilder.make[String]
     b += "hello"
     b += someString
@@ -246,7 +246,7 @@ class ArrayBuilderTest {
     assertEquals("world", erase(a(1)))
   }
 
-  @Test def String_normal_case_noinline(): Unit = {
+  @Test def stringNormalCaseNoinline(): Unit = {
     val b = makeNoInline[String]
     b += "hello"
     b += someString
@@ -259,14 +259,14 @@ class ArrayBuilderTest {
     assertEquals("world", erase(a(1)))
   }
 
-  @Test def String_zeros_inline(): Unit = {
+  @Test def stringZerosInline(): Unit = {
     val a = zerosInline[String](3)
     assertSame(classOf[Array[String]], a.getClass)
     assertEquals(3, a.length)
     assertEquals(null, erase(a(0)))
   }
 
-  @Test def String_zeros_noinline(): Unit = {
+  @Test def stringZerosNoinline(): Unit = {
     val a = zerosNoInline[String](3)
     assertSame(classOf[Array[String]], a.getClass)
     assertEquals(3, a.length)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayTest.scala
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 class ArrayTest {
-  @Test def unapplySeq_issue_3445(): Unit = {
+  @Test def unapplySeq_Issue3445(): Unit = {
     val args: Array[String] = Array("foo", "bar", "foobar")
     val Array(x, xs @ _*) = args
     assertEquals("foo", x)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
@@ -24,7 +24,7 @@ import org.scalajs.testsuite.utils.Platform._
 
 class ClassTagTest {
 
-  @Test def apply_should_get_the_existing_instances_for_predefined_ClassTags(): Unit = {
+  @Test def applyReturnsExistingInstancesForPredefinedClassTags(): Unit = {
     assertSame(ClassTag.Byte, ClassTag(classOf[Byte]))
     assertSame(ClassTag.Short, ClassTag(classOf[Short]))
     assertSame(ClassTag.Char, ClassTag(classOf[Char]))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
@@ -20,7 +20,7 @@ import org.scalajs.testsuite.utils.Platform._
 
 class EnumerationTest {
 
-  @Test def should_use_explicit_naming_for_enumerated_values_issue_38(): Unit = {
+  @Test def valueStringEqualsToString_Issue38(): Unit = {
     object HelpLevel extends Enumeration {
       type HelpLevel = Value
       val None = Value("None")
@@ -34,7 +34,7 @@ class EnumerationTest {
     assertEquals("None", h.toString)
   }
 
-  @Test def should_allow_implicit_naming_for_values(): Unit = {
+  @Test def valueImplicitEqualsToString(): Unit = {
     object HelpLevel extends Enumeration {
       type HelpLevel = Value
       val None, Basic, Medium, Full = Value
@@ -48,7 +48,7 @@ class EnumerationTest {
     assertEquals("$div", HelpLevel./.toString)
   }
 
-  @Test def should_give_a_pseudo_toString_to_unnamed_values(): Unit = {
+  @Test def valueStringNullToStringResult(): Unit = {
     if (!executingInJVM) {
       object Test extends Enumeration {
         private val nullStr: String = null
@@ -60,7 +60,7 @@ class EnumerationTest {
     }
   }
 
-  @Test def should_give_a_graceful_error_message_upon_name_based_query_when_unnamed_fields_are_present(): Unit = {
+  @Test def withNameThrowsForValueStringNull(): Unit = {
     object Test extends Enumeration {
       private val nullStr: String = null
       val A = Value(nullStr) // Circumvent compiler replacement and warning
@@ -75,16 +75,16 @@ class EnumerationTest {
     }
   }
 
-  @Test def should_respond_to_toString(): Unit = {
+  @Test def testToString(): Unit = {
     assertEquals("FooBarEnum", FooBarEnum.toString)
   }
 
-  @Test def should_respond_to_values(): Unit = {
+  @Test def valuesToString(): Unit = {
     assertEquals("FooBarEnum.ValueSet(A, B, C, D, E, F)",
         FooBarEnum.values.toString)
   }
 
-  @Test def should_allow_setting_nextName(): Unit = {
+  @Test def nextNameAssignment(): Unit = {
     object Test extends Enumeration {
       nextName = Iterator("x","y","z")
       val a, b, c = Value

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/NameTransformerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/NameTransformerTest.scala
@@ -19,7 +19,7 @@ import org.junit.Assert._
 
 class NameTransformerTest {
 
-  @Test def decode_issue_1602(): Unit = {
+  @Test def decode_Issue1602(): Unit = {
     /* Mostly to make sure it links.
      * We trust the Scala implementation for correctness. And if it isn't,
      * well, behaving the same as Scala is the correct thing do for us

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/RangesTest.scala
@@ -23,21 +23,21 @@ import org.scalajs.testsuite.utils.Platform._
 
 class RangesTest {
 
-  @Test def Iterable_range_should_not_emit_dce_warnings_issue_650(): Unit = {
+  @Test def iterableRangeLinks_Issue650(): Unit = {
     Iterable.range(1, 10)
   }
 
-  @Test def Iterable_range_and_simple_range_should_be_equal(): Unit = {
+  @Test def iterableRangeAndSimpleRangeAreEqual(): Unit = {
     // Mostly to exercise more methods of ranges for dce warnings
     assertEquals((0 until 10).toList, Iterable.range(0, 10).toList)
   }
 
-  @Test def NumericRange_overflow_issue_2407(): Unit = {
+  @Test def numericRangeOverflow_Issue2407(): Unit = {
     val nr = NumericRange(Int.MinValue, Int.MaxValue, 1 << 23)
     assertEquals(Int.MinValue, nr.sum)
   }
 
-  @Test def Range_foreach_issue_2409(): Unit = {
+  @Test def rangeForeach_Issue2409(): Unit = {
     val r = Int.MinValue to Int.MaxValue by (1 << 23)
     var i = 0
     r.foreach(_ => i += 1)
@@ -46,7 +46,7 @@ class RangesTest {
     assertEquals(Int.MinValue, r.sum)
   }
 
-  @Test def Range_toString_issue_2412(): Unit = {
+  @Test def rangeToString_Issue2412(): Unit = {
     if (scalaVersion.startsWith("2.11.")) {
       assertEquals("Range(1, 3, 5, 7, 9)", (1 to 10 by 2).toString)
       assertEquals("Range()", (1 until 1 by 2).toString)
@@ -61,7 +61,7 @@ class RangesTest {
     }
   }
 
-  @Test def NumericRange_toString_issue_2412(): Unit = {
+  @Test def numericRangeToString_Issue2412(): Unit = {
     if (scalaVersion.startsWith("2.11.")) {
       assertEquals("NumericRange(0, 2, 4, 6, 8, 10)",
           NumericRange.inclusive(0, 10, 2).toString())
@@ -75,7 +75,7 @@ class RangesTest {
     }
   }
 
-  @Test def NumericRange_with_arbitrary_integral(): Unit = {
+  @Test def numericRangeWithArbitraryIntegral(): Unit = {
     // This is broken in Scala JVM up to (including) 2.11.8, 2.12.1 (SI-10086).
     assumeFalse("Assumed not on JVM for 2.12.1",
         executingInJVM && scalaVersion == "2.12.1")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ScalaRunTimeTest.scala
@@ -19,7 +19,7 @@ import scala.concurrent.Future
 
 class ScalaRunTimeTest {
 
-  @Test def ScalaRunTime_isArray(): Unit = {
+  @Test def scalaRunTimeIsArray(): Unit = {
     def isScalaArray(x: Any): Boolean = {
       x match {
         case _: Array[_] => true

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/SymbolTest.scala
@@ -19,7 +19,7 @@ import org.scalajs.testsuite.utils.Platform.scalaVersion
 
 class SymbolTest {
 
-  @Test def should_ensure_unique_identity(): Unit = {
+  @Test def testIdentity(): Unit = {
     def expectEqual(sym1: Symbol, sym2: Symbol): Unit = {
       assertTrue(sym1 eq sym2)
       assertEquals(sym2, sym1)
@@ -41,7 +41,7 @@ class SymbolTest {
     assertEquals(42, map(`42`))
   }
 
-  @Test def should_support_name(): Unit = {
+  @Test def name(): Unit = {
     val scalajs = Symbol("ScalaJS")
 
     assertEquals("ScalaJS", scalajs.name)
@@ -53,7 +53,7 @@ class SymbolTest {
     assertEquals("\"", Symbol("\"").name)
   }
 
-  @Test def should_support_toString(): Unit = {
+  @Test def testToString(): Unit = {
     val scalajs = Symbol("ScalaJS")
 
     val toStringUsesQuoteSyntax = {


### PR DESCRIPTION
Overall the changes are mostly removing `_` and changing the next character to uppercase. Some other transformations are as follows:

1. Make sure the test name starts with lowercase.
2. Remove backticked method names and replace symbols with words.
3. Remove `_a_` because single characters do not toggle well and omitting still reads ok. Remove `_an_` on similar named tests to make them consistent.
4. Make sure `@Test def` are on the same line for easier searching and to make consistent - only one or two.

The other thing to note is that `JS` vs `Js` is not 100% consistent. Both read fine but `Js` is more consistent with toggle case even if it is an abbreviation and `_js_` resulted in `Js`. Other abbreviations may be all caps or toggle case. For the most part I changed the minimum.

The file `SplittableRandom` has the class `SplittableRandomTest`.