### PR TITLE
Upgrade to scalajs-js-envs/scalajs-env-nodejs v1.2.1.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1073,7 +1073,7 @@ object Build {
       name := "Scala.js sbt test adapter",
       libraryDependencies ++= Seq(
           "org.scala-sbt" % "test-interface" % "1.0",
-          "org.scala-js" %% "scalajs-js-envs" % "1.1.1",
+          "org.scala-js" %% "scalajs-js-envs" % "1.2.1",
           "com.google.jimfs" % "jimfs" % "1.1" % "test",
       ),
       libraryDependencies ++= JUnitDeps,
@@ -1102,8 +1102,8 @@ object Build {
       mimaBinaryIssueFilters ++= BinaryIncompatibilities.SbtPlugin,
 
       addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.1"),
-      libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.2.0",
-      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.2.0",
+      libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.2.1",
+      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.2.1",
 
       scriptedLaunchOpts += "-Dplugin.version=" + version.value,
 
@@ -2334,7 +2334,7 @@ object Build {
 
       resolvers += Resolver.typesafeIvyRepo("releases"),
 
-      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.1.1",
+      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.2.1",
 
       artifactPath in fetchScalaSource :=
         baseDirectory.value.getParentFile / "fetchedSources" / scalaVersion.value,

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -10,8 +10,8 @@ libraryDependencies += "com.google.jimfs" % "jimfs" % "1.1"
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.2.0.201312181205-r"
 
-libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.2.0"
-libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.2.0"
+libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.2.1"
+libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.2.1"
 
 Compile / unmanagedSourceDirectories ++= {
   val root = baseDirectory.value.getParentFile


### PR DESCRIPTION
To make Scala.js works on Node.js 17 out of the box.

I verified that this allows `testSuite2_12/test` to pass on Node.js 17, which was not the case before.