### PR TITLE
Rename master/slave to controller/worker in the testing infrastructure.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -166,7 +166,10 @@ def Tasks = [
         testInterface$v/compile:doc testBridge$v/compile:doc &&
     sbtretry ++$scala headerCheck &&
     sbtretry ++$scala partest$v/fetchScalaSource &&
-    sbtretry ++$scala library$v/mimaReportBinaryIssues testInterface$v/mimaReportBinaryIssues
+    sbtretry ++$scala \
+        library$v/mimaReportBinaryIssues \
+        testInterface$v/mimaReportBinaryIssues \
+        jUnitRuntime$v/mimaReportBinaryIssues
   ''',
 
   "test-suite-default-esversion": '''

--- a/junit-runtime/src/main/scala/com/novocode/junit/JUnitFramework.scala
+++ b/junit-runtime/src/main/scala/com/novocode/junit/JUnitFramework.scala
@@ -30,6 +30,7 @@ final class JUnitFramework extends Framework {
     f.runner(args, remoteArgs, testClassLoader)
   }
 
+  // Aka `workerRunner`; see the Scaladoc of `sbt.testing.Framework` about the name.
   def slaveRunner(args: Array[String], remoteArgs: Array[String],
       testClassLoader: ClassLoader, send: String => Unit): Runner = {
     f.slaveRunner(args, remoteArgs, testClassLoader, send)

--- a/junit-runtime/src/main/scala/org/scalajs/junit/JUnitFramework.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/JUnitFramework.scala
@@ -33,6 +33,7 @@ final class JUnitFramework extends Framework {
     new JUnitRunner(args, remoteArgs, parseRunSettings(args))
   }
 
+  // Aka `workerRunner`; see the Scaladoc of `sbt.testing.Framework` about the name.
   def slaveRunner(args: Array[String], remoteArgs: Array[String],
       testClassLoader: ClassLoader, send: String => Unit): Runner = {
     new JUnitRunner(args, remoteArgs, parseRunSettings(args))

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -16,13 +16,18 @@ object BinaryIncompatibilities {
   val SbtPlugin = Seq(
   )
 
-  val TestCommon = Seq(
-  )
-
-  val TestAdapter = TestCommon ++ Seq(
+  val TestAdapter = Seq(
       // private[adapter], not an issue
       ProblemFilters.exclude[IncompatibleMethTypeProblem](
           "org.scalajs.testing.adapter.JSEnvRPC.this"),
+
+      // private[testing], not an issue
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.testing.common.JVMEndpoints.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.testing.common.JSEndpoints.*"),
+      ProblemFilters.exclude[DirectMissingMethodProblem](
+          "org.scalajs.testing.common.FrameworkMessage.*"),
   )
 
   val Library = Seq(

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -30,4 +30,7 @@ object BinaryIncompatibilities {
 
   val TestInterface = Seq(
   )
+
+  val JUnitRuntime = Seq(
+  )
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1604,6 +1604,8 @@ object Build {
       crossVersion := CrossVersion.binary, // no _sjs suffix
       fatalWarningsSettings,
       name := "Scala.js JUnit test runtime",
+      previousArtifactSetting,
+      mimaBinaryIssueFilters ++= BinaryIncompatibilities.JUnitRuntime,
 
       headerSources in Compile ~= { srcs =>
         srcs.filter { src =>

--- a/sbt-plugin/src/sbt-test/testing/multi-framework/testFramework/shared/src/main/scala/sbttest/framework/BaseRunner.scala
+++ b/sbt-plugin/src/sbt-test/testing/multi-framework/testFramework/shared/src/main/scala/sbttest/framework/BaseRunner.scala
@@ -17,8 +17,8 @@ abstract class BaseRunner(
   private[framework] def taskDone(): Unit
 
   /** Tasks need to wait for this future to complete if they get called with a
-   *  continuation. This is used to ensure that the master/slave message channel
-   *  eventually delivers messages.
+   *  continuation. This is used to ensure that the controller/worker message
+   *  channel eventually delivers messages.
    */
   private[framework] val taskBlock: Future[Unit]
 

--- a/sbt-plugin/src/sbt-test/testing/multi-framework/testFramework/shared/src/main/scala/sbttest/framework/DummyFramework.scala
+++ b/sbt-plugin/src/sbt-test/testing/multi-framework/testFramework/shared/src/main/scala/sbttest/framework/DummyFramework.scala
@@ -15,11 +15,12 @@ final class DummyFramework extends Framework {
   def fingerprints: Array[Fingerprint] = Array(DummyFingerprint)
 
   def runner(args: Array[String], remoteArgs: Array[String],
-      testClassLoader: ClassLoader): MasterRunner =
-    new MasterRunner(args, remoteArgs, testClassLoader)
+      testClassLoader: ClassLoader): ControllerRunner =
+    new ControllerRunner(args, remoteArgs, testClassLoader)
 
+  // Aka `workerRunner`; see the Scaladoc of `sbt.testing.Framework` about the name.
   def slaveRunner(args: Array[String], remoteArgs: Array[String],
-      testClassLoader: ClassLoader, send: String => Unit): SlaveRunner =
-    new SlaveRunner(args, remoteArgs, testClassLoader, send)
+      testClassLoader: ClassLoader, send: String => Unit): WorkerRunner =
+    new WorkerRunner(args, remoteArgs, testClassLoader, send)
 
 }

--- a/sbt-plugin/src/sbt-test/testing/multi-framework/testFramework/shared/src/main/scala/sbttest/framework/WorkerRunner.scala
+++ b/sbt-plugin/src/sbt-test/testing/multi-framework/testFramework/shared/src/main/scala/sbttest/framework/WorkerRunner.scala
@@ -4,7 +4,7 @@ import sbt.testing._
 
 import scala.concurrent._
 
-final class SlaveRunner(
+final class WorkerRunner(
     args: Array[String],
     remoteArgs: Array[String],
     testClassLoader: ClassLoader,
@@ -14,16 +14,16 @@ final class SlaveRunner(
   /** Number of tasks completed on this node */
   private[this] var doneCount = 0
 
-  /** Whether we have seen a Hello message from the master yet */
+  /** Whether we have seen a Hello message from the controller yet */
   private[this] val seenHello = Promise[Unit]()
 
   private[framework] override val taskBlock = seenHello.future
 
-  // Notify master of our existence
+  // Notify the controller of our existence
   send("s")
 
   def tasks(taskDefs: Array[TaskDef]): Array[Task] = {
-    // Notify master of new tasks
+    // Notify the controller of new tasks
     send("t" + taskDefs.length)
     taskDefs.map(newTask)
   }

--- a/test-common/src/main/scala/org/scalajs/testing/common/FrameworkMessage.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/FrameworkMessage.scala
@@ -12,12 +12,12 @@
 
 package org.scalajs.testing.common
 
-private[testing] final class FrameworkMessage(val slaveId: Long, val msg: String)
+private[testing] final class FrameworkMessage(val workerId: Long, val msg: String)
 
 private[testing] object FrameworkMessage {
   implicit object FrameworkMessageSerializer extends Serializer[FrameworkMessage] {
     def serialize(x: FrameworkMessage, out: Serializer.SerializeState): Unit = {
-      out.write(x.slaveId)
+      out.write(x.workerId)
       out.write(x.msg)
     }
 

--- a/test-common/src/main/scala/org/scalajs/testing/common/JSEndpoints.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/JSEndpoints.scala
@@ -18,16 +18,16 @@ private[testing] object JSEndpoints {
   val detectFrameworks: RPCEndpoint.EP[List[List[String]], List[Option[FrameworkInfo]]] =
     RPCEndpoint[List[List[String]], List[Option[FrameworkInfo]]](2)
 
-  val createMasterRunner: RPCEndpoint.EP[RunnerArgs, Unit] =
+  val createControllerRunner: RPCEndpoint.EP[RunnerArgs, Unit] =
     RPCEndpoint[RunnerArgs, Unit](3)
 
-  val createSlaveRunner: RPCEndpoint.EP[RunnerArgs, Unit] =
+  val createWorkerRunner: RPCEndpoint.EP[RunnerArgs, Unit] =
     RPCEndpoint[RunnerArgs, Unit](4)
 
-  val msgSlave: MsgEndpoint.EP[RunMux[String]] =
+  val msgWorker: MsgEndpoint.EP[RunMux[String]] =
     MsgEndpoint[RunMux[String]](5)
 
-  val msgMaster: MsgEndpoint.EP[RunMux[FrameworkMessage]] =
+  val msgController: MsgEndpoint.EP[RunMux[FrameworkMessage]] =
     MsgEndpoint[RunMux[FrameworkMessage]](6)
 
   val tasks: RPCEndpoint.EP[RunMux[List[TaskDef]], List[TaskInfo]] =

--- a/test-common/src/main/scala/org/scalajs/testing/common/JVMEndpoints.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/JVMEndpoints.scala
@@ -15,9 +15,9 @@ package org.scalajs.testing.common
 import sbt.testing.Event
 
 private[testing] object JVMEndpoints {
-  val msgSlave: MsgEndpoint.EP[RunMux[String]] = MsgEndpoint[RunMux[String]](2)
+  val msgWorker: MsgEndpoint.EP[RunMux[String]] = MsgEndpoint[RunMux[String]](2)
 
-  val msgMaster: MsgEndpoint.EP[RunMux[FrameworkMessage]] =
+  val msgController: MsgEndpoint.EP[RunMux[FrameworkMessage]] =
     MsgEndpoint[RunMux[FrameworkMessage]](3)
 
   val event: MsgEndpoint.EP[RunMux[Event]] = MsgEndpoint[RunMux[Event]](4)

--- a/test-common/src/main/scala/org/scalajs/testing/common/RPCCore.scala
+++ b/test-common/src/main/scala/org/scalajs/testing/common/RPCCore.scala
@@ -94,10 +94,10 @@ private[testing] abstract class RPCCore()(implicit ec: ExecutionContext) {
                * future, we can improve this.
                */
               val detail = opCode match {
-                case JSEndpoints.msgSlave.opCode =>
+                case JSEndpoints.msgWorker.opCode =>
                   "; " +
-                  "The test adapter could not send a message to a slave, " +
-                  "which probably happens because the slave terminated early, " +
+                  "The test adapter could not send a message to a worker, " +
+                  "which probably happens because the worker terminated early, " +
                   "without waiting for the reply to a call to send(). " +
                   "This is probably a bug in the testing framework you are " +
                   "using. See also #3201."

--- a/test-interface/src/main/scala/sbt/testing/Framework.scala
+++ b/test-interface/src/main/scala/sbt/testing/Framework.scala
@@ -46,9 +46,15 @@ trait Framework {
   def runner(args: Array[String], remoteArgs: Array[String],
       testClassLoader: ClassLoader): Runner
 
-  /** Scala.js specific: Creates a slave runner for a given run.
+  /** Scala.js specific: Creates a worker runner for a given run.
    *
-   *  The slave may send a message to the master runner by calling `send`.
+   *  The worker may send a message to the controller runner by calling `send`.
+   *
+   *  @note
+   *    This method is called `slaveRunner` rather than `workerRunner` for
+   *    historical reasons. To preserve binary compatibility, it cannot be
+   *    renamed. Moreover, since it must be implemented by user code, we cannot
+   *    add another method with the right name and deprecate this one either.
    */
   def slaveRunner(args: Array[String], remoteArgs: Array[String],
       testClassLoader: ClassLoader, send: String => Unit): Runner

--- a/test-interface/src/main/scala/sbt/testing/Runner.scala
+++ b/test-interface/src/main/scala/sbt/testing/Runner.scala
@@ -25,10 +25,11 @@ package sbt.testing
  *  <code>IllegalStateException</code>.
  *
  *  In Scala.js, the client may request multiple instances of
- *  <code>Runner</code>, where one of these instances is considered the master.
- *  The slaves receive a communication channel to the master. Once the master's
- *  <code>done</code> method is invoked, nothing may be invoked on the slaves
- *  or the master. Slaves can be de-commissioned before the master terminates.
+ *  <code>Runner</code>, where one of these instances is considered the
+ *  controller. The workers receive a communication channel to the controller.
+ *  Once the controller's <code>done</code> method is invoked, nothing may be
+ *  invoked on the workers nor on the controller. Workers can be
+ *  de-commissioned before the controller terminates.
  */
 trait Runner {
 
@@ -102,9 +103,10 @@ trait Runner {
    *  the Framework should throw an IllegalStateException (since it cannot
    *  block).
    *
-   *  Further, if this is the master, the client must not call this method
-   *  before, all done methods of all slaves have returned (otherwise,
-   *  IllegalStateException). If this is a slave, the returned string is ignored.
+   *  Further, if this is the controller, the client must not call this method
+   *  before all `done` methods of all workers have returned (otherwise, an
+   *  `IllegalStateException` is thrown). If this is a worker, the returned
+   *  string is ignored.
    *
    *  @return a possibly multi-line summary string, or the empty string if no
    *          summary is provided
@@ -126,16 +128,17 @@ trait Runner {
    */
   def args: Array[String]
 
-  /** Scala.js specific: Invoked on the master <code>Runner</code>, if a slave
-   *  sends a message (through the channel provided by the client).
+  /** Scala.js specific: Invoked on the controller <code>Runner</code> when a
+   *  worker sends a message (through the channel provided by the client).
    *
-   *  The master may send a message back to the sending slave by returning the
-   *  message in a Some.
+   *  The controller may send a message back to the sending worker by returning
+   *  the message in a `Some`.
    *
-   *  Invoked on a slave <code>Runner</code>, if the master responds to a
-   *  message (sent by the slave via the supplied closure in
-   *  <code>slaveRunner</code>). The return value of the call is ignored in
-   *  this case.
+   *  Invoked on a worker <code>Runner</code> when the controller responds to a
+   *  message (sent by the worker via the supplied closure in
+   *  <code>slaveRunner</code>, aka `workerRunner`; see the Scaladoc of
+   *  `sbt.testing.Framework` about the name.). The return value of the call is
+   *  ignored in this case.
    */
   def receiveMessage(msg: String): Option[String]
 


### PR DESCRIPTION
This is just to avoid the controversial pair of words "master/slave". The change aligns with how those things were named in Scala Native.

The method `sbt.testing.Framework.slaveRunner` is not renamed, because doing so would break binary compatibility.

In BinaryIncompatibilities, we merge `TestCommon` and `TestAdapter`. `TestCommon` used to be reused for the `test-bridge` artifact, but that one does not have any binary compatibility constraints anymore, so the distinction was artificial.

---

This PR is a direct consequence of the [Scala Center Advisory Board Recommendation SCP-025](https://github.com/scalacenter/advisoryboard/blob/master/proposals/025-inclusive-language.md), which was adopted at the latest Advisory Board Meeting. Although we have not worked on a list of words to avoid yet, it is clear that the "master/slave" association will end up on the eventual list (even if it's the only thing that ends up there). So this PR is a first step in that direction.

/cc @olafurpg, since you were interested in the issue with the `slaveRunner` method.