### PR TITLE
Fix #4350: Handle non-matching groups in Matcher#replace*.

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -97,7 +97,9 @@ final class Matcher private[regex] (
           while (i < len && isDigit(replacement.charAt(i)))
             i += 1
           val group = Integer.parseInt(replacement.substring(j, i))
-          sb.append(this.group(group))
+          val replaced = this.group(group)
+          if (replaced != null)
+            sb.append(replaced)
 
         case '\\' =>
           i += 1

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -374,6 +374,13 @@ class RegexMatcherTest  {
     assertEquals("-foo-foo-foo-", matcher.replaceAll("-"))
   }
 
+  @Test def replaceAllIn(): Unit = {
+    val matcher = Pattern
+      .compile("(?:(ab)|(a))c(d)|(e)")
+      .matcher("abcd")
+    assertEquals("1=ab,2=,3=d,4=", matcher.replaceAll("1=$1,2=$2,3=$3,4=$4"))
+  }
+
   @Test def replaceFirst(): Unit = {
     // From the JavaDoc
     val matcher = Pattern


### PR DESCRIPTION
This is a minimal PR to make the behavior of `Matcher#replace*` methods behave like their JVM counterpart by not appending the String `"null"` when a match group is `null`.
Fixes https://github.com/scala-js/scala-js/issues/4350.