### PR TITLE
Introducing `WeakNoModule`

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -117,6 +117,15 @@ def Tasks = [
         ++$scala helloworld$v/run \
         helloworld$v/clean &&
     sbtretry ++$scala \
+        'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withModuleKind(ModuleKind.WeakNoModule))' \
+        helloworld$v/run \
+        helloworld$v/clean &&
+    sbtretry ++$scala \
+        'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withModuleKind(ModuleKind.WeakNoModule))' \
+        'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallestModules))' \
+        helloworld$v/run \
+        helloworld$v/clean &&
+    sbtretry ++$scala \
         'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         helloworld$v/run \
         helloworld$v/clean &&
@@ -214,6 +223,16 @@ def Tasks = [
     sbtretry 'set scalacOptions in $testSuite.v$v += "-Xexperimental"' \
         'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.WeakNoModule))' \
+        ++$scala $testSuite$v/test &&
+    sbtretry \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.WeakNoModule))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallestModules))' \
+        ++$scala $testSuite$v/test &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.WeakNoModule))' \
+        'set scalaJSStage in Global := FullOptStage' \
+        ++$scala $testSuite$v/test \
+        $testSuite$v/clean &&
     sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         ++$scala $testSuite$v/test &&
     sbtretry \
@@ -305,6 +324,19 @@ def Tasks = [
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
     sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion).withAllowBigIntsForLongs(true)).withOptimizer(false))' \
+        ++$scala $testSuite$v/test \
+        $testSuite$v/clean &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.WeakNoModule))' \
+        ++$scala $testSuite$v/test &&
+    sbtretry \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallestModules))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.WeakNoModule))' \
+        ++$scala $testSuite$v/test &&
+    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.WeakNoModule))' \
+        'set scalaJSStage in Global := FullOptStage' \
         ++$scala $testSuite$v/test \
         $testSuite$v/clean &&
     sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleKind.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/ModuleKind.scala
@@ -24,6 +24,7 @@ object ModuleKind {
    */
   val All: List[ModuleKind] = List(
       NoModule,
+      WeakNoModule,
       ESModule,
       CommonJSModule)
 
@@ -34,6 +35,16 @@ object ModuleKind {
    *  Imports are not supported.
    */
   case object NoModule extends ModuleKind
+
+  /** Weak No module structure.
+   *
+   *  With this module kind, exports are stored on the global object.
+   *
+   *  Imports are not supported.
+   *
+   *  Analyzer ignores all modules warnings.
+   */
+  case object WeakNoModule extends ModuleKind
 
   /** An ECMAScript 2015 module.
    *
@@ -55,6 +66,7 @@ object ModuleKind {
     override def fingerprint(moduleKind: ModuleKind): String = {
       moduleKind match {
         case NoModule       => "NoModule"
+        case WeakNoModule   => "WeakNoModule"
         case ESModule       => "ESModule"
         case CommonJSModule => "CommonJSModule"
       }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Report.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Report.scala
@@ -114,6 +114,7 @@ object Report {
         case ModuleKind.NoModule       => 0
         case ModuleKind.ESModule       => 1
         case ModuleKind.CommonJSModule => 2
+        case ModuleKind.WeakNoModule   => 3
       }
       writeByte(i)
     }
@@ -150,6 +151,7 @@ object Report {
         case 0 => ModuleKind.NoModule
         case 1 => ModuleKind.ESModule
         case 2 => ModuleKind.CommonJSModule
+        case 3 => ModuleKind.WeakNoModule
         case v => throw new IllegalArgumentException(s"unknown module byte: $v")
       }
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -1129,7 +1129,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       exportedValue: js.Tree)(
       implicit pos: Position): WithGlobals[js.Tree] = {
     moduleKind match {
-      case ModuleKind.NoModule =>
+      case ModuleKind.NoModule | ModuleKind.WeakNoModule =>
         genAssignToNoModuleExportVar(exportName, exportedValue)
 
       case ModuleKind.ESModule =>
@@ -1170,7 +1170,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     val varScope = (className, field.name)
 
     moduleKind match {
-      case ModuleKind.NoModule =>
+      case ModuleKind.NoModule | ModuleKind.WeakNoModule =>
         /* Initial value of the export. Updates are taken care of explicitly
          * when we assign to the static field.
          */

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -79,7 +79,7 @@ final class Emitter(config: Emitter.Config) {
     val WithGlobals(body, globalRefs) = emitInternal(moduleSet, logger)
 
     moduleKind match {
-      case ModuleKind.NoModule =>
+      case ModuleKind.NoModule | ModuleKind.WeakNoModule=>
         assert(moduleSet.modules.size <= 1)
         val topLevelVars = moduleSet.modules
           .headOption.toList
@@ -308,7 +308,7 @@ final class Emitter(config: Emitter.Config) {
     ).toList.sortBy(_._1.name)
 
     moduleKind match {
-      case ModuleKind.NoModule =>
+      case ModuleKind.NoModule | ModuleKind.WeakNoModule =>
         WithGlobals(Nil)
 
       case ModuleKind.ESModule =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1439,7 +1439,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               transformExpr(rhs, lhs.tpe))
           lhs match {
             case SelectStatic(className, FieldIdent(field))
-                if moduleKind == ModuleKind.NoModule =>
+                if (moduleKind == ModuleKind.NoModule || moduleKind == ModuleKind.WeakNoModule) =>
               val mirrors =
                 globalKnowledge.getStaticFieldMirrors(className, field)
               mirrors.foldLeft(base) { (prev, mirror) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -139,7 +139,7 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
 
   private def computeStaticFieldMirrors(
       moduleSet: ModuleSet): Map[ClassName, Map[FieldName, List[String]]] = {
-    if (config.moduleKind != ModuleKind.NoModule) {
+    if (config.moduleKind != ModuleKind.NoModule && config.moduleKind != ModuleKind.WeakNoModule) {
       Map.empty
     } else {
       var result = Map.empty[ClassName, Map[FieldName, List[String]]]

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -460,7 +460,7 @@ private[emitter] final class SJSGen(
 
       case irt.JSNativeLoadSpec.ImportWithGlobalFallback(importSpec, globalSpec) =>
         moduleKind match {
-          case ModuleKind.NoModule =>
+          case ModuleKind.NoModule | ModuleKind.WeakNoModule =>
             genLoadJSFromSpec(globalSpec, keepOnlyDangerousVarNames)
           case ModuleKind.ESModule | ModuleKind.CommonJSModule =>
             genLoadJSFromSpec(importSpec, keepOnlyDangerousVarNames)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -159,7 +159,7 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
       val moduleName = config.internalModulePattern(moduleID)
 
       val moduleTree = config.moduleKind match {
-        case ModuleKind.NoModule =>
+        case ModuleKind.NoModule | ModuleKind.WeakNoModule =>
           /* If we get here, it means that what we are trying to import is in a
            * different module than the module we're currently generating
            * (otherwise we'd take the other branch of `foldSameModule`). But
@@ -274,7 +274,7 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
       WithGlobals(tree)
     } else {
       val export = config.moduleKind match {
-        case ModuleKind.NoModule =>
+        case ModuleKind.NoModule | ModuleKind.WeakNoModule =>
           throw new AssertionError("non-public module in NoModule mode")
 
         case ModuleKind.ESModule =>

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -728,7 +728,7 @@ object AnalyzerTest {
       implicit ec: ExecutionContext): Future[Unit] = {
 
     testForEachModuleKind(classDefs, moduleInitializers) { (kind, analysis) =>
-      if (kind == ModuleKind.NoModule)
+      if (kind == ModuleKind.NoModule || kind == ModuleKind.WeakNoModule)
         scriptTest(analysis)
       else
         moduleTest(analysis)

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -465,6 +465,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
 
         mainModule.moduleKind match {
           case ModuleKind.NoModule       => Input.Script(path)
+          case ModuleKind.WeakNoModule   => Input.Script(path)
           case ModuleKind.ESModule       => Input.ESModule(path)
           case ModuleKind.CommonJSModule => Input.CommonJSModule(path)
         }

--- a/sbt-plugin/src/sbt-test/linker/custom-linker/custom-linker/src/main/scala/customlinker/EntryPointAnalyzerBackend.scala
+++ b/sbt-plugin/src/sbt-test/linker/custom-linker/custom-linker/src/main/scala/customlinker/EntryPointAnalyzerBackend.scala
@@ -18,7 +18,7 @@ final class EntryPointAnalyzerBackend(linkerConfig: StandardConfig,
     entryPointOutputFile: Path)
     extends LinkerBackend  {
 
-  require(linkerConfig.moduleKind != ModuleKind.NoModule,
+  require(linkerConfig.moduleKind != ModuleKind.NoModule || linkerConfig.moduleKind != ModuleKind.WeakNoModule,
       s"linkerConfig.moduleKind was ${linkerConfig.moduleKind}")
 
   private val standard = StandardLinkerBackend(linkerConfig)


### PR DESCRIPTION
The idea behind `WeakNoModule` is quite simple: let force `Analyzer` to ignore checking of used modules from `.sjsir` which is linking.

It might be required when someone is tried to use inside web-project a library which is universal and has checking to loading used modules like `ws` in runtime.

Without `WeakNoModule` this project can't be linked because it fails at linking stage with error like:
```
[error] BlaBla needs to be imported from module 'xxx' but module support is disabled
```