### PR TITLE
Directly call ES2015 builtins instead of storing them in a var.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -442,20 +442,17 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     } yield {
       implicit val pos = field.pos
 
-      val symbolValue = {
+      val symbolValueWithGlobals = {
         def description = origName.getOrElse(name).toString()
         val args =
           if (semantics.productionMode) Nil
           else js.StringLiteral(description) :: Nil
-
-        if (esFeatures.esVersion >= ESVersion.ES2015)
-          js.Apply(js.VarRef(js.Ident("Symbol")), args)
-        else
-          genCallHelper("privateJSFieldSymbol", args: _*)
+        genCallPolyfillableBuiltin(PolyfillableBuiltin.PrivateSymbolBuiltin, args: _*)
       }
 
-      globalVarDef("r", (tree.className, name), symbolValue,
-          origName.orElse(name))
+      symbolValueWithGlobals.flatMap { symbolValue =>
+        globalVarDef("r", (tree.className, name), symbolValue, origName.orElse(name))
+      }
     }
 
     WithGlobals.list(defs)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/PolyfillableBuiltin.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/PolyfillableBuiltin.scala
@@ -1,0 +1,46 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.emitter
+
+import org.scalajs.linker.interface.ESVersion
+
+private[emitter] sealed abstract class PolyfillableBuiltin(
+    val builtinName: String, val availableInESVersion: ESVersion)
+
+private[emitter] object PolyfillableBuiltin {
+  lazy val All: List[PolyfillableBuiltin] = List(
+    ObjectIsBuiltin,
+    ImulBuiltin,
+    FroundBuiltin,
+    Clz32Builtin,
+    PrivateSymbolBuiltin,
+    GetOwnPropertyDescriptorsBuiltin
+  )
+
+  sealed abstract class GlobalVarBuiltin(val globalVar: String,
+      builtinName: String, availableInESVersion: ESVersion)
+      extends PolyfillableBuiltin(builtinName, availableInESVersion)
+
+  sealed abstract class NamespacedBuiltin(val namespaceGlobalVar: String,
+      builtinName: String, availableInESVersion: ESVersion)
+      extends PolyfillableBuiltin(builtinName, availableInESVersion)
+
+  case object ObjectIsBuiltin extends NamespacedBuiltin("Object", "is", ESVersion.ES2015)
+  case object ImulBuiltin extends NamespacedBuiltin("Math", "imul", ESVersion.ES2015)
+  case object FroundBuiltin extends NamespacedBuiltin("Math", "fround", ESVersion.ES2015)
+  case object Clz32Builtin extends NamespacedBuiltin("Math", "clz32", ESVersion.ES2015)
+  case object PrivateSymbolBuiltin
+      extends GlobalVarBuiltin("Symbol", "privateJSFieldSymbol", ESVersion.ES2015)
+  case object GetOwnPropertyDescriptorsBuiltin
+      extends NamespacedBuiltin("Object", "getOwnPropertyDescriptors", ESVersion.ES2017)
+}


### PR DESCRIPTION
Previously, when emitting ES2015, we stored some builtins that we often use in global var defs:
```js
var $imul = Math.imul;
var $fround = Math.fround;
var $clz32 = Math.clz32;
```
It turns out that engines, especially V8, do a better job at optimizing direct calls such as `Math.fround(x)` rather than indirect calls such as `$fround(x)`. And that despite the fact that `$fround` can be "proven" to be constant, contrary to `Math` or `Math.fround`.

Now, when emitting ES2015, we directly emit calls to `Math.fround(x)` instead of storing `$fround`. The same applies to `Math.imul` and `Math.clz32`.

We were already applying that strategy to `Object.is` (also ES2015+) and `Object.getOwnPropertyDescriptors` (ES2017+). We consolidate the logic used for all five of these polyfillable builtins.