### PR TITLE
Fix #4478: Port the fixes to `Array.apply` optimization from upstream.

### DIFF
--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.5/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.5/BlacklistedTests.txt
@@ -1119,8 +1119,3 @@ run/t10594.scala
 # Badly uses constract of Console.print (no flush)
 run/t429.scala
 run/t6102.scala
-
-### Buglisted tests ###
-
-# scala-js#4478
-run/t11882-class-cast.scala

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1684,7 +1684,7 @@ object Build {
 
           case "2.13.5" =>
             Some(ExpectedSizes(
-                fastLink = 780000 to 781000,
+                fastLink = 776000 to 777000,
                 fullLink = 169000 to 170000,
                 fastLinkGz = 98000 to 99000,
                 fullLinkGz = 43000 to 44000,


### PR DESCRIPTION
This commit ports the following two upstream commits:

* https://github.com/scala/scala/commit/7d81f22f4e7738f864dff3f3b86ae0f131149eec
* https://github.com/scala/scala/commit/3393616658fbd9946a9cc0520be42907b756964f