### PR TITLE
Setup for scalafmt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,10 @@ target/
 /linker-interface/**/scalajs-logging-src-jars/
 /node_modules/
 
+# script generated
+scripts/.coursier
+scripts/.scalafmt*
+
 # IDE specific
 .cache
 .classpath

--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,0 +1,28 @@
+# Overall we are trying to use default settings to the
+# maximum extent possible. Removing non-default
+# settings is preferred over adding especially as
+# the Scala language evolves and styles change.
+# Test upgrades: $ scripts/scalafmt --test 2> diff.txt
+version = "3.0.0-RC5"
+docstrings.style = AsteriskSpace
+project.git = true
+project.excludePaths = [
+  "glob:**/scalalib/**",
+  "glob:**/project/**"
+]
+# This creates less of a diff but is not default
+# but is more aligned with Scala.js syntax.
+newlines.beforeCurlyLambdaParams = multilineWithCaseOnly
+
+# Keep control sites more streamlined
+indent.ctrlSite = 4
+danglingParentheses.ctrlSite = false
+
+# default value is 10,000
+# Message about NirGenExpr.scala goes away between 18k and 20k
+runner.optimizer.maxVisitsPerToken = 20000
+rewriteTokens = {
+  "⇒": "=>"
+  "→": "->"
+  "←": "<-"
+}

--- a/scripts/scalafmt
+++ b/scripts/scalafmt
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -e
+
+HERE="`dirname $0`"
+VERSION="3.0.0-RC5"
+COURSIER="$HERE/.coursier"
+SCALAFMT="$HERE/.scalafmt-$VERSION"
+
+if [ ! -f $COURSIER ]; then
+  curl -L -o $COURSIER https://git.io/coursier-cli
+  chmod +x $COURSIER
+fi
+
+if [ ! -f $SCALAFMT ]; then
+  $COURSIER bootstrap org.scalameta:scalafmt-cli_2.13:$VERSION --main org.scalafmt.cli.Cli -o $SCALAFMT
+  chmod +x $SCALAFMT
+fi
+
+$SCALAFMT "$@"


### PR DESCRIPTION
A lot of changes but not too bad I don't think. `scalafmt` is very strict about line length, for comments too. The trailing paren is new but I think that is more consistent with how braces are aligned anyway and much closer to Scala 3 style.

The project dir is omitted because of a `maxVisit` thing plus the builds get lots of changes.

Diff: [diff.txt](https://github.com/scala-js/scala-js/files/6756209/diff.txt)

Just a consideration - same format as Scala Native.
