### PR TITLE
Implement `java.lang.{Byte,Short}.{toUnsignedInt,toUnsignedLong}`

### DIFF
--- a/javalanglib/src/main/scala/java/lang/Byte.scala
+++ b/javalanglib/src/main/scala/java/lang/Byte.scala
@@ -96,4 +96,10 @@ object Byte {
 
   @inline def compare(x: scala.Byte, y: scala.Byte): scala.Int =
     x - y
+
+  @inline def toUnsignedInt(x: scala.Byte): scala.Int =
+    x.toInt & 0xff
+
+  @inline def toUnsignedLong(x: scala.Byte): scala.Long =
+    toUnsignedInt(x).toLong
 }

--- a/javalanglib/src/main/scala/java/lang/Short.scala
+++ b/javalanglib/src/main/scala/java/lang/Short.scala
@@ -98,4 +98,10 @@ object Short {
 
   def reverseBytes(i: scala.Short): scala.Short =
     (((i >>> 8) & 0xff) + ((i & 0xff) << 8)).toShort
+
+  @inline def toUnsignedInt(x: scala.Short): scala.Int =
+    x.toInt & 0xffff
+
+  @inline def toUnsignedLong(x: scala.Short): scala.Long =
+    toUnsignedInt(x).toLong
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ByteTest.scala
@@ -43,6 +43,22 @@ class ByteTest {
     assertEquals(0, compare(3.toByte, 3.toByte))
   }
 
+  @Test def toUnsignedInt(): Unit = {
+    assertEquals(0, JByte.toUnsignedInt(0.toByte))
+    assertEquals(42, JByte.toUnsignedInt(42.toByte))
+    assertEquals(214, JByte.toUnsignedInt(-42.toByte))
+    assertEquals(128, JByte.toUnsignedInt(Byte.MinValue))
+    assertEquals(127, JByte.toUnsignedInt(Byte.MaxValue))
+  }
+
+  @Test def toUnsignedLong(): Unit = {
+    assertEquals(0L, JByte.toUnsignedLong(0.toByte))
+    assertEquals(42L, JByte.toUnsignedLong(42.toByte))
+    assertEquals(214L, JByte.toUnsignedLong(-42.toByte))
+    assertEquals(128L, JByte.toUnsignedLong(Byte.MinValue))
+    assertEquals(127L, JByte.toUnsignedLong(Byte.MaxValue))
+  }
+
   @Test def parseString(): Unit = {
     def test(s: String, v: Byte): Unit = {
       assertEquals(v, JByte.parseByte(s))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ShortTest.scala
@@ -43,6 +43,22 @@ class ShortTest {
     assertEquals(0, compare(3.toShort, 3.toShort))
   }
 
+  @Test def toUnsignedInt(): Unit = {
+    assertEquals(0, JShort.toUnsignedInt(0.toShort))
+    assertEquals(42, JShort.toUnsignedInt(42.toShort))
+    assertEquals(65494, JShort.toUnsignedInt(-42.toShort))
+    assertEquals(32768, JShort.toUnsignedInt(Short.MinValue))
+    assertEquals(32767, JShort.toUnsignedInt(Short.MaxValue))
+  }
+
+  @Test def toUnsignedLong(): Unit = {
+    assertEquals(0L, JShort.toUnsignedLong(0.toShort))
+    assertEquals(42L, JShort.toUnsignedLong(42.toShort))
+    assertEquals(65494L, JShort.toUnsignedLong(-42.toShort))
+    assertEquals(32768L, JShort.toUnsignedLong(Short.MinValue))
+    assertEquals(32767L, JShort.toUnsignedLong(Short.MaxValue))
+  }
+
   @Test def parseString(): Unit = {
     def test(s: String, v: Short): Unit = {
       assertEquals(v, JShort.parseShort(s))


### PR DESCRIPTION
Let's try this again :)

This PR implements `java.lang.Byte.toUnsignedInt` and `java.lang.Byte.toUnsignedLong`.

I confirm that I did not look at any JDK sources.

Thanks!