### PR TITLE
Use an IIFE to protect arguments to ApplyDynamicImport

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -155,4 +155,10 @@ private[emitter] final class JSGen(val config: Emitter.Config) {
 
     Block(stats)
   }
+
+  def genIIFE(captures: List[(ParamDef, Tree)], body: Tree)(
+      implicit pos: Position): Tree = {
+    val (params, args) = captures.unzip
+    Apply(genArrowFunction(params, body), args)
+  }
 }


### PR DESCRIPTION
This has multiple advantages:
- Less complicated code.
- Less generated code (when arrow functions are in use).
- Consistent with how we deal with captures of closures.