### PR TITLE
Fix #4311: Avoid moving input files in HTMLRunnerBuilder

### DIFF
--- a/TESTING.md
+++ b/TESTING.md
@@ -7,6 +7,20 @@ The following HTML-runners must be manually tested:
     examples/helloworld/helloworld-{2.11|2.12}{|-fastopt}.html
     examples/reversi/reversi-{2.11|2.12}{|-fastopt}.html
 
+## HTML-Test Runner with Modules
+
+Still manual, because jsdom does not support modules yet
+[jsdom/jsdom#2475](https://github.com/jsdom/jsdom/issues/2475).
+
+```
+$ sbt
+> set scalaJSLinkerConfig in testingExample.v2_12 ~= (_.withOutputPatterns(OutputPatterns.fromJSFile("%s.mjs")).withModuleSplitStyle(ModuleSplitStyle.SmallestModules).withModuleKind(ModuleKind.ESModule))
+> testingExample2_12/testHtml
+> exit
+$ python3 -m http.server -d examples/testing/.2.12/target/scala-2.12
+// Open http://localhost:8000/testing-fastopt-test-html/index.html
+```
+
 ## Sourcemaps
 
 To test source maps, do the following on:

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -126,9 +126,16 @@ object MyScalaJSPlugin extends AutoPlugin {
       },
 
       testHtmlJSDom in Test := {
-        val runner = (testHtml in Test).value.data.getAbsolutePath()
+        val target = crossTarget.value.toPath().toAbsolutePath()
 
-        val code = new ProcessBuilder("node", "scripts/test-html.js", runner)
+        // When serving `target` over HTTP, the path of the runner file.
+        val runnerPath = {
+          val runner = (testHtml in Test).value.data.toPath().toAbsolutePath()
+          target.relativize(runner).toString()
+        }
+
+        val code = new ProcessBuilder(
+            "node", "scripts/test-html.js", target.toString(), runnerPath)
           .inheritIO()
           .start()
           .waitFor()

--- a/scripts/test-html.js
+++ b/scripts/test-html.js
@@ -1,15 +1,15 @@
 const process = require("process");
 const { JSDOM } = require("jsdom");
-const path = require("path");
 const http = require("http");
 const static = require('node-static');
 
-const { dir, base: filename } = path.parse(process.argv[2]);
+const servingDirectory = process.argv[2];
+const requestPath = process.argv[3];
 
-console.log(`serving: ${dir}`);
+console.log(`serving: ${servingDirectory}`);
 
-serveDirectory(dir).then(server => {
-  const url = makeURL(server.address(), filename);
+serveDirectory(servingDirectory).then(server => {
+  const url = makeURL(server.address(), requestPath);
 
   console.log(`loading ${url}`);
 
@@ -69,14 +69,14 @@ function serveDirectory(dir) {
   });
 }
 
-function makeURL(serverAddress, filename) {
+function makeURL(serverAddress, path) {
   const { port, address, family } = serverAddress;
 
   if (family === "IPv4")
-    return `http://${address}:${port}/${filename}`
+    return `http://${address}:${port}/${path}`
 
   if (family === "IPv6")
-    return `http://[${address}]:${port}/${filename}`
+    return `http://[${address}]:${port}/${path}`
 
   throw new Error(`do not know how to construct URL for address family ${family}`);
 }

--- a/test-adapter/src/test/scala/org/scalajs/testing/adapter/HTMLRunnerBuilderTest.scala
+++ b/test-adapter/src/test/scala/org/scalajs/testing/adapter/HTMLRunnerBuilderTest.scala
@@ -15,8 +15,11 @@ package org.scalajs.testing.adapter
 import java.nio.file.Files
 
 import org.junit.Test
+import org.junit.Assert._
 
 import com.google.common.jimfs.Jimfs
+
+import org.scalajs.jsenv.Input
 
 class HTMLRunnerBuilderTest {
 
@@ -32,4 +35,41 @@ class HTMLRunnerBuilderTest {
         Nil, Nil)
   }
 
+  @Test
+  def supportMultipleFileSystems(): Unit = {
+    val fs0 = Jimfs.newFileSystem()
+    val fs1 = Jimfs.newFileSystem()
+
+    val output = fs0.getPath("runner.html")
+    val artifactsDir = fs0.getPath("artifacts")
+
+    val inputFiles = Seq(fs0.getPath("my.js"), fs1.getPath("my.js"))
+    val input = inputFiles.map(Input.Script(_))
+
+    Files.createDirectory(artifactsDir)
+    inputFiles.foreach(Files.write(_, Array[Byte]()))
+
+    HTMLRunnerBuilder.write(output, artifactsDir, "This is only a test", input,
+        Nil, Nil)
+  }
+
+  @Test
+  def checksOutputsOnSameFileSystems(): Unit = {
+    val fs0 = Jimfs.newFileSystem()
+    val fs1 = Jimfs.newFileSystem()
+
+    val output = fs0.getPath("runner.html")
+    val artifactsDir = fs1.getPath("artifacts")
+
+    Files.createDirectory(artifactsDir)
+
+    try {
+      HTMLRunnerBuilder.write(output, artifactsDir, "This is only a test", Nil,
+          Nil, Nil)
+      fail("expected exception")
+    } catch {
+      case e: IllegalArgumentException =>
+        assertEquals("cannot relativize `artifactsDir` with respect to `output`", e.getMessage())
+    }
+  }
 }


### PR DESCRIPTION
We directly refer to an input if it is on the same filesystem than the
output/artifactsDir.

Further, we add a section to TESTING to test ES module support in the
browser (the full testSuite is not in there yet, due to #4312).