### PR TITLE
Fix #4368: Revert "Work around #4368: Disable coursier in the scripted tests using sbt 1.4.x."

### DIFF
--- a/sbt-plugin/src/sbt-test/scala3/basic/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/basic/build.sbt
@@ -7,6 +7,3 @@ libraryDependencies +=
   ("org.scala-js" %%% "scalajs-ir" % scalaJSVersion).cross(CrossVersion.for3Use2_13)
 
 scalaJSUseMainModuleInitializer := true
-
-// Work around #4368
-ThisBuild / useCoursier := false

--- a/sbt-plugin/src/sbt-test/scala3/junit/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/junit/build.sbt
@@ -1,6 +1,3 @@
 enablePlugins(ScalaJSPlugin, ScalaJSJUnitPlugin)
 
 scalaVersion := "3.0.0"
-
-// Work around #4368
-ThisBuild / useCoursier := false


### PR DESCRIPTION
This reverts commit 8ad2dce29c4c1c639e3d7a6e1a0f1c46f69fde63.

It seems we managed to fix the issue in b44f23179260e000db8e1d065fed9271b7b92717 by using the `COURSIER_CACHE` environment variable, rather than an option to sbt.

---

~~Draft for now to see if it actually works on the CI.~~