### PR TITLE
Fix #4705: Avoid emitting identifiers called 'await'.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/CompatComponent.scala
@@ -127,6 +127,7 @@ trait CompatComponent {
   object WarningCategoryCompat {
     object Reporting {
       object WarningCategory {
+        val Deprecation: Any = null
         val Other: Any = null
       }
     }

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -1033,12 +1033,6 @@ class JSExportTest extends DirectTest with TestHelpers {
 
   }
 
-  private def since(v: String): String = {
-    val version = scala.util.Properties.versionNumberString
-    if (version.startsWith("2.11.")) ""
-    else s" (since $v)"
-  }
-
   @Test
   def noExportTopLevelTrait(): Unit = {
     """

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/TestHelpers.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/TestHelpers.scala
@@ -32,6 +32,12 @@ trait TestHelpers extends DirectTest {
   /** will be prefixed to every code that is compiled. use for imports */
   def preamble: String = ""
 
+  protected def since(v: String): String = {
+    val version = scala.util.Properties.versionNumberString
+    if (version.startsWith("2.11.")) ""
+    else s" (since $v)"
+  }
+
   /** pimps a string to compile it and apply the specified test */
   implicit class CompileTests(val code: String) {
     private lazy val (success, output) = {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -863,6 +863,11 @@ object Trees {
      *  - The identifier `arguments`, because any attempt to refer to it always
      *    refers to the magical `arguments` pseudo-array from the enclosing
      *    function, rather than a global variable.
+     *
+     *  This set does *not* contain `await`, although it is a reserved word
+     *  within ES modules. It used to be allowed before 1.11.0, and even
+     *  browsers do not seem to reject it. For compatibility reasons, we only
+     *  warn about it at compile time, but the IR allows it.
      */
     final val ReservedJSIdentifierNames: Set[String] = Set(
         "arguments", "break", "case", "catch", "class", "const", "continue",

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
@@ -355,6 +355,8 @@ private object NameGen {
    *  - All ECMAScript 2015 keywords;
    *  - Identifier names that are treated as keywords in ECMAScript 2015
    *    Strict Mode;
+   *  - Identifier names that are treated as keywords in some contexts, such as
+   *    ES modules;
    *  - The identifiers `arguments` and `eval`, because they cannot be used for
    *    local variable names in ECMAScript 2015 Strict Mode;
    *  - The identifier `undefined`, because that's way too confusing if it does
@@ -362,13 +364,13 @@ private object NameGen {
    *    cliffs we can trigger with that.
    */
   private final val ReservedJSIdentifierNames: Set[String] = Set(
-      "arguments", "break", "case", "catch", "class", "const", "continue",
-      "debugger", "default", "delete", "do", "else", "enum", "eval", "export",
-      "extends", "false", "finally", "for", "function", "if", "implements",
-      "import", "in", "instanceof", "interface", "let", "new", "null",
-      "package", "private", "protected", "public", "return", "static", "super",
-      "switch", "this", "throw", "true", "try", "typeof", "undefined", "var",
-      "void", "while", "with", "yield"
+      "arguments", "await", "break", "case", "catch", "class", "const",
+      "continue", "debugger", "default", "delete", "do", "else", "enum",
+      "eval", "export", "extends", "false", "finally", "for", "function", "if",
+      "implements", "import", "in", "instanceof", "interface", "let", "new",
+      "null", "package", "private", "protected", "public", "return", "static",
+      "super", "switch", "this", "throw", "true", "try", "typeof", "undefined",
+      "var", "void", "while", "with", "yield"
   )
 
   private val compressedPrefixes: List[(UTF8String, String)] = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -5954,11 +5954,11 @@ private[optimizer] object OptimizerCore {
      *  (with ASCII characters only).
      */
     private val EmitterReservedJSIdentifiers = List(
-        "arguments", "break", "case", "catch", "class", "const", "continue",
-        "debugger", "default", "delete", "do", "else", "enum", "eval",
-        "export", "extends", "false", "finally", "for", "function", "if",
-        "implements", "import", "in", "instanceof", "interface", "let", "new",
-        "null", "package", "private", "protected", "public", "return",
+        "arguments", "await", "break", "case", "catch", "class", "const",
+        "continue", "debugger", "default", "delete", "do", "else", "enum",
+        "eval", "export", "extends", "false", "finally", "for", "function",
+        "if", "implements", "import", "in", "instanceof", "interface", "let",
+        "new", "null", "package", "private", "protected", "public", "return",
         "static", "super", "switch", "this", "throw", "true", "try", "typeof",
         "undefined", "var", "void", "while", "with", "yield"
     )


### PR DESCRIPTION
'await' is conditionally reserved in ECMAScript, namely when it is within an ES Module.

We then also warn about using it as a global ref.