### PR TITLE
Fix #4408: Compute the list of dispatchers that we need.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -828,6 +828,15 @@ object Emitter {
               StringArgConstructorName)
         },
 
+        // See systemIdentityHashCode in CoreJSLib
+        callMethod(BoxedBooleanClass, hashCodeMethodName),
+        callMethod(BoxedDoubleClass, hashCodeMethodName),
+        callMethod(BoxedStringClass, hashCodeMethodName),
+        callMethod(BoxedUnitClass, hashCodeMethodName),
+        cond(config.esFeatures.allowBigIntsForLongs) {
+          callMethod(BoxedLongClass, hashCodeMethodName)
+        },
+
         cond(!config.esFeatures.allowBigIntsForLongs) {
           multiple(
               instanceTests(LongImpl.RuntimeLongClass),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterNames.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterNames.scala
@@ -16,15 +16,10 @@ import org.scalajs.ir.Names._
 import org.scalajs.ir.Types._
 
 private[emitter] object EmitterNames {
+  // Class names
+
   val UndefinedBehaviorErrorClass =
     ClassName("org.scalajs.linker.runtime.UndefinedBehaviorError")
-
-  /* In theory, some of the following could be computed from the Class
-   * Hierarchy. However, that would be require dealing with incremental runs,
-   * which would be overkill since these things are in fact known to be static.
-   */
-
-  val CharSequenceClass = ClassName("java.lang.CharSequence")
 
   val ThrowableClass = ClassName("java.lang.Throwable")
 
@@ -33,26 +28,11 @@ private[emitter] object EmitterNames {
   val StringArgConstructorName = MethodName.constructor(List(ClassRef(BoxedStringClass)))
   val ThrowableArgConsructorName = MethodName.constructor(List(ClassRef(ThrowableClass)))
 
-  val getClassMethodName = MethodName("getClass", Nil, ClassRef(ClassClass))
   val cloneMethodName = MethodName("clone", Nil, ClassRef(ObjectClass))
-  val finalizeMethodName = MethodName("finalize", Nil, VoidRef)
-  val notifyMethodName = MethodName("notify", Nil, VoidRef)
-  val notifyAllMethodName = MethodName("notifyAll", Nil, VoidRef)
-  val toStringMethodName = MethodName("toString", Nil, ClassRef(BoxedStringClass))
-  val equalsMethodName = MethodName("equals", List(ClassRef(ObjectClass)), BooleanRef)
+  val getClassMethodName = MethodName("getClass", Nil, ClassRef(ClassClass))
   val hashCodeMethodName = MethodName("hashCode", Nil, IntRef)
-  val compareToMethodName = MethodName("compareTo", List(ClassRef(ObjectClass)), IntRef)
-  val lengthMethodName = MethodName("length", Nil, IntRef)
-  val charAtMethodName = MethodName("charAt", List(IntRef), CharRef)
-  val subSequenceMethodName =
-    MethodName("subSequence", List(IntRef, IntRef), ClassRef(ClassName("java.lang.CharSequence")))
-  val byteValueMethodName = MethodName("byteValue", Nil, ByteRef)
-  val shortValueMethodName = MethodName("shortValue", Nil, ShortRef)
-  val intValueMethodName = MethodName("intValue", Nil, IntRef)
-  val longValueMethodName = MethodName("longValue", Nil, LongRef)
-  val floatValueMethodName = MethodName("floatValue", Nil, FloatRef)
-  val doubleValueMethodName = MethodName("doubleValue", Nil, DoubleRef)
+  val toStringMethodName = MethodName("toString", Nil, ClassRef(BoxedStringClass))
+
   val getNameMethodName = MethodName("getName", Nil, ClassRef(BoxedStringClass))
   val getSuperclassMethodName = MethodName("getSuperclass", Nil, ClassRef(ClassClass))
-
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2181,28 +2181,6 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                  */
                 genDispatchApply()
 
-              case ClassType(CharSequenceClass)
-                  if !hijackedMethodsOfStringWithDispatcher.contains(methodName) =>
-                /* This case is required as a hack around a peculiar behavior
-                 * of the optimizer. In theory, it should never happen, because
-                 * we should always have a dispatcher when the receiver is not
-                 * a concrete hijacked class. However, if the optimizer inlines
-                 * a method of CharSequence from String (because there is no
-                 * other CharSequence in the whole program), we can end up with
-                 * the inlined code calling another method of String although
-                 * its receiver is still declared as a CharSequence.
-                 *
-                 * TODO The proper fix for this would be to improve how the
-                 * optimizer handles inlinings such as those: it should refine
-                 * the type of `this` within the inlined body.
-                 *
-                 * This cannot happen with other ancestors of hijacked classes
-                 * because all the other ones have several hijacked classes
-                 * implementing them, which prevents that form of inlining from
-                 * happening.
-                 */
-                genHijackedMethodApply(BoxedStringClass)
-
               case ClassType(className) if !HijackedClasses.contains(className) =>
                 /* This is a strict ancestor of a hijacked class. We need to
                  * use the dispatcher available in the helper method.
@@ -2932,23 +2910,11 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
      * additional global knowledge for no practical reason.
      */
     val hijackedMethodsInheritedFromObject: Set[MethodName] = Set(
-        getClassMethodName, cloneMethodName, finalizeMethodName,
-        notifyMethodName, notifyAllMethodName
-    )
-
-    val hijackedMethodsOfStringWithDispatcher: Set[MethodName] = Set(
         getClassMethodName,
         cloneMethodName,
-        finalizeMethodName,
-        notifyMethodName,
-        notifyAllMethodName,
-        toStringMethodName,
-        equalsMethodName,
-        hashCodeMethodName,
-        compareToMethodName,
-        lengthMethodName,
-        charAtMethodName,
-        subSequenceMethodName
+        MethodName("finalize", Nil, VoidRef),
+        MethodName("notify", Nil, VoidRef),
+        MethodName("notifyAll", Nil, VoidRef)
     )
 
     private def transformParamDef(paramDef: ParamDef): js.ParamDef = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -95,12 +95,14 @@ private[emitter] trait GlobalKnowledge {
    */
   def getModule(className: ClassName): ModuleID
 
-  /** Whether the given public non-static method exists on the given representative class.
+  /** The list of all the concrete non-static methods in representative classes.
    *
-   *  @returns false if the class or the method does not exist.
+   *  The list of method names is ordered for stability.
+   *
+   *  Each method name is associated with a set of representative classes that
+   *  have an implementation for that method. That set is not ordered.
    */
-  def representativeClassHasPublicMethod(className: ClassName,
-      methodName: MethodName): Boolean
+  def methodsInRepresentativeClasses(): List[(MethodName, Set[ClassName])]
 
   /** The public (non-static) methods of java.lang.Object. */
   def methodsInObject(): List[Versioned[MethodDef]]

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1667,14 +1667,14 @@ object Build {
           case "2.11.12" =>
             Some(ExpectedSizes(
                 fastLink = 519000 to 520000,
-                fullLink = 107000 to 108000,
+                fullLink = 108000 to 109000,
                 fastLinkGz = 66000 to 67000,
                 fullLinkGz = 28000 to 29000,
             ))
 
           case "2.12.12" =>
             Some(ExpectedSizes(
-                fastLink = 781000 to 782000,
+                fastLink = 780000 to 781000,
                 fullLink = 148000 to 149000,
                 fastLinkGz = 91000 to 92000,
                 fullLinkGz = 36000 to 37000,


### PR DESCRIPTION
Instead of hard-coding the list of methods of hijacked classes that need dispatchers, along with the hijacked classes that define them, we compute the above information from the class hierarchy.

It turns out that the required information was already in the global knowledge, except it was exposed in a weaker form. So this change does not make incremental runs more sensitive.

These changes allow to get rid of the `CharSequence` hack in `FunctionEmitter`, which was unsound.