### PR TITLE
Catch up with Scala 2.13.4

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -166,7 +166,8 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
 
       checkJSNameAnnots(sym)
 
-      val transformedTree: Tree = tree match {
+      // @unchecked needed because MemberDef is not marked `sealed`
+      val transformedTree: Tree = (tree: @unchecked) match {
         case tree: ImplDef =>
           if (shouldPrepareExports)
             registerClassOrModuleExports(sym)
@@ -827,6 +828,9 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                   parseGlobalPath(globalPathName))
             }
             Some(loadSpec)
+
+          case Some(annot) =>
+            abort(s"checkAndGetJSNativeLoadingSpecAnnotOf returned unexpected annotation $annot")
 
           case None =>
             /* We already emitted an error. Invent something not to cause

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/MatchASTTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/MatchASTTest.scala
@@ -25,7 +25,8 @@ class MatchASTTest extends JSASTTest {
   def stripIdentityMatchEndNonUnitResult: Unit = {
     """
     object A {
-      def foo = "a" match {
+      def aString: String = "a"
+      def foo = aString match {
         case "a" => true
         case "b" => false
       }
@@ -39,7 +40,8 @@ class MatchASTTest extends JSASTTest {
   def stripIdentityMatchEndUnitResult: Unit = {
     """
     object A {
-      def foo = "a" match {
+      def aString: String = "a"
+      def foo = aString match {
         case "a" =>
         case "b" =>
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -582,8 +582,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           }
 
         case Assign(select @ ArraySelect(array, index), rhs) =>
-          unnest(List(array, index, rhs)) {
-            case (List(newArray, newIndex, newRhs), env0) =>
+          unnest(array, index, rhs) { (newArray, newIndex, newRhs, env0) =>
               implicit val env = env0
               val genArray = transformExprNoChar(newArray)
               val genIndex = transformExprNoChar(newIndex)
@@ -616,8 +615,8 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           }
 
         case Assign(select @ JSSelect(qualifier, item), rhs) =>
-          unnest(List(qualifier, item, rhs)) {
-            case (List(newQualifier, newItem, newRhs), env0) =>
+          unnest(qualifier, item, rhs) {
+            (newQualifier, newItem, newRhs, env0) =>
               implicit val env = env0
               js.Assign(
                   genBracketSelect(transformExprNoChar(newQualifier),
@@ -626,8 +625,8 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           }
 
         case Assign(select @ JSSuperSelect(superClass, qualifier, item), rhs) =>
-          unnest(List(superClass, qualifier, item, rhs)) {
-            case (List(newSuperClass, newQualifier, newItem, newRhs), env0) =>
+          unnest(superClass, qualifier, item, rhs) {
+            (newSuperClass, newQualifier, newItem, newRhs, env0) =>
               implicit val env = env0
               genCallHelper("superSet", transformExprNoChar(newSuperClass),
                   transformExprNoChar(newQualifier), transformExprNoChar(item),
@@ -1070,17 +1069,39 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
     /** Same as above, for a single argument */
     def unnest(arg: Tree)(makeStat: (Tree, Env) => js.Tree)(
         implicit env: Env): js.Tree = {
-      unnest(List(arg)) {
-        case (List(newArg), env) => makeStat(newArg, env)
+      unnest(List(arg)) { (newArgs, env) =>
+        val newArg :: Nil = newArgs
+        makeStat(newArg, env)
       }
     }
 
     /** Same as above, for two arguments */
-    def unnest(lhs: Tree, rhs: Tree)(
+    def unnest(arg1: Tree, arg2: Tree)(
         makeStat: (Tree, Tree, Env) => js.Tree)(
         implicit env: Env): js.Tree = {
-      unnest(List(lhs, rhs)) {
-        case (List(newLhs, newRhs), env) => makeStat(newLhs, newRhs, env)
+      unnest(List(arg1, arg2)) { (newArgs, env) =>
+        val newArg1 :: newArg2 :: Nil = newArgs
+        makeStat(newArg1, newArg2, env)
+      }
+    }
+
+    /** Same as above, for 3 arguments */
+    def unnest(arg1: Tree, arg2: Tree, arg3: Tree)(
+        makeStat: (Tree, Tree, Tree, Env) => js.Tree)(
+        implicit env: Env): js.Tree = {
+      unnest(List(arg1, arg2, arg3)) { (newArgs, env) =>
+        val newArg1 :: newArg2 :: newArg3 :: Nil = newArgs
+        makeStat(newArg1, newArg2, newArg3, env)
+      }
+    }
+
+    /** Same as above, for 4 arguments */
+    def unnest(arg1: Tree, arg2: Tree, arg3: Tree, arg4: Tree)(
+        makeStat: (Tree, Tree, Tree, Tree, Env) => js.Tree)(
+        implicit env: Env): js.Tree = {
+      unnest(List(arg1, arg2, arg3, arg4)) { (newArgs, env) =>
+        val newArg1 :: newArg2 :: newArg3 :: newArg4 :: Nil = newArgs
+        makeStat(newArg1, newArg2, newArg3, newArg4, env)
       }
     }
 
@@ -1702,8 +1723,8 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           }
 
         case JSSuperSelect(superClass, qualifier, item) =>
-          unnest(List(superClass, qualifier, item)) {
-            case (List(newSuperClass, newQualifier, newItem), env) =>
+          unnest(superClass, qualifier, item) {
+            (newSuperClass, newQualifier, newItem, env) =>
               redo(JSSuperSelect(newSuperClass, newQualifier, newItem))(env)
           }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -78,8 +78,8 @@ class RegressionTest {
   }
 
   @Test def should_correctly_call_subSequence_on_non_string_CharSequences_issue_55(): Unit = {
-    val arr: CharSequence = Array('a','b','c','d')
-    val ss = arr.subSequence(2,3)
+    val arr: CharSequence = java.nio.CharBuffer.wrap(Array('a', 'b', 'c', 'd'))
+    val ss = arr.subSequence(2, 3)
     assertEquals(1, ss.length())
     assertEquals('c', ss.charAt(0))
   }


### PR DESCRIPTION
* Use `CharBuffer.wrap` to get a `CharSequence` from an `Array[Char]`.
* Address new warnings with the stricter patmat exhaustivity of 2.13.4.
* Adapt `MatchASTTest` for Scala 2.13.4.

---

Supersedes #4272 now that https://github.com/scala/scala/pull/9299 upstream tuned down most of the warnings. Also address two other incompatibilities with 2.13.4.

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.4-bin-e6a6ac6
> testSuite2_13/test:compile # with manual inspection of the warnings in the test suite
> testSuite2_13/test
> testSuiteEx2_13/test
> compiler2_13/test
> ir2_13/test
> linker2_13/test
> testSuite2_13/bootstrap:test
```