### PR TITLE
Fix #4596: Allow hashbang comments at the beginning of the jsHeader.

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -115,9 +115,11 @@ final class StandardConfig private (
    *
    *  The header must satisfy the following constraints:
    *
-   *  - It must contain only valid JS whitespace and/or JS comments (single- or multi-line).
+   *  - It must contain only valid JS whitespace and/or JS comments (single- or
+   *    multi-line comment, or, at the very beginning, a hashbang comment).
    *  - It must not use new line characters that are not UNIX new lines (`"\n"`).
    *  - If non-empty, it must end with a new line.
+   *  - It must not contain unpaired surrogate characters (i.e., it must be a valid UTF-16 string).
    *
    *  Those requirements can be checked with [[StandardConfig.isValidJSHeader]].
    *
@@ -273,7 +275,8 @@ object StandardConfig {
    *
    *  A header is valid if and only if it satisfies the following constraints:
    *
-   *  - It must contain only valid JS whitespace and/or JS comments (single- or multi-line).
+   *  - It must contain only valid JS whitespace and/or JS comments (single- or
+   *    multi-line comment, or, at the very beginning, a hashbang comment).
    *  - It must not use new line characters that are not UNIX new lines (`"\n"`).
    *  - If non-empty, it must end with a new line.
    *  - It must not contain unpaired surrogate characters (i.e., it must be a valid UTF-16 string).
@@ -341,6 +344,17 @@ object StandardConfig {
             case _ =>
               return false
           }
+
+        /* Accept a hashbang comment, but only at the very beginning
+         * This is a Stage 3 proposal:
+         * https://github.com/tc39/proposal-hashbang
+         * Documentation on MDN:
+         * https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#hashbang_comments
+         */
+        case '#' if i == 1 && len >= 2 && jsHeader.charAt(1) == '!' =>
+          i += 1
+          while (i != len && jsHeader.charAt(i) != '\n')
+            i += 1
 
         /* Accept JavaScript Whitespace that are not Unicode new lines
          * https://262.ecma-international.org/12.0/#sec-white-space

--- a/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigTest.scala
+++ b/linker-interface/shared/src/test/scala/org/scalajs/linker/interface/StandardConfigTest.scala
@@ -104,8 +104,32 @@ class StandardConfigTest {
     testInvalid("/* \uD834 */\n")
     testInvalid("/* \uDD1E */\n")
 
+    // Valid hashbang comments
+    testValid("#!/usr/bin/env node\n")
+    testValid("#!\n")
+    testValid("#! foo\n")
+    testValid("#! foo\tbar\n")
+    testValid("#! one\n// two\n")
+    testValid("#! α\n") // U+03B1 α Greek Small Letter Alpha
+    testValid("#! \uD834\uDD1E\n") // U+1D11E 𝄞 Musical Symbol G Clef
+
+    // Invalid hashbang comments
+    testInvalid("#!")
+    testInvalid("#! foo")
+    testInvalid("#! foo\nbar\n")
+    testInvalid("#! \uD834\n")
+    testInvalid("#! \uDD1E\n")
+    testInvalid("  \t #! foo\n")
+    testInvalid(" #!foo\n")
+    testInvalid("\n#!foo\n")
+    testInvalid("// bar\n#!foo\n")
+    testInvalid("#foo\n")
+    testInvalid("#")
+    testInvalid("#\n")
+    testInvalid("##foo\n")
+
     // Valid combination
-    testValid("  // foo\n\t/* foo bar\nbaz hello\n*/\n/**///foo\n")
+    testValid("#!foo\n  // foo\n\t/* foo bar\nbaz hello\n*/\n/**///foo\n")
 
     // Invalid combination
     testInvalid(" ! // foo\n\t/* foo bar\nbaz hello\n*/\n/**///foo\n")
@@ -114,5 +138,6 @@ class StandardConfigTest {
     testInvalid("  // foo\n\t/* foo bar\nbaz hello\n*/\n/**/!//foo\n")
     testInvalid("  // foo\n\t/* foo bar\nbaz hello\n*/\n/**//!/foo\n")
     testInvalid("  // foo\n\t/* foo bar\nbaz hello\n*/\n/**///foo\n!")
+    testInvalid("  // foo\n\t/* foo bar\nbaz hello\n*/\n#!foo\n/**///foo\n")
   }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
@@ -43,6 +43,7 @@ class EmitterTest {
     val t = "\t"
     val gClef = "\uD834\uDD1E"
     val header = s"""
+      |#!/usr/bin/env node
       |// foo
       |  $t
       |  /* bar


### PR DESCRIPTION
There is a Stage 3 proposal for ECMAScript to officially allow hashbang comments at the very beginning of source files (scripts and modules):
https://github.com/tc39/proposal-hashbang

According to the proposal, they are to be true comments from the point of view of ECMAScript, so it makes sense to accept them in `jsHeader`. The current spec text specifies that, after the starting `#!`, they can contain the same characters as single-line comments starting with `//`.