### PR TITLE
Use sbt 1.5.4 and Scala 3.0.0 final for the Scala 3.x scripted tests.

### DIFF
--- a/sbt-plugin/src/sbt-test/scala3/basic/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/basic/build.sbt
@@ -1,10 +1,10 @@
 enablePlugins(ScalaJSPlugin)
 
-scalaVersion := "3.0.0-M1"
+scalaVersion := "3.0.0"
 
-// Test withDottyCompat for %%% dependencies
+// Test CrossVersion.for3Use2_13 for %%% dependencies
 libraryDependencies +=
-  ("org.scala-js" %%% "scalajs-ir" % scalaJSVersion).withDottyCompat(scalaVersion.value)
+  ("org.scala-js" %%% "scalajs-ir" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
 
 scalaJSUseMainModuleInitializer := true
 

--- a/sbt-plugin/src/sbt-test/scala3/basic/project/build.properties
+++ b/sbt-plugin/src/sbt-test/scala3/basic/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.2
+sbt.version=1.5.4

--- a/sbt-plugin/src/sbt-test/scala3/basic/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/basic/project/plugins.sbt
@@ -1,4 +1,3 @@
 val scalaJSVersion = sys.props("plugin.version")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")

--- a/sbt-plugin/src/sbt-test/scala3/junit/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/junit/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalaJSPlugin, ScalaJSJUnitPlugin)
 
-scalaVersion := "3.0.0-M1"
+scalaVersion := "3.0.0"
 
 // Work around #4368
 ThisBuild / useCoursier := false

--- a/sbt-plugin/src/sbt-test/scala3/junit/project/build.properties
+++ b/sbt-plugin/src/sbt-test/scala3/junit/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.2
+sbt.version=1.5.4

--- a/sbt-plugin/src/sbt-test/scala3/junit/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/junit/project/plugins.sbt
@@ -1,4 +1,3 @@
 val scalaJSVersion = sys.props("plugin.version")
 
 addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
-addSbtPlugin("ch.epfl.lamp" % "sbt-dotty" % "0.4.5")


### PR DESCRIPTION
Drop sbt-dotty, since its functionality has been absorbed by sbt 1.5.x itself.