### PR TITLE
Upgrade to JUnit 4.13.2 and its assertThrows method.

### DIFF
--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -5,6 +5,7 @@ package org.junit
 
 import java.util.Objects
 
+import org.junit.function.ThrowingRunnable
 import org.junit.internal.InexactComparisonCriteria
 import org.junit.internal.ExactComparisonCriteria
 import org.hamcrest.Matcher
@@ -341,6 +342,9 @@ object Assert {
     }
   }
 
+  private def formatClass(value: Class[_]): String =
+    value.getName()
+
   private def formatClassAndValue(value: Any, valueString: String): String = {
     val className = if (value == null) "null" else value.getClass.getName
     s"$className<$valueString>"
@@ -354,41 +358,36 @@ object Assert {
   def assertThat[T](reason: String, actual: T, matcher: Matcher[T]): Unit =
     MatcherAssert.assertThat(reason, actual, matcher)
 
-  // The following methods will be available on JUnit 4.13, a backport implementation
-  // is being tested in JUnitAssertionTest until 4.13 is released.
-
-  /*
   @noinline
-  def assertThrows(expectedThrowable: Class[_ <: Throwable],
-      runnable: ThrowingRunnable): Unit = {
-    expectThrows(expectedThrowable, runnable)
-  }
+  def assertThrows[T <: Throwable](expectedThrowable: Class[T], runnable: ThrowingRunnable): T =
+    assertThrows(null, expectedThrowable, runnable)
 
   @noinline
-  def expectThrows[T <: Throwable](expectedThrowable: Class[T], runnable: ThrowingRunnable): T = {
+  def assertThrows[T <: Throwable](message: String, expectedThrowable: Class[T],
+      runnable: ThrowingRunnable): T = {
+    // scalastyle:off return
+
+    def buildPrefix: String =
+      if (message != null && !message.isEmpty()) message + ": " else ""
+
     try {
       runnable.run()
-      val message =
-        s"expected ${expectedThrowable.getSimpleName} to be thrown," +
-        " but nothing was thrown"
-      throw new AssertionError(message)
     } catch {
+      case actualThrown: Throwable if expectedThrowable.isInstance(actualThrown) =>
+        return actualThrown.asInstanceOf[T]
+
       case actualThrown: Throwable =>
-        if (expectedThrowable.isInstance(actualThrown)) {
-          actualThrown.asInstanceOf[T]
-        } else {
-          val mismatchMessage = format("unexpected exception type thrown;",
-            expectedThrowable.getSimpleName, actualThrown.getClass.getSimpleName)
-
-          val assertionError = new AssertionError(mismatchMessage)
-          assertionError.initCause(actualThrown)
-          throw assertionError
-        }
+        val expected = formatClass(expectedThrowable)
+        val actual = formatClass(actualThrown.getClass())
+        throw new AssertionError(
+            buildPrefix + format("unexpected exception type thrown;", expected, actual),
+            actualThrown)
     }
-  }
 
-  trait ThrowingRunnable {
-    def run(): Unit
+    throw new AssertionError(
+        buildPrefix +
+        String.format("expected %s to be thrown, but nothing was thrown", formatClass(expectedThrowable)))
+
+    // scalastyle:on return
   }
-  */
 }

--- a/junit-runtime/src/main/scala/org/junit/TestCouldNotBeSkippedException.scala
+++ b/junit-runtime/src/main/scala/org/junit/TestCouldNotBeSkippedException.scala
@@ -1,0 +1,7 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit
+
+class TestCouldNotBeSkippedException(cause: internal.AssumptionViolatedException)
+    extends RuntimeException("Test could not be skipped due to other failures", cause)

--- a/junit-runtime/src/main/scala/org/junit/function/ThrowingRunnable.scala
+++ b/junit-runtime/src/main/scala/org/junit/function/ThrowingRunnable.scala
@@ -1,0 +1,8 @@
+/*
+ * Ported from https://github.com/junit-team/junit
+ */
+package org.junit.function
+
+trait ThrowingRunnable {
+  def run(): Unit
+}

--- a/junit-runtime/src/main/scala/org/scalajs/junit/Reporter.scala
+++ b/junit-runtime/src/main/scala/org/scalajs/junit/Reporter.scala
@@ -64,10 +64,10 @@ private[junit] final class Reporter(eventHandler: EventHandler,
     }
   }
 
-  def reportAssumptionViolation(method: String, timeInSeconds: Double, e: Throwable): Unit = {
-    logTestException(_.warn, "Test assumption in test ", Some(method), e,
+  def reportAssumptionViolation(method: Option[String], timeInSeconds: Double, e: Throwable): Unit = {
+    logTestException(_.warn, "Test assumption in test ", method, e,
         timeInSeconds)
-    emitEvent(Some(method), Status.Skipped)
+    emitEvent(method, Status.Skipped)
   }
 
   private def logTestInfo(level: Reporter.Level, method: Option[String], msg: String): Unit =
@@ -80,18 +80,9 @@ private[junit] final class Reporter(eventHandler: EventHandler,
       (settings.logAssert || !ex.isInstanceOf[AssertionError])
     }
 
-    val fmtName = if (logException) {
-      val name = {
-        if (ex.isInstanceOf[AssumptionViolatedException])
-          classOf[internal.AssumptionViolatedException].getName
-        else
-          ex.getClass.getName
-      }
-
-      formatClass(name, Ansi.RED) + ": "
-    } else {
-      ""
-    }
+    val fmtName =
+      if (logException) formatClass(ex.getClass.getName, Ansi.RED) + ": "
+      else ""
 
     val m = formatTest(method, Ansi.RED)
     val msg = s"$prefix$m failed: $fmtName${ex.getMessage}, took $timeInSeconds sec"

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_.txt
@@ -1,8 +1,10 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_a.txt
@@ -1,8 +1,10 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_n.txt
@@ -1,8 +1,10 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_na.txt
@@ -1,8 +1,10 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nv.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nva.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nvc.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nvca.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_v.txt
@@ -1,8 +1,10 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_va.txt
@@ -1,8 +1,10 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vc.txt
@@ -1,8 +1,10 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vs.txt
@@ -1,8 +1,10 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vsn.txt
@@ -1,8 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.AssumeAfterAssume.assumeFail
-leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_.txt
@@ -2,7 +2,7 @@ ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_a.txt
@@ -2,7 +2,7 @@ ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_n.txt
@@ -2,7 +2,7 @@ ldTest run started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.AssumeAfterClassTest ignored
+lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-ldTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_na.txt
@@ -2,7 +2,7 @@ ldTest run started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.AssumeAfterClassTest ignored
+lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-ldTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nv.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.AssumeAfterClassTest ignored
+lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nva.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.AssumeAfterClassTest ignored
+lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nvc.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.AssumeAfterClassTest ignored
+lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nvca.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.AssumeAfterClassTest ignored
+lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_v.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_va.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vc.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vs.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 1 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vsn.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
 e0org.scalajs.junit.AssumeAfterClassTest.test
-liTest org.scalajs.junit.AssumeAfterClassTest ignored
+lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeAfterClassTest
-liTest run finished: 0 failed, 1 ignored, 1 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_.txt
@@ -2,7 +2,8 @@ ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_a.txt
@@ -2,7 +2,8 @@ ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_n.txt
@@ -2,7 +2,8 @@ ldTest run started
 ldTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_na.txt
@@ -2,7 +2,8 @@ ldTest run started
 ldTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nv.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nva.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nvc.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.AssumeAfterException.test failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nvca.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.AssumeAfterException.test failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_v.txt
@@ -2,7 +2,8 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_va.txt
@@ -2,7 +2,8 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vc.txt
@@ -2,7 +2,8 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vs.txt
@@ -2,7 +2,8 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vsn.txt
@@ -2,7 +2,8 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
 e2org.scalajs.junit.AssumeAfterException.test
-leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeInAfter.test started
-lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeInAfter.test started
-lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.AssumeInAfter.test started
-lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.AssumeInAfter.test started
-lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.AssumeInAfter.test started
-lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeInAfter.test
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeTest.assumeFail started
-lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeTest.assumeFail started
-lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.AssumeTest.assumeFail started
-lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.AssumeTest.assumeFail started
-lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
-lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.AssumeTest.assumeFail started
-lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.AssumeTest.assumeFail
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
-liTest org.scalajs.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
-liTest org.scalajs.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run started
-liTest org.scalajs.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run started
-liTest org.scalajs.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest org.scalajs.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest org.scalajs.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest org.scalajs.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest org.scalajs.junit.[33mBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.BeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.BeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_.txt
@@ -1,6 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_a.txt
@@ -1,6 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_n.txt
@@ -1,6 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
-leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_na.txt
@@ -1,6 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
-leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nv.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
-leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nva.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
-leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nvc.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
-leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nvca.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
-leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_v.txt
@@ -1,6 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_va.txt
@@ -1,6 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vc.txt
@@ -1,6 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vs.txt
@@ -1,6 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
-leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vsn.txt
@@ -1,6 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
-leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
+leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 e2org.scalajs.junit.ExceptionAfterAssume.assumeFail
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m start
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m start
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m start
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m start
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
@@ -10,7 +10,7 @@ liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m start
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
-lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.internal.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
@@ -10,7 +10,7 @@ liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
 e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
-lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.internal.AssumptionViolatedException: This assume should not pass, took <TIME>
+lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
-liTest org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
-liTest org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run started
-liTest org.scalajs.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run started
-liTest org.scalajs.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
-liTest org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m ignored
+lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
+li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run started
-liTest org.scalajs.junit.MultiBeforeAssumeFailTest ignored
+lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
 e3org.scalajs.junit.MultiBeforeAssumeFailTest
-liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
+liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -260,6 +260,11 @@ object Build {
     if (hasNewCollections(scalaV)) sourceDir / "scala-new-collections"
     else sourceDir / "scala-old-collections"
 
+  val JUnitDeps = Seq(
+    "com.novocode" % "junit-interface" % "0.11" % "test",
+    "junit" % "junit" % "4.13.2" % "test",
+  )
+
   val javaVersion = settingKey[Int](
     "The major Java SDK version that should be assumed for compatibility. " +
     "Defaults to what sbt is running with.")
@@ -697,8 +702,7 @@ object Build {
       id = "ir", base = file("ir/jvm")
   ).settings(
       commonIrProjectSettings,
-      libraryDependencies +=
-        "com.novocode" % "junit-interface" % "0.9" % "test"
+      libraryDependencies ++= JUnitDeps,
   )
 
   lazy val irProjectJS: MultiScalaProject = MultiScalaProject(
@@ -722,8 +726,8 @@ object Build {
       libraryDependencies ++= Seq(
           "org.scala-lang" % "scala-compiler" % scalaVersion.value,
           "org.scala-lang" % "scala-reflect" % scalaVersion.value,
-          "com.novocode" % "junit-interface" % "0.9" % "test"
       ),
+      libraryDependencies ++= JUnitDeps,
       exportJars := true,
 
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-a"),
@@ -790,8 +794,8 @@ object Build {
       commonLinkerInterfaceSettings,
       libraryDependencies ++= Seq(
           "org.scala-js" %% "scalajs-logging" % "1.1.1",
-          "com.novocode" % "junit-interface" % "0.11" % "test",
       ),
+      libraryDependencies ++= JUnitDeps,
   ).dependsOn(irProject, jUnitAsyncJVM % "test")
 
   lazy val linkerInterfaceJS: MultiScalaProject = MultiScalaProject(
@@ -924,11 +928,11 @@ object Build {
   ).settings(
       libraryDependencies ++= Seq(
           "com.google.javascript" % "closure-compiler" % "v20210406",
-          "com.novocode" % "junit-interface" % "0.9" % "test",
           "com.google.jimfs" % "jimfs" % "1.1" % "test"
       ) ++ (
           parallelCollectionsDependencies(scalaVersion.value)
       ),
+      libraryDependencies ++= JUnitDeps,
 
       resourceGenerators in Compile += Def.task {
         val s = streams.value
@@ -1017,9 +1021,9 @@ object Build {
       libraryDependencies ++= Seq(
           "org.scala-sbt" % "test-interface" % "1.0",
           "org.scala-js" %% "scalajs-js-envs" % "1.1.1",
-          "com.novocode" % "junit-interface" % "0.11" % "test",
           "com.google.jimfs" % "jimfs" % "1.1" % "test",
       ),
+      libraryDependencies ++= JUnitDeps,
       previousArtifactSetting,
       mimaBinaryIssueFilters ++= BinaryIncompatibilities.TestAdapter,
       unmanagedSourceDirectories in Compile +=
@@ -1597,8 +1601,8 @@ object Build {
       name := "Tests for Scala.js JUnit output in JVM.",
       libraryDependencies ++= Seq(
           "org.scala-sbt" % "test-interface" % "1.0" % "test",
-          "com.novocode" % "junit-interface" % "0.11" % "test"
-      )
+      ),
+      libraryDependencies ++= JUnitDeps,
   ).dependsOn(
        jUnitAsyncJVM % "test"
   )
@@ -2115,8 +2119,7 @@ object Build {
           "-Dline.separator=\n"
       ),
 
-      libraryDependencies +=
-        "com.novocode" % "junit-interface" % "0.11" % "test"
+      libraryDependencies ++= JUnitDeps,
   )
 
   /* Dummies for javalib extensions that can be implemented outside the core.
@@ -2211,8 +2214,7 @@ object Build {
           "-Dline.separator=\n"
       ),
 
-      libraryDependencies +=
-        "com.novocode" % "junit-interface" % "0.11" % "test",
+      libraryDependencies ++= JUnitDeps,
   ).dependsOn(
       testSuiteJVM
   )

--- a/scala-test-suite/src/test/resources/2.11.12/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.11.12/BlacklistedTests.txt
@@ -49,6 +49,7 @@ scala/tools/nsc/transform/delambdafy/DelambdafyTest.scala
 scala/tools/nsc/transform/patmat/SolvingTest.scala
 scala/tools/nsc/util/ClassPathImplComparator.scala
 scala/tools/nsc/util/StackTraceTest.scala
+scala/util/SpecVersionTest.scala
 
 ## Do not link
 scala/StringContextTest.scala

--- a/scala-test-suite/src/test/resources/2.13.0/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.0/BlacklistedTests.txt
@@ -6,6 +6,7 @@ scala/StringTest.scala
 scala/collection/FactoriesTest.scala
 scala/collection/LazyZipOpsTest.scala
 scala/collection/immutable/IndexedSeqTest.scala
+scala/collection/immutable/RangeTest.scala
 scala/lang/annotations/BytecodeTest.scala
 scala/lang/annotations/RunTest.scala
 scala/lang/traits/BytecodeTest.scala

--- a/scala-test-suite/src/test/resources/2.13.1/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.1/BlacklistedTests.txt
@@ -6,6 +6,7 @@ scala/StringTest.scala
 scala/collection/FactoriesTest.scala
 scala/collection/LazyZipOpsTest.scala
 scala/collection/immutable/IndexedSeqTest.scala
+scala/collection/immutable/RangeTest.scala
 scala/lang/annotations/BytecodeTest.scala
 scala/lang/annotations/RunTest.scala
 scala/lang/traits/BytecodeTest.scala

--- a/scala-test-suite/src/test/resources/2.13.2/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.2/BlacklistedTests.txt
@@ -7,6 +7,8 @@ scala/collection/FactoriesTest.scala
 scala/collection/LazyZipOpsTest.scala
 scala/collection/immutable/IndexedSeqTest.scala
 scala/collection/immutable/MapHashcodeTest.scala
+scala/collection/immutable/RangeTest.scala
+scala/collection/mutable/BitSetTest.scala
 scala/lang/annotations/BytecodeTest.scala
 scala/lang/annotations/RunTest.scala
 scala/lang/traits/BytecodeTest.scala
@@ -116,6 +118,7 @@ scala/tools/nsc/typechecker/ParamAliasTest.scala
 scala/tools/nsc/typechecker/TypedTreeTest.scala
 scala/tools/nsc/util/StackTraceTest.scala
 scala/util/ChainingOpsTest.scala
+scala/util/TryTest.scala
 
 ## Do not link
 scala/CollectTest.scala

--- a/scala-test-suite/src/test/resources/2.13.4/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.4/BlacklistedTests.txt
@@ -13,12 +13,14 @@ scala/collection/immutable/IntMapTest.scala
 scala/collection/immutable/ListMapTest.scala
 scala/collection/immutable/LongMapTest.scala
 scala/collection/immutable/MapHashcodeTest.scala
+scala/collection/immutable/RangeTest.scala
 scala/collection/immutable/SeqTest.scala
 scala/collection/immutable/SmallMapTest.scala
 scala/collection/immutable/SortedMapTest.scala
 scala/collection/immutable/SortedSetTest.scala
 scala/collection/immutable/TreeMapTest.scala
 scala/collection/immutable/TreeSetTest.scala
+scala/collection/mutable/BitSetTest.scala
 scala/lang/annotations/BytecodeTest.scala
 scala/lang/annotations/RunTest.scala
 scala/lang/traits/BytecodeTest.scala

--- a/scala-test-suite/src/test/resources/2.13.5/BlacklistedTests.txt
+++ b/scala-test-suite/src/test/resources/2.13.5/BlacklistedTests.txt
@@ -146,10 +146,6 @@ scala/tools/nsc/util/StackTraceTest.scala
 scala/tools/testkit/ReflectUtilTest.scala
 scala/util/ChainingOpsTest.scala
 
-# Do not compile because they need JUnit 4.13.1's `assertThrows`
-scala/collection/immutable/RangeTest.scala
-scala/collection/mutable/BitSetTest.scala
-
 ## Do not link
 scala/CollectTest.scala
 scala/MatchErrorSerializationTest.scala

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTestEx.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Additional tests for java.lang.Object that have to be in a separate
  *  codebase than testSuite to be meaningful.

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTestEx.scala
@@ -17,8 +17,6 @@ import java.util.Locale
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
-
 /** Additional tests for java.lang.String that require `java.util.Locale`. */
 class StringTestEx {
   val English = new Locale("en")

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/time/InstantTest.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/time/InstantTest.scala
@@ -17,7 +17,7 @@ import java.time.{DateTimeException, Instant}
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Sanity tests for the dummy implementation of `java.time.Instant`.
  *

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTestEx.scala
@@ -18,7 +18,7 @@ import java.time.Instant
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Additional tests for `java.util.Date` that require javalib extension
  *  dummies.

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LocaleTest.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/LocaleTest.scala
@@ -17,8 +17,6 @@ import java.util.Locale
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
-
 /** Sanity tests for the dummy implementation of `java.util.Locale`.
  *
  *  These tests ensure that our dummy implementation of `java.util.Locale`

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -12,50 +12,12 @@
 
 package org.scalajs.testsuite.utils
 
-/** This is a copy of the implementation in the testSuite */
+import org.junit.Assert
+import org.junit.function.ThrowingRunnable
+
 object AssertThrows {
-  /** Backport implementation of Assert.assertThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def assertThrowsBackport[T <: Throwable](expectedThrowable: Class[T],
-      runnable: ThrowingRunnable): T = {
-    val result = {
-      try {
-        runnable.run()
-        null.asInstanceOf[T]
-      } catch {
-        case actualThrown: Throwable =>
-          if (expectedThrowable.isInstance(actualThrown)) {
-            actualThrown.asInstanceOf[T]
-          } else {
-            val mismatchMessage = {
-              "unexpected exception type thrown;" +
-              expectedThrowable.getSimpleName + " " + actualThrown.getClass.getSimpleName
-            }
-
-            val assertionError = new AssertionError(mismatchMessage)
-            assertionError.initCause(actualThrown)
-            throw assertionError
-          }
-      }
-    }
-    if (result == null) {
-      throw new AssertionError("expected " + expectedThrowable.getSimpleName +
-          " to be thrown, but nothing was thrown")
-    } else {
-      result
-    }
-  }
-
-  /** Backport implementation of Assert.ThrowingRunnable to be used until
-   *  JUnit 4.13 is released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private trait ThrowingRunnable {
-    def run(): Unit
-  }
-
   def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
-    assertThrowsBackport(expectedThrowable, new ThrowingRunnable {
+    Assert.assertThrows(expectedThrowable, new ThrowingRunnable {
       def run(): Unit = code
     })
   }

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -17,15 +17,7 @@ object AssertThrows {
   /** Backport implementation of Assert.assertThrows to be used until JUnit 4.13 is
    *  released. See org.junit.Assert.scala in jUnitRuntime.
    */
-  private def assertThrowsBackport(expectedThrowable: Class[_ <: Throwable],
-      runnable: ThrowingRunnable): Unit = {
-    expectThrowsBackport(expectedThrowable, runnable)
-  }
-
-  /** Backport implementation of Assert.expectThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def expectThrowsBackport[T <: Throwable](expectedThrowable: Class[T],
+  private def assertThrowsBackport[T <: Throwable](expectedThrowable: Class[T],
       runnable: ThrowingRunnable): T = {
     val result = {
       try {
@@ -62,21 +54,9 @@ object AssertThrows {
     def run(): Unit
   }
 
-  private def throwingRunnable(code: => Unit): ThrowingRunnable = {
-    new ThrowingRunnable {
+  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
+    assertThrowsBackport(expectedThrowable, new ThrowingRunnable {
       def run(): Unit = code
-    }
-  }
-
-  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): Unit = {
-    assertThrowsBackport(expectedThrowable, throwingRunnable {
-      code
-    })
-  }
-
-  def expectThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
-    expectThrowsBackport(expectedThrowable, throwingRunnable {
-      code
     })
   }
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/InteroperabilityTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.JSAssert._
 import org.scalajs.testsuite.utils.Platform._
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/LongJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/LongJSTest.scala
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 /** Tests the re-patching of native longs */

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypeTestsJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypeTestsJSTest.scala
@@ -18,7 +18,7 @@ import scala.scalajs.js.annotation.JSGlobal
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class RuntimeTypeTestsJSTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectJSTest.scala
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform
 
 import scala.scalajs.js

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/TimerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/javalib/util/TimerTest.scala
@@ -16,7 +16,7 @@ import org.junit.Assert._
 import org.junit.Test
 
 import org.scalajs.testsuite.jsinterop.TimeoutMock
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import java.util.Timer
 import java.util.TimerTask

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DictionaryTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class DictionaryTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ExportsTest.scala
@@ -16,7 +16,7 @@ import scala.scalajs.js
 import scala.scalajs.js.annotation._
 import scala.scalajs.js.Dynamic.global
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.JSAssert._
 import org.scalajs.testsuite.utils.JSUtils
 import org.scalajs.testsuite.utils.Platform._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/FunctionTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.useECMAScript2015Semantics
 
 class FunctionTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/JSExportStaticTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.jsinterop
 import scala.scalajs.js
 import js.annotation._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import org.junit.Assert._

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MapTest.scala
@@ -18,7 +18,7 @@ import org.junit.{BeforeClass, Test}
 
 import scala.scalajs.js
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 object MapTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -52,9 +52,9 @@ class MiscInteropTest {
 
     assertEquals("undefined",
         js.typeOf(js.Dynamic.global.thisGlobalVarDoesNotExist))
-    expectThrows(classOf[js.JavaScriptException],
+    assertThrows(classOf[js.JavaScriptException],
         js.typeOf(nonExistentGlobalVarNoInline()))
-    expectThrows(classOf[js.JavaScriptException],
+    assertThrows(classOf[js.JavaScriptException],
         js.typeOf(nonExistentGlobalVarInline()))
   }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -19,7 +19,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class MiscInteropTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform
 
 class SpecialTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThrowAndCatchTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/ThrowAndCatchTest.scala
@@ -17,8 +17,6 @@ import scala.scalajs.js
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
-
 class ThrowAndCatchTest {
   import ThrowAndCatchTest._
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/UndefOrTest.scala
@@ -17,7 +17,7 @@ import scala.scalajs.js
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.JSAssert._
 
 class UndefOrTest {

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ArrayOpsTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.scalaVersion
 
 import scala.reflect.{ClassTag, classTag}

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/ReflectTest.scala
@@ -16,7 +16,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import scala.scalajs.reflect._

--- a/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/lang/CharacterTestOnJDK11.scala
+++ b/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/lang/CharacterTestOnJDK11.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class CharacterTestOnJDK11 {
 

--- a/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/lang/StringTestOnJDK11.scala
+++ b/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/lang/StringTestOnJDK11.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class StringTestOnJDK11 {
   @Test def repeat(): Unit = {

--- a/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/util/OptionalTestOnJDK11.scala
+++ b/test-suite/shared/src/test/require-jdk11/org/scalajs/testsuite/javalib/util/OptionalTestOnJDK11.scala
@@ -18,7 +18,7 @@ import org.junit.Test
 import java.util.Optional
 import java.util.function._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class OptionalTestOnJDK11 {
 

--- a/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/WasPublicBeforeTyperTestScala2.scala
+++ b/test-suite/shared/src/test/require-scala2/org/scalajs/testsuite/compiler/WasPublicBeforeTyperTestScala2.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.compiler
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class WasPublicBeforeTyperTestScala2 {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.hasCompliantArrayIndexOutOfBounds
 
 class ArrayTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
@@ -369,7 +369,7 @@ class ReflectiveCallTest {
       else "scala.scalajs.js.JavaScriptException"
 
     def testWith(body: => Unit): Unit = {
-      val exception = expectThrows(classOf[Throwable], body)
+      val exception = assertThrows(classOf[Throwable], body)
       assertEquals(expectedClassName, exception.getClass.getName)
     }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
@@ -19,7 +19,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.Platform
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import java.lang.{Float => JFloat, Double => JDouble}
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import org.scalajs.testsuite.utils.Platform
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -858,7 +858,7 @@ class RegressionTest {
       var b: Nothing = throw new IllegalStateException("never")
     }
 
-    val ex1 = expectThrows(classOf[IllegalStateException], new EagerFieldsWithNothingType)
+    val ex1 = assertThrows(classOf[IllegalStateException], new EagerFieldsWithNothingType)
     assertEquals("always", ex1.getMessage())
 
     class LazyFieldsWithNothingType {
@@ -866,7 +866,7 @@ class RegressionTest {
     }
 
     val obj = new LazyFieldsWithNothingType
-    val ex2 = expectThrows(classOf[IllegalStateException], obj.a)
+    val ex2 = assertThrows(classOf[IllegalStateException], obj.a)
     assertEquals("lazily always", ex2.getMessage())
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypeTestsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypeTestsTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import scala.reflect.{ClassTag, classTag}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayReaderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayReaderTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.io
 import java.io._
 import org.junit.Assert._
 import org.junit.Test
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class CharArrayReaderTest {
   private val hw: Array[Char] = Array('H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd')

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CharArrayWriterTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.io
 import java.io.{CharArrayWriter, StringWriter}
 import org.junit.Assert._
 import org.junit.Test
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class CharArrayWriterTest {
   private val hw: Array[Char] = Array('H', 'e', 'l', 'l', 'o', 'W', 'o', 'r', 'l', 'd')

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 trait CommonStreamsTests {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/CommonStreamsTests.scala
@@ -69,10 +69,10 @@ trait CommonStreamsTests {
     assertEquals(0, stream.read(buf, 10, 0))
     assertArrayEqualsSeq(6 to 25, buf)
 
-    expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, -1, 0))
-    expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 0, -1))
-    expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 100, 0))
-    expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 10, 100))
+    assertThrows(classOf[IndexOutOfBoundsException], stream.read(buf, -1, 0))
+    assertThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 0, -1))
+    assertThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 100, 0))
+    assertThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 10, 100))
     assertArrayEqualsSeq(6 to 25, buf)
 
     assertEquals(20L, stream.skip(20))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataInputStreamTest.scala
@@ -14,7 +14,7 @@ package org.scalajs.testsuite.javalib.io
 
 import java.io._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 import org.junit._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/DataOutputStreamTest.scala
@@ -17,7 +17,7 @@ import java.io._
 import org.junit._
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 object DataOutputStreamTest {
   class DataOutputStreamWrittenAccess(out: OutputStream)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
@@ -17,7 +17,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class InputStreamTest extends CommonStreamsTests {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/InputStreamTest.scala
@@ -51,9 +51,9 @@ class InputStreamTest extends CommonStreamsTests {
     assertArrayEquals(((1 to 10) ++ (51 to 70) ++ (31 to 50)).toArray.map(_.toByte), buf)
 
     // Test some Exception conditions
-    expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, -1, 10))
-    expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 0, -1))
-    expectThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 10, 100))
+    assertThrows(classOf[IndexOutOfBoundsException], stream.read(buf, -1, 10))
+    assertThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 0, -1))
+    assertThrows(classOf[IndexOutOfBoundsException], stream.read(buf, 10, 100))
 
     // Buffer should be unmodified
     assertArrayEquals(

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
@@ -17,7 +17,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class OutputStreamWriterTest {
   private def newOSWriter(): (OutputStreamWriter, MockByteArrayOutputStream) = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/OutputStreamWriterTest.scala
@@ -51,11 +51,11 @@ class OutputStreamWriterTest {
     osw.close()
 
     // when closed, other operations cause error
-    expectThrows(classOf[IOException], osw.write('A'))
-    expectThrows(classOf[IOException], osw.write("never printed"))
-    expectThrows(classOf[IOException], osw.write(Array('a', 'b')))
-    expectThrows(classOf[IOException], osw.append("hello", 1, 3))
-    expectThrows(classOf[IOException], osw.flush())
+    assertThrows(classOf[IOException], osw.write('A'))
+    assertThrows(classOf[IOException], osw.write("never printed"))
+    assertThrows(classOf[IOException], osw.write(Array('a', 'b')))
+    assertThrows(classOf[IOException], osw.append("hello", 1, 3))
+    assertThrows(classOf[IOException], osw.flush())
 
     // at the end of it all, bos is still what it was when it was closed
     assertArrayEquals(Array[Byte](1, 65, 66, 67), bos.toByteArray())
@@ -136,7 +136,7 @@ class OutputStreamWriterTest {
   }
 
   @Test def constructorThrowUnsupportedEncodingExceptionIfUnsupportedCharsetNameGiven(): Unit = {
-    val ex = expectThrows(classOf[UnsupportedEncodingException],
+    val ex = assertThrows(classOf[UnsupportedEncodingException],
       new OutputStreamWriter(new ByteArrayOutputStream(), "UNSUPPORTED-CHARSET"))
     assertTrue("Cause should be null since constructor does not accept cause",
       ex.getCause == null)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -87,7 +87,7 @@ class StringReaderTest {
     assertEquals(-1, r.read())
 
     r.close()
-    expectThrows(classOf[IOException], r.ready())
+    assertThrows(classOf[IOException], r.ready())
   }
 
   @Test def markReset(): Unit = {
@@ -121,7 +121,7 @@ class StringReaderTest {
     val r = newReader
 
     r.close()
-    expectThrows(classOf[IOException], r.read())
+    assertThrows(classOf[IOException], r.read())
   }
 
   @Test def mark(): Unit = {
@@ -129,7 +129,7 @@ class StringReaderTest {
   }
 
   @Test def markThrowsWithNegativeLookahead(): Unit = {
-    expectThrows(classOf[IllegalArgumentException], newReader.mark(-10))
+    assertThrows(classOf[IllegalArgumentException], newReader.mark(-10))
   }
 
   @Test def skipAcceptsNegativeLookaheadAsLookback(): Unit = {
@@ -298,7 +298,7 @@ class BufferedReaderTest {
   }
 
   @Test def markThrowsWithNegativeLookahead(): Unit = {
-    expectThrows(classOf[IllegalArgumentException], newReader.mark(-10))
+    assertThrows(classOf[IllegalArgumentException], newReader.mark(-10))
   }
 }
 
@@ -344,7 +344,7 @@ class InputStreamReaderTest {
     // Do it twice to check for a regression where this used to throw
     assertEquals(-1, streamReader.read(bytes))
     assertEquals(-1, streamReader.read(bytes))
-    expectThrows(classOf[IndexOutOfBoundsException], streamReader.read(bytes, 10, 3))
+    assertThrows(classOf[IndexOutOfBoundsException], streamReader.read(bytes, 10, 3))
     assertEquals(0, streamReader.read(new Array[Char](0)))
   }
 
@@ -361,6 +361,6 @@ class InputStreamReaderTest {
   @Test def markThrowsNotSupported(): Unit = {
     val data = "Lorem ipsum".getBytes()
     val r = new InputStreamReader(new ByteArrayInputStream(data))
-    expectThrows(classOf[IOException], r.mark(0))
+    assertThrows(classOf[IOException], r.mark(0))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/ReadersTest.scala
@@ -19,7 +19,7 @@ import java.io._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Tests for our implementation of java.io._ reader classes */
 class ReaderTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
@@ -17,7 +17,7 @@ import java.lang.{Boolean => JBoolean}
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Tests the implementation of the java standard library Boolean
  */

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/BooleanTest.scala
@@ -26,7 +26,7 @@ class BooleanTest {
   @Test def booleanValue(): Unit = {
     assertEquals(true, JBoolean.TRUE.booleanValue())
     assertEquals(false, JBoolean.FALSE.booleanValue())
-    expectThrows(classOf[Exception], (null: JBoolean).booleanValue())
+    assertThrows(classOf[Exception], (null: JBoolean).booleanValue())
   }
 
   @Test def compareTo(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
@@ -59,8 +59,8 @@ class ByteTest {
 
   @Test def parseStringInvalidThrows(): Unit = {
     def test(s: String): Unit = {
-      expectThrows(classOf[NumberFormatException], JByte.parseByte(s))
-      expectThrows(classOf[NumberFormatException], JByte.decode(s))
+      assertThrows(classOf[NumberFormatException], JByte.parseByte(s))
+      assertThrows(classOf[NumberFormatException], JByte.decode(s))
     }
 
     test("abc")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
@@ -17,7 +17,7 @@ import java.lang.{Byte => JByte}
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Tests the implementation of the java standard library Byte
  */

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
@@ -304,7 +304,7 @@ class CharacterTest {
     assertTrue(Character.toChars(0x10401) sameElements Array('\uD801', '\uDC01'))
     assertTrue(Character.toChars(0x10FFFF) sameElements Array('\uDBFF', '\uDFFF'))
 
-    expectThrows(classOf[IllegalArgumentException], Character.toChars(Integer.MAX_VALUE))
+    assertThrows(classOf[IllegalArgumentException], Character.toChars(Integer.MAX_VALUE))
   }
 
   @Test def toCharsInPlace(): Unit = {
@@ -339,7 +339,7 @@ class CharacterTest {
       assertTrue(dst sameElements Array(0.toChar, 0.toChar, '\uDBFF', '\uDFFF'))
     }
 
-    expectThrows(classOf[IllegalArgumentException], Character.toChars(Integer.MAX_VALUE, new Array(2), 0))
+    assertThrows(classOf[IllegalArgumentException], Character.toChars(Integer.MAX_VALUE, new Array(2), 0))
   }
 
   @Test def isDigit(): Unit = {
@@ -1034,9 +1034,9 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0, Character.codePointCount(s, s.length - 1, s.length - 1))
     assertEquals(0, Character.codePointCount(s, s.length, s.length))
 
-    expectThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(s, -3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(s, 6, 2))
-    expectThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(s, 10, 30))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(s, -3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(s, 6, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(s, 10, 30))
   }
 
   @Test def codePointCountCharSequence(): Unit = {
@@ -1059,9 +1059,9 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0, Character.codePointCount(cs, cs.length - 1, cs.length - 1))
     assertEquals(0, Character.codePointCount(cs, cs.length, cs.length))
 
-    expectThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, -3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, 6, 2))
-    expectThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, 10, 30))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, -3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, 6, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, 10, 30))
   }
 
   @Test def compare(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class CharacterTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterUnicodeBlockTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterUnicodeBlockTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.lang
 import java.lang.Character.UnicodeBlock
 import org.junit.Test
 import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class CharacterUnicodeBlockTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -348,7 +348,7 @@ class DoubleTest {
       def pad(s: String): String = padding + s + padding
 
       def test(s: String): Unit =
-        expectThrows(classOf[NumberFormatException], JDouble.parseDouble(pad(s)))
+        assertThrows(classOf[NumberFormatException], JDouble.parseDouble(pad(s)))
 
       test("asdf")
       test("4.3.5")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/DoubleTest.scala
@@ -20,7 +20,7 @@ import java.lang.{Double => JDouble}
 
 import scala.util.Try
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class DoubleTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -20,7 +20,7 @@ import java.lang.{Float => JFloat}
 
 import scala.util.Try
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.{executingInJVM, hasAccurateFloats}
 
 class FloatTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -378,7 +378,7 @@ class FloatTest {
 
   @Test def parseFloatInvalidThrows(): Unit = {
     def test(s: String): Unit =
-      expectThrows(classOf[NumberFormatException], JFloat.parseFloat(s))
+      assertThrows(classOf[NumberFormatException], JFloat.parseFloat(s))
 
     test("4.3.5")
     test("4e3.5")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class IntegerTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
@@ -519,9 +519,9 @@ class IntegerTest {
 
   @Test def parseStringInvalidThrows(): Unit = {
     def test(s: String, radix: Int = 10): Unit = {
-      expectThrows(classOf[NumberFormatException], Integer.parseInt(s, radix))
+      assertThrows(classOf[NumberFormatException], Integer.parseInt(s, radix))
       if (radix == 10 && s != null)
-        expectThrows(classOf[NumberFormatException], Integer.decode(s))
+        assertThrows(classOf[NumberFormatException], Integer.decode(s))
     }
 
     test("abc")
@@ -566,7 +566,7 @@ class IntegerTest {
 
   @Test def parseUnsignedIntInvalidThrows(): Unit = {
     def test(s: String, radix: Int = 10): Unit = {
-      expectThrows(classOf[NumberFormatException],
+      assertThrows(classOf[NumberFormatException],
           Integer.parseUnsignedInt(s, radix))
     }
 
@@ -720,7 +720,7 @@ class IntegerTest {
 
   @Test def parseUnsignedIntRadixInvalidThrows(): Unit = {
     def test(s: String, radix: Int = 10): Unit =
-      expectThrows(classOf[NumberFormatException], Integer.parseUnsignedInt(s, radix))
+      assertThrows(classOf[NumberFormatException], Integer.parseUnsignedInt(s, radix))
 
     test("abc")
     test("5a")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
@@ -155,7 +155,7 @@ class LongTest {
 
   @Test def parseStringInvalidThrows(): Unit = {
     def test(s: String): Unit =
-      expectThrows(classOf[NumberFormatException], JLong.parseLong(s))
+      assertThrows(classOf[NumberFormatException], JLong.parseLong(s))
 
     test("abc")
     test("asdf")
@@ -207,8 +207,8 @@ class LongTest {
 
   @Test def parseStringsBaseLessThanTwoOrBaseLargerThan36Throws(): Unit = {
     def test(s: String, radix: Int): Unit = {
-      expectThrows(classOf[NumberFormatException], JLong.parseLong(s, radix))
-      expectThrows(classOf[NumberFormatException], JLong.valueOf(s, radix).longValue())
+      assertThrows(classOf[NumberFormatException], JLong.parseLong(s, radix))
+      assertThrows(classOf[NumberFormatException], JLong.valueOf(s, radix).longValue())
     }
 
     List[Int](-10, -5, 0, 1, 37, 38, 50, 100).foreach(test("5", _))
@@ -602,7 +602,7 @@ class LongTest {
 
   @Test def parseUnsignedLongFailureCases(): Unit = {
     def test(s: String, radix: Int = 10): Unit =
-      expectThrows(classOf[NumberFormatException], JLong.parseUnsignedLong(s, radix))
+      assertThrows(classOf[NumberFormatException], JLong.parseUnsignedLong(s, radix))
 
     // Bad radix
     test("0", MinRadix - 1)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
@@ -17,7 +17,7 @@ import java.lang.{Long => JLong}
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Tests the implementation of the java standard library Long
  *  requires jsinterop/LongTest to work to make sense

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assume._
 
 import java.lang.Math
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class MathTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
@@ -477,13 +477,13 @@ class MathTest {
     assertEquals(Int.MaxValue, Math.addExact(1, 2147483646))
     assertEquals(Int.MinValue, Math.addExact(-1073741824, -1073741824))
 
-    expectThrows(classOf[ArithmeticException], Math.addExact(Int.MinValue, -1))
-    expectThrows(classOf[ArithmeticException], Math.addExact(-1, Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.addExact(Int.MinValue, Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.addExact(Int.MaxValue, 1))
-    expectThrows(classOf[ArithmeticException], Math.addExact(1, Int.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.addExact(Int.MaxValue, Int.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.addExact(1073741824, 1073741824))
+    assertThrows(classOf[ArithmeticException], Math.addExact(Int.MinValue, -1))
+    assertThrows(classOf[ArithmeticException], Math.addExact(-1, Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.addExact(Int.MinValue, Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.addExact(Int.MaxValue, 1))
+    assertThrows(classOf[ArithmeticException], Math.addExact(1, Int.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.addExact(Int.MaxValue, Int.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.addExact(1073741824, 1073741824))
 
     assertEquals(0L, Math.addExact(0L, 0L))
     assertEquals(1L, Math.addExact(0L, 1L))
@@ -506,13 +506,13 @@ class MathTest {
     assertEquals(Long.MaxValue, Math.addExact(1, 9223372036854775806L))
     assertEquals(Long.MinValue, Math.addExact(-4611686018427387904L, -4611686018427387904L))
 
-    expectThrows(classOf[ArithmeticException], Math.addExact(Long.MinValue, -1))
-    expectThrows(classOf[ArithmeticException], Math.addExact(-1, Long.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.addExact(Long.MinValue, Long.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.addExact(Long.MaxValue, 1))
-    expectThrows(classOf[ArithmeticException], Math.addExact(1, Long.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.addExact(Long.MaxValue, Long.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.addExact(4611686018427387904L, 4611686018427387904L))
+    assertThrows(classOf[ArithmeticException], Math.addExact(Long.MinValue, -1))
+    assertThrows(classOf[ArithmeticException], Math.addExact(-1, Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.addExact(Long.MinValue, Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.addExact(Long.MaxValue, 1))
+    assertThrows(classOf[ArithmeticException], Math.addExact(1, Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.addExact(Long.MaxValue, Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.addExact(4611686018427387904L, 4611686018427387904L))
   }
 
   @Test def subtractExact(): Unit = {
@@ -532,13 +532,13 @@ class MathTest {
     assertEquals(-2147483647, Math.subtractExact(0, Int.MaxValue))
     assertEquals(Int.MaxValue, Math.subtractExact(-1, Int.MinValue))
     assertEquals(Int.MinValue, Math.subtractExact(-1073741824, 1073741824))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(0, Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Int.MinValue, 1))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Int.MinValue, Int.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(-2, Int.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Int.MaxValue, -1))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Int.MaxValue, Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(1073741824, -1073741824))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(0, Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Int.MinValue, 1))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Int.MinValue, Int.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(-2, Int.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Int.MaxValue, -1))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Int.MaxValue, Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(1073741824, -1073741824))
 
     assertEquals(0L, Math.subtractExact(0L, 0L))
     assertEquals(1L, Math.subtractExact(1L, 0L))
@@ -557,14 +557,14 @@ class MathTest {
     assertEquals(Long.MaxValue, Math.subtractExact(-1, Long.MinValue))
     assertEquals(Long.MinValue, Math.subtractExact(-4611686018427387904L, 4611686018427387904L))
 
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(0, Long.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Long.MinValue, 1))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Long.MinValue, Long.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Long.MinValue, 1))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(-2, Long.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Long.MaxValue, -1))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(Long.MaxValue, Long.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.subtractExact(4611686018427387904L, -4611686018427387904L))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(0, Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Long.MinValue, 1))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Long.MinValue, Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Long.MinValue, 1))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(-2, Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Long.MaxValue, -1))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(Long.MaxValue, Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.subtractExact(4611686018427387904L, -4611686018427387904L))
   }
 
   @Test def multiplyExact(): Unit = {
@@ -581,16 +581,16 @@ class MathTest {
     assertEquals(Int.MinValue, Math.multiplyExact(1073741824, -2))
     assertEquals(Int.MinValue, Math.multiplyExact(-2, 1073741824))
 
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MinValue, -1))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(-1, Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MinValue, Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MaxValue, Int.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MinValue, Int.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MaxValue, Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(1073741824, 2))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(2, 1073741824))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(1073741825, -2))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(-2, 1073741825))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MinValue, -1))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(-1, Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MinValue, Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MaxValue, Int.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MinValue, Int.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Int.MaxValue, Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(1073741824, 2))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(2, 1073741824))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(1073741825, -2))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(-2, 1073741825))
 
     for (n <- Seq(Long.MinValue, -1L, 0L, 1L, Long.MaxValue)) {
       assertEquals(0L, Math.multiplyExact(n, 0))
@@ -607,32 +607,32 @@ class MathTest {
     assertEquals(Long.MinValue, Math.multiplyExact(4611686018427387904L, -2))
     assertEquals(Long.MinValue, Math.multiplyExact(-2, 4611686018427387904L))
 
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MinValue, -1))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(-1, Long.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MinValue, Long.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MaxValue, Long.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MinValue, Long.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MaxValue, Long.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(4611686018427387904L, 2))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(2, 4611686018427387904L))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(4611686018427387905L, -2))
-    expectThrows(classOf[ArithmeticException], Math.multiplyExact(-2, 4611686018427387905L))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MinValue, -1))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(-1, Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MinValue, Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MaxValue, Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MinValue, Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(Long.MaxValue, Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(4611686018427387904L, 2))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(2, 4611686018427387904L))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(4611686018427387905L, -2))
+    assertThrows(classOf[ArithmeticException], Math.multiplyExact(-2, 4611686018427387905L))
   }
 
   @Test def incrementExact(): Unit = {
     assertEquals(Int.MaxValue, Math.incrementExact(Int.MaxValue - 1))
     assertEquals(Long.MaxValue, Math.incrementExact(Long.MaxValue - 1))
 
-    expectThrows(classOf[ArithmeticException], Math.incrementExact(Int.MaxValue))
-    expectThrows(classOf[ArithmeticException], Math.incrementExact(Long.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.incrementExact(Int.MaxValue))
+    assertThrows(classOf[ArithmeticException], Math.incrementExact(Long.MaxValue))
   }
 
   @Test def decrementExact(): Unit = {
     assertEquals(Int.MinValue, Math.decrementExact(Int.MinValue + 1))
     assertEquals(Long.MinValue, Math.decrementExact(Long.MinValue + 1))
 
-    expectThrows(classOf[ArithmeticException], Math.decrementExact(Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.decrementExact(Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.decrementExact(Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.decrementExact(Long.MinValue))
   }
 
   @Test def negateExact(): Unit = {
@@ -641,16 +641,16 @@ class MathTest {
     assertEquals(Long.MaxValue, Math.negateExact(Long.MinValue + 1))
     assertEquals(Long.MinValue + 1, Math.negateExact(Long.MaxValue))
 
-    expectThrows(classOf[ArithmeticException], Math.negateExact(Int.MinValue))
-    expectThrows(classOf[ArithmeticException], Math.negateExact(Long.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.negateExact(Int.MinValue))
+    assertThrows(classOf[ArithmeticException], Math.negateExact(Long.MinValue))
   }
 
   @Test def toIntExact(): Unit = {
     assertEquals(Int.MinValue, Math.toIntExact(-2147483648L))
     assertEquals(Int.MaxValue, Math.toIntExact(2147483647L))
 
-    expectThrows(classOf[ArithmeticException], Math.toIntExact(-2147483649L))
-    expectThrows(classOf[ArithmeticException], Math.toIntExact(2147483648L))
+    assertThrows(classOf[ArithmeticException], Math.toIntExact(-2147483649L))
+    assertThrows(classOf[ArithmeticException], Math.toIntExact(2147483648L))
   }
 
   @Test def floorDiv(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
@@ -15,7 +15,6 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
 import org.scalajs.testsuite.utils.Platform._
 
 // scalastyle:off disallow.space.before.token

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
@@ -17,7 +17,7 @@ import java.lang.{Short => JShort}
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 /** Tests the implementation of the java standard library Short
  */

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
@@ -60,8 +60,8 @@ class ShortTest {
 
   @Test def parseStringInvalidThrows(): Unit = {
     def test(s: String): Unit = {
-      expectThrows(classOf[NumberFormatException], JShort.parseShort(s))
-      expectThrows(classOf[NumberFormatException], JShort.decode(s))
+      assertThrows(classOf[NumberFormatException], JShort.parseShort(s))
+      assertThrows(classOf[NumberFormatException], JShort.decode(s))
     }
 
     test("abc")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.lang
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 import WrappedStringCharSequence.charSequence

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBufferTest.scala
@@ -43,7 +43,7 @@ class StringBufferTest {
     assertEquals("hello", new StringBuffer("hello").toString())
 
     if (executingInJVM) {
-      expectThrows(classOf[NullPointerException],
+      assertThrows(classOf[NullPointerException],
           new StringBuffer(null: String))
     }
   }
@@ -52,7 +52,7 @@ class StringBufferTest {
     assertEquals("hello", new StringBuffer(charSequence("hello")).toString())
 
     if (executingInJVM) {
-      expectThrows(classOf[NullPointerException],
+      assertThrows(classOf[NullPointerException],
           new StringBuffer(null: CharSequence))
     }
   }
@@ -99,11 +99,11 @@ class StringBufferTest {
     assertEquals("ello", resultFor("hello", 1, 5))
     assertEquals("ob", resultFor(charSequence("foobar"), 2, 4))
 
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor(charSequence("he"), 1, 3))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor(charSequence("he"), -1, 2))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor(charSequence("he"), 2, 1))
   }
 
@@ -113,7 +113,7 @@ class StringBufferTest {
     assertEquals("hello", resultFor(Array('h', 'e', 'l', 'l', 'o')))
 
     if (executingInJVM)
-      expectThrows(classOf[NullPointerException], resultFor(null))
+      assertThrows(classOf[NullPointerException], resultFor(null))
   }
 
   @Test def appendCharArrayOffsetLen(): Unit = {
@@ -125,11 +125,11 @@ class StringBufferTest {
     assertEquals("ell", resultFor(arr, 1, 3))
 
     if (executingInJVM)
-      expectThrows(classOf[NullPointerException], resultFor(null, 0, 0))
+      assertThrows(classOf[NullPointerException], resultFor(null, 0, 0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], resultFor(arr, -1, 2))
-    expectThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, 3))
-    expectThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, -2))
+    assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, -1, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, 3))
+    assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, -2))
   }
 
   @Test def appendPrimitive(): Unit = {
@@ -155,8 +155,8 @@ class StringBufferTest {
     assertEquals("\ud801\udc01", resultFor(0x10401))
     assertEquals("\udbff\udfff", resultFor(0x10ffff))
 
-    expectThrows(classOf[IllegalArgumentException], resultFor(0x111111))
-    expectThrows(classOf[IllegalArgumentException], resultFor(-1))
+    assertThrows(classOf[IllegalArgumentException], resultFor(0x111111))
+    assertThrows(classOf[IllegalArgumentException], resultFor(-1))
   }
 
   @Test def delete(): Unit = {
@@ -169,9 +169,9 @@ class StringBufferTest {
     assertEquals("hello", resultFor("hello", 5, 5))
     assertEquals("hel", resultFor("hello", 3, 8))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("hello", -1, 2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("hello", 3, 2))
   }
 
@@ -183,9 +183,9 @@ class StringBufferTest {
     assertEquals("123", resultFor("0123", 0))
     assertEquals("012", resultFor("0123", 3))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", -1))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", 4))
   }
 
@@ -201,15 +201,15 @@ class StringBufferTest {
     assertEquals("0xxxx123", resultFor("0123", 1, 1, "xxxx"))
     assertEquals("0123x", resultFor("0123", 4, 5, "x"))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", -1, 3, "x"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", 4, 3, "x"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", 5, 8, "x"))
 
     if (executingInJVM)
-      expectThrows(classOf[NullPointerException], resultFor("0123", 1, 3, null))
+      assertThrows(classOf[NullPointerException], resultFor("0123", 1, 3, null))
   }
 
   @Test def insertCharArrayOffsetLen(): Unit = {
@@ -223,19 +223,19 @@ class StringBufferTest {
     assertEquals("0bc12", resultFor("012", 1, arr, 1, 2))
     assertEquals("abcdef", resultFor("abef", 2, arr, 2, 2))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", -1, arr, 1, 2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 6, arr, 1, 2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 1, arr, -1, 2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 1, arr, 1, -2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 1, arr, 4, 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[NullPointerException],
+      assertThrows(classOf[NullPointerException],
           resultFor("1234", 1, null, 0, 0))
     }
   }
@@ -249,9 +249,9 @@ class StringBufferTest {
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
     assertEquals("01foobar234", resultFor("01234", 2, charSequence("foobar")))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", -1, "foo"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 6, "foo"))
   }
 
@@ -262,9 +262,9 @@ class StringBufferTest {
     assertEquals("01null234", resultFor("01234", 2, null))
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", -1, "foo"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 6, "foo"))
   }
 
@@ -277,13 +277,13 @@ class StringBufferTest {
     assertEquals("0abcde12", resultFor("012", 1, arr))
     assertEquals("ababcdeef", resultFor("abef", 2, arr))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", -1, arr))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 6, arr))
 
     if (executingInJVM)
-      expectThrows(classOf[NullPointerException], resultFor("1234", 1, null))
+      assertThrows(classOf[NullPointerException], resultFor("1234", 1, null))
   }
 
   @Test def insertCharSequence(): Unit = {
@@ -294,9 +294,9 @@ class StringBufferTest {
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
     assertEquals("01foobar234", resultFor("01234", 2, charSequence("foobar")))
 
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", -1, "foo"))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 6, "foo"))
   }
 
@@ -310,19 +310,19 @@ class StringBufferTest {
     assertEquals("01ello234", resultFor("01234", 2, "hello", 1, 5))
     assertEquals("01ba234", resultFor("01234", 2, charSequence("foobar"), 3, 5))
 
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", -1, charSequence("foobar"), 1, 3))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 6, charSequence("foobar"), 1, 3))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), -1, 3))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), 2, -1))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), 3, 1))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), 7, 8))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), 2, 8))
   }
 
@@ -339,9 +339,9 @@ class StringBufferTest {
     assertEquals("a4bcd", initBuffer("abcd").insert(1, 4.toByte).toString)
     assertEquals("a304bcd", initBuffer("abcd").insert(1, 304.toShort).toString)
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         initBuffer("abcd").insert(5, 56))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         initBuffer("abcd").insert(-1, 56))
   }
 
@@ -421,7 +421,7 @@ class StringBufferTest {
   @Test def setLength(): Unit = {
     val b = initBuffer("foobar")
 
-    expectThrows(classOf[StringIndexOutOfBoundsException], b.setLength(-3))
+    assertThrows(classOf[StringIndexOutOfBoundsException], b.setLength(-3))
 
     b.setLength(3)
     assertEquals("foo", b.toString)
@@ -438,9 +438,9 @@ class StringBufferTest {
     assertEquals('\udc02', resultFor("ab\ud801\udc02cd", 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[IndexOutOfBoundsException], resultFor("hello", -1))
-      expectThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 5))
-      expectThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 6))
+      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", -1))
+      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 5))
+      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 6))
     }
   }
 
@@ -459,9 +459,9 @@ class StringBufferTest {
     assertEquals(0xd834, resultFor("abc\ud834", 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           resultFor("abc\ud834\udf06def", -1))
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           resultFor("abc\ud834\udf06def", 15))
     }
   }
@@ -480,9 +480,9 @@ class StringBufferTest {
     assertEquals(0xdf06, resultFor("\udf06abc", 1))
 
     if (executingInJVM) {
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           resultFor("abc\ud834\udf06def", 0))
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           resultFor("abc\ud834\udf06def", 15))
     }
   }
@@ -505,9 +505,9 @@ class StringBufferTest {
     assertEquals(0, sb.codePointCount(sb.length - 1, sb.length - 1))
     assertEquals(0, sb.codePointCount(sb.length, sb.length))
 
-    expectThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(6, 2))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(10, 30))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(6, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(10, 30))
   }
 
   @Test def offsetByCodePoints(): Unit = {
@@ -527,9 +527,9 @@ class StringBufferTest {
     assertEquals(sb.length - 1, sb.offsetByCodePoints(sb.length - 1, 0))
     assertEquals(sb.length, sb.offsetByCodePoints(sb.length, 0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
   }
 
   @Test def offsetByCodePointsBackwards(): Unit = {
@@ -549,9 +549,9 @@ class StringBufferTest {
     assertEquals(sb.length - 1, sb.offsetByCodePoints(sb.length - 1, -0))
     assertEquals(sb.length, sb.offsetByCodePoints(sb.length, -0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
   }
 
   @Test def getChars(): Unit = {
@@ -570,9 +570,9 @@ class StringBufferTest {
     assertEquals("foxbar", resultFor("foobar", 2, 'x'))
     assertEquals("foobah", resultFor("foobar", 5, 'h'))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("foobar", -1, 'h'))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("foobar", 6,  'h'))
   }
 
@@ -584,9 +584,9 @@ class StringBufferTest {
     assertEquals("", resultFor("hello", 5))
 
     if (executingInJVM) {
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", -1))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 8))
     }
   }
@@ -604,13 +604,13 @@ class StringBufferTest {
     assertEquals("hel", resultFor("hello", 0, 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", -1, 3))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 8, 8))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 3, 2))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 3, 8))
     }
   }
@@ -624,13 +624,13 @@ class StringBufferTest {
     assertEquals("hel", resultFor("hello", 0, 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", -1, 3))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 8, 8))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 3, 2))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 3, 8))
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
@@ -45,7 +45,7 @@ class StringBuilderTest {
     assertEquals("hello", new StringBuilder("hello").toString())
 
     if (executingInJVM) {
-      expectThrows(classOf[NullPointerException],
+      assertThrows(classOf[NullPointerException],
           new StringBuilder(null: String))
     }
   }
@@ -54,7 +54,7 @@ class StringBuilderTest {
     assertEquals("hello", new StringBuilder(charSequence("hello")).toString())
 
     if (executingInJVM) {
-      expectThrows(classOf[NullPointerException],
+      assertThrows(classOf[NullPointerException],
           new StringBuilder(null: CharSequence))
     }
   }
@@ -101,11 +101,11 @@ class StringBuilderTest {
     assertEquals("ello", resultFor("hello", 1, 5))
     assertEquals("ob", resultFor(charSequence("foobar"), 2, 4))
 
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor(charSequence("he"), 1, 3))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor(charSequence("he"), -1, 2))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor(charSequence("he"), 2, 1))
   }
 
@@ -115,7 +115,7 @@ class StringBuilderTest {
     assertEquals("hello", resultFor(Array('h', 'e', 'l', 'l', 'o')))
 
     if (executingInJVM)
-      expectThrows(classOf[NullPointerException], resultFor(null))
+      assertThrows(classOf[NullPointerException], resultFor(null))
   }
 
   @Test def appendCharArrayOffsetLen(): Unit = {
@@ -127,11 +127,11 @@ class StringBuilderTest {
     assertEquals("ell", resultFor(arr, 1, 3))
 
     if (executingInJVM)
-      expectThrows(classOf[NullPointerException], resultFor(null, 0, 0))
+      assertThrows(classOf[NullPointerException], resultFor(null, 0, 0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], resultFor(arr, -1, 2))
-    expectThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, 3))
-    expectThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, -2))
+    assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, -1, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, 3))
+    assertThrows(classOf[IndexOutOfBoundsException], resultFor(arr, 3, -2))
   }
 
   @Test def appendPrimitive(): Unit = {
@@ -157,8 +157,8 @@ class StringBuilderTest {
     assertEquals("\ud801\udc01", resultFor(0x10401))
     assertEquals("\udbff\udfff", resultFor(0x10ffff))
 
-    expectThrows(classOf[IllegalArgumentException], resultFor(0x111111))
-    expectThrows(classOf[IllegalArgumentException], resultFor(-1))
+    assertThrows(classOf[IllegalArgumentException], resultFor(0x111111))
+    assertThrows(classOf[IllegalArgumentException], resultFor(-1))
   }
 
   @Test def delete(): Unit = {
@@ -171,9 +171,9 @@ class StringBuilderTest {
     assertEquals("hello", resultFor("hello", 5, 5))
     assertEquals("hel", resultFor("hello", 3, 8))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("hello", -1, 2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("hello", 3, 2))
   }
 
@@ -185,9 +185,9 @@ class StringBuilderTest {
     assertEquals("123", resultFor("0123", 0))
     assertEquals("012", resultFor("0123", 3))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", -1))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", 4))
   }
 
@@ -203,15 +203,15 @@ class StringBuilderTest {
     assertEquals("0xxxx123", resultFor("0123", 1, 1, "xxxx"))
     assertEquals("0123x", resultFor("0123", 4, 5, "x"))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", -1, 3, "x"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", 4, 3, "x"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("0123", 5, 8, "x"))
 
     if (executingInJVM)
-      expectThrows(classOf[NullPointerException], resultFor("0123", 1, 3, null))
+      assertThrows(classOf[NullPointerException], resultFor("0123", 1, 3, null))
   }
 
   @Test def insertCharArrayOffsetLen(): Unit = {
@@ -225,19 +225,19 @@ class StringBuilderTest {
     assertEquals("0bc12", resultFor("012", 1, arr, 1, 2))
     assertEquals("abcdef", resultFor("abef", 2, arr, 2, 2))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", -1, arr, 1, 2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 6, arr, 1, 2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 1, arr, -1, 2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 1, arr, 1, -2))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 1, arr, 4, 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[NullPointerException],
+      assertThrows(classOf[NullPointerException],
           resultFor("1234", 1, null, 0, 0))
     }
   }
@@ -251,9 +251,9 @@ class StringBuilderTest {
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
     assertEquals("01foobar234", resultFor("01234", 2, charSequence("foobar")))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", -1, "foo"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 6, "foo"))
   }
 
@@ -264,9 +264,9 @@ class StringBuilderTest {
     assertEquals("01null234", resultFor("01234", 2, null))
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", -1, "foo"))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 6, "foo"))
   }
 
@@ -279,13 +279,13 @@ class StringBuilderTest {
     assertEquals("0abcde12", resultFor("012", 1, arr))
     assertEquals("ababcdeef", resultFor("abef", 2, arr))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", -1, arr))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("1234", 6, arr))
 
     if (executingInJVM)
-      expectThrows(classOf[NullPointerException], resultFor("1234", 1, null))
+      assertThrows(classOf[NullPointerException], resultFor("1234", 1, null))
   }
 
   @Test def insertCharSequence(): Unit = {
@@ -296,9 +296,9 @@ class StringBuilderTest {
     assertEquals("01hello234", resultFor("01234", 2, "hello"))
     assertEquals("01foobar234", resultFor("01234", 2, charSequence("foobar")))
 
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", -1, "foo"))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 6, "foo"))
   }
 
@@ -312,19 +312,19 @@ class StringBuilderTest {
     assertEquals("01ello234", resultFor("01234", 2, "hello", 1, 5))
     assertEquals("01ba234", resultFor("01234", 2, charSequence("foobar"), 3, 5))
 
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", -1, charSequence("foobar"), 1, 3))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 6, charSequence("foobar"), 1, 3))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), -1, 3))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), 2, -1))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), 3, 1))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), 7, 8))
-    expectThrows(classOf[IndexOutOfBoundsException],
+    assertThrows(classOf[IndexOutOfBoundsException],
         resultFor("1234", 1, charSequence("foobar"), 2, 8))
   }
 
@@ -341,9 +341,9 @@ class StringBuilderTest {
     assertEquals("a4bcd", initBuilder("abcd").insert(1, 4.toByte).toString)
     assertEquals("a304bcd", initBuilder("abcd").insert(1, 304.toShort).toString)
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         initBuilder("abcd").insert(5, 56))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         initBuilder("abcd").insert(-1, 56))
   }
 
@@ -423,7 +423,7 @@ class StringBuilderTest {
   @Test def setLength(): Unit = {
     val b = initBuilder("foobar")
 
-    expectThrows(classOf[StringIndexOutOfBoundsException], b.setLength(-3))
+    assertThrows(classOf[StringIndexOutOfBoundsException], b.setLength(-3))
 
     b.setLength(3)
     assertEquals("foo", b.toString)
@@ -440,9 +440,9 @@ class StringBuilderTest {
     assertEquals('\udc02', resultFor("ab\ud801\udc02cd", 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[IndexOutOfBoundsException], resultFor("hello", -1))
-      expectThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 5))
-      expectThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 6))
+      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", -1))
+      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 5))
+      assertThrows(classOf[IndexOutOfBoundsException], resultFor("hello", 6))
     }
   }
 
@@ -461,9 +461,9 @@ class StringBuilderTest {
     assertEquals(0xd834, resultFor("abc\ud834", 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           resultFor("abc\ud834\udf06def", -1))
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           resultFor("abc\ud834\udf06def", 15))
     }
   }
@@ -482,9 +482,9 @@ class StringBuilderTest {
     assertEquals(0xdf06, resultFor("\udf06abc", 1))
 
     if (executingInJVM) {
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           resultFor("abc\ud834\udf06def", 0))
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           resultFor("abc\ud834\udf06def", 15))
     }
   }
@@ -507,9 +507,9 @@ class StringBuilderTest {
     assertEquals(0, sb.codePointCount(sb.length - 1, sb.length - 1))
     assertEquals(0, sb.codePointCount(sb.length, sb.length))
 
-    expectThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(6, 2))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(10, 30))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(6, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.codePointCount(10, 30))
   }
 
   @Test def offsetByCodePoints(): Unit = {
@@ -529,9 +529,9 @@ class StringBuilderTest {
     assertEquals(sb.length - 1, sb.offsetByCodePoints(sb.length - 1, 0))
     assertEquals(sb.length, sb.offsetByCodePoints(sb.length, 0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
   }
 
   @Test def offsetByCodePointsBackwards(): Unit = {
@@ -551,9 +551,9 @@ class StringBuilderTest {
     assertEquals(sb.length - 1, sb.offsetByCodePoints(sb.length - 1, -0))
     assertEquals(sb.length, sb.offsetByCodePoints(sb.length, -0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
-    expectThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(6, 18))
+    assertThrows(classOf[IndexOutOfBoundsException], sb.offsetByCodePoints(30, 2))
   }
 
   @Test def getChars(): Unit = {
@@ -572,9 +572,9 @@ class StringBuilderTest {
     assertEquals("foxbar", resultFor("foobar", 2, 'x'))
     assertEquals("foobah", resultFor("foobar", 5, 'h'))
 
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("foobar", -1, 'h'))
-    expectThrows(classOf[StringIndexOutOfBoundsException],
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         resultFor("foobar", 6,  'h'))
   }
 
@@ -586,9 +586,9 @@ class StringBuilderTest {
     assertEquals("", resultFor("hello", 5))
 
     if (executingInJVM) {
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", -1))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 8))
     }
   }
@@ -606,13 +606,13 @@ class StringBuilderTest {
     assertEquals("hel", resultFor("hello", 0, 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", -1, 3))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 8, 8))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 3, 2))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 3, 8))
     }
   }
@@ -626,13 +626,13 @@ class StringBuilderTest {
     assertEquals("hel", resultFor("hello", 0, 3))
 
     if (executingInJVM) {
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", -1, 3))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 8, 8))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 3, 2))
-      expectThrows(classOf[StringIndexOutOfBoundsException],
+      assertThrows(classOf[StringIndexOutOfBoundsException],
           resultFor("hello", 3, 8))
     }
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringBuilderTest.scala
@@ -17,7 +17,7 @@ import java.lang.StringBuilder
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 import WrappedStringCharSequence.charSequence

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -17,7 +17,7 @@ import java.nio.charset.Charset
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class StringTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -167,9 +167,9 @@ class StringTest {
     assertEquals(0xD834, "abc\uD834".codePointAt(3))
 
     if (executingInJVM) {
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           "abc\ud834\udf06def".codePointAt(-1))
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           "abc\ud834\udf06def".codePointAt(15))
     }
   }
@@ -185,9 +185,9 @@ class StringTest {
     assertEquals(0xdf06, "\udf06abc".codePointBefore(1))
 
     if (executingInJVM) {
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           "abc\ud834\udf06def".codePointBefore(0))
-      expectThrows(classOf[IndexOutOfBoundsException],
+      assertThrows(classOf[IndexOutOfBoundsException],
           "abc\ud834\udf06def".codePointBefore(15))
     }
   }
@@ -208,9 +208,9 @@ class StringTest {
     assertEquals(0, s.codePointCount(s.length - 1, s.length - 1))
     assertEquals(0, s.codePointCount(s.length, s.length))
 
-    expectThrows(classOf[IndexOutOfBoundsException], s.codePointCount(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], s.codePointCount(6, 2))
-    expectThrows(classOf[IndexOutOfBoundsException], s.codePointCount(10, 30))
+    assertThrows(classOf[IndexOutOfBoundsException], s.codePointCount(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], s.codePointCount(6, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], s.codePointCount(10, 30))
   }
 
   @Test def offsetByCodePoints(): Unit = {
@@ -229,9 +229,9 @@ class StringTest {
     assertEquals(s.length - 1, s.offsetByCodePoints(s.length - 1, 0))
     assertEquals(s.length, s.offsetByCodePoints(s.length, 0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(6, 18))
-    expectThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(6, 18))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(30, 2))
   }
 
   @Test def offsetByCodePointsBackwards(): Unit = {
@@ -250,9 +250,9 @@ class StringTest {
     assertEquals(s.length - 1, s.offsetByCodePoints(s.length - 1, -0))
     assertEquals(s.length, s.offsetByCodePoints(s.length, -0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(-3, 4))
-    expectThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(6, 18))
-    expectThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(-3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(6, 18))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(30, 2))
   }
 
   @Test def subSequence(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemPropertiesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemPropertiesTest.scala
@@ -16,7 +16,6 @@ import org.junit.{After, Test}
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
 import org.scalajs.testsuite.utils.Platform._
 
 class SystemPropertiesTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -188,7 +188,7 @@ class SystemTest {
   @Test def getenvReturnsUnmodifiableMap(): Unit = {
     assertTrue(System.getenv().isInstanceOf[java.util.Map[String, String]])
 
-    expectThrows(classOf[Exception], System.getenv.put("", ""))
+    assertThrows(classOf[Exception], System.getenv.put("", ""))
   }
 
   @Test def getenvLinksAndDoesNotThrow(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -16,7 +16,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class SystemTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -522,7 +522,7 @@ class  BigDecimalArithmeticTest {
     val aScale = 15
     val aNumber = new BigDecimal(new BigInteger(a), aScale)
     val bNumber = BigDecimal.valueOf(0L)
-    expectThrows(classOf[ArithmeticException], aNumber.divide(bNumber))
+    assertThrows(classOf[ArithmeticException], aNumber.divide(bNumber))
   }
 
   @Test def testDivideExceptionInvalidRM(): Unit = {
@@ -532,7 +532,7 @@ class  BigDecimalArithmeticTest {
     val bScale = 10
     val aNumber = new BigDecimal(new BigInteger(a), aScale)
     val bNumber = new BigDecimal(new BigInteger(b), bScale)
-    expectThrows(classOf[IllegalArgumentException], aNumber.divide(bNumber, 100))
+    assertThrows(classOf[IllegalArgumentException], aNumber.divide(bNumber, 100))
   }
 
   @Test def testDivideExceptionRM(): Unit = {
@@ -542,7 +542,7 @@ class  BigDecimalArithmeticTest {
     val bScale = 10
     val aNumber = new BigDecimal(new BigInteger(a), aScale)
     val bNumber = new BigDecimal(new BigInteger(b), bScale)
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         aNumber.divide(bNumber, BigDecimal.ROUND_UNNECESSARY))
   }
 
@@ -591,7 +591,7 @@ class  BigDecimalArithmeticTest {
   @Test def testDivideLargeScale(): Unit = {
     val arg1 = new BigDecimal("320.0E+2147483647")
     val arg2 = new BigDecimal("6E-2147483647")
-    expectThrows(classOf[ArithmeticException],
+    assertThrows(classOf[ArithmeticException],
         arg1.divide(arg2, Int.MaxValue, RoundingMode.CEILING))
   }
 
@@ -1005,9 +1005,9 @@ class  BigDecimalArithmeticTest {
     assertTrue(BigDecimal.ZERO == quotient)
     quotient = BigDecimal.ZERO.negate().divide(BigDecimal.ONE)
     assertTrue(BigDecimal.ZERO == quotient)
-    expectThrows(classOf[ArithmeticException], BigDecimal.ZERO.divide(BigDecimal.ZERO))
-    expectThrows(classOf[ArithmeticException], BigDecimal.ONE.divide(BigDecimal.ZERO))
-    expectThrows(classOf[ArithmeticException], BigDecimal.ONE.divideToIntegralValue(BigDecimal.ZERO))
+    assertThrows(classOf[ArithmeticException], BigDecimal.ZERO.divide(BigDecimal.ZERO))
+    assertThrows(classOf[ArithmeticException], BigDecimal.ONE.divide(BigDecimal.ZERO))
+    assertThrows(classOf[ArithmeticException], BigDecimal.ONE.divideToIntegralValue(BigDecimal.ZERO))
   }
 
   @Test def testDivideToIntegralValueOnFloatingPoints_Issue1979(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalArithmeticTest.scala
@@ -24,7 +24,7 @@ import java.math._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class  BigDecimalArithmeticTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
@@ -36,7 +36,7 @@ class BigDecimalConstructorsTest {
     val aNumber = new BigDecimal(bA)
     assertTrue(aNumber.unscaledValue() == bA)
     assertEquals(0, aNumber.scale())
-    expectThrows(classOf[NullPointerException], new BigDecimal(null.asInstanceOf[BigInteger]))
+    assertThrows(classOf[NullPointerException], new BigDecimal(null.asInstanceOf[BigInteger]))
   }
 
   @Test def testConstrBigIntegerMathContext(): Unit = {
@@ -82,7 +82,7 @@ class BigDecimalConstructorsTest {
     val resScale = 427
     assertEquals(result.toString, res)
     assertEquals(result.scale(), resScale)
-    expectThrows(classOf[NumberFormatException], new BigDecimal(Array[Char]()))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(Array[Char]()))
   }
 
   @Test def testConstrCharIntInt(): Unit = {
@@ -94,7 +94,7 @@ class BigDecimalConstructorsTest {
     val resScale = 46
     assertEquals(result.toString, res)
     assertEquals(result.scale(), resScale)
-    expectThrows(classOf[NumberFormatException], new BigDecimal(Array[Char](), 0, 0))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(Array[Char](), 0, 0))
   }
 
   @Test def testConstrCharIntIntMathContext(): Unit = {
@@ -109,7 +109,7 @@ class BigDecimalConstructorsTest {
     val resScale = 43
     assertEquals(result.toString, res)
     assertEquals(result.scale(), resScale)
-    expectThrows(classOf[NumberFormatException],
+    assertThrows(classOf[NumberFormatException],
         new BigDecimal(Array(), 0, 0, MathContext.DECIMAL32))
   }
 
@@ -120,7 +120,7 @@ class BigDecimalConstructorsTest {
     val precision = 4
     val rm = RoundingMode.CEILING
     val mc = new MathContext(precision, rm)
-    expectThrows(classOf[NumberFormatException], new BigDecimal(value, offset, len, mc))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(value, offset, len, mc))
   }
 
   @Test def testConstrCharIntIntMathContextException2(): Unit = {
@@ -130,7 +130,7 @@ class BigDecimalConstructorsTest {
     val precision = 4
     val rm = RoundingMode.CEILING
     val mc = new MathContext(precision, rm)
-    expectThrows(classOf[NumberFormatException], new BigDecimal(value, offset, len, mc))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(value, offset, len, mc))
   }
 
   @Test def testConstrCharMathContext(): Unit = {
@@ -143,7 +143,7 @@ class BigDecimalConstructorsTest {
     val resScale = 43
     assertEquals(result.toString, res)
     assertEquals(result.scale(), resScale)
-    expectThrows(classOf[NumberFormatException], new BigDecimal(Array[Char](), MathContext.DECIMAL32))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(Array[Char](), MathContext.DECIMAL32))
   }
 
   @Test def testConstrDouble(): Unit = {
@@ -183,10 +183,10 @@ class BigDecimalConstructorsTest {
     val result = new BigDecimal(a, mc)
     val expected = new BigDecimal("732546982374982e21")
     assertTrue(result.minus(expected) < 1e21)
-    expectThrows(classOf[NumberFormatException], new BigDecimal(Double.NaN))
-    expectThrows(classOf[NumberFormatException],
+    assertThrows(classOf[NumberFormatException], new BigDecimal(Double.NaN))
+    assertThrows(classOf[NumberFormatException],
         new BigDecimal(Double.PositiveInfinity))
-    expectThrows(classOf[NumberFormatException],
+    assertThrows(classOf[NumberFormatException],
         new BigDecimal(Double.NegativeInfinity))
   }
 
@@ -199,17 +199,17 @@ class BigDecimalConstructorsTest {
 
   @Test def testConstrDoubleNaN(): Unit = {
     val a: Double = Double.NaN
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrDoubleNegInfinity(): Unit = {
     val a: Double = Double.NegativeInfinity
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrDoublePosInfinity(): Unit = {
     val a: Double = Double.PositiveInfinity
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrInt(): Unit = {
@@ -256,27 +256,27 @@ class BigDecimalConstructorsTest {
 
   @Test def testConstrStringException(): Unit = {
     val a = "-238768.787678287a+10"
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrStringExceptionEmptyExponent1(): Unit = {
     val a = "-238768.787678287e"
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrStringExceptionEmptyExponent2(): Unit = {
     val a = "-238768.787678287e-"
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrStringExceptionExponentGreaterIntegerMax(): Unit = {
     val a = "-238768.787678287e214748364767876"
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrStringExceptionExponentLessIntegerMin(): Unit = {
     val a = "-238768.787678287e-214748364767876"
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrStringExponentIntegerMax(): Unit = {
@@ -290,17 +290,17 @@ class BigDecimalConstructorsTest {
 
   @Test def testConstrStringExponentIntegerMin(): Unit = {
     val a = ".238768e-2147483648"
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrStringMultipleSignsStartWithPlus(): Unit = {
     val a = "+-3"
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrStringMultipleSignsStartWithMinus(): Unit = {
     val a = "-+3"
-    expectThrows(classOf[NumberFormatException], new BigDecimal(a))
+    assertThrows(classOf[NumberFormatException], new BigDecimal(a))
   }
 
   @Test def testConstrStringMathContext(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConstructorsTest.scala
@@ -24,7 +24,7 @@ import java.math._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class BigDecimalConstructorsTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
@@ -24,7 +24,7 @@ import java.math._
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class BigDecimalConvertTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
@@ -32,7 +32,7 @@ class BigDecimalConvertTest {
     assertEquals(1.toByte, BigDecimal.ONE.byteValue())
     assertEquals(BigDecimal.valueOf(255).byteValue(), -1.toByte)
     assertEquals(BigDecimal.ONE.byteValueExact(), 1.toByte)
-    expectThrows(classOf[ArithmeticException], BigDecimal.valueOf(255).byteValueExact())
+    assertThrows(classOf[ArithmeticException], BigDecimal.valueOf(255).byteValueExact())
   }
 
   @Test def testDoubleValueNeg(): Unit = {
@@ -96,7 +96,7 @@ class BigDecimalConvertTest {
     val aNumber = new BigDecimal(a)
     val result = 218520473
     assertEquals(aNumber.intValue(), result)
-    expectThrows(classOf[ArithmeticException], aNumber.intValueExact())
+    assertThrows(classOf[ArithmeticException], aNumber.intValueExact())
   }
 
   @Test def testIntValuePos(): Unit = {
@@ -104,7 +104,7 @@ class BigDecimalConvertTest {
     val aNumber = new BigDecimal(a)
     val result = -218520473
     assertEquals(aNumber.intValue(), result)
-    expectThrows(classOf[ArithmeticException], aNumber.intValueExact())
+    assertThrows(classOf[ArithmeticException], aNumber.intValueExact())
   }
 
   @Test def testLongValueNeg(): Unit = {
@@ -112,7 +112,7 @@ class BigDecimalConvertTest {
     val aNumber = new BigDecimal(a)
     val result = -1246043477766677607L
     assertTrue(aNumber.longValue() == result)
-    expectThrows(classOf[ArithmeticException], aNumber.longValueExact())
+    assertThrows(classOf[ArithmeticException], aNumber.longValueExact())
   }
 
   @Test def testLongValuePos(): Unit = {
@@ -120,7 +120,7 @@ class BigDecimalConvertTest {
     val aNumber = new BigDecimal(a)
     val result = 1246043477766677607L
     assertTrue(aNumber.longValue() == result)
-    expectThrows(classOf[ArithmeticException], aNumber.longValueExact())
+    assertThrows(classOf[ArithmeticException], aNumber.longValueExact())
   }
 
   @Test def testLongValueMinMaxValues(): Unit = {
@@ -201,7 +201,7 @@ class BigDecimalConvertTest {
   @Test def testShortValue(): Unit = {
     val value = BigDecimal.valueOf(0x13fff)
     assertEquals(value.shortValue(), 0x3fff)
-    expectThrows(classOf[ArithmeticException], value.shortValueExact())
+    assertThrows(classOf[ArithmeticException], value.shortValueExact())
   }
 
   @Test def testToBigIntegerExact1(): Unit = {
@@ -215,7 +215,7 @@ class BigDecimalConvertTest {
   @Test def testToBigIntegerExactException(): Unit = {
     val a = "-123809648392384754573567356745735.63567890295784902768787678287E-10"
     val aNumber = new BigDecimal(a)
-    expectThrows(classOf[ArithmeticException],  aNumber.toBigIntegerExact())
+    assertThrows(classOf[ArithmeticException],  aNumber.toBigIntegerExact())
   }
 
   @Test def testToBigIntegerNeg1(): Unit = {
@@ -361,7 +361,7 @@ class BigDecimalConvertTest {
 
   @Test def testValueOfDoubleNaN(): Unit = {
     val a = Double.NaN
-    expectThrows(classOf[NumberFormatException],  BigDecimal.valueOf(a))
+    assertThrows(classOf[NumberFormatException],  BigDecimal.valueOf(a))
   }
 
   @Test def testValueOfDoubleNeg(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
@@ -27,7 +27,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.Platform
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class BigIntegerConstructorsTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConstructorsTest.scala
@@ -33,7 +33,7 @@ class BigIntegerConstructorsTest {
 
   @Test def testConstructorBytesException(): Unit = {
     val aBytes = Array[Byte]()
-    expectThrows(classOf[NumberFormatException], new BigInteger(aBytes))
+    assertThrows(classOf[NumberFormatException], new BigInteger(aBytes))
   }
 
   @Test def testConstructorBytesNegative1(): Unit = {
@@ -170,13 +170,13 @@ class BigIntegerConstructorsTest {
   @Test def testConstructorSignBytesException1(): Unit = {
     val aBytes = Array[Byte](123, 45, -3, -76)
     val aSign = 3
-    expectThrows(classOf[NumberFormatException], new BigInteger(aSign, aBytes))
+    assertThrows(classOf[NumberFormatException], new BigInteger(aSign, aBytes))
   }
 
   @Test def testConstructorSignBytesException2(): Unit = {
     val aBytes = Array[Byte](123, 45, -3, -76)
     val aSign = 0
-    expectThrows(classOf[NumberFormatException], new BigInteger(aSign, aBytes))
+    assertThrows(classOf[NumberFormatException], new BigInteger(aSign, aBytes))
   }
 
   @Test def testConstructorSignBytesNegative1(): Unit = {
@@ -441,7 +441,7 @@ class BigIntegerConstructorsTest {
 
   @Test def testConstructorStringException(): Unit = {
     def test(s: String, radix: Int): Unit =
-      expectThrows(classOf[NumberFormatException], new BigInteger(s, radix))
+      assertThrows(classOf[NumberFormatException], new BigInteger(s, radix))
 
     test("9234853876401", 45)
     test("   9234853876401", 10)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
@@ -25,7 +25,7 @@ import java.util.Arrays
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class BigIntegerModPowTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
@@ -149,7 +149,7 @@ class BigIntegerModPowTest {
     val mSign = -1
     val aNumber = new BigInteger(aSign, aBytes)
     val modulus = new BigInteger(mSign, mBytes)
-    expectThrows(classOf[ArithmeticException], aNumber.modInverse(modulus))
+    assertThrows(classOf[ArithmeticException], aNumber.modInverse(modulus))
   }
 
   @Test def testmodInverseNeg1(): Unit = {
@@ -191,7 +191,7 @@ class BigIntegerModPowTest {
     val mSign = 1
     val aNumber = new BigInteger(aSign, aBytes)
     val modulus = new BigInteger(mSign, mBytes)
-    expectThrows(classOf[ArithmeticException], aNumber.modInverse(modulus))
+    assertThrows(classOf[ArithmeticException], aNumber.modInverse(modulus))
   }
 
   @Test def testmodInversePos1(): Unit = {
@@ -249,7 +249,7 @@ class BigIntegerModPowTest {
     assertTrue(Arrays.equals(aBytes, aNumber.toByteArray))
     val exp = new BigInteger(eSign, eBytes)
     val modulus = new BigInteger(mSign, mBytes)
-    expectThrows(classOf[ArithmeticException], aNumber.modPow(exp, modulus))
+    assertThrows(classOf[ArithmeticException], aNumber.modPow(exp, modulus))
   }
 
   @Test def testModPowNegExp(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
@@ -236,7 +236,7 @@ class BigIntegerMultiplyTest {
     val aSign = 1
     val exp = -5
     val aNumber = new BigInteger(aSign, aBytes)
-    expectThrows(classOf[ArithmeticException], aNumber.pow(exp))
+    assertThrows(classOf[ArithmeticException], aNumber.pow(exp))
   }
 
   @Test def testPowNegativeNumToEvenExp(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerMultiplyTest.scala
@@ -24,7 +24,7 @@ import java.math.BigInteger
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class BigIntegerMultiplyTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
@@ -24,7 +24,7 @@ import java.math.BigInteger
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class BigIntegerOperateBitsTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerOperateBitsTest.scala
@@ -95,7 +95,7 @@ class BigIntegerOperateBitsTest {
     val aSign = 1
     val number = -7
     val aNumber = new BigInteger(aSign, aBytes)
-    expectThrows(classOf[ArithmeticException], aNumber.clearBit(number))
+    assertThrows(classOf[ArithmeticException], aNumber.clearBit(number))
   }
 
   @Test def testClearBitNegativeInside1(): Unit = {
@@ -340,7 +340,7 @@ class BigIntegerOperateBitsTest {
     val aSign = 1
     val number = -7
     val aNumber = new BigInteger(aSign, aBytes)
-    expectThrows(classOf[ArithmeticException], aNumber.flipBit(number))
+    assertThrows(classOf[ArithmeticException], aNumber.flipBit(number))
   }
 
   @Test def testFlipBitLeftmostNegative(): Unit = {
@@ -579,7 +579,7 @@ class BigIntegerOperateBitsTest {
     val aSign = 1
     val number = -7
     var aNumber = new BigInteger(aSign, aBytes)
-    expectThrows(classOf[ArithmeticException], aNumber.setBit(number))
+    assertThrows(classOf[ArithmeticException], aNumber.setBit(number))
   }
 
   @Test def testSetBitLeftmostNegative(): Unit = {
@@ -1034,7 +1034,7 @@ class BigIntegerOperateBitsTest {
     val aSign = 1
     val number = -7
     val aNumber = new BigInteger(aSign, aBytes)
-    expectThrows(classOf[ArithmeticException],  aNumber.testBit(number))
+    assertThrows(classOf[ArithmeticException],  aNumber.testBit(number))
   }
 
   @Test def testTestBitNegative1(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
@@ -24,7 +24,7 @@ import java.math.{MathContext, RoundingMode}
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class MathContextTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/MathContextTest.scala
@@ -54,20 +54,20 @@ class MathContextTest {
     assertTrue(mc8.getPrecision == 23)
     assertTrue(mc8.getRoundingMode == RoundingMode.UP)
 
-    expectThrows(classOf[IllegalArgumentException],
+    assertThrows(classOf[IllegalArgumentException],
         new MathContext("prcision=27 roundingMode=CEILING"))
-    expectThrows(classOf[IllegalArgumentException],
+    assertThrows(classOf[IllegalArgumentException],
         new MathContext("precision=26 roundingMoe=CEILING"))
-    expectThrows(classOf[IllegalArgumentException],
+    assertThrows(classOf[IllegalArgumentException],
         new MathContext("precision=25 roundingMode=CEILINGFAN"))
-    expectThrows(classOf[IllegalArgumentException],
+    assertThrows(classOf[IllegalArgumentException],
         new MathContext("precision=24 roundingMode=HALF"))
-    expectThrows(classOf[IllegalArgumentException],
+    assertThrows(classOf[IllegalArgumentException],
         new MathContext("precision=23 roundingMode=UPSIDEDOWN"))
-    expectThrows(classOf[IllegalArgumentException],
+    assertThrows(classOf[IllegalArgumentException],
         new MathContext("precision=22roundingMode=UP"))
-    expectThrows(classOf[IllegalArgumentException], new MathContext(""))
-    expectThrows(classOf[NullPointerException], new MathContext(null))
+    assertThrows(classOf[IllegalArgumentException], new MathContext(""))
+    assertThrows(classOf[NullPointerException], new MathContext(null))
   }
 
   @Test def testMathContextConstructorEquality(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
@@ -17,7 +17,7 @@ import java.net.{URI, URISyntaxException}
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class URITest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
@@ -453,8 +453,8 @@ class URITest {
   }
 
   @Test def badEscapeSequenceThrows(): Unit = {
-    expectThrows(classOf[URISyntaxException], new URI("http://booh/%E"))
-    expectThrows(classOf[URISyntaxException], new URI("http://booh/%Ep"))
+    assertThrows(classOf[URISyntaxException], new URI("http://booh/%E"))
+    assertThrows(classOf[URISyntaxException], new URI("http://booh/%Ep"))
   }
 
   @Test def validIPv4(): Unit = {
@@ -462,8 +462,8 @@ class URITest {
   }
 
   @Test def invalidIPv4Throws(): Unit = {
-    expectThrows(classOf[URISyntaxException], new URI("http","256.1.1.1", "", ""))
-    expectThrows(classOf[URISyntaxException], new URI("http","123.45.67.890", "", ""))
+    assertThrows(classOf[URISyntaxException], new URI("http","256.1.1.1", "", ""))
+    assertThrows(classOf[URISyntaxException], new URI("http","123.45.67.890", "", ""))
   }
 
   @Test def opaqueUrlEqualityHandlesCase(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URLDecoderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URLDecoderTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.net
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 import java.net.URLDecoder

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
@@ -16,7 +16,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import java.util.{ Arrays, Comparator }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
@@ -145,12 +145,12 @@ class ArraysTest {
   @Test def sortIllegalArgumentException(): Unit = {
     val array = Array(0, 1, 3, 4)
 
-    val e1 = expectThrows(classOf[IllegalArgumentException],
+    val e1 = assertThrows(classOf[IllegalArgumentException],
         Arrays.sort(array, 3, 2))
     assertEquals("fromIndex(3) > toIndex(2)", e1.getMessage)
 
     // start/end comparison is made before index ranges checks
-    val e2 = expectThrows(classOf[IllegalArgumentException],
+    val e2 = assertThrows(classOf[IllegalArgumentException],
         Arrays.sort(array, 7, 5))
     assertEquals("fromIndex(7) > toIndex(5)", e2.getMessage)
   }
@@ -522,12 +522,12 @@ class ArraysTest {
   @Test def binarySearchIllegalArgumentException(): Unit = {
     val array = Array(0, 1, 3, 4)
 
-    val e1 = expectThrows(classOf[IllegalArgumentException],
+    val e1 = assertThrows(classOf[IllegalArgumentException],
         Arrays.binarySearch(array, 3, 2, 2))
     assertEquals("fromIndex(3) > toIndex(2)", e1.getMessage)
 
     // start/end comparison is made before index ranges checks
-    val e2 = expectThrows(classOf[IllegalArgumentException],
+    val e2 = assertThrows(classOf[IllegalArgumentException],
         Arrays.binarySearch(array, 7, 5, 2))
     assertEquals("fromIndex(7) > toIndex(5)", e2.getMessage)
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/Base64Test.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/Base64Test.scala
@@ -22,7 +22,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform
 
 class Base64Test {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -19,8 +19,7 @@ import org.junit.Assert._
 
 import org.scalajs.testsuite.javalib.lang.IterableFactory
 import org.scalajs.testsuite.javalib.lang.IterableTest
-import org.scalajs.testsuite.utils.AssertThrows._
-
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import scala.reflect.ClassTag
 
 import Utils._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -182,7 +182,7 @@ trait CollectionTest extends IterableTest {
     if (factory.allowsNullElementQuery) {
       assertFalse(coll.contains(null))
     } else {
-      expectThrows(classOf[Exception], coll.contains(null))
+      assertThrows(classOf[Exception], coll.contains(null))
     }
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedCollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedCollectionTest.scala
@@ -50,8 +50,8 @@ trait CollectionsCheckedCollectionTest
   @Test def testCheckedCollectionBadInputs(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
-    expectThrows(classOf[ClassCastException], superColl().add(new A))
-    expectThrows(classOf[ClassCastException],
+    assertThrows(classOf[ClassCastException], superColl().add(new A))
+    assertThrows(classOf[ClassCastException],
         superColl().addAll(TrivialImmutableCollection(new A)))
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedCollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedCollectionTest.scala
@@ -20,7 +20,7 @@ import org.junit.Test
 
 import org.scalajs.testsuite.javalib.util.concurrent.CopyOnWriteArrayListFactory
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import scala.reflect.ClassTag

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
@@ -56,8 +56,8 @@ trait CollectionsCheckedListTest
   @Test def testCheckedListBadInputs(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
-    expectThrows(classOf[ClassCastException], superList().add(0, new A))
-    expectThrows(classOf[ClassCastException],
+    assertThrows(classOf[ClassCastException], superList().add(0, new A))
+    assertThrows(classOf[ClassCastException],
         superList().addAll(0, TrivialImmutableCollection(new A)))
     testOnFirstPositionOfIterator[ju.ListIterator[A]](
         superList().listIterator _,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedListTest.scala
@@ -19,7 +19,7 @@ import org.junit.Assume._
 import org.junit.Test
 
 import org.scalajs.testsuite.javalib.util.concurrent.CopyOnWriteArrayListFactory
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import scala.reflect.ClassTag

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedMapTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import scala.reflect.ClassTag

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnCheckedMapTest.scala
@@ -53,9 +53,9 @@ trait CollectionsOnCheckedMapTest extends CollectionsOnMapsTest {
   @Test def testCheckedMapBadInputs(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
-    expectThrows(classOf[ClassCastException], superMap().put(new A, new C))
-    expectThrows(classOf[ClassCastException], superMap().put(new C, new A))
-    expectThrows(classOf[ClassCastException], superMap().put(new A, new A))
+    assertThrows(classOf[ClassCastException], superMap().put(new A, new C))
+    assertThrows(classOf[ClassCastException], superMap().put(new C, new A))
+    assertThrows(classOf[ClassCastException], superMap().put(new A, new A))
 
     def singletonMap(): ju.Map[A, A] = {
       val m = factory.empty[B, B]
@@ -63,7 +63,7 @@ trait CollectionsOnCheckedMapTest extends CollectionsOnMapsTest {
       m.asInstanceOf[ju.Map[A, A]]
     }
     val firstEntry = singletonMap().entrySet().iterator().next()
-    expectThrows(classOf[ClassCastException], firstEntry.setValue(new A))
+    assertThrows(classOf[ClassCastException], firstEntry.setValue(new A))
   }
 
   private def superMap(): ju.Map[A, A] =
@@ -100,9 +100,9 @@ trait CollectionsOnCheckedSortedMapTest extends CollectionsOnSortedMapsTest {
   @Test def testCheckedMapBadInputs(): Unit = {
     assumeTrue("Assumed compliant asInstanceOf", hasCompliantAsInstanceOfs)
 
-    expectThrows(classOf[ClassCastException], superMap().put(new A, new C))
-    expectThrows(classOf[ClassCastException], superMap().put(new C, new A))
-    expectThrows(classOf[ClassCastException], superMap().put(new A, new A))
+    assertThrows(classOf[ClassCastException], superMap().put(new A, new C))
+    assertThrows(classOf[ClassCastException], superMap().put(new C, new A))
+    assertThrows(classOf[ClassCastException], superMap().put(new A, new A))
 
     def singletonMap(): ju.Map[A, A] = {
       val m = factory.empty[B, B]
@@ -110,7 +110,7 @@ trait CollectionsOnCheckedSortedMapTest extends CollectionsOnSortedMapsTest {
       m.asInstanceOf[ju.Map[A, A]]
     }
     val firstEntry = singletonMap().entrySet().iterator().next()
-    expectThrows(classOf[ClassCastException], firstEntry.setValue(new A))
+    assertThrows(classOf[ClassCastException], firstEntry.setValue(new A))
   }
 
   private def superMap(): ju.Map[A, A] =

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import org.junit.Test
 
 import org.scalajs.testsuite.javalib.util.concurrent.CopyOnWriteArrayListFactory
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.CollectionsTestBase
 
 import scala.reflect.ClassTag

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsOnListsTest.scala
@@ -321,7 +321,7 @@ trait CollectionsOnListTest extends CollectionsOnCollectionsTest {
       dest.clear()
       range.foreach(i => source.add(toElem(i)))
       range.take(range.size / 2).foreach(i => dest.add(toElem(-i)))
-      expectThrows(classOf[IndexOutOfBoundsException], ju.Collections.copy(dest, source))
+      assertThrows(classOf[IndexOutOfBoundsException], ju.Collections.copy(dest, source))
     }
 
     test[jl.Integer](_.toInt)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
@@ -17,7 +17,7 @@ import java.{util => ju}
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.CollectionsTestBase
 
 import scala.reflect.ClassTag

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionsTest.scala
@@ -28,19 +28,19 @@ class CollectionsTest extends CollectionsTestBase {
 
   private def checkImmutablilityOfCollectionApi[E](coll: ju.Collection[E],
       elem: E): Unit = {
-    expectThrows(classOf[UnsupportedOperationException], coll.add(elem))
-    expectThrows(classOf[UnsupportedOperationException],
+    assertThrows(classOf[UnsupportedOperationException], coll.add(elem))
+    assertThrows(classOf[UnsupportedOperationException],
         coll.addAll(TrivialImmutableCollection(elem)))
     assertFalse(coll.addAll(TrivialImmutableCollection[E]()))
 
     if (ju.Collections.frequency(coll, elem) != coll.size)
-      expectThrows(classOf[Exception], coll.retainAll(TrivialImmutableCollection(elem)))
+      assertThrows(classOf[Exception], coll.retainAll(TrivialImmutableCollection(elem)))
     else
       assertFalse(coll.retainAll(TrivialImmutableCollection(elem)))
 
     if (coll.contains(elem)) {
-      expectThrows(classOf[Exception], coll.remove(elem))
-      expectThrows(classOf[Exception], coll.removeAll(TrivialImmutableCollection(elem)))
+      assertThrows(classOf[Exception], coll.remove(elem))
+      assertThrows(classOf[Exception], coll.removeAll(TrivialImmutableCollection(elem)))
     } else {
       assertFalse(coll.remove(elem))
       assertFalse(coll.removeAll(TrivialImmutableCollection(elem)))
@@ -48,7 +48,7 @@ class CollectionsTest extends CollectionsTestBase {
     assertFalse(coll.removeAll(TrivialImmutableCollection[E]()))
 
     if (!coll.isEmpty()) {
-      expectThrows(classOf[Throwable], coll.clear())
+      assertThrows(classOf[Throwable], coll.clear())
     } else {
       coll.clear() // Should not throw
     }
@@ -59,27 +59,27 @@ class CollectionsTest extends CollectionsTestBase {
 
   private def checkImmutablilityOfListApi[E](list: ju.List[E], elem: E): Unit = {
     checkImmutablilityOfCollectionApi(list, elem)
-    expectThrows(classOf[UnsupportedOperationException], list.add(0, elem))
+    assertThrows(classOf[UnsupportedOperationException], list.add(0, elem))
     assertFalse(list.addAll(0, TrivialImmutableCollection[E]()))
-    expectThrows(classOf[UnsupportedOperationException],
+    assertThrows(classOf[UnsupportedOperationException],
         list.addAll(0, TrivialImmutableCollection(elem)))
-    expectThrows(classOf[UnsupportedOperationException], list.remove(0))
+    assertThrows(classOf[UnsupportedOperationException], list.remove(0))
   }
 
   private def checkImmutablilityOfMapApi[K, V](map: ju.Map[K, V], k: K,
       v: V): Unit = {
-    expectThrows(classOf[UnsupportedOperationException], map.put(k, v))
-    expectThrows(classOf[UnsupportedOperationException],
+    assertThrows(classOf[UnsupportedOperationException], map.put(k, v))
+    assertThrows(classOf[UnsupportedOperationException],
         map.putAll(TrivialImmutableMap(k -> v)))
     map.putAll(TrivialImmutableMap[K, V]()) // Should not throw
 
     if (map.containsKey(k))
-      expectThrows(classOf[Throwable], map.remove(k))
+      assertThrows(classOf[Throwable], map.remove(k))
     else
       assertNull(map.remove(k).asInstanceOf[AnyRef])
 
     if (!map.isEmpty())
-      expectThrows(classOf[Throwable], map.clear())
+      assertThrows(classOf[Throwable], map.clear())
     else
       map.clear() // Should not throw
   }
@@ -88,8 +88,8 @@ class CollectionsTest extends CollectionsTestBase {
     def freshIter: ju.Iterator[Int] = ju.Collections.emptyIterator[Int]
 
     assertFalse(freshIter.hasNext)
-    expectThrows(classOf[NoSuchElementException], freshIter.next())
-    expectThrows(classOf[IllegalStateException], freshIter.remove())
+    assertThrows(classOf[NoSuchElementException], freshIter.next())
+    assertThrows(classOf[IllegalStateException], freshIter.remove())
   }
 
   @Test def emptyListIterator(): Unit = {
@@ -98,12 +98,12 @@ class CollectionsTest extends CollectionsTestBase {
 
       assertFalse(freshIter.hasNext)
       assertFalse(freshIter.hasPrevious)
-      expectThrows(classOf[NoSuchElementException], freshIter.next())
-      expectThrows(classOf[NoSuchElementException], freshIter.previous())
-      expectThrows(classOf[IllegalStateException], freshIter.remove())
-      expectThrows(classOf[UnsupportedOperationException],
+      assertThrows(classOf[NoSuchElementException], freshIter.next())
+      assertThrows(classOf[NoSuchElementException], freshIter.previous())
+      assertThrows(classOf[IllegalStateException], freshIter.remove())
+      assertThrows(classOf[UnsupportedOperationException],
           freshIter.add(toElem(0)))
-      expectThrows(classOf[IllegalStateException], freshIter.set(toElem(0)))
+      assertThrows(classOf[IllegalStateException], freshIter.set(toElem(0)))
     }
 
     test[Int](_.toInt)
@@ -115,7 +115,7 @@ class CollectionsTest extends CollectionsTestBase {
     def freshEnum: ju.Enumeration[Int] = ju.Collections.emptyEnumeration[Int]
 
     assertFalse(freshEnum.hasMoreElements)
-    expectThrows(classOf[NoSuchElementException], freshEnum.nextElement())
+    assertThrows(classOf[NoSuchElementException], freshEnum.nextElement())
   }
 
   @Test def emptySet(): Unit = {
@@ -228,7 +228,7 @@ class CollectionsTest extends CollectionsTestBase {
       checkImmutablilityOfListApi(zeroCopies, toElem(0))
 
       for (n <- Seq(-1, -4, -543)) {
-        expectThrows(classOf[IllegalArgumentException],
+        assertThrows(classOf[IllegalArgumentException],
           ju.Collections.nCopies(n, toElem(0)))
       }
     }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/DateTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 /**

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
@@ -17,7 +17,7 @@ import java.math.{BigDecimal, BigInteger}
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import java.util._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
@@ -115,7 +115,7 @@ class FormatterTest {
   def expectFormatterThrows[T <: Throwable](exeption: Class[T], format: String,
       args: Any*): T = {
     val fmt = new Formatter()
-    expectThrows(exeption,
+    assertThrows(exeption,
         fmt.format(format, args.asInstanceOf[Seq[AnyRef]]: _*))
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/IteratorTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/IteratorTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import java.{util => ju}
 import java.util.function.Consumer
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class IteratorTest {
   @Test def testRemove(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.util
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.CollectionsTestBase
 
 import java.{lang => jl}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
@@ -40,8 +40,8 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals("one", lst.get(0))
     assertEquals("two", lst.get(1))
 
-    expectThrows(classOf[IndexOutOfBoundsException], lst.get(-1))
-    expectThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.get(-1))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
   @Test def addIntGetIndex(): Unit = {
@@ -55,8 +55,8 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals(1, lst.get(0))
     assertEquals(2, lst.get(1))
 
-    expectThrows(classOf[IndexOutOfBoundsException], lst.get(-1))
-    expectThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.get(-1))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
   @Test def addDoubleGetIndex(): Unit = {
@@ -79,8 +79,8 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertTrue(lst.get(3).equals(+0.0))
     assertTrue(lst.get(4).equals(-0.0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], lst.get(-1))
-    expectThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.get(-1))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
   @Test def addCustomObjectsGetIndex(): Unit = {
@@ -92,8 +92,8 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals(1, lst.size())
     assertEquals(TestObj(100), lst.get(0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], lst.get(-1))
-    expectThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.get(-1))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
   @Test def removeStringRemoveIndex(): Unit = {
@@ -111,8 +111,8 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals(1, lst.size())
     assertEquals("three", lst.get(0))
 
-    expectThrows(classOf[IndexOutOfBoundsException], lst.remove(-1))
-    expectThrows(classOf[IndexOutOfBoundsException], lst.remove(lst.size))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.remove(-1))
+    assertThrows(classOf[IndexOutOfBoundsException], lst.remove(lst.size))
   }
 
   @Test def removeDoubleOnCornerCases(): Unit = {
@@ -187,8 +187,8 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals("four", al.get(1))
     assertEquals("three", al.get(2))
 
-    expectThrows(classOf[IndexOutOfBoundsException], al.set(-1, ""))
-    expectThrows(classOf[IndexOutOfBoundsException], al.set(al.size, ""))
+    assertThrows(classOf[IndexOutOfBoundsException], al.set(-1, ""))
+    assertThrows(classOf[IndexOutOfBoundsException], al.set(al.size, ""))
   }
 
   @Test def iterator(): Unit = {
@@ -240,8 +240,8 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertEquals("three", al.get(1))
     assertEquals("one", al.get(2))
 
-    expectThrows(classOf[IndexOutOfBoundsException], al.add(-1, ""))
-    expectThrows(classOf[IndexOutOfBoundsException], al.add(al.size + 1, ""))
+    assertThrows(classOf[IndexOutOfBoundsException], al.add(-1, ""))
+    assertThrows(classOf[IndexOutOfBoundsException], al.add(al.size + 1, ""))
   }
 
   @Test def indexOf(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -20,7 +20,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import org.scalajs.testsuite.javalib.util.concurrent.ConcurrentMapFactory
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import scala.reflect.ClassTag

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -291,7 +291,7 @@ trait MapTest {
       assertNull(mp.get(null))
       assertNull(mp.remove(null))
     } else {
-      expectThrows(classOf[NullPointerException], mp.put(null, "one"))
+      assertThrows(classOf[NullPointerException], mp.put(null, "one"))
     }
   }
 
@@ -308,7 +308,7 @@ trait MapTest {
       assertEquals(30, mp.size())
       assertNull(mp.get("one"))
     } else {
-      expectThrows(classOf[NullPointerException], mp.put("one", null))
+      assertThrows(classOf[NullPointerException], mp.put("one", null))
     }
   }
 
@@ -348,7 +348,7 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(mp.containsKey(null))
     else
-      expectThrows(classOf[NullPointerException], mp.containsKey(null))
+      assertThrows(classOf[NullPointerException], mp.containsKey(null))
   }
 
   @Test def testContainsValue(): Unit = {
@@ -360,7 +360,7 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(mp.containsValue(null))
     else
-      expectThrows(classOf[NullPointerException], mp.containsValue(null))
+      assertThrows(classOf[NullPointerException], mp.containsValue(null))
   }
 
   @Test def testPutAll(): Unit = {
@@ -382,7 +382,7 @@ trait MapTest {
       assertEquals("one", mp.get("ONE"))
       assertEquals("b", mp.get("A"))
     } else {
-      expectThrows(classOf[NullPointerException], mp.putAll(nullMap))
+      assertThrows(classOf[NullPointerException], mp.putAll(nullMap))
     }
   }
 
@@ -453,7 +453,7 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(values.contains(null))
     else
-      expectThrows(classOf[NullPointerException], values.contains(null))
+      assertThrows(classOf[NullPointerException], values.contains(null))
 
     mp.put("THREE", "three")
 
@@ -483,7 +483,7 @@ trait MapTest {
     if (factory.allowsNullValuesQueries)
       assertFalse(values.contains(null))
     else
-      expectThrows(classOf[NullPointerException], values.contains(null))
+      assertThrows(classOf[NullPointerException], values.contains(null))
 
     mp.put(testObj(3), testObj(33))
 
@@ -653,7 +653,7 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(keySet.contains(null))
     else
-      expectThrows(classOf[NullPointerException], keySet.contains(null))
+      assertThrows(classOf[NullPointerException], keySet.contains(null))
 
     mp.put("THREE", "three")
 
@@ -683,7 +683,7 @@ trait MapTest {
     if (factory.allowsNullKeysQueries)
       assertFalse(keySet.contains(null))
     else
-      expectThrows(classOf[NullPointerException], keySet.contains(null))
+      assertThrows(classOf[NullPointerException], keySet.contains(null))
 
     mp.put(testObj(3), TestObj(33))
 
@@ -1477,10 +1477,10 @@ trait MapTest {
   @Test def additionToKeySet(): Unit = {
     val set = factory.empty[String, String].keySet()
 
-    expectThrows(classOf[UnsupportedOperationException], set.add("ONE"))
-    expectThrows(classOf[UnsupportedOperationException], set.addAll(ju.Arrays.asList("ONE")))
-    expectThrows(classOf[UnsupportedOperationException], set.addAll(ju.Arrays.asList(null)))
-    expectThrows(classOf[UnsupportedOperationException], set.add(null))
+    assertThrows(classOf[UnsupportedOperationException], set.add("ONE"))
+    assertThrows(classOf[UnsupportedOperationException], set.addAll(ju.Arrays.asList("ONE")))
+    assertThrows(classOf[UnsupportedOperationException], set.addAll(ju.Arrays.asList(null)))
+    assertThrows(classOf[UnsupportedOperationException], set.add(null))
   }
 }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ObjectsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ObjectsTest.scala
@@ -16,7 +16,7 @@ import java.{util => ju}
 
 import org.junit.Test
 import org.junit.Assert._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ObjectsTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ObjectsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ObjectsTest.scala
@@ -108,7 +108,7 @@ class ObjectsTest {
       }
     }
 
-    val e = expectThrows(classOf[NullPointerException],
+    val e = assertThrows(classOf[NullPointerException],
         ju.Objects.requireNonNull(null, successSupplier))
     assertEquals(message, e.getMessage())
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/OptionalTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/OptionalTest.scala
@@ -18,7 +18,7 @@ import org.junit.Test
 import java.util.Optional
 import java.util.function._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class OptionalTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/OptionalTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/OptionalTest.scala
@@ -172,7 +172,7 @@ class OptionalTest {
             throw new AssertionError("Optional.of().orElseThrow() should not call its argument")
         }))
 
-    val ex = expectThrows(classOf[IllegalArgumentException],
+    val ex = assertThrows(classOf[IllegalArgumentException],
         Optional.empty[String]().orElseThrow(new Supplier[IllegalArgumentException] {
           def get(): IllegalArgumentException =
             new IllegalArgumentException("fallback")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PropertiesTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/PropertiesTest.scala
@@ -21,7 +21,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import Utils._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/RandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/RandomTest.scala
@@ -17,7 +17,7 @@ import org.junit.Test
 
 import java.util.Random
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class RandomTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.javalib.util
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import java.{util => ju, lang => jl}
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SetTest.scala
@@ -164,7 +164,7 @@ trait SetTest extends CollectionTest {
       assertTrue(hs.add(null))
       assertTrue(hs.contains(null))
     } else {
-      expectThrows(classOf[Exception], hs.add(null))
+      assertThrows(classOf[Exception], hs.add(null))
     }
   }
 
@@ -180,7 +180,7 @@ trait SetTest extends CollectionTest {
       assertTrue(hs.contains("TWO"))
       assertTrue(hs.contains(null))
     } else {
-      expectThrows(classOf[Exception], hs.addAll(l))
+      assertThrows(classOf[Exception], hs.addAll(l))
     }
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SplittableRandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/SplittableRandomTest.scala
@@ -17,8 +17,6 @@ import org.junit.Test
 
 import java.util.SplittableRandom
 
-import org.scalajs.testsuite.utils.AssertThrows._
-
 class SplittableRandomTest {
 
   @Test def nextLong(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/StringTokenizerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/StringTokenizerTest.scala
@@ -17,7 +17,7 @@ import java.util.StringTokenizer
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class StringTokenizerTest {
   import StringTokenizerTest.assertTokenizerResult

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import java.{util => ju}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
@@ -75,7 +75,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     assertEquals(0, ts.size())
     assertTrue(ts.isEmpty)
     assertFalse(ts.remove(333))
-    expectThrows(classOf[NoSuchElementException], ts.first)
+    assertThrows(classOf[NoSuchElementException], ts.first)
 
     if (factory.allowsNullElement) {
       assertTrue(ts.asInstanceOf[TreeSet[Any]].add(null))
@@ -254,7 +254,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
       assertTrue(hs.add(null))
       assertTrue(hs.contains(null))
     } else {
-      expectThrows(classOf[Exception], hs.add(null))
+      assertThrows(classOf[Exception], hs.add(null))
     }
   }
 
@@ -268,7 +268,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
       assertTrue(ts1.contains("ONE"))
       assertFalse(ts1.contains("THREE"))
     } else {
-      expectThrows(classOf[Exception], ts1.addAll(l))
+      assertThrows(classOf[Exception], ts1.addAll(l))
     }
   }
 
@@ -279,7 +279,7 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
 
     val ts1 = factory.empty[TestObj]
     assertEquals(0, ts1.size())
-    expectThrows(classOf[ClassCastException], ts1.add(new TestObj(111)))
+    assertThrows(classOf[ClassCastException], ts1.add(new TestObj(111)))
   }
 
   @Test def headSetTailSetSubSetThrowsOnAddElementOutOfBounds(): Unit = {
@@ -292,14 +292,14 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     val hs1 = ts.headSet(5, true)
     assertTrue(hs1.add(4))
     assertTrue(hs1.add(5))
-    expectThrows(classOf[IllegalArgumentException], hs1.add(6))
+    assertThrows(classOf[IllegalArgumentException], hs1.add(6))
 
     ts.clear()
     ts.addAll(l)
 
     val hs2 = ts.headSet(5, false)
     assertTrue(hs2.add(4))
-    expectThrows(classOf[IllegalArgumentException], hs2.add(5))
+    assertThrows(classOf[IllegalArgumentException], hs2.add(5))
 
     ts.clear()
     ts.addAll(l)
@@ -307,14 +307,14 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     val ts1 = ts.tailSet(1, true)
     assertTrue(ts1.add(7))
     assertTrue(ts1.add(1))
-    expectThrows(classOf[IllegalArgumentException], ts1.add(0))
+    assertThrows(classOf[IllegalArgumentException], ts1.add(0))
 
     ts.clear()
     ts.addAll(l)
 
     val ts2 = ts.tailSet(1, false)
     assertTrue(ts2.add(7))
-    expectThrows(classOf[IllegalArgumentException], ts2.add(1))
+    assertThrows(classOf[IllegalArgumentException], ts2.add(1))
 
     ts.clear()
     ts.addAll(l)
@@ -322,17 +322,17 @@ abstract class TreeSetTest(val factory: TreeSetFactory)
     val ss1 = ts.subSet(1, true, 5, true)
     assertTrue(ss1.add(4))
     assertTrue(ss1.add(1))
-    expectThrows(classOf[IllegalArgumentException], ss1.add(0))
+    assertThrows(classOf[IllegalArgumentException], ss1.add(0))
     assertTrue(ss1.add(5))
-    expectThrows(classOf[IllegalArgumentException], ss1.add(6))
+    assertThrows(classOf[IllegalArgumentException], ss1.add(6))
 
     ts.clear()
     ts.addAll(l)
 
     val ss2 = ts.subSet(1, false, 5, false)
     assertTrue(ss2.add(4))
-    expectThrows(classOf[IllegalArgumentException], ss2.add(1))
-    expectThrows(classOf[IllegalArgumentException], ss2.add(5))
+    assertThrows(classOf[IllegalArgumentException], ss2.add(1))
+    assertThrows(classOf[IllegalArgumentException], ss2.add(5))
   }
 }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTest.scala
@@ -17,7 +17,7 @@ import org.junit.Test
 
 import java.util.UUID
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class UUIDTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentHashMapTest.scala
@@ -22,7 +22,7 @@ import org.junit.Assert._
 import org.junit.Test
 
 import org.scalajs.testsuite.javalib.util.MapTest
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ConcurrentHashMapTest extends MapTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
@@ -50,7 +50,7 @@ class ConcurrentSkipListSetTest {
     assertEquals(0, csls.size())
     assertTrue(csls.isEmpty)
     assertFalse(csls.remove(333))
-    expectThrows(classOf[NoSuchElementException], csls.first)
+    assertThrows(classOf[NoSuchElementException], csls.first)
   }
 
   @Test def adddRemoveString(): Unit = {
@@ -404,7 +404,7 @@ class ConcurrentSkipListSetTest {
     val csls = new ConcurrentSkipListSet[TestObj]()
 
     assertEquals(0, csls.size())
-    expectThrows(classOf[ClassCastException], {
+    assertThrows(classOf[ClassCastException], {
       // Throw either when the first or second element is added
       csls.add(new TestObj(111))
       csls.add(new TestObj(222))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ConcurrentSkipListSetTest.scala
@@ -22,7 +22,7 @@ import org.junit.Test
 import org.scalajs.testsuite.javalib.util.NavigableSetFactory
 import org.scalajs.testsuite.javalib.util.TrivialImmutableCollection
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 import scala.reflect.ClassTag

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/SemaphoreTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/SemaphoreTest.scala
@@ -18,7 +18,7 @@ import java.util.concurrent.Semaphore
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class SemaphoreTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import java.util.concurrent.ThreadLocalRandom
 import scala.math.{max, min}
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class ThreadLocalRandomTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/locks/ReentrantLockTest.scala
@@ -19,7 +19,7 @@ import java.lang.Thread
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ReentrantLockTest {
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/BiConsumerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/BiConsumerTest.scala
@@ -17,7 +17,7 @@ import java.util.function.BiConsumer
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class BiConsumerTest {
   import BiConsumerTest._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/BiPredicateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/BiPredicateTest.scala
@@ -17,7 +17,7 @@ import java.util.function.BiPredicate
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class BiPredicateTest {
   import BiPredicateTest._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/ConsumerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/ConsumerTest.scala
@@ -17,7 +17,7 @@ import java.util.function.Consumer
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class ConsumerTest {
   import ConsumerTest._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/DoublePredicateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/DoublePredicateTest.scala
@@ -17,7 +17,7 @@ import java.util.function.DoublePredicate
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class DoublePredicateTest {
   import DoublePredicateTest._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/IntPredicateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/IntPredicateTest.scala
@@ -17,7 +17,7 @@ import java.util.function.IntPredicate
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class IntPredicateTest {
   import IntPredicateTest._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/LongPredicateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/LongPredicateTest.scala
@@ -17,7 +17,7 @@ import java.util.function.LongPredicate
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class LongPredicateTest {
   import LongPredicateTest._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/PredicateTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/function/PredicateTest.scala
@@ -17,7 +17,7 @@ import java.util.function.Predicate
 import org.junit.Assert._
 import org.junit.Test
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 class PredicateTest {
   import PredicateTest._

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexMatcherTest.scala
@@ -19,7 +19,7 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.Platform._
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import scala.util.matching.Regex
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexPatternTest.scala
@@ -17,7 +17,7 @@ import java.util.regex.Pattern
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class RegexPatternTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
@@ -345,18 +345,18 @@ class JUnitAssertionsTest {
 
   @Test
   def testExpectThrows(): Unit = {
-    testIfAsserts(expectThrows(classOf[Exception], throw new Exception))
-    testIfAsserts(expectThrows(classOf[IndexOutOfBoundsException],
+    testIfAsserts(assertThrows(classOf[Exception], throw new Exception))
+    testIfAsserts(assertThrows(classOf[IndexOutOfBoundsException],
         throw new IndexOutOfBoundsException))
 
     testIfAsserts {
-      val ex = expectThrows(classOf[Exception], throw new Exception("abc"))
+      val ex = assertThrows(classOf[Exception], throw new Exception("abc"))
       assertEquals(ex.getMessage, "abc")
     }
 
-    testIfAsserts(expectThrows(classOf[IndexOutOfBoundsException],
+    testIfAsserts(assertThrows(classOf[IndexOutOfBoundsException],
         throw new Exception), ShallNotPass)
-    testIfAsserts(expectThrows(classOf[IndexOutOfBoundsException],()),
+    testIfAsserts(assertThrows(classOf[IndexOutOfBoundsException],()),
         ShallNotPass)
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/junit/JUnitAssertionsTest.scala
@@ -17,7 +17,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.hamcrest.CoreMatchers._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import scala.util.{Failure, Success, Try}
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
@@ -20,7 +20,7 @@ import org.junit.Assume._
 
 import org.scalajs.testsuite.niobuffer.ByteBufferFactories.SlicedAllocByteBufferFactory
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 abstract class BaseBufferTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
@@ -39,11 +39,11 @@ abstract class BaseBufferTest {
 
     assertEquals(0, allocBuffer(0).capacity)
 
-    expectThrows(classOf[Exception], allocBuffer(-1))
-    expectThrows(classOf[Throwable], allocBuffer(0, -1, 1))
-    expectThrows(classOf[Throwable], allocBuffer(1, 0, 1))
-    expectThrows(classOf[Throwable], allocBuffer(0, 1, 0))
-    expectThrows(classOf[Throwable], allocBuffer(1, 0, 0))
+    assertThrows(classOf[Exception], allocBuffer(-1))
+    assertThrows(classOf[Throwable], allocBuffer(0, -1, 1))
+    assertThrows(classOf[Throwable], allocBuffer(1, 0, 1))
+    assertThrows(classOf[Throwable], allocBuffer(0, 1, 0))
+    assertThrows(classOf[Throwable], allocBuffer(1, 0, 0))
 
     val buf2 = allocBuffer(1, 5, 9)
     assertEquals(1, buf2.position())
@@ -68,8 +68,8 @@ abstract class BaseBufferTest {
     buf.position(0)
     assertEquals(0, buf.position())
 
-    expectThrows(classOf[IllegalArgumentException], buf.position(-1))
-    expectThrows(classOf[IllegalArgumentException], buf.position(11))
+    assertThrows(classOf[IllegalArgumentException], buf.position(-1))
+    assertThrows(classOf[IllegalArgumentException], buf.position(11))
     assertEquals(0, buf.position())
 
     val buf2 = allocBuffer(1, 5, 9)
@@ -77,7 +77,7 @@ abstract class BaseBufferTest {
 
     buf2.position(5)
     assertEquals(5, buf2.position())
-    expectThrows(classOf[IllegalArgumentException], buf2.position(6))
+    assertThrows(classOf[IllegalArgumentException], buf2.position(6))
     assertEquals(5, buf2.position())
   }
 
@@ -87,9 +87,9 @@ abstract class BaseBufferTest {
     buf.limit(7)
     assertEquals(7, buf.limit())
     assertEquals(3, buf.position())
-    expectThrows(classOf[IllegalArgumentException], buf.limit(11))
+    assertThrows(classOf[IllegalArgumentException], buf.limit(11))
     assertEquals(7, buf.limit())
-    expectThrows(classOf[IllegalArgumentException], buf.limit(-1))
+    assertThrows(classOf[IllegalArgumentException], buf.limit(-1))
     assertEquals(7, buf.limit())
     assertEquals(3, buf.position())
 
@@ -103,7 +103,7 @@ abstract class BaseBufferTest {
     val buf = allocBuffer(10)
 
     // Initially, the mark should not be set
-    expectThrows(classOf[InvalidMarkException], buf.reset())
+    assertThrows(classOf[InvalidMarkException], buf.reset())
 
     // Simple test
     buf.position(3)
@@ -119,7 +119,7 @@ abstract class BaseBufferTest {
 
     // setting position() below the mark should clear the mark
     buf.position(2)
-    expectThrows(classOf[InvalidMarkException], buf.reset())
+    assertThrows(classOf[InvalidMarkException], buf.reset())
   }
 
   @Test def clear(): Unit = {
@@ -131,7 +131,7 @@ abstract class BaseBufferTest {
     assertEquals(0, buf.position())
     assertEquals(10, buf.limit()) // the capacity
     assertEquals(10, buf.capacity())
-    expectThrows(classOf[InvalidMarkException], buf.reset())
+    assertThrows(classOf[InvalidMarkException], buf.reset())
   }
 
   @Test def flip(): Unit = {
@@ -143,7 +143,7 @@ abstract class BaseBufferTest {
     assertEquals(0, buf.position())
     assertEquals(4, buf.limit()) // old position
     assertEquals(10, buf.capacity())
-    expectThrows(classOf[InvalidMarkException], buf.reset())
+    assertThrows(classOf[InvalidMarkException], buf.reset())
   }
 
   @Test def rewind(): Unit = {
@@ -155,7 +155,7 @@ abstract class BaseBufferTest {
     assertEquals(0, buf.position())
     assertEquals(6, buf.limit()) // unchanged
     assertEquals(10, buf.capacity())
-    expectThrows(classOf[InvalidMarkException], buf.reset())
+    assertThrows(classOf[InvalidMarkException], buf.reset())
   }
 
   @Test def remainingAndHasRemaining(): Unit = {
@@ -188,11 +188,11 @@ abstract class BaseBufferTest {
     assertEquals(elemFromInt(3), buf.get(3))
     assertEquals(0, buf.position())
 
-    expectThrows(classOf[IndexOutOfBoundsException], buf.get(-1))
-    expectThrows(classOf[IndexOutOfBoundsException], buf.get(15))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.get(-1))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.get(15))
 
     buf.limit(4)
-    expectThrows(classOf[IndexOutOfBoundsException], buf.get(5))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.get(5))
   }
 
   @Test def absolutePut(): Unit = {
@@ -205,18 +205,18 @@ abstract class BaseBufferTest {
       assertEquals(elemFromInt(42), buf.get(5))
       assertEquals(elemFromInt(0), buf.get(7))
 
-      expectThrows(classOf[IndexOutOfBoundsException], buf.put(-1, 2))
-      expectThrows(classOf[IndexOutOfBoundsException], buf.put(14, 9))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.put(-1, 2))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.put(14, 9))
 
       buf.limit(4)
-      expectThrows(classOf[IndexOutOfBoundsException], buf.put(4, 1))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.put(4, 1))
     } else {
-      expectThrows(classOf[ReadOnlyBufferException], buf.put(2, 1))
+      assertThrows(classOf[ReadOnlyBufferException], buf.put(2, 1))
       assertEquals(elemFromInt(0), buf.get(2))
       assertEquals(0, buf.position())
 
-      expectThrows(classOf[ReadOnlyBufferException], buf.put(-2, 1))
-      expectThrows(classOf[ReadOnlyBufferException], buf.put(12, 1))
+      assertThrows(classOf[ReadOnlyBufferException], buf.put(-2, 1))
+      assertThrows(classOf[ReadOnlyBufferException], buf.put(12, 1))
     }
   }
 
@@ -229,7 +229,7 @@ abstract class BaseBufferTest {
     assertEquals(4, buf.position())
 
     buf.limit(4)
-    expectThrows(classOf[BufferUnderflowException], buf.get())
+    assertThrows(classOf[BufferUnderflowException], buf.get())
   }
 
   @Test def relativePut(): Unit = {
@@ -245,14 +245,14 @@ abstract class BaseBufferTest {
       assertEquals(elemFromInt(36), buf.get(3))
 
       buf.position(10)
-      expectThrows(classOf[BufferOverflowException], buf.put(3))
+      assertThrows(classOf[BufferOverflowException], buf.put(3))
     } else {
-      expectThrows(classOf[ReadOnlyBufferException], buf.put(5))
+      assertThrows(classOf[ReadOnlyBufferException], buf.put(5))
       assertEquals(0, buf.position())
       assertEquals(elemFromInt(0), buf.get(0))
 
       buf.position(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.put(3))
+      assertThrows(classOf[ReadOnlyBufferException], buf.put(3))
     }
   }
 
@@ -268,7 +268,7 @@ abstract class BaseBufferTest {
     assertArrayEquals(boxedElemsFromInt(0, 6, 7, 3), boxed(a))
     assertEquals(8, buf.position())
 
-    expectThrows(classOf[Exception], buf.get(a))
+    assertThrows(classOf[Exception], buf.get(a))
     assertEquals(8, buf.position())
     assertArrayEquals(boxedElemsFromInt(0, 6, 7, 3), boxed(a))
   }
@@ -285,11 +285,11 @@ abstract class BaseBufferTest {
       assertArrayEquals(boxedElemsFromInt(6, 7, 66, 77, 0), boxed((0 to 4).map(buf.get).toArray))
       assertEquals(4, buf.position())
 
-      expectThrows(classOf[BufferOverflowException], buf.put(Array.fill[ElementType](10)(0)))
+      assertThrows(classOf[BufferOverflowException], buf.put(Array.fill[ElementType](10)(0)))
       assertEquals(4, buf.position())
       assertArrayEquals(boxedElemsFromInt(6, 7, 66, 77, 0), boxed((0 to 4).map(buf.get).toArray))
     } else {
-      expectThrows(classOf[ReadOnlyBufferException], buf.put(Array[ElementType](6, 7, 12)))
+      assertThrows(classOf[ReadOnlyBufferException], buf.put(Array[ElementType](6, 7, 12)))
       assertEquals(0, buf.position())
       assertEquals(elemFromInt(0), buf.get(0))
 
@@ -300,7 +300,7 @@ abstract class BaseBufferTest {
        */
       buf.position(8)
       val exception =
-        expectThrows(classOf[RuntimeException], buf.put(Array[ElementType](6, 7, 12)))
+        assertThrows(classOf[RuntimeException], buf.put(Array[ElementType](6, 7, 12)))
       assertTrue(
           exception.isInstanceOf[ReadOnlyBufferException] ||
           exception.isInstanceOf[BufferOverflowException])
@@ -322,13 +322,13 @@ abstract class BaseBufferTest {
       buf.compact()
       assertEquals(4, buf.position())
       assertEquals(10, buf.limit())
-      expectThrows(classOf[InvalidMarkException], buf.reset())
+      assertThrows(classOf[InvalidMarkException], buf.reset())
 
       for (i <- 0 until 4)
         assertEquals(elemFromInt(i + 6), buf.get(i))
     } else {
       val buf = allocBuffer(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.compact())
+      assertThrows(classOf[ReadOnlyBufferException], buf.compact())
     }
   }
 
@@ -341,7 +341,7 @@ abstract class BaseBufferTest {
     assertEquals(0, buf2.position())
     assertEquals(4, buf2.limit())
     assertEquals(4, buf2.capacity())
-    expectThrows(classOf[InvalidMarkException], buf2.reset())
+    assertThrows(classOf[InvalidMarkException], buf2.reset())
 
     assertEquals(elemFromInt(4), buf2.get(1))
 
@@ -355,7 +355,7 @@ abstract class BaseBufferTest {
       assertEquals(3, buf1.position())
     }
 
-    expectThrows(classOf[IllegalArgumentException], buf2.limit(5))
+    assertThrows(classOf[IllegalArgumentException], buf2.limit(5))
     assertEquals(4, buf2.limit())
 
     buf2.limit(3)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
@@ -47,7 +47,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(0x8281, buf.getChar().toInt)
     assertEquals(0x8483, buf.getChar().toInt)
 
-    expectThrows(classOf[BufferUnderflowException], buf.getChar())
+    assertThrows(classOf[BufferUnderflowException], buf.getChar())
   }
 
   @Test def relativePutChar(): Unit = {
@@ -69,9 +69,9 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x82.toByte, buf.get(7))
       assertEquals(0x81.toByte, buf.get(8))
 
-      expectThrows(classOf[BufferOverflowException], buf.putChar(0x8384))
+      assertThrows(classOf[BufferOverflowException], buf.putChar(0x8384))
     } else {
-      expectThrows(classOf[ReadOnlyBufferException], buf.putChar(0x7576))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putChar(0x7576))
       assertEquals(0, buf.get(0))
       assertEquals(0, buf.position())
     }
@@ -90,7 +90,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(0x7e7d, buf.getChar(2).toInt)
     assertEquals(0x8483, buf.getChar(8).toInt)
 
-    expectThrows(classOf[IndexOutOfBoundsException], buf.getChar(9))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.getChar(9))
   }
 
   @Test def absolutePutChar(): Unit = {
@@ -114,10 +114,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x82.toByte, buf.get(6))
       assertEquals(0x81.toByte, buf.get(7))
 
-      expectThrows(classOf[IndexOutOfBoundsException], buf.putChar(9, 0x8384))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.putChar(9, 0x8384))
     } else {
       val buf = allocBuffer(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putChar(3, 0x7576))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putChar(3, 0x7576))
       assertEquals(0, buf.get(3))
       assertEquals(0, buf.position())
     }
@@ -183,7 +183,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
       buf.limit(8).position(1)
 
       val charBuf1 = buf.asReadOnlyBuffer().asCharBuffer()
-      expectThrows(classOf[ReadOnlyBufferException], charBuf1.put(1, 0x7e7f.toChar))
+      assertThrows(classOf[ReadOnlyBufferException], charBuf1.put(1, 0x7e7f.toChar))
     }
   }
 
@@ -200,7 +200,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(0xffff8281, buf.getShort())
     assertEquals(0xffff8483, buf.getShort())
 
-    expectThrows(classOf[BufferUnderflowException], buf.getShort())
+    assertThrows(classOf[BufferUnderflowException], buf.getShort())
   }
 
   @Test def relativePutShort(): Unit = {
@@ -222,10 +222,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x82.toByte, buf.get(7))
       assertEquals(0x81.toByte, buf.get(8))
 
-      expectThrows(classOf[BufferOverflowException], buf.putShort(0xffff8384))
+      assertThrows(classOf[BufferOverflowException], buf.putShort(0xffff8384))
     } else {
       val buf = allocBuffer(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putShort(0x7576))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putShort(0x7576))
       assertEquals(0, buf.get(0))
       assertEquals(0, buf.position())
     }
@@ -244,7 +244,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(0x7e7d, buf.getShort(2))
     assertEquals(0xffff8483, buf.getShort(8))
 
-    expectThrows(classOf[IndexOutOfBoundsException], buf.getShort(9))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.getShort(9))
   }
 
   @Test def absolutePutShort(): Unit = {
@@ -268,10 +268,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x82.toByte, buf.get(6))
       assertEquals(0x81.toByte, buf.get(7))
 
-      expectThrows(classOf[IndexOutOfBoundsException], buf.putShort(9, 0xffff8384))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.putShort(9, 0xffff8384))
     } else {
       val buf = allocBuffer(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putShort(3, 0x7576))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putShort(3, 0x7576))
       assertEquals(0, buf.get(3))
       assertEquals(0, buf.position())
     }
@@ -337,7 +337,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
       buf.limit(8).position(1)
 
       val shortBuf1 = buf.asReadOnlyBuffer().asShortBuffer()
-      expectThrows(classOf[ReadOnlyBufferException], shortBuf1.put(1, 0x7e7f.toShort))
+      assertThrows(classOf[ReadOnlyBufferException], shortBuf1.put(1, 0x7e7f.toShort))
     }
   }
 
@@ -353,7 +353,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     buf.position(6)
     assertEquals(0x84838281, buf.getInt())
 
-    expectThrows(classOf[BufferUnderflowException], buf.getInt())
+    assertThrows(classOf[BufferUnderflowException], buf.getInt())
   }
 
   @Test def relativePutInt(): Unit = {
@@ -381,10 +381,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x82.toByte, buf.get(5))
       assertEquals(0x81.toByte, buf.get(6))
 
-      expectThrows(classOf[BufferOverflowException], buf.putInt(0xffff8384))
+      assertThrows(classOf[BufferOverflowException], buf.putInt(0xffff8384))
     } else {
       val buf = allocBuffer(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putInt(0x75767778))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putInt(0x75767778))
       assertEquals(0, buf.get(0))
       assertEquals(0, buf.position())
     }
@@ -403,7 +403,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(0x807f7e7d, buf.getInt(2))
     assertEquals(0x84838281, buf.getInt(6))
 
-    expectThrows(classOf[IndexOutOfBoundsException], buf.getInt(7))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.getInt(7))
   }
 
   @Test def absolutePutInt(): Unit = {
@@ -433,10 +433,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x82.toByte, buf.get(8))
       assertEquals(0x81.toByte, buf.get(9))
 
-      expectThrows(classOf[IndexOutOfBoundsException], buf.putInt(9, 0xffff8384))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.putInt(9, 0xffff8384))
     } else {
       val buf = allocBuffer(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putInt(3, 0x7576))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putInt(3, 0x7576))
       assertEquals(0, buf.get(3))
       assertEquals(0, buf.position())
     }
@@ -510,7 +510,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
       buf.limit(10).position(1)
 
       val intBuf1 = buf.asReadOnlyBuffer().asIntBuffer()
-      expectThrows(classOf[ReadOnlyBufferException], intBuf1.put(1, 0x7e7f8081))
+      assertThrows(classOf[ReadOnlyBufferException], intBuf1.put(1, 0x7e7f8081))
     }
   }
 
@@ -526,7 +526,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     buf.position(6)
     assertEquals(0x838281807f7e7d7cL, buf.getLong())
 
-    expectThrows(classOf[BufferUnderflowException], buf.getLong())
+    assertThrows(classOf[BufferUnderflowException], buf.getLong())
   }
 
   @Test def relativePutLong(): Unit = {
@@ -566,10 +566,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x82.toByte, buf.get(13))
       assertEquals(0x81.toByte, buf.get(14))
 
-      expectThrows(classOf[BufferOverflowException], buf.putLong(0xffff8384))
+      assertThrows(classOf[BufferOverflowException], buf.putLong(0xffff8384))
     } else {
       val buf = allocBuffer(20)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putLong(0x75767778))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putLong(0x75767778))
       assertEquals(0, buf.get(0))
       assertEquals(0, buf.position())
     }
@@ -588,7 +588,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     assertEquals(0x8584838281807f7eL, buf.getLong(8))
     assertEquals(0x8988878685848382L, buf.getLong(12))
 
-    expectThrows(classOf[IndexOutOfBoundsException], buf.getLong(15))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.getLong(15))
   }
 
   @Test def absolutePutLong(): Unit = {
@@ -630,10 +630,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x82.toByte, buf.get(15))
       assertEquals(0x81.toByte, buf.get(16))
 
-      expectThrows(classOf[IndexOutOfBoundsException], buf.putLong(16, 0xffff8384))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.putLong(16, 0xffff8384))
     } else {
       val buf = allocBuffer(20)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putLong(3, 0x7576))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putLong(3, 0x7576))
       assertEquals(0, buf.get(3))
       assertEquals(0, buf.position())
     }
@@ -723,7 +723,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
       buf.limit(19).position(3)
 
       val longBuf1 = buf.asReadOnlyBuffer().asLongBuffer()
-      expectThrows(classOf[ReadOnlyBufferException], longBuf1.put(1, 0x8182838485868788L))
+      assertThrows(classOf[ReadOnlyBufferException], longBuf1.put(1, 0x8182838485868788L))
     }
   }
 
@@ -740,7 +740,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     buf.position(6)
     assertEquals(-7.2966893e-13f, buf.getFloat(), 0.0f)
 
-    expectThrows(classOf[BufferUnderflowException], buf.getFloat())
+    assertThrows(classOf[BufferUnderflowException], buf.getFloat())
   }
 
   @Test def relativePutFloat(): Unit = {
@@ -768,10 +768,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x4d, buf.get(5))
       assertEquals(0xab.toByte, buf.get(6))
 
-      expectThrows(classOf[BufferOverflowException], buf.putFloat(654.4f))
+      assertThrows(classOf[BufferOverflowException], buf.putFloat(654.4f))
     } else {
       val buf = allocBuffer(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putFloat(151.189f))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putFloat(151.189f))
       assertEquals(0, buf.get(0))
       assertEquals(0, buf.position())
     }
@@ -790,7 +790,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     buf.position(8)
     assertEquals(-7.2966893e-13f, buf.getFloat(6), 0.0f)
 
-    expectThrows(classOf[IndexOutOfBoundsException], buf.getFloat(7))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.getFloat(7))
   }
 
   @Test def absolutePutFloat(): Unit = {
@@ -820,10 +820,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x4d, buf.get(7))
       assertEquals(0xab.toByte, buf.get(8))
 
-      expectThrows(classOf[IndexOutOfBoundsException], buf.putFloat(9, 3.141592f))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.putFloat(9, 3.141592f))
     } else {
       val buf = allocBuffer(10)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putFloat(3, 151.189f))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putFloat(3, 151.189f))
       assertEquals(0, buf.get(3))
       assertEquals(0, buf.position())
     }
@@ -900,7 +900,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
       buf.limit(10).position(1)
 
       val floatBuf1 = buf.asReadOnlyBuffer().asFloatBuffer()
-      expectThrows(classOf[ReadOnlyBufferException], floatBuf1.put(1, 3.141592f))
+      assertThrows(classOf[ReadOnlyBufferException], floatBuf1.put(1, 3.141592f))
     }
   }
 
@@ -919,7 +919,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     buf.position(12)
     assertEquals(-3.492426300334232e-51, buf.getDouble(), 0.0)
 
-    expectThrows(classOf[BufferUnderflowException], buf.getDouble())
+    assertThrows(classOf[BufferUnderflowException], buf.getDouble())
   }
 
   @Test def relativePutDouble(): Unit = {
@@ -959,10 +959,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x74, buf.get(13))
       assertEquals(0xb5.toByte, buf.get(14))
 
-      expectThrows(classOf[BufferOverflowException], buf.putDouble(1511.1989))
+      assertThrows(classOf[BufferOverflowException], buf.putDouble(1511.1989))
     } else {
       val buf = allocBuffer(20)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putDouble(1511.1989))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putDouble(1511.1989))
       assertEquals(0, buf.get(0))
       assertEquals(0, buf.position())
     }
@@ -983,7 +983,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
     buf.position(8)
     assertEquals(-3.492426300334232e-51, buf.getDouble(12), 0.0)
 
-    expectThrows(classOf[IndexOutOfBoundsException], buf.getDouble(15))
+    assertThrows(classOf[IndexOutOfBoundsException], buf.getDouble(15))
   }
 
   @Test def absolutePutDouble(): Unit = {
@@ -1025,10 +1025,10 @@ abstract class ByteBufferTest extends BaseBufferTest {
       assertEquals(0x74, buf.get(15))
       assertEquals(0xb5.toByte, buf.get(16))
 
-      expectThrows(classOf[IndexOutOfBoundsException], buf.putDouble(17, 1511.1989))
+      assertThrows(classOf[IndexOutOfBoundsException], buf.putDouble(17, 1511.1989))
     } else {
       val buf = allocBuffer(20)
-      expectThrows(classOf[ReadOnlyBufferException], buf.putDouble(3, 1511.1989))
+      assertThrows(classOf[ReadOnlyBufferException], buf.putDouble(3, 1511.1989))
       assertEquals(0, buf.get(3))
       assertEquals(0, buf.position())
     }
@@ -1122,7 +1122,7 @@ abstract class ByteBufferTest extends BaseBufferTest {
       buf.limit(19).position(3)
 
       val doubleBuf1 = buf.asReadOnlyBuffer().asDoubleBuffer()
-      expectThrows(classOf[ReadOnlyBufferException], doubleBuf1.put(1, Math.PI))
+      assertThrows(classOf[ReadOnlyBufferException], doubleBuf1.put(1, Math.PI))
     }
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/ByteBufferTest.scala
@@ -18,7 +18,7 @@ import org.junit.Test
 import org.junit.Assert._
 import org.scalajs.testsuite.niobuffer.BufferFactory.ByteBufferFactory
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 abstract class ByteBufferTest extends BaseBufferTest {
   type Factory = BufferFactory.ByteBufferFactory

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
@@ -59,9 +59,9 @@ class CharsetTest {
     assertSame(UTF_16, Charset.forName("UnicodeBig"))
 
     // Issue #2040
-    expectThrows(classOf[UnsupportedCharsetException], Charset.forName("UTF_8"))
+    assertThrows(classOf[UnsupportedCharsetException], Charset.forName("UTF_8"))
 
-    expectThrows(classOf[UnsupportedCharsetException],
+    assertThrows(classOf[UnsupportedCharsetException],
         Charset.forName("this-charset-does-not-exist"))
   }
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niocharset/CharsetTest.scala
@@ -19,7 +19,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalajs.testsuite.javalib.util.TrivialImmutableCollection
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class CharsetTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
@@ -68,7 +68,7 @@ class EnumerationTest {
 
     if (!executingInJVM) {
       // In the JVM the exception thrown is a ClassCastException
-      val ex = expectThrows(classOf[NoSuchElementException], Test.withName("A"))
+      val ex = assertThrows(classOf[NoSuchElementException], Test.withName("A"))
       val subMsg = "Couldn't find enum field with name A.\n" +
           "However, there were the following unnamed fields:"
       assertTrue(ex.getMessage.contains(subMsg))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/scalalib/EnumerationTest.scala
@@ -15,7 +15,7 @@ package org.scalajs.testsuite.scalalib
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
 class EnumerationTest {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -12,49 +12,12 @@
 
 package org.scalajs.testsuite.utils
 
-import scala.util.{Failure, Try, Success}
+import org.junit.Assert
+import org.junit.function.ThrowingRunnable
 
 object AssertThrows {
-  /** Backport implementation of Assert.assertThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def assertThrowsBackport[T <: Throwable](expectedThrowable: Class[T],
-      runnable: ThrowingRunnable): T = {
-    val result = {
-      try {
-        runnable.run()
-        null.asInstanceOf[T]
-      } catch {
-        case actualThrown: Throwable =>
-          if (expectedThrowable.isInstance(actualThrown)) {
-            actualThrown.asInstanceOf[T]
-          } else {
-            val mismatchMessage = "unexpected exception type thrown;" +
-                expectedThrowable.getSimpleName + " " + actualThrown.getClass.getSimpleName
-
-            val assertionError = new AssertionError(mismatchMessage)
-            assertionError.initCause(actualThrown)
-            throw assertionError
-          }
-      }
-    }
-    if (result == null) {
-      throw new AssertionError("expected " + expectedThrowable.getSimpleName +
-          " to be thrown, but nothing was thrown")
-    } else {
-      result
-    }
-  }
-
-  /** Backport implementation of Assert.ThrowingRunnable to be used until
-   *  JUnit 4.13 is released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private trait ThrowingRunnable {
-    def run(): Unit
-  }
-
   def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
-    assertThrowsBackport(expectedThrowable, new ThrowingRunnable {
+    Assert.assertThrows(expectedThrowable, new ThrowingRunnable {
       def run(): Unit = code
     })
   }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/AssertThrows.scala
@@ -18,15 +18,7 @@ object AssertThrows {
   /** Backport implementation of Assert.assertThrows to be used until JUnit 4.13 is
    *  released. See org.junit.Assert.scala in jUnitRuntime.
    */
-  private def assertThrowsBackport(expectedThrowable: Class[_ <: Throwable],
-      runnable: ThrowingRunnable): Unit = {
-    expectThrowsBackport(expectedThrowable, runnable)
-  }
-
-  /** Backport implementation of Assert.expectThrows to be used until JUnit 4.13 is
-   *  released. See org.junit.Assert.scala in jUnitRuntime.
-   */
-  private def expectThrowsBackport[T <: Throwable](expectedThrowable: Class[T],
+  private def assertThrowsBackport[T <: Throwable](expectedThrowable: Class[T],
       runnable: ThrowingRunnable): T = {
     val result = {
       try {
@@ -61,21 +53,9 @@ object AssertThrows {
     def run(): Unit
   }
 
-  private def throwingRunnable(code: => Unit): ThrowingRunnable = {
-    new ThrowingRunnable {
+  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
+    assertThrowsBackport(expectedThrowable, new ThrowingRunnable {
       def run(): Unit = code
-    }
-  }
-
-  def assertThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): Unit = {
-    assertThrowsBackport(expectedThrowable, throwingRunnable {
-      code
-    })
-  }
-
-  def expectThrows[T <: Throwable, U](expectedThrowable: Class[T], code: => U): T = {
-    expectThrowsBackport(expectedThrowable, throwingRunnable {
-      code
     })
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/CollectionsTestBase.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/CollectionsTestBase.scala
@@ -44,12 +44,12 @@ trait CollectionsTestBase {
 
   def testCollectionUnmodifiability[E](coll: ju.Collection[E], elem: E): Unit = {
     val empty = TrivialImmutableCollection[E]()
-    expectThrows(classOf[UnsupportedOperationException], coll.add(elem))
-    expectThrows(classOf[UnsupportedOperationException], coll.addAll(empty))
-    expectThrows(classOf[UnsupportedOperationException], coll.clear())
-    expectThrows(classOf[UnsupportedOperationException], coll.remove(elem))
-    expectThrows(classOf[UnsupportedOperationException], coll.removeAll(empty))
-    expectThrows(classOf[UnsupportedOperationException], coll.retainAll(empty))
+    assertThrows(classOf[UnsupportedOperationException], coll.add(elem))
+    assertThrows(classOf[UnsupportedOperationException], coll.addAll(empty))
+    assertThrows(classOf[UnsupportedOperationException], coll.clear())
+    assertThrows(classOf[UnsupportedOperationException], coll.remove(elem))
+    assertThrows(classOf[UnsupportedOperationException], coll.removeAll(empty))
+    assertThrows(classOf[UnsupportedOperationException], coll.retainAll(empty))
     testIteratorsUnmodifiability(() => coll.iterator())
   }
 
@@ -71,11 +71,11 @@ trait CollectionsTestBase {
   def testListUnmodifiability[E](list: ju.List[E], elem: E,
       recursive: Boolean = false): Unit = {
     testCollectionUnmodifiability(list, elem)
-    expectThrows(classOf[UnsupportedOperationException], list.add(0, elem))
-    expectThrows(classOf[UnsupportedOperationException],
+    assertThrows(classOf[UnsupportedOperationException], list.add(0, elem))
+    assertThrows(classOf[UnsupportedOperationException],
         list.addAll(0, TrivialImmutableCollection[E]()))
-    expectThrows(classOf[UnsupportedOperationException], list.remove(0))
-    expectThrows(classOf[UnsupportedOperationException], list.set(0, elem))
+    assertThrows(classOf[UnsupportedOperationException], list.remove(0))
+    assertThrows(classOf[UnsupportedOperationException], list.set(0, elem))
     def testSublist(sl: ju.List[E]): Unit = {
       if (recursive) testCollectionUnmodifiability(sl, elem)
       else testListUnmodifiability(sl, elem, true)
@@ -92,16 +92,16 @@ trait CollectionsTestBase {
     if (it.hasNext) {
       it.next()
       expectedException match {
-        case Some(exClass) => expectThrows(exClass, action(it))
+        case Some(exClass) => assertThrows(exClass, action(it))
         case None => action(it)
       }
     }
   }
 
   def testMapUnmodifiability[K, V](map: ju.Map[K, V], key: K, value: V): Unit = {
-    expectThrows(classOf[UnsupportedOperationException], map.clear())
-    expectThrows(classOf[UnsupportedOperationException], map.put(key, value))
-    expectThrows(classOf[UnsupportedOperationException],
+    assertThrows(classOf[UnsupportedOperationException], map.clear())
+    assertThrows(classOf[UnsupportedOperationException], map.put(key, value))
+    assertThrows(classOf[UnsupportedOperationException],
         map.putAll(TrivialImmutableMap[K, V]()))
     testSetUnmodifiability(map.entrySet(),
         new ju.AbstractMap.SimpleImmutableEntry(key, value))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/CollectionsTestBase.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/utils/CollectionsTestBase.scala
@@ -14,7 +14,7 @@ package org.scalajs.testsuite.utils
 
 import java.{lang => jl, util => ju}
 
-import org.scalajs.testsuite.utils.AssertThrows._
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import org.scalajs.testsuite.javalib.util.TrivialImmutableCollection
 import org.scalajs.testsuite.javalib.util.TrivialImmutableMap


### PR DESCRIPTION
This unfortunately creates zillions of clashes between `org.junit.Assert.assertThrows` and our own `AssertThrows.assertThrows`. The latter is more Scala friendly, so we want to keep it. We use named imports when we use it to force it over the one coming from `org.unit.Assert._`.

This allows to re-enable some tests in the scalaTestSuite in recent versions of Scala, at the cost of having to disable them (and some others) in older versions.

In addition, JUnit 4.13 brings some changes in how failed assumptions are reported. This triggers changes in the JUnit Test Outputs files as well as in our implementation.