### PR TITLE
Generate less calls to {wrap,unwrap}JavaScriptException.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -2885,8 +2885,35 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
     }
 
     private def genTryCatch(body: js.Tree, catches: List[CaseDef],
-        resultType: jstpe.Type,
-        isStat: Boolean)(implicit pos: Position): js.Tree = {
+        resultType: jstpe.Type, isStat: Boolean)(
+        implicit pos: Position): js.Tree = {
+
+      catches match {
+        case CaseDef(Ident(nme.WILDCARD), _, catchAllBody) :: Nil =>
+          genTryCatchCatchIgnoreAll(body, catchAllBody, resultType, isStat)
+
+        case CaseDef(Typed(Ident(nme.WILDCARD), tpt), _, catchAllBody) :: Nil
+            if tpt.tpe.typeSymbol == ThrowableClass =>
+          genTryCatchCatchIgnoreAll(body, catchAllBody, resultType, isStat)
+
+        case _ =>
+          genTryCatchNotIgnoreAll(body, catches, resultType, isStat)
+      }
+    }
+
+    private def genTryCatchCatchIgnoreAll(body: js.Tree, catchAllBody: Tree,
+        resultType: jstpe.Type, isStat: Boolean)(
+        implicit pos: Position): js.Tree = {
+
+      js.TryCatch(body, freshLocalIdent("e"), NoOriginalName,
+          genStatOrExpr(catchAllBody, isStat))(
+          resultType)
+    }
+
+    private def genTryCatchNotIgnoreAll(body: js.Tree, catches: List[CaseDef],
+        resultType: jstpe.Type, isStat: Boolean)(
+        implicit pos: Position): js.Tree = {
+
       val exceptIdent = freshLocalIdent("e")
       val origExceptVar = js.VarRef(exceptIdent)(jstpe.AnyType)
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -2398,7 +2398,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         case Throw(expr) =>
           val ex = genExpr(expr)
           js.Throw {
-            if (isMaybeJavaScriptException(expr.tpe)) {
+            if (!ex.isInstanceOf[js.Null] && isMaybeJavaScriptException(expr.tpe)) {
               genApplyMethod(
                   genLoadModule(RuntimePackageModule),
                   Runtime_unwrapJavaScriptException,

--- a/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
+++ b/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
@@ -73,7 +73,7 @@ private[regex] object PatternCompiler {
       new js.RegExp("", flags)
       true
     } catch {
-      case _: js.JavaScriptException =>
+      case _: Throwable =>
         false
     }
   }
@@ -1658,7 +1658,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
       try {
         new js.RegExp(s"\\p{sc=$canonical}", "u")
       } catch {
-        case _: js.JavaScriptException =>
+        case _: Throwable =>
           parseError(s"Unknown character script name {$scriptName}")
       }
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 187512,
-      expectedFullLinkSizeWithoutClosure = 174703,
-      expectedFullLinkSizeWithClosure = 31649,
+      expectedFastLinkSize = 183410,
+      expectedFullLinkSizeWithoutClosure = 171474,
+      expectedFullLinkSizeWithClosure = 30958,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1730,7 +1730,7 @@ object Build {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 521000 to 522000,
+                fastLink = 520000 to 521000,
                 fullLink = 108000 to 109000,
                 fastLinkGz = 66000 to 67000,
                 fullLinkGz = 28000 to 29000,
@@ -1738,9 +1738,9 @@ object Build {
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 783000 to 784000,
+                fastLink = 782000 to 783000,
                 fullLink = 149000 to 150000,
-                fastLinkGz = 92000 to 93000,
+                fastLinkGz = 91000 to 92000,
                 fullLinkGz = 36000 to 37000,
             ))
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1730,25 +1730,25 @@ object Build {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 520000 to 521000,
-                fullLink = 108000 to 109000,
+                fastLink = 516000 to 517000,
+                fullLink = 107000 to 108000,
                 fastLinkGz = 66000 to 67000,
                 fullLinkGz = 28000 to 29000,
             ))
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 782000 to 783000,
-                fullLink = 149000 to 150000,
+                fastLink = 780000 to 781000,
+                fullLink = 148000 to 149000,
                 fastLinkGz = 91000 to 92000,
                 fullLinkGz = 36000 to 37000,
             ))
 
           case Default2_13ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 732000 to 733000,
-                fullLink = 157000 to 158000,
-                fastLinkGz = 92000 to 93000,
+                fastLink = 730000 to 731000,
+                fullLink = 156000 to 157000,
+                fastLinkGz = 91000 to 92000,
                 fullLinkGz = 40000 to 41000,
             ))
 


### PR DESCRIPTION
Extracted from #4677, with all the changes that involve the codegen, and related library changes that avoid calls to `{wrap,unwrap}JavaScriptException`.

After these changes, there remains a single such call in the javalib. It's an `unwrapJavaScriptException` at
https://github.com/scala-js/scala-js/blob/212a01f429138e4db9ac7a625139808282ec6069/javalib/src/main/scala/java/util/Optional.scala#L71-L73
That one cannot be avoided without altering semantics, since the exception is an arbitrary, *user-provided* `Throwable`. We will need a different kind of solution, more invasive, to address this particular reference to the Scala library. I'll keep that one out of this PR.