### PR TITLE
Repair the import for bloop-based IDEs.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -287,8 +287,9 @@ object Build {
   private def buildInfoOrStubs(config: Configuration, stubsBaseDir: Def.Initialize[File]) = {
     if (isGeneratingForIDE) {
       Def.settings(
-          unmanagedSourceDirectories in config +=
-            stubsBaseDir.value / "scala-ide-stubs"
+        unmanagedSourceDirectories in config +=
+          stubsBaseDir.value / "scala-ide-stubs",
+        config / buildInfoOptions := Nil,
       )
     } else {
       Def.settings(


### PR DESCRIPTION
This was subtly broken in 478c7a48099bb337ddc0793fae05248f9bed2bcb because the projects' settings want to `+=` to `buildInfoOptions`. When we don't include the settings of `BuildInfoPlugin`, there is no initial value for that setting, and therefore the build fails.

I've now used this on 3 different machines, both Linux and Windows, and it seems to work well. :)