### PR TITLE
Fix #3706: Use a new instance for the result of divideToIntegralValue.

### DIFF
--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -1015,9 +1015,7 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
     if (resultPrecision > mcPrecision)
       throw new ArithmeticException("Division impossible")
 
-    integralValue._scale = safeLongToInt(finalScale)
-    integralValue.setUnscaledValue(strippedBI)
-    integralValue
+    new BigDecimal(strippedBI, safeLongToInt(finalScale))
     // scalastyle:on return
   }
 

--- a/scala-test-suite/src/test/resources/2.13.0/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.0/BlacklistedTests.txt
@@ -172,9 +172,6 @@ scala/util/matching/RegexTest.scala
 # Require strict-floats
 scala/math/BigDecimalTest.scala
 
-# Fails for a BigDecimal range with augmented precision (might be an actual bug)
-scala/collection/immutable/NumericRangeTest.scala
-
 # Tests passed but are too slow (timeouts)
 scala/collection/immutable/ListSetTest.scala
 scala/util/SortingTest.scala

--- a/scala-test-suite/src/test/resources/2.13.1/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.1/BlacklistedTests.txt
@@ -173,9 +173,6 @@ scala/util/matching/RegexTest.scala
 # Require strict-floats
 scala/math/BigDecimalTest.scala
 
-# Fails for a BigDecimal range with augmented precision (might be an actual bug)
-scala/collection/immutable/NumericRangeTest.scala
-
 # Tests passed but are too slow (timeouts)
 scala/collection/immutable/ListSetTest.scala
 scala/util/SortingTest.scala

--- a/scala-test-suite/src/test/resources/2.13.2/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.2/BlacklistedTests.txt
@@ -180,9 +180,6 @@ scala/util/matching/RegexTest.scala
 # Require strict-floats
 scala/math/BigDecimalTest.scala
 
-# Fails for a BigDecimal range with augmented precision (might be an actual bug)
-scala/collection/immutable/NumericRangeTest.scala
-
 # Tests passed but are too slow (timeouts)
 scala/collection/immutable/ListSetTest.scala
 scala/util/SortingTest.scala

--- a/scala-test-suite/src/test/resources/2.13.3/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.3/BlacklistedTests.txt
@@ -205,9 +205,6 @@ scala/util/matching/RegexTest.scala
 # Require strict-floats
 scala/math/BigDecimalTest.scala
 
-# Fails for a BigDecimal range with augmented precision (might be an actual bug)
-scala/collection/immutable/NumericRangeTest.scala
-
 # Tests passed but are too slow (timeouts)
 scala/collection/immutable/ListSetTest.scala
 scala/util/SortingTest.scala

--- a/scala-test-suite/src/test/resources/2.13.4/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.4/BlacklistedTests.txt
@@ -200,9 +200,6 @@ scala/util/matching/RegexTest.scala
 # Require strict-floats
 scala/math/BigDecimalTest.scala
 
-# Fails for a BigDecimal range with augmented precision (might be an actual bug)
-scala/collection/immutable/NumericRangeTest.scala
-
 # Tests passed but are too slow (timeouts)
 scala/collection/immutable/ListSetTest.scala
 scala/util/SortingTest.scala

--- a/scalalib/overrides-2.12/scala/collection/immutable/NumericRange.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/NumericRange.scala
@@ -1,10 +1,14 @@
-/*                     __                                               *\
-**     ________ ___   / /  ___     Scala API                            **
-**    / __/ __// _ | / /  / _ |    (c) 2006-2013, LAMP/EPFL             **
-**  __\ \/ /__/ __ |/ /__/ __ |    http://scala-lang.org/               **
-** /____/\___/_/ |_/____/_/ | |                                         **
-**                          |/                                          **
-\*                                                                      */
+/*
+ * Scala (https://www.scala-lang.org)
+ *
+ * Copyright EPFL and Lightbend, Inc.
+ *
+ * Licensed under Apache License 2.0
+ * (http://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
 
 package scala
 package collection
@@ -30,7 +34,6 @@ package immutable
  *  }}}
  *
  *  @author  Paul Phillips
- *  @version 2.8
  *  @define Coll `NumericRange`
  *  @define coll numeric range
  *  @define mayNotTerminateInf
@@ -119,7 +122,7 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
     //   (Integral <: Ordering). This can happen for custom Integral types.
     // - The Ordering is the default Ordering of a well-known Integral type.
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
-      if (num.signum(step) > 0) start
+      if (num.signum(step) > 0) head
       else last
     } else super.min(ord)
 
@@ -127,7 +130,7 @@ extends AbstractSeq[T] with IndexedSeq[T] with Serializable {
     // See comment for fast path in min().
     if ((ord eq num) || defaultOrdering.get(num).exists(ord eq _)) {
       if (num.signum(step) > 0) last
-      else start
+      else head
     } else super.max(ord)
 
   // Motivated by the desire for Double ranges with BigDecimal precision,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -992,6 +992,14 @@ class  BigDecimalArithmeticTest {
     assertEquals(result.scale(), resScale)
   }
 
+  @Test def testDivideToIntegralValueMathContext_Issue3706(): Unit = {
+    val diff = new BigDecimal("1e-30")
+    val step = new BigDecimal("1e-38")
+    val quotient = diff.divideToIntegralValue(step, MathContext.DECIMAL128)
+    val limit = new BigDecimal(Int.MaxValue)
+    assertTrue(quotient.compareTo(limit) < 0)
+  }
+
   @Test def testDivideZero(): Unit = {
     var quotient = BigDecimal.ZERO.divide(BigDecimal.ONE)
     assertTrue(BigDecimal.ZERO == quotient)


### PR DESCRIPTION
Previously, we reused the instance `integralValue` and reset its fields. However, we had forgotten to reset `_precision` which caused an internally inconsistent instance to leak to callers.

We could have fixed it just by resetting `_precision`, but this is not something that is usually done elsewhere in the implementation of `BigDecimal`. Instead, we simply return a brand new instance, which will not be tainted by previous calculations.