### PR TITLE
Optimize getOrElse{,Update} for js.Dictionary and js.Map.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.10.2-SNAPSHOT",
+    current = "1.11.0-SNAPSHOT",
     binaryEmitted = "1.8"
 )
 

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedDictionary.scala
@@ -54,6 +54,23 @@ final class WrappedDictionary[A](private val dict: js.Dictionary[A])
       throw new NoSuchElementException("key not found: " + key)
   }
 
+  override def getOrElse[V1 >: A](key: String, default: => V1): V1 = {
+    if (contains(key))
+      rawApply(key)
+    else
+      default
+  }
+
+  override def getOrElseUpdate(key: String, op: => A): A = {
+    if (contains(key)) {
+      rawApply(key)
+    } else {
+      val v = op
+      update(key, v)
+      v
+    }
+  }
+
   @inline
   private def rawApply(key: String): A =
     dict.asInstanceOf[DictionaryRawApply[A]].rawApply(key)

--- a/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/WrappedMap.scala
@@ -40,17 +40,38 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
 
   def get(key: K): Option[V] = {
     if (contains(key))
-      Some(underlying.asInstanceOf[js.Map.Raw[K, V]].get(key))
+      Some(rawApply(key))
     else
       None
   }
 
   override def apply(key: K): V = {
     if (contains(key))
-      underlying.asInstanceOf[js.Map.Raw[K, V]].get(key)
+      rawApply(key)
     else
       throw new NoSuchElementException("key not found: " + key)
   }
+
+  override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
+    if (contains(key))
+      rawApply(key)
+    else
+      default
+  }
+
+  override def getOrElseUpdate(key: K, op: => V): V = {
+    if (contains(key)) {
+      rawApply(key)
+    } else {
+      val v = op
+      update(key, v)
+      v
+    }
+  }
+
+  @inline
+  private def rawApply(key: K): V =
+    underlying.asInstanceOf[js.Map.Raw[K, V]].get(key)
 
   override def size: Int =
     underlying.size

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedDictionary.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedDictionary.scala
@@ -45,6 +45,23 @@ final class WrappedDictionary[A](private val dict: js.Dictionary[A])
       throw new NoSuchElementException("key not found: " + key)
   }
 
+  override def getOrElse[V1 >: A](key: String, default: => V1): V1 = {
+    if (contains(key))
+      rawApply(key)
+    else
+      default
+  }
+
+  override def getOrElseUpdate(key: String, op: => A): A = {
+    if (contains(key)) {
+      rawApply(key)
+    } else {
+      val v = op
+      update(key, v)
+      v
+    }
+  }
+
   @inline
   private def rawApply(key: String): A =
     dict.asInstanceOf[DictionaryRawApply[A]].rawApply(key)

--- a/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/WrappedMap.scala
@@ -28,17 +28,38 @@ final class WrappedMap[K, V](private val underlying: js.Map[K, V])
 
   def get(key: K): Option[V] = {
     if (contains(key))
-      Some(underlying.asInstanceOf[js.Map.Raw[K, V]].get(key))
+      Some(rawApply(key))
     else
       None
   }
 
   override def apply(key: K): V = {
     if (contains(key))
-      underlying.asInstanceOf[js.Map.Raw[K, V]].get(key)
+      rawApply(key)
     else
       throw new NoSuchElementException("key not found: " + key)
   }
+
+  override def getOrElse[V1 >: V](key: K, default: => V1): V1 = {
+    if (contains(key))
+      rawApply(key)
+    else
+      default
+  }
+
+  override def getOrElseUpdate(key: K, op: => V): V = {
+    if (contains(key)) {
+      rawApply(key)
+    } else {
+      val v = op
+      update(key, v)
+      v
+    }
+  }
+
+  @inline
+  private def rawApply(key: K): V =
+    underlying.asInstanceOf[js.Map.Raw[K, V]].get(key)
 
   override def size: Int =
     underlying.size

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 183410,
-      expectedFullLinkSizeWithoutClosure = 171474,
-      expectedFullLinkSizeWithClosure = 30958,
+      expectedFastLinkSize = 146336,
+      expectedFullLinkSizeWithoutClosure = 135798,
+      expectedFullLinkSizeWithClosure = 22074,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )


### PR DESCRIPTION
The default implementations go through `get`, which allocates a `Some` instance.

This improvement causes `ju.regex.PatternCompiler` not to reach `Some`, `None` and `Option` anymore, which dramatically reduces its test size, although that improvement will not be seen in actual codebases that reach `Option` types anywhere else.

This is a forward binary incompatible change, because the overrides in `js.WrappedDictionary` have a more precise binary signature (taking a `String` for the `key` instead of an `Object` in the erased superclass).

---

I came to this when investigating what caused the huge code size improvement in what remains of #4677. It turns out that the overwhelming majority comes from not depending on `Some`/`None`/`Option`. Looking at where it was used, I found this "hot spot" and figured that it could also be achieved with the optimization. Code size led me to this, but the reason why we would want to merge this PR is speed, as in any realistic code base, it won't make a difference in code size.