### PR TITLE
Fix #4412: Publish sbt-scalajs to Maven Central, like everything else.

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -9,14 +9,12 @@
     1. Ping people on the commit for review.
     1. Once you have LGTM, push to master (do *not* create a merge commit).
 1. Testing (post results as comments to commit):
-    - Nightly
-    - Weekly
+    - Full build
     - [Manual testing][3]
 1. If all tests pass, tag the commit with the release version.
 1. Perform [manual testing][3] that needs the tagging (source maps).
 1. Publish:
     - Sonatype, bintray (`./script/publish.sh`)
-    - [Publish the CLI][4]
     - Docs to website: Use
       `~/fetchapis.sh <full sjs version> <binary sjs version>` on the webserver
       once artifacts are on maven central.
@@ -30,12 +28,11 @@
       webserver)
     - Announce on Twitter using the @scala_js account
     - Announce on [Gitter](https://gitter.im/scala-js/scala-js)
-    - Announce on the mailing list (scala-js@googlegroups.com)
-    - Cross-post to scala-announce (scala-announce@googlegroups.com)
+    - Cross-post as an Announcement in Scala Users ([example][7])
 
 [1]: https://github.com/scala-js/scala-js/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aclosed%20no%3Amilestone%20-label%3Ainvalid%20-label%3Aduplicate%20-label%3Aas-designed%20-label%3Aquestion%20-label%3Awontfix%20-label%3A%22can%27t%20reproduce%22%20-label%3A%22separate%20repo%22
-[2]: https://github.com/scala-js/scala-js/commit/a09e8cdd92b962e90c83ec124b9764970a4889ff
-[3]: https://github.com/scala-js/scala-js/blob/master/TESTING
-[4]: https://github.com/scala-js/scala-js-cli/blob/master/RELEASING.md
-[5]: https://github.com/scala-js/scala-js/commit/c51f8b65d3eca45de84397f7167058c91d6b6aa1
-[6]: https://github.com/scala-js/scala-js-website/commit/8dc9e9d3ee63ec47e6eb154fa7bd5a2ae8d1d42d
+[2]: https://github.com/scala-js/scala-js/commit/c3520bb9dae46757a975cccd428a77b8d6e6a75e
+[3]: https://github.com/scala-js/scala-js/blob/master/TESTING.md
+[5]: https://github.com/scala-js/scala-js/commit/c6c82e80f56bd2008ff8273088bbbbbbbc30f777
+[6]: https://github.com/scala-js/scala-js-website/commit/057f743c3fb8abe6077fb4debeeec45cd5c53d5d
+[7]: https://users.scala-lang.org/t/announcing-scala-js-1-4-0/7013

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -14,7 +14,7 @@
 1. If all tests pass, tag the commit with the release version.
 1. Perform [manual testing][3] that needs the tagging (source maps).
 1. Publish:
-    - Sonatype, bintray (`./script/publish.sh`)
+    - Sonatype (`./script/publish.sh`)
     - Docs to website: Use
       `~/fetchapis.sh <full sjs version> <binary sjs version>` on the webserver
       once artifacts are on maven central.

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -223,9 +223,6 @@ object MyScalaJSPlugin extends AutoPlugin {
 object Build {
   import MyScalaJSPlugin.{addScalaJSCompilerOption, addScalaJSCompilerOptionInConfig, isGeneratingForIDE}
 
-  val bintrayProjectName = settingKey[String](
-      "Project name on Bintray")
-
   val scalastyleCheck = taskKey[Unit]("Run scalastyle")
 
   val fetchScalaSource = taskKey[File](
@@ -542,26 +539,6 @@ object Build {
 
         Seq(outputDir)
       }
-  )
-
-  private def publishToBintraySettings = Def.settings(
-      publishTo := {
-        val proj = bintrayProjectName.value
-        val ver = version.value
-        if (isSnapshot.value) {
-          None // Bintray does not support snapshots
-        } else {
-          val url = new java.net.URL(
-              s"https://api.bintray.com/content/scala-js/scala-js-releases/$proj/$ver")
-          val patterns = Resolver.ivyStylePatterns
-          Some(Resolver.url("bintray", url)(patterns))
-        }
-      }
-  )
-
-  val publishIvySettings = Def.settings(
-      publishToBintraySettings,
-      publishMavenStyle := false
   )
 
   private def parallelCollectionsDependencies(
@@ -1032,11 +1009,10 @@ object Build {
   lazy val plugin: Project = Project(id = "sbtPlugin", base = file("sbt-plugin"))
       .enablePlugins(ScriptedPlugin).settings(
       commonSettings,
-      publishIvySettings,
+      publishSettings,
       fatalWarningsSettings,
       name := "Scala.js sbt plugin",
       normalizedName := "sbt-scalajs",
-      bintrayProjectName := "sbt-scalajs-plugin", // "sbt-scalajs" was taken
       sbtPlugin := true,
       crossScalaVersions := Seq("2.12.12"),
       scalaVersion := crossScalaVersions.value.head,


### PR DESCRIPTION
After this commit, `git grep -i bintray` returns no result.