### PR TITLE
Floating point bits polyfill implementations without js.Math functions.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1735,7 +1735,7 @@ object Build {
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 783000 to 784000,
+                fastLink = 784000 to 785000,
                 fullLink = 150000 to 151000,
                 fastLinkGz = 92000 to 93000,
                 fullLinkGz = 37000 to 38000,

--- a/project/MiniLib.scala
+++ b/project/MiniLib.scala
@@ -24,7 +24,6 @@ object MiniLib {
         "String",
 
         "FloatingPointBits",
-        "FloatingPointBits$EncodeIEEE754Result",
 
         "Throwable",
         "StackTrace",


### PR DESCRIPTION
Already launching the CI. I'll come back here to post benchmark results. Spoiler: they're actually pretty good (4x speedup in the Normal form case, which is by far the most common.)

---

When encoding, to compute the exponent, we perform a binary search inside an array of all exact powers of 2. The loop executes exactly 11 times for Doubles, and 8 times for Floats. It replaces a call to `log`, `floor` and `pow`, in addition to two conditions to fix up `e` and `significand`.

When decoding, we also use the same array to get the power of 2 via direct indexing, rather than calling `pow`.