### PR TITLE
Make `FloatingPointBits.numberHashCode()` allocation-free.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1662,7 +1662,7 @@ object Build {
         scalaVersion.value match {
           case "2.11.12" =>
             Some(ExpectedSizes(
-                fastLink = 520000 to 521000,
+                fastLink = 519000 to 520000,
                 fullLink = 108000 to 109000,
                 fastLinkGz = 66000 to 67000,
                 fullLinkGz = 28000 to 29000,
@@ -1679,7 +1679,7 @@ object Build {
           case "2.13.4" =>
             Some(ExpectedSizes(
                 fastLink = 780000 to 781000,
-                fullLink = 170000 to 171000,
+                fullLink = 169000 to 170000,
                 fastLinkGz = 98000 to 99000,
                 fullLinkGz = 43000 to 44000,
             ))


### PR DESCRIPTION
It seems a waste to allocate an instance of `RuntimeLong` to compute the Int hashCode() of a Double value. With a bit of refactoring and manual inlining, we can avoid all allocations in this low-level method.