### PR TITLE
Address two deprecation warnings in the latest 2.13.x.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -1135,8 +1135,8 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       case ModuleKind.ESModule =>
         val field = fileLevelVar("e", exportName)
         val let = js.Let(field.ident, mutable = true, Some(exportedValue))
-        val export = js.Export((field.ident -> js.ExportName(exportName)) :: Nil)
-        WithGlobals(js.Block(let, export))
+        val exportStat = js.Export((field.ident -> js.ExportName(exportName)) :: Nil)
+        WithGlobals(js.Block(let, exportStat))
 
       case ModuleKind.CommonJSModule =>
         globalRef("exports").map { exportsVarRef =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -273,7 +273,7 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
     if (moduleContext.public) {
       WithGlobals(tree)
     } else {
-      val export = config.moduleKind match {
+      val exportStat = config.moduleKind match {
         case ModuleKind.NoModule =>
           throw new AssertionError("non-public module in NoModule mode")
 
@@ -299,7 +299,7 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
           }
       }
 
-      export.map(Block(tree, _))
+      exportStat.map(Block(tree, _))
     }
   }
 


### PR DESCRIPTION
`export` becomes a keyword in Scala 3, so Scala 2.13.7 starts reporting a deprecation warning when we try to declare a value with that name.

Locally tested with ++2.13.7-bin-7247dfe.