### PR TITLE
Fix #4675: Handle ES2021 in the ClosureLinkerBackend.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -505,8 +505,8 @@ def allESVersions = [
   "ES2017",
   "ES2018",
   // "ES2019", // We do not use anything specifically from ES2019
-  "ES2020"
-  // "ES2021", // We do not use anything specifically from ES2021
+  "ES2020",
+  "ES2021" // We do not use anything specifically from ES2021, but always test the latest to avoid #4675
 ]
 
 // Scala 2.11 does not support newer Java versions

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,7 +2,7 @@ version: '{build}'
 image: Visual Studio 2015
 environment:
   global:
-    NODEJS_VERSION: "14"
+    NODEJS_VERSION: "16"
     JAVA_HOME: C:\Program Files\Java\jdk1.8.0
 install:
   - ps: Install-Product node $env:NODEJS_VERSION

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -76,6 +76,7 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
       case ESVersion.ES2018 => ECMASCRIPT_2018
       case ESVersion.ES2019 => ECMASCRIPT_2019
       case ESVersion.ES2020 => ECMASCRIPT_2020
+      case ESVersion.ES2021 => ECMASCRIPT_2021
 
       case _ =>
         throw new AssertionError(s"Unknown ES version ${esFeatures.esVersion}")

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -199,7 +199,7 @@ object MyScalaJSPlugin extends AutoPlugin {
       },
 
       testHtmlJSDom in Test := {
-        val target = crossTarget.value.toPath().toAbsolutePath()
+        val target = (baseDirectory in LocalRootProject).value.toPath().toAbsolutePath()
 
         // When serving `target` over HTTP, the path of the runner file.
         val runnerPath = {


### PR DESCRIPTION
This was probably forgotten in 07b0250e62f08e0c37fac0086a373225dbd858cb.

---

This was pending an upgrade of Node.js on our CI. We now need at least v15 which added support for `||=` and `&&=`. The new version is v16.15.1. Thanks to our sysadmin!