### PR TITLE
Fix #4491: Check the body of a JS constructor as an expression.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -484,7 +484,7 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
       typecheckExprOrSpread(arg, preparedEnv)
 
     val restEnv = preparedEnv.withThis(AnyType)
-    typecheckStat(Block(restStats)(methodDef.pos), restEnv)
+    typecheckExpr(Block(restStats)(methodDef.pos), restEnv)
   }
 
   private def checkExportedPropertyDef(propDef: JSPropertyDef,

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -188,6 +188,65 @@ class IRCheckerTest {
     }
   }
 
+  @Test
+  def jsClassConstructorBodyMustBeExpr1_Issue4491(): AsyncResult = await {
+    val classDefs = Seq(
+      JSObjectLikeClassDef,
+
+      classDef(
+        "Foo",
+        kind = ClassKind.JSClass,
+        superClass = Some(JSObjectLikeClass),
+        memberDefs = List(
+          JSMethodDef(EMF, str("constructor"), Nil, None, Block(
+            JSSuperConstructorCall(Nil)
+          ))(EOH, None)
+        )
+      ),
+
+      mainTestClassDef(Block(
+        LoadJSConstructor("Foo")
+      ))
+    )
+
+    for (log <- testLinkIRErrors(classDefs, MainTestModuleInitializers)) yield {
+      log.assertContainsError(
+          "Expression tree has type NoType")
+      log.assertContainsError(
+          "Invalid expression tree")
+    }
+  }
+
+  @Test
+  def jsClassConstructorBodyMustBeExpr2_Issue4491(): AsyncResult = await {
+    val classDefs = Seq(
+      JSObjectLikeClassDef,
+
+      classDef(
+        "Foo",
+        kind = ClassKind.JSClass,
+        superClass = Some(JSObjectLikeClass),
+        memberDefs = List(
+          JSMethodDef(EMF, str("constructor"), Nil, None, Block(
+            JSSuperConstructorCall(Nil),
+            VarDef("x", NON, IntType, mutable = false, int(5))
+          ))(EOH, None)
+        )
+      ),
+
+      mainTestClassDef(Block(
+        LoadJSConstructor("Foo")
+      ))
+    )
+
+    for (log <- testLinkIRErrors(classDefs, MainTestModuleInitializers)) yield {
+      log.assertContainsError(
+          "Expression tree has type NoType")
+      log.assertContainsError(
+          "Invalid expression tree")
+    }
+  }
+
 }
 
 object IRCheckerTest {

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -110,6 +110,17 @@ object TestIRBuilder {
   def mainModuleInitializers(moduleClassName: String): List[ModuleInitializer] =
     ModuleInitializer.mainMethodWithArgs(moduleClassName, "main") :: Nil
 
+  val JSObjectLikeClass = ClassName("JSObject")
+
+  val JSObjectLikeClassDef: ClassDef = {
+    classDef(
+      JSObjectLikeClass,
+      kind = ClassKind.NativeJSClass,
+      superClass = Some(ObjectClass),
+      jsNativeLoadSpec = Some(JSNativeLoadSpec.Global("Object", Nil))
+    )
+  }
+
   implicit def string2LocalName(name: String): LocalName =
     LocalName(name)
   implicit def string2LabelName(name: String): LabelName =


### PR DESCRIPTION
Instead of a statement.

---

Currently [`IRCheckerTest`](https://github.com/scala-js/scala-js/blob/v1.5.1/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala) is limited to fairly intricate issues. It is very, very far from being exhaustive. Is it worth adding a test for this? Should we say that every new or fixed rule in `IRChecker` needs to have appropriate tests from now on?