### PR TITLE
Fix #4560: Explicitly redirect JS envs outputs to System.{out,err}.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -20,6 +20,9 @@ object BinaryIncompatibilities {
   )
 
   val TestAdapter = TestCommon ++ Seq(
+      // private[adapter], not an issue
+      ProblemFilters.exclude[IncompatibleMethTypeProblem](
+          "org.scalajs.testing.adapter.JSEnvRPC.this"),
   )
 
   val Library = Seq(

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/PipeOutputThread.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/PipeOutputThread.scala
@@ -1,0 +1,45 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.sbtplugin
+
+import scala.annotation.tailrec
+
+import java.io._
+
+// !!! Duplicate code with adapter/PipeOutputThread.scala.
+private[sbtplugin] object PipeOutputThread {
+  def start(from: InputStream, to: OutputStream): Thread = {
+    val thread = new PipeOutputThread(from, to)
+    thread.start()
+    thread
+  }
+}
+
+private final class PipeOutputThread(from: InputStream, to: OutputStream) extends Thread {
+  override def run(): Unit = {
+    try {
+      val buffer = new Array[Byte](8192)
+      @tailrec def loop(): Unit = {
+        val byteCount = from.read(buffer)
+        if (byteCount > 0) {
+          to.write(buffer, 0, byteCount)
+          to.flush() // if the sender flushed (which we can't tell), we need to propagate the flush
+          loop()
+        }
+      }
+      loop()
+    } finally {
+      from.close()
+    }
+  }
+}

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/PipeOutputThread.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/PipeOutputThread.scala
@@ -1,0 +1,45 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testing.adapter
+
+import scala.annotation.tailrec
+
+import java.io._
+
+// !!! Duplicate code with sbtplugin/PipeOutputThread.scala.
+private[adapter] object PipeOutputThread {
+  def start(from: InputStream, to: OutputStream): Thread = {
+    val thread = new PipeOutputThread(from, to)
+    thread.start()
+    thread
+  }
+}
+
+private final class PipeOutputThread(from: InputStream, to: OutputStream) extends Thread {
+  override def run(): Unit = {
+    try {
+      val buffer = new Array[Byte](8192)
+      @tailrec def loop(): Unit = {
+        val byteCount = from.read(buffer)
+        if (byteCount > 0) {
+          to.write(buffer, 0, byteCount)
+          to.flush() // if the sender flushed (which we can't tell), we need to propagate the flush
+          loop()
+        }
+      }
+      loop()
+    } finally {
+      from.close()
+    }
+  }
+}

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
@@ -125,8 +125,7 @@ final class TestAdapter(jsEnv: JSEnv, input: Seq[Input], config: TestAdapter.Con
     // Otherwise we might leak runners.
     require(!closed, "We are closed. Cannot create new runner.")
 
-    val runConfig = RunConfig().withLogger(config.logger)
-    val com = new JSEnvRPC(jsEnv, input, runConfig)
+    val com = new JSEnvRPC(jsEnv, input, config.logger)
     val mux = new RunMuxRPC(com)
 
     new ManagedRunner(threadId, com, mux)


### PR DESCRIPTION
When running in server mode, sbt installs alternative streams for `System.out` and `System.err`. However, those alternatives are not guaranteed to be used when launching JSEnvs with `inheritOut` and `inheritErr` set to `true`. In particular, a JSEnv that spawns separate processes with the inheritIO mode will bypass redirections set up with `System.set{Out,Err}`.

We now explicitly redirect the outputs of JS envs to `System.out` and `System.err`, so that they always take the alternative streams set up by sbt into account.

---

Resubmission of #4580 with a squashed commit.