### PR TITLE
Add js.WeakRef and js.FinalizationRegistry

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 image: Visual Studio 2015
 environment:
   global:
-    NODEJS_VERSION: "12"
+    NODEJS_VERSION: "14"
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0
     SCALA_VERSION: 2.12.12
 install:

--- a/assets/additional-doc-styles.css
+++ b/assets/additional-doc-styles.css
@@ -1,4 +1,4 @@
-.badge-ecma6, .badge-ecma2015, .badge-ecma2017, .badge-ecma2018, .badge-ecma2019, .badge-ecma2020 {
+.badge-ecma6, .badge-ecma2015, .badge-ecma2017, .badge-ecma2018, .badge-ecma2019, .badge-ecma2020, .badge-ecma2021 {
   background-color: #E68A00;
 }
 

--- a/library/src/main/scala/scala/scalajs/js/FinalizationRegistry.scala
+++ b/library/src/main/scala/scala/scalajs/js/FinalizationRegistry.scala
@@ -1,0 +1,64 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+/** <span class="badge badge-ecma2021" style="float: right;">ECMAScript 2021</span>
+ *
+ *  A FinalizationRegistry object lets you request a callback when an object is garbage-collected.
+ *
+ *  FinalizationRegistry provides a way to request that a cleanup callback get called at some point
+ *  when an object registered with the registry has been reclaimed (garbage-collected).
+ *  (Cleanup callbacks are sometimes called finalizers.)
+ *
+ *  MDN
+ *
+ *  @tparam A Type of the target object to register
+ *  @tparam B Type of value to pass to the finalizer
+ *  @tparam C Type of an unregistration token
+ */
+@js.native
+@JSGlobal
+class FinalizationRegistry[-A, -B, -C](finalizer: js.Function1[B, scala.Any]) extends js.Object {
+  /** The `register` method registers an object with a FinalizationRegistry instance so that if
+   *  the object is garbage-collected, the registry's callback may get called.
+   *
+   *  @param theObject The target object to register.
+   *  @param heldValue The value to pass to the finalizer for this object. This cannot be the target object.
+   *  @param unregistrationToken
+   *    A token that may be used with the `unregister` method later to
+   *    unregister the target object. If provided (and not `undefined`),
+   *    this must be an object. If not provided, the target cannot be unregistered.
+   */
+  def register(theObject: A, heldValue: B, unregistrationToken: C): Unit = js.native
+
+  /** The `register` method registers an object with a FinalizationRegistry instance so that if
+   *  the object is garbage-collected, the registry's callback may get called.
+   *
+   *  @param theObject The target object to register.
+   *  @param heldValue The value to pass to the finalizer for this object. This cannot be the target object.
+   */
+  def register(theObject: A, heldValue: B): Unit = js.native
+
+  /** The `unregister`` unregisters a target object from a `FinalizationRegistry` instance.
+   *
+   *  When a target object has been reclaimed, it is no longer registered in the registry.
+   *  There is no need to all `unregister` in your cleanup callback. Only call `unregister` if
+   *  you haven't received a cleanup callback and no longer need to receive one.
+   *
+   *  @param unregistrationToken The token used with the register method when registering the target object.
+   */
+  def unregister(unregistrationToken: C): Unit = js.native
+}

--- a/library/src/main/scala/scala/scalajs/js/WeakRef.scala
+++ b/library/src/main/scala/scala/scalajs/js/WeakRef.scala
@@ -1,0 +1,33 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation.JSGlobal
+
+/** <span class="badge badge-ecma2021" style="float: right;">ECMAScript 2021</span>
+ *
+ *  A WeakRef object lets you hold a weak reference to another object, without preventing
+ *  that object from getting garbage-collected.
+ *
+ *  MDN
+ *
+ *  @param targetObject An object whose weak reference contained by an instance of WeakRef.
+ *  @tparam T unconstrained, but the constructor will throw a TypeError if targetObject is not an Object.
+ */
+@js.native
+@JSGlobal
+class WeakRef[+T](targetObject: T) extends js.Object {
+  /** The target object of the WeakRef, or undefined if the object has been garbage-collected. */
+  def deref[S >: T](): js.UndefOr[S] = js.native
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/FinalizationRegistryTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/FinalizationRegistryTest.scala
@@ -1,0 +1,36 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.library
+
+import org.junit.Test
+
+import scala.scalajs.js
+
+class FinalizationRegistryTest {
+  @Test def testMethods(): Unit = {
+    val registry = new js.FinalizationRegistry[js.Date, String, Any]((heldValue: String) => ())
+
+    val obj1 = new js.Date()
+    registry.register(obj1, "foo")
+
+    val obj2 = new js.Date()
+    registry.register(obj2, "bar", obj2)
+
+    val obj3 = new js.Date()
+    val unregisterToken = new js.Object()
+    registry.register(obj3, "bar", unregisterToken)
+
+    registry.unregister(obj1)
+    registry.unregister(unregisterToken)
+  }
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WeakRefTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WeakRefTest.scala
@@ -1,0 +1,28 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.library
+
+import org.junit.Assert._
+import org.junit.Test
+
+import scala.scalajs.js
+
+class WeakRefTest {
+  @Test def testDeref(): Unit = {
+    val obj = new js.Date()
+    val ref = new js.WeakRef(obj)
+    val derefedInferredType = ref.deref()
+    val derefedAssertType: js.UndefOr[js.Date] = derefedInferredType
+    assertTrue(derefedAssertType.contains(obj))
+  }
+}


### PR DESCRIPTION
This PR adds [WeakRef](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/WeakRef) and [FinalizationRegistry](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/FinalizationRegistry).

This could be a foundation to implement java.util.WeakHashMap #3503 or similar.