### PR TITLE
Fix #4292: Return `-1` at first `EOF` at `Base64.DecodingInputStream` 

### DIFF
--- a/javalib/src/main/scala/java/util/Base64.scala
+++ b/javalib/src/main/scala/java/util/Base64.scala
@@ -389,7 +389,8 @@ object Base64 {
         -1
       } else {
         iterate()
-        written
+        if (written == 0 && eof) -1
+        else written
       }
     }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/Base64Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/Base64Test.scala
@@ -12,7 +12,7 @@
 
 package org.scalajs.testsuite.javalib.util
 
-import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException}
+import java.io.{ByteArrayInputStream, ByteArrayOutputStream, IOException, InputStream}
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets.ISO_8859_1
 import java.util.Base64
@@ -283,6 +283,13 @@ class Base64Test {
       val bb = Base64.getMimeDecoder.decode(ByteBuffer.wrap(input.getBytes))
       assertEquals(0, bb.limit())
     }
+  }
+
+  @Test def decodeInputStreamFirstEOF(): Unit = {
+    val emptyInputStream = new InputStream {
+      override def read(): Int = -1
+    }
+    assertEquals(-1, Base64.getDecoder.wrap(emptyInputStream).read())
   }
 
   private def decodeInputStream(decoder: Decoder, input: String,


### PR DESCRIPTION
When `InputStream` that is used as source for `Base64.DecodingInputStream` returns `-1` (aka EOF) at the first read, the `Base64.DecodingInputStream.read` returns `0` that broke contract for this method.

The root cause of the issue that `eof` flag doesn't checked after `iterate`.

Fixed it.