### PR TITLE
JUnit: Add Int overloads to assertEquals and assertNotEquals.

### DIFF
--- a/junit-runtime/src/main/scala/org/junit/Assert.scala
+++ b/junit-runtime/src/main/scala/org/junit/Assert.scala
@@ -74,6 +74,18 @@ object Assert {
     fail(s"$checkedMessage. Actual: $actual")
   }
 
+  // Not part of the JVM API: make sure to keep Ints instead of Longs
+  @noinline
+  def assertNotEquals(message: String, unexpected: Int, actual: Int): Unit = {
+    if (unexpected == actual)
+      failEquals(message, actual)
+  }
+
+  // Not part of the JVM API: make sure to keep Ints instead of Longs
+  @noinline
+  def assertNotEquals(unexpected: Int, actual: Int): Unit =
+    assertNotEquals(null, unexpected, actual)
+
   @noinline
   def assertNotEquals(message: String, unexpected: Long, actual: Long): Unit = {
     if (unexpected == actual)
@@ -114,6 +126,16 @@ object Assert {
     fail("Use assertEquals(expected, actual, delta) to compare " +
         "floating-point numbers")
   }
+
+  // Not part of the JVM API: make sure to keep Ints instead of Longs
+  @noinline
+  def assertEquals(expected: Int, actual: Int): Unit =
+    assertEquals(null, expected, actual)
+
+  // Not part of the JVM API: make sure to keep Ints instead of Longs
+  @noinline
+  def assertEquals(message: String, expected: Int, actual: Int): Unit =
+    assertEquals(message, expected: Any, actual: Any)
 
   @noinline
   def assertEquals(expected: Long, actual: Long): Unit =


### PR DESCRIPTION
JUnit has overloads of `assertEquals` and `assertNotEquals` that take `Long`s and `Double`s as parameters, but not the other primitive types. That means that when calling those methods with `Int`s (or `Byte`s, `Short`s, `Char`s), the overload with `Long`s is selected. While correct, this incurs a significant cost in Scala.js.

We therefore introduce overloads taking `Int`s, although they are not part of the JVM API.

The size of the fastopt.js file for our test suite is reduced by 40% (!) with this change. I could not measure a significant difference in terms of link time or execution time, however.