### PR TITLE
Fix #4515: Implement java.util.concurrent.atomic.LongAdder 

### DIFF
--- a/javalib/src/main/scala/java/util/concurrent/atomic/LongAdder.scala
+++ b/javalib/src/main/scala/java/util/concurrent/atomic/LongAdder.scala
@@ -1,0 +1,55 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util.concurrent.atomic
+
+import java.io.Serializable
+
+class LongAdder extends Number with Serializable {
+  private[this] var value: Long = 0L
+
+  final def add(x: Long): Unit =
+    value = value + x
+
+  final def increment(): Unit =
+    value = value + 1
+
+  final def decrement(): Unit =
+    value = value - 1
+
+  final def sum(): Long =
+    value
+
+  final def reset(): Unit =
+    value = 0
+
+  final def sumThenReset(): Long = {
+    val result = value
+    reset()
+    result
+  }
+
+  override def toString(): String =
+    String.valueOf(value)
+
+  final def longValue(): Long =
+    value
+
+  final def intValue(): Int =
+    value.toInt
+
+  final def floatValue(): Float =
+    value.toFloat
+
+  final def doubleValue(): Double =
+    value.toDouble
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/atomic/LongAdderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/atomic/LongAdderTest.scala
@@ -1,0 +1,103 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util.concurrent.atomic
+
+import org.junit.Test
+import org.junit.Assert._
+
+class LongAdderTest {
+
+  @Test def longAdderIncrementTest(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    assertEquals(0L, value.sum())
+    value.increment()
+    assertEquals(1L, value.sum())
+    value.increment()
+    assertEquals(2L, value.sum())
+  }
+
+  @Test def longAdderDecrementTest(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    assertEquals(0L, value.sum())
+    value.increment()
+    value.increment()
+    value.increment()
+    assertEquals(3L, value.sum())
+    value.decrement()
+    assertEquals(2L, value.sum())
+    value.decrement()
+    assertEquals(1L, value.sum())
+  }
+
+  @Test def longAdderLongValue(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    value.add(100L)
+    assertEquals(100L, value.longValue())
+    value.add(100L)
+    assertEquals(200L, value.longValue())
+  }
+
+  @Test def longAdderIntValue(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    value.add(10)
+    assertEquals(10, value.intValue())
+    value.add(10)
+    assertEquals(20, value.intValue())
+  }
+
+  @Test def longAdderFloatValue(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    value.add(10)
+    assertEquals(10f, value.floatValue(), 0)
+    value.add(10)
+    assertEquals(20f, value.floatValue(), 0)
+  }
+
+  @Test def longAdderDoubleValue(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    value.add(10)
+    assertEquals(10d, value.doubleValue(), 0)
+    value.add(10)
+    assertEquals(20d, value.doubleValue(), 0)
+  }
+
+  @Test def longAdderReset(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    value.add(10)
+    assertEquals(10, value.sum())
+    value.reset()
+    assertEquals(0, value.sum())
+  }
+
+  @Test def longAdderAdd(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    value.add(10)
+    assertEquals(10, value.sum())
+    value.add(0)
+    assertEquals(10, value.sum())
+  }
+
+  @Test def longAdderSumThenReset(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    value.add(10)
+    val res = value.sumThenReset()
+    assertEquals(0, value.sum())
+    assertEquals(10, res)
+  }
+
+  @Test def longAdderToString(): Unit = {
+    val value = new java.util.concurrent.atomic.LongAdder
+    value.add(10)
+    assertEquals("10", value.toString())
+  }
+}


### PR DESCRIPTION
Naive implementation of [java.util.concurrent.atomic.LongAdder](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/atomic/LongAdder.html)
Fix #4515.