### PR TITLE
Allow to specify target versions of ECMAScript > 2015.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -167,7 +167,7 @@ def Tasks = [
     sbtretry ++$scala library$v/mimaReportBinaryIssues testInterface$v/mimaReportBinaryIssues
   ''',
 
-  "test-suite-ecma-script2015": '''
+  "test-suite-default-esversion": '''
     setJavaVersion $java
     npm install &&
     sbtretry ++$scala jUnitTestOutputsJVM$v/test jUnitTestOutputsJS$v/test testBridge$v/test \
@@ -235,98 +235,98 @@ def Tasks = [
         ++$scala $testSuite$v/test
   ''',
 
-  "test-suite-ecma-script5-force-polyfills": '''
+  "test-suite-custom-esversion-force-polyfills": '''
     setJavaVersion $java
     npm install &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := false)' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
         ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := false)' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := false)' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := false)' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := false)' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := false)' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean
   ''',
 
-  "test-suite-ecma-script5": '''
+  "test-suite-custom-esversion": '''
     setJavaVersion $java
     npm install &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false).withAllowBigIntsForLongs(true)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion).withAllowBigIntsForLongs(true)))' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false).withAllowBigIntsForLongs(true)).withOptimizer(false))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion).withAllowBigIntsForLongs(true)).withOptimizer(false))' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         ++$scala $testSuite$v/test &&
     sbtretry \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallestModules))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
         ++$scala $testSuite$v/test &&
     sbtretry \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallestModules))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
         ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withUseECMAScript2015(false)))' \
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test
@@ -435,20 +435,32 @@ def otherScalaVersions = [
   "2.13.3"
 ]
 
+def allESVersions = [
+  "ES5_1",
+  "ES2015",
+  // "ES2016", // We do not use anything specifically from ES2016
+  "ES2017",
+  "ES2018",
+  // "ES2019", // We do not use anything specifically from ES2019
+  "ES2020"
+]
+
 // The 'quick' matrix
 def quickMatrix = []
 mainScalaVersions.each { scalaVersion ->
   allJavaVersions.each { javaVersion ->
     quickMatrix.add([task: "main", scala: scalaVersion, java: javaVersion])
   }
-  quickMatrix.add([task: "test-suite-ecma-script2015", scala: scalaVersion, java: mainJavaVersion, testSuite: "testSuite"])
-  quickMatrix.add([task: "test-suite-ecma-script5", scala: scalaVersion, java: mainJavaVersion, testSuite: "testSuite"])
-  quickMatrix.add([task: "test-suite-ecma-script2015", scala: scalaVersion, java: mainJavaVersion, testSuite: "scalaTestSuite"])
-  quickMatrix.add([task: "test-suite-ecma-script5", scala: scalaVersion, java: mainJavaVersion, testSuite: "scalaTestSuite"])
+  quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testSuite: "testSuite"])
+  quickMatrix.add([task: "test-suite-custom-esversion", scala: scalaVersion, java: mainJavaVersion, esVersion: "ES5_1", testSuite: "testSuite"])
+  quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testSuite: "scalaTestSuite"])
+  quickMatrix.add([task: "test-suite-custom-esversion", scala: scalaVersion, java: mainJavaVersion, esVersion: "ES5_1", testSuite: "scalaTestSuite"])
   quickMatrix.add([task: "bootstrap", scala: scalaVersion, java: mainJavaVersion])
   quickMatrix.add([task: "partest-fastopt", scala: scalaVersion, java: mainJavaVersion])
 }
-quickMatrix.add([task: "test-suite-ecma-script5-force-polyfills", scala: mainScalaVersion, java: mainJavaVersion, testSuite: "testSuite"])
+allESVersions.each { esVersion ->
+  quickMatrix.add([task: "test-suite-custom-esversion-force-polyfills", scala: mainScalaVersion, java: mainJavaVersion, esVersion: esVersion, testSuite: "testSuite"])
+}
 allJavaVersions.each { javaVersion ->
   quickMatrix.add([task: "tools-sbtplugin", scala: "2.12.12", java: javaVersion])
   quickMatrix.add([task: "tools", scala: "2.11.12", java: javaVersion])
@@ -463,8 +475,7 @@ otherScalaVersions.each { scalaVersion ->
 }
 mainScalaVersions.each { scalaVersion ->
   otherJavaVersions.each { javaVersion ->
-    quickMatrix.add([task: "test-suite-ecma-script2015", scala: scalaVersion, java: javaVersion, testSuite: "testSuite"])
-    quickMatrix.add([task: "test-suite-ecma-script5", scala: scalaVersion, java: javaVersion, testSuite: "testSuite"])
+    quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: javaVersion, testSuite: "testSuite"])
   }
   fullMatrix.add([task: "partest-noopt", scala: scalaVersion, java: mainJavaVersion])
   fullMatrix.add([task: "partest-fullopt", scala: scalaVersion, java: mainJavaVersion])

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,8 +17,8 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.5.2-SNAPSHOT",
-    binaryEmitted = "1.5"
+    current = "1.6.0-SNAPSHOT",
+    binaryEmitted = "1.6-SNAPSHOT"
 )
 
 /** Helper class to allow for testing of logic. */

--- a/javalanglib/src/main/scala/java/lang/ClassValue.scala
+++ b/javalanglib/src/main/scala/java/lang/ClassValue.scala
@@ -17,12 +17,13 @@ import java.util.HashMap
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.runtime.linkingInfo
+import scala.scalajs.LinkingInfo.ESVersion
 
 import Utils._
 
 abstract class ClassValue[T] protected () {
   private val jsMap: js.Map[Class[_], T] = {
-    if (linkingInfo.assumingES6 || js.typeOf(js.Dynamic.global.Map) != "undefined")
+    if (linkingInfo.esVersion >= ESVersion.ES2015 || js.typeOf(js.Dynamic.global.Map) != "undefined")
       new js.Map()
     else
       null
@@ -34,7 +35,7 @@ abstract class ClassValue[T] protected () {
      * emitting ES 2015 code, which allows to dead-code-eliminate the branches
      * using `HashMap`s, and therefore `HashMap` itself.
      */
-    linkingInfo.assumingES6 || jsMap != null
+    linkingInfo.esVersion >= ESVersion.ES2015 || jsMap != null
   }
 
   /* We use a HashMap instead of an IdentityHashMap because the latter is

--- a/javalanglib/src/main/scala/java/lang/FloatingPointBits.scala
+++ b/javalanglib/src/main/scala/java/lang/FloatingPointBits.scala
@@ -13,8 +13,9 @@
 package java.lang
 
 import scala.scalajs.js
-import js.Dynamic.global
-import js.typedarray
+import scala.scalajs.js.Dynamic.global
+import scala.scalajs.js.typedarray
+import scala.scalajs.LinkingInfo.ESVersion
 
 /** Manipulating the bits of floating point numbers. */
 private[lang] object FloatingPointBits {
@@ -22,8 +23,8 @@ private[lang] object FloatingPointBits {
   import scala.scalajs.runtime.linkingInfo
 
   private[this] val _areTypedArraysSupported = {
-    // Here we use `assumingES6` to dce the 4 subsequent tests
-    linkingInfo.assumingES6 || {
+    // Here we use the `esVersion` test to dce the 4 subsequent tests
+    linkingInfo.esVersion >= ESVersion.ES2015 || {
       js.typeOf(global.ArrayBuffer) != "undefined" &&
       js.typeOf(global.Int32Array) != "undefined" &&
       js.typeOf(global.Float32Array) != "undefined" &&
@@ -35,13 +36,13 @@ private[lang] object FloatingPointBits {
   private def areTypedArraysSupported: scala.Boolean = {
     /* We have a forwarder to the internal `val _areTypedArraysSupported` to
      * be able to inline it. This achieves the following:
-     * * If we emit ES6, dce `|| _areTypedArraysSupported` and replace
+     * * If we emit ES2015+, dce `|| _areTypedArraysSupported` and replace
      *   `areTypedArraysSupported` by `true` in the calling code, allowing
      *   polyfills in the calling code to be dce'ed in turn.
      * * If we emit ES5, replace `areTypedArraysSupported` by
      *   `_areTypedArraysSupported` so we do not calculate it multiple times.
      */
-    linkingInfo.assumingES6 || _areTypedArraysSupported
+    linkingInfo.esVersion >= ESVersion.ES2015 || _areTypedArraysSupported
   }
 
   private val arrayBuffer =

--- a/javalanglib/src/main/scala/java/lang/Math.scala
+++ b/javalanglib/src/main/scala/java/lang/Math.scala
@@ -17,13 +17,14 @@ import scala.scalajs.js
 import js.Dynamic.{ global => g }
 
 import scala.scalajs.runtime.linkingInfo
+import scala.scalajs.LinkingInfo.ESVersion
 
 object Math {
   final val E  = 2.718281828459045
   final val PI = 3.141592653589793
 
   @inline private def assumingES6: scala.Boolean =
-    linkingInfo.assumingES6
+    linkingInfo.esVersion >= ESVersion.ES2015
 
   @inline def abs(a: scala.Int): scala.Int = if (a < 0) -a else a
   @inline def abs(a: scala.Long): scala.Long = if (a < 0) -a else a

--- a/library/src/main/scala/scala/scalajs/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/LinkingInfo.scala
@@ -78,8 +78,60 @@ object LinkingInfo {
   def developmentMode: Boolean =
     !productionMode
 
+  /** Version (edition) of the ECMAScript Language Specification that is
+   *  assumed to be supported by the runtime.
+   *
+   *  This is an integer that represents the *edition* of the ECMAScript
+   *  Language Specification. For example, ECMAScript 2015 is represented with
+   *  the value `6`.
+   *
+   *  As an exception, ECMAScript 5.1 is represented with the value `5`.
+   *
+   *  This value can be used to:
+   *
+   *  - avoid feature tests and dead-code-eliminate polyfills (see below), or
+   *  - conditionally offer library features that depend on underlying
+   *    ECMAScript support.
+   *
+   *  ---
+   *
+   *  This ends up being constant-folded to a constant at link-time. So
+   *  constant-folding, inlining, and other local optimizations can be
+   *  leveraged with this "constant" to write polyfills that can be
+   *  dead-code-eliminated.
+   *
+   *  A typical usage of this method is:
+   *  {{{
+   *  if (esVersion >= ESVersion.ES2018 || featureTest())
+   *    useES2018Feature()
+   *  else
+   *    usePolyfill()
+   *  }}}
+   *
+   *  At link-time, `esVersion` will either be a constant less than
+   *  `ESVersion.ES2018`, in which case the above snippet folds into
+   *  {{{
+   *  if (featureTest())
+   *    useES2018Feature()
+   *  else
+   *    usePolyfill()
+   *  }}}
+   *  or a constant greater or equal to `ESVersion.ES2018`, in which case it
+   *  folds into
+   *  {{{
+   *  useES2018Feature()
+   *  }}}
+   */
+  @inline
+  def esVersion: Int =
+    linkingInfo.esVersion
+
   /** Returns true if we are assuming that the target platform supports
    *  ECMAScript 6, false otherwise.
+   *
+   *  This is `true` if and only if `esVersion >= ESVersion.ES2015`.
+   *
+   *  ---
    *
    *  This ends up being constant-folded to a constant at link-time. So
    *  constant-folding, inlining, and other local optimizations can be
@@ -107,8 +159,127 @@ object LinkingInfo {
    *  useES6Feature()
    *  }}}
    */
+  @deprecated("use esVersion >= ESVersion.ES2015 instead", "1.6.0")
   @inline
   def assumingES6: Boolean =
-    linkingInfo.assumingES6
+    esVersion >= ESVersion.ES2015
 
+  /** Whether Scala.js language features use ECMAScript 2015 (edition 6)
+   *  semantics or not.
+   *
+   *  When `true`, the following semantics apply:
+   *
+   *  - JavaScript classes are true `class`'es, therefore a) they can extend
+   *    native JavaScript `class`'es and b) they inherit static members from
+   *    their parent class.
+   *  - Lambdas for `js.Function`s that are not also `js.ThisFunction`s are
+   *    JavaScript arrow functions (`=>`). Lambdas for `js.ThisFunction`s are
+   *    `function` functions.
+   *  - Throwable classes are proper JavaScript error classes, recognized as
+   *    such by debuggers.
+   *  - In Script (`NoModule`) mode, top-level exports are defined as `let`s.
+   *
+   *  When `false`, the following semantics apply:
+   *
+   *  - All classes defined in Scala.js are `function`s instead of `class`'es.
+   *    Non-native JS classes cannot extend native JS `class`'es and they do
+   *    not inherit static members from their parent class.
+   *  - All lambdas for `js.Function`s are `function`s.
+   *  - Throwable classes have JavaScript's `Error.prototype` in their
+   *    prototype chain, but they are not considered proper error classes.
+   *  - In Script (`NoModule`) mode, top-level exports are defined as `var`s.
+   *
+   *  Prefer reading this value instead of `esVersion` to determine which
+   *  semantics apply.
+   *
+   *  For example, it can be used in tests whose results depend on which
+   *  semantics are used.
+   *
+   *  ---
+   *
+   *  This ends up being constant-folded to a constant at link-time. So
+   *  constant-folding, inlining, and other local optimizations can be
+   *  leveraged with this "constant" to write alternatives that can be
+   *  dead-code-eliminated.
+   *
+   *  A typical usage of this method is:
+   *  {{{
+   *  if (useECMAScript2015Semantics)
+   *    implementationWithES2015Semantics()
+   *  else
+   *    implementationWithoutES2015Semantics()
+   *  }}}
+   *
+   *  At link-time, `useECMAScript2015Semantics` will either be a constant
+   *  true, in which case the above snippet folds into
+   *  {{{
+   *  implementationWithES2015Semantics()
+   *  }}}
+   *  or a constant false, in which case it folds into
+   *  {{{
+   *  implementationWithoutES2015Semantics()
+   *  }}}
+   */
+  @inline
+  def useECMAScript2015Semantics: Boolean =
+    linkingInfo.assumingES6 // name mismatch for historical reasons
+
+  /** Constants for the value of `esVersion`. */
+  object ESVersion {
+    /** ECMAScrîpt 5.1. */
+    final val ES5_1 = 5
+
+    /** ECMAScript 2015 (6th edition). */
+    final val ES2015 = 6
+
+    /** ECMAScript 2016 (7th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - The `**` operator for numbers
+     *  - `async`/`await`
+     */
+    final val ES2016 = 7
+
+    /** ECMAScript 2017 (8th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - Async functions
+     *  - Shared Memory and Atomics (via `SharedArrayBuffer`)
+     *  - `Object.values`, `Object.entries`, and `Object.getOwnPropertyDescriptors`
+     */
+    final val ES2017 = 8
+
+    /** ECMAScript 2018 (9th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - Asynchronous iteration via the `AsyncIterator` protocol and async generators
+     *  - Regular expression features: the dotAll flag `'s'`, named capture groups,
+     *    Unicode property escapes (`\p{}` and `\P{}`) and look-behind assertions
+     *  - Rest parameter and spread operator support for object properties
+     */
+    final val ES2018 = 9
+
+    /** ECMAScript 2019 (10th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - Minor additions to the built-in library functions
+     */
+    final val ES2019 = 10
+
+    /** ECMAScript 2020 (11th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - Dynamic `import()` calls
+     *  - `BigInt`
+     *  - `globalThis`
+     *  - `export * as ns from 'module'`
+     *  - `import.meta`
+     */
+    final val ES2020 = 11
+  }
 }

--- a/library/src/main/scala/scala/scalajs/js/BigInt.scala
+++ b/library/src/main/scala/scala/scalajs/js/BigInt.scala
@@ -15,7 +15,7 @@ package scala.scalajs.js
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSGlobal
 
-/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+/** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
  *
  *  A built-in object that provides a way to represent whole numbers larger than
  *  2 ^ 53 - 1, which is the largest number JavaScript can reliably represent
@@ -73,7 +73,7 @@ final class BigInt private[this] () extends js.Object {
 }
 
 
-/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+/** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
  *
  *  A companion object of BigInt class.
  *

--- a/library/src/main/scala/scala/scalajs/js/import.scala
+++ b/library/src/main/scala/scala/scalajs/js/import.scala
@@ -14,7 +14,7 @@ package scala.scalajs.js
 
 import scala.scalajs.js
 
-/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+/** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
  *  Dynamic `import(specifier)`.
  *
  *  This is an object rather than a simple `def` to reserve the possibility to
@@ -22,7 +22,7 @@ import scala.scalajs.js
  *  meta-property of ECMAScript (still being specified).
  */
 object `import` { // scalastyle:ignore
-  /** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+  /** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
    *  Dynamic `import(specifier)`.
    */
   def apply[A <: js.Any](specifier: String): js.Promise[A] =

--- a/library/src/main/scala/scala/scalajs/js/typedarray/BigInt64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/BigInt64Array.scala
@@ -15,7 +15,7 @@ package scala.scalajs.js.typedarray
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
-/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+/** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
  *
  *  A [[TypedArray]] of signed 64-bit integers represented as [[js.BigInt]].
  */
@@ -43,7 +43,7 @@ class BigInt64Array private[this] () extends TypedArray[js.BigInt, BigInt64Array
 
 }
 
-/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+/** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
  *  [[BigInt64Array]] companion
  */
 @js.native

--- a/library/src/main/scala/scala/scalajs/js/typedarray/BigUint64Array.scala
+++ b/library/src/main/scala/scala/scalajs/js/typedarray/BigUint64Array.scala
@@ -15,7 +15,7 @@ package scala.scalajs.js.typedarray
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
-/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+/** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
  *
  *  A [[TypedArray]] of unsigned 64-bit integers represented as [[js.BigInt]].
  */
@@ -44,8 +44,7 @@ class BigUint64Array private[this] ()
 
 }
 
-
-/** <span class="badge badge-ecma2019" style="float: right;">ECMAScript 2019</span>
+/** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
  *  [[BigUint64Array]] companion
  */
 @js.native

--- a/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/LinkingInfo.scala
@@ -16,7 +16,24 @@ import scala.scalajs.js
 
 /** Information about link-time configuration of Scala.js. */
 sealed trait LinkingInfo extends js.Object {
-  /** Whether we are assuming ECMAScript 6 support or not. */
+  /** Version (edition) of ECMAScript that is assumed to be supported by the
+   *  runtime.
+   *
+   *  This is an integer that represents the *edition* of the ECMAScript
+   *  Language Specification. For example, ECMAScript 2015 is represented with
+   *  the value `6`.
+   *
+   *  As an exception, ECMAScript 5.1 is represented with the value `5`.
+   */
+  val esVersion: Int
+
+  // Note: this cannot be renamed because it would prevent a newer linker from linking an older library
+  /** Whether Scala.js language features use ECMAScript 2015 (edition 6)
+   *  semantics or not.
+   *
+   *  For historical reasons, this is called `assumingES6`, but a better name
+   *  would be `useECMAScript2015Semantics`.
+   */
   val assumingES6: Boolean
 
   /** Whether we are linking in production mode. */

--- a/library/src/main/scala/scala/scalajs/runtime/PrivateFieldsSymbolHolder.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/PrivateFieldsSymbolHolder.scala
@@ -13,10 +13,12 @@
 package scala.scalajs.runtime
 
 import scala.scalajs.js
+import scala.scalajs.LinkingInfo.ESVersion
 
 private[runtime] object PrivateFieldsSymbolHolder {
   val privateFieldsSymbol: Any = {
-    if (scala.scalajs.LinkingInfo.assumingES6 ||
+    // Cannot import scala.scalajs.LinkingInfo because it is shadowed by runtime.LinkingInfo
+    if (scala.scalajs.LinkingInfo.esVersion >= ESVersion.ES2015 ||
         js.typeOf(js.Symbol) != "undefined") {
       js.Symbol("privateFields")
     } else {

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESVersion.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESVersion.scala
@@ -1,0 +1,98 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import Fingerprint.FingerprintBuilder
+
+final class ESVersion private (val edition: Int, val name: String)
+    extends Ordered[ESVersion] {
+
+  import ESVersion._
+
+  def compare(that: ESVersion): Int = this.edition.compareTo(that.edition)
+
+  override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
+
+  override def hashCode(): Int = edition.##
+
+  override def toString(): String =
+    s"$name (edition $edition)"
+}
+
+object ESVersion {
+  /** ECMAScrîpt 5.1. */
+  val ES5_1: ESVersion = new ESVersion(5, "ECMAScript 5.1")
+
+  /** ECMAScript 2015 (6th edition). */
+  val ES2015: ESVersion = new ESVersion(6, "ECMAScript 2015")
+
+  /** ECMAScript 2016 (7th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - The `**` operator for numbers
+   *  - `async`/`await`
+   */
+  val ES2016: ESVersion = new ESVersion(7, "ECMAScript 2016")
+
+  /** ECMAScript 2017 (8th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - Async functions
+   *  - Shared Memory and Atomics (via `SharedArrayBuffer`)
+   *  - `Object.values`, `Object.entries`, and `Object.getOwnPropertyDescriptors`
+   */
+  val ES2017: ESVersion = new ESVersion(8, "ECMAScript 2017")
+
+  /** ECMAScript 2018 (9th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - Asynchronous iteration via the `AsyncIterator` protocol and async generators
+   *  - Regular expression features: the dotAll flag `'s'`, named capture groups,
+   *    Unicode property escapes (`\p{}` and `\P{}`) and look-behind assertions
+   *  - Rest parameter and spread operator support for object properties
+   */
+  val ES2018: ESVersion = new ESVersion(9, "ECMAScript 2018")
+
+  /** ECMAScript 2019 (10th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - Minor additions to the built-in library functions
+   */
+  val ES2019: ESVersion = new ESVersion(10, "ECMAScript 2019")
+
+  /** ECMAScript 2020 (11th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - Dynamic `import()` calls
+   *  - `BigInt`
+   *  - `globalThis`
+   *  - `export * as ns from 'module'`
+   *  - `import.meta`
+   */
+  val ES2020: ESVersion = new ESVersion(11, "ECMAScript 2020")
+
+  private[interface] implicit object ESVersionFingerprint
+      extends Fingerprint[ESVersion] {
+
+    override def fingerprint(esVersion: ESVersion): String = {
+      new FingerprintBuilder("ESVersion")
+        .addField("edition", esVersion.edition)
+        .build()
+    }
+  }
+}

--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/ESFeaturesTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/ESFeaturesTest.scala
@@ -1,0 +1,37 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import org.junit.Test
+import org.junit.Assert._
+
+class ESFeaturesTest {
+  @deprecated("test deprecated features", "forever")
+  @Test def esVersionAndUseECMAScript2015AreLinked(): Unit = {
+    import ESFeatures.Defaults
+
+    assertEquals(ESVersion.ES2015, Defaults.esVersion)
+    assertTrue(Defaults.useECMAScript2015)
+
+    assertFalse(Defaults.withESVersion(ESVersion.ES5_1).useECMAScript2015)
+    assertEquals(ESVersion.ES5_1, Defaults.withUseECMAScript2015(false).esVersion)
+
+    val esFeaturesWithES2018 = Defaults.withESVersion(ESVersion.ES2018)
+    assertTrue(esFeaturesWithES2018.useECMAScript2015)
+
+    assertEquals(ESVersion.ES2018, esFeaturesWithES2018.withUseECMAScript2015(true).esVersion)
+    assertEquals(ESVersion.ES5_1, esFeaturesWithES2018.withUseECMAScript2015(false).esVersion)
+
+    assertFalse(esFeaturesWithES2018.withESVersion(ESVersion.ES5_1).useECMAScript2015)
+  }
+}

--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigFingerprintTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigFingerprintTest.scala
@@ -41,8 +41,8 @@ class StandardConfigFingerprintTest {
 
   @Test
   def noFingerprintCollisionESFeatures(): Unit = {
-    val sc1 = StandardConfig().withESFeatures(_.withUseECMAScript2015(true))
-    val sc2 = StandardConfig().withESFeatures(_.withUseECMAScript2015(false))
+    val sc1 = StandardConfig().withESFeatures(_.withESVersion(ESVersion.ES2015))
+    val sc2 = StandardConfig().withESFeatures(_.withESVersion(ESVersion.ES5_1))
     assertFingerprintsNotEquals(sc1, sc2)
   }
 

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -64,9 +64,22 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
 
   override def injectedIRFiles: Seq[IRFile] = emitter.injectedIRFiles
 
-  private val languageMode =
-    if (esFeatures.useECMAScript2015) ClosureOptions.LanguageMode.ECMASCRIPT_2015
-    else ClosureOptions.LanguageMode.ECMASCRIPT5_STRICT
+  private val languageMode: ClosureOptions.LanguageMode = {
+    import ClosureOptions.LanguageMode._
+
+    esFeatures.esVersion match {
+      case ESVersion.ES5_1  => ECMASCRIPT5_STRICT
+      case ESVersion.ES2015 => ECMASCRIPT_2015
+      case ESVersion.ES2016 => ECMASCRIPT_2016
+      case ESVersion.ES2017 => ECMASCRIPT_2017
+      case ESVersion.ES2018 => ECMASCRIPT_2018
+      case ESVersion.ES2019 => ECMASCRIPT_2019
+      case ESVersion.ES2020 => ECMASCRIPT_2020
+
+      case _ =>
+        throw new AssertionError(s"Unknown ES version ${esFeatures.esVersion}")
+    }
+  }
 
   /** Emit the given [[standard.ModuleSet ModuleSet]] to the target output.
    *

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -448,7 +448,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
           if (semantics.productionMode) Nil
           else js.StringLiteral(description) :: Nil
 
-        if (esFeatures.useECMAScript2015)
+        if (esFeatures.esVersion >= ESVersion.ES2015)
           js.Apply(js.VarRef(js.Ident("Symbol")), args)
         else
           genCallHelper("privateJSFieldSymbol", args: _*)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -88,7 +88,7 @@ final class Emitter(config: Emitter.Config) {
 
         val header = {
           val maybeTopLevelVarDecls = if (topLevelVars.nonEmpty) {
-            val kw = if (esFeatures.useECMAScript2015) "let " else "var "
+            val kw = if (esFeatures.useECMAScript2015Semantics) "let " else "var "
             topLevelVars.mkString(kw, ",", ";\n")
           } else {
             ""

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -316,6 +316,9 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
   private class JSDesugar()(
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge) {
 
+    // For convenience
+    private val es2015 = esFeatures.esVersion >= ESVersion.ES2015
+
     // Name management
 
     /** Whether we are running in the "optimistic naming" run.
@@ -511,10 +514,10 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case other                                        => other
       }
 
-      val actualArrowFun = arrow && useArrowFunctions
+      val actualArrowFun = arrow && esFeatures.useECMAScript2015Semantics
       val jsParams = params.map(transformParamDef(_))
 
-      if (esFeatures.useECMAScript2015) {
+      if (es2015) {
         val jsRestParam = restParam.map(transformParamDef(_))
         js.Function(actualArrowFun, jsParams, jsRestParam, cleanedNewBody)
       } else {
@@ -871,7 +874,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
             implicit val env = env0
             val jsArgs = newArgs.map(transformExprNoChar(_))
 
-            if (esFeatures.useECMAScript2015)
+            if (es2015)
               js.Apply(js.DotSelect(jsArgs.head, js.Ident("copyTo")), jsArgs.tail)
             else
               genCallHelper("systemArraycopy", jsArgs: _*)
@@ -1211,7 +1214,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
       require(!allowSideEffects || allowUnpure)
 
       def testJSArg(tree: TreeOrJSSpread): Boolean = tree match {
-        case JSSpread(items) => esFeatures.useECMAScript2015 && test(items)
+        case JSSpread(items) => es2015 && test(items)
         case tree: Tree      => test(tree)
       }
 
@@ -1987,7 +1990,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
     }
 
     private def needsToTranslateAnySpread(args: List[TreeOrJSSpread]): Boolean =
-      !esFeatures.useECMAScript2015 && args.exists(_.isInstanceOf[JSSpread])
+      !es2015 && args.exists(_.isInstanceOf[JSSpread])
 
     private def spreadToArgArray(args: List[TreeOrJSSpread])(
         implicit env: Env, pos: Position): Tree = {
@@ -2026,7 +2029,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
     private def doesObjectConstrRequireDesugaring(
         tree: JSObjectConstr): Boolean = {
       def computedNamesAllowed: Boolean =
-        esFeatures.useECMAScript2015
+        es2015
 
       def hasComputedName: Boolean =
         tree.fields.exists(!_._1.isInstanceOf[StringLiteral])
@@ -2064,7 +2067,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
     def transformJSArg(tree: TreeOrJSSpread)(implicit env: Env): js.Tree = {
       tree match {
         case JSSpread(items) =>
-          assert(esFeatures.useECMAScript2015)
+          assert(es2015)
           js.Spread(transformExprNoChar(items))(tree.pos)
         case tree: Tree =>
           transformExprNoChar(tree)
@@ -2347,7 +2350,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                     newLhs, newRhs)
               } else {
                 val objectIs =
-                  if (!esFeatures.useECMAScript2015) globalVar("is", CoreVar)
+                  if (!es2015) globalVar("is", CoreVar)
                   else genIdentBracketSelect(genGlobalVarRef("Object"), "is")
                 val objectIsCall = js.Apply(objectIs, newLhs :: newRhs :: Nil)
                 if (op == ===) objectIsCall
@@ -2655,7 +2658,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case Transient(ArrayToTypedArray(expr, primRef)) =>
           val value = transformExprNoChar(expr)
 
-          if (esFeatures.useECMAScript2015) {
+          if (es2015) {
             js.Apply(genIdentBracketSelect(value.u, "slice"), Nil)
           } else {
             val typedArrayClass = extractWithGlobals(typedArrayRef(primRef).get)
@@ -2665,7 +2668,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case Transient(TypedArrayToArray(expr, primRef)) =>
           val value = transformExprNoChar(expr)
 
-          val arrayValue = if (esFeatures.useECMAScript2015) {
+          val arrayValue = if (es2015) {
             js.Apply(genIdentBracketSelect(value, "slice"), Nil)
           } else {
             /* Array.prototype.slice.call(value)
@@ -2696,8 +2699,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           js.New(transformExprNoChar(constr), args.map(transformJSArg))
 
         case Transient(JSNewVararg(constr, argsArray)) =>
-          assert(!esFeatures.useECMAScript2015,
-              s"generated a JSNewVargs in ES 2015 mode at ${tree.pos}")
+          assert(!es2015, s"generated a JSNewVargs with ES 2015+ at ${tree.pos}")
           genCallHelper("newJSObjectWithVarargs",
               transformExprNoChar(constr), transformExprNoChar(argsArray))
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1478,11 +1478,11 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
 
       /** Extract a definition of the lhs if it is a VarDef, to avoid changing
        *  its scope.
-       *  This only matters in ECMAScript 6, because we emit Lets.
+       *  This only matters when we emit lets and consts.
        */
       def extractLet(inner: Lhs => js.Tree)(
           implicit env: Env): js.Tree = {
-        if (esFeatures.useECMAScript2015) {
+        if (useLets) {
           lhs match {
             case Lhs.VarDef(name, tpe, mutable) =>
               js.Block(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -117,9 +117,9 @@ private[emitter] final class SJSGen(
   def getArrayUnderlyingTypedArrayClassRef(elemTypeRef: NonArrayTypeRef)(
       implicit pos: Position): Option[WithGlobals[VarRef]] = {
     elemTypeRef match {
-      case _ if !esFeatures.useECMAScript2015 => None
-      case primRef: PrimRef                   => typedArrayRef(primRef)
-      case _                                  => None
+      case _ if esFeatures.esVersion < ESVersion.ES2015 => None
+      case primRef: PrimRef                             => typedArrayRef(primRef)
+      case _                                            => None
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3940,8 +3940,11 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case (JSLinkingInfo(), StringLiteral("productionMode")) =>
         BooleanLiteral(semantics.productionMode)
 
+      case (JSLinkingInfo(), StringLiteral("esVersion")) =>
+        IntLiteral(esFeatures.esVersion.edition)
+
       case (JSLinkingInfo(), StringLiteral("assumingES6")) =>
-        BooleanLiteral(esFeatures.useECMAScript2015)
+        BooleanLiteral(esFeatures.useECMAScript2015Semantics)
 
       case (JSLinkingInfo(), StringLiteral("version")) =>
         StringLiteral(ScalaJSVersions.current)

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -23,6 +23,9 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+    // New method in a sealed trait (even a JS trait), not an issue
+    ProblemFilters.exclude[ReversedMissingMethodProblem](
+        "scala.scalajs.runtime.LinkingInfo.esVersion"),
   )
 
   val TestInterface = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1662,7 +1662,7 @@ object Build {
         scalaVersion.value match {
           case "2.11.12" =>
             Some(ExpectedSizes(
-                fastLink = 520000 to 521000,
+                fastLink = 519000 to 520000,
                 fullLink = 108000 to 109000,
                 fastLinkGz = 66000 to 67000,
                 fullLinkGz = 28000 to 29000,
@@ -1670,7 +1670,7 @@ object Build {
 
           case "2.12.12" =>
             Some(ExpectedSizes(
-                fastLink = 781000 to 782000,
+                fastLink = 780000 to 781000,
                 fullLink = 148000 to 149000,
                 fastLinkGz = 91000 to 92000,
                 fullLinkGz = 36000 to 37000,
@@ -1678,7 +1678,7 @@ object Build {
 
           case "2.13.4" =>
             Some(ExpectedSizes(
-                fastLink = 780000 to 781000,
+                fastLink = 779000 to 780000,
                 fullLink = 169000 to 170000,
                 fastLinkGz = 98000 to 99000,
                 fullLinkGz = 43000 to 44000,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -51,6 +51,8 @@ object ExposedValues extends AutoPlugin {
 
     val CheckedBehavior = org.scalajs.linker.interface.CheckedBehavior
 
+    val ESVersion = org.scalajs.linker.interface.ESVersion
+
     val ModuleSplitStyle = org.scalajs.linker.interface.ModuleSplitStyle
 
     type NodeJSEnvForcePolyfills = build.NodeJSEnvForcePolyfills
@@ -2006,7 +2008,8 @@ object Build {
               "compliantModuleInit" -> (sems.moduleInit == CheckedBehavior.Compliant),
               "strictFloats" -> sems.strictFloats,
               "productionMode" -> sems.productionMode,
-              "es2015" -> linkerConfig.esFeatures.useECMAScript2015
+              "esVersion" -> linkerConfig.esFeatures.esVersion.edition,
+              "useECMAScript2015Semantics" -> linkerConfig.esFeatures.useECMAScript2015Semantics,
           )
         }.taskValue
       },

--- a/project/ConstantHolderGenerator.scala
+++ b/project/ConstantHolderGenerator.scala
@@ -36,6 +36,7 @@ object ConstantHolderGenerator {
   private final def literal(v: Any): String = v match {
     case s: String  => "\"" + escapeJS(s) + "\"" // abuse escapeJS to escape Scala
     case b: Boolean => b.toString
+    case i: Int     => i.toString
     case f: File    => literal(f.getAbsolutePath)
 
     case m: Map[_, _] =>

--- a/project/NodeJSEnvForcePolyfills.scala
+++ b/project/NodeJSEnvForcePolyfills.scala
@@ -8,13 +8,20 @@ import com.google.common.jimfs.Jimfs
 import org.scalajs.jsenv._
 import org.scalajs.jsenv.nodejs._
 
-final class NodeJSEnvForcePolyfills(config: NodeJSEnv.Config) extends JSEnv {
-  def this() = this(NodeJSEnv.Config())
+import org.scalajs.linker.interface.ESVersion
 
-  val name: String = "Node.js forcing polyfills"
+final class NodeJSEnvForcePolyfills(esVersion: ESVersion, config: NodeJSEnv.Config) extends JSEnv {
+  def this(esVersion: ESVersion) = this(esVersion, NodeJSEnv.Config())
 
-  // Always deactivate source maps because source-map-support requires `Map`
-  private val nodeJSEnv = new NodeJSEnv(config.withSourceMap(false))
+  val name: String = s"Node.js forcing polyfills for $esVersion"
+
+  // Deactivate source maps if esVersion < ES2015 because source-map-support requires `Map`
+  private val nodeJSEnv = {
+    val config1 =
+      if (esVersion >= ESVersion.ES2015) config
+      else config.withSourceMap(false)
+    new NodeJSEnv(config1)
+  }
 
   def start(input: Seq[Input], runConfig: RunConfig): JSRun =
     nodeJSEnv.start(forcePolyfills +: input, runConfig)
@@ -28,38 +35,87 @@ final class NodeJSEnvForcePolyfills(config: NodeJSEnv.Config) extends JSEnv {
    *  native functions.
    */
   private def forcePolyfills(): Input = {
+    import ESVersion._
+
+    def cond(version: ESVersion, stat: String): String =
+      if (esVersion < version) stat
+      else ""
+
+    var script = ""
+
+    if (esVersion < ES2015) {
+      script += """
+        |delete Object.is;
+        |
+        |delete Reflect.ownKeys;
+        |
+        |delete Math.fround;
+        |delete Math.imul;
+        |delete Math.clz32;
+        |delete Math.log10;
+        |delete Math.log1p;
+        |delete Math.cbrt;
+        |delete Math.hypot;
+        |delete Math.expm1;
+        |delete Math.sinh;
+        |delete Math.cosh;
+        |delete Math.tanh;
+        |
+        |delete global.Map;
+        |delete global.Promise;
+        |delete global.Set;
+        |delete global.Symbol;
+        |
+        |delete global.Int8Array;
+        |delete global.Int16Array;
+        |delete global.Int32Array;
+        |delete global.Uint8Array;
+        |delete global.Uint16Array;
+        |delete global.Uint32Array;
+        |delete global.Float32Array;
+        |delete global.Float64Array;
+      """.stripMargin
+    }
+
+    if (esVersion < ES2017) {
+      script += """
+        |delete Object.getOwnPropertyDescriptors;
+      """.stripMargin
+    }
+
+    if (esVersion < ES2018) {
+      script += s"""
+        |global.RegExp = (function(OrigRegExp) {
+        |  return function RegExp(pattern, flags) {
+        |    if (typeof flags === 'string') {
+        |${cond(ES2015, """
+        |      if (flags.indexOf('u') >= 0)
+        |        throw new SyntaxError("unsupported flag 'u'");
+        |      if (flags.indexOf('y') >= 0)
+        |        throw new SyntaxError("unsupported flag 'y'");
+        |""".stripMargin)}
+        |      if (flags.indexOf('s') >= 0)
+        |        throw new SyntaxError("unsupported flag 's'");
+        |    }
+        |
+        |    if (typeof pattern === 'string') {
+        |      if (pattern.indexOf('(?<=') >= 0 || pattern.indexOf('(?<!') >= 0)
+        |        throw new SyntaxError("unsupported look-behinds");
+        |      if (pattern.indexOf('(?<') >= 0)
+        |        throw new SyntaxError("unsupported named capture groups");
+        |      if (pattern.indexOf('\\\\p{') >= 0 || pattern.indexOf('\\\\P{') >= 0)
+        |        throw new SyntaxError("unsupported Unicode character classes");
+        |    }
+        |
+        |    return new OrigRegExp(pattern, flags);
+        |  }
+        |})(global.RegExp);
+      """.stripMargin
+    }
+
     val p = Files.write(
         Jimfs.newFileSystem().getPath("scalaJSEnvInfo.js"),
-        """
-          |delete Object.is;
-          |delete Object.getOwnPropertyDescriptors;
-          |
-          |delete Math.fround;
-          |delete Math.imul;
-          |delete Math.clz32;
-          |delete Math.log10;
-          |delete Math.log1p;
-          |delete Math.cbrt;
-          |delete Math.hypot;
-          |delete Math.expm1;
-          |delete Math.sinh;
-          |delete Math.cosh;
-          |delete Math.tanh;
-          |
-          |delete global.Map;
-          |delete global.Promise;
-          |delete global.Set;
-          |delete global.Symbol;
-          |
-          |delete global.Int8Array;
-          |delete global.Int16Array;
-          |delete global.Int32Array;
-          |delete global.Uint8Array;
-          |delete global.Uint16Array;
-          |delete global.Uint32Array;
-          |delete global.Float32Array;
-          |delete global.Float64Array;
-        """.stripMargin.getBytes(StandardCharsets.UTF_8))
+        script.getBytes(StandardCharsets.UTF_8))
     Input.Script(p)
   }
 }

--- a/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
+++ b/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
@@ -28,5 +28,6 @@ private[utils] object BuildInfo {
   final val compliantModuleInit = false
   final val strictFloats = false
   final val productionMode = false
-  final val es2015 = false
+  final val esVersion = 0
+  final val useECMAScript2015Semantics = false
 }

--- a/test-suite/js/src/test/require-multi-modules/org/scalajs/testsuite/jsinterop/SJSDynamicImportTest.scala
+++ b/test-suite/js/src/test/require-multi-modules/org/scalajs/testsuite/jsinterop/SJSDynamicImportTest.scala
@@ -16,7 +16,6 @@ import scala.concurrent.Future
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
-import scala.scalajs.LinkingInfo
 
 import org.junit.Assert._
 import org.junit.Assume._
@@ -24,10 +23,13 @@ import org.junit.{BeforeClass, Test}
 
 import org.scalajs.junit.async._
 
+import org.scalajs.testsuite.utils.Platform._
+
 object SJSDynamicImportTest {
   @BeforeClass
   def assumeRuntimeSupportsPromise(): Unit = {
-    assumeTrue("Assume ES6", LinkingInfo.assumingES6)
+    assumeTrue("Requires Promises",
+        assumeES2015 || js.typeOf(js.Dynamic.global.Promise) != "undefined")
   }
 }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemJSTest.scala
@@ -15,7 +15,6 @@ package org.scalajs.testsuite.javalib.lang
 import org.scalajs.testsuite.utils.Platform
 
 import scala.scalajs.js
-import scala.scalajs.LinkingInfo.assumingES6
 import scala.scalajs.runtime.linkingInfo
 
 import org.junit.Test
@@ -44,7 +43,7 @@ class SystemJSTest {
   }
 
   @Test def identityHashCodeForJSObjects(): Unit = {
-    if (assumingES6 || js.typeOf(js.Dynamic.global.WeakMap) != "undefined") {
+    if (Platform.assumeES2015 || js.typeOf(js.Dynamic.global.WeakMap) != "undefined") {
       /* This test is more restrictive than the spec, but we know our
        * implementation will always pass the test.
        */

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowableJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ThrowableJSTest.scala
@@ -13,11 +13,12 @@
 package org.scalajs.testsuite.javalib.lang
 
 import scala.scalajs.js
-import scala.scalajs.LinkingInfo.assumingES6
 
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.Platform._
 
 class ThrowableJSTest {
 
@@ -27,7 +28,7 @@ class ThrowableJSTest {
   }
 
   @Test def throwablesAreTrueErrors(): Unit = {
-    assumeTrue("Requires ECMAScript 2015", assumingES6)
+    assumeTrue("Requires ECMAScript 2015 semantics", useECMAScript2015Semantics)
 
     def coreToString(x: Any): String = {
       js.constructorOf[js.Object].prototype

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -819,7 +819,7 @@ class ExportsTest {
 
     assertEquals("function", js.typeOf(constr))
 
-    val body = if (assumeES2015) {
+    val body = if (useECMAScript2015Semantics) {
       """
       class SubClass extends constr {
         constructor(x) {
@@ -1469,7 +1469,7 @@ class ExportsTest {
     val g = JSUtils.globalObject
 
     // Do we expect to get undefined when looking up the exports in the global object?
-    val undefinedExpected = assumeES2015
+    val undefinedExpected = useECMAScript2015Semantics
 
     assertEquals(undefinedExpected, js.isUndefined(g.TopLevelExportedObject))
     assertEquals(undefinedExpected, js.isUndefined(g.SJSDefinedTopLevelExportedObject))

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
@@ -13,13 +13,13 @@
 package org.scalajs.testsuite.jsinterop
 
 import scala.scalajs.js
-import scala.scalajs.LinkingInfo.assumingES6
 
 import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
 import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform.useECMAScript2015Semantics
 
 class FunctionTest {
 
@@ -47,7 +47,7 @@ class FunctionTest {
   }
 
   @Test def functionWithConversionIsAnArrowFunction(): Unit = {
-    assumeTrue("In ES 5.1, arrow functions do not exist", assumingES6)
+    assumeTrue("Requires ECMAScript 2015 semantics", useECMAScript2015Semantics)
 
     val ctor: js.Function = (x: js.Any) => x
     val ctorDyn = ctor.asInstanceOf[js.Dynamic]
@@ -59,7 +59,7 @@ class FunctionTest {
   }
 
   @Test def functionWithSAMIsAnArrowFunction(): Unit = {
-    assumeTrue("In ES 5.1, arrow functions do not exist", assumingES6)
+    assumeTrue("Requires ECMAScript 2015 semantics", useECMAScript2015Semantics)
 
     val ctor: js.Function1[js.Any, Any] = (x: js.Any) => x
     val ctorDyn = ctor.asInstanceOf[js.Dynamic]

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
@@ -279,7 +279,7 @@ class JSExportStaticTest {
   // Inherited members
 
   @Test def testInheritedMembersInECMAScript2015(): Unit = {
-    assumeTrue("Requires ECMAScript 2015", assumeES2015)
+    assumeTrue("Requires ECMAScript 2015 semantics", useECMAScript2015Semantics)
 
     val parent = js.constructorOf[JSExportStaticTest.StaticExportsParent]
     val child = js.constructorOf[JSExportStaticTest.StaticExportsChild]

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
@@ -15,14 +15,16 @@ package org.scalajs.testsuite.jsinterop
 import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.{BeforeClass, Test}
-import org.scalajs.testsuite.utils.AssertThrows._
 
-import scala.scalajs.{LinkingInfo, js}
+import scala.scalajs.js
+
+import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.Platform._
 
 object MapTest {
   @BeforeClass
   def assumeRuntimeSupportsMap(): Unit = {
-    assumeTrue("Assume ES6", LinkingInfo.assumingES6)
+    assumeTrue("Requires js.Map support", jsMaps)
   }
 }
 
@@ -95,4 +97,3 @@ class MapTest {
     assertEquals("babar", obj.get(2).get)
   }
 }
-

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -102,31 +102,15 @@ class MiscInteropTest {
     test[ConcreteJSClass](concreteCtor)
     test[AbstractJSClass](abstractCtor)
 
-    /* TODO When targeting ES6, we cannot yet use indirect calls (with
-     * actual varargs) to `js.Dynamic.newInstance` because of
-     *   TypeError: Class constructors cannot be invoked without 'new'
-     * This will be fixed when we can use ...spread calls with `new`, which
-     * we can't yet do because the latest io.js does not support them yet.
-     */
-    import scala.scalajs.LinkingInfo.assumingES6
-
     val concreteInstance = {
       val tag = js.constructorTag[ConcreteJSClass]
-      if (assumingES6)
-        js.Dynamic.newInstance(tag.constructor)().asInstanceOf[ConcreteJSClass]
-      else
-        tag.newInstance()
+      tag.newInstance()
     }
     assertTrue((concreteInstance: Any).isInstanceOf[ConcreteJSClass])
 
     val instance = {
       val tag = js.constructorTag[OtherwiseUnreferencedJSClassForTag]
-      if (assumingES6) {
-        js.Dynamic.newInstance(tag.constructor)(35)
-            .asInstanceOf[OtherwiseUnreferencedJSClassForTag]
-      } else {
-        tag.newInstance(35)
-      }
+      tag.newInstance(35)
     }
     assertEquals(35, instance.x)
   }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SetTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SetTest.scala
@@ -16,12 +16,15 @@ import org.junit.Assert._
 import org.junit.Assume.assumeTrue
 import org.junit.{BeforeClass, Test}
 
-import scala.scalajs.{LinkingInfo, js}
+import scala.scalajs.js
+
+import org.scalajs.testsuite.utils.Platform._
 
 object SetTest {
   @BeforeClass
   def assumeRuntimeSupportsSet(): Unit = {
-    assumeTrue("Assume ES6", LinkingInfo.assumingES6)
+    assumeTrue("Requires js.Set support",
+        assumeES2015 || js.typeOf(js.Dynamic.global.Set) != "undefined")
   }
 }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
@@ -13,6 +13,7 @@
 package org.scalajs.testsuite.library
 
 import scala.scalajs.LinkingInfo
+import scala.scalajs.LinkingInfo.ESVersion
 
 import org.junit.Assert._
 import org.junit.Test
@@ -26,6 +27,23 @@ class LinkingInfoTest {
   @Test def developmentMode(): Unit =
     assertEquals(!Platform.isInProductionMode, LinkingInfo.developmentMode)
 
+  @Test def esVersion(): Unit =
+    assertEquals(Platform.assumedESVersion, LinkingInfo.esVersion)
+
   @Test def assumingES6(): Unit =
-    assertEquals(Platform.assumeES2015, LinkingInfo.assumingES6)
+    assertEquals(Platform.assumedESVersion >= ESVersion.ES2015, LinkingInfo.assumingES6)
+
+  @Test def useECMAScript2015Semantics(): Unit =
+    assertEquals(Platform.useECMAScript2015Semantics, LinkingInfo.useECMAScript2015Semantics)
+
+  @Test def esVersionConstants(): Unit = {
+    // The numeric values behind the constants are meaningful, so we test them.
+    assertEquals(5, ESVersion.ES5_1)
+    assertEquals(6, ESVersion.ES2015)
+    assertEquals(7, ESVersion.ES2016)
+    assertEquals(8, ESVersion.ES2017)
+    assertEquals(9, ESVersion.ES2018)
+    assertEquals(10, ESVersion.ES2019)
+    assertEquals(11, ESVersion.ES2020)
+  }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ObjectTest.scala
@@ -15,10 +15,12 @@ package org.scalajs.testsuite.library
 import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
-import org.scalajs.testsuite.utils.Platform
 
 import scala.scalajs.js
 import scala.scalajs.js.annotation.{ JSBracketAccess, JSName }
+import scala.scalajs.LinkingInfo.ESVersion
+
+import org.scalajs.testsuite.utils.Platform._
 
 class ObjectTest {
   import ObjectTest._
@@ -27,9 +29,7 @@ class ObjectTest {
   private lazy val symB = js.Symbol.forKey("b")
 
   @Test def getOwnPropertySymbols(): Unit = {
-    assumeTrue(
-        "Symbol is not defined (should only happen with NodeJSEnvForcePolyfills)",
-        js.typeOf(js.Dynamic.global.Symbol) != "undefined")
+    assumeTrue("requires Symbols", jsSymbols)
 
     val obj = (new js.Object()).asInstanceOf[ObjectCreator]
     obj(symA) = "localSymbol"
@@ -39,8 +39,8 @@ class ObjectTest {
   }
 
   @Test def is(): Unit = {
-    assumeTrue(
-        "Object.is is not defined (should only happen with NodeJSEnvForcePolyfills)",
+    assumeTrue("requires Object.is",
+        assumedESVersion >= ESVersion.ES2015 ||
         js.typeOf(js.Dynamic.global.Object.is) != "undefined")
 
     val a = new js.Object()
@@ -56,6 +56,10 @@ class ObjectTest {
   }
 
   @Test def entriesFromObject(): Unit = {
+    assumeTrue("requires Object.entries",
+        assumedESVersion >= ESVersion.ES2017 ||
+        js.typeOf(js.Dynamic.global.Object.entries) != "undefined")
+
     val obj = new js.Object {
       val a = 42
       val b = "foo"
@@ -73,6 +77,10 @@ class ObjectTest {
   }
 
   @Test def entriesFromDictionary(): Unit = {
+    assumeTrue("requires Object.entries",
+        assumedESVersion >= ESVersion.ES2017 ||
+        js.typeOf(js.Dynamic.global.Object.entries) != "undefined")
+
     val dict = js.Dictionary[Int]("a" -> 42, "b" -> 0)
     val entries = js.Object.entries(dict)
     assertEquals(2, entries.length)
@@ -89,6 +97,10 @@ class ObjectTest {
   }
 
   @Test def fromEntriesArray(): Unit = {
+    assumeTrue("requires Object.fromEntries",
+        assumedESVersion >= ESVersion.ES2020 ||
+        js.typeOf(js.Dynamic.global.Object.fromEntries) != "undefined")
+
     // from Array
     val array = js.Array(js.Tuple2("a", 42), js.Tuple2("b", "foo"))
     val obj1 = js.Object.fromEntries(array)
@@ -97,7 +109,11 @@ class ObjectTest {
   }
 
   @Test def fromEntriesJSMap(): Unit = {
-    assumeTrue("requires js.Map", Platform.jsMaps)
+    assumeTrue("requires Object.fromEntries",
+        assumedESVersion >= ESVersion.ES2020 ||
+        js.typeOf(js.Dynamic.global.Object.fromEntries) != "undefined")
+
+    assumeTrue("requires js.Map", jsMaps)
 
     val map = js.Map("a" -> 42, "b" -> "foo")
     val obj = js.Object.fromEntries(map)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/RegExpTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/RegExpTest.scala
@@ -13,9 +13,12 @@
 package org.scalajs.testsuite.library
 
 import org.junit.Assert._
+import org.junit.Assume._
 import org.junit.Test
 
 import scala.scalajs.js
+
+import org.scalajs.testsuite.utils.Platform.jsRegExps2018
 
 class RegExpTest {
   @Test def execNoGroup(): Unit = {
@@ -32,6 +35,8 @@ class RegExpTest {
   }
 
   @Test def execWithGroupNoMatch(): Unit = {
+    assumeTrue("requires named capture groups in js.RegExp", jsRegExps2018)
+
     val result = js.RegExp("(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})")
       .exec("abc")
 
@@ -39,6 +44,8 @@ class RegExpTest {
   }
 
   @Test def execWithGroupMatch(): Unit = {
+    assumeTrue("requires named capture groups in js.RegExp", jsRegExps2018)
+
     val result = js.RegExp("(?<year>[0-9]{4})-(?<month>[0-9]{2})-(?<day>[0-9]{2})")
       .exec("1992-12-31")
 
@@ -57,6 +64,8 @@ class RegExpTest {
   }
 
   @Test def execWithOptGroupMatch(): Unit = {
+    assumeTrue("requires named capture groups in js.RegExp", jsRegExps2018)
+
     val result = js.RegExp("foo(?<prop>bar)?baz")
       .exec("foobaz")
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedMapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedMapTest.scala
@@ -17,12 +17,15 @@ import org.junit.Assume.assumeTrue
 import org.junit.{BeforeClass, Test}
 
 import scala.collection.mutable
-import scala.scalajs.{LinkingInfo, js}
+
+import scala.scalajs.js
+
+import org.scalajs.testsuite.utils.Platform._
 
 object WrappedMapTest {
   @BeforeClass
-  def assumeRuntimeSupportsSet(): Unit = {
-    assumeTrue("Assume ES6", LinkingInfo.assumingES6)
+  def assumeRuntimeSupportsMap(): Unit = {
+    assumeTrue("Requires js.Map support", jsMaps)
   }
 }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedSetTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/WrappedSetTest.scala
@@ -17,12 +17,16 @@ import org.junit.Assume.assumeTrue
 import org.junit.{BeforeClass, Test}
 
 import scala.collection.mutable
-import scala.scalajs.{LinkingInfo, js}
+
+import scala.scalajs.js
+
+import org.scalajs.testsuite.utils.Platform._
 
 object WrappedSetTest {
   @BeforeClass
   def assumeRuntimeSupportsSet(): Unit = {
-    assumeTrue("Assume ES6", LinkingInfo.assumingES6)
+    assumeTrue("Requires js.Set support",
+        assumeES2015 || js.typeOf(js.Dynamic.global.Set) != "undefined")
   }
 }
 


### PR DESCRIPTION
We introduce a new setting ESFeatures.esVersion to select specific ES versions to target for compliance. Values of `ESVersion` are defined from ES 5.1 up to ES 2020. The existing `useECMAScript2015` is remapped to be the same as `esVersion >= ESVersion.ES2015`.

We leverage `esVersion >= ESVersion.ES2017` in one place in the core JS lib. More tests like that could be introduced in the future.

We add `esVersion` in the generated `BuildInfo` for the test suite, and use it to better constrain some our tests of JS features.

The `esVersion` is also made available to user-space libraries through `LinkingInfo.assumedESVersion`, like `assumeES6`. This is not used yet in this commit, but will be used by the new `regex` support.

We enhance `NodeJSEnvForcePolyfills` and our Jenkins scripts to test with various target versions of ECMAScript.

---

Extracted from #4455 because I think this is generally useful, and it can be independently reviewed.