### PR TITLE
Fix #3953: Patch the types of ParamDefs to match their method signature.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -870,6 +870,27 @@ class RegressionTest {
     assertEquals("lazily always", ex2.getMessage())
   }
 
+  @Test def paramDefWithWrongTypeWithHKTAndTypeAliases_Issue3953(): Unit = {
+    assumeFalse("Scala/JVM 2.11.x produces wrong bytecode for this test",
+        Platform.executingInJVM && Platform.scalaVersion.startsWith("2.11."))
+
+    import scala.language.higherKinds
+
+    sealed class StreamT[M[_]](val step: M[Step[StreamT[M]]])
+
+    sealed abstract class Step[S]
+
+    def mustMatch[A](actual: A)(f: PartialFunction[A, Boolean]): Boolean =
+      f.applyOrElse(actual, (_: Any) => false)
+
+    type Id[A] = A
+
+    val result = mustMatch(new StreamT[Id](null).step) {
+      case _ => true
+    }
+    assertTrue(result)
+  }
+
 }
 
 object RegressionTest {


### PR DESCRIPTION
In some rare cases that involve Higher Kinded Types and type aliases, scalac produces DefDef's whose params' types do not match the method type. This is filed upstream as scala/bug#11884

We work around the issue by patching a posteriori the types of `js.ParamDef`s and their `js.VarRef`s to match the type advertised by the method type.

In the entire test suite, the only method that requires a patch is the `PartialFunction`'s `applyOrElse` in the newly added test case.