### PR TITLE
Upgrade sbt to 1.3.13.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -638,6 +638,9 @@ object Build {
   }
 
   val thisBuildSettings = Def.settings(
+      // Disable sbt 1.3.x+'s supershell, because it's terribly annoying
+      useSuperShell := false,
+
       // JDK version we are running with
       javaVersion in Global := {
         val fullVersion = System.getProperty("java.version")

--- a/project/ExternalCompile.scala
+++ b/project/ExternalCompile.scala
@@ -78,7 +78,7 @@ object ExternalCompile {
             def log(level: Level.Value, message: => String) = {
               val msg = message
               if (level != Level.Info ||
-                  !msg.startsWith("Running (fork) scala.tools.nsc.Main"))
+                  !msg.startsWith("running (fork) scala.tools.nsc.Main"))
                 logger.log(level, msg)
             }
             def success(message: => String) = logger.success(message)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.13


### PR DESCRIPTION
This is the latest (and very likely last) 1.3.x version.

Recent versions of Metals cannot import builds using sbt 1.2.x anymore. The initial import fails with a LinkageError because it wants to access a setting that was added in sbt 1.3.0.

This change may make our sbt plugin incompatible with sbt 1.2.x builds, as our main source of tests for it are our own build. However, almost all the scripted tests force to use sbt 1.2.8, and should give some confidence that we aren't breaking anything.

If we do, oh well, sbt 1.2.x is a bit old anyway.