### PR TITLE
Fix #3843: Allow Match nodes to be used for string switches.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -18,7 +18,7 @@ import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
     current = "1.7.0-SNAPSHOT",
-    binaryEmitted = "1.6"
+    binaryEmitted = "1.7-SNAPSHOT"
 )
 
 /** Helper class to allow for testing of logic. */

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1087,7 +1087,7 @@ object Serializers {
         case TagThrow    => Throw(readTree())
         case TagMatch    =>
           Match(readTree(), List.fill(readInt()) {
-            (readTrees().map(_.asInstanceOf[IntLiteral]), readTree())
+            (readTrees().map(_.asInstanceOf[MatchableLiteral]), readTree())
           }, readTree())(readType())
         case TagDebugger => Debugger()
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1663,7 +1663,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               val newCases = {
                 for {
                   (values, body) <- cases
-                  newValues = values.map(v => js.IntLiteral(v.value)(v.pos))
+                  newValues = values.map(transformExprNoChar(_))
                   // add the break statement
                   newBody = js.Block(
                       pushLhsInto(newLhs, body, tailPosLabels),


### PR DESCRIPTION
We only allow selectors of type `int` or `java.lang.String`, and
only allow alternatives that int, string, or null literals. The
Scaladoc of `Match` explains the rationale.

---

Old description:

It's a bit ugly because:
* We have to disallow any selector that *could* be a -0.0, otherwise it would erroneously be matched by an `IntLiteral(0)`
* In practice we only need to use `IntLiteral`, `StringLiteral` and `Null`, and have selectors of type `IntType` or `java.lang.String`
* But in theory we can also deal with `BooleanLiteral`s and `Undefined`

Probably we should only allows ints and strings, though. Given the problem with -0.0, I don't think allowing other stuff is meaningful.