### PR TITLE
Highlight the using `nowarnGlobalExecutionContext` option within Scala 3

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -393,7 +393,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                   |
                   |If you do not care about macrotask fairness, you can silence this warning by:
                   |- Adding @nowarn("cat=other") (Scala >= 2.13.x only)
-                  |- Setting the -P:scalajs:nowarnGlobalExecutionContext compiler option
+                  |- Setting the -P:scalajs:nowarnGlobalExecutionContext compiler option (Scala < 3.x.y only)
                   |- Using scala.scalajs.concurrent.JSExecutionContext.queue
                   |  (the implementation of ExecutionContext.global in Scala.js) directly.
                   |

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/GlobalExecutionContextWarnTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/GlobalExecutionContextWarnTest.scala
@@ -42,7 +42,7 @@ class GlobalExecutionContextWarnTest extends DirectTest with TestHelpers {
       |
       |If you do not care about macrotask fairness, you can silence this warning by:
       |- Adding @nowarn("cat=other") (Scala >= 2.13.x only)
-      |- Setting the -P:scalajs:nowarnGlobalExecutionContext compiler option
+      |- Setting the -P:scalajs:nowarnGlobalExecutionContext compiler option (Scala < 3.x.y only)
       |- Using scala.scalajs.concurrent.JSExecutionContext.queue
       |  (the implementation of ExecutionContext.global in Scala.js) directly.
       |
@@ -77,7 +77,7 @@ class GlobalExecutionContextWarnTest extends DirectTest with TestHelpers {
       |
       |If you do not care about macrotask fairness, you can silence this warning by:
       |- Adding @nowarn("cat=other") (Scala >= 2.13.x only)
-      |- Setting the -P:scalajs:nowarnGlobalExecutionContext compiler option
+      |- Setting the -P:scalajs:nowarnGlobalExecutionContext compiler option (Scala < 3.x.y only)
       |- Using scala.scalajs.concurrent.JSExecutionContext.queue
       |  (the implementation of ExecutionContext.global in Scala.js) directly.
       |


### PR DESCRIPTION
To prevent users against the compilation error `bad option: -P:scalajs:nowarnGlobalExecutionContext`.