### PR TITLE
Fix #3667: Allow strings longer than Short.MaxValue in test adapter

### DIFF
--- a/test-common/src/test/scala/org/scalajs/testing/common/SerializerTest.scala
+++ b/test-common/src/test/scala/org/scalajs/testing/common/SerializerTest.scala
@@ -37,4 +37,12 @@ class SerializerTest {
     assertNull(deserialized.getFileName)
     assertEquals("MyClass.myMethod(Unknown Source)", deserialized.toString)
   }
+
+  // #3667
+  @Test
+  def serializeLargeString: Unit = {
+    val x = new String(Array.tabulate(Short.MaxValue + 1)(_.toChar))
+    val y = roundTrip(x)
+    assertEquals(x, y)
+  }
 }


### PR DESCRIPTION
I have manually checked that the new test fails without the changes.