### PR TITLE
Fix #4402: Allow native JS (module) classes not to have a native load spec.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -176,8 +176,6 @@ object Analysis {
       subClassInfo: ClassInfo, from: From)
       extends Error
 
-  final case class MissingJSNativeLoadSpec(info: ClassInfo, from: From) extends Error
-
   final case class NotAModule(info: ClassInfo, from: From) extends Error
   final case class MissingMethod(info: MethodInfo, from: From) extends Error
   final case class MissingJSNativeMember(info: ClassInfo, name: MethodName, from: From) extends Error
@@ -231,8 +229,6 @@ object Analysis {
         s"${superIntfInfo.displayName} (of kind ${superIntfInfo.kind}) is " +
         s"not a valid interface implemented by ${subClassInfo.displayName} " +
         s"(of kind ${subClassInfo.kind})"
-      case MissingJSNativeLoadSpec(info, _) =>
-        s"${info.displayName} is a native class but does not have a JSNativeLoadSpec"
       case NotAModule(info, _) =>
         s"Cannot access module for non-module ${info.displayName}"
       case MissingMethod(info, _) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1003,12 +1003,8 @@ private final class Analyzer(config: CommonPhaseConfig,
               staticInit => staticInit.reachStatic()
             }
           } else {
-            data.jsNativeLoadSpec match {
-              case None =>
-                _errors += MissingJSNativeLoadSpec(this, from)
-              case Some(jsNativeLoadSpec) =>
-                validateLoadSpec(jsNativeLoadSpec, jsNativeMember = None)
-            }
+            for (jsNativeLoadSpec <- data.jsNativeLoadSpec)
+              validateLoadSpec(jsNativeLoadSpec, jsNativeMember = None)
           }
 
           for (reachabilityInfo <- data.exportedMembers)
@@ -1025,12 +1021,10 @@ private final class Analyzer(config: CommonPhaseConfig,
 
         if (!isNativeJSClass) {
           for (clazz <- superClass) {
-            clazz.jsNativeLoadSpec match {
-              case None =>
-                staticDependencies += clazz.className
-              case Some(loadSpec) =>
-                addLoadSpec(externalDependencies, loadSpec)
-            }
+            if (clazz.isNativeJSClass)
+              clazz.jsNativeLoadSpec.foreach(addLoadSpec(externalDependencies, _))
+            else
+              staticDependencies += clazz.className
           }
         }
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -264,27 +264,6 @@ class AnalyzerTest {
   }
 
   @Test
-  def missingJSNativeLoadSpec(): AsyncResult = await {
-    val kinds = Seq(
-        ClassKind.NativeJSClass,
-        ClassKind.NativeJSModuleClass
-    )
-
-    Future.traverse(kinds) { kind =>
-      val classDefs = Seq(
-          classDef("A", kind = kind, superClass = Some(ObjectClass))
-      )
-
-      val analysis = computeAnalysis(classDefs,
-          reqsFactory.instantiateClass("A", NoArgConstructorName))
-
-      assertContainsError("MissingJSNativeLoadSpec(A)", analysis) {
-        case MissingJSNativeLoadSpec(ClsInfo("A"), `fromUnitTest`) => true
-      }
-    }
-  }
-
-  @Test
   def notAModule(): AsyncResult = await {
     val classDefs = Seq(
         classDef("A", superClass = Some(ObjectClass),

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NestedJSClassTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NestedJSClassTest.scala
@@ -584,6 +584,34 @@ class NestedJSClassTest {
     assertNotSame(obj.constructor, fun().constructor)
     assertNotSame(obj.constructor, js.constructorOf[js.Object])
   }
+
+  @Test
+  def extendInnerJSClassInClass_Issue4402(): Unit = {
+    val msg = "hello world"
+
+    val outer = js.Dynamic.literal(
+      InnerClass = js.constructorOf[DynamicInnerClass_Issue4402]
+    ).asInstanceOf[OuterNativeClass_Issue4402]
+
+    class Subclass(arg: String) extends outer.InnerClass(arg)
+
+    val obj = new Subclass(msg)
+    assertEquals(msg, obj.message)
+  }
+
+  @Test
+  def extendInnerJSClassInTrait_Issue4402(): Unit = {
+    val msg = "hello world"
+
+    val outer = js.Dynamic.literal(
+      InnerClass = js.constructorOf[DynamicInnerClass_Issue4402]
+    ).asInstanceOf[OuterNativeTrait_Issue4402]
+
+    class Subclass(arg: String) extends outer.InnerClass(arg)
+
+    val obj = new Subclass(msg)
+    assertEquals(msg, obj.message)
+  }
 }
 
 object NestedJSClassTest {
@@ -754,6 +782,27 @@ object NestedJSClassTest {
 
   class TriplyNestedClass_Issue4114 extends TriplyNestedObject_Issue4114.middle.InnerClass {
     def foo(x: String): String = x
+  }
+
+  class DynamicInnerClass_Issue4402(arg: String) extends js.Object {
+    val message: String = arg
+  }
+
+  @js.native
+  @JSGlobal("OuterNativeClass_Issue4402") // this does not actually exist; we just cast to this class
+  class OuterNativeClass_Issue4402 extends js.Object {
+    @js.native
+    class InnerClass(arg: String) extends js.Object {
+      def message: String = js.native
+    }
+  }
+
+  @js.native
+  trait OuterNativeTrait_Issue4402 extends js.Object {
+    @js.native
+    class InnerClass(arg: String) extends js.Object {
+      def message: String = js.native
+    }
   }
 }
 


### PR DESCRIPTION
A native load spec is only required if there is a "call site" for that class with `LoadJSConstructor`, `LoadJSModule` or as `superClass` of a JS class without `jsSuperClass` tree.