### PR TITLE
Upgrade to GCC v20210601.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -927,7 +927,7 @@ object Build {
     commonLinkerSettings _
   ).settings(
       libraryDependencies ++= Seq(
-          "com.google.javascript" % "closure-compiler" % "v20210406",
+          "com.google.javascript" % "closure-compiler" % "v20210601",
           "com.google.jimfs" % "jimfs" % "1.1" % "test"
       ) ++ (
           parallelCollectionsDependencies(scalaVersion.value)


### PR DESCRIPTION
JSModule was renamed to JSChunk.

Number nodes cannot contain NaNs, Infinities nor negative values anymore. Instead, we have to create NAME nodes for `NaN` and `Infinity`, and NEG nodes for negative values.