### PR TITLE
Fix #4409: Do not emit abstract methods in non-native JS classes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -1820,11 +1820,16 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         val methodName = encodeMethodSym(sym)
         val originalName = originalNameOfMethod(sym)
 
+        val isAbstract = isAbstractMethod(dd)
+
         def jsParams = params.map(genParamDef(_))
 
         if (scalaPrimitives.isPrimitive(sym)) {
           None
-        } else if (isAbstractMethod(dd)) {
+        } else if (isAbstract && isNonNativeJSClass(currentClassSym)) {
+          // #4409: Do not emit abstract methods in non-native JS classes
+          None
+        } else if (isAbstract) {
           val body = if (scalaUsesImplClasses &&
               sym.hasAnnotation(JavaDefaultMethodAnnotation)) {
             /* For an interface method with @JavaDefaultMethod, make it a

--- a/ir/shared/src/main/scala/org/scalajs/ir/InvalidIRException.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/InvalidIRException.scala
@@ -12,5 +12,5 @@
 
 package org.scalajs.ir
 
-class InvalidIRException(val tree: Trees.Tree, message: String)
+class InvalidIRException(val tree: Trees.IRNode, message: String)
     extends Exception(message)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1354,7 +1354,7 @@ object Serializers {
 
       // #4409: Filter out abstract methods in non-native JS classes for version < 1.5
       if (ownerKind.isJSClass) {
-        if (true) { // temp: test backward compat
+        if (hacks.use14) {
           memberDefs.filter { m =>
             m match {
               case MethodDef(_, _, _, _, _, None) => false


### PR DESCRIPTION
@gzm0 Is this an appropriate way to fix this in 1.5? Throwing the exception would be moved to the `ClassDefChecker` in the future.