### PR TITLE
Fix #4621: Preserve the side effects of JS binary and unary ops.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1256,8 +1256,6 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case If(cond, thenp, elsep)  => test(cond) && test(thenp) && test(elsep)
         case BinaryOp(_, lhs, rhs)   => test(lhs) && test(rhs)
         case UnaryOp(_, lhs)         => test(lhs)
-        case JSBinaryOp(_, lhs, rhs) => test(lhs) && test(rhs)
-        case JSUnaryOp(_, lhs)       => test(lhs)
         case ArrayLength(array)      => test(array)
         case RecordSelect(record, _) => test(record)
         case IsInstanceOf(expr, _)   => test(expr)
@@ -1346,6 +1344,10 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           allowSideEffects
         case LoadJSModule(_) =>
           allowSideEffects
+        case JSBinaryOp(_, lhs, rhs) =>
+          allowSideEffects && test(lhs) && test(rhs)
+        case JSUnaryOp(_, lhs) =>
+          allowSideEffects && test(lhs)
         case JSGlobalRef(_) =>
           allowSideEffects
         case JSTypeOfGlobalRef(_) =>


### PR DESCRIPTION
The emitter wrongly thought that these operators preserve pureness. However, they can have side effects in two cases:

* For BigInts, division by 0 and unary + throw.
* For custom objects, if their `valueOf()` method throws, it will be propagated by the JS binary and unary ops.