### PR TITLE
Use constant extractors of AnnotationInfos for JSName

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSGlobalAddons.scala
@@ -350,9 +350,10 @@ trait JSGlobalAddons extends JSDefinitions
       sym.getAnnotation(JSNameAnnotation).fold[JSName] {
         JSName.Literal(defaultJSNameOf(sym))
       } { annotation =>
-        annotation.args.head match {
-          case Literal(Constant(name: String)) => JSName.Literal(name)
-          case tree                            => JSName.Computed(tree.symbol)
+        annotation.constantAtIndex(0).collect {
+          case Constant(name: String) => JSName.Literal(name)
+        }.getOrElse {
+          JSName.Computed(annotation.args.head.symbol)
         }
       }
     }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -1205,7 +1205,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
     private def checkJSNameArgument(memberSym: Symbol, annot: AnnotationInfo): Unit = {
       val argTree = annot.args.head
       if (argTree.tpe.typeSymbol == StringClass) {
-        if (!argTree.isInstanceOf[Literal]) {
+        if (annot.stringArg(0).isEmpty) {
           reporter.error(argTree.pos,
               "A string argument to JSName must be a literal string")
         }


### PR DESCRIPTION
This is to future-proof for when scala/scala#9342 lands and prevent a
similar issue to #3737 for JSName.