### PR TITLE
Fix #4416: Remove stale methods from the Emitter's caches.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -599,6 +599,7 @@ final class Emitter(config: Emitter.Config) {
     def startRun(): Unit = {
       _cacheUsed = false
       _methodCaches.foreach(_.valuesIterator.foreach(_.startRun()))
+      _memberMethodCache.valuesIterator.foreach(_.startRun())
       _constructorCache.foreach(_.startRun())
     }
 


### PR DESCRIPTION
Previously, we forgot to reset the `_cacheUsed` flag of non-static-like methods in the Emitter's caches. This caused them never to be removed even if they were not used in a run.

The fix is beneficial anyway for memory consumption, but it should not have been necessary for correctness. The issue happened because the `IncOptimizer` can reuse past values of `version` for a given method, if it was removed in a run and then reappeared. This observation raises a larger question about whether that is valid (and therefore should be accounted for in subsequent phases like the Emitter), but that is left for a later fix.