### PR TITLE
Fix #4434: java.lang.Class.getSimpleName parses incorrectly

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Class.scala
+++ b/javalanglib/src/main/scala/java/lang/Class.scala
@@ -74,6 +74,9 @@ final class Class[A] private (data0: Object) extends Object {
   def getSimpleName(): String = {
     val name = data.name
     var idx = name.length - 1
+    while (idx >= 0 && name.charAt(idx) != '$') {
+      idx -= 1
+    }
     while (idx >= 0 && name.charAt(idx) == '$') {
       idx -= 1
     }


### PR DESCRIPTION
This skips the last '$' character to match the output of the JVM