### PR TITLE
Address new warnings with the strict patmat exhaustivity of 2.13.4.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -166,7 +166,8 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
 
       checkJSNameAnnots(sym)
 
-      val transformedTree: Tree = tree match {
+      // @unchecked needed on 2.13.4+ because MemberDef is not marked `sealed`
+      val transformedTree: Tree = (tree: @unchecked) match {
         case tree: ImplDef =>
           if (shouldPrepareExports)
             registerClassOrModuleExports(sym)
@@ -827,6 +828,9 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                   parseGlobalPath(globalPathName))
             }
             Some(loadSpec)
+
+          case Some(annot) =>
+            abort(s"checkAndGetJSNativeLoadingSpecAnnotOf returned unexpected annotation $annot")
 
           case None =>
             /* We already emitted an error. Invent something not to cause

--- a/ir/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/src/main/scala/org/scalajs/ir/Trees.scala
@@ -1235,7 +1235,7 @@ object Trees {
 
     def isConstructor: Boolean = (ordinal & ConstructorFlag) != 0
 
-    def prefixString: String = this match {
+    def prefixString: String = (this: @unchecked) match {
       case Public            => ""
       case Private           => "private "
       case PublicStatic      => "static "

--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -222,7 +222,7 @@ object BigDecimal {
     val absFraction = Math.abs(fraction)
     val sigFraction = java.lang.Integer.signum(fraction)
     // the carry after rounding
-    roundingMode match {
+    (roundingMode: @unchecked) match {
       case UP          => sigFraction
       case DOWN        => 0
       case CEILING     => Math.max(sigFraction, 0)

--- a/javalib/src/main/scala/java/nio/charset/CharsetDecoder.scala
+++ b/javalib/src/main/scala/java/nio/charset/CharsetDecoder.scala
@@ -116,7 +116,7 @@ abstract class CharsetDecoder protected (cs: Charset,
           if (result2.isUnmappable()) unmappableCharacterAction()
           else malformedInputAction()
 
-        action match {
+        (action: @unchecked) match {
           case CodingErrorAction.REPLACE =>
             if (out.remaining() < replacement().length) {
               CoderResult.OVERFLOW

--- a/javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
+++ b/javalib/src/main/scala/java/nio/charset/CharsetEncoder.scala
@@ -139,7 +139,7 @@ abstract class CharsetEncoder protected (cs: Charset,
           if (result2.isUnmappable()) unmappableCharacterAction()
           else malformedInputAction()
 
-        action match {
+        (action: @unchecked) match {
           case CodingErrorAction.REPLACE =>
             if (out.remaining() < replacement().length) {
               CoderResult.OVERFLOW

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleKind.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleKind.scala
@@ -53,7 +53,7 @@ object ModuleKind {
       extends Fingerprint[ModuleKind] {
 
     override def fingerprint(moduleKind: ModuleKind): String = {
-      moduleKind match {
+      (moduleKind: @unchecked) match {
         case NoModule       => "NoModule"
         case ESModule       => "ESModule"
         case CommonJSModule => "CommonJSModule"

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleSplitStyle.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleSplitStyle.scala
@@ -31,7 +31,7 @@ object ModuleSplitStyle {
       extends Fingerprint[ModuleSplitStyle] {
 
     override def fingerprint(moduleSplitStyle: ModuleSplitStyle): String = {
-      moduleSplitStyle match {
+      (moduleSplitStyle: @unchecked) match {
         case FewestModules   => "FewestModules"
         case SmallestModules => "SmallestModules"
       }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Report.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Report.scala
@@ -110,7 +110,7 @@ object Report {
     }
 
     private def writeModuleKind(kind: ModuleKind): Unit = {
-      val i = kind match {
+      val i = (kind: @unchecked) match {
         case ModuleKind.NoModule       => 0
         case ModuleKind.ESModule       => 1
         case ModuleKind.CommonJSModule => 2

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -571,7 +571,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
         methodFun0
       }
 
-      val field = namespace match {
+      val field = (namespace: @unchecked) match {
         case MemberNamespace.Private           => "p"
         case MemberNamespace.PublicStatic      => "s"
         case MemberNamespace.PrivateStatic     => "ps"
@@ -1220,7 +1220,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
   private def genConstValueExportDef(exportName: String,
       exportedValue: js.Tree)(
       implicit pos: Position): WithGlobals[js.Tree] = {
-    moduleKind match {
+    (moduleKind: @unchecked) match {
       case ModuleKind.NoModule =>
         genAssignToNoModuleExportVar(exportName, exportedValue)
 
@@ -1261,7 +1261,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
 
     val varScope = (className, field.name)
 
-    moduleKind match {
+    (moduleKind: @unchecked) match {
       case ModuleKind.NoModule =>
         /* Initial value of the export. Updates are taken care of explicitly
          * when we assign to the static field.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -78,7 +78,7 @@ final class Emitter(config: Emitter.Config) {
   def emit(moduleSet: ModuleSet, logger: Logger): Result = {
     val WithGlobals(body, globalRefs) = emitInternal(moduleSet, logger)
 
-    moduleKind match {
+    (moduleKind: @unchecked) match {
       case ModuleKind.NoModule =>
         assert(moduleSet.modules.size <= 1)
         val topLevelVars = moduleSet.modules
@@ -294,7 +294,7 @@ final class Emitter(config: Emitter.Config) {
         )
     ).toList.sortBy(_._1.name)
 
-    moduleKind match {
+    (moduleKind: @unchecked) match {
       case ModuleKind.NoModule =>
         WithGlobals(Nil)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -188,6 +188,10 @@ private[emitter] final class SJSGen(
       case BoxedFloatClass     => genIsFloat(expr)
       case BoxedDoubleClass    => typeof(expr) === "number"
       case BoxedStringClass    => typeof(expr) === "string"
+
+      case _ =>
+        throw new IllegalArgumentException(
+            s"hijacked class required but got ${className.nameString}")
     }
   }
 
@@ -351,7 +355,7 @@ private[emitter] final class SJSGen(
         }
 
       case irt.JSNativeLoadSpec.ImportWithGlobalFallback(importSpec, globalSpec) =>
-        moduleKind match {
+        (moduleKind: @unchecked) match {
           case ModuleKind.NoModule =>
             genLoadJSFromSpec(globalSpec, keepOnlyDangerousVarNames)
           case ModuleKind.ESModule | ModuleKind.CommonJSModule =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -207,7 +207,7 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
     if (moduleContext.public) {
       WithGlobals(tree)
     } else {
-      val export = config.moduleKind match {
+      val export = (config.moduleKind: @unchecked) match {
         case ModuleKind.NoModule =>
           throw new AssertionError("non-public module in NoModule mode")
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -1486,7 +1486,7 @@ object IRChecker {
       extends AnyVal {
 
     override def toString(): String = {
-      val (pos, name) = nodeOrLinkedClass match {
+      val (pos, name) = (nodeOrLinkedClass: @unchecked) match {
         case tree: IRNode             => (tree.pos, tree.getClass.getSimpleName)
         case linkedClass: LinkedClass => (linkedClass.pos, "ClassDef")
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LinkerFrontendImpl.scala
@@ -45,7 +45,7 @@ final class LinkerFrontendImpl private (config: LinkerFrontendImpl.Config)
 
   private[this] val refiner: Refiner = new Refiner(config.commonConfig)
 
-  private[this] val splitter: ModuleSplitter = config.moduleSplitStyle match {
+  private[this] val splitter: ModuleSplitter = (config.moduleSplitStyle: @unchecked) match {
     case ModuleSplitStyle.FewestModules   => ModuleSplitter.maxSplitter()
     case ModuleSplitStyle.SmallestModules => ModuleSplitter.minSplitter()
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/modulesplitter/ModuleSplitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/modulesplitter/ModuleSplitter.scala
@@ -155,7 +155,7 @@ final class ModuleSplitter private (analyzer: ModuleAnalyzer) {
       add(tle.tree.moduleID, tle.staticDependencies)
 
     for (mi <- unit.moduleInitializers) {
-      val dep = mi.initializer match {
+      val dep = (mi.initializer: @unchecked) match {
         case ModuleInitializerImpl.VoidMainMethod(className, _) =>
           className
         case ModuleInitializerImpl.MainMethodWithArgs(className, _, _) =>

--- a/test-suite/js/src/test/resources/SourceMapTestTemplate.scala
+++ b/test-suite/js/src/test/resources/SourceMapTestTemplate.scala
@@ -486,7 +486,7 @@ class Json extends Writer2{
         linePos = chLinePos
         charPos = chCharPos
         val kind: Int = chKind
-        kind match {
+        (kind: @unchecked) match {
           case Letter =>
             val first = chMark
             while (chKind == Letter || chKind == Digit) {
@@ -628,7 +628,7 @@ class Json extends Writer2{
     }
     def getJson(): JsValue = {
       val kind: Int = tokenKind
-      val result: JsValue = kind match {
+      val result: JsValue = (kind: @unchecked) match {
         case ID =>
           val result: JsValue = tokenValue match {
             case "true" => JsTrue

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InstanceTestsHijackedBoxedClassesTest.scala
@@ -72,7 +72,7 @@ class InstanceTestsHijackedBoxedClassesTest {
     assertTrue((1.2: Any).isInstanceOf[Float])
 
     // from the bug report
-    def test(x: Any): String = x match {
+    def test(x: Any): String = (x: @unchecked) match {
       case f: Float => "ok"
     }
     assertEquals("ok", test(0.2))

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSSymbolTest.scala
@@ -169,7 +169,7 @@ class JSSymbolTest {
   @Test def native_with_overloaded_runtime_dispatch_methods(): Unit = {
     val obj = mkObject(
         sym1 -> { (x: Any) =>
-          x match {
+          (x: @unchecked) match {
             case x: Int    => x + 3
             case x: String => "Hello " + x
           }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
@@ -309,9 +309,11 @@ class ArrayOpsTest {
     import js.Any.jsArrayOps
 
     val array = js.Array[Any](1, "one", 2, "two", 3, "three")
-    val resultInferType = array.partitionMap {
-      case x: Int    => Left(x)
-      case x: String => Right(x)
+    val resultInferType = array.partitionMap { x =>
+      (x: @unchecked) match {
+        case x: Int    => Left(x)
+        case x: String => Right(x)
+      }
     }
     val result: (js.Array[Int], js.Array[String]) = resultInferType
     assertJSArrayPairEquals((js.Array(1, 2, 3), js.Array("one", "two", "three")), result)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -39,8 +39,10 @@ class RegressionTest {
     object PatternMatchGuards {
       def go(f: Int => Int): Int = f(1)
       def main(): Unit = {
-        go {
-          case x if false => x
+        go { y =>
+          (y: @unchecked) match {
+            case x if false => x
+          }
         }
       }
     }
@@ -814,7 +816,7 @@ class RegressionTest {
     import Bug3281._
 
     val l: Any = 0 :: Nil
-    val r = overloaded(l match {
+    val r = overloaded((l: @unchecked) match {
       case x :: xs => 5
     })
     assertEquals(5L, r)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/BaseCharsetTest.scala
@@ -135,7 +135,7 @@ class BaseCharsetTest(val charset: Charset) {
             finally buf.reset()
             expectedChars ++= bufArray
           case Malformed(len) =>
-            malformedAction match {
+            (malformedAction: @unchecked) match {
               case CodingErrorAction.IGNORE  =>
               case CodingErrorAction.REPLACE =>
                 expectedChars ++= decoder.replacement()
@@ -143,7 +143,7 @@ class BaseCharsetTest(val charset: Charset) {
                 throw new MalformedInputException(len)
             }
           case Unmappable(len) =>
-            unmappableAction match {
+            (unmappableAction: @unchecked) match {
               case CodingErrorAction.IGNORE  =>
               case CodingErrorAction.REPLACE =>
                 expectedChars ++= decoder.replacement()
@@ -218,7 +218,7 @@ class BaseCharsetTest(val charset: Charset) {
             finally buf.reset()
             expectedBytes ++= bufArray
           case Malformed(len) =>
-            malformedAction match {
+            (malformedAction: @unchecked) match {
               case CodingErrorAction.IGNORE  =>
               case CodingErrorAction.REPLACE =>
                 expectedBytes ++= encoder.replacement()
@@ -226,7 +226,7 @@ class BaseCharsetTest(val charset: Charset) {
                 throw new MalformedInputException(len)
             }
           case Unmappable(len) =>
-            unmappableAction match {
+            (unmappableAction: @unchecked) match {
               case CodingErrorAction.IGNORE  =>
               case CodingErrorAction.REPLACE =>
                 expectedBytes ++= encoder.replacement()
@@ -302,6 +302,8 @@ object BaseCharsetTest {
           case bytes: Array[Byte] => buf ++= bytes
           case bytes: Seq[_]      =>
             buf ++= bytes.map(_.asInstanceOf[Number].byteValue())
+          case x =>
+            throw new IllegalArgumentException(s"""illegal value in bb"...": $x""")
         }
         appendStr(strings.next())
       }


### PR DESCRIPTION
In 2.13.4, the pattern match exhaustivity analysis has become much stricter. It remains active in the presence of non-sealed classes, guards, and custom extractors. This change causes a lot of new warnings in our codebase.

See scala/scala#9140

We address most warnings with `@unchecked`, but for some we throw more specialized exceptions instead.

---

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.4-bin-200c122
> testSuite2_13/test:compile # with manual inspection of the warnings
> testSuite2_13/test
> testSuiteEx2_13/test
> compiler2_13/test:compile
> ir2_13/test
> linker2_13/test
> testSuite2_13/bootstrap:test
```