### PR TITLE
Fix #3918: Record names of mutated fields instead of symbols.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -891,6 +891,20 @@ class RegressionTest {
     assertTrue(result)
   }
 
+  @Test
+  def traitMixinInLocalLazyVal_Issue3918(): Unit = {
+    trait TraitMixedInLocalLazyVal {
+      val foo = "foobar"
+    }
+
+    lazy val localLazyVal = {
+      class ClassExtendsTraitInLocalLazyVal extends TraitMixedInLocalLazyVal
+      val obj = new ClassExtendsTraitInLocalLazyVal
+      obj.foo
+    }
+    assertEquals("foobar", localLazyVal)
+  }
+
 }
 
 object RegressionTest {


### PR DESCRIPTION
The analysis in the issue shows that scalac generates different symbols for the same field in rare situations: one in the class info decls, and another one in the trees. This was a problem for our `unexpectedMutatedField` handling.

We work around this issue by storing the *names* of the mutated fields, instead of their symbols. By only doing that for fields in the current class, we ensure that it remains non ambiguous. In addition, we store the names of all mutated fields, not only the ones that were not "suspected" to be mutable; in 2.13, the symbol in the trees is correctly marked as mutable but not the one in the class decls.