### PR TITLE
Fix #3563: Add config for a header comment to add to .js files.

### DIFF
--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigTest.scala
@@ -1,0 +1,118 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.interface
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.function.ThrowingRunnable
+
+class StandardConfigTest {
+  @Test
+  def jsHeader(): Unit = {
+    def testValid(header: String): Unit = {
+      assertTrue(header, StandardConfig.isValidJSHeader(header))
+      assertEquals(header, StandardConfig().withJSHeader(header).jsHeader)
+    }
+
+    def testInvalid(header: String): Unit = {
+      assertFalse(header, StandardConfig.isValidJSHeader(header))
+      assertThrows(classOf[IllegalArgumentException], new ThrowingRunnable {
+        def run(): Unit = StandardConfig().withJSHeader(header)
+      })
+    }
+
+    // Valid whitespace
+    testValid("")
+    testValid("  \n")
+    testValid("  \t  \n")
+    testValid("\ufeff  \n")
+    testValid("  \u00a0 \n")
+    testValid("  \u3000  \n")
+    testValid("  \n \t \n")
+
+    // Missing \n at the end of whitespace
+    testInvalid("  ")
+    testInvalid("\t")
+    testInvalid("\ufeff")
+
+    // Invalid tokens
+    testInvalid("foo\n")
+    testInvalid("/a\n")
+    testInvalid("/\n")
+    testInvalid("/")
+    testInvalid("α") // U+03B1 α Greek Small Letter Alpha
+    testInvalid("\uD834\uDD1E") // U+1D11E 𝄞 Musical Symbol G Clef
+    testInvalid("\uD834")
+    testInvalid("\uDD1E")
+
+    // Invalid newlines outside comments
+    testInvalid("  \r  \n")
+    testInvalid("  \r\n  \n")
+    testInvalid("  \u000B  \n")
+    testInvalid("  \u000C  \n")
+    testInvalid("  \u2028  \n")
+    testInvalid("  \u2029  \n")
+
+    // Invalid newlines inside comments
+    testInvalid("/*  \r  */\n")
+    testInvalid("/*  \r\n  */\n")
+    testInvalid("/*  \u000B  */\n")
+    testInvalid("/*  \u000C  */\n")
+    testInvalid("/*  \u2028  */\n")
+    testInvalid("/*  \u2029  */\n")
+
+    // Valid single-line comments
+    testValid("//\n")
+    testValid("// foo\n")
+    testValid("// foo\tbar\n")
+    testValid("// one\n// two\n")
+    testValid("  \t // foo\n")
+    testValid("// α\n") // U+03B1 α Greek Small Letter Alpha
+    testValid("// \uD834\uDD1E\n") // U+1D11E 𝄞 Musical Symbol G Clef
+
+    // Invalid single-line comments
+    testInvalid("//")
+    testInvalid("// foo")
+    testInvalid("// foo\nbar\n")
+    testInvalid("// \uD834\n")
+    testInvalid("// \uDD1E\n")
+
+    // Valid multi-line comments
+    testValid("/**/\n")
+    testValid("/* foo bar */\n")
+    testValid("/* foo\n * bar */\n")
+    testValid("/* α */\n") // U+03B1 α Greek Small Letter Alpha
+    testValid("/* \uD834\uDD1E */\n") // U+1D11E 𝄞 Musical Symbol G Clef
+
+    // Invalid multi-line comments
+    testInvalid("/**/")
+    testInvalid("/*\n")
+    testInvalid("/*")
+    testInvalid("/* foo\n")
+    testInvalid("/* /* foo */ */\n") // multi-line comments do not nest
+    testInvalid("/*/\n")
+    testInvalid("/* \uD834 */\n")
+    testInvalid("/* \uDD1E */\n")
+
+    // Valid combination
+    testValid("  // foo\n\t/* foo bar\nbaz hello\n*/\n/**///foo\n")
+
+    // Invalid combination
+    testInvalid(" ! // foo\n\t/* foo bar\nbaz hello\n*/\n/**///foo\n")
+    testInvalid("  // foo\n!\t/* foo bar\nbaz hello\n*/\n/**///foo\n")
+    testInvalid("  // foo\n\t/* foo bar\nbaz hello\n*/!\n/**///foo\n")
+    testInvalid("  // foo\n\t/* foo bar\nbaz hello\n*/\n/**/!//foo\n")
+    testInvalid("  // foo\n\t/* foo bar\nbaz hello\n*/\n/**//!/foo\n")
+    testInvalid("  // foo\n\t/* foo bar\nbaz hello\n*/\n/**///foo\n!")
+  }
+}

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -53,6 +53,7 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
 
   private[this] val emitter = {
     val emitterConfig = Emitter.Config(config.commonConfig.coreSpec)
+      .withJSHeader(config.jsHeader)
       .withOptimizeBracketSelects(false)
       .withTrackAllGlobalRefs(true)
       .withInternalModulePattern(m => OutputPatternsImpl.moduleName(config.outputPatterns, m.id))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -35,6 +35,7 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
 
   private[this] val emitter = {
     val emitterConfig = Emitter.Config(config.commonConfig.coreSpec)
+      .withJSHeader(config.jsHeader)
       .withInternalModulePattern(m => OutputPatternsImpl.moduleName(config.outputPatterns, m.id))
 
     new Emitter(emitterConfig)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/LinkerBackendImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/LinkerBackendImpl.scala
@@ -19,7 +19,7 @@ import java.net.URI
 import org.scalajs.logging.Logger
 
 import org.scalajs.linker._
-import org.scalajs.linker.interface.OutputPatterns
+import org.scalajs.linker.interface.{OutputPatterns, StandardConfig}
 import org.scalajs.linker.standard._
 
 /** A backend of the Scala.js linker.
@@ -45,6 +45,8 @@ object LinkerBackendImpl {
   final class Config private (
       /** Common phase config. */
       val commonConfig: CommonPhaseConfig,
+      /** A header that will be added at the top of generated .js files. */
+      val jsHeader: String,
       /** Whether to emit a source map. */
       val sourceMap: Boolean,
       /** Name patterns for output. */
@@ -63,6 +65,7 @@ object LinkerBackendImpl {
     private def this() = {
       this(
           commonConfig = CommonPhaseConfig(),
+          jsHeader = "",
           sourceMap = true,
           outputPatterns = OutputPatterns.Defaults,
           relativizeSourceMapBase = None,
@@ -73,6 +76,11 @@ object LinkerBackendImpl {
 
     def withCommonConfig(commonConfig: CommonPhaseConfig): Config =
       copy(commonConfig = commonConfig)
+
+    def withJSHeader(jsHeader: String): Config = {
+      require(StandardConfig.isValidJSHeader(jsHeader), jsHeader)
+      copy(jsHeader = jsHeader)
+    }
 
     def withSourceMap(sourceMap: Boolean): Config =
       copy(sourceMap = sourceMap)
@@ -94,13 +102,14 @@ object LinkerBackendImpl {
 
     private def copy(
         commonConfig: CommonPhaseConfig = commonConfig,
+        jsHeader: String = jsHeader,
         sourceMap: Boolean = sourceMap,
         outputPatterns: OutputPatterns = outputPatterns,
         relativizeSourceMapBase: Option[URI] = relativizeSourceMapBase,
         closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
         prettyPrint: Boolean = prettyPrint,
         maxConcurrentWrites: Int = maxConcurrentWrites): Config = {
-      new Config(commonConfig, sourceMap, outputPatterns,
+      new Config(commonConfig, jsHeader, sourceMap, outputPatterns,
           relativizeSourceMapBase, closureCompilerIfAvailable, prettyPrint,
           maxConcurrentWrites)
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -93,7 +93,7 @@ final class Emitter(config: Emitter.Config) {
           } else {
             ""
           }
-          maybeTopLevelVarDecls + "(function(){\n"
+          config.jsHeader + maybeTopLevelVarDecls + "(function(){\n"
         }
 
         val footer = "}).call(this);\n"
@@ -101,7 +101,7 @@ final class Emitter(config: Emitter.Config) {
         new Result(header, body, footer, topLevelVars, globalRefs)
 
       case ModuleKind.ESModule | ModuleKind.CommonJSModule =>
-        new Result("", body, "", Nil, globalRefs)
+        new Result(config.jsHeader, body, "", Nil, globalRefs)
     }
   }
 
@@ -718,6 +718,7 @@ object Emitter {
       val semantics: Semantics,
       val moduleKind: ModuleKind,
       val esFeatures: ESFeatures,
+      val jsHeader: String,
       val internalModulePattern: ModuleID => String,
       val optimizeBracketSelects: Boolean,
       val trackAllGlobalRefs: Boolean
@@ -730,6 +731,7 @@ object Emitter {
           semantics,
           moduleKind,
           esFeatures,
+          jsHeader = "",
           internalModulePattern = "./" + _.id,
           optimizeBracketSelects = true,
           trackAllGlobalRefs = false)
@@ -744,6 +746,11 @@ object Emitter {
     def withESFeatures(f: ESFeatures => ESFeatures): Config =
       copy(esFeatures = f(esFeatures))
 
+    def withJSHeader(jsHeader: String): Config = {
+      require(StandardConfig.isValidJSHeader(jsHeader), jsHeader)
+      copy(jsHeader = jsHeader)
+    }
+
     def withInternalModulePattern(internalModulePattern: ModuleID => String): Config =
       copy(internalModulePattern = internalModulePattern)
 
@@ -757,11 +764,12 @@ object Emitter {
         semantics: Semantics = semantics,
         moduleKind: ModuleKind = moduleKind,
         esFeatures: ESFeatures = esFeatures,
+        jsHeader: String = jsHeader,
         internalModulePattern: ModuleID => String = internalModulePattern,
         optimizeBracketSelects: Boolean = optimizeBracketSelects,
         trackAllGlobalRefs: Boolean = trackAllGlobalRefs): Config = {
-      new Config(semantics, moduleKind, esFeatures, internalModulePattern,
-          optimizeBracketSelects, trackAllGlobalRefs)
+      new Config(semantics, moduleKind, esFeatures, jsHeader,
+          internalModulePattern, optimizeBracketSelects, trackAllGlobalRefs)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerBackend.scala
@@ -19,6 +19,7 @@ object StandardLinkerBackend {
   def apply(config: StandardConfig): LinkerBackend = {
     val backendConfig = LinkerBackendImpl.Config()
       .withCommonConfig(CommonPhaseConfig.fromStandardConfig(config))
+      .withJSHeader(config.jsHeader)
       .withSourceMap(config.sourceMap)
       .withOutputPatterns(config.outputPatterns)
       .withRelativizeSourceMapBase(config.relativizeSourceMapBase)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1695,6 +1695,16 @@ object Build {
       name := "Reversi - Scala.js example",
       moduleName := "reversi",
 
+      scalaJSLinkerConfig ~= {
+        _.withJSHeader(
+          """
+            |/* The Scala.js Reversi demo
+            | * with a header to check that source maps take it into account.
+            | */
+          """.stripMargin.trim() + "\n"
+        )
+      },
+
       MyScalaJSPlugin.expectedSizes := {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
@@ -1707,10 +1717,10 @@ object Build {
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 782000 to 783000,
+                fastLink = 783000 to 784000,
                 fullLink = 150000 to 151000,
                 fastLinkGz = 92000 to 93000,
-                fullLinkGz = 36000 to 37000,
+                fullLinkGz = 37000 to 38000,
             ))
 
           case Default2_13ScalaVersion =>
@@ -1956,6 +1966,16 @@ object Build {
 
       scalaJSLinkerConfig ~= { _.withSemantics(TestSuiteLinkerOptions.semantics _) },
       scalaJSModuleInitializers in Test ++= TestSuiteLinkerOptions.moduleInitializers,
+
+      scalaJSLinkerConfig ~= {
+        _.withJSHeader(
+          """
+            |/* The Scala.js test suite
+            | * with a header to check that source maps take it into account.
+            | */
+          """.stripMargin.trim() + "\n"
+        )
+      },
 
       /* The script that calls setExportsNamespaceForExportsTest to provide
        * ExportsTest with a loopback reference to its own exports namespace.


### PR DESCRIPTION
This commits adds a new setting in `StandardConfig` to specify a header comment to prepend to the generated .js files. It can be set in sbt with
```scala
scalaJSLinkerConfig ~= { _.withJSHeader("// foo\n") }
```
The header must satisfy the following properties:

* It must contain only valid JavaScript comments and whitespace.
* It cannot contain Unicode new line characters except NL ('\n').
* If non-empty, it must end with a new line.

This ensures that the generated code is still valid, and that the `jsHeader` option cannot be abused to insert JavaScript code that breaks the linker's abstractions.

As discussed on the issue, if someone *really* wants to insert a shebang line in their generated .js file, it is possible to insert an empty line with `withJSHeader("\n")`, and then post-process the .js file to replace that empty line with a shebang line. That would preserve the line numbers in the source maps.

---

I manually tested the source map tests for the Reversi in fastOpt and fullOpt (2.12 only), as described in TESTING.md