### PR TITLE
Make match in zeroOf exhaustive

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
@@ -267,7 +267,7 @@ object Types {
   }
 
   /** Generates a literal zero of the given type. */
-  def zeroOf(tpe: Type)(implicit pos: Position): Literal = tpe match {
+  def zeroOf(tpe: Type)(implicit pos: Position): Tree = tpe match {
     case BooleanType => BooleanLiteral(false)
     case CharType    => CharLiteral('\u0000')
     case ByteType    => ByteLiteral(0)
@@ -278,7 +278,14 @@ object Types {
     case DoubleType  => DoubleLiteral(0.0)
     case StringType  => StringLiteral("")
     case UndefType   => Undefined()
-    case _           => Null()
+
+    case NullType | AnyType | _:ClassType | _:ArrayType => Null()
+
+    case tpe: RecordType =>
+      RecordValue(tpe, tpe.fields.map(f => zeroOf(f.tpe)))
+
+    case NothingType | NoType =>
+      throw new IllegalArgumentException(s"cannot generate a zero for $tpe")
   }
 
   /** Tests whether a type `lhs` is a subtype of `rhs` (or equal).

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -2295,7 +2295,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       RecordType.Field(name, originalName, tpe, mutable) <- structure.recordType.fields
     } yield {
       Binding(Binding.Local(name.toLocalName, originalName), tpe, mutable,
-          PreTransLit(zeroOf(tpe)))
+          PreTransTree(zeroOf(tpe)))
     }
 
     withNewLocalDefs(initialFieldBindings) { (initialFieldLocalDefList, cont1) =>


### PR DESCRIPTION
This has two side-effects:
- Fail for NothingType / NoType (follow-up to #4377).
- Return a proper zero for records (widens the result type to Tree).

We adjust the OptimizerCore that was the only place that used the
narrower result type. We note however, that `PreTransList` is merely a
constructor for `PreTransTree`. So in terms of overall behavior /
type-safety, we do not loose (or gain) anything.