### PR TITLE
CLA check: URL-encode the PR author.

### DIFF
--- a/ci/check-cla.sh
+++ b/ci/check-cla.sh
@@ -3,7 +3,8 @@ set -eux
 
 AUTHOR=$GITHUB_ACTOR
 echo "Pull request submitted by $AUTHOR";
-signed=$(curl -s https://www.lightbend.com/contribute/cla/scala/check/$AUTHOR | jq -r ".signed");
+URL_AUTHOR=$(jq -rn --arg x "$AUTHOR" '$x|@uri')
+signed=$(curl -s "https://www.lightbend.com/contribute/cla/scala/check/$URL_AUTHOR" | jq -r ".signed");
 if [ "$signed" = "true" ] ; then
   echo "CLA check for $AUTHOR successful";
 else


### PR DESCRIPTION
This allows the CLA check to process usernames such as `dependabot[bot]`. The existing CLA checker that we call considers that this user has signed the CLA, so this is enough to make our CLA check accept PRs from that bot.

---

With this change, we get the following execution:
```
$ GITHUB_ACTOR=dependabot[bot] ./ci/check-cla.sh
+ AUTHOR='dependabot[bot]'
+ echo 'Pull request submitted by dependabot[bot]'
Pull request submitted by dependabot[bot]
++ jq -rn --arg x 'dependabot[bot]' '$x|@uri'
+ URL_AUTHOR=dependabot%5Bbot%5D
++ curl -s https://www.lightbend.com/contribute/cla/scala/check/dependabot%5Bbot%5D
++ jq -r .signed
+ signed=true
+ '[' true = true ']'
+ echo 'CLA check for dependabot[bot] successful'
CLA check for dependabot[bot] successful
```