### PR TITLE
Add an ugly way to call `**`

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/BigInt.scala
+++ b/library/src/main/scala/scala/scalajs/js/BigInt.scala
@@ -52,6 +52,10 @@ final class BigInt private[this] () extends js.Object {
   def >(x: BigInt): Boolean = js.native
   def >=(x: BigInt): Boolean = js.native
 
+  // TODO: migrate to **
+  /** Scala.js does not recongnize ** as operator */
+  def pow(exp: BigInt): BigInt = BigInt.powFunction(this, exp)
+
   /** Returns a localized string representation of this BigInt.
    *
    *  @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/toLocaleString
@@ -103,6 +107,9 @@ object BigInt extends js.Object {
 
   /** @see https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt/asUintN */
   def asUintN(width: Int, bigint: BigInt): BigInt = js.native
+
+  private[js] val powFunction: Function2[BigInt, BigInt, BigInt] = js.eval("var f = function(b, p) { return b ** p; }; f;")
+    .asInstanceOf[js.Function2[js.BigInt, js.BigInt, js.BigInt]]
 
   // scalastyle:off line.size.limit
   /** Type of the `options` parameter of [[BigInt.toLocaleString]].

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/BigIntTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/BigIntTest.scala
@@ -80,9 +80,8 @@ class BigIntTest {
     val mod = multi % js.BigInt(10)
     assertEquals(mod, js.BigInt("2"))
 
-    // TODO: Scala.js does not recongnize ** as operator
-    //    val bigN = js.BigInt(2) ** js.BigInt(54)
-    //    assertEquals(bigN, js.BigInt("18014398509481984"))
+    val bigN = js.BigInt(2) pow js.BigInt(54)
+    assertEquals(bigN, js.BigInt("81129638414606663681390495662081"))
 
     val negative = -js.BigInt("18014398509481984")
     assertEquals(negative, js.BigInt("-18014398509481984"))


### PR DESCRIPTION
One of the main benefits of `BigInt` is `**` for a large number and it is shame that Scala.JS can't do it out of the box.

Let me add it in an ugly way, but much better than as users to research the way to do it.