### PR TITLE
Add constants for ES2021 in ESVersion and LinkingInfo.ESVersion.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -443,6 +443,7 @@ def allESVersions = [
   "ES2018",
   // "ES2019", // We do not use anything specifically from ES2019
   "ES2020"
+  // "ES2021", // We do not use anything specifically from ES2021
 ]
 
 // The 'quick' matrix

--- a/library/src/main/scala/scala/scalajs/LinkingInfo.scala
+++ b/library/src/main/scala/scala/scalajs/LinkingInfo.scala
@@ -281,5 +281,15 @@ object LinkingInfo {
      *  - `import.meta`
      */
     final val ES2020 = 11
+
+    /** ECMAScript 2021 (12th edition).
+     *
+     *  Contains the following notable features:
+     *
+     *  - `WeakRef` and `FinalizationRegistry`
+     *  - `AggregateError`
+     *  - Separators for numeric literals (e.g., `1_000`)
+     */
+    final val ES2021 = 12
   }
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESVersion.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ESVersion.scala
@@ -86,6 +86,16 @@ object ESVersion {
    */
   val ES2020: ESVersion = new ESVersion(11, "ECMAScript 2020")
 
+  /** ECMAScript 2021 (12th edition).
+   *
+   *  Contains the following notable features:
+   *
+   *  - `WeakRef` and `FinalizationRegistry`
+   *  - `AggregateError`
+   *  - Separators for numeric literals (e.g., `1_000`)
+   */
+  val ES2021: ESVersion = new ESVersion(12, "ECMAScript 2021")
+
   private[interface] implicit object ESVersionFingerprint
       extends Fingerprint[ESVersion] {
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkingInfoTest.scala
@@ -45,5 +45,6 @@ class LinkingInfoTest {
     assertEquals(9, ESVersion.ES2018)
     assertEquals(10, ESVersion.ES2019)
     assertEquals(11, ESVersion.ES2020)
+    assertEquals(12, ESVersion.ES2021)
   }
 }


### PR DESCRIPTION
ECMAScript 2021, the 12th edition, was published in June 2021.