### PR TITLE
Avoid using the (?m) flag in the regexes in linker-interface.

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ReportToLinkerOutputAdapter.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ReportToLinkerOutputAdapter.scala
@@ -151,7 +151,10 @@ object ReportToLinkerOutputAdapter {
     }
   }
 
-  private val sourceMapRe = """(?m)^//# sourceMappingURL=.*$""".r
+  /* This regex would normally be written with the (?m) flag, but that would
+   * require ES2018, so we work around it.
+   */
+  private val sourceMapRe = """(?:^|\n)(//# sourceMappingURL=[^\n]*)(?:\n|$)""".r
 
   /** Patches the JS file content to have the provided source map link (or none)
    *
@@ -170,14 +173,14 @@ object ReportToLinkerOutputAdapter {
     } { reMatch =>
       val res = new StringBuilder
 
-      res.append(reMatch.before)
+      res.append(reMatch.before(1))
 
       /* If there is no source map link, keep an empty line to not break a
        * potential (unlinked) source map
        */
       newLine.foreach(res.append(_))
 
-      res.append(reMatch.after)
+      res.append(reMatch.after(1))
 
       res.toString()
     }
@@ -193,7 +196,7 @@ object ReportToLinkerOutputAdapter {
    * So as a legacy mechanism, this is OK-ish. It keeps us from having to build
    * the infrastructure to parse JSON cross platform.
    */
-  private val fileFieldRe = """(?m)([,{])\s*"file"\s*:\s*".*"\s*([,}])""".r
+  private val fileFieldRe = """([,{])\s*"file"\s*:\s*"[^"]*"\s*([,}])""".r
 
   /** Patches the source map content to have the provided JS file link (or none).
    *

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -869,9 +869,6 @@ object Build {
 
         fileSet.toSeq.filter(_.getPath().endsWith(".scala"))
       }.taskValue,
-
-      // Required for the regex (?m) flag in ReportToLinkerOutputAdapter.scala
-      scalaJSLinkerConfig ~= { _.withESFeatures(_.withESVersion(ESVersion.ES2018)) },
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
       library, irProjectJS, jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test",
   )
@@ -1045,9 +1042,6 @@ object Build {
           Seq(output)
         }.taskValue,
       },
-
-      // Required for the regex (?m) flag in ReportToLinkerOutputAdapter.scala
-      scalaJSLinkerConfig ~= { _.withESFeatures(_.withESVersion(ESVersion.ES2018)) },
 
       scalaJSLinkerConfig in Test ~= (_.withModuleKind(ModuleKind.CommonJSModule))
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(


### PR DESCRIPTION
The `(?m)` flag required ES2018. Avoiding it allows the linker-interface (and linker) to work with earlier versions of ECMAScript.

The regex `fileFieldRe` used the `(?m)` but for no purpose. We just remove it.

The regex `sourceMapRe` did use the properties of `(?m)` for `^` and `$`. We use `(?:^|\n)` and `(?:\n|$)` instead, and adjust the code using the regex to account for the potential extra `\n`'s that are matched.

While we are there, we fix potential performance issues in those two regexes. We replace `.*x` by `[^x]*x` to avoid excessive backtracking.