### PR TITLE
Fix `checkClassType` for Scala 2.13.5.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
@@ -54,6 +54,15 @@ trait CompatComponent {
     }
   }
 
+  implicit final class TyperCompat(self: analyzer.Typer) {
+    // Added in Scala 2.13.5 to make it clearer what is allowed since 2.13.4
+    def checkClassOrModuleType(tpt: Tree): Boolean =
+      self.checkClassType(tpt)
+
+    def checkClassType(tpt: Tree): Boolean =
+      infiniteLoop()
+  }
+
   private implicit final class FlagsCompat(self: Flags.type) {
     def IMPLCLASS: Long = infiniteLoop()
   }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -466,7 +466,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
             if predef.symbol == PredefModule =>
           if (scalaJSOpts.fixClassOf) {
             // Replace call by literal constant containing type
-            if (typer.checkClassType(tpeArg)) {
+            if (typer.checkClassOrModuleType(tpeArg)) {
               typer.typed { Literal(Constant(tpeArg.tpe.dealias.widen)) }
             } else {
               reporter.error(tpeArg.pos, s"Type ${tpeArg} is not a class type")


### PR DESCRIPTION
`checkClassType` was renamed to `checkClassOrModuleType` upstream, to be released in Scala 2.13.5, to account for its change in behavior that was introduced in Scala 2.13.4. The renaming was done in https://github.com/scala/scala/commit/53121483d349f61999f080272f330efd34cc786a

This commit introduces a compat hack to use the new method. This is only in the hack for `classOf` desugaring, which corresponds to the fact that `typedClassOf` upstream started using the renamed method upstream.

---

See https://travis-ci.org/github/scala-js/scala-js-test-scala-nightly/jobs/757001181

Locally tested with
```
> set resolvers in Global += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.5-bin-6da2a93
> testSuite2_13/test
> compiler2_13/test
```