### PR TITLE
Fix #4632: Fix strict-floats + optimized semantics.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2597,7 +2597,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           genIsInstanceOf(transformExprNoChar(expr), testType)
 
         case AsInstanceOf(expr, tpe) =>
-          genAsInstanceOf(transformExprNoChar(expr), tpe)
+          extractWithGlobals(genAsInstanceOf(transformExprNoChar(expr), tpe))
 
         case GetClass(expr) =>
           genCallHelper("objectGetClass", transformExprNoChar(expr))


### PR DESCRIPTION
This was broken in e4b60eb6f16a1b733fab4482dd528382b9d12d62, which left a stray `genCallHelper("fround")` in the generation of `AsInstanceOf` for strict-floats coupled with unchecked asInstanceOfs.

---

Tested locally with:
```
> set testSuite.v2_12/scalaJSLinkerConfig ~= { _.withSemantics(_.withStrictFloats(true).optimized) }
> testSuite2_12/test
> set Global/scalaJSStage := FullOptStage
> testSuite2_12/test
> partestSuite2_12/testOnly -- --fullOpt run/issue192.scala
```