### PR TITLE
Manually inline System.identityHashCode into Object.hashCode.

### DIFF
--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -63,7 +63,7 @@ object JavaLangObject {
             GetClass(This()(ThisType))
           })(OptimizerHints.empty.withInline(true), None),
 
-        /* def hashCode(): Int = System.identityHashCode(this) */
+        /* def hashCode(): Int = <identityHashCode>(this) */
         MethodDef(
           MemberFlags.empty,
           MethodIdent(MethodName("hashCode", Nil, IntRef)),
@@ -71,12 +71,8 @@ object JavaLangObject {
           Nil,
           IntType,
           Some {
-            Apply(
-              EAF,
-              LoadModule(ClassName("java.lang.System$")),
-              MethodIdent(MethodName("identityHashCode", List(ObjectClassRef), IntRef)),
-              List(This()(ThisType)))(IntType)
-          })(OptimizerHints.empty, None),
+            IdentityHashCode(This()(ThisType))
+          })(OptimizerHints.empty.withInline(true), None),
 
         /* def equals(that: Object): Boolean = this eq that */
         MethodDef(

--- a/project/MiniLib.scala
+++ b/project/MiniLib.scala
@@ -5,7 +5,6 @@ object MiniLib {
     val inJavaLang = List(
         "Object",
         "Class",
-        "System",
 
         "CharSequence",
         "Cloneable",


### PR DESCRIPTION
Since there is a dedicated IR node for the identity hash code, we can directly use that in `j.l.Object.hashCode()`.

This simplifies the hard-coded IR of `j.l.Object`, and allows to remove `System` from the minilib.