### PR TITLE
Fix the result type of FinalizationRegistry.unregister to Boolean.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/FinalizationRegistry.scala
+++ b/library/src/main/scala/scala/scalajs/js/FinalizationRegistry.scala
@@ -60,5 +60,5 @@ class FinalizationRegistry[-A, -B, -C](finalizer: js.Function1[B, scala.Any]) ex
    *
    *  @param unregistrationToken The token used with the register method when registering the target object.
    */
-  def unregister(unregistrationToken: C): Unit = js.native
+  def unregister(unregistrationToken: C): Boolean = js.native
 }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/FinalizationRegistryTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/FinalizationRegistryTest.scala
@@ -12,6 +12,7 @@
 
 package org.scalajs.testsuite.library
 
+import org.junit.Assert._
 import org.junit.Test
 
 import scala.scalajs.js
@@ -30,7 +31,15 @@ class FinalizationRegistryTest {
     val unregisterToken = new js.Object()
     registry.register(obj3, "bar", unregisterToken)
 
-    registry.unregister(obj1)
-    registry.unregister(unregisterToken)
+    val nonExistingUnregisterToken = new js.Object()
+    assertFalse(registry.unregister(nonExistingUnregisterToken))
+
+    assertFalse(registry.unregister(obj1))
+
+    assertTrue(registry.unregister(obj2))
+    assertFalse(registry.unregister(obj2))
+
+    assertTrue(registry.unregister(unregisterToken))
+    assertFalse(registry.unregister(unregisterToken))
   }
 }


### PR DESCRIPTION
While the MDN docs say it returns `undefined`, the spec at https://tc39.es/ecma262/#sec-finalization-registry.prototype.unregister shows that it returns a boolean. It returns true if at least one registration record was removed, and false otherwise.

/cc @exoego 