### PR TITLE
FF ONLY Towards 1.3.2.

### DIFF
--- a/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.3.1",
+    current = "1.3.2-SNAPSHOT",
     binaryEmitted = "1.3"
 )
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,9 +8,6 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
-      // No guarantee of binary compatibility
-      ProblemFilters.exclude[Problem](
-          "org.scalajs.linker.backend.*"),
   )
 
   val LinkerInterface = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -154,7 +154,7 @@ object Build {
 
   val packageMinilib = taskKey[File]("Produces the minilib jar.")
 
-  val previousVersion = "1.3.0"
+  val previousVersion = "1.3.1"
   val previousBinaryCrossVersion = CrossVersion.binaryWith("sjs1_", "")
 
   val scalaVersionsUsedForPublishing: Set[String] =


### PR DESCRIPTION
@gzm0 I did not remove the MiMa exclusions in `BinaryIncompatibilities.scala`, according to your suggestion. We should decide now whether this is the way we want to go.