### PR TITLE
Fix #4301: Survey (and fix) all non-internal usages of Path#getParent

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputFile.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputFile.scala
@@ -20,8 +20,9 @@ import org.scalajs.linker.interface.unstable.OutputFileImpl
 @deprecated("Part of old Linker interface. Use PathOutputDirectory instead.", "1.3.0")
 object PathOutputFile {
   def apply(path: Path): LinkerOutput.File = {
-    val dir = PathOutputDirectory(path.getParent())
-    new OutputFileImpl(path.getFileName().toString(), dir)
+    val np = path.toAbsolutePath().normalize()
+    val dir = PathOutputDirectory(np.getParent())
+    new OutputFileImpl(np.getFileName().toString(), dir)
   }
 
   def atomic(path: Path): LinkerOutput.File =

--- a/linker/jvm/src/test/scala/org/scalajs/linker/PathOutputDirectoryTest.scala
+++ b/linker/jvm/src/test/scala/org/scalajs/linker/PathOutputDirectoryTest.scala
@@ -36,7 +36,7 @@ class PathOutputDirectoryTest {
 
   @Test
   def avoidUnnecessaryWrite(): AsyncResult = await {
-    val dir = Jimfs.newFileSystem().getPath("tmp").toAbsolutePath()
+    val dir = Jimfs.newFileSystem().getPath("tmp")
     Files.createDirectory(dir)
 
     val fileName = "file.js"
@@ -59,7 +59,7 @@ class PathOutputDirectoryTest {
 
   @Test
   def readFull(): AsyncResult = await {
-    val dir = Jimfs.newFileSystem().getPath("tmp").toAbsolutePath()
+    val dir = Jimfs.newFileSystem().getPath("tmp")
     Files.createDirectory(dir)
 
     val fileName = "file.js"
@@ -82,7 +82,7 @@ class PathOutputDirectoryTest {
       .setAttributeViews("basic", "posix")
       .build()
 
-    val dir = Jimfs.newFileSystem(config).getPath("/tmp") // we forced Unix, so /tmp is fine
+    val dir = Jimfs.newFileSystem(config).getPath("tmp")
     Files.createDirectory(dir)
 
     val fileName = "file.js"

--- a/linker/jvm/src/test/scala/org/scalajs/linker/PathOutputFileTest.scala
+++ b/linker/jvm/src/test/scala/org/scalajs/linker/PathOutputFileTest.scala
@@ -1,0 +1,43 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker
+
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import java.nio.ByteBuffer
+import java.nio.file.Files
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.junit.async._
+
+import com.google.common.jimfs.Jimfs
+
+import org.scalajs.linker.interface.unstable.OutputFileImpl
+
+@deprecated("Mark deprecated to silence warnings", "never/always")
+class PathOutputFileTest {
+
+  @Test // #4301
+  def withRelativePath(): AsyncResult = await {
+    val file = Jimfs.newFileSystem().getPath("file")
+
+    val impl = OutputFileImpl.fromOutputFile(PathOutputFile(file))
+
+    impl.writeFull(ByteBuffer.wrap(Array())).map { _ =>
+      assertTrue(Files.exists(file))
+    }
+  }
+
+}

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -96,7 +96,7 @@ class MainGenericRunner {
     val linker = StandardImpl.linker(linkerConfig)
 
     val sjsCode = {
-      val dir = Jimfs.newFileSystem().getPath("tmp").toAbsolutePath()
+      val dir = Jimfs.newFileSystem().getPath("tmp")
       Files.createDirectory(dir)
 
       val cache = StandardImpl.irFileCache().newCache

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -936,6 +936,7 @@ object Build {
           "org.scala-sbt" % "test-interface" % "1.0",
           "org.scala-js" %% "scalajs-js-envs" % "1.1.1",
           "com.novocode" % "junit-interface" % "0.11" % "test",
+          "com.google.jimfs" % "jimfs" % "1.1" % "test",
       ),
       previousArtifactSetting,
       mimaBinaryIssueFilters ++= BinaryIncompatibilities.TestAdapter,

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LinkerImpl.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LinkerImpl.scala
@@ -41,8 +41,10 @@ trait LinkerImpl {
   def outputDirectory(path: Path): OutputDirectory
 
   @deprecated("Use outputDirectory instead", "1.3.0")
-  final def outputFile(path: Path): LinkerOutput.File =
-    new OutputFileImpl(path.getFileName().toString(), outputDirectory(path.getParent()))
+  final def outputFile(path: Path): LinkerOutput.File = {
+    val np = path.toAbsolutePath().normalize()
+    new OutputFileImpl(np.getFileName().toString(), outputDirectory(np.getParent()))
+  }
 }
 
 /** Factory methods and concrete implementations of `LinkerImpl`.

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/HTMLRunnerBuilder.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/HTMLRunnerBuilder.scala
@@ -55,10 +55,12 @@ object HTMLRunnerBuilder {
   def write(output: Path, artifactsDir: Path, title: String, input: Seq[Input],
       frameworkImplClassNames: List[List[String]],
       taskDefs: List[TaskDef]): Unit = {
+    val absoluteArtifacts = artifactsDir.toAbsolutePath()
+    val outputDir = output.toAbsolutePath().normalize().getParent()
 
     def artifactPath(name: String): (String, Path) = {
-      val path = artifactsDir.resolve(name)
-      val relPath = output.getParent().relativize(path)
+      val path = absoluteArtifacts.resolve(name)
+      val relPath = outputDir.relativize(path)
       (joinRelPath(relPath), path)
     }
 

--- a/test-adapter/src/test/scala/org/scalajs/testing/adapter/HTMLRunnerBuilderTest.scala
+++ b/test-adapter/src/test/scala/org/scalajs/testing/adapter/HTMLRunnerBuilderTest.scala
@@ -1,0 +1,35 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testing.adapter
+
+import java.nio.file.Files
+
+import org.junit.Test
+
+import com.google.common.jimfs.Jimfs
+
+class HTMLRunnerBuilderTest {
+
+  @Test // #4301
+  def relativeOutputFile(): Unit = {
+    val fs = Jimfs.newFileSystem()
+    val output = fs.getPath("runner.html")
+    val artifactsDir = fs.getPath("artifacts")
+
+    Files.createDirectory(artifactsDir)
+
+    HTMLRunnerBuilder.write(output, artifactsDir, "This is only a test", Nil,
+        Nil, Nil)
+  }
+
+}


### PR DESCRIPTION
`Path#getParent` simply truncates the last element, even if it is a "special" one like `..`. Moreover, `getParent` on a single element relative path returns `null`, potentially causing NPEs down the line.

It turns out that most of our usages of `getParent` were OK in their context. This PR fixes the others.