### PR TITLE
Fix #3664: Upgrade source-map-support to 0.5.19

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -747,9 +747,9 @@
       "dev": true
     },
     "source-map-support": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.7.tgz",
-      "integrity": "sha512-xkQxe0zaJhFZe/Q59dWlg9WM8nmcQVgHNdlRnm80qr4y3ypleexZ/B3bY0UUig9XvhQfM+1/QD62QrA40MJ0ng==",
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.19.tgz",
+      "integrity": "sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==",
       "dev": true,
       "requires": {
         "buffer-from": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "devDependencies": {
-    "source-map-support": "0.5.7",
+    "source-map-support": "0.5.19",
     "jszip": "3.1.4",
     "jsdom": "16.3.0",
     "node-static": "0.7.11"


### PR DESCRIPTION
The issue with original names was likely due to
evanw/node-source-map-support#253 and not Scala.js related.