### PR TITLE
Fix #4434: Return a sensible result for local classes in getSimpleName().

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Class.scala
+++ b/javalanglib/src/main/scala/java/lang/Class.scala
@@ -100,34 +100,38 @@ final class Class[A] private (data0: Object) extends Object {
   private def computeCachedSimpleNameBestEffort(): String = {
     @inline def isDigit(c: Char): scala.Boolean = c >= '0' && c <= '9'
 
-    val name = data.name
-    var idx = name.length - 1
+    if (isArray()) {
+      getComponentType().getSimpleName() + "[]"
+    } else {
+      val name = data.name
+      var idx = name.length - 1
 
-    // Include trailing '$'s for module class names
-    while (idx >= 0 && name.charAt(idx) == '$') {
-      idx -= 1
-    }
-
-    // Include '$'s followed by '0-9's for local class names
-    if (idx >= 0 && isDigit(name.charAt(idx))) {
-      idx -= 1
-      while (idx >= 0 && isDigit(name.charAt(idx))) {
-        idx -= 1
-      }
+      // Include trailing '$'s for module class names
       while (idx >= 0 && name.charAt(idx) == '$') {
         idx -= 1
       }
-    }
 
-    // Include until the next '$' (inner class) or '.' (top-level class)
-    while (idx >= 0 && {
-      val currChar = name.charAt(idx)
-      currChar != '.' && currChar != '$'
-    }) {
-      idx -= 1
-    }
+      // Include '$'s followed by '0-9's for local class names
+      if (idx >= 0 && isDigit(name.charAt(idx))) {
+        idx -= 1
+        while (idx >= 0 && isDigit(name.charAt(idx))) {
+          idx -= 1
+        }
+        while (idx >= 0 && name.charAt(idx) == '$') {
+          idx -= 1
+        }
+      }
 
-    name.substring(idx + 1)
+      // Include until the next '$' (inner class) or '.' (top-level class)
+      while (idx >= 0 && {
+        val currChar = name.charAt(idx)
+        currChar != '.' && currChar != '$'
+      }) {
+        idx -= 1
+      }
+
+      name.substring(idx + 1)
+    }
   }
 
   def getSuperclass(): Class[_ >: A] =

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1662,7 +1662,7 @@ object Build {
         scalaVersion.value match {
           case "2.11.12" =>
             Some(ExpectedSizes(
-                fastLink = 519000 to 520000,
+                fastLink = 520000 to 521000,
                 fullLink = 108000 to 109000,
                 fastLinkGz = 66000 to 67000,
                 fullLinkGz = 28000 to 29000,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
@@ -134,11 +134,23 @@ class ClassTest {
   object TestObject
 
   @Test def getSimpleName(): Unit = {
+    class LocalClassForGetSimpleName
+    object LocalObjectForGetSimpleName
+
+    def assertMatch(expectedPattern: String, actual: String): Unit = {
+      if (!actual.matches(expectedPattern))
+        fail(s"expected string matching $expectedPattern; got $actual")
+    }
+
     assertEquals("Integer", classOf[java.lang.Integer].getSimpleName())
     assertEquals("Class", classOf[java.lang.Class[_]].getSimpleName())
     assertEquals("Map", classOf[scala.collection.Map[_, _]].getSimpleName())
     assertEquals("InnerClass", classOf[ClassTestClass#InnerClass].getSimpleName())
     assertEquals("TestObject$", TestObject.getClass.getSimpleName())
+    assertMatch("^LocalClassForGetSimpleName\\$[0-9]+$",
+        classOf[LocalClassForGetSimpleName].getSimpleName())
+    assertMatch("^LocalObjectForGetSimpleName\\$[0-9]+\\$$",
+        LocalObjectForGetSimpleName.getClass.getSimpleName())
   }
 
   @Test def isAssignableFrom(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
@@ -151,6 +151,18 @@ class ClassTest {
         classOf[LocalClassForGetSimpleName].getSimpleName())
     assertMatch("^LocalObjectForGetSimpleName\\$[0-9]+\\$$",
         LocalObjectForGetSimpleName.getClass.getSimpleName())
+
+    assertEquals("int", classOf[Int].getSimpleName())
+
+    assertEquals("int[]", classOf[Array[Int]].getSimpleName())
+    assertEquals("String[]", classOf[Array[String]].getSimpleName())
+    assertEquals("String[][]", classOf[Array[Array[String]]].getSimpleName())
+    assertEquals("InnerClass[]", classOf[Array[ClassTestClass#InnerClass]].getSimpleName())
+    assertEquals("TestObject$[]", Array(TestObject).getClass.getSimpleName())
+    assertMatch("^LocalClassForGetSimpleName\\$[0-9]+\\[\\]$",
+        classOf[Array[LocalClassForGetSimpleName]].getSimpleName())
+    assertMatch("^LocalObjectForGetSimpleName\\$[0-9]+\\$\\[\\]$",
+        Array(LocalObjectForGetSimpleName).getClass.getSimpleName())
   }
 
   @Test def isAssignableFrom(): Unit = {


### PR DESCRIPTION
As the implementation is getting more complicated, we also extract the computation in a slow path, and cache the result.