### PR TITLE
Fix #4672: Load loopback modules asynchronously

### DIFF
--- a/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ExportLoopback.scala
+++ b/test-suite/js/src/test/require-modules/org/scalajs/testsuite/jsinterop/ExportLoopback.scala
@@ -1,0 +1,27 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+import scala.concurrent.Future
+
+object ExportLoopback {
+  val exportsNamespace: Future[js.Dynamic] =
+    js.dynamicImport(mainModule).toFuture
+
+  @js.native
+  @JSImport("./main.js", JSImport.Namespace)
+  private val mainModule: js.Dynamic = js.native
+}

--- a/test-suite/js/src/test/require-multi-modules/org/scalajs/testsuite/jsinterop/MultiExportsTest.scala
+++ b/test-suite/js/src/test/require-multi-modules/org/scalajs/testsuite/jsinterop/MultiExportsTest.scala
@@ -12,27 +12,51 @@
 
 package org.scalajs.testsuite.jsinterop
 
+import scala.scalajs.js
 import scala.scalajs.js.annotation._
+
+import scala.concurrent._
+import scala.concurrent.ExecutionContext.Implicits.global
 
 import org.junit.Assert._
 import org.junit.Test
 
+import org.scalajs.junit.async._
+
 class MultiExportsTest {
-  import ExportsTest.exportsNameSpace
+  import MultiExportsTest._
 
   @Test
-  def exportsToDifferentModules(): Unit = {
-    assertEquals("Hello World from mod1",
-        exportsNameSpace("mod1").MultiTopLevelExport("World"))
-
-    assertEquals("Hello World from mod2",
-        exportsNameSpace("mod2").MultiTopLevelExport("World"))
+  def exportsToDifferentModulesMod1(): AsyncResult = await {
+    for (res <- js.dynamicImport(mod1Fun("World")).toFuture)
+      yield assertEquals("Hello World from mod1", res)
   }
 
   @Test
-  def overloadsInASingleModule(): Unit = {
-    assertEquals(5, exportsNameSpace("mod1").MultiTopLevelExport(2, 3))
+  def exportsToDifferentModulesMod2(): AsyncResult = await {
+    for (res <- js.dynamicImport(mod2Fun("World")).toFuture)
+      yield assertEquals("Hello World from mod2", res)
   }
+
+  @Test
+  def overloadsInASingleModule(): AsyncResult = await {
+    for (res <- js.dynamicImport(mod1Fun(2, 3)).toFuture)
+      yield assertEquals(5, res)
+  }
+}
+
+object MultiExportsTest {
+  @js.native
+  @JSImport("./mod1.js", "MultiTopLevelExport")
+  def mod1Fun(x: Int, y: Int): Int = js.native
+
+  @js.native
+  @JSImport("./mod1.js", "MultiTopLevelExport")
+  def mod1Fun(x: String): String = js.native
+
+  @js.native
+  @JSImport("./mod2.js", "MultiTopLevelExport")
+  def mod2Fun(x: String): String = js.native
 }
 
 object MultiTopLevelExports {

--- a/test-suite/js/src/test/require-multi-modules/org/scalajs/testsuite/jsinterop/SJSDynamicImportTest.scala
+++ b/test-suite/js/src/test/require-multi-modules/org/scalajs/testsuite/jsinterop/SJSDynamicImportTest.scala
@@ -281,12 +281,12 @@ class SJSDynamicImportTest {
      * condition. By using the indirection via an export, we can avoid this and
      * trigger the relevant condition.
      */
-    ExportsTest
-      .exportsNameSpace("shared_dep_mod")
-      .useSharedDependencyInPublicModule()
-      .asInstanceOf[js.Promise[Int]]
-      .toFuture
-      .map(assertEquals(2, _))
+    for {
+      facade <- js.dynamicImport(SharedDepFacade).toFuture
+      res <- facade.useSharedDependencyInPublicModule().toFuture
+    } yield {
+      assertEquals(2, res)
+    }
   }
 
   private def assertDynamicLoad[T](promise: js.Promise[T]): Future[Unit] = {
@@ -310,6 +310,12 @@ private object FailureOnLoad extends js.Object
 @JSImport("../test-classes/fail-load.js", JSImport.Default)
 @js.native
 private class FailureOnLoad extends js.Object
+
+@js.native
+@JSImport("./shared_dep_mod.js", JSImport.Namespace)
+private object SharedDepFacade extends js.Object{
+  def useSharedDependencyInPublicModule(): js.Promise[Int] = js.native
+}
 
 private object UseSharedDependencyInPublicModule {
   @JSExportTopLevel("useSharedDependencyInPublicModule", "shared_dep_mod")

--- a/test-suite/js/src/test/require-no-modules/org/scalajs/testsuite/jsinterop/ExportLoopback.scala
+++ b/test-suite/js/src/test/require-no-modules/org/scalajs/testsuite/jsinterop/ExportLoopback.scala
@@ -1,0 +1,22 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+
+import scala.concurrent.Future
+
+object ExportLoopback {
+  def exportsNamespace: Future[js.Dynamic] =
+    throw new AssertionError("attempted to get exportsNamsepace in NoModule mode")
+}


### PR DESCRIPTION
The export-loopback script comes from a time where we didn't have
async testing support.