### PR TITLE
Remove as many implicit conversions in the test suite as possible.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.compiler
 
-import scala.language.implicitConversions
-
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
@@ -22,6 +20,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.JSAssert._
 import org.scalajs.testsuite.utils.Platform._
 
 /*
@@ -31,14 +30,8 @@ import org.scalajs.testsuite.utils.Platform._
 class InteroperabilityTest {
   import InteroperabilityTest._
 
-  implicit def jsArray2Array[T](a: js.Array[T]): Array[AnyRef] =
-    a.map(_.asInstanceOf[AnyRef]).toArray
-
-  implicit def array2Array[T](a: Array[T]): Array[AnyRef] =
-    a.map(_.asInstanceOf[AnyRef])
-
-  def assertArrayDynEquals[T](expected: Array[T], actual: js.Dynamic): Unit = {
-    assertArrayEquals(expected, jsArray2Array(actual.asInstanceOf[js.Array[Any]]))
+  def assertArrayDynEquals(expected: js.Array[Any], actual: js.Dynamic): Unit = {
+    assertJSArrayEquals(expected, actual.asInstanceOf[js.Array[Any]])
   }
 
   @Test def backquotesToEscapeScalaFields(): Unit = {
@@ -289,16 +282,16 @@ class InteroperabilityTest {
     val elems = Seq[js.Any]("plop", 42, 51)
 
     val dyn = obj.asInstanceOf[js.Dynamic]
-    assertArrayDynEquals(Array[String](), dyn.foo())
-    assertArrayDynEquals(Array(3, 6), dyn.foo(3, 6))
-    assertArrayDynEquals(Array("hello", false), dyn.foo("hello", false))
-    assertArrayDynEquals(Array("plop", 42, 51), dyn.applyDynamic("foo")(elems: _*))
+    assertArrayDynEquals(js.Array(), dyn.foo())
+    assertArrayDynEquals(js.Array(3, 6), dyn.foo(3, 6))
+    assertArrayDynEquals(js.Array("hello", false), dyn.foo("hello", false))
+    assertArrayDynEquals(js.Array("plop", 42, 51), dyn.applyDynamic("foo")(elems: _*))
 
     val stat = obj.asInstanceOf[InteroperabilityTestVariadicMethod]
-    assertArrayEquals(Array[String](), stat.foo())
-    assertArrayEquals(Array(3, 6), stat.foo(3, 6))
-    assertArrayEquals(Array("hello", false), stat.foo("hello", false))
-    assertArrayEquals(Array("plop", 42, 51), stat.foo(elems: _*))
+    assertJSArrayEquals(js.Array[Any](), stat.foo())
+    assertJSArrayEquals(js.Array[Any](3, 6), stat.foo(3, 6))
+    assertJSArrayEquals(js.Array("hello", false), stat.foo("hello", false))
+    assertJSArrayEquals(js.Array("plop", 42, 51), stat.foo(elems: _*))
   }
 
   @Test def callPolytypeNullaryMethod_Issue2445(): Unit = {
@@ -346,19 +339,19 @@ class InteroperabilityTest {
     val ctor = js.Dynamic.global.InteroperabilityTestVariadicCtor
 
     val args0 = jsnew(ctor)().args
-    assertArrayDynEquals(Array[String](), args0)
+    assertArrayDynEquals(js.Array(), args0)
     val args1 = jsnew(ctor)(3, 6).args
-    assertArrayDynEquals(Array(3, 6), args1)
+    assertArrayDynEquals(js.Array(3, 6), args1)
     val args2 = jsnew(ctor)("hello", false).args
-    assertArrayDynEquals(Array("hello", false), args2)
+    assertArrayDynEquals(js.Array("hello", false), args2)
     val args3 = jsnew(ctor)(elems: _*).args
-    assertArrayDynEquals(Array("plop", 42, 51), args3)
+    assertArrayDynEquals(js.Array("plop", 42, 51), args3)
 
     import org.scalajs.testsuite.compiler.{InteroperabilityTestVariadicCtor => C}
-    assertArrayEquals(Array[String](), new C().args)
-    assertArrayEquals(Array(3, 6), new C(3, 6).args)
-    assertArrayEquals(Array("hello", false), new C("hello", false).args)
-    assertArrayEquals(Array("plop", 42, 51), new C(elems: _*).args)
+    assertJSArrayEquals(js.Array[Any](), new C().args)
+    assertJSArrayEquals(js.Array[Any](3, 6), new C(3, 6).args)
+    assertJSArrayEquals(js.Array("hello", false), new C("hello", false).args)
+    assertJSArrayEquals(js.Array("plop", 42, 51), new C(elems: _*).args)
   }
 
   @Test def accessTopLevelJSObjectsViaScalaObjectWithAnnotJSGlobalScope(): Unit = {
@@ -516,10 +509,10 @@ class InteroperabilityTest {
       }
     """);
 
-    assertArrayEquals(Array(6, 8), new InteroperabilityTestCtor().values)
-    assertArrayEquals(Array(6, 7), new InteroperabilityTestCtor(y = 7).values)
-    assertArrayEquals(Array(3, 8), new InteroperabilityTestCtor(3).values)
-    assertArrayEquals(Array(10, 2), new InteroperabilityTestCtor(10, 2).values)
+    assertJSArrayEquals(js.Array(6, 8), new InteroperabilityTestCtor().values)
+    assertJSArrayEquals(js.Array(6, 7), new InteroperabilityTestCtor(y = 7).values)
+    assertJSArrayEquals(js.Array(3, 8), new InteroperabilityTestCtor(3).values)
+    assertJSArrayEquals(js.Array(10, 2), new InteroperabilityTestCtor(10, 2).values)
   }
 
   @Test def constructorParamsThatAreValsVarsInFacades_Issue1277(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.compiler
 
-import scala.language.implicitConversions
-
 import scala.scalajs.js
 import js.annotation.JSGlobal
 
@@ -102,8 +100,6 @@ class ReflectionTest {
   }
 
   @Test def getClassForAntiBoxedPrimitiveTypes(): Unit = {
-    implicit def classAsAny(c: java.lang.Class[_]): js.Any =
-      c.asInstanceOf[js.Any]
     assertEquals(classOf[java.lang.Boolean], (false: Any).getClass)
     assertEquals(classOf[java.lang.Character], ('a': Any).getClass)
     assertEquals(classOf[java.lang.Byte], (1.toByte: Any).getClass)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -14,8 +14,6 @@ package org.scalajs.testsuite.javalib.lang
 
 import org.scalajs.testsuite.utils.Platform
 
-import language.implicitConversions
-
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo.assumingES6
 import scala.scalajs.runtime.linkingInfo

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ArrayTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.jsinterop
 
-import scala.language.implicitConversions
-
 import scala.scalajs.js
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/AsyncTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.jsinterop
 
-import scala.language.implicitConversions
-
 import scala.scalajs.js
 import scala.scalajs.js.JSConverters._
 import scala.scalajs.js.|
@@ -30,9 +28,6 @@ import org.junit.Test
 import org.scalajs.junit.async._
 
 class AsyncTest {
-  implicit def eraseArray[T](a: Array[T]): Array[AnyRef] =
-    a.map(_.asInstanceOf[AnyRef])
-
   def asyncTest(implicit ec: ExecutionContext): ArrayBuffer[String] = {
     val steps = new ArrayBuffer[String]
 
@@ -64,22 +59,22 @@ class AsyncTest {
 
     val res = asyncTest
 
-    assertArrayEquals(Array(
+    assertArrayEquals(Array[AnyRef](
       "prep-future",
       "prep-map",
       "prep-foreach",
-      "done"), res.toArray)
+      "done"), res.toArray[AnyRef])
 
     processQueue()
 
-    assertArrayEquals(Array(
+    assertArrayEquals(Array[AnyRef](
       "prep-future",
       "prep-map",
       "prep-foreach",
       "done",
       "future",
       "map",
-      "foreach"), res.toArray)
+      "foreach"), res.toArray[AnyRef])
   }
 
   @Test def scalaScalajsConcurrentJSExecutionContextQueue(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.jsinterop
 
-import scala.language.implicitConversions
-
 import scala.scalajs.js
 import js.JSConverters._
 
@@ -23,15 +21,6 @@ import org.junit.Test
 import org.scalajs.testsuite.utils.JSAssert._
 
 class DynamicTest {
-
-  implicit def dyn2Bool(dyn: js.Dynamic): Boolean =
-    dyn.asInstanceOf[Boolean]
-
-  implicit def dyn2Int(dyn: js.Dynamic): Int =
-    dyn.asInstanceOf[Int]
-
-  implicit def dyn2AnyRef(dyn: js.Dynamic): AnyRef =
-    dyn.asInstanceOf[AnyRef]
 
   // scala.scalajs.js.Dynamic
 
@@ -71,7 +60,7 @@ class DynamicTest {
     val obj2_elem1 = obj2.elem1
     assertEquals(42, obj2_elem1)
     val obj2_elem2 = obj2.elem2
-    assertTrue(obj2_elem2)
+    assertEquals(true, obj2_elem2)
 
     def obj3Args: Seq[js.Any] = Seq("Scala.js", 42, true)
     val obj3 = js.Dynamic.newInstance(DynamicTestClassVarArgs)(obj3Args: _*)
@@ -82,7 +71,7 @@ class DynamicTest {
     val obj3_elem1 = obj3.elem1
     assertEquals(42, obj3_elem1)
     val obj3_elem2 = obj3.elem2
-    assertTrue(obj3_elem2)
+    assertEquals(true, obj3_elem2)
   }
 
   @Test def objectLiteralConstruction(): Unit = {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TupleTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/TupleTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.jsinterop
 
-import scala.language.implicitConversions
-
 import scala.scalajs.js
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/UnionTypeTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.library
 
-import scala.language.implicitConversions
-
 import scala.collection.mutable
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/JSUtils.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/JSUtils.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.utils
 
-import scala.language.implicitConversions
-
 import scala.scalajs.js
 import js.annotation.JSExport
 

--- a/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/lang/StringTestOnJDK11.scala
+++ b/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/lang/StringTestOnJDK11.scala
@@ -12,15 +12,10 @@
 
 package org.scalajs.testsuite.javalib.lang
 
-import java.nio.charset.Charset
-
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 
 import org.scalajs.testsuite.utils.AssertThrows._
-import org.scalajs.testsuite.utils.Platform._
 
 class StringTestOnJDK11 {
   @Test def repeat(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ByteArrayOutputStreamTest.scala
@@ -14,8 +14,6 @@ package org.scalajs.testsuite.javalib.io
 
 import java.io._
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
@@ -14,8 +14,6 @@ package org.scalajs.testsuite.javalib.io
 
 import java.io._
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
@@ -29,8 +27,8 @@ trait CommonStreamsTests {
   private val length = 50
   private def newStream: InputStream = mkStream(1 to length)
 
-  private implicit def seqToArray(seq: Seq[Int]): Array[Byte] =
-    seq.toArray.map(_.toByte)
+  private def assertArrayEqualsSeq(expected: Seq[Int], actual: Array[Byte]): Unit =
+    assertArrayEquals(expected.toArray.map(_.toByte), actual)
 
   @Test def read(): Unit = {
     val stream = newStream
@@ -47,12 +45,12 @@ trait CommonStreamsTests {
     val buf = new Array[Byte](10)
 
     assertEquals(10, stream.read(buf))
-    assertArrayEquals(1 to 10, buf)
+    assertArrayEqualsSeq(1 to 10, buf)
 
     assertEquals(35L, stream.skip(35))
 
     assertEquals(5, stream.read(buf))
-    assertArrayEquals((46 to 50) ++ (6 to 10), buf)
+    assertArrayEqualsSeq((46 to 50) ++ (6 to 10), buf)
 
     assertEquals(-1, stream.read(buf))
     assertEquals(-1, stream.read())
@@ -63,27 +61,27 @@ trait CommonStreamsTests {
     val buf = new Array[Byte](20)
 
     assertEquals(5, stream.read(buf, 10, 5))
-    assertArrayEquals(Seq.fill(10)(0) ++ (1 to 5) ++ Seq.fill(5)(0), buf)
+    assertArrayEqualsSeq(Seq.fill(10)(0) ++ (1 to 5) ++ Seq.fill(5)(0), buf)
 
     assertEquals(20, stream.read(buf, 0, 20))
-    assertArrayEquals(6 to 25, buf)
+    assertArrayEqualsSeq(6 to 25, buf)
 
     assertEquals(0, stream.read(buf, 10, 0))
-    assertArrayEquals(6 to 25, buf)
+    assertArrayEqualsSeq(6 to 25, buf)
 
     expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, -1, 0))
     expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 0, -1))
     expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 100, 0))
     expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 10, 100))
-    assertArrayEquals(6 to 25, buf)
+    assertArrayEqualsSeq(6 to 25, buf)
 
     assertEquals(20L, stream.skip(20))
 
     assertEquals(5, stream.read(buf, 0, 10))
-    assertArrayEquals((46 to 50) ++ (11 to 25), buf)
+    assertArrayEqualsSeq((46 to 50) ++ (11 to 25), buf)
 
     assertEquals(-1, stream.read(buf, 0, 10))
-    assertArrayEquals((46 to 50) ++ (11 to 25), buf)
+    assertArrayEqualsSeq((46 to 50) ++ (11 to 25), buf)
 
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
@@ -14,8 +14,6 @@ package org.scalajs.testsuite.javalib.io
 
 import java.io._
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/PrintWriterTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.io
 
-import scala.language.implicitConversions
-
 import java.io._
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -14,8 +14,6 @@ package org.scalajs.testsuite.javalib.lang
 
 import java.nio.charset.Charset
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemPropertiesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemPropertiesTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.lang
 
-import language.implicitConversions
-
 import org.junit.{After, Test}
 import org.junit.Assert._
 import org.junit.Assume._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.lang
 
-import language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util
 
-import language.implicitConversions
-
 import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
@@ -33,8 +31,16 @@ object ArraysTest extends ArraysTest
 class ArraysTest {
 
   // To invoke org.junit.Assert.assertArrayEquals on Array[T]
-  implicit def array2erasedArray[T](arr: Array[T]): Array[AnyRef] =
-    arr.map(_.asInstanceOf[AnyRef])
+  def assertArrayEquals[T](expected: Array[T], actual: Array[T]): Unit = {
+    (expected, actual) match {
+      case (expected: Array[AnyRef], actual: Array[AnyRef]) =>
+        org.junit.Assert.assertArrayEquals(expected, actual)
+      case _ =>
+        org.junit.Assert.assertArrayEquals(
+            expected.map(_.asInstanceOf[AnyRef]),
+            actual.map(_.asInstanceOf[AnyRef]))
+    }
+  }
 
   /** Overridden by typedarray tests */
   def Array[T: ClassTag](v: T*): scala.Array[T] = scala.Array(v: _*)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/HashSetTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util
 
-import scala.language.implicitConversions
-
 import java.{util => ju}
 
 import scala.reflect.ClassTag

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LinkedListTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PriorityQueueTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util
 
-import scala.language.implicitConversions
-
 import scala.reflect.ClassTag
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
@@ -14,8 +14,6 @@ package org.scalajs.testsuite.javalib.util
 
 import org.junit.Assert._
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util.concurrent
 
-import scala.language.implicitConversions
-
 import scala.collection.mutable
 import scala.reflect.ClassTag
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/atomic/AtomicTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/atomic/AtomicTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util.concurrent.atomic
 
-import scala.language.implicitConversions
-
 import org.junit.Test
 import org.junit.Assert._
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util.regex
 
-import scala.language.implicitConversions
-
 import java.util.regex._
 
 import org.junit.Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.javalib.util.regex
 
-import scala.language.implicitConversions
-
 import java.util.regex.Pattern
 
 import org.junit.Test
@@ -24,8 +22,11 @@ import org.scalajs.testsuite.utils.Platform._
 
 class RegexPatternTest {
 
-  implicit def toAnyRefArray(arr: Array[String]): Array[AnyRef] =
-    arr.map(_.asInstanceOf[AnyRef])
+  private def assertArrayStringEquals(expected: Array[String],
+      actual: Array[String]): Unit = {
+    assertArrayEquals(expected.asInstanceOf[Array[AnyRef]],
+        actual.asInstanceOf[Array[AnyRef]])
+  }
 
   @Test def matches(): Unit = {
     assertTrue(Pattern.matches("[Scal]*\\.js", "Scala.js"))
@@ -49,7 +50,7 @@ class RegexPatternTest {
     val result = Pattern.compile("[aj]").split("Scala.js")
     val expected = Array("Sc", "l", ".", "s")
     assertEquals(4, result.length)
-    assertArrayEquals(expected, result)
+    assertArrayStringEquals(expected, result)
 
     // Tests from JavaDoc
     split("boo:and:foo", ":", Array("boo", "and", "foo"))
@@ -95,7 +96,7 @@ class RegexPatternTest {
 
     def split(input: String, regex: String, expected: Array[String]): Unit = {
       val result = Pattern.compile(regex).split(input)
-      assertArrayEquals(expected, result)
+      assertArrayStringEquals(expected, result)
     }
   }
 
@@ -137,7 +138,7 @@ class RegexPatternTest {
     def splitWithLimit(input: String, regex: String, limit: Int,
         expected: Array[String]): Unit = {
       val result = Pattern.compile(regex).split(input, limit)
-      assertArrayEquals(expected, result)
+      assertArrayStringEquals(expected, result)
     }
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ArrayBuilderTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.scalalib
 
-import scala.language.implicitConversions
-
 import scala.reflect._
 import scala.collection.mutable.ArrayBuilder
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/ClassTagTest.scala
@@ -12,8 +12,6 @@
 
 package org.scalajs.testsuite.scalalib
 
-import scala.language.implicitConversions
-
 import scala.reflect._
 
 import org.junit.Test


### PR DESCRIPTION
The test suite contained a lot of implicit conversions that were not really necessary. This commit replaces them by explicit conversions or better use of overloads.