### PR TITLE
Remove dead code testing for Array[Unit] after Array[AnyRef].

### DIFF
--- a/scalalib/overrides-2.11/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.11/scala/runtime/ScalaRunTime.scala
@@ -80,7 +80,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => x(idx).asInstanceOf[Any]
       case x: Array[Short]   => x(idx).asInstanceOf[Any]
       case x: Array[Boolean] => x(idx).asInstanceOf[Any]
-      case x: Array[Unit]    => x(idx).asInstanceOf[Any]
       case null => throw new NullPointerException
     }
   }
@@ -97,7 +96,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
       case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
       case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
-      case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
       case null => throw new NullPointerException
     }
   }
@@ -113,7 +111,6 @@ object ScalaRunTime {
     case x: Array[Byte]    => x.length
     case x: Array[Short]   => x.length
     case x: Array[Boolean] => x.length
-    case x: Array[Unit]    => x.length
     case null => throw new NullPointerException
   }
 
@@ -127,7 +124,6 @@ object ScalaRunTime {
     case x: Array[Byte]    => ArrayRuntime.cloneArray(x)
     case x: Array[Short]   => ArrayRuntime.cloneArray(x)
     case x: Array[Boolean] => ArrayRuntime.cloneArray(x)
-    case x: Array[Unit]    => x
     case null => throw new NullPointerException
   }
 

--- a/scalalib/overrides-2.13/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides-2.13/scala/runtime/ScalaRunTime.scala
@@ -64,7 +64,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => x(idx).asInstanceOf[Any]
       case x: Array[Short]   => x(idx).asInstanceOf[Any]
       case x: Array[Boolean] => x(idx).asInstanceOf[Any]
-      case x: Array[Unit]    => x(idx).asInstanceOf[Any]
       case null => throw new NullPointerException
     }
   }
@@ -81,7 +80,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
       case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
       case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
-      case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
       case null => throw new NullPointerException
     }
   }

--- a/scalalib/overrides/scala/runtime/ScalaRunTime.scala
+++ b/scalalib/overrides/scala/runtime/ScalaRunTime.scala
@@ -60,7 +60,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => x(idx).asInstanceOf[Any]
       case x: Array[Short]   => x(idx).asInstanceOf[Any]
       case x: Array[Boolean] => x(idx).asInstanceOf[Any]
-      case x: Array[Unit]    => x(idx).asInstanceOf[Any]
       case null => throw new NullPointerException
     }
   }
@@ -77,7 +76,6 @@ object ScalaRunTime {
       case x: Array[Byte]    => x(idx) = value.asInstanceOf[Byte]
       case x: Array[Short]   => x(idx) = value.asInstanceOf[Short]
       case x: Array[Boolean] => x(idx) = value.asInstanceOf[Boolean]
-      case x: Array[Unit]    => x(idx) = value.asInstanceOf[Unit]
       case null => throw new NullPointerException
     }
   }
@@ -93,7 +91,6 @@ object ScalaRunTime {
     case x: Array[Byte]    => x.length
     case x: Array[Short]   => x.length
     case x: Array[Boolean] => x.length
-    case x: Array[Unit]    => x.length
     case null => throw new NullPointerException
   }
 
@@ -107,7 +104,6 @@ object ScalaRunTime {
     case x: Array[Byte]    => x.clone()
     case x: Array[Short]   => x.clone()
     case x: Array[Boolean] => x.clone()
-    case x: Array[Unit]    => x
     case null => throw new NullPointerException
   }
 


### PR DESCRIPTION
Since `Array[Unit]` is implemented as `Array[BoxedUnit]`, any `Array[Unit]` already qualifies as an `Array[AnyRef]`. Therefore, all the removed cases were dead code.

This commit is a port of the upstream PR https://github.com/scala/scala/pull/9369.