### PR TITLE
Two changes in tests to make them friendly to Scala 3 true union types

### DIFF
--- a/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
+++ b/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212.scala
@@ -199,14 +199,12 @@ class JSOptionalTest212 {
     assertEquals(Some(3), obj.z)
   }
 
-  @Test def traitWithOptionalFunction(): Unit = {
-    val obj = new TraitWithOptionalFunction {
-      override val f = js.defined(x => x + 1)
-    }
-
-    assertEquals("function", js.typeOf(obj.f))
-    assertEquals(6, obj.f.get(5))
-  }
+  /* @Test def traitWithOptionalFunction(): Unit
+   * Moved to JSOptionalTest212FunParamInference.scala because Scala 3 cannot
+   * infer the parameter type yet when using true union types.
+   *
+   * See https://github.com/lampepfl/dotty/issues/11694
+   */
 }
 
 object JSOptionalTest212 {
@@ -246,9 +244,5 @@ object JSOptionalTest212 {
     def y: js.UndefOr[String]
     def y2: js.UndefOr[String]
     var z: js.UndefOr[Option[Int]]
-  }
-
-  trait TraitWithOptionalFunction extends js.Object {
-    val f: js.UndefOr[js.Function1[Int, Int]] = js.undefined
   }
 }

--- a/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212FunParamInference.scala
+++ b/test-suite/js/src/test/require-2.12/org/scalajs/testsuite/jsinterop/JSOptionalTest212FunParamInference.scala
@@ -1,0 +1,43 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import org.junit.Assert._
+import org.junit.Test
+
+/** Extracted from JSOptionalTest212.scala because Scala 3 cannot infer the
+ *  parameter type yet when using true union types.
+ *
+ *  See https://github.com/lampepfl/dotty/issues/11694
+ */
+class JSOptionalTest212FunParamInference {
+  import JSOptionalTest212FunParamInference._
+
+  @Test def traitWithOptionalFunction(): Unit = {
+    val obj = new TraitWithOptionalFunction {
+      override val f = js.defined(x => x + 1)
+    }
+
+    assertEquals("function", js.typeOf(obj.f))
+    assertEquals(6, obj.f.get(5))
+  }
+}
+
+object JSOptionalTest212FunParamInference {
+  trait TraitWithOptionalFunction extends js.Object {
+    val f: js.UndefOr[js.Function1[Int, Int]] = js.undefined
+  }
+}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PromiseMock.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/PromiseMock.scala
@@ -166,7 +166,7 @@ object PromiseMock {
     // 25.4.1.3.2 Promise Resolve Functions
     private[this] def resolve(resolution: A | Thenable[A]): Unit = {
       if (state == Pending) {
-        if ((resolution: AnyRef) eq (this: AnyRef)) {
+        if (resolution.asInstanceOf[AnyRef] eq this) {
           reject(new js.TypeError("Self resolution"))
         } else if (isNotAnObject(resolution)) {
           fulfill(resolution.asInstanceOf[A])


### PR DESCRIPTION
See https://github.com/lampepfl/dotty/pull/11671#issuecomment-795916705, and also https://github.com/lampepfl/dotty/issues/11694

/cc @smarter