### PR TITLE
Fix #4601: Patch the type of Labeled nodes in the 1.5 deser hack.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1231,12 +1231,19 @@ object Serializers {
         if (!hacks.use15) {
           body
         } else {
-          // #4442 Patch If and TryCatch nodes in statement position to have type NoType
+          /* #4442 and #4601: Patch Labeled, If, Match and TryCatch nodes in
+           * statement position to have type NoType. These 4 nodes are the
+           * control structures whose result type is explicitly specified (and
+           * not derived from their children like Block or TryFinally, or
+           * constant like While).
+           */
           new Transformers.Transformer {
             override def transform(tree: Tree, isStat: Boolean): Tree = {
               val newTree = super.transform(tree, isStat)
               if (isStat && newTree.tpe != NoType) {
                 newTree match {
+                  case Labeled(label, _, body) =>
+                    Labeled(label, NoType, body)(newTree.pos)
                   case If(cond, thenp, elsep) =>
                     If(cond, thenp, elsep)(NoType)(newTree.pos)
                   case Match(selector, cases, default) =>


### PR DESCRIPTION
The deserialization hack introduced in 3601272fd49d56d452e2b252d0ee171922031e00 sometimes created invalid IR from valid IR. This happened when a Labeled block in statement position was typed with something else than `NoType`, and contained an `If` or `Match` node of that same type. The deserialization hack would change the type of the `If` or `Match` to `NoType`, but not the type of the enclosing `Labeled` node. This pattern of IR is produced by Scala 3.0.x, which emits IR version 1.5.

We fix this issue by adding `Labeled` to the list of nodes whose type is patched by the hack. As written in the elaborated comment, this is the last of the 4 nodes that are control structures whose type is explicitly specified. Only those need to be adapted, because:

1. The other control structures directly get their type from their children, and are therefore valid by construction.
2. Non-control structures do not transfer their "status" of being in expression position or in statement position.

This is unfortunately not tested.We would have to either load IR generated by Scala 3.0.0, or write hand-coded IR v1.5 and load it back in the linker tests. We do not have the required infrastructure for either of these solutions.

---

I locally tested this by confirming that the reproduction in issue #4601 correctly links in fastOptJS (with forced `checkIR = true`) and fullOptJS (as reported) with the changes of this commit.