### PR TITLE
Do not attempt to throw an NPE in the Optimizer

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -51,8 +51,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
     val factory = SymbolRequirement.factory("optimizer")
     import factory._
 
-    callMethods(LongImpl.RuntimeLongClass, LongImpl.AllIntrinsicMethods.toList) ++
-    instantiateClass(OptimizerCore.NullPointerExceptionClass, NoArgConstructorName)
+    callMethods(LongImpl.RuntimeLongClass, LongImpl.AllIntrinsicMethods.toList)
   }
 
   /** Are we in batch mode? I.e., are we running from scratch?

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1455,10 +1455,8 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case NothingType =>
         cont(treceiver)
       case NullType =>
-        cont(Block(
-            finishTransformStat(treceiver),
-            Throw(New(NullPointerExceptionClass,
-                MethodIdent(NoArgConstructorName), Nil))).toPreTransform)
+        // Apply on null is UB, just create a well-typed tree.
+        cont(Block(finishTransformStat(treceiver), Throw(Null())).toPreTransform)
       case _ =>
         if (methodName.isReflectiveProxy) {
           // Never inline reflective proxies
@@ -4364,7 +4362,6 @@ private[optimizer] object OptimizerCore {
 
   private val thisOriginalName: OriginalName = OriginalName("this")
 
-  val NullPointerExceptionClass = ClassName("java.lang.NullPointerException")
   private val Tuple2Class = ClassName("scala.Tuple2")
   private val NilClass = ClassName("scala.collection.immutable.Nil$")
   private val JSWrappedArrayClass = ClassName("scala.scalajs.js.WrappedArray")

--- a/project/MiniLib.scala
+++ b/project/MiniLib.scala
@@ -40,7 +40,6 @@ object MiniLib {
         "ClassCastException",
         "CloneNotSupportedException",
         "IndexOutOfBoundsException",
-        "NullPointerException",
         "StringIndexOutOfBoundsException"
     ).map("java/lang/" + _)
 


### PR DESCRIPTION
This allows us to remove a symbol requirement.