### PR TITLE
Clean up j.u.regex.* and use the native 'd' flag when available

### DIFF
--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -19,7 +19,7 @@ import scala.annotation.switch
 import scala.scalajs.js
 
 final class Matcher private[regex] (
-    private var pattern0: Pattern, private var input0: CharSequence)
+    private var pattern0: Pattern, private var input0: String)
     extends AnyRef with MatchResult {
 
   import Matcher._
@@ -29,7 +29,7 @@ final class Matcher private[regex] (
   // Region configuration (updated by reset() and region())
   private var regionStart0 = 0
   private var regionEnd0 = input0.length()
-  private var inputstr = input0.toString()
+  private var inputstr = input0
 
   // Match result (updated by successful matches)
   private var position: Int = 0 // within `inputstr`, not `input0`
@@ -155,12 +155,13 @@ final class Matcher private[regex] (
   def reset(): Matcher = {
     regionStart0 = 0
     regionEnd0 = input0.length()
-    inputstr = input0.toString()
+    inputstr = input0
     resetMatch()
   }
 
+  @inline // `input` is almost certainly a String at call site
   def reset(input: CharSequence): Matcher = {
-    input0 = input
+    input0 = input.toString()
     reset()
   }
 
@@ -242,7 +243,7 @@ final class Matcher private[regex] (
   def region(start: Int, end: Int): Matcher = {
     regionStart0 = start
     regionEnd0 = end
-    inputstr = input0.subSequence(regionStart0, regionEnd0).toString
+    inputstr = input0.substring(start, end)
     resetMatch()
   }
 

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -19,16 +19,17 @@ import scala.annotation.switch
 import scala.scalajs.js
 
 final class Matcher private[regex] (
-    private var pattern0: Pattern, private var input0: CharSequence,
-    private var regionStart0: Int, private var regionEnd0: Int)
+    private var pattern0: Pattern, private var input0: CharSequence)
     extends AnyRef with MatchResult {
 
   import Matcher._
 
   def pattern(): Pattern = pattern0
 
-  // Configuration (updated manually)
-  private var inputstr = input0.subSequence(regionStart0, regionEnd0).toString
+  // Region configuration (updated by reset() and region())
+  private var regionStart0 = 0
+  private var regionEnd0 = input0.length()
+  private var inputstr = input0.toString()
 
   // Match result (updated by successful matches)
   private var position: Int = 0 // within `inputstr`, not `input0`
@@ -151,8 +152,12 @@ final class Matcher private[regex] (
     this
   }
 
-  def reset(): Matcher =
-    region(0, input0.length())
+  def reset(): Matcher = {
+    regionStart0 = 0
+    regionEnd0 = input0.length()
+    inputstr = input0.toString()
+    resetMatch()
+  }
 
   def reset(input: CharSequence): Matcher = {
     input0 = input
@@ -229,7 +234,7 @@ final class Matcher private[regex] (
   // Similar difficulties as with hitEnd()
   //def requireEnd(): Boolean
 
-  // Stub methods for region management
+  // Region management
 
   def regionStart(): Int = regionStart0
   def regionEnd(): Int = regionEnd0

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -139,15 +139,19 @@ final class Pattern private[regex] (
 
   override def toString(): String = pattern()
 
+  @inline // `input` is almost certainly a String at call site
   def matcher(input: CharSequence): Matcher =
-    new Matcher(this, input)
+    new Matcher(this, input.toString())
 
+  @inline // `input` is almost certainly a String at call site
   def split(input: CharSequence): Array[String] =
     split(input, 0)
 
-  def split(input: CharSequence, limit: Int): Array[String] = {
-    val inputStr = input.toString
+  @inline // `input` is almost certainly a String at call site
+  def split(input: CharSequence, limit: Int): Array[String] =
+    split(input.toString(), limit)
 
+  private def split(inputStr: String, limit: Int): Array[String] = {
     // If the input string is empty, always return Array("") - #987, #2592
     if (inputStr == "") {
       Array("")
@@ -210,7 +214,11 @@ object Pattern {
   def compile(regex: String): Pattern =
     compile(regex, 0)
 
+  @inline // `input` is almost certainly a String at call site
   def matches(regex: String, input: CharSequence): Boolean =
+    matches(regex, input.toString())
+
+  private def matches(regex: String, input: String): Boolean =
     compile(regex).matcher(input).matches()
 
   def quote(s: String): String = {

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -140,7 +140,7 @@ final class Pattern private[regex] (
   override def toString(): String = pattern()
 
   def matcher(input: CharSequence): Matcher =
-    new Matcher(this, input, 0, input.length)
+    new Matcher(this, input)
 
   def split(input: CharSequence): Array[String] =
     split(input, 0)

--- a/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
+++ b/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
@@ -90,6 +90,10 @@ private[regex] object PatternCompiler {
   private val _supportsDotAll =
     (esVersion >= ESVersion.ES2018) || featureTest("us")
 
+  /** Cache for `Support.supportsIndices`. */
+  private val _supportsIndices =
+    featureTest("d")
+
   /** Feature-test methods.
    *
    *  They are located in a separate object so that the methods can be fully
@@ -111,6 +115,11 @@ private[regex] object PatternCompiler {
     @inline
     def supportsDotAll: Boolean =
       (esVersion >= ESVersion.ES2018) || _supportsDotAll
+
+    /** Tests whether the underlying JS RegExp supports the 'd' flag. */
+    @inline
+    def supportsIndices: Boolean =
+      _supportsIndices
 
     /** Tests whether features requiring support for the 'u' flag are enabled.
      *

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 186584,
-      expectedFullLinkSizeWithoutClosure = 173740,
-      expectedFullLinkSizeWithClosure = 31549,
+      expectedFastLinkSize = 186941,
+      expectedFullLinkSizeWithoutClosure = 174097,
+      expectedFullLinkSizeWithClosure = 31577,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 186693,
-      expectedFullLinkSizeWithoutClosure = 173849,
-      expectedFullLinkSizeWithClosure = 31572,
+      expectedFastLinkSize = 186584,
+      expectedFullLinkSizeWithoutClosure = 173740,
+      expectedFullLinkSizeWithClosure = 31549,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 187486,
-      expectedFullLinkSizeWithoutClosure = 174649,
-      expectedFullLinkSizeWithClosure = 31827,
+      expectedFastLinkSize = 186816,
+      expectedFullLinkSizeWithoutClosure = 173972,
+      expectedFullLinkSizeWithClosure = 31629,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 188076,
-      expectedFullLinkSizeWithoutClosure = 175219,
-      expectedFullLinkSizeWithClosure = 32036,
+      expectedFastLinkSize = 187486,
+      expectedFullLinkSizeWithoutClosure = 174649,
+      expectedFullLinkSizeWithClosure = 31827,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 186816,
-      expectedFullLinkSizeWithoutClosure = 173972,
-      expectedFullLinkSizeWithClosure = 31629,
+      expectedFastLinkSize = 186693,
+      expectedFullLinkSizeWithoutClosure = 173849,
+      expectedFullLinkSizeWithClosure = 31572,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/NodeJSEnvForcePolyfills.scala
+++ b/project/NodeJSEnvForcePolyfills.scala
@@ -85,7 +85,7 @@ final class NodeJSEnvForcePolyfills(esVersion: ESVersion, config: NodeJSEnv.Conf
       """.stripMargin
     }
 
-    if (esVersion < ES2018) {
+    if (true) { // esVersion < ES2022 ('d' flag)
       script += s"""
         |global.RegExp = (function(OrigRegExp) {
         |  return function RegExp(pattern, flags) {
@@ -96,10 +96,15 @@ final class NodeJSEnvForcePolyfills(esVersion: ESVersion, config: NodeJSEnv.Conf
         |      if (flags.indexOf('y') >= 0)
         |        throw new SyntaxError("unsupported flag 'y'");
         |""".stripMargin)}
+        |${cond(ES2018, """
         |      if (flags.indexOf('s') >= 0)
         |        throw new SyntaxError("unsupported flag 's'");
+        |""".stripMargin)}
+        |      if (flags.indexOf('d') >= 0)
+        |        throw new SyntaxError("unsupported flag 'd'");
         |    }
         |
+        |${cond(ES2018, """
         |    if (typeof pattern === 'string') {
         |      if (pattern.indexOf('(?<=') >= 0 || pattern.indexOf('(?<!') >= 0)
         |        throw new SyntaxError("unsupported look-behinds");
@@ -108,6 +113,7 @@ final class NodeJSEnvForcePolyfills(esVersion: ESVersion, config: NodeJSEnv.Conf
         |      if (pattern.indexOf('\\\\p{') >= 0 || pattern.indexOf('\\\\P{') >= 0)
         |        throw new SyntaxError("unsupported Unicode character classes");
         |    }
+        |""".stripMargin)}
         |
         |    return new OrigRegExp(pattern, flags);
         |  }


### PR DESCRIPTION
~~Based on #4455.~~

Manually tested with `testSuite2_12/testHtml` in Firefox, which already supports the `'d'` flag by default.