### PR TITLE
Fix #4496: Add js.import.meta to access ES2020's `import.meta`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -4967,6 +4967,10 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           val arg = genArgs1
           js.JSImportCall(arg)
 
+        case JS_IMPORT_META =>
+          // js.import.meta
+          js.JSImportMeta()
+
         case DYNAMIC_IMPORT =>
           assert(args.size == 1,
               s"Expected exactly 1 argument for JS primitive $code but got " +

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -95,6 +95,7 @@ trait JSDefinitions {
     lazy val JSImportModule = getRequiredModule("scala.scalajs.js.import")
     lazy val JSImportModuleClass = JSImportModule.moduleClass
       lazy val JSImport_apply = getMemberMethod(JSImportModuleClass, nme.apply)
+      lazy val JSImport_meta = getMemberMethod(JSImportModuleClass, newTermName("meta"))
 
     lazy val SpecialPackageModule = getPackageObject("scala.scalajs.js.special")
       lazy val Special_strictEquals = getMemberMethod(SpecialPackageModule, newTermName("strictEquals"))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
@@ -46,9 +46,10 @@ abstract class JSPrimitives {
 
   final val UNITVAL = JS_NATIVE + 1 // () value, which is undefined
 
-  final val JS_IMPORT = UNITVAL + 1 // js.import.apply(specifier)
+  final val JS_IMPORT = UNITVAL + 1        // js.import.apply(specifier)
+  final val JS_IMPORT_META = JS_IMPORT + 1 // js.import.meta
 
-  final val CONSTRUCTOROF = JS_IMPORT + 1                              // runtime.constructorOf(clazz)
+  final val CONSTRUCTOROF = JS_IMPORT_META + 1                         // runtime.constructorOf(clazz)
   final val CREATE_INNER_JS_CLASS = CONSTRUCTOROF + 1                  // runtime.createInnerJSClass
   final val CREATE_LOCAL_JS_CLASS = CREATE_INNER_JS_CLASS + 1          // runtime.createLocalJSClass
   final val WITH_CONTEXTUAL_JS_CLASS_VALUE = CREATE_LOCAL_JS_CLASS + 1 // runtime.withContextualJSClassValue
@@ -93,6 +94,7 @@ abstract class JSPrimitives {
     addPrimitive(BoxedUnit_UNIT, UNITVAL)
 
     addPrimitive(JSImport_apply, JS_IMPORT)
+    addPrimitive(JSImport_meta, JS_IMPORT_META)
 
     addPrimitive(Runtime_constructorOf, CONSTRUCTOROF)
     addPrimitive(Runtime_createInnerJSClass, CREATE_INNER_JS_CLASS)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -393,6 +393,9 @@ object Hashers {
           mixTag(TagJSImportCall)
           mixTree(arg)
 
+        case JSImportMeta() =>
+          mixTag(TagJSImportMeta)
+
         case LoadJSConstructor(className) =>
           mixTag(TagLoadJSConstructor)
           mixName(className)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -638,6 +638,9 @@ object Printers {
           print(arg)
           print(')')
 
+        case JSImportMeta() =>
+          print("import.meta")
+
         case LoadJSConstructor(className) =>
           print("constructorOf[")
           print(className)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -448,6 +448,9 @@ object Serializers {
           writeTagAndPos(TagJSImportCall)
           writeTree(arg)
 
+        case JSImportMeta() =>
+          writeTagAndPos(TagJSImportMeta)
+
         case LoadJSConstructor(className) =>
           writeTagAndPos(TagLoadJSConstructor)
           writeName(className)
@@ -1146,6 +1149,7 @@ object Serializers {
           JSSuperMethodCall(readTree(), readTree(), readTree(), readTreeOrJSSpreads())
         case TagJSSuperConstructorCall => JSSuperConstructorCall(readTreeOrJSSpreads())
         case TagJSImportCall         => JSImportCall(readTree())
+        case TagJSImportMeta         => JSImportMeta()
         case TagLoadJSConstructor    => LoadJSConstructor(readClassName())
         case TagLoadJSModule         => LoadJSModule(readClassName())
         case TagJSDelete             => JSDelete(readTree(), readTree())

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -114,6 +114,10 @@ private[ir] object Tags {
 
   final val TagClone = TagApplyDynamicImport + 1
 
+  // New in 1.6
+
+  final val TagJSImportMeta = TagClone + 1
+
   // Tags for member defs
 
   final val TagFieldDef = 1

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -217,8 +217,8 @@ object Transformers {
         // Trees that need not be transformed
 
         case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic | _:SelectJSNativeMember |
-            _:LoadJSConstructor | _:LoadJSModule  | _:JSLinkingInfo |
-            _:Literal | _:VarRef | _:This | _:JSGlobalRef | _:Transient  =>
+            _:LoadJSConstructor | _:LoadJSModule | _:JSImportMeta  | _:JSLinkingInfo |
+            _:Literal | _:VarRef | _:This | _:JSGlobalRef  =>
           tree
       }
     }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -221,8 +221,8 @@ object Traversers {
       // Trees that need not be traversed
 
       case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic | _:SelectJSNativeMember |
-          _:LoadJSConstructor | _:LoadJSModule | _:JSLinkingInfo | _:Literal |
-          _:VarRef | _:This | _:JSGlobalRef =>
+          _:LoadJSConstructor | _:LoadJSModule | _:JSImportMeta | _:JSLinkingInfo |
+          _:Literal | _:VarRef | _:This | _:JSGlobalRef =>
     }
 
     def traverseClassDef(tree: ClassDef): Unit = {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -655,6 +655,19 @@ object Trees {
     val tpe = AnyType // it is a JavaScript Promise
   }
 
+  /** JavaScript meta-property `import.meta`.
+   *
+   *  This form is its own node, rather than using something like
+   *  {{{
+   *  JSSelect(JSImport(), StringLiteral("meta"))
+   *  }}}
+   *  because `import` is not a first-class term in JavaScript. `import.meta`
+   *  is a dedicated syntactic form that cannot be dissociated.
+   */
+  sealed case class JSImportMeta()(implicit val pos: Position) extends Tree {
+    val tpe = AnyType
+  }
+
   /** Loads the constructor of a JS class (native or not).
    *
    *  `className` must represent a non-trait JS class (native or not).

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -667,6 +667,10 @@ class PrintersTest {
     assertPrintEquals("""import("foo.js")""", JSImportCall(StringLiteral("foo.js")))
   }
 
+  @Test def printJSImportMeta(): Unit = {
+    assertPrintEquals("import.meta", JSImportMeta())
+  }
+
   @Test def printLoadJSConstructor(): Unit = {
     assertPrintEquals("constructorOf[Test]", LoadJSConstructor("Test"))
   }

--- a/library/src/main/scala/scala/scalajs/js/import.scala
+++ b/library/src/main/scala/scala/scalajs/js/import.scala
@@ -15,16 +15,18 @@ package scala.scalajs.js
 import scala.scalajs.js
 
 /** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
- *  Dynamic `import(specifier)`.
- *
- *  This is an object rather than a simple `def` to reserve the possibility to
- *  add "fields" to the function, notably to support the `import.meta`
- *  meta-property of ECMAScript (still being specified).
+ *  Dynamic `import(specifier)` and meta-property `import.meta`.
  */
 object `import` { // scalastyle:ignore
   /** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
    *  Dynamic `import(specifier)`.
    */
   def apply[A <: js.Any](specifier: String): js.Promise[A] =
+    throw new java.lang.Error("stub")
+
+  /** <span class="badge badge-ecma2020" style="float: right;">ECMAScript 2020</span>
+   *  Meta-property `import.meta`.
+   */
+  def meta: js.Dynamic =
     throw new java.lang.Error("stub")
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -200,6 +200,8 @@ object Analysis {
 
   final case class DynamicImportWithoutModuleSupport(from: From) extends Error
 
+  final case class ImportMetaWithoutESModule(from: From) extends Error
+
   sealed trait From
   final case class FromMethod(methodInfo: MethodInfo) extends From
   final case class FromClass(classInfo: ClassInfo) extends From
@@ -257,6 +259,8 @@ object Analysis {
         moduleIDs.map(_.id).mkString("[", ", ", "]")
       case DynamicImportWithoutModuleSupport(_) =>
         "Uses dynamic import but module support is disabled"
+      case ImportMetaWithoutESModule(_) =>
+        "Uses import.meta with a module kind other than ESModule"
     }
 
     logger.log(level, headMsg)

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1348,6 +1348,10 @@ private final class Analyzer(config: CommonPhaseConfig,
             .foreach(addLoadSpec(externalDependencies, _))
       }
     }
+
+    if (data.accessedImportMeta && config.coreSpec.moduleKind != ModuleKind.ESModule) {
+      _errors += ImportMetaWithoutESModule(from)
+    }
   }
 
   @tailrec

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -89,13 +89,14 @@ object Infos {
       val accessedModules: List[ClassName],
       val usedInstanceTests: List[ClassName],
       val accessedClassData: List[ClassName],
-      val referencedClasses: List[ClassName]
+      val referencedClasses: List[ClassName],
+      val accessedImportMeta: Boolean
   )
 
   object ReachabilityInfo {
     val Empty: ReachabilityInfo = {
       new ReachabilityInfo(Map.empty, Map.empty, Map.empty, Map.empty,
-          Map.empty, Map.empty, Map.empty, Nil, Nil, Nil, Nil, Nil)
+          Map.empty, Map.empty, Map.empty, Nil, Nil, Nil, Nil, Nil, false)
     }
   }
 
@@ -158,6 +159,7 @@ object Infos {
     private val usedInstanceTests = mutable.Set.empty[ClassName]
     private val accessedClassData = mutable.Set.empty[ClassName]
     private val referencedClasses = mutable.Set.empty[ClassName]
+    private var accessedImportMeta = false
 
     def addPrivateJSFieldUsed(cls: ClassName, field: FieldName): this.type = {
       privateJSFieldsUsed.getOrElseUpdate(cls, mutable.Set.empty) += field
@@ -306,6 +308,11 @@ object Infos {
       this
     }
 
+    def addAccessImportMeta(): this.type = {
+      accessedImportMeta = true
+      this
+    }
+
     def result(): ReachabilityInfo = {
       def toMapOfLists[A, B](m: mutable.Map[A, mutable.Set[B]]): Map[A, List[B]] =
         m.map(kv => kv._1 -> kv._2.toList).toMap
@@ -322,7 +329,8 @@ object Infos {
           accessedModules = accessedModules.toList,
           usedInstanceTests = usedInstanceTests.toList,
           accessedClassData = accessedClassData.toList,
-          referencedClasses = referencedClasses.toList
+          referencedClasses = referencedClasses.toList,
+          accessedImportMeta = accessedImportMeta
       )
     }
   }
@@ -563,6 +571,9 @@ object Infos {
 
             case JSPrivateSelect(qualifier, className, field) =>
               builder.addPrivateJSFieldUsed(className, field.name)
+
+            case JSImportMeta() =>
+              builder.addAccessImportMeta()
 
             case LoadJSConstructor(className) =>
               builder.addInstantiatedClass(className)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1341,6 +1341,8 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           allowSideEffects && test(superClass) && test(qualifier) && test(item)
         case JSImportCall(arg) =>
           allowSideEffects && test(arg)
+        case JSImportMeta() =>
+          allowSideEffects
         case LoadJSModule(_) =>
           allowSideEffects
         case JSGlobalRef(_) =>
@@ -2752,6 +2754,9 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
 
         case JSImportCall(arg) =>
           js.ImportCall(transformExprNoChar(arg))
+
+        case JSImportMeta() =>
+          js.ImportMeta()
 
         case LoadJSConstructor(className) =>
           extractWithGlobals(genJSClassConstructor(className))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -377,6 +377,9 @@ object Printers {
           print(arg)
           print(')')
 
+        case ImportMeta()  =>
+          print("import.meta")
+
         case Spread(items) =>
           print("...")
           print(items)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -249,6 +249,9 @@ object Trees {
   sealed case class ImportCall(arg: Tree)(implicit val pos: Position)
       extends Tree
 
+  /** Meta-property `import.meta`. */
+  sealed case class ImportMeta()(implicit val pos: Position) extends Tree
+
   /** `...items`, the "spread" operator of ECMAScript 6.
    *
    *  It is only valid in ECMAScript 6, in the `args`/`items` of a [[New]],

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -1090,6 +1090,8 @@ private final class IRChecker(unit: LinkingUnit, logger: Logger) {
       case JSImportCall(arg) =>
         typecheckExpr(arg, env)
 
+      case JSImportMeta() =>
+
       case LoadJSConstructor(className) =>
         val clazz = lookupClass(className)
         val valid = clazz.kind match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -653,7 +653,7 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       // Trees that need not be transformed
 
       case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic |
-          _:SelectJSNativeMember | _:LoadJSConstructor | _:LoadJSModule |
+          _:SelectJSNativeMember | _:JSImportMeta | _:LoadJSConstructor | _:LoadJSModule |
           _:JSLinkingInfo | _:JSGlobalRef | _:JSTypeOfGlobalRef | _:Literal =>
         tree
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -778,6 +778,7 @@ object AnalyzerTest {
       if kind != ModuleKind.NoModule
     } yield {
       val analysis = computeAnalysis(classDefs,
+          moduleInitializers = moduleInitializers,
           config = StandardConfig().withModuleKind(kind))
       analysis.map(moduleTest(_))
     }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1905,7 +1905,9 @@ object Build {
         includeIf(testDir / "require-multi-modules",
             hasModules && !linkerConfig.closureCompiler) :::
         includeIf(testDir / "require-dynamic-import",
-            moduleKind == ModuleKind.ESModule) // this is an approximation that works for now
+            moduleKind == ModuleKind.ESModule) ::: // this is an approximation that works for now
+        includeIf(testDir / "require-esmodule",
+            moduleKind == ModuleKind.ESModule)
       },
 
       unmanagedResourceDirectories in Test ++= {

--- a/test-suite/js/src/test/require-esmodule/org/scalajs/testsuite/jsinterop/ImportMetaTest.scala
+++ b/test-suite/js/src/test/require-esmodule/org/scalajs/testsuite/jsinterop/ImportMetaTest.scala
@@ -1,0 +1,32 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.Platform._
+
+class ImportMetaTest {
+  @Test def testImportMeta(): Unit = {
+    val meta = js.`import`.meta
+    assertEquals("object", js.typeOf(meta))
+
+    assertSame(meta, js.`import`.meta)
+
+    if (executingInNodeJS)
+      assertEquals("string", js.typeOf(meta.url))
+  }
+}


### PR DESCRIPTION
Since in ECMAScript, `import.meta` is a dedicated syntactic form, we add a new IR node for this meta-property. We make it accessible at the language level through
```scala
js.`import`.meta
```
It is a linking error to reference `import.meta` when the module kind is not `ESModule`, since attempting to use it in a Script results in an early SyntaxError.