### PR TITLE
Fix #4325: Fix GCC pretty printing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -105,6 +105,7 @@ def Tasks = [
     npm install &&
     sbtretry ++$scala helloworld$v/run &&
     sbtretry 'set scalaJSStage in Global := FullOptStage' \
+        'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withPrettyPrint(true))' \
         ++$scala helloworld$v/run \
         helloworld$v/clean &&
     sbtretry 'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withOptimizer(false))' \

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -22,8 +22,6 @@ import org.scalajs.linker.backend.javascript.Trees._
 import org.scalajs.linker.backend.javascript.SourceFileUtil
 
 import com.google.javascript.rhino._
-import com.google.javascript.rhino.StaticSourceFile.SourceKind
-import com.google.javascript.jscomp.SourceFile
 import com.google.javascript.jscomp.parsing.parser.FeatureSet
 
 import scala.annotation.tailrec
@@ -531,7 +529,7 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
 
   private def attachSourceFile(node: Node, source: URI): node.type = {
     val str = SourceFileUtil.webURI(relativizeBaseURI, source)
-    val file = new SourceFile(str, SourceKind.STRONG)
+    val file = new SimpleSourceFile(str, StaticSourceFile.SourceKind.STRONG)
 
     /* A lot of Closure code makes the assumption that the InputId is the
      * filename. We follow this assumption so we can use more of the already


### PR DESCRIPTION
Our usage of `SourceFile` was wrong: It has provisions to retrieve the
original source code and some of the pretty printing functionality
attempts to use this (e.g. to write a number as it was written in the
original source).

We switch to `SimpleSourceFile` which contains a minimum
implementation of `StaticSourceFile` (the interface actually required
by `Node`).