### PR TITLE
Fix #4466: Use a dedicated function for Long-to-Float conversions.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -3344,7 +3344,10 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                 js.UnaryOp(IntToLong, intValue)
             }
           case jstpe.FloatType =>
-            js.UnaryOp(js.UnaryOp.DoubleToFloat, doubleValue)
+            if (from == jstpe.LongType)
+              js.UnaryOp(js.UnaryOp.LongToFloat, value)
+            else
+              js.UnaryOp(js.UnaryOp.DoubleToFloat, doubleValue)
           case jstpe.DoubleType =>
             doubleValue
         }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -372,7 +372,7 @@ object Printers {
               "(int)"
             case IntToLong | DoubleToLong =>
               "(long)"
-            case DoubleToFloat =>
+            case DoubleToFloat | LongToFloat =>
               "(float)"
             case IntToDouble | LongToDouble | FloatToDouble =>
               "(double)"

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -306,6 +306,9 @@ object Trees {
     final val LongToDouble = 14
     final val DoubleToLong = 15
 
+    // Long -> Float (neither widening nor narrowing), introduced in 1.6
+    final val LongToFloat = 16
+
     def resultTypeOf(op: Code): Type = (op: @switch) match {
       case Boolean_! =>
         BooleanType
@@ -319,7 +322,7 @@ object Trees {
         IntType
       case IntToLong | DoubleToLong =>
         LongType
-      case DoubleToFloat =>
+      case DoubleToFloat | LongToFloat =>
         FloatType
       case IntToDouble | LongToDouble | FloatToDouble =>
         DoubleType

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -394,6 +394,8 @@ class PrintersTest {
 
     assertPrintEquals("((double)x)", UnaryOp(LongToDouble, ref("x", LongType)))
     assertPrintEquals("((long)x)", UnaryOp(DoubleToLong, ref("x", DoubleType)))
+
+    assertPrintEquals("((float)x)", UnaryOp(LongToFloat, ref("x", LongType)))
   }
 
   @Test def printPseudoUnaryOp(): Unit = {

--- a/javalanglib/src/main/scala/java/lang/Double.scala
+++ b/javalanglib/src/main/scala/java/lang/Double.scala
@@ -197,6 +197,8 @@ object Double {
      *
      * Of course, we remember that we need to apply a correction to the
      * exponent of the final result.
+     *
+     * (A similar strategy is used in the primitive Long-to-Float conversion.)
      */
     val mantissaStrLen = mantissaStr.length()
     val needsCorrection2 = mantissaStrLen > maxPrecisionChars

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2303,6 +2303,13 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                 genCallHelper("doubleToLong", newLhs)
               else
                 genLongModuleApply(LongImpl.fromDouble, newLhs)
+
+            // Long -> Float (neither widening nor narrowing)
+            case LongToFloat =>
+              if (useBigIntForLongs)
+                genCallHelper("longToFloat", newLhs)
+              else
+                genLongMethodApply(newLhs, LongImpl.toFloat)
           }
 
         case BinaryOp(op, lhs, rhs) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
@@ -62,6 +62,7 @@ private[linker] object LongImpl {
   final val >=  = compareOp("$greater$eq")
 
   final val toInt    = MethodName("toInt", Nil, IntRef)
+  final val toFloat  = MethodName("toFloat", Nil, FloatRef)
   final val toDouble = MethodName("toDouble", Nil, DoubleRef)
 
   final val byteValue   = MethodName("byteValue", Nil, ByteRef)
@@ -79,7 +80,7 @@ private[linker] object LongImpl {
 
   private val OperatorMethods = Set(
       UNARY_-, UNARY_~, this.+, this.-, *, /, %, |, &, ^, <<, >>>, >>,
-      ===, !==, <, <=, >, >=, toInt, toDouble)
+      ===, !==, <, <=, >, >=, toInt, toFloat, toDouble)
 
   private val BoxedLongMethods = Set(
       byteValue, shortValue, intValue, longValue, floatValue, doubleValue,

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -960,7 +960,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
             ShortType
           case IntToLong | IntToDouble | IntToChar | IntToByte | IntToShort =>
             IntType
-          case LongToInt | LongToDouble =>
+          case LongToInt | LongToDouble | LongToFloat =>
             LongType
           case FloatToDouble =>
             FloatType

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -2656,6 +2656,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case DoubleToLong =>
             expandLongModuleOp(LongImpl.fromDouble, arg)
 
+          case LongToFloat =>
+            expandUnaryOp(LongImpl.toFloat, arg, FloatType)
+
           case _ =>
             cont(pretrans)
         }
@@ -2887,6 +2890,18 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
             PreTransLit(LongLiteral(v.toLong))
           case PreTransUnaryOp(IntToDouble, x) =>
             foldUnaryOp(IntToLong, x)
+          case _ =>
+            default
+        }
+
+      // Long -> Float
+
+      case LongToFloat =>
+        arg match {
+          case PreTransLit(LongLiteral(v)) =>
+            PreTransLit(FloatLiteral(v.toFloat))
+          case PreTransUnaryOp(IntToLong, x) =>
+            foldUnaryOp(DoubleToFloat, foldUnaryOp(IntToDouble, x))
           case _ =>
             default
         }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1664,7 +1664,7 @@ object Build {
         scalaVersion.value match {
           case "2.11.12" =>
             Some(ExpectedSizes(
-                fastLink = 519000 to 520000,
+                fastLink = 520000 to 521000,
                 fullLink = 108000 to 109000,
                 fastLinkGz = 66000 to 67000,
                 fullLinkGz = 28000 to 29000,
@@ -1672,7 +1672,7 @@ object Build {
 
           case "2.12.12" =>
             Some(ExpectedSizes(
-                fastLink = 780000 to 781000,
+                fastLink = 781000 to 782000,
                 fullLink = 148000 to 149000,
                 fastLinkGz = 91000 to 92000,
                 fullLinkGz = 36000 to 37000,
@@ -1680,7 +1680,7 @@ object Build {
 
           case "2.13.4" =>
             Some(ExpectedSizes(
-                fastLink = 779000 to 780000,
+                fastLink = 780000 to 781000,
                 fullLink = 169000 to 170000,
                 fastLinkGz = 98000 to 99000,
                 fullLinkGz = 43000 to 44000,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -609,8 +609,8 @@ class LongTest {
     test(8801656334077465992L, lg(2076251528, 2049295309))
   }
 
-  @Test def toFloatStrict(): Unit = {
-    assumeTrue("Assumed strict floats", hasStrictFloats)
+  @Test def toFloat(): Unit = {
+    assumeTrue("Assumed accurate floats", hasAccurateFloats)
 
     @inline def test(expected: Float, x: Long, epsilon: Float = 0.0f): Unit = {
       assertEquals(expected, x.toFloat, epsilon)
@@ -645,6 +645,24 @@ class LongTest {
     test(4.00884963E18f, lg(787691795, 933383012))
     test(-1.43511611E18f, lg(1189057493, -334139018))
     test(3.81415059E18f, lg(-618946450, 888051141))
+
+    // #4466 Long values that are close to Float midpoints
+
+    test(3.7930952e16f, 0x86c2007fffffffL)
+    test(3.7930952e16f, 0x86c20080000000L) // midpoint, even is downwards
+    test(3.7930956e16f, 0x86c20080000001L) // this is the value from #4466
+
+    test(3.7930965e16f, 0x86c2037fffffffL)
+    test(3.7930969e16f, 0x86c20380000000L) // midpoint, even is upwards
+    test(3.7930969e16f, 0x86c20380000001L)
+
+    test(-3.7930952e16f, -0x86c2007fffffffL)
+    test(-3.7930952e16f, -0x86c20080000000L) // midpoint, even is downwards
+    test(-3.7930956e16f, -0x86c20080000001L)
+
+    test(-3.7930965e16f, -0x86c2037fffffffL)
+    test(-3.7930969e16f, -0x86c20380000000L) // midpoint, even is upwards
+    test(-3.7930969e16f, -0x86c20380000001L)
   }
 
   @Test def toDouble(): Unit = {


### PR DESCRIPTION
The previous approach of first converting to Double then converting the Double to Float was not correct for values close to Float midpoints.

That encoding was baked in the IR, so we have to introduce a new `UnaryOp.LongToFloat` operation, which we compile as calling `RuntimeLong.toFloat`.

We then fix the implementation of `toFloat` to correctly handle values that are close to Float midpoints, using a strategy similar to what we had used in `parseFloat` for the hexadecimal format.