### PR TITLE
Fix usages of Jimfs in tests on Windows.

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ environment:
   global:
     NODEJS_VERSION: "12"
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0
-    SCALA_VERSION: 2.12.11
+    SCALA_VERSION: 2.12.12
 install:
   - ps: Install-Product node $env:NODEJS_VERSION
   - npm install
@@ -14,7 +14,8 @@ install:
 build: off
 test_script:
   # Very far from testing everything, but at least it is a good sanity check
-  - cmd: sbt ";clean;++%SCALA_VERSION%;testSuite2_12/test"
+  # For slow things (partest and scripted), we execute only one test
+  - cmd: sbt ";clean;++%SCALA_VERSION%;testSuite2_12/test;linker2_12/test;partestSuite2_12/testOnly -- --fastOpt run/option-fold.scala;sbtPlugin/scripted settings/module-init"
 cache:
   - C:\sbt
   - C:\Users\appveyor\.ivy2\cache

--- a/linker/jvm/src/test/scala/org/scalajs/linker/PathOutputDirectoryTest.scala
+++ b/linker/jvm/src/test/scala/org/scalajs/linker/PathOutputDirectoryTest.scala
@@ -36,7 +36,7 @@ class PathOutputDirectoryTest {
 
   @Test
   def avoidUnnecessaryWrite(): AsyncResult = await {
-    val dir = Jimfs.newFileSystem().getPath("/tmp")
+    val dir = Jimfs.newFileSystem().getPath("tmp").toAbsolutePath()
     Files.createDirectory(dir)
 
     val fileName = "file.js"
@@ -59,7 +59,7 @@ class PathOutputDirectoryTest {
 
   @Test
   def readFull(): AsyncResult = await {
-    val dir = Jimfs.newFileSystem().getPath("/tmp")
+    val dir = Jimfs.newFileSystem().getPath("tmp").toAbsolutePath()
     Files.createDirectory(dir)
 
     val fileName = "file.js"
@@ -82,7 +82,7 @@ class PathOutputDirectoryTest {
       .setAttributeViews("basic", "posix")
       .build()
 
-    val dir = Jimfs.newFileSystem(config).getPath("/tmp")
+    val dir = Jimfs.newFileSystem(config).getPath("/tmp") // we forced Unix, so /tmp is fine
     Files.createDirectory(dir)
 
     val fileName = "file.js"

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -96,7 +96,7 @@ class MainGenericRunner {
     val linker = StandardImpl.linker(linkerConfig)
 
     val sjsCode = {
-      val dir = Jimfs.newFileSystem().getPath("/tmp")
+      val dir = Jimfs.newFileSystem().getPath("tmp").toAbsolutePath()
       Files.createDirectory(dir)
 
       val cache = StandardImpl.irFileCache().newCache


### PR DESCRIPTION
Jimfs defaults to using a configuration that matches the OS it is running on. On Windows, that means that there is no such thing as a top-level `/tmp` path. Instead, we now use `getPath("tmp").toAbsolutePath()`.

We add some smoke tests in the AppVeyor build to prevent regressions in the future.