### PR TITLE
Fix #4335: Call `cleanAfterRun` on LinkedJSMethodPropDefInfoCache

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/MemOutputDirectory.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/MemOutputDirectory.scala
@@ -25,6 +25,9 @@ import org.scalajs.linker.interface.unstable.OutputDirectoryImpl
 sealed trait MemOutputDirectory extends OutputDirectory {
   /** Content of the file with `name` or `None` if the file was not written. */
   def content(name: String): Option[Array[Byte]]
+
+  /** Names of files that are present (in no particular order). */
+  def fileNames(): List[String]
 }
 
 object MemOutputDirectory {
@@ -36,6 +39,10 @@ object MemOutputDirectory {
 
     def content(name: String): Option[Array[Byte]] = synchronized {
       _content.get(name)
+    }
+
+    def fileNames(): List[String] = synchronized {
+      _content.keys.toList
     }
 
     def writeFull(name: String, buf: ByteBuffer)(
@@ -56,7 +63,7 @@ object MemOutputDirectory {
     }
 
     def listFiles()(implicit ec: ExecutionContext): Future[List[String]] = synchronized {
-      Future.successful(_content.keys.toList)
+      Future.successful(fileNames())
     }
 
     def delete(name: String)(implicit ec: ExecutionContext): Future[Unit] = synchronized {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -269,8 +269,10 @@ private object Refiner {
       }
     }
 
-    // Just for consistency of API wrt. LinkedMethodDefsInfosCache
-    def cleanAfterRun(): Unit = ()
+    def cleanAfterRun(): Unit = {
+      if (caches != null)
+        caches.foreach(_.cleanAfterRun())
+    }
   }
 
   private object LinkedJSMethodPropDefsInfosCache {

--- a/linker/shared/src/test/scala/org/scalajs/linker/IncrementalTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IncrementalTest.scala
@@ -1,0 +1,147 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker
+
+import scala.concurrent._
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.ir.ClassKind
+import org.scalajs.ir.Names._
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
+
+import org.scalajs.logging._
+
+import org.scalajs.junit.async._
+
+import org.scalajs.linker._
+import org.scalajs.linker.interface._
+
+import org.scalajs.linker.testutils._
+import org.scalajs.linker.testutils.TestIRBuilder._
+
+class IncrementalTest {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  import IncrementalTest._
+
+  @Test // #4335
+  def testChangeMethodReachedFromExport(): AsyncResult = await {
+
+    val FooClass = ClassName("Foo")
+
+    val jsMethodName = StringLiteral("foo")
+    val staticMethodName = m("value", Nil, IntRef)
+
+    def classDefs(pre: Boolean) = Seq(
+        mainTestClassDef(
+            consoleLog(JSMethodApply(LoadModule(FooClass), jsMethodName, Nil))
+        ),
+        classDef(
+            FooClass,
+            kind = ClassKind.ModuleClass,
+            superClass = Some(ObjectClass),
+            memberDefs = List(
+                trivialCtor(FooClass),
+                JSMethodDef(
+                    EMF, jsMethodName, Nil,
+                    if (pre) int(5)
+                    else ApplyStatic(EAF, FooClass, staticMethodName, Nil)(IntType))(
+                    EOH, None),
+                MethodDef(EMF.withNamespace(MemberNamespace.PublicStatic),
+                    staticMethodName, NON, Nil, IntType, Some(int(6)))(EOH, None)
+            )
+        )
+    )
+
+    testIncremental(classDefs(_), _ => MainTestModuleInitializers)
+  }
+
+}
+
+object IncrementalTest {
+
+  def testIncremental(
+      classDefs: Boolean => Seq[ClassDef],
+      moduleInitializers: Boolean => List[ModuleInitializer],
+      config: StandardConfig = StandardConfig())(
+      implicit ec: ExecutionContext): Future[Unit] = {
+    for {
+      _ <- testIncrementalStep(backward = false, classDefs, moduleInitializers, config)
+      _ <- testIncrementalStep(backward = true, classDefs, moduleInitializers, config)
+    } yield ()
+  }
+
+  private def testIncrementalStep(
+      backward: Boolean,
+      classDefs: Boolean => Seq[ClassDef],
+      moduleInitializers: Boolean => List[ModuleInitializer],
+      config: StandardConfig = StandardConfig())(
+      implicit ec: ExecutionContext): Future[Unit] = {
+
+    val outputInc = MemOutputDirectory()
+    val outputBatch = MemOutputDirectory()
+
+    val linkerInc = StandardImpl.linker(config)
+    val linkerBatch = StandardImpl.linker(config)
+
+    val logger = new ScalaConsoleLogger(Level.Error)
+
+    for {
+      minilib <- TestIRRepo.minilib
+      classDefs0 = minilib ++ classDefs(!backward).map(MemClassDefIRFile(_))
+      classDefs1 = minilib ++ classDefs(backward).map(MemClassDefIRFile(_))
+      inits0 = moduleInitializers(backward)
+      inits1 = moduleInitializers(!backward)
+      _ <- linkerInc.link(classDefs0, inits0, outputInc, logger)
+      reportInc <- linkerInc.link(classDefs1, inits1, outputInc, logger)
+      reportBatch <- linkerBatch.link(classDefs1, inits1, outputBatch, logger)
+    } yield {
+      assertModulesEqual(s"Public modules in report equal (backward = $backward)",
+          reportInc.publicModules, reportBatch.publicModules)
+
+      assertOutputEquals(s"Outputs equal (backward = $backward)",
+          outputInc, outputBatch)
+    }
+  }
+
+  private def assertModulesEqual(msg: String, inc: Iterable[Report.Module],
+      batch: Iterable[Report.Module]): Unit = {
+    // Poor man's equality based on toString()
+
+    def strs(ms: Iterable[Report.Module]) =
+      ms.map(m => m.moduleID -> m.toString()).toMap
+
+    assertEquals(msg, strs(inc), strs(batch))
+  }
+
+  private def assertOutputEquals(msg: String, inc: MemOutputDirectory,
+      batch: MemOutputDirectory): Unit = {
+    val filesInc = inc.fileNames()
+    val filesBatch = batch.fileNames()
+
+    assertEquals(s"$msg: set of files", filesInc.toSet, filesBatch.toSet)
+
+    for (f <- filesInc.sorted) {
+      assertEquals(
+          s"$msg: content of $f",
+          new String(inc.content(f).get, UTF_8),
+          new String(batch.content(f).get, UTF_8)
+      )
+    }
+  }
+}

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -10,6 +10,10 @@ object BinaryIncompatibilities {
   val Linker = Seq(
       // Breaking in stable API. OK in Minor version.
       exclude[Problem]("org.scalajs.linker.standard.*"),
+
+      // New method in sealed trait, not an issue.
+      exclude[ReversedMissingMethodProblem](
+          "org.scalajs.linker.MemOutputDirectory.fileNames"),
   )
 
   val LinkerInterface = Seq(


### PR DESCRIPTION
I have manually verified that the test case fails without the fix.