### PR TITLE
Fix #4370: Encode fields of type Nothing with scala.runtime.Nothing$.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -18,7 +18,7 @@ import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
     current = "1.5.0-SNAPSHOT",
-    binaryEmitted = "1.4"
+    binaryEmitted = "1.5-SNAPSHOT"
 )
 
 /** Helper class to allow for testing of logic. */

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1044,7 +1044,7 @@ object Serializers {
 
         case TagAssign =>
           val lhs0 = readTree()
-          val lhs = if (lhs0.tpe == NothingType) { // temp: test backward compat
+          val lhs = if (hacks.use14 && lhs0.tpe == NothingType) {
             /* Note [Nothing FieldDef rewrite]
              * (throw qual.field[null]) = rhs  -->  qual.field[null] = rhs
              */
@@ -1089,7 +1089,7 @@ object Serializers {
           val field = readFieldIdent()
           val tpe = readType()
 
-          if (tpe == NothingType) { // temp: test backward compat
+          if (hacks.use14 && tpe == NothingType) {
             /* Note [Nothing FieldDef rewrite]
              * qual.field[nothing]  -->  throw qual.field[null]
              */
@@ -1208,7 +1208,7 @@ object Serializers {
           val originalName = readOriginalName()
 
           val ftpe0 = readType()
-          val ftpe = if (ftpe0 == NothingType) { // temp: test backward compat
+          val ftpe = if (hacks.use14 && ftpe0 == NothingType) {
             /* Note [Nothing FieldDef rewrite]
              * val field: nothing  -->  val field: null
              */
@@ -1639,6 +1639,10 @@ object Serializers {
     val use11: Boolean = use10 || sourceVersion == "1.1"
 
     val use12: Boolean = use11 || sourceVersion == "1.2"
+
+    private val use13: Boolean = use12 || sourceVersion == "1.3"
+
+    val use14: Boolean = use13 || sourceVersion == "1.4"
   }
 
   /** Names needed for hacks. */

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -338,8 +338,8 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
         typecheckExpect(name, Env.empty, AnyType)
     }
 
-    if (fieldDef.ftpe == NoType)
-      reportError(i"FieldDef cannot have type NoType")
+    if (fieldDef.ftpe == NoType || fieldDef.ftpe == NothingType)
+      reportError(i"FieldDef cannot have type ${fieldDef.ftpe}")
   }
 
   private def checkMethodDef(methodDef: MethodDef,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -852,6 +852,24 @@ class RegressionTest {
     assertEquals(4, staticForwardersAvoidanceObjectAfterClass.checkValue)
   }
 
+  @Test def fieldsWithNothingType_Issue4370(): Unit = {
+    class EagerFieldsWithNothingType {
+      val a: Nothing = throw new IllegalStateException("always")
+      var b: Nothing = throw new IllegalStateException("never")
+    }
+
+    val ex1 = expectThrows(classOf[IllegalStateException], new EagerFieldsWithNothingType)
+    assertEquals("always", ex1.getMessage())
+
+    class LazyFieldsWithNothingType {
+      lazy val a: Nothing = throw new IllegalStateException("lazily always")
+    }
+
+    val obj = new LazyFieldsWithNothingType
+    val ex2 = expectThrows(classOf[IllegalStateException], obj.a)
+    assertEquals("lazily always", ex2.getMessage())
+  }
+
 }
 
 object RegressionTest {


### PR DESCRIPTION
In the end, I kept my original strategy for the deserialization hack, but used `null` inside of `scala.runtime.Nothing$` as the replacement type. That strategy was easier to implement using only local knowledge, especially in the `Assign` case, and has the added benefit that it does not hide other IR errors like assignment to a non-existing field.