### PR TITLE
Allow delegating JS Class constructor calls with default params

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -692,7 +692,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
       }
     }
 
-    private def genCallDefaultGetter(sym: Symbol, paramIndex: Int,
+    def genCallDefaultGetter(sym: Symbol, paramIndex: Int,
         paramPos: Position, static: Boolean, captures: List[js.Tree])(
         previousArgsValues: Int => List[js.Tree])(
         implicit pos: Position): js.Tree = {

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/NonNativeJSTypeTest.scala
@@ -844,20 +844,6 @@ class NonNativeJSTypeTest extends DirectTest with TestHelpers {
     """
   }
 
-  @Test
-  def noCallOtherConstructorsWithLeftOutDefaultParams: Unit = {
-    """
-    class A(x: Int, y: String = "default") extends js.Object {
-      def this() = this(12)
-    }
-    """ hasErrors
-    """
-      |newSource1.scala:6: error: Implementation restriction: in a JS class, a secondary constructor calling another constructor with default parameters must provide the values of all parameters.
-      |      def this() = this(12)
-      |          ^
-    """
-  }
-
   @Test // #4511
   def noConflictingProperties: Unit = {
     """

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NestedJSClassTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NestedJSClassTest.scala
@@ -436,6 +436,10 @@ class NestedJSClassTest {
     // Check that we do not create two companion modules.
     new container.InnerJSClassDefaultParams_Issue4465()()
     assertEquals(1, container.moduleSideEffect)
+
+    // Check constructor delegation.
+    val inner2 = new container.InnerJSClassDefaultParams_Issue4465(1)
+    assertEquals("container 1 1 foo", inner2.foo())
   }
 
   @Test def defaultCtorParamsInnerJSClassTraitContainer_Issue4465(): Unit = {
@@ -449,6 +453,10 @@ class NestedJSClassTest {
     // Check that we do not create two companion modules.
     new container.InnerJSClassDefaultParams_Issue4465()()
     assertEquals(1, container.moduleSideEffect)
+
+    // Check constructor delegation.
+    val inner2 = new container.InnerJSClassDefaultParams_Issue4465(1)
+    assertEquals("container 1 1 foo", inner2.foo())
   }
 
   @Test def defaultCtorParamsInnerJSClassJSContainer_Issue4465(): Unit = {
@@ -467,6 +475,10 @@ class NestedJSClassTest {
 
     // Check that we do not create two companion modules.
     assertEquals(1, container.moduleSideEffect)
+
+    // Check constructor delegation.
+    val inner2 = new container.InnerJSClassDefaultParams_Issue4465(1)
+    assertEquals("container 1 1 foo", inner2.foo())
   }
 
   @Test def defaultCtorParamsInnerJSClassPrivateCompanion_Issue4526(): Unit = {
@@ -696,6 +708,8 @@ object NestedJSClassTest {
 
     class InnerJSClassDefaultParams_Issue4465(withDefault: String = "inner")(
         dependentDefault: String = withDefault) extends js.Object {
+      def this(x: Int) = this(x.toString)()
+
       def foo(methodDefault: String = "foo"): String =
         s"$xxx $withDefault $dependentDefault $methodDefault"
     }
@@ -739,6 +753,8 @@ object NestedJSClassTest {
 
     class InnerJSClassDefaultParams_Issue4465(withDefault: String = "inner")(
         dependentDefault: String = withDefault) extends js.Object {
+      def this(x: Int) = this(x.toString)()
+
       def foo(methodDefault: String = "foo"): String =
         s"$xxx $withDefault $dependentDefault $methodDefault"
     }
@@ -846,6 +862,8 @@ object NestedJSClassTest {
 
     class InnerJSClassDefaultParams_Issue4465(withDefault: String = "inner")(
         dependentDefault: String = withDefault) extends js.Object {
+      def this(x: Int) = this(x.toString)()
+
       def foo(methodDefault: String = "foo"): String =
         s"$xxx $withDefault $dependentDefault $methodDefault"
     }

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/NonNativeJSTypeTest.scala
@@ -1018,6 +1018,14 @@ class NonNativeJSTypeTest {
     assertEquals(7, baz10.bar)
   }
 
+  @Test def secondaryConstructorUseDefaultParam(): Unit = {
+    val a = new SecondaryConstructorUseDefaultParam(1)
+    assertEquals(a.y, "1y")
+
+    val b = new SecondaryConstructorUseDefaultParam()()
+    assertEquals(b.y, "xy")
+  }
+
   @Test def polytypeNullaryMethod_Issue2445(): Unit = {
     class PolyTypeNullaryMethod extends js.Object {
       def emptyArray[T]: js.Array[T] = js.Array()
@@ -2001,6 +2009,10 @@ object NonNativeJSTypeTest {
     }
     def this(a: String, x: String, b: String = "", y: String = "") =
       this((a + b).length, (x + y).length)
+  }
+
+  class SecondaryConstructorUseDefaultParam(x: String = "x")(val y: String = x + "y") extends js.Object {
+    def this(x: Int) = this(x.toString())()
   }
 
   class SimpleConstructorAutoFields(val x: Int, var y: Int) extends js.Object {


### PR DESCRIPTION
Previously this was not allowed, since implementing it was
difficult. After the refactoring of the JS Class constrcutor call
generation (8093f28876f84111287fbe2b86c0ec602195445b), implementing
this is not hard anymore, so we lift the implementation restriction.