### PR TITLE
Fix #4545: Add empty definitions of j.l.constant.{Constable,ConstantDesc}.

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Boolean.scala
+++ b/javalanglib/src/main/scala/java/lang/Boolean.scala
@@ -12,13 +12,16 @@
 
 package java.lang
 
+import java.lang.constant.Constable
+
 import scala.scalajs.js
 
 /* This is a hijacked class. Its instances are primitive booleans.
  * Constructors are not emitted.
  */
 final class Boolean private ()
-    extends AnyRef with java.io.Serializable with Comparable[Boolean] {
+    extends AnyRef with java.io.Serializable with Comparable[Boolean]
+    with Constable {
 
   def this(value: scala.Boolean) = this()
   def this(v: String) = this()

--- a/javalanglib/src/main/scala/java/lang/Byte.scala
+++ b/javalanglib/src/main/scala/java/lang/Byte.scala
@@ -12,12 +12,15 @@
 
 package java.lang
 
+import java.lang.constant.Constable
+
 import scala.scalajs.js
 
 /* This is a hijacked class. Its instances are primitive numbers.
  * Constructors are not emitted.
  */
-final class Byte private () extends Number with Comparable[Byte] {
+final class Byte private ()
+    extends Number with Comparable[Byte] with Constable {
 
   def this(value: scala.Byte) = this()
   def this(s: String) = this()

--- a/javalanglib/src/main/scala/java/lang/Character.scala
+++ b/javalanglib/src/main/scala/java/lang/Character.scala
@@ -15,6 +15,7 @@ package java.lang
 import scala.annotation.{tailrec, switch}
 import scala.scalajs.js
 
+import java.lang.constant.Constable
 import java.util.{ArrayList, Arrays, HashMap}
 
 /* This is a hijacked class. Its instances are primitive chars.
@@ -26,7 +27,8 @@ import java.util.{ArrayList, Arrays, HashMap}
  * Constructors are not emitted.
  */
 class Character private ()
-    extends AnyRef with java.io.Serializable with Comparable[Character] {
+    extends AnyRef with java.io.Serializable with Comparable[Character]
+    with Constable {
 
   def this(value: scala.Char) = this()
 

--- a/javalanglib/src/main/scala/java/lang/Double.scala
+++ b/javalanglib/src/main/scala/java/lang/Double.scala
@@ -12,12 +12,15 @@
 
 package java.lang
 
+import java.lang.constant.{Constable, ConstantDesc}
+
 import scala.scalajs.js
 
 /* This is a hijacked class. Its instances are primitive numbers.
  * Constructors are not emitted.
  */
-final class Double private () extends Number with Comparable[Double] {
+final class Double private ()
+    extends Number with Comparable[Double] with Constable with ConstantDesc {
 
   def this(value: scala.Double) = this()
   def this(s: String) = this()

--- a/javalanglib/src/main/scala/java/lang/Float.scala
+++ b/javalanglib/src/main/scala/java/lang/Float.scala
@@ -12,6 +12,7 @@
 
 package java.lang
 
+import java.lang.constant.{Constable, ConstantDesc}
 import java.math.BigInteger
 
 import scala.scalajs.js
@@ -19,7 +20,8 @@ import scala.scalajs.js
 /* This is a hijacked class. Its instances are primitive numbers.
  * Constructors are not emitted.
  */
-final class Float private () extends Number with Comparable[Float] {
+final class Float private ()
+    extends Number with Comparable[Float] with Constable with ConstantDesc {
 
   def this(value: scala.Float) = this()
   def this(s: String) = this()

--- a/javalanglib/src/main/scala/java/lang/Integer.scala
+++ b/javalanglib/src/main/scala/java/lang/Integer.scala
@@ -12,12 +12,15 @@
 
 package java.lang
 
+import java.lang.constant.{Constable, ConstantDesc}
+
 import scala.scalajs.js
 
 /* This is a hijacked class. Its instances are primitive numbers.
  * Constructors are not emitted.
  */
-final class Integer private () extends Number with Comparable[Integer] {
+final class Integer private ()
+    extends Number with Comparable[Integer] with Constable with ConstantDesc {
 
   def this(value: scala.Int) = this()
   def this(s: String) = this()

--- a/javalanglib/src/main/scala/java/lang/Long.scala
+++ b/javalanglib/src/main/scala/java/lang/Long.scala
@@ -14,12 +14,16 @@ package java.lang
 
 import scala.annotation.{switch, tailrec}
 
+import java.lang.constant.{Constable, ConstantDesc}
+
 import scala.scalajs.js
 
 /* This is a hijacked class. Its instances are the representation of scala.Longs.
  * Constructors are not emitted.
  */
-final class Long private () extends Number with Comparable[Long] {
+final class Long private ()
+    extends Number with Comparable[Long] with Constable with ConstantDesc {
+
   def this(value: scala.Long) = this()
   def this(s: String) = this()
 

--- a/javalanglib/src/main/scala/java/lang/Short.scala
+++ b/javalanglib/src/main/scala/java/lang/Short.scala
@@ -12,10 +12,13 @@
 
 package java.lang
 
+import java.lang.constant.Constable
+
 /* This is a hijacked class. Its instances are primitive numbers.
  * Constructors are not emitted.
  */
-final class Short private () extends Number with Comparable[Short] {
+final class Short private ()
+    extends Number with Comparable[Short] with Constable {
 
   def this(value: scala.Short) = this()
   def this(s: String) = this()

--- a/javalanglib/src/main/scala/java/lang/_String.scala
+++ b/javalanglib/src/main/scala/java/lang/_String.scala
@@ -21,6 +21,7 @@ import scala.scalajs.js.annotation._
 import scala.scalajs.runtime.linkingInfo
 import scala.scalajs.LinkingInfo.ESVersion
 
+import java.lang.constant.{Constable, ConstantDesc}
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.util.Locale
@@ -38,7 +39,7 @@ import Utils.Implicits.enableJSStringOps
  */
 final class _String private () // scalastyle:ignore
     extends AnyRef with java.io.Serializable with Comparable[String]
-    with CharSequence {
+    with CharSequence with Constable with ConstantDesc {
 
   import _String._
 

--- a/javalanglib/src/main/scala/java/lang/constant/Constable.scala
+++ b/javalanglib/src/main/scala/java/lang/constant/Constable.scala
@@ -1,0 +1,20 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.lang.constant
+
+// scalastyle:off empty.class
+
+trait Constable {
+  // Cannot be implemented
+  //def describeConstable(): java.util.Optional[_ <: ConstantDesc]
+}

--- a/javalanglib/src/main/scala/java/lang/constant/ConstantDesc.scala
+++ b/javalanglib/src/main/scala/java/lang/constant/ConstantDesc.scala
@@ -1,0 +1,20 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.lang.constant
+
+// scalastyle:off empty.class
+
+trait ConstantDesc {
+  // Cannot be implemented
+  //def resolveConstantDesc(lookup: java.lang.invoke.MethodHandles.Lookup): Object
+}

--- a/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
+++ b/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
@@ -39,8 +39,7 @@ import scala.annotation.tailrec
 
 /** Emulates a Long on the JavaScript platform. */
 @inline
-final class RuntimeLong(val lo: Int, val hi: Int)
-    extends java.lang.Number with java.lang.Comparable[java.lang.Long] {
+final class RuntimeLong(val lo: Int, val hi: Int) {
   a =>
 
   import RuntimeLong._
@@ -72,22 +71,28 @@ final class RuntimeLong(val lo: Int, val hi: Int)
 
   // java.lang.Number
 
-  @inline override def byteValue(): Byte = toByte
-  @inline override def shortValue(): Short = toShort
+  @inline def byteValue(): Byte = toByte
+  @inline def shortValue(): Short = toShort
   @inline def intValue(): Int = toInt
   @inline def longValue(): Long = toLong
   @inline def floatValue(): Float = toFloat
   @inline def doubleValue(): Double = toDouble
 
-  // Comparisons and java.lang.Comparable interface
+  // java.lang.Comparable, including bridges
 
   @inline
-  def compareTo(b: RuntimeLong): Int =
-    RuntimeLong.compare(a.lo, a.hi, b.lo, b.hi)
+  def compareTo(that: Object): Int =
+    compareTo(that.asInstanceOf[RuntimeLong])
 
   @inline
   def compareTo(that: java.lang.Long): Int =
     compareTo(that.asInstanceOf[RuntimeLong])
+
+  // Comparisons
+
+  @inline
+  def compareTo(b: RuntimeLong): Int =
+    RuntimeLong.compare(a.lo, a.hi, b.lo, b.hi)
 
   @inline
   private def inline_equals(b: RuntimeLong): Boolean =

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -351,10 +351,8 @@ private[emitter] final class SJSGen(
     BoxedStringClass,
     BoxedDoubleClass,
     BoxedBooleanClass,
-    BoxedUnitClass
-  ) ::: (
-    if (useBigIntForLongs) List(BoxedLongClass) else Nil
-  ) ::: List(
+    BoxedUnitClass,
+    BoxedLongClass,
     BoxedCharacterClass
   )
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 186941,
-      expectedFullLinkSizeWithoutClosure = 174097,
-      expectedFullLinkSizeWithClosure = 31577,
+      expectedFastLinkSize = 187341,
+      expectedFullLinkSizeWithoutClosure = 174498,
+      expectedFullLinkSizeWithClosure = 31513,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1726,7 +1726,7 @@ object Build {
             Some(ExpectedSizes(
                 fastLink = 783000 to 784000,
                 fullLink = 150000 to 151000,
-                fastLinkGz = 91000 to 92000,
+                fastLinkGz = 92000 to 93000,
                 fullLinkGz = 37000 to 38000,
             ))
 
@@ -1799,6 +1799,7 @@ object Build {
         List(sharedTestDir / "scala", sharedTestDir / "require-scala2") :::
         collectionsEraDependentDirectory(scalaV, sharedTestDir) ::
         includeIf(sharedTestDir / "require-jdk11", javaV >= 11) :::
+        includeIf(sharedTestDir / "require-jdk15", javaV >= 15) :::
         includeIf(testDir / "require-2.12", isJSTest && isScalaAtLeast212) :::
         includeIf(testDir / "require-scala2", isJSTest)
       },

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1726,13 +1726,13 @@ object Build {
             Some(ExpectedSizes(
                 fastLink = 783000 to 784000,
                 fullLink = 150000 to 151000,
-                fastLinkGz = 92000 to 93000,
+                fastLinkGz = 91000 to 92000,
                 fullLinkGz = 37000 to 38000,
             ))
 
           case Default2_13ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 777000 to 778000,
+                fastLink = 778000 to 779000,
                 fullLink = 169000 to 170000,
                 fastLinkGz = 98000 to 99000,
                 fullLinkGz = 43000 to 44000,

--- a/project/MiniLib.scala
+++ b/project/MiniLib.scala
@@ -45,7 +45,12 @@ object MiniLib {
         "Serializable"
     ).map("java/io/" + _)
 
-    val allBaseNames = inJavaLang ::: inJavaIO
+    val inJavaLangConstant = List(
+        "Constable",
+        "ConstantDesc"
+    ).map("java/lang/constant/" + _)
+
+    val allBaseNames = inJavaLang ::: inJavaIO ::: inJavaLangConstant
 
     allBaseNames.flatMap(name => List(name + ".sjsir", name + "$.sjsir")).toSet
   }

--- a/test-suite/shared/src/test/require-jdk15/org/scalajs/testsuite/javalib/lang/ConstableTest.scala
+++ b/test-suite/shared/src/test/require-jdk15/org/scalajs/testsuite/javalib/lang/ConstableTest.scala
@@ -1,0 +1,42 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang.constant
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.lang.constant.Constable
+
+class ConstableTest {
+
+  @Test def knownConstables(): Unit = {
+    def test(expected: Boolean, value: Any): Unit = {
+      assertEquals("" + value, expected, value.isInstanceOf[Constable])
+    }
+
+    test(true, false)
+    test(true, 'A')
+    test(true, 5.toByte)
+    test(true, 300.toShort)
+    test(true, 100000)
+    test(true, 5L)
+    test(true, 1.5f)
+    test(true, 1.4)
+    test(true, "foo")
+
+    test(false, null)
+    test(false, ())
+    test(false, List(5))
+  }
+
+}

--- a/test-suite/shared/src/test/require-jdk15/org/scalajs/testsuite/javalib/lang/ConstantDescTest.scala
+++ b/test-suite/shared/src/test/require-jdk15/org/scalajs/testsuite/javalib/lang/ConstantDescTest.scala
@@ -1,0 +1,49 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang.constant
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.lang.constant.ConstantDesc
+
+import org.scalajs.testsuite.utils.Platform.executingInJVM
+
+class ConstantDescTest {
+
+  @Test def knownConstantDescs(): Unit = {
+    def test(expected: Boolean, value: Any): Unit =
+      assertEquals("" + value, expected, value.isInstanceOf[ConstantDesc])
+
+    test(true, 100000)
+    test(true, 5L)
+    test(true, 1.5f)
+    test(true, 1.4)
+    test(true, "foo")
+
+    // The following are transitively Integers, and therefore must be ConstantDescs
+    test(!executingInJVM, 5.toByte)
+    test(!executingInJVM, 300.toShort)
+
+    // Nevertheless, their j.l.Class'es do not extend ConstantDesc
+    assertFalse(classOf[ConstantDesc].isAssignableFrom(classOf[java.lang.Byte]))
+    assertFalse(classOf[ConstantDesc].isAssignableFrom(classOf[java.lang.Short]))
+
+    test(false, false)
+    test(false, 'A')
+    test(false, null)
+    test(false, ())
+    test(false, List(5))
+  }
+
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -905,6 +905,26 @@ class RegressionTest {
     assertEquals("foobar", localLazyVal)
   }
 
+  @Test
+  def inferConstableOrConstantDesc_Issue4545(): Unit = {
+    /* Depending on the JDK version used to compile this test, the types
+     * inferred for the arrays will change. On JDK 12+, they will involve
+     * Constable and/or ConstantDesc.
+     */
+
+    // On JDK 12+, both Constable and ConstantDesc
+    val b = Array("foo", java.lang.Integer.valueOf(5))
+    assertEquals(2, b.length)
+    assertEquals("foo", b(0))
+    assertEquals(5, b(1))
+
+    // On JDK 15+, both Constable but Boolean is not a ConstantDesc
+    val a = Array("foo", java.lang.Boolean.TRUE)
+    assertEquals(2, a.length)
+    assertEquals("foo", a(0))
+    assertEquals(true, a(1))
+  }
+
 }
 
 object RegressionTest {


### PR DESCRIPTION
We cannot implement the methods of these interfaces, so they are not declared.

---

Locally tested on a JDK 16. I have asked Fabien to install a JDK 15 on the CI machines, so that we can add that to the CI.