### PR TITLE
Fix #4669: Use PR author and not workflow initiator in CLA check

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -5,4 +5,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v1
-    - run: ./ci/check-cla.sh
+    - run: ./ci/check-cla.sh "${{ github.event.pull_request.user.login }}"

--- a/ci/check-cla.sh
+++ b/ci/check-cla.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -eux
 
-AUTHOR=$GITHUB_ACTOR
+AUTHOR="$1"
 echo "Pull request submitted by $AUTHOR";
 URL_AUTHOR=$(jq -rn --arg x "$AUTHOR" '$x|@uri')
 signed=$(curl -s "https://www.lightbend.com/contribute/cla/scala/check/$URL_AUTHOR" | jq -r ".signed");


### PR DESCRIPTION
$GITHUB_ACTOR contains the initiator of the workflow. However, we want
the autor of the PR.

See https://github.community/t/how-to-get-the-author-of-a-pr/135089