### PR TITLE
Fix #4560: Explicitly redirect JS envs outputs to System.{out,err}.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -20,6 +20,9 @@ object BinaryIncompatibilities {
   )
 
   val TestAdapter = TestCommon ++ Seq(
+      // private[adapter], not an issue
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.testing.adapter.JSEnvRPC.this"),
   )
 
   val Library = Seq(

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/PipeOutputThread.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/PipeOutputThread.scala
@@ -1,0 +1,41 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.sbtplugin
+
+import scala.annotation.tailrec
+
+import java.io._
+
+private[sbtplugin] final class PipeOutputThread(from: InputStream, to: OutputStream) extends Thread {
+  override def run(): Unit = {
+    /* Copied from scala.sys.process.BasicIO.transferFully, except that we
+     * don't have the try/catch around `flush()` because we do not use this
+     * method for stdin (only for stdout and stderr).
+     */
+    try {
+      val buffer = new Array[Byte](8192)
+      @tailrec def loop(): Unit = {
+        val byteCount = from.read(buffer)
+        if (byteCount > 0) {
+          to.write(buffer, 0, byteCount)
+          to.flush()
+          loop()
+        }
+      }
+      loop()
+    } catch {
+      case _: InterruptedIOException => ()
+    }
+    from.close()
+  }
+}

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -21,6 +21,7 @@ import scala.concurrent.duration._
 import scala.util.{Failure, Success}
 import scala.util.control.NonFatal
 
+import java.io.{InputStream, OutputStream}
 import java.util.concurrent.atomic.AtomicReference
 
 import sbt._
@@ -553,10 +554,16 @@ private[sbtplugin] object ScalaJSPluginInternal {
 
         /* The list of threads that are piping output to System.out and
          * System.err. This is not an AtomicReference or any other thread-safe
-         * structure because the `onOutputStream` callback is always called
-         * within the thread that calls `env.start()`.
+         * structure because:
+         * - `onOutputStream` is guaranteed to be called exactly once, and
+         * - `pipeOutputThreads` is only read once the run is completed
+         *   (although the JSEnv interface does not explicitly specify that the
+         *   call to `onOutputStream must happen before that, anything else is
+         *   just plain unreasonable).
+         * We only mark it as `@volatile` to ensure that there is an
+         * appropriate memory barrier between writing to it and reading it back.
          */
-        var pipeOutputThreads: List[Thread] = Nil
+        @volatile var pipeOutputThreads: List[Thread] = Nil
 
         /* #4560 Explicitly redirect out/err to System.out/System.err, instead
          * of relying on `inheritOut` and `inheritErr`, so that streams
@@ -569,27 +576,31 @@ private[sbtplugin] object ScalaJSPluginInternal {
           .withInheritOut(false)
           .withInheritErr(false)
           .withOnOutputStream { (out, err) =>
-            for ((optInput, output) <- List(out -> System.out, err -> System.err)) {
-              for (input <- optInput) {
-                val pipeOutputThread = new PipeOutputThread(input, output)
-                pipeOutputThreads ::= pipeOutputThread
-                pipeOutputThread.start()
-              }
-            }
+            pipeOutputThreads = (
+              out.map(PipeOutputThread.start(_, System.out)).toList :::
+              err.map(PipeOutputThread.start(_, System.err)).toList
+            )
           }
 
-        val run = env.start(input, config)
+        try {
+          val run = env.start(input, config)
 
-        enhanceNotInstalledException(resolvedScoped.value, log) {
-          Await.result(run.future, Duration.Inf)
+          enhanceNotInstalledException(resolvedScoped.value, log) {
+            Await.result(run.future, Duration.Inf)
+          }
+        } finally {
+          /* Wait for the pipe output threads to be done, to make sure that we
+           * do not finish the `run` task before *all* output has been
+           * transferred to System.out and System.err.
+           * We do that in a `finally` block so that the stdout and stderr
+           * streams are propagated even if the run finishes with a failure.
+           * `join()` itself does not throw except if the current thread is
+           * interrupted, which is not supposed to happen (if it does happen,
+           * the interrupted exception will shadow any error from the run).
+           */
+          for (pipeOutputThread <- pipeOutputThreads)
+            pipeOutputThread.join()
         }
-
-        /* Wait for the pipe output threads to be done, to make sure that we
-         * do not finish the `run` task before *all* output has been
-         * transferred to System.out and System.err.
-         */
-        for (pipeOutputThread <- pipeOutputThreads)
-          pipeOutputThread.join()
       },
 
       runMain := {

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/JSEnvRPC.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/JSEnvRPC.scala
@@ -38,8 +38,8 @@ private[adapter] final class JSEnvRPC(
       .withInheritOut(false)
       .withInheritErr(false)
       .withOnOutputStream { (out, err) =>
-        out.foreach(o => new PipeOutputThread(o, System.out).start())
-        err.foreach(e => new PipeOutputThread(e, System.err).start())
+        out.foreach(o => PipeOutputThread.start(o, System.out))
+        err.foreach(e => PipeOutputThread.start(e, System.err))
       }
 
     jsenv.startWithCom(input, runConfig, handleMessage)

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/JSEnvRPC.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/JSEnvRPC.scala
@@ -15,14 +15,35 @@ package org.scalajs.testing.adapter
 import scala.concurrent.ExecutionContext
 
 import org.scalajs.jsenv._
+import org.scalajs.logging.Logger
 import org.scalajs.testing.common._
 
 /** RPC Core for use with a [[JSEnv]]. */
 private[adapter] final class JSEnvRPC(
-    jsenv: JSEnv, input: Seq[Input], config: RunConfig)(
+    jsenv: JSEnv, input: Seq[Input], logger: Logger)(
     implicit ec: ExecutionContext) extends RPCCore {
 
-  private val run = jsenv.startWithCom(input, config, handleMessage)
+  private val run: JSComRun = {
+    /* #4560 Explicitly redirect out/err to System.out/System.err, instead of
+     * relying on `inheritOut` and `inheritErr`, so that streams installed with
+     * `System.setOut` and `System.setErr` are always taken into account.
+     * sbt installs such alternative outputs when it runs in server mode.
+     *
+     * We never wait for these threads to finish. In theory, tasks that use the
+     * test adapter may complete before all output has been transferred to
+     * `System.out` and `System.err`.
+     */
+    val runConfig = RunConfig()
+      .withLogger(logger)
+      .withInheritOut(false)
+      .withInheritErr(false)
+      .withOnOutputStream { (out, err) =>
+        out.foreach(o => new PipeOutputThread(o, System.out).start())
+        err.foreach(e => new PipeOutputThread(e, System.err).start())
+      }
+
+    jsenv.startWithCom(input, runConfig, handleMessage)
+  }
 
   /* Once the com closes, ensure all still pending calls are failing.
    * This can be necessary, if the JSEnv terminates unexpectedly.

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/PipeOutputThread.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/PipeOutputThread.scala
@@ -10,14 +10,14 @@
  * additional information regarding copyright ownership.
  */
 
-package org.scalajs.sbtplugin
+package org.scalajs.testing.adapter
 
 import scala.annotation.tailrec
 
 import java.io._
 
-// !!! Duplicate code with adapter/PipeOutputThread.scala.
-private[sbtplugin] final class PipeOutputThread(from: InputStream, to: OutputStream) extends Thread {
+// !!! Duplicate code with sbtplugin/PipeOutputThread.scala.
+private[adapter] final class PipeOutputThread(from: InputStream, to: OutputStream) extends Thread {
   override def run(): Unit = {
     /* Copied from scala.sys.process.BasicIO.transferFully, except that we
      * don't have the try/catch around `flush()` because we do not use this

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/PipeOutputThread.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/PipeOutputThread.scala
@@ -17,26 +17,29 @@ import scala.annotation.tailrec
 import java.io._
 
 // !!! Duplicate code with sbtplugin/PipeOutputThread.scala.
-private[adapter] final class PipeOutputThread(from: InputStream, to: OutputStream) extends Thread {
+private[adapter] object PipeOutputThread {
+  def start(from: InputStream, to: OutputStream): Thread = {
+    val thread = new PipeOutputThread(from, to)
+    thread.start()
+    thread
+  }
+}
+
+private final class PipeOutputThread(from: InputStream, to: OutputStream) extends Thread {
   override def run(): Unit = {
-    /* Copied from scala.sys.process.BasicIO.transferFully, except that we
-     * don't have the try/catch around `flush()` because we do not use this
-     * method for stdin (only for stdout and stderr).
-     */
     try {
       val buffer = new Array[Byte](8192)
       @tailrec def loop(): Unit = {
         val byteCount = from.read(buffer)
         if (byteCount > 0) {
           to.write(buffer, 0, byteCount)
-          to.flush()
+          to.flush() // if the sender flushed (which we can't tell), we need to propagate the flush
           loop()
         }
       }
       loop()
-    } catch {
-      case _: InterruptedIOException => ()
+    } finally {
+      from.close()
     }
-    from.close()
   }
 }

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
@@ -125,7 +125,7 @@ final class TestAdapter(jsEnv: JSEnv, input: Seq[Input], config: TestAdapter.Con
     // Otherwise we might leak runners.
     require(!closed, "We are closed. Cannot create new runner.")
 
-    val com = new JSEnvRPC(jsEnv, input, config.runConfig)
+    val com = new JSEnvRPC(jsEnv, input, config.logger)
     val mux = new RunMuxRPC(com)
 
     new ManagedRunner(threadId, com, mux)
@@ -134,26 +134,21 @@ final class TestAdapter(jsEnv: JSEnv, input: Seq[Input], config: TestAdapter.Con
 
 object TestAdapter {
   final class Config private (
-      val runConfig: RunConfig
+      val logger: Logger
   ) {
     private def this() = {
       this(
-          runConfig = RunConfig()
+          logger = NullLogger
       )
     }
 
-    val logger: Logger = runConfig.logger
-
-    def withRunConfig(runConfig: RunConfig): Config =
-      copy(runConfig = runConfig)
-
     def withLogger(logger: Logger): Config =
-      withRunConfig(runConfig.withLogger(logger))
+      copy(logger = logger)
 
     private def copy(
-        runConfig: RunConfig = runConfig
+        logger: Logger = logger
     ): Config = {
-      new Config(runConfig)
+      new Config(logger)
     }
   }
 

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
@@ -125,8 +125,7 @@ final class TestAdapter(jsEnv: JSEnv, input: Seq[Input], config: TestAdapter.Con
     // Otherwise we might leak runners.
     require(!closed, "We are closed. Cannot create new runner.")
 
-    val runConfig = RunConfig().withLogger(config.logger)
-    val com = new JSEnvRPC(jsEnv, input, runConfig)
+    val com = new JSEnvRPC(jsEnv, input, config.runConfig)
     val mux = new RunMuxRPC(com)
 
     new ManagedRunner(threadId, com, mux)
@@ -135,21 +134,26 @@ final class TestAdapter(jsEnv: JSEnv, input: Seq[Input], config: TestAdapter.Con
 
 object TestAdapter {
   final class Config private (
-      val logger: Logger
+      val runConfig: RunConfig
   ) {
     private def this() = {
       this(
-          logger = NullLogger
+          runConfig = RunConfig()
       )
     }
 
+    val logger: Logger = runConfig.logger
+
+    def withRunConfig(runConfig: RunConfig): Config =
+      copy(runConfig = runConfig)
+
     def withLogger(logger: Logger): Config =
-      copy(logger = logger)
+      withRunConfig(runConfig.withLogger(logger))
 
     private def copy(
-        logger: Logger = logger
+        runConfig: RunConfig = runConfig
     ): Config = {
-      new Config(logger)
+      new Config(runConfig)
     }
   }
 


### PR DESCRIPTION
For discussion in #4560.

---

When running in server mode, sbt installs alternative streams for `System.out` and `System.err`. However, those alternatives are not used when launching separate processes with the inheritIO mode. By default, JS envs do precisely that, so they bypass the alternative streams set up by sbt.

We now explicitly redirect the outputs of JS envs to `System.out` and `System.err`, so that they take the alternative streams set up by sbt into account.