### PR TITLE
Improve/fix check for whether an $is_ function needs to be defined

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -803,13 +803,10 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
         }
       }
 
-      val needIsFunction = !isHijackedClass && (isExpression match {
-        case js.BinaryOp(JSBinaryOp.instanceof, _, _) =>
-          // This is a simple `instanceof`. It will always be inlined at call site.
-          false
-        case _ =>
-          true
-      })
+      val needIsFunction = !isHijackedClass && {
+        !tree.kind.isClass ||
+        globalKnowledge.isAncestorOfHijackedClass(className)
+      }
 
       val createIsStatWithGlobals = if (needIsFunction) {
         globalFunctionDef("is", className, List(objParam), js.Return(isExpression))


### PR DESCRIPTION
Since 4f855d3 (Avoid fake classes by
constant-folding "impossible" instance tests), we would start defining
an (unused) $is_ function for classes that have no instances.

Instead of basing the check on the generated tree, we base it on the
same condition than the code that generates the call-sites.

As a further side-effect, this does not generate (unused) $is_
functions anymore for hijacked classes.