### PR TITLE
Performance tweaks for the `fround` polyfills.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -237,9 +237,8 @@ private[emitter] object CoreJSLib {
              * in org.scalajs.testsuite.compiler.DoubleTest.
              */
             // scalastyle:on line.size.limit
-            val isNegative = varRef("isNegative")
+            val sign = varRef("sign")
             val av = varRef("av")
-            val absResult = varRef("absResult")
             val p = varRef("p")
 
             val Inf = double(Double.PositiveInfinity)
@@ -248,11 +247,10 @@ private[emitter] object CoreJSLib {
 
             val noTypedArrayPolyfill = genArrowFunction(paramList(v), Block(
               v := +v, // turns `null` into +0, making sure not to deoptimize what follows
-              const(isNegative, v < 0), // false for NaN, +0 and -0
-              const(av, If(isNegative, -v, v)), // abs(v), or -0 if v is -0
-              genEmptyMutableLet(absResult.ident), // abs(result), or -0 if the result is -0
+              const(sign, If(v < 0, -1, 1)), // 1 for NaN, +0 and -0
+              const(av, sign * v), // abs(v), or -0 if v is -0
               If(av >= overflowThreshold, { // also handles the case av === Infinity
-                absResult := Inf
+                Return(sign * Inf)
               }, If(av >= normalThreshold, Block(
                 /* Here, we know that both the input and output are expressed
                  * in a Double normal form, so standard floating point
@@ -299,7 +297,7 @@ private[emitter] object CoreJSLib {
                  * proofs to Boldo's.
                  */
                 const(p, av * 536870913),
-                absResult := (p + (av - p))
+                Return(sign * (p + (av - p)))
               ), {
                 /* Here, the result is represented as a subnormal form in a
                  * float32 representation.
@@ -329,9 +327,8 @@ private[emitter] object CoreJSLib {
                  * happens to be an identity, and is therefore correct as well.
                  */
                 val roundingFactor = double(Double.MinPositiveValue / Float.MinPositiveValue.toDouble)
-                absResult := (av * roundingFactor) / roundingFactor
-              })),
-              Return(If(isNegative, -absResult, absResult))
+                Return(sign * ((av * roundingFactor) / roundingFactor))
+              }))
             ))
 
             If(typeof(Float32ArrayRef) !== str("undefined"),


### PR DESCRIPTION
The first one is for the polyfill without typed arrays, and brings roughly a 25% improvement.
The second one is for the polyfill with typed arrays, and brings an order of magnitude improvement.

After these changes, the `tracerFloat` benchmark (`tracer` for the first line) exhibits the following rough performance figures:

| Implementation | Running time | SEM |
|-------|----|----|
| Double version | 1063.04 | 2.15 |
| Native `fround` | 1230.82 | 2.21 |
| With `Float32Array` | 1609.60 | 4.03 |
| Without typed arrays | 3721.57 | 6.81 |

---

The full generated code for `$fround` when emitting ES 5.1 is now
```js
var $fround = (Math.fround || (((typeof Float32Array) !== "undefined") ? (function(array) {
  return (function(v) {
    array[0] = v;
    return array[0]
  })
})(new Float32Array(1)) : (function(v) {
  v = (+v);
  var sign = ((v < 0) ? (-1) : 1);
  var av = (sign * v);
  if ((av >= 3.4028235677973366E38)) {
    return (sign * Infinity)
  } else if ((av >= 1.1754943508222875E-38)) {
    var p = (av * 536870913);
    return (sign * (p + (av - p)))
  } else {
    return (sign * ((av * 3.5257702653609953E-279) / 3.5257702653609953E-279))
  }
})));
```