### PR TITLE
(Possibly) a faster StringBuilder

### DIFF
--- a/javalanglib/src/main/scala/java/lang/StringBuilder.scala
+++ b/javalanglib/src/main/scala/java/lang/StringBuilder.scala
@@ -12,37 +12,54 @@
 
 package java.lang
 
-class StringBuilder
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+class StringBuilder(initialCapacity: Int)
     extends AnyRef with CharSequence with Appendable with java.io.Serializable {
 
-  private[this] var content: String = ""
+  if (initialCapacity < 0)
+    throw new NegativeArraySizeException()
 
-  def this(str: String) = {
-    this()
-    if (str eq null)
-      throw new NullPointerException
-    content = str
+  private[this] var content: js.typedarray.Uint16Array = new js.typedarray.Uint16Array(initialCapacity)
+  private[this] var length: Int = 0
+
+  private[this] def expand(newCapacity: Int): Unit = {
+    // TODO what if newCapacity somehow is less than content.length?
+    val newContent = new js.typedarray.Uint16Array(newCapacity)
+    newContent.set(content)
+    content = newContent
   }
 
-  def this(initialCapacity: Int) = {
-    this()
-    if (initialCapacity < 0)
-      throw new NegativeArraySizeException()
+  def this(str: String) = {
+    this((if (str eq null) throw new NullPointerException else str.length) * 2)
+    this.append(str)
+  }
+
+  def this() = {
+    this(16)
   }
 
   def this(seq: CharSequence) = this(seq.toString)
 
   @inline
   def append(obj: AnyRef): StringBuilder = {
-    // If (obj eq null), this appends "null", otherwise obj.toString()
-    content += obj
+    append(if (obj eq null) "null" else obj.toString)
     this
   }
 
   @inline
   def append(str: String): StringBuilder = {
-    content += str // if (str eq null), this appends "null"
-    this
+    if (str eq null) {
+      append("null")
+    } else {
+      var idx: Int = 0
+      while(idx < str.length) {
+        append(str.charAt(idx))
+        idx += 1
+      }
+      this
+    }
   }
 
   def append(sb: StringBuffer): StringBuilder = append(sb: AnyRef)
@@ -53,13 +70,31 @@ class StringBuilder
     append((if (s == null) "null" else s).subSequence(start, end))
 
   def append(str: Array[scala.Char]): StringBuilder =
-    append(String.valueOf(str))
+    append(str, 0, str.length)
 
-  def append(str: Array[scala.Char], offset: Int, len: Int): StringBuilder =
-    append(String.valueOf(str, offset, len))
+  def append(str: Array[scala.Char], offset: Int, len: Int): StringBuilder = {
+    var idx = offset
+    while(idx < (offset + len)) {
+      append(str(idx))
+      idx += 1
+    }
+    this
+  }
 
   def append(b: scala.Boolean): StringBuilder = append(b.toString())
-  def append(c: scala.Char): StringBuilder = append(c.toString())
+
+  def append(c: scala.Char): StringBuilder = {
+    // TODO should one pull this out into the Array[Char] append to only if-check once?
+    if (length >= content.length) {
+      expand(length * 2)
+    }
+
+    content(length) = c.toInt
+    length += 1
+
+    this
+  }
+
   def append(i: scala.Int): StringBuilder = append(i.toString())
   def append(lng: scala.Long): StringBuilder = append(lng.toString())
   def append(f: scala.Float): StringBuilder = append(f.toString())
@@ -75,22 +110,57 @@ class StringBuilder
     /* This is not equivalent to `delete(index, index + 1)` when
      * `index == length`.
      */
-    val oldContent = content
-    if (index < 0 || index >= oldContent.length)
+    if (index < 0 || index >= length)
       throw new StringIndexOutOfBoundsException(index)
-    content = oldContent.substring(0, index) + oldContent.substring(index + 1)
+
+    length -= 1
+    var idx = index
+    while(idx < length) {
+      content(idx) = content(idx + 1)
+      idx += 1
+    }
+
     this
   }
 
   def replace(start: Int, end: Int, str: String): StringBuilder = {
-    val oldContent = content
-    val length = oldContent.length
     if (start < 0 || start > length || start > end)
       throw new StringIndexOutOfBoundsException(start)
-    val firstPart = oldContent.substring(0, start) + str
-    content =
-      if (end >= length) firstPart
-      else firstPart + oldContent.substring(end)
+
+    val replacementLength = end - start
+    val insertLength = str.length
+
+    if(insertLength > replacementLength) {
+      // Hard case, we copy characters forward which means we have to work back-to-front
+      val displacement = insertLength - replacementLength
+      length += displacement
+      if(length >= content.length)
+        expand(length + displacement)
+
+      var idx = length
+      while(idx > (end + displacement)) {
+        content(idx) = content(idx - displacement)
+        idx -= 1
+      }
+    } else if (insertLength < replacementLength) {
+      // Easy case, we copy characters backward
+      val displacement = replacementLength - insertLength
+      length -= displacement
+
+      var idx = end
+      while(idx < (length + displacement)) {
+        content(idx) = content(idx + displacement)
+        idx += 1
+      }
+    }
+
+    // Now emplace the actual string
+    var idx = start
+    while(idx < end) {
+      content(idx) = str.charAt(idx).toInt
+      idx += 1
+    }
+
     this
   }
 
@@ -103,11 +173,7 @@ class StringBuilder
     insert(offset, String.valueOf(obj))
 
   def insert(offset: Int, str: String): StringBuilder = {
-    val oldContent = content
-    if (offset < 0 || offset > oldContent.length)
-      throw new StringIndexOutOfBoundsException(offset)
-    content =
-      oldContent.substring(0, offset) + str + oldContent.substring(offset)
+    replace(offset, offset, str)
     this
   }
 
@@ -140,97 +206,213 @@ class StringBuilder
   def insert(offset: Int, d: scala.Double): StringBuilder =
     insert(offset, d.toString)
 
-  def indexOf(str: String): Int = content.indexOf(str)
+  def indexOf(str: String): Int =
+    indexOf(str, 0)
 
-  def indexOf(str: String, fromIndex: Int): Int =
-    content.indexOf(str, fromIndex)
+  def indexOf(str: String, fromIndex: Int): Int = {
+    // TODO should fromIndex be checked for OOB access?
+    var idx = fromIndex
+    var run = 0
+    while((idx + run) < length && run < str.length) {
+      if (str.charAt(run).toInt == content(idx + run)) {
+        run += 1
+      } else if (run != 0) {
+        idx += run
+        run = 0
+      } else {
+        idx += 1
+      }
+    }
 
-  def lastIndexOf(str: String): Int = content.lastIndexOf(str)
+    if(run == str.length) {
+      idx
+    } else {
+      -1
+    }
+  }
 
-  def lastIndexOf(str: String, fromIndex: Int): Int =
-    content.lastIndexOf(str, fromIndex)
+  def lastIndexOf(str: String): Int =
+    lastIndexOf(str, length)
+
+  def lastIndexOf(str: String, fromIndex: Int): Int = {
+    // TODO should fromIndex be checked for OOB access?
+    var idx = fromIndex
+    var run = 0
+    while((idx - run) >= 0 && run < str.length) {
+      if (str.charAt((str.length - 1) - run).toInt == content(idx - run)) {
+        run += 1
+      } else if (run != 0) {
+        idx -= run
+        run = 0
+      } else {
+        idx -= 1
+      }
+    }
+
+    if(run == str.length) {
+      idx
+    } else {
+      -1
+    }
+  }
 
   def reverse(): StringBuilder = {
-    val original = content
-    var result = ""
-    var i = original.length - 1
+    val newContent = new js.typedarray.Uint16Array(length)
+    var i = length - 1
     while (i > 0) {
-      val c = original.charAt(i)
+      val c = content(i).toChar
       if (Character.isLowSurrogate(c)) {
-        val c2 = original.charAt(i - 1)
+        val c2 = content(i - 1).toChar
         if (Character.isHighSurrogate(c2)) {
-          result = result + c2.toString + c.toString
+          newContent((length - 1) - i) = content(i - 1)
+          newContent((length - 1) - (i + 1)) = content(i)
           i -= 2
         } else {
-          result += c.toString
+          newContent((length - 1) - i) = content(i)
           i -= 1
         }
       } else {
-        result += c.toString
+        newContent((length - 1) - i) = content(i)
         i -= 1
       }
     }
     if (i == 0)
-      result += original.charAt(0).toString
-    content = result
+      newContent(length - 1) = content(0)
+    content = newContent
     this
   }
 
-  override def toString(): String = content
+  override def toString(): String = substring(0)
 
-  def length(): Int = content.length()
+  def length(): Int = length
 
-  def capacity(): Int = length()
+  def capacity(): Int = content.length
 
-  def ensureCapacity(minimumCapacity: Int): Unit = ()
+  def ensureCapacity(minimumCapacity: Int): Unit = expand(minimumCapacity)
 
-  def trimToSize(): Unit = ()
+  def trimToSize(): Unit = {
+    val newContent = new js.typedarray.Uint16Array(length)
+    newContent.set(content)
+    content = newContent
+  }
 
   def setLength(newLength: Int): Unit = {
     if (newLength < 0)
       throw new StringIndexOutOfBoundsException(newLength)
-    var newContent = content
-    val additional = newLength - newContent.length // cannot overflow
-    if (additional < 0) {
-      newContent = newContent.substring(0, newLength)
-    } else {
-      var i = 0
-      while (i != additional) {
-        newContent += "\u0000"
-        i += 1
-      }
+
+    while (length < newLength) {
+      append('\u0000')
     }
-    content = newContent
   }
 
-  def charAt(index: Int): Char = content.charAt(index)
+  def charAt(index: Int): Char = content(index).toChar // TODO handle index out of bounds
 
-  def codePointAt(index: Int): Int = content.codePointAt(index)
+  def codePointAt(index: Int): Int = {
+    // TODO handle index out of bounds
+    val c: Char = content(index).toChar
+    if (Character.isHighSurrogate(c)) {
+      val c2: Char = content(index + 1).toChar
+      if (Character.isLowSurrogate(c2)) {
+        Character.toCodePoint(c, c2)
+      } else {
+        content(index)
+      }
+    } else {
+      content(index)
+    }
+  }
 
-  def codePointBefore(index: Int): Int = content.codePointBefore(index)
+  def codePointBefore(index: Int): Int = {
+    // TODO handle index out of bounds
+    val c: Char = content(index - 1).toChar
+    if (Character.isLowSurrogate(c)) {
+      val c2: Char = content(index - 2).toChar
+      if (Character.isHighSurrogate(c2)) {
+        Character.toCodePoint(c2, c)
+      } else {
+        content(index)
+      }
+    } else {
+      content(index)
+    }
+  }
 
-  def codePointCount(beginIndex: Int, endIndex: Int): Int =
-    content.codePointCount(beginIndex, endIndex)
+  def codePointCount(beginIndex: Int, endIndex: Int): Int = {
+    // TODO handle index out of bounds
+    var count = 0
+    var idx = beginIndex
+    while(idx < endIndex) {
+      if (Character.isHighSurrogate(content(idx).toChar)) {
+        if (Character.isLowSurrogate(content(idx + 1).toChar)) {
+          idx += 2
+        } else {
+          idx += 1
+        }
+      } else {
+        idx += 1
+      }
+      count += 1
+    }
+    count
+  }
 
-  def offsetByCodePoints(index: Int, codePointOffset: Int): Int =
-    content.offsetByCodePoints(index, codePointOffset)
+  def offsetByCodePoints(index: Int, codePointOffset: Int): Int = {
+    // TODO handle index out of bounds
+    var count = 0
+    var idx = index
+    while (count < codePointOffset) {
+      if (Character.isHighSurrogate(content(idx).toChar)) {
+        if (Character.isLowSurrogate(content(idx + 1).toChar)) {
+          idx += 2
+        } else {
+          idx += 1
+        }
+      } else {
+        idx += 1
+      }
+      count += 1
+    }
+    idx
+  }
 
   def getChars(srcBegin: Int, srcEnd: Int, dst: Array[scala.Char],
       dstBegin: Int): Unit = {
-    content.getChars(srcBegin, srcEnd, dst, dstBegin)
+    // TODO handle index out of bounds
+    var srcIdx = srcBegin
+    var dstIdx = dstBegin
+    while (srcIdx < srcEnd) {
+      dst(dstIdx) = content(srcIdx).toChar
+      srcIdx += 1
+      dstIdx += 1
+    }
   }
 
   def setCharAt(index: Int, ch: scala.Char): Unit = {
-    val oldContent = content
-    if (index < 0 || index >= oldContent.length)
+    if (index < 0 || index >= length)
       throw new StringIndexOutOfBoundsException(index)
-    content =
-      oldContent.substring(0, index) + ch + oldContent.substring(index + 1)
+
+    content(index) = ch.toInt
   }
 
-  def substring(start: Int): String = content.substring(start)
+  def substring(start: Int): String = substring(start, length)
 
   def subSequence(start: Int, end: Int): CharSequence = substring(start, end)
 
-  def substring(start: Int, end: Int): String = content.substring(start, end)
+  def substring(start: Int, end: Int): String = {
+    val view = content.subarray(start, end)
+    StringBuilder.JSString.fromCharCode.apply(null, view)
+  }
+}
+
+object StringBuilder {
+
+  @js.native @JSGlobal("String")
+  private object JSString extends js.Object {
+    @js.native
+    object fromCharCode extends js.Any {
+      @JSName("apply")
+      def apply(thisValue: Any, args: Any*): String = js.native
+    }
+  }
+
 }

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -272,8 +272,8 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
     private def genLoadFromLoadSpec(loadSpec: JSNativeLoadSpec)(
         implicit pos: Position): Tree = {
       loadSpec match {
-        case JSNativeLoadSpec.Global(globalRef, Nil) =>
-          JSGlobalRef(globalRef)
+        case JSNativeLoadSpec.Global(globalRef, path) =>
+          path.foldLeft[Tree](JSGlobalRef(globalRef)) { case (ref, segment) => JSSelect(ref, StringLiteral(segment)) }
         case _ =>
           reportError(
               s"unsupported load spec $loadSpec; " +


### PR DESCRIPTION
Attempts to modify StringBuilder to be backed by `Uint16Array`.

Current issues:
- [ ] Compilation fails somewhere in the IR processing phase; the needed reference to `String.fromCharCode.apply(null, ` is most likely the culprit, but I don't know how to fix it
- [ ] Out-of-bounds accesses are not checked for properly on many members

Future issues:
- [ ] This should be benchmarked against the original implementation, it's not guaranteed to be faster