### PR TITLE
Fix #4413: Handle JS symbols and bigints in `systemIdentityHashCode`.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -829,13 +829,8 @@ object Emitter {
         },
 
         // See systemIdentityHashCode in CoreJSLib
-        callMethod(BoxedBooleanClass, hashCodeMethodName),
         callMethod(BoxedDoubleClass, hashCodeMethodName),
         callMethod(BoxedStringClass, hashCodeMethodName),
-        callMethod(BoxedUnitClass, hashCodeMethodName),
-        cond(config.esFeatures.allowBigIntsForLongs) {
-          callMethod(BoxedLongClass, hashCodeMethodName)
-        },
 
         cond(!config.esFeatures.allowBigIntsForLongs) {
           multiple(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
@@ -47,6 +47,8 @@ private[emitter] object TreeDSL {
       UnaryOp(ir.Trees.JSUnaryOp.-, self)
     def unary_!(implicit pos: Position): Tree =
       UnaryOp(ir.Trees.JSUnaryOp.!, self)
+    def unary_~(implicit pos: Position): Tree =
+      UnaryOp(ir.Trees.JSUnaryOp.~, self)
 
     def &&(that: Tree)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.&&, self, that)
@@ -70,6 +72,8 @@ private[emitter] object TreeDSL {
       BinaryOp(ir.Trees.JSBinaryOp.|, self, that)
     def |(that: Int)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.|, self, IntLiteral(that))
+    def ^(that: Tree)(implicit pos: Position): Tree =
+      BinaryOp(ir.Trees.JSBinaryOp.^, self, that)
 
     def <<(that: Tree)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.<<, self, that)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1666,7 +1666,7 @@ object Build {
         scalaVersion.value match {
           case "2.11.12" =>
             Some(ExpectedSizes(
-                fastLink = 519000 to 520000,
+                fastLink = 520000 to 521000,
                 fullLink = 108000 to 109000,
                 fastLinkGz = 66000 to 67000,
                 fullLinkGz = 28000 to 29000,
@@ -1674,7 +1674,7 @@ object Build {
 
           case "2.12.12" =>
             Some(ExpectedSizes(
-                fastLink = 780000 to 781000,
+                fastLink = 781000 to 782000,
                 fullLink = 148000 to 149000,
                 fastLinkGz = 91000 to 92000,
                 fullLinkGz = 36000 to 37000,
@@ -1683,7 +1683,7 @@ object Build {
           case "2.13.4" =>
             Some(ExpectedSizes(
                 fastLink = 780000 to 781000,
-                fullLink = 169000 to 170000,
+                fullLink = 170000 to 171000,
                 fastLinkGz = 98000 to 99000,
                 fullLinkGz = 43000 to 44000,
             ))

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -44,6 +44,9 @@ object Platform {
   def jsMaps: Boolean =
     assumeES2015 || js.typeOf(js.Dynamic.global.Map) != "undefined"
 
+  def jsBigInts: Boolean =
+    js.typeOf(js.Dynamic.global.BigInt) != "undefined"
+
   def sourceMaps: Boolean = BuildInfo.hasSourceMaps && executingInNodeJS
 
   def assumeES2015: Boolean = BuildInfo.es2015

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
@@ -14,8 +14,10 @@ package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform
 
 import scala.scalajs.js
 
@@ -40,5 +42,72 @@ class ObjectJSTest {
 
     val obj = new CloneOnNonScalaObject()
     assertThrows(classOf[CloneNotSupportedException], obj.boom())
+  }
+
+  @Test def hashCodeOfSymbols(): Unit = {
+    /* None of the specific values here are by-spec. This test is highly
+     * implementation-dependent. It is written like this to make sure that we
+     * are returning different values for different arguments, but the specific
+     * values are irrelevant and could be changed at any time.
+     *
+     * By-spec, however, hashCode() delegates to System.identityHashCode() for
+     * symbols, since they are not Scala objects nor primitives that correspond
+     * to a hijacked class. So the values here must be equal to those in
+     * `SystemJSTest.identityHashCodeOfSymbols()`.
+     */
+
+    assumeTrue("requires JS symbols", Platform.jsSymbols)
+
+    @noinline def test(hash: Int, x: js.Symbol): Unit =
+      assertEquals(hash, x.hashCode())
+
+    // unfortunately, all symbols without description hash to the same value
+    test(0, js.Symbol())
+
+    test(0, js.Symbol(""))
+    test(-1268878963, js.Symbol("foobar"))
+    test(93492084, js.Symbol("babar"))
+    test(3392903, js.Symbol(null))
+
+    test(-1268878963, js.Symbol.forKey("foobar"))
+    test(93492084, js.Symbol.forKey("babar"))
+    test(3392903, js.Symbol.forKey(null))
+  }
+
+  @Test def hashCodeOfBigInts(): Unit = {
+    /* None of the specific values here are by-spec. This test is highly
+     * implementation-dependent. It is written like this to make sure that we
+     * are returning different values for different arguments, but the specific
+     * values are irrelevant and could be changed at any time.
+     *
+     * By-spec, however, hashCode() delegates to System.identityHashCode() for
+     * bigints, since they are not Scala objects nor primitives that correspond
+     * to a hijacked class (except for those that fit in a Long when we
+     * implement Longs as bigints). So the values here must be equal to those
+     * in `SystemJSTest.identityHashCodeOfBigInts()`.
+     */
+
+    assumeTrue("requires JS bigints", Platform.jsBigInts)
+
+    @noinline def test(hash: Int, x: js.BigInt): Unit =
+      assertEquals(hash, System.identityHashCode(x))
+
+    test(0, js.BigInt("0"))
+    test(1, js.BigInt("1"))
+    test(0, js.BigInt("-1"))
+
+    test(-1746700373, js.BigInt("4203407456681260900"))
+    test(1834237377, js.BigInt("-4533628472446063315"))
+    test(1917535332, js.BigInt("-8078028383605336161"))
+    test(1962981592, js.BigInt("-1395767907951999837"))
+    test(1771769687, js.BigInt("4226100786750107409"))
+    test(-1655946833, js.BigInt("8283069451989884520"))
+    test(969818862, js.BigInt("-4956907030691723841"))
+    test(-614637591, js.BigInt("7053247622210876606"))
+    test(1345794172, js.BigInt("4113526825251053222"))
+    test(-575359500, js.BigInt("7285869072471305893"))
+
+    test(-413046144, js.BigInt("52943860994923075240706774564564704640410650435892"))
+    test(-726153056, js.BigInt("-89593710930720640163135273078359588137037151908747"))
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -67,8 +67,6 @@ class SystemJSTest {
   @Test def systemProperties(): Unit = {
     def get(key: String): String = java.lang.System.getProperty(key)
 
-    def trueCount(xs: Boolean*): Int = xs.count(identity)
-
     // Defined in System.scala
 
     assertEquals("1.8", get("java.version"))

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -20,6 +20,7 @@ import scala.scalajs.runtime.linkingInfo
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 class SystemJSTest {
 
@@ -62,6 +63,127 @@ class SystemJSTest {
       assertEquals(x1FirstHash, x1.hashCode())
       assertEquals(x1FirstHash, System.identityHashCode(x1))
     }
+  }
+
+  @Test def identityHashCodeOfValuesImplementedAsJSPrimitives(): Unit = {
+    /* None of the specific values here are by-spec. This test is highly
+     * implementation-dependent. It is written like this to make sure that we
+     * are returning different values for different arguments, but the specific
+     * values are irrelevant and could be changed at any time.
+     */
+
+    @noinline def test(hash: Int, x: Any): Unit =
+      assertEquals(hash, System.identityHashCode(x))
+
+    test(101574, "foo")
+    test(0, "")
+
+    test(1237, false)
+    test(1231, true)
+
+    test(5, 5)
+    test(789456, 789456)
+
+    test(0, 0.0)
+    test(-2147483648, -0.0)
+    test(1234, 1234.0)
+    test(1073217536, 1.5)
+    test(340593891, Math.PI)
+    test(-54, -54.0)
+
+    test(1, Double.MinPositiveValue)
+    test(1048576, Double.MinValue)
+    test(-2146435072, Double.MaxValue)
+
+    test(2146959360, Double.NaN)
+    test(2146435072, Double.PositiveInfinity)
+    test(-1048576, Double.NegativeInfinity)
+
+    test(0, ())
+
+    if (js.typeOf(0L) == "bigint") {
+      test(0, 0L)
+      test(1, 1L)
+      test(0, -1L)
+
+      test(-1746700373, 4203407456681260900L)
+      test(1834237377, -4533628472446063315L)
+      test(1917535332, -8078028383605336161L)
+      test(1962981592, -1395767907951999837L)
+      test(1771769687, 4226100786750107409L)
+      test(-1655946833, 8283069451989884520L)
+      test(969818862, -4956907030691723841L)
+      test(-614637591, 7053247622210876606L)
+      test(1345794172, 4113526825251053222L)
+      test(-575359500, 7285869072471305893L)
+    }
+  }
+
+  @Test def identityHashCodeOfSymbols(): Unit = {
+    /* None of the specific values here are by-spec. This test is highly
+     * implementation-dependent. It is written like this to make sure that we
+     * are returning different values for different arguments, but the specific
+     * values are irrelevant and could be changed at any time.
+     *
+     * By-spec, however, hashCode() delegates to System.identityHashCode() for
+     * symbols, since they are not Scala objects nor primitives that correspond
+     * to a hijacked class. So the values here must be equal to those in
+     * `ObjectJSTest.hashCodeOfSymbols()`.
+     */
+
+    assumeTrue("requires JS symbols", Platform.jsSymbols)
+
+    @noinline def test(hash: Int, x: js.Symbol): Unit =
+      assertEquals(hash, System.identityHashCode(x))
+
+    // unfortunately, all symbols without description hash to the same value
+    test(0, js.Symbol())
+
+    test(0, js.Symbol(""))
+    test(-1268878963, js.Symbol("foobar"))
+    test(93492084, js.Symbol("babar"))
+    test(3392903, js.Symbol(null))
+
+    test(-1268878963, js.Symbol.forKey("foobar"))
+    test(93492084, js.Symbol.forKey("babar"))
+    test(3392903, js.Symbol.forKey(null))
+  }
+
+  @Test def identityHashCodeOfBigInts(): Unit = {
+    /* None of the specific values here are by-spec. This test is highly
+     * implementation-dependent. It is written like this to make sure that we
+     * are returning different values for different arguments, but the specific
+     * values are irrelevant and could be changed at any time.
+     *
+     * By-spec, however, hashCode() delegates to System.identityHashCode() for
+     * bigints, since they are not Scala objects nor primitives that correspond
+     * to a hijacked class (except for those that fit in a Long when we
+     * implement Longs as bigints). So the values here must be equal to those
+     * in `SystemJSTest.identityHashCodeOfBigInts()`.
+     */
+
+    assumeTrue("requires JS bigints", Platform.jsBigInts)
+
+    @noinline def test(hash: Int, x: js.BigInt): Unit =
+      assertEquals(hash, System.identityHashCode(x))
+
+    test(0, js.BigInt("0"))
+    test(1, js.BigInt("1"))
+    test(0, js.BigInt("-1"))
+
+    test(-1746700373, js.BigInt("4203407456681260900"))
+    test(1834237377, js.BigInt("-4533628472446063315"))
+    test(1917535332, js.BigInt("-8078028383605336161"))
+    test(1962981592, js.BigInt("-1395767907951999837"))
+    test(1771769687, js.BigInt("4226100786750107409"))
+    test(-1655946833, js.BigInt("8283069451989884520"))
+    test(969818862, js.BigInt("-4956907030691723841"))
+    test(-614637591, js.BigInt("7053247622210876606"))
+    test(1345794172, js.BigInt("4113526825251053222"))
+    test(-575359500, js.BigInt("7285869072471305893"))
+
+    test(-413046144, js.BigInt("52943860994923075240706774564564704640410650435892"))
+    test(-726153056, js.BigInt("-89593710930720640163135273078359588137037151908747"))
   }
 
   @Test def systemProperties(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -168,26 +168,12 @@ class SystemTest {
     val list2 = List(1, 3, 5)
     assertEquals(list2, list1)
     assertEquals(list2.hashCode(), list1.hashCode())
-    assertNotEquals(System.identityHashCode(list1), System.identityHashCode(list2))
+    if (!executingInJVM)
+      assertNotEquals(System.identityHashCode(list1), System.identityHashCode(list2))
   }
 
   @Test def identityHashCodeOfNull(): Unit = {
     assertEquals(0, System.identityHashCode(null))
-  }
-
-  @Test def identityHashCodeOfValuesImplementedAsJSPrimitives(): Unit = {
-    if (!executingInJVM) {
-      assertEquals("foo".hashCode(), System.identityHashCode("foo"))
-      assertEquals("".hashCode(), System.identityHashCode(""))
-
-      assertEquals(false.hashCode(), System.identityHashCode(false))
-      assertEquals(true.hashCode(), System.identityHashCode(true))
-
-      assertEquals(5.hashCode(), System.identityHashCode(5))
-      assertEquals(789456.hashCode(), System.identityHashCode(789456))
-
-      assertEquals(().hashCode(), System.identityHashCode(()))
-    }
   }
 
   @Test def lineSeparator(): Unit = {


### PR DESCRIPTION
By spec, for values that are not Scala objects nor primitives corresponding to a hijacked class, `x.hashCode()` resolves to `j.l.Object.hashCode()`, which delegates to `System.identityHashCode()`.

Previously, the implementation of the latter would jump back to `j.l.Object.hashCode()` for JS `bigint`s, and crash with a `TypeError` for `symbol`s.

The main cause of these issues is that we thought we could delegate back to `j.l.Object.hashCode()` for all primitives, because they are supposed to be covered by hijacked classes. We had forgotten `symbol`s, though, and anyway it does not work because not all JS primitives are covered by a hijacked class.

In this commit, we break this cycle. `systemIdentityHashCode` never delegates back to `j.l.Object.hashCode()` anymore. Instead, it separately handles every type of primitive in JavaScript with a dedicated hash code implementation. For strings and numbers, we reuse `j.l.String.hashCode()` and `j.l.Double.hashCode()`, because we can. For other values, we have an inline implementation.