### PR TITLE
Remove all uses of toIterable in code compiled with Scala 2.13.x.

### DIFF
--- a/junit-test/output-jvm/src/test/scala/org/scalajs/junit/utils/JUnitTestPlatformImpl.scala
+++ b/junit-test/output-jvm/src/test/scala/org/scalajs/junit/utils/JUnitTestPlatformImpl.scala
@@ -37,7 +37,7 @@ object JUnitTestPlatformImpl {
   }
 
   def writeLines(lines: List[String], file: String): Unit =
-    Files.write(Paths.get(file), lines.toIterable.asJava, UTF_8)
+    Files.write(Paths.get(file), (lines: Iterable[String]).asJava, UTF_8)
 
   def readLines(file: String): List[String] =
     Files.readAllLines(Paths.get(file), UTF_8).asScala.toList

--- a/sbt-plugin/src/sbt-test/linker/custom-linker/custom-linker/src/main/scala/customlinker/EntryPointAnalyzerBackend.scala
+++ b/sbt-plugin/src/sbt-test/linker/custom-linker/custom-linker/src/main/scala/customlinker/EntryPointAnalyzerBackend.scala
@@ -32,7 +32,7 @@ final class EntryPointAnalyzerBackend(linkerConfig: StandardConfig,
       implicit ec: ExecutionContext): Future[Report] = {
 
     val modules = moduleSet.modules.flatMap(_.externalDependencies).toSet
-    Files.write(entryPointOutputFile, modules.toIterable.asJava,
+    Files.write(entryPointOutputFile, (modules: Iterable[String]).asJava,
         StandardCharsets.UTF_8)
 
     standard.emit(moduleSet, output, logger)

--- a/scalalib/overrides-2.13/scala/Enumeration.scala
+++ b/scalalib/overrides-2.13/scala/Enumeration.scala
@@ -292,8 +292,8 @@ abstract class Enumeration (initial: Int) extends Serializable {
     override protected def fromSpecific(coll: IterableOnce[Value]) = ValueSet.fromSpecific(coll)
     override protected def newSpecificBuilder = ValueSet.newBuilder
 
-    def map(f: Value => Value): ValueSet = fromSpecific(new View.Map(toIterable, f))
-    def flatMap(f: Value => IterableOnce[Value]): ValueSet = fromSpecific(new View.FlatMap(toIterable, f))
+    def map(f: Value => Value): ValueSet = fromSpecific(new View.Map(this, f))
+    def flatMap(f: Value => IterableOnce[Value]): ValueSet = fromSpecific(new View.FlatMap(this, f))
 
     // necessary for disambiguation:
     override def map[B](f: Value => B)(implicit @implicitNotFound(ValueSet.ordMsg) ev: Ordering[B]): immutable.SortedSet[B] =


### PR DESCRIPTION
It will be deprecated in Scala 2.13.7.

See https://github.com/scala/scala/pull/9774 (not yet reviewed at the time of this writing)

After these changes, the only remaining uses of `.toIterable` are in code that is 2.11- or 2.12-specific:
```
$ git grep -w toIterable
library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala:    underlying.asInstanceOf[js.Map.Raw[K, V]].keys().toIterator.toIterable
scalalib/overrides-2.11/scala/collection/immutable/Range.scala:  override def toIterable = this
scalalib/overrides-2.12/scala/collection/immutable/Range.scala:  override def toIterable = this
```