### PR TITLE
Add groups to RegExp.ExecResult

### DIFF
--- a/assets/additional-doc-styles.css
+++ b/assets/additional-doc-styles.css
@@ -1,4 +1,4 @@
-.badge-ecma6, .badge-ecma2015, .badge-ecma2017, .badge-ecma2019, .badge-ecma2020 {
+.badge-ecma6, .badge-ecma2015, .badge-ecma2017, .badge-ecma2018, .badge-ecma2019, .badge-ecma2020 {
   background-color: #E68A00;
 }
 

--- a/library/src/main/scala/scala/scalajs/js/RegExp.scala
+++ b/library/src/main/scala/scala/scalajs/js/RegExp.scala
@@ -117,5 +117,9 @@ object RegExp extends js.Object {
   trait ExecResult extends js.Array[js.UndefOr[String]] {
     var index: Int
     var input: String
+
+    /** <span class="badge badge-ecma2018" style="float: right;">ECMAScript 2018</span>
+     */
+    var groups: js.UndefOr[js.Dictionary[js.UndefOr[String]]]
   }
 }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -33,6 +33,10 @@ object BinaryIncompatibilities {
   val Library = Seq(
       // New concrete method in native JS trait, not an issue.
       exclude[ReversedMissingMethodProblem]("scala.scalajs.js.typedarray.TypedArray.fill"),
+
+      // New optional member in JS trait, not an issue.
+      exclude[ReversedMissingMethodProblem]("scala.scalajs.js.RegExp#ExecResult.groups"),
+      exclude[ReversedMissingMethodProblem]("scala.scalajs.js.RegExp#ExecResult.groups_="),
   )
 
   val TestInterface = Seq(

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/RegExpTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/RegExpTest.scala
@@ -1,0 +1,71 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.library
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.scalajs.js
+
+class RegExpTest {
+  @Test def execNoGroup(): Unit = {
+    val result = js.RegExp("([0-9]{4})-([0-9]{2})-([0-9]{2})")
+      .exec("1992-12-31")
+
+    assertEquals(4, result.length)
+    assertEquals("1992-12-31", result(0))
+    assertEquals("1992", result(1))
+    assertEquals("12", result(2))
+    assertEquals("31", result(3))
+    assertEquals(js.undefined, result(4))
+    assertEquals(js.undefined, result.groups)
+  }
+
+  @Test def execWithGroupNoMatch(): Unit = {
+    val result = js.RegExp("(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})")
+      .exec("abc")
+
+    assertEquals(null, result)
+  }
+
+  @Test def execWithGroupMatch(): Unit = {
+    val result = js.RegExp("(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})")
+      .exec("1992-12-31")
+
+    assertEquals(4, result.length)
+    assertEquals("1992-12-31", result(0))
+    assertEquals("1992", result(1))
+    assertEquals("12", result(2))
+    assertEquals("31", result(3))
+    assertEquals(js.undefined, result(4))
+
+    val groups = result.groups.get
+    assertEquals(3, js.Object.entries(groups).length)
+    assertEquals("1992", groups("year"))
+    assertEquals("12", groups("month"))
+    assertEquals("31", groups("day"))
+  }
+
+  @Test def execWithOptGroupMatch(): Unit = {
+    val result = js.RegExp("foo(?<prop>bar)?baz")
+      .exec("foobaz")
+
+    assertEquals(2, result.length)
+    assertEquals("foobaz", result(0))
+    assertEquals(js.undefined, result(1))
+
+    val groups = result.groups.get
+    assertEquals(1, js.Object.entries(groups).length)
+    assertEquals(js.undefined, groups("prop"))
+  }
+}


### PR DESCRIPTION
Add `groups` to `RegExp.ExecResult` (added in [ECMAScript 2018](https://ecma-international.org/ecma-262/9.0/), original [proposal](https://github.com/tc39/proposal-regexp-named-groups))

Tested in
- browsers: here Chrome 87 but similar results in Firefox 84 and Safari 13.1
<img width="671" alt="Screenshot 2020-12-29 at 09 18 03" src="https://user-images.githubusercontent.com/6972399/103269840-eaf91500-49b6-11eb-85f8-df967a196597.png">

- Node.js 12
<img width="603" alt="Screenshot 2020-12-29 at 09 17 50" src="https://user-images.githubusercontent.com/6972399/103269864-019f6c00-49b7-11eb-97d8-f4e1e3e38097.png">

⚠️ Questions:
- [Contributing guidelines](https://github.com/scala-js/scala-js/blob/master/CONTRIBUTING.md) mentions `All code contributed to the user-facing standard library (the library/ directory) should come accompanied with documentation`. Should I do it as other members of `ExecResult` are not documented?
- I was not able to find a place to add a unit test, can you point me to the correct location please?