### PR TITLE
Fix #4657: Implement UUID.randomUUID() using java.security.SecureRandom.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.9.1-SNAPSHOT",
+    current = "1.10.0-SNAPSHOT",
     binaryEmitted = "1.8"
 )
 

--- a/javalib-ext-dummies/src/main/scala/java/security/SecureRandom.scala
+++ b/javalib-ext-dummies/src/main/scala/java/security/SecureRandom.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.security
+
+/** Fake implementation of `SecureRandom` that is not actually secure at all.
+ *
+ *  It directly delegates to `java.util.Random`.
+ */
+class SecureRandom extends java.util.Random

--- a/javalib/src/main/scala/java/util/UUID.scala
+++ b/javalib/src/main/scala/java/util/UUID.scala
@@ -136,13 +136,26 @@ object UUID {
   private final val NameBased = 3
   private final val Random = 4
 
-  private lazy val rng = new Random() // TODO Use java.security.SecureRandom
+  // Typed as `Random` so that the IR typechecks when SecureRandom is not available
+  private lazy val csprng: Random = new java.security.SecureRandom()
+  private lazy val randomUUIDBuffer: Array[Byte] = new Array[Byte](16)
 
   def randomUUID(): UUID = {
-    val i1 = rng.nextInt()
-    val i2 = (rng.nextInt() & ~0x0000f000) | 0x00004000
-    val i3 = (rng.nextInt() & ~0xc0000000) | 0x80000000
-    val i4 = rng.nextInt()
+    val buffer = randomUUIDBuffer // local copy
+
+    /* We use nextBytes() because that is the primitive of most secure RNGs,
+     * and therefore it allows to perform a unique call to the underlying
+     * secure RNG.
+     */
+    csprng.nextBytes(randomUUIDBuffer)
+
+    @inline def intFromBuffer(i: Int): Int =
+      (buffer(i) << 24) | ((buffer(i + 1) & 0xff) << 16) | ((buffer(i + 2) & 0xff) << 8) | (buffer(i + 3) & 0xff)
+
+    val i1 = intFromBuffer(0)
+    val i2 = (intFromBuffer(4) & ~0x0000f000) | 0x00004000
+    val i3 = (intFromBuffer(8) & ~0xc0000000) | 0x80000000
+    val i4 = intFromBuffer(12)
     new UUID(i1, i2, i3, i4, null, null)
   }
 

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTestEx.scala
@@ -1,0 +1,37 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util
+
+import java.util.UUID
+
+import org.junit.Test
+import org.junit.Assert._
+
+/** Additional tests for `java.util.UUID` that require
+ *  `java.security.SecureRandom`.
+ */
+class UUIDTestEx {
+
+  @Test def randomUUID(): Unit = {
+    val uuid1 = UUID.randomUUID()
+    assertEquals(2, uuid1.variant())
+    assertEquals(4, uuid1.version())
+
+    val uuid2 = UUID.randomUUID()
+    assertEquals(2, uuid2.variant())
+    assertEquals(4, uuid2.version())
+
+    assertNotEquals(uuid1, uuid2)
+  }
+
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/UUIDTest.scala
@@ -142,12 +142,6 @@ class UUIDTest {
       new UUID(0x0000000000001000L, 0x8000000000000000L).toString)
   }
 
-  @Test def randomUUID(): Unit = {
-    val uuid = UUID.randomUUID()
-    assertEquals(2, uuid.variant())
-    assertEquals(4, uuid.version())
-  }
-
   @Test def fromString(): Unit = {
     val uuid1 = UUID.fromString("f81d4fae-7dec-11d0-a765-00a0c91e6bf6")
     assertTrue(uuid1.equals(new UUID(0xf81d4fae7dec11d0L, 0xa76500a0c91e6bf6L)))


### PR DESCRIPTION
Since Scala.js core does not implement `SecureRandom`, this means that `randomUUID()` will fail to link unless `SecureRandom` is otherwise provided.

We move the tests for `randomUUID()` in the test-suite-ex, and we implement a fake `SecureRandom` in the javalib-ext-dummies for testing purposes.

---

Accompanying PRs in https://github.com/scala-js/scala-js-java-securerandom and https://github.com/scala-js/scala-js-fake-insecure-java-securerandom are coming.