### PR TITLE
Fix #4281: Do not treat anonymous JS classes as lambdas

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -499,8 +499,16 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
 
       sym.addAnnotation(JSTypeAnnot)
 
-      val isJSLambda =
-        sym.isAnonymousClass && AllJSFunctionClasses.exists(sym.isSubClass(_))
+      val isJSLambda = {
+        /* Under 2.11, sym.isAnonymousFunction does not properly recognize
+         * anonymous functions here (because they seem to not be marked as
+         * synthetic).
+         */
+        sym.name == tpnme.ANON_FUN_NAME &&
+        sym.info.member(nme.apply).isSynthetic &&
+        AllJSFunctionClasses.exists(sym.isSubClass(_))
+      }
+
       if (isJSLambda)
         transformJSLambdaImplDef(implDef)
       else

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
@@ -95,6 +95,40 @@ class NonNativeJSTypeTest extends DirectTest with TestHelpers {
     """
   }
 
+  @Test // #4281
+  def noExtendJSFunctionAnon: Unit = {
+    """
+    @js.native
+    @JSGlobal("bad")
+    abstract class BadFunction extends js.Function1[Int, String]
+
+    object Test {
+      new BadFunction {
+        def apply(x: Int): String = "f"
+      }
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:11: error: A non-native JS class cannot declare a method named `apply` without `@JSName`
+      |        def apply(x: Int): String = "f"
+      |            ^
+    """
+
+    """
+    class $anonfun extends js.Function1[Int, String] {
+      def apply(x: Int): String = "f"
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: Non-native JS types cannot directly extend native JS traits.
+      |    class $anonfun extends js.Function1[Int, String] {
+      |          ^
+      |newSource1.scala:6: error: A non-native JS class cannot declare a method named `apply` without `@JSName`
+      |      def apply(x: Int): String = "f"
+      |          ^
+    """
+  }
+
   @Test
   def noBracketAccess: Unit = {
     """


### PR DESCRIPTION
This merely improves the error messages.