### PR TITLE
Add logo and link to scala-js.org to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+<p align="left">
+  <a href="http://www.scala-js.org/">
+    <img src="http://www.scala-js.org/assets/img/scala-js-logo.svg" height="128">
+    <h1 align="left">Scala.js</h1> 
+  </a>
+</p>
+
 This is the repository for
 [Scala.js, the Scala to JavaScript compiler](https://www.scala-js.org/).
 


### PR DESCRIPTION
Hi there! 👋🏽 

I found about this awesome project and seemed to me that the main `README.md` was missing a distinctive logo.

I added the one from the docs and a link to them.

Hope you like it and help other people to identify this repo better and makes it easier to access the docs 😊 