### PR TITLE
Fix the nightly 2.13.x build: get rid of warnings about non-cooperative equals

### DIFF
--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -3,6 +3,8 @@
  */
 package org.junit
 
+import java.util.Objects
+
 import org.junit.internal.InexactComparisonCriteria
 import org.junit.internal.ExactComparisonCriteria
 import org.hamcrest.Matcher
@@ -38,7 +40,7 @@ object Assert {
 
   @noinline
   def assertEquals(message: String, expected: Any, actual: Any): Unit = {
-    if (!equalsRegardingNull(expected, actual)) {
+    if (!Objects.equals(expected, actual)) {
       (expected, actual) match {
         case (expectedString: String, actualString: String) =>
           val cleanMsg: String = if (message == null) "" else message
@@ -50,22 +52,13 @@ object Assert {
     }
   }
 
-  @inline
-  private def equalsRegardingNull(expected: Any, actual: Any): Boolean =
-    if (expected == null) actual == null
-    else isEquals(expected, actual)
-
-  @inline
-  private def isEquals(expected: Any, actual: Any): Boolean =
-    expected.equals(actual)
-
   @noinline
   def assertEquals(expected: Any, actual: Any): Unit =
     assertEquals(null, expected, actual)
 
   @noinline
   def assertNotEquals(message: String, unexpected: Any, actual: Any): Unit = {
-    if (equalsRegardingNull(unexpected, actual))
+    if (Objects.equals(unexpected, actual))
       failEquals(message, actual)
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/IntTest.scala
@@ -331,7 +331,7 @@ class IntTest {
 
   @Test def `percent_should_never_produce_a_negative_0_#1984`(): Unit = {
     @noinline def value: Int = -8
-    assertTrue((value % 8).asInstanceOf[java.lang.Integer].equals(0))
+    assertEquals(0, value % 8)
   }
 
   @Test def `should_support_shift_left`(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -69,12 +69,15 @@ class LongTest {
   }
 
   @Test def equals_Any(): Unit = {
+    @inline def inlineCallEquals(lhs: Long, rhs: Any): Boolean =
+      lhs.asInstanceOf[AnyRef].equals(rhs.asInstanceOf[AnyRef])
+
     @inline def test(expected: Boolean, lhs: Long, rhs: Any): Unit = {
-      assertEquals(expected, lhs.equals(rhs))
-      assertEquals(expected, hideFromOptimizer(lhs).equals(rhs))
-      assertEquals(expected, lhs.equals(hideAnyFromOptimizer(rhs)))
+      assertEquals(expected, inlineCallEquals(lhs, rhs))
+      assertEquals(expected, inlineCallEquals(hideFromOptimizer(lhs), rhs))
+      assertEquals(expected, inlineCallEquals(lhs, hideAnyFromOptimizer(rhs)))
       assertEquals(expected,
-          hideFromOptimizer(lhs).equals(hideAnyFromOptimizer(rhs)))
+          inlineCallEquals(hideFromOptimizer(lhs), hideAnyFromOptimizer(rhs)))
     }
 
     test(false, lg(0, 0), 0)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/UnitTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/UnitTest.scala
@@ -23,14 +23,12 @@ class UnitTest {
   }
 
   @Test def `should_equal_itself`(): Unit = {
-    assertTrue(().equals(()))
-    assertTrue(((): Any).equals((): Any))
+    assertTrue(().asInstanceOf[AnyRef].equals(().asInstanceOf[AnyRef]))
   }
 
   @Test def `should_not_equal_other_values`(): Unit = {
     def testAgainst(v: Any): Unit = {
-      assertFalse(().equals(v))
-      assertFalse(((): Any).equals(v))
+      assertFalse(().asInstanceOf[AnyRef].equals(v.asInstanceOf[AnyRef]))
     }
 
     testAgainst(0)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -123,10 +123,10 @@ class DoubleTest {
             r1.equals(v))
         val r2 = JDouble.valueOf(s2)
         assertTrue(s"""Double.valueOf("$s2") must be $v, was $r2""",
-            r2.equals(v))
+            r2.equals(JDouble.valueOf(v)))
         val r3 = new JDouble(s2)
         assertTrue(s"""new Double("$s2") must be $v, was $r3""",
-            r3.equals(v))
+            r3.equals(JDouble.valueOf(v)))
       }
 
       // Specials

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowablesTest.scala
@@ -205,7 +205,8 @@ class ThrowablesTest {
 
   @Test def throwableStillHasMethodsOfObject(): Unit = {
     @noinline
-    def callEquals(a: Any, b: Any): Boolean = a.equals(b)
+    def callEquals(a: Any, b: Any): Boolean =
+      a.asInstanceOf[AnyRef].equals(b.asInstanceOf[AnyRef])
 
     val t = new Throwable("foo")
     assertTrue(callEquals(t, t))


### PR DESCRIPTION
See https://travis-ci.org/github/scala-js/scala-js-test-scala-nightly/jobs/738834559

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.4-bin-991ff8a
> testSuite2_13/test
> testSuiteEx2_13/test
```
