### PR TITLE
Remove separate treatment of innerEnv in unnest

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -994,16 +994,9 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               case Block(stats :+ expr) =>
                 val (jsStats, newEnv) = transformBlockStats(stats)
                 val result = rec(expr)(newEnv)
+                innerEnv = newEnv
                 // Put the stats in a Block because ++=: is not smart
                 js.Block(jsStats) +=: extractedStatements
-                innerEnv = stats.foldLeft(innerEnv) { (prev, stat) =>
-                  stat match {
-                    case VarDef(name, _, _, mutable, _) =>
-                      prev.withDef(name, mutable)
-                    case _ =>
-                      prev
-                  }
-                }
                 result
 
               case UnaryOp(op, lhs) =>


### PR DESCRIPTION
This has become unnecessary with the introduction of JSVarRef (00b3729e4cc04c79e5ab2ba11697a5aa2f61bf2c) but was never removed.