### PR TITLE
Fix #4548: Import modules from which a JS class' class data is accessed.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1043,8 +1043,13 @@ private final class Analyzer(config: CommonPhaseConfig,
     }
 
     def accessData()(implicit from: From): Unit = {
-      if (!isDataAccessed)
+      if (!isDataAccessed) {
         isDataAccessed = true
+
+        // #4548 The `isInstance` function will refer to the class value
+        if (kind == ClassKind.NativeJSClass)
+          jsNativeLoadSpec.foreach(addLoadSpec(externalDependencies, _))
+      }
     }
 
     def callMethod(methodName: MethodName)(implicit from: From): Unit = {

--- a/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ModulesTest.scala
+++ b/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ModulesTest.scala
@@ -104,6 +104,11 @@ class ModulesTest {
     val instance = new ChildOfNativeClass("Bob")
     assertEquals("Hello Bob", instance.x)
   }
+
+  @Test def testClassReferencedOnlyInClassData_Issue4548(): Unit = {
+    val cls = classOf[JSClassReferencedOnlyInClassData]
+    assertFalse(cls.isInstance(new js.Date()))
+  }
 }
 
 package object modulestestpackageobject {
@@ -197,4 +202,11 @@ object ModulesTest {
 
   class ChildOfNativeClass(name: String)
       extends NativeParentClass("Hello " + name)
+
+  // #4548 Test that a class referenced only in class data *is* imported.
+  @js.native
+  @JSImport(
+      "../test-classes/modules-test-referenced-only-in-classdata.js",
+      "JSClassReferencedOnlyInClassData")
+  class JSClassReferencedOnlyInClassData() extends js.Object
 }

--- a/test-suite/js/src/test/resources-commonjs/modules-test-referenced-only-in-classdata.js
+++ b/test-suite/js/src/test/resources-commonjs/modules-test-referenced-only-in-classdata.js
@@ -1,0 +1,4 @@
+function JSClassReferencedOnlyInClassData() {
+}
+
+exports.JSClassReferencedOnlyInClassData = JSClassReferencedOnlyInClassData;

--- a/test-suite/js/src/test/resources-esmodule/modules-test-referenced-only-in-classdata.js
+++ b/test-suite/js/src/test/resources-esmodule/modules-test-referenced-only-in-classdata.js
@@ -1,0 +1,2 @@
+export function JSClassReferencedOnlyInClassData() {
+}


### PR DESCRIPTION
The class data of a native JS class always reference the JS class value, in the generated `isInstance` function. We therefore need to mark the external dependencies as referenced when the class data is accessed.