### PR TITLE
Checked behavior for StringIndexOutOfBoundExceptions.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -2236,7 +2236,10 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           isJSFunctionDef(currentClassSym)) {
         val flags = js.MemberFlags.empty.withNamespace(namespace)
         val body = {
-          if (isImplClass(currentClassSym)) {
+          if (currentClassSym.get == HackedStringClass && methodName.name == charAtMethodName) {
+            // Hijack the body of String.charAt and replace it with a String_charAt binary op
+            js.BinaryOp(js.BinaryOp.String_charAt, genThis(), jsParams.head.ref)
+          } else if (isImplClass(currentClassSym)) {
             val thisParam = jsParams.head
             withScopedVars(
                 thisLocalVarIdent := Some(thisParam.name)
@@ -7058,6 +7061,9 @@ private object GenJSCode {
 
   private val ObjectArgConstructorName =
     MethodName.constructor(List(jstpe.ClassRef(ir.Names.ObjectClass)))
+
+  private val charAtMethodName =
+    MethodName("charAt", List(jstpe.IntRef), jstpe.CharRef)
 
   private val thisOriginalName = OriginalName("this")
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -501,6 +501,10 @@ object Names {
   val ArrayIndexOutOfBoundsExceptionClass: ClassName =
     ClassName("java.lang.ArrayIndexOutOfBoundsException")
 
+  /** The exception thrown by a `BinaryOp.String_charAt` that is out of bounds. */
+  val StringIndexOutOfBoundsExceptionClass: ClassName =
+    ClassName("java.lang.StringIndexOutOfBoundsException")
+
   /** The exception thrown by an `AsInstanceOf` that fails. */
   val ClassCastExceptionClass: ClassName =
     ClassName("java.lang.ClassCastException")

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -356,6 +356,10 @@ object Printers {
           print(method)
           printArgs(args)
 
+        case UnaryOp(UnaryOp.String_length, lhs) =>
+          print(lhs)
+          print(".length")
+
         case UnaryOp(op, lhs) =>
           import UnaryOp._
           print('(')

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -411,6 +411,12 @@ object Printers {
           print(rhs)
           print(')')
 
+        case BinaryOp(BinaryOp.String_charAt, lhs, rhs) =>
+          print(lhs)
+          print('[')
+          print(rhs)
+          print(']')
+
         case BinaryOp(op, lhs, rhs) =>
           import BinaryOp._
           print('(')

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -420,6 +420,9 @@ object Trees {
     final val Double_>  = 56
     final val Double_>= = 57
 
+    // New in 1.11
+    final val String_charAt = 58
+
     def resultTypeOf(op: Code): Type = (op: @switch) match {
       case === | !== |
           Boolean_== | Boolean_!= | Boolean_| | Boolean_& |
@@ -439,6 +442,8 @@ object Trees {
         FloatType
       case Double_+ | Double_- | Double_* | Double_/ | Double_% =>
         DoubleType
+      case String_charAt =>
+        CharType
     }
   }
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -320,6 +320,9 @@ object Trees {
     // Long -> Float (neither widening nor narrowing), introduced in 1.6
     final val LongToFloat = 16
 
+    // String.length, introduced in 1.11
+    final val String_length = 17
+
     def resultTypeOf(op: Code): Type = (op: @switch) match {
       case Boolean_! =>
         BooleanType
@@ -329,7 +332,7 @@ object Trees {
         ByteType
       case IntToShort =>
         ShortType
-      case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt =>
+      case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt | String_length =>
         IntType
       case IntToLong | DoubleToLong =>
         LongType

--- a/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
@@ -297,6 +297,22 @@ object Types {
       throw new IllegalArgumentException(s"cannot generate a zero for $tpe")
   }
 
+  val BoxedClassToPrimType: Map[ClassName, PrimType] = Map(
+    BoxedUnitClass -> UndefType,
+    BoxedBooleanClass -> BooleanType,
+    BoxedCharacterClass -> CharType,
+    BoxedByteClass -> ByteType,
+    BoxedShortClass -> ShortType,
+    BoxedIntegerClass -> IntType,
+    BoxedLongClass -> LongType,
+    BoxedFloatClass -> FloatType,
+    BoxedDoubleClass -> DoubleType,
+    BoxedStringClass -> StringType
+  )
+
+  val PrimTypeToBoxedClass: Map[PrimType, ClassName] =
+    BoxedClassToPrimType.map(_.swap)
+
   /** Tests whether a type `lhs` is a subtype of `rhs` (or equal).
    *  @param isSubclass A function testing whether a class/interface is a
    *                    subclass of another class/interface.
@@ -316,26 +332,11 @@ object Types {
       case (NullType, ClassType(_)) => true
       case (NullType, ArrayType(_)) => true
 
-      case (UndefType, ClassType(className)) =>
-        isSubclass(BoxedUnitClass, className)
-      case (BooleanType, ClassType(className)) =>
-        isSubclass(BoxedBooleanClass, className)
-      case (CharType, ClassType(className)) =>
-        isSubclass(BoxedCharacterClass, className)
-      case (ByteType, ClassType(className)) =>
-        isSubclass(BoxedByteClass, className)
-      case (ShortType, ClassType(className)) =>
-        isSubclass(BoxedShortClass, className)
-      case (IntType, ClassType(className)) =>
-        isSubclass(BoxedIntegerClass, className)
-      case (LongType, ClassType(className)) =>
-        isSubclass(BoxedLongClass, className)
-      case (FloatType, ClassType(className)) =>
-        isSubclass(BoxedFloatClass, className)
-      case (DoubleType, ClassType(className)) =>
-        isSubclass(BoxedDoubleClass, className)
-      case (StringType, ClassType(className)) =>
-        isSubclass(BoxedStringClass, className)
+      case (primType: PrimType, ClassType(rhsClass)) =>
+        val lhsClass = PrimTypeToBoxedClass.getOrElse(primType, {
+          throw new AssertionError(s"unreachable case for isSubtype($lhs, $rhs)")
+        })
+        isSubclass(lhsClass, rhsClass)
 
       case (ArrayType(ArrayTypeRef(lhsBase, lhsDims)),
           ArrayType(ArrayTypeRef(rhsBase, rhsDims))) =>

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -396,6 +396,8 @@ class PrintersTest {
     assertPrintEquals("((long)x)", UnaryOp(DoubleToLong, ref("x", DoubleType)))
 
     assertPrintEquals("((float)x)", UnaryOp(LongToFloat, ref("x", LongType)))
+
+    assertPrintEquals("x.length", UnaryOp(String_length, ref("x", StringType)))
   }
 
   @Test def printPseudoUnaryOp(): Unit = {

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -538,6 +538,9 @@ class PrintersTest {
         BinaryOp(Double_>, ref("x", DoubleType), ref("y", DoubleType)))
     assertPrintEquals("(x >=[double] y)",
         BinaryOp(Double_>=, ref("x", DoubleType), ref("y", DoubleType)))
+
+    assertPrintEquals("x[y]",
+        BinaryOp(String_charAt, ref("x", StringType), ref("y", IntType)))
   }
 
   @Test def printNewArray(): Unit = {

--- a/javalib/src/main/scala/java/lang/StackTrace.scala
+++ b/javalib/src/main/scala/java/lang/StackTrace.scala
@@ -228,12 +228,12 @@ private[lang] object StackTrace {
         if (i < compressedPrefixes.length) {
           val prefix = compressedPrefixes(i)
           if (encodedName.startsWith(prefix))
-            dictRawApply(decompressedPrefixes, prefix) + encodedName.substring(prefix.length)
+            dictRawApply(decompressedPrefixes, prefix) + encodedName.jsSubstring(prefix.length)
           else
             loop(i+1)
         } else {
           // no prefix matches
-          if (encodedName.startsWith("L")) encodedName.substring(1)
+          if (encodedName.startsWith("L")) encodedName.jsSubstring(1)
           else encodedName // just in case
         }
       }
@@ -284,7 +284,7 @@ private[lang] object StackTrace {
     } else {
       val methodNameLen = encodedName.indexOf("__")
       if (methodNameLen < 0) encodedName
-      else encodedName.substring(0, methodNameLen)
+      else encodedName.jsSubstring(0, methodNameLen)
     }
   }
 

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -47,6 +47,10 @@ final class _String private () // scalastyle:ignore
     this.asInstanceOf[String]
 
   @inline
+  def length(): Int =
+    throw new Error("stub") // body replaced by the compiler back-end
+
+  @inline
   def charAt(index: Int): Char =
     throw new Error("stub") // body replaced by the compiler back-end
 
@@ -279,10 +283,6 @@ final class _String private () // scalastyle:ignore
     else thisString.jsLastIndexOf(str, fromIndex)
 
   @inline
-  def length(): Int =
-    this.asInstanceOf[js.Dynamic].length.asInstanceOf[Int]
-
-  @inline
   def matches(regex: String): scala.Boolean =
     Pattern.matches(regex, thisString)
 
@@ -374,20 +374,20 @@ final class _String private () // scalastyle:ignore
 
   @inline
   def substring(beginIndex: Int): String = {
-    // Bounds check (cleverly not using length() yet reporting errors in the appropriate cases)
-    if (beginIndex != 0)
-      charAt(beginIndex - 1)
+    // Bounds check
+    if (beginIndex < 0 || beginIndex > length())
+      charAt(beginIndex)
 
     thisString.jsSubstring(beginIndex)
   }
 
   @inline
   def substring(beginIndex: Int, endIndex: Int): String = {
-    // Bounds check (cleverly not using length() yet reporting errors in the appropriate cases)
-    if (beginIndex != 0)
-      charAt(beginIndex - 1)
-    if (endIndex != 0)
-      charAt(endIndex - 1)
+    // Bounds check
+    if (beginIndex < 0)
+      charAt(beginIndex)
+    if (endIndex > length())
+      charAt(endIndex)
     if (endIndex < beginIndex)
       charAt(-1)
 

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -48,10 +48,11 @@ final class _String private () // scalastyle:ignore
 
   @inline
   def charAt(index: Int): Char =
-    this.asInstanceOf[js.Dynamic].charCodeAt(index).asInstanceOf[Int].toChar
+    throw new Error("stub") // body replaced by the compiler back-end
 
   def codePointAt(index: Int): Int = {
     if (linkingInfo.esVersion >= ESVersion.ES2015) {
+      charAt(index) // bounds check
       this.asInstanceOf[js.Dynamic].codePointAt(index).asInstanceOf[Int]
     } else {
       val high = charAt(index)
@@ -372,12 +373,26 @@ final class _String private () // scalastyle:ignore
     substring(beginIndex, endIndex)
 
   @inline
-  def substring(beginIndex: Int): String =
+  def substring(beginIndex: Int): String = {
+    // Bounds check (cleverly not using length() yet reporting errors in the appropriate cases)
+    if (beginIndex != 0)
+      charAt(beginIndex - 1)
+
     thisString.jsSubstring(beginIndex)
+  }
 
   @inline
-  def substring(beginIndex: Int, endIndex: Int): String =
+  def substring(beginIndex: Int, endIndex: Int): String = {
+    // Bounds check (cleverly not using length() yet reporting errors in the appropriate cases)
+    if (beginIndex != 0)
+      charAt(beginIndex - 1)
+    if (endIndex != 0)
+      charAt(endIndex - 1)
+    if (endIndex < beginIndex)
+      charAt(-1)
+
     thisString.jsSubstring(beginIndex, endIndex)
+  }
 
   def toCharArray(): Array[Char] = {
     val len = length()

--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -751,7 +751,7 @@ final class Formatter private (private[this] var dest: Appendable,
       width: Int, precision: Int, str: String): Unit = {
 
     val truncatedStr =
-      if (precision < 0) str
+      if (precision < 0 || precision >= str.length()) str
       else str.substring(0, precision)
     padAndSendToDestNoZeroPad(flags, width,
         applyUpperCase(localeInfo, flags, truncatedStr))

--- a/javalib/src/main/scala/java/util/regex/IndicesBuilder.scala
+++ b/javalib/src/main/scala/java/util/regex/IndicesBuilder.scala
@@ -17,6 +17,7 @@ import scala.annotation.{tailrec, switch}
 import java.lang.Utils._
 
 import scala.scalajs.js
+import scala.scalajs.js.JSStringOps._
 
 import Pattern.IndicesArray
 
@@ -419,7 +420,7 @@ private[regex] object IndicesBuilder {
             }
 
           case '(' =>
-            val indicator = pattern.substring(pIndex + 1, pIndex + 3)
+            val indicator = pattern.jsSubstring(pIndex + 1, pIndex + 3)
             if (indicator == "?=" || indicator == "?!") {
               // Look-ahead group
               pIndex += 3
@@ -427,7 +428,7 @@ private[regex] object IndicesBuilder {
               new LookAroundNode(isLookBehind = false, indicator, inner)
             } else if (indicator == "?<") {
               // Look-behind group, which must be ?<= or ?<!
-              val fullIndicator = pattern.substring(pIndex + 1, pIndex + 4)
+              val fullIndicator = pattern.jsSubstring(pIndex + 1, pIndex + 4)
               pIndex += 4
               val inner = parseInsideParensAndClosingParen()
               new LookAroundNode(isLookBehind = true, fullIndicator, inner)
@@ -464,7 +465,7 @@ private[regex] object IndicesBuilder {
               while (isDigit(pattern.charAt(pIndex)))
                 pIndex += 1
               new BackReferenceNode(
-                  Integer.parseInt(pattern.substring(startIndex + 1, pIndex)))
+                  Integer.parseInt(pattern.jsSubstring(startIndex + 1, pIndex)))
             } else {
               // it is a character escape, or one of \b, \B, \d, \D, \p{...} or \P{...}
               if (c == 'p' || c == 'P') {
@@ -472,7 +473,7 @@ private[regex] object IndicesBuilder {
                   pIndex += 1
                 pIndex += 1
               }
-              new LeafRegexNode(pattern.substring(startIndex, pIndex))
+              new LeafRegexNode(pattern.jsSubstring(startIndex, pIndex))
             }
 
           case '[' =>
@@ -487,13 +488,13 @@ private[regex] object IndicesBuilder {
 
             val startIndex = pIndex
             pIndex = loop(startIndex + 1)
-            val regex = pattern.substring(startIndex, pIndex)
+            val regex = pattern.jsSubstring(startIndex, pIndex)
             new LeafRegexNode(regex)
 
           case _ =>
             val start = pIndex
             pIndex += Character.charCount(dispatchCP)
-            new LeafRegexNode(pattern.substring(start, pIndex))
+            new LeafRegexNode(pattern.jsSubstring(start, pIndex))
         }
 
         if (baseNode ne null) { // null if we just completed an alternative
@@ -505,7 +506,7 @@ private[regex] object IndicesBuilder {
               else
                 pIndex += 1
 
-              val repeater = pattern.substring(startIndex, pIndex)
+              val repeater = pattern.jsSubstring(startIndex, pIndex)
               sequence.push(new RepeatedNode(baseNode, repeater))
 
             case '{' =>
@@ -514,7 +515,7 @@ private[regex] object IndicesBuilder {
               pIndex = pattern.indexOf("}", startIndex + 1) + 1
               if (pattern.charAt(pIndex) == '?') // non-greedy mark
                 pIndex += 1
-              val repeater = pattern.substring(startIndex, pIndex)
+              val repeater = pattern.jsSubstring(startIndex, pIndex)
               sequence.push(new RepeatedNode(baseNode, repeater))
 
             case _ =>

--- a/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
+++ b/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
@@ -29,6 +29,7 @@ import java.lang.Utils._
 import java.util.ScalaOps._
 
 import scala.scalajs.js
+import scala.scalajs.js.JSStringOps.enableJSStringOps
 import scala.scalajs.runtime.linkingInfo
 import scala.scalajs.LinkingInfo.ESVersion
 
@@ -807,7 +808,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
     val jsPattern = if (isLiteral) {
       literal(pattern)
     } else {
-      if (pattern.substring(pIndex, pIndex + 2) == "\\G") {
+      if (pattern.jsSubstring(pIndex, pIndex + 2) == "\\G") {
         sticky = true
         pIndex += 2
       }
@@ -1133,7 +1134,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
       pIndex += 1
     }
 
-    pattern.substring(startOfRepeater, pIndex)
+    pattern.jsSubstring(startOfRepeater, pIndex)
   }
 
   /** Builds a possessive quantifier, which is sugar for an atomic group over
@@ -1262,7 +1263,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
       // Boundary matchers
 
       case 'b' =>
-        if (pattern.substring(pIndex, pIndex + 4) == "b{g}") {
+        if (pattern.jsSubstring(pIndex, pIndex + 4) == "b{g}") {
           parseError("\\b{g} is not supported")
         } else {
           /* Compile as is if both `UNICODE_CASE` and `UNICODE_CHARACTER_CLASS` are false.
@@ -1345,11 +1346,11 @@ private final class PatternCompiler(private val pattern: String, private var fla
 
         // In most cases, one of the first two conditions is immediately false
         while (end != len && isDigit(pattern.charAt(end)) &&
-            parseInt(pattern.substring(start, end + 1), 10) <= originalGroupCount) {
+            parseInt(pattern.jsSubstring(start, end + 1), 10) <= originalGroupCount) {
           end += 1
         }
 
-        val groupString = pattern.substring(start, end)
+        val groupString = pattern.jsSubstring(start, end)
         val groupNumber = parseInt(groupString, 10)
         if (groupNumber > originalGroupCount)
           parseError(s"numbered capturing group <$groupNumber> does not exist")
@@ -1379,10 +1380,10 @@ private final class PatternCompiler(private val pattern: String, private var fla
         val end = pattern.indexOf("\\E", start)
         if (end < 0) {
           pIndex = pattern.length()
-          literal(pattern.substring(start))
+          literal(pattern.jsSubstring(start))
         } else {
           pIndex = end + 2
-          literal(pattern.substring(start, end))
+          literal(pattern.jsSubstring(start, end))
         }
 
       // Other
@@ -1527,7 +1528,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
     val lowStart = end + 2
     val lowEnd = lowStart + 4
 
-    if (isHighSurrogateCP(codeUnit) && pattern.substring(end, lowStart) == "\\u") {
+    if (isHighSurrogateCP(codeUnit) && pattern.jsSubstring(end, lowStart) == "\\u") {
       val low = parseHexCodePoint(lowStart, lowEnd, "Unicode")
       if (isLowSurrogateCP(low)) {
         pIndex = lowEnd
@@ -1554,7 +1555,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
 
     val cp =
       if (end - start > 6) Character.MAX_CODE_POINT + 1
-      else parseInt(pattern.substring(start, end), 16)
+      else parseInt(pattern.jsSubstring(start, end), 16)
     if (cp > Character.MAX_CODE_POINT)
       parseError("Hexadecimal codepoint is too big")
 
@@ -1604,9 +1605,9 @@ private final class PatternCompiler(private val pattern: String, private var fla
       if (innerEnd < 0)
         parseError("Unclosed character family")
       pIndex = innerEnd
-      pattern.substring(innerStart, innerEnd)
+      pattern.jsSubstring(innerStart, innerEnd)
     } else {
-      pattern.substring(start, start + 1)
+      pattern.jsSubstring(start, start + 1)
     }
 
     val result = if (!unicodeCharacterClass && dictContains(asciiPOSIXCharacterClasses, property)) {
@@ -1631,7 +1632,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
           // Error
           parseError(s"Unknown Unicode character class '$property'")
         }
-        CompiledCharClass.posP("sc=" + canonicalizeScriptName(property.substring(scriptPrefixLen)))
+        CompiledCharClass.posP("sc=" + canonicalizeScriptName(property.jsSubstring(scriptPrefixLen)))
       }
     }
 
@@ -1796,7 +1797,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
       if (c1 == ':' || c1 == '=' || c1 == '!') {
         // Non-capturing group or look-ahead
         pIndex = start + 3
-        pattern.substring(start, start + 3) + compileInsideGroup() + ")"
+        pattern.jsSubstring(start, start + 3) + compileInsideGroup() + ")"
       } else if (c1 == '<') {
         if (start + 3 == len)
           parseError("Unclosed group")
@@ -1820,7 +1821,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
             parseError("Unknown look-behind group")
           requireES2018Features("Look-behind group")
           pIndex = start + 4
-          pattern.substring(start, start + 4) + compileInsideGroup() + ")"
+          pattern.jsSubstring(start, start + 4) + compileInsideGroup() + ")"
         }
       } else if (c1 == '>') {
         // Atomic group
@@ -1848,6 +1849,6 @@ private final class PatternCompiler(private val pattern: String, private var fla
       pIndex += 1
     if (pIndex == len || pattern.charAt(pIndex) != '>')
       parseError("named capturing group is missing trailing '>'")
-    pattern.substring(start, pIndex)
+    pattern.jsSubstring(start, pIndex)
   }
 }

--- a/library/src/main/scala/scala/scalajs/runtime/PrivateFieldsSymbolHolder.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/PrivateFieldsSymbolHolder.scala
@@ -13,6 +13,7 @@
 package scala.scalajs.runtime
 
 import scala.scalajs.js
+import scala.scalajs.js.JSStringOps._
 import scala.scalajs.LinkingInfo.ESVersion
 
 private[runtime] object PrivateFieldsSymbolHolder {
@@ -23,9 +24,9 @@ private[runtime] object PrivateFieldsSymbolHolder {
       js.Symbol("privateFields")
     } else {
       def rand32(): String = {
-        val s = (js.Math.random() * 4294967296.0).asInstanceOf[js.Dynamic]
+        val s = ((js.Math.random() * 4294967296.0).asInstanceOf[js.Dynamic] >>> 0.asInstanceOf[js.Dynamic])
           .applyDynamic("toString")(16).asInstanceOf[String]
-        "00000000".substring(s.length) + s
+        "00000000".jsSubstring(s.length) + s
       }
       rand32() + rand32() + rand32() + rand32()
     }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
@@ -18,6 +18,7 @@ import Fingerprint.FingerprintBuilder
 final class Semantics private (
     val asInstanceOfs: CheckedBehavior,
     val arrayIndexOutOfBounds: CheckedBehavior,
+    val stringIndexOutOfBounds: CheckedBehavior,
     val moduleInit: CheckedBehavior,
     val strictFloats: Boolean,
     val productionMode: Boolean,
@@ -30,6 +31,9 @@ final class Semantics private (
 
   def withArrayIndexOutOfBounds(behavior: CheckedBehavior): Semantics =
     copy(arrayIndexOutOfBounds = behavior)
+
+  def withStringIndexOutOfBounds(behavior: CheckedBehavior): Semantics =
+    copy(stringIndexOutOfBounds = behavior)
 
   def withModuleInit(moduleInit: CheckedBehavior): Semantics =
     copy(moduleInit = moduleInit)
@@ -53,6 +57,7 @@ final class Semantics private (
   def optimized: Semantics = {
     copy(asInstanceOfs = this.asInstanceOfs.optimized,
         arrayIndexOutOfBounds = this.arrayIndexOutOfBounds.optimized,
+        stringIndexOutOfBounds = this.stringIndexOutOfBounds.optimized,
         moduleInit = this.moduleInit.optimized,
         productionMode = true)
   }
@@ -61,6 +66,7 @@ final class Semantics private (
     case that: Semantics =>
       this.asInstanceOfs == that.asInstanceOfs &&
       this.arrayIndexOutOfBounds == that.arrayIndexOutOfBounds &&
+      this.stringIndexOutOfBounds == that.stringIndexOutOfBounds &&
       this.moduleInit == that.moduleInit &&
       this.strictFloats == that.strictFloats &&
       this.productionMode == that.productionMode &&
@@ -74,26 +80,29 @@ final class Semantics private (
     var acc = HashSeed
     acc = mix(acc, asInstanceOfs.##)
     acc = mix(acc, arrayIndexOutOfBounds.##)
+    acc = mix(acc, stringIndexOutOfBounds.##)
     acc = mix(acc, moduleInit.##)
     acc = mix(acc, strictFloats.##)
     acc = mix(acc, productionMode.##)
     acc = mixLast(acc, runtimeClassNameMapper.##)
-    finalizeHash(acc, 6)
+    finalizeHash(acc, 7)
   }
 
   override def toString(): String = {
     s"""Semantics(
-       |  asInstanceOfs         = $asInstanceOfs,
-       |  arrayIndexOutOfBounds = $arrayIndexOutOfBounds,
-       |  moduleInit            = $moduleInit,
-       |  strictFloats          = $strictFloats,
-       |  productionMode        = $productionMode
+       |  asInstanceOfs          = $asInstanceOfs,
+       |  arrayIndexOutOfBounds  = $arrayIndexOutOfBounds,
+       |  stringIndexOutOfBounds = $stringIndexOutOfBounds,
+       |  moduleInit             = $moduleInit,
+       |  strictFloats           = $strictFloats,
+       |  productionMode         = $productionMode
        |)""".stripMargin
   }
 
   private def copy(
       asInstanceOfs: CheckedBehavior = this.asInstanceOfs,
       arrayIndexOutOfBounds: CheckedBehavior = this.arrayIndexOutOfBounds,
+      stringIndexOutOfBounds: CheckedBehavior = this.stringIndexOutOfBounds,
       moduleInit: CheckedBehavior = this.moduleInit,
       strictFloats: Boolean = this.strictFloats,
       productionMode: Boolean = this.productionMode,
@@ -102,6 +111,7 @@ final class Semantics private (
     new Semantics(
         asInstanceOfs = asInstanceOfs,
         arrayIndexOutOfBounds = arrayIndexOutOfBounds,
+        stringIndexOutOfBounds = stringIndexOutOfBounds,
         moduleInit = moduleInit,
         strictFloats = strictFloats,
         productionMode = productionMode,
@@ -217,6 +227,7 @@ object Semantics {
       new FingerprintBuilder("Semantics")
         .addField("asInstanceOfs", semantics.asInstanceOfs)
         .addField("arrayIndexOutOfBounds", semantics.arrayIndexOutOfBounds)
+        .addField("stringIndexOutOfBounds", semantics.stringIndexOutOfBounds)
         .addField("moduleInit", semantics.moduleInit)
         .addField("strictFloats", semantics.strictFloats)
         .addField("productionMode", semantics.productionMode)
@@ -228,6 +239,7 @@ object Semantics {
   val Defaults: Semantics = new Semantics(
       asInstanceOfs = Fatal,
       arrayIndexOutOfBounds = Fatal,
+      stringIndexOutOfBounds = Fatal,
       moduleInit = Unchecked,
       strictFloats = true,
       productionMode = false,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -794,8 +794,12 @@ private[emitter] object CoreJSLib {
           case _                 => None
         }
 
-        def genHijackedMethodApply(className: ClassName): Tree =
-          Apply(globalVar("f", (className, methodName)), instance :: args)
+        def genHijackedMethodApply(className: ClassName): Tree = {
+          val instanceAsPrimitive =
+            if (className == BoxedCharacterClass) genCallHelper("uC", instance)
+            else instance
+          Apply(globalVar("f", (className, methodName)), instanceAsPrimitive :: args)
+        }
 
         def genBodyNoSwitch(hijackedClasses: List[ClassName]): Tree = {
           val normalCall = Return(Apply(instance DOT genName(methodName), args))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -365,7 +365,7 @@ private[emitter] object CoreJSLib {
         case PrivateSymbolBuiltin =>
           /* function privateJSFieldSymbol(description) {
            *   function rand32() {
-           *     const s = ((Math.random() * 4294967296.0) | 0).toString(16);
+           *     const s = ((Math.random() * 4294967296.0) >>> 0).toString(16);
            *     return "00000000".substring(s.length) + s;
            *   }
            *   return description + rand32() + rand32() + rand32() + rand32();
@@ -386,9 +386,9 @@ private[emitter] object CoreJSLib {
                   genLet(s.ident, mutable = false, {
                       val randomDouble =
                         Apply(genIdentBracketSelect(MathRef, "random"), Nil)
-                      val randomInt =
-                        (randomDouble * double(4294967296.0)) | 0
-                      Apply(genIdentBracketSelect(randomInt, "toString"), 16 :: Nil)
+                      val randomUint =
+                        (randomDouble * double(4294967296.0)) >>> 0
+                      Apply(genIdentBracketSelect(randomUint, "toString"), 16 :: Nil)
                   }),
                   {
                     val padding = Apply(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -828,7 +828,12 @@ object Emitter {
               StringArgConstructorName)
         },
 
-        cond(asInstanceOfs == Fatal || arrayIndexOutOfBounds == Fatal) {
+        cond(stringIndexOutOfBounds != Unchecked) {
+          instantiateClass(StringIndexOutOfBoundsExceptionClass,
+              IntArgConstructorName)
+        },
+
+        cond(asInstanceOfs == Fatal || arrayIndexOutOfBounds == Fatal || stringIndexOutOfBounds == Fatal) {
           instantiateClass(UndefinedBehaviorErrorClass,
               ThrowableArgConsructorName)
         },

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterNames.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterNames.scala
@@ -31,6 +31,7 @@ private[emitter] object EmitterNames {
   // Method names
 
   val AnyArgConstructorName = MethodName.constructor(List(ClassRef(ObjectClass)))
+  val IntArgConstructorName = MethodName.constructor(List(IntRef))
   val StringArgConstructorName = MethodName.constructor(List(ClassRef(BoxedStringClass)))
   val ThrowableArgConsructorName = MethodName.constructor(List(ClassRef(ThrowableClass)))
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2378,6 +2378,10 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                 genCallHelper("longToFloat", newLhs)
               else
                 genLongMethodApply(newLhs, LongImpl.toFloat)
+
+            // String.length
+            case String_length =>
+              genIdentBracketSelect(newLhs, "length")
           }
 
         case BinaryOp(op, lhs, rhs) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -489,6 +489,8 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
             FloatType
           case DoubleToInt | DoubleToFloat | DoubleToLong =>
             DoubleType
+          case String_length =>
+            StringType
         }
         typecheckExpect(lhs, env, expectedArgType)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -128,7 +128,7 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
     } { body =>
       val thisType =
         if (static) NoType
-        else ClassType(classDef.name.name)
+        else thisTypeForScalaClass(classDef)
 
       val inConstructorOf =
         if (flags.namespace.isConstructor) Some(classDef.name.name)
@@ -171,7 +171,7 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
     val thisType = {
       if (static) NoType
       else if (clazz.kind.isJSClass) AnyType
-      else ClassType(clazz.name.name)
+      else thisTypeForScalaClass(clazz)
     }
 
     val bodyEnv = Env.fromSignature(thisType)
@@ -188,7 +188,7 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
     val thisType =
       if (flags.namespace.isStatic) NoType
       else if (clazz.kind.isJSClass) AnyType
-      else ClassType(clazz.name.name)
+      else thisTypeForScalaClass(clazz)
 
     val env = Env.fromSignature(thisType)
 
@@ -198,6 +198,10 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
       typecheck(body, env)
     }
   }
+
+  private def thisTypeForScalaClass(clazz: LinkedClass): Type =
+    if (clazz.kind == ClassKind.HijackedClass) BoxedClassToPrimType(clazz.name.name)
+    else ClassType(clazz.name.name)
 
   private def typecheckExpect(tree: Tree, env: Env, expectedType: Type)(
       implicit ctx: ErrorContext): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -513,10 +513,12 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
               Double_== | Double_!= |
               Double_< | Double_<= | Double_> | Double_>= =>
             DoubleType
+          case String_charAt =>
+            StringType
         }
         val expectedRhsType = (op: @switch) match {
-          case Long_<< | Long_>>> | Long_>> => IntType
-          case _                            => expectedLhsType
+          case Long_<< | Long_>>> | Long_>> | String_charAt => IntType
+          case _                                            => expectedLhsType
         }
         typecheckExpect(lhs, env, expectedLhsType)
         typecheckExpect(rhs, env, expectedRhsType)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -240,6 +240,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
 
     def thisType: Type =
       if (namespace.isStatic) NoType
+      else if (linkedClass.kind == ClassKind.HijackedClass) BoxedClassToPrimType(className)
       else ClassType(className)
 
     val methods = mutable.Map.empty[MethodName, MethodImpl]

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3242,110 +3242,6 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     }
   }
 
-  private def constantFoldBinaryOp_except_String_+(op: BinaryOp.Code,
-      lhs: Literal, rhs: Literal)(implicit pos: Position): Literal = {
-    import BinaryOp._
-
-    @inline def int(lit: Literal): Int = (lit: @unchecked) match {
-      case IntLiteral(value) => value
-    }
-
-    @inline def long(lit: Literal): Long = (lit: @unchecked) match {
-      case LongLiteral(value) => value
-    }
-
-    @inline def float(lit: Literal): Float = (lit: @unchecked) match {
-      case FloatLiteral(value) => value
-    }
-
-    @inline def double(lit: Literal): Double = (lit: @unchecked) match {
-      case DoubleLiteral(value) => value
-    }
-
-    @inline def boolean(lit: Literal): Boolean = (lit: @unchecked) match {
-      case BooleanLiteral(value) => value
-    }
-
-    @inline def string(lit: Literal): String = (lit: @unchecked) match {
-      case StringLiteral(value) => value
-    }
-
-    (op: @switch) match {
-      case === => BooleanLiteral(literal_===(lhs, rhs, isJSStrictEq = false))
-      case !== => BooleanLiteral(!literal_===(lhs, rhs, isJSStrictEq = false))
-
-      case String_+ =>
-        throw new IllegalArgumentException(
-            "constFoldBinaryOp_except_String_+ must not be called for String_+")
-
-      case Int_+ => IntLiteral(int(lhs) + int(rhs))
-      case Int_- => IntLiteral(int(lhs) - int(rhs))
-      case Int_* => IntLiteral(int(lhs) * int(rhs))
-      case Int_/ => IntLiteral(int(lhs) / int(rhs))
-      case Int_% => IntLiteral(int(lhs) % int(rhs))
-
-      case Int_|   => IntLiteral(int(lhs) | int(rhs))
-      case Int_&   => IntLiteral(int(lhs) & int(rhs))
-      case Int_^   => IntLiteral(int(lhs) ^ int(rhs))
-      case Int_<<  => IntLiteral(int(lhs) << int(rhs))
-      case Int_>>> => IntLiteral(int(lhs) >>> int(rhs))
-      case Int_>>  => IntLiteral(int(lhs) >> int(rhs))
-
-      case Int_== => BooleanLiteral(int(lhs) == int(rhs))
-      case Int_!= => BooleanLiteral(int(lhs) != int(rhs))
-      case Int_<  => BooleanLiteral(int(lhs) < int(rhs))
-      case Int_<= => BooleanLiteral(int(lhs) <= int(rhs))
-      case Int_>  => BooleanLiteral(int(lhs) > int(rhs))
-      case Int_>= => BooleanLiteral(int(lhs) >= int(rhs))
-
-      case Long_+ => LongLiteral(long(lhs) + long(rhs))
-      case Long_- => LongLiteral(long(lhs) - long(rhs))
-      case Long_* => LongLiteral(long(lhs) * long(rhs))
-      case Long_/ => LongLiteral(long(lhs) / long(rhs))
-      case Long_% => LongLiteral(long(lhs) % long(rhs))
-
-      case Long_|   => LongLiteral(long(lhs) | long(rhs))
-      case Long_&   => LongLiteral(long(lhs) & long(rhs))
-      case Long_^   => LongLiteral(long(lhs) ^ long(rhs))
-      case Long_<<  => LongLiteral(long(lhs) << int(rhs))
-      case Long_>>> => LongLiteral(long(lhs) >>> int(rhs))
-      case Long_>>  => LongLiteral(long(lhs) >> int(rhs))
-
-      case Long_== => BooleanLiteral(long(lhs) == long(rhs))
-      case Long_!= => BooleanLiteral(long(lhs) != long(rhs))
-      case Long_<  => BooleanLiteral(long(lhs) < long(rhs))
-      case Long_<= => BooleanLiteral(long(lhs) <= long(rhs))
-      case Long_>  => BooleanLiteral(long(lhs) > long(rhs))
-      case Long_>= => BooleanLiteral(long(lhs) >= long(rhs))
-
-      case Float_+ => FloatLiteral(float(lhs) + float(rhs))
-      case Float_- => FloatLiteral(float(lhs) - float(rhs))
-      case Float_* => FloatLiteral(float(lhs) * float(rhs))
-      case Float_/ => FloatLiteral(float(lhs) / float(rhs))
-      case Float_% => FloatLiteral(float(lhs) % float(rhs))
-
-      case Double_+ => DoubleLiteral(double(lhs) + double(rhs))
-      case Double_- => DoubleLiteral(double(lhs) - double(rhs))
-      case Double_* => DoubleLiteral(double(lhs) * double(rhs))
-      case Double_/ => DoubleLiteral(double(lhs) / double(rhs))
-      case Double_% => DoubleLiteral(double(lhs) % double(rhs))
-
-      case Double_== => BooleanLiteral(double(lhs) == double(rhs))
-      case Double_!= => BooleanLiteral(double(lhs) != double(rhs))
-      case Double_<  => BooleanLiteral(double(lhs) < double(rhs))
-      case Double_<= => BooleanLiteral(double(lhs) <= double(rhs))
-      case Double_>  => BooleanLiteral(double(lhs) > double(rhs))
-      case Double_>= => BooleanLiteral(double(lhs) >= double(rhs))
-
-      case Boolean_== => BooleanLiteral(boolean(lhs) == boolean(rhs))
-      case Boolean_!= => BooleanLiteral(boolean(lhs) != boolean(rhs))
-      case Boolean_|  => BooleanLiteral(boolean(lhs) | boolean(rhs))
-      case Boolean_&  => BooleanLiteral(boolean(lhs) & boolean(rhs))
-
-      case String_charAt => CharLiteral(string(lhs).charAt(int(rhs)))
-    }
-  }
-
   /** Translate literals to their Scala.js String representation. */
   private def foldToStringForString_+(preTrans: PreTransform)(
       implicit pos: Position): PreTransform = preTrans match {
@@ -3391,47 +3287,6 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     }
   }
 
-  private def foldBinaryOp(op: BinaryOp.Code, lhs: PreTransform,
-      rhs: PreTransform)(
-      implicit pos: Position): PreTransform = {
-    import BinaryOp._
-
-    def constant(lhsLit: Literal, rhsLit: Literal): PreTransform =
-      PreTransLit(constantFoldBinaryOp_except_String_+(op, lhsLit, rhsLit))
-
-    def nonConstant(): PreTransform = foldBinaryOpNonConstant(op, lhs, rhs)
-
-    (lhs, rhs) match {
-      case (PreTransLit(lhsLit), PreTransLit(rhsLit)) =>
-        op match {
-          case String_+ =>
-            nonConstant()
-          case Int_/ | Int_% =>
-            rhsLit match {
-              case IntLiteral(0) => nonConstant()
-              case _             => constant(lhsLit, rhsLit)
-            }
-          case Long_/ | Long_% =>
-            rhsLit match {
-              case LongLiteral(0) => nonConstant()
-              case _              => constant(lhsLit, rhsLit)
-            }
-          case String_charAt =>
-            (lhsLit, rhsLit) match {
-              case (StringLiteral(lhsStr), IntLiteral(rhsInt)) if rhsInt < 0 || rhsInt >= lhsStr.length() =>
-                nonConstant()
-              case _ =>
-                constant(lhsLit, rhsLit)
-            }
-          case _ =>
-            constant(lhsLit, rhsLit)
-        }
-
-      case _ =>
-        nonConstant()
-    }
-  }
-
   private val MaybeHijackedPrimNumberClasses = {
     /* In theory, we could figure out the ancestors from the global knowledge,
      * but that would be overkill.
@@ -3442,13 +3297,26 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
         ClassName("java.lang.Number"))
   }
 
-  private def foldBinaryOpNonConstant(op: BinaryOp.Code, lhs: PreTransform,
+  private def foldBinaryOp(op: BinaryOp.Code, lhs: PreTransform,
       rhs: PreTransform)(
       implicit pos: Position): PreTransform = {
     import BinaryOp._
 
-    @inline def default =
+    @inline def default: PreTransform =
       PreTransBinaryOp(op, lhs, rhs)
+
+    @inline def booleanLit(value: Boolean): PreTransform =
+      PreTransLit(BooleanLiteral(value))
+    @inline def charLit(value: Char): PreTransform =
+      PreTransLit(CharLiteral(value))
+    @inline def intLit(value: Int): PreTransform =
+      PreTransLit(IntLiteral(value))
+    @inline def longLit(value: Long): PreTransform =
+      PreTransLit(LongLiteral(value))
+    @inline def floatLit(value: Float): PreTransform =
+      PreTransLit(FloatLiteral(value))
+    @inline def doubleLit(value: Double): PreTransform =
+      PreTransLit(DoubleLiteral(value))
 
     (op: @switch) match {
       case === | !== =>
@@ -3480,24 +3348,25 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
             false
         }
 
-        val lhsTpe = lhs.tpe
-        val rhsTpe = rhs.tpe
-        val canOptimizeAsJSStrictEq = (
+        def canOptimizeAsJSStrictEq(lhsTpe: RefinedType, rhsTpe: RefinedType): Boolean = (
             !canBePrimitiveNum(lhsTpe) ||
             !canBePrimitiveNum(rhsTpe) ||
             (isWhole(lhsTpe) && isWhole(rhsTpe))
         )
 
-        if (canOptimizeAsJSStrictEq) {
-          foldJSBinaryOp(
-              if (op == ===) JSBinaryOp.=== else JSBinaryOp.!==,
-              lhs, rhs)
-        } else {
-          default
+        (lhs, rhs) match {
+          case (PreTransLit(l), PreTransLit(r)) =>
+            val isSame = literal_===(l, r, isJSStrictEq = false)
+            PreTransLit(BooleanLiteral(if (op == ===) isSame else !isSame))
+          case _ if canOptimizeAsJSStrictEq(lhs.tpe, rhs.tpe) =>
+            foldJSBinaryOp(
+                if (op == ===) JSBinaryOp.=== else JSBinaryOp.!==,
+                lhs, rhs)
+          case _ =>
+            default
         }
 
       case String_+ =>
-        // Here things can be constant!
         val lhs1 = foldToStringForString_+(lhs)
         val rhs1 = foldToStringForString_+(rhs)
 
@@ -3521,8 +3390,48 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
             stringDefault
       }
 
+      case Boolean_== | Boolean_!= =>
+        val positive = (op == Boolean_==)
+        (lhs, rhs) match {
+          case (PreTransLit(BooleanLiteral(l)), PreTransLit(BooleanLiteral(r))) =>
+            booleanLit(if (positive) l == r else l != r)
+          case (PreTransLit(_), _) =>
+            foldBinaryOp(op, rhs, lhs)
+
+          case (PreTransLit(BooleanLiteral(l)), _) =>
+            if (l == positive) rhs
+            else foldUnaryOp(UnaryOp.Boolean_!, rhs)
+
+          case _ =>
+            default
+        }
+
+      case Boolean_| =>
+        (lhs, rhs) match {
+          case (PreTransLit(BooleanLiteral(l)), PreTransLit(BooleanLiteral(r))) =>
+            booleanLit(l | r)
+
+          case (_, PreTransLit(BooleanLiteral(false))) => lhs
+          case (PreTransLit(BooleanLiteral(false)), _) => rhs
+
+          case _ => default
+        }
+
+      case Boolean_& =>
+        (lhs, rhs) match {
+          case (PreTransLit(BooleanLiteral(l)), PreTransLit(BooleanLiteral(r))) =>
+            booleanLit(l & r)
+
+          case (_, PreTransLit(BooleanLiteral(true))) => lhs
+          case (PreTransLit(BooleanLiteral(true)), _) => rhs
+
+          case _ => default
+        }
+
       case Int_+ =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l + r)
           case (_, PreTransLit(IntLiteral(_))) =>
             foldBinaryOp(Int_+, rhs, lhs)
           case (PreTransLit(IntLiteral(0)), _) =>
@@ -3538,6 +3447,8 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_- =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l - r)
           case (_, PreTransLit(IntLiteral(r))) =>
             foldBinaryOp(Int_+, lhs, PreTransLit(IntLiteral(-r)))
 
@@ -3558,6 +3469,8 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_* =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l * r)
           case (_, PreTransLit(IntLiteral(_))) =>
             foldBinaryOp(Int_*, rhs, lhs)
 
@@ -3585,6 +3498,11 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_/ =>
         (lhs, rhs) match {
+          case (_, PreTransLit(IntLiteral(0))) =>
+            default
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l / r)
+
           case (_, PreTransLit(IntLiteral(1)))  =>
             lhs
           case (_, PreTransLit(IntLiteral(-1))) =>
@@ -3595,6 +3513,11 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_% =>
         (lhs, rhs) match {
+          case (_, PreTransLit(IntLiteral(0))) =>
+            default
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l % r)
+
           case (_, PreTransLit(IntLiteral(1 | -1))) =>
             Block(finishTransformStat(lhs), IntLiteral(0)).toPreTransform
 
@@ -3603,6 +3526,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_| =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l | r)
+
           case (_, PreTransLit(IntLiteral(_))) => foldBinaryOp(Int_|, rhs, lhs)
           case (PreTransLit(IntLiteral(0)), _) => rhs
 
@@ -3618,6 +3544,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_& =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l & r)
+
           case (_, PreTransLit(IntLiteral(_)))  => foldBinaryOp(Int_&, rhs, lhs)
           case (PreTransLit(IntLiteral(-1)), _) => rhs
 
@@ -3633,6 +3562,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_^ =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l ^ r)
+
           case (_, PreTransLit(IntLiteral(_))) => foldBinaryOp(Int_^, rhs, lhs)
           case (PreTransLit(IntLiteral(0)), _) => rhs
 
@@ -3645,6 +3577,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_<< =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l << r)
+
           case (PreTransLit(IntLiteral(0)), _) =>
             PreTransBlock(finishTransformStat(rhs), lhs)
 
@@ -3668,6 +3603,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_>>> =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l >>> r)
+
           case (PreTransLit(IntLiteral(0)), _) =>
             PreTransBlock(finishTransformStat(rhs), lhs)
 
@@ -3699,6 +3637,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Int_>> =>
         (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            intLit(l >> r)
+
           case (PreTransLit(IntLiteral(0 | -1)), _) =>
             PreTransBlock(finishTransformStat(rhs), lhs)
 
@@ -3721,8 +3662,85 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case _ => default
         }
 
+      case Int_== | Int_!= =>
+        (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            booleanLit(if (op == Int_==) l == r else l != r)
+
+          case (PreTransBinaryOp(Int_+, PreTransLit(IntLiteral(x)), y),
+              PreTransLit(IntLiteral(z))) =>
+            foldBinaryOp(op, y, PreTransLit(IntLiteral(z - x)))
+
+          case (PreTransBinaryOp(Int_-, PreTransLit(IntLiteral(x)), y),
+              PreTransLit(IntLiteral(z))) =>
+            foldBinaryOp(op, y, PreTransLit(IntLiteral(x - z)))
+
+          case (PreTransBinaryOp(Int_^, PreTransLit(IntLiteral(x)), y),
+              PreTransLit(IntLiteral(z))) =>
+            foldBinaryOp(op, y, PreTransLit(IntLiteral(x ^ z)))
+
+          case (PreTransLit(_), _) => foldBinaryOp(op, rhs, lhs)
+
+          case _ => default
+        }
+
+      case Int_< | Int_<= | Int_> | Int_>= =>
+        def flippedOp = (op: @switch) match {
+          case Int_<  => Int_>
+          case Int_<= => Int_>=
+          case Int_>  => Int_<
+          case Int_>= => Int_<=
+        }
+
+        (lhs, rhs) match {
+          case (PreTransLit(IntLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            booleanLit((op: @switch) match {
+              case Int_<  => l < r
+              case Int_<= => l <= r
+              case Int_>  => l > r
+              case Int_>= => l >= r
+            })
+
+          case (_, PreTransLit(IntLiteral(y))) =>
+            y match {
+              case Int.MinValue =>
+                if (op == Int_< || op == Int_>=) {
+                  Block(finishTransformStat(lhs),
+                      BooleanLiteral(op == Int_>=)).toPreTransform
+                } else {
+                  foldBinaryOp(if (op == Int_<=) Int_== else Int_!=, lhs, rhs)
+                }
+
+              case Int.MaxValue =>
+                if (op == Int_> || op == Int_<=) {
+                  Block(finishTransformStat(lhs),
+                      BooleanLiteral(op == Int_<=)).toPreTransform
+                } else {
+                  foldBinaryOp(if (op == Int_>=) Int_== else Int_!=, lhs, rhs)
+                }
+
+              case _ if y == Int.MinValue + 1 && (op == Int_< || op == Int_>=) =>
+                foldBinaryOp(if (op == Int_<) Int_== else Int_!=, lhs,
+                    PreTransLit(IntLiteral(Int.MinValue)))
+
+              case _ if y == Int.MaxValue - 1 && (op == Int_> || op == Int_<=) =>
+                foldBinaryOp(if (op == Int_>) Int_== else Int_!=, lhs,
+                    PreTransLit(IntLiteral(Int.MaxValue)))
+
+              case _ => default
+            }
+
+          case (PreTransLit(IntLiteral(_)), _) =>
+            foldBinaryOp(flippedOp, rhs, lhs)
+
+          case _ => default
+        }
+
       case Long_+ =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            longLit(l + r)
+
           case (_, PreTransLit(LongLiteral(_))) => foldBinaryOp(Long_+, rhs, lhs)
           case (PreTransLit(LongLiteral(0)), _) => rhs
 
@@ -3736,6 +3754,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_- =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            longLit(l - r)
+
           case (_, PreTransLit(LongLiteral(r))) =>
             foldBinaryOp(Long_+, PreTransLit(LongLiteral(-r)), lhs)
 
@@ -3755,6 +3776,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_* =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            longLit(l * r)
+
           case (_, PreTransLit(LongLiteral(_))) =>
             foldBinaryOp(Long_*, rhs, lhs)
 
@@ -3782,6 +3806,11 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_/ =>
         (lhs, rhs) match {
+          case (_, PreTransLit(LongLiteral(0L))) =>
+            default
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            longLit(l / r)
+
           case (_, PreTransLit(LongLiteral(1))) =>
             lhs
           case (_, PreTransLit(LongLiteral(-1))) =>
@@ -3796,6 +3825,11 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_% =>
         (lhs, rhs) match {
+          case (_, PreTransLit(LongLiteral(0L))) =>
+            default
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            longLit(l % r)
+
           case (_, PreTransLit(LongLiteral(1L | -1L))) =>
             Block(finishTransformStat(lhs), LongLiteral(0L)).toPreTransform
 
@@ -3807,6 +3841,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_| =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            longLit(l | r)
+
           case (_, PreTransLit(LongLiteral(_))) =>
             foldBinaryOp(Long_|, rhs, lhs)
           case (PreTransLit(LongLiteral(0)), _) =>
@@ -3824,6 +3861,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_& =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            longLit(l & r)
+
           case (_, PreTransLit(LongLiteral(_))) =>
             foldBinaryOp(Long_&, rhs, lhs)
           case (PreTransLit(LongLiteral(-1)), _) =>
@@ -3841,6 +3881,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_^ =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            longLit(l ^ r)
+
           case (_, PreTransLit(LongLiteral(_))) =>
             foldBinaryOp(Long_^, rhs, lhs)
           case (PreTransLit(LongLiteral(0)), _) =>
@@ -3855,6 +3898,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_<< =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            longLit(l << r)
+
           case (_, PreTransLit(IntLiteral(x))) if x % 64 == 0 => lhs
 
           case _ => default
@@ -3862,6 +3908,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_>>> =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            longLit(l >>> r)
+
           case (_, PreTransLit(IntLiteral(x))) if x % 64 == 0 => lhs
 
           case _ => default
@@ -3869,6 +3918,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Long_>> =>
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            longLit(l >> r)
+
           case (_, PreTransLit(IntLiteral(x))) if x % 64 == 0 => lhs
 
           case _ => default
@@ -3877,6 +3929,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       case Long_== | Long_!= =>
         val positive = (op == Long_==)
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            booleanLit(if (op == Long_==) l == r else l != r)
+
           case (LongFromInt(x), LongFromInt(y)) =>
             foldBinaryOp(if (positive) Int_== else Int_!=, x, y)
           case (LongFromInt(x), PreTransLit(LongLiteral(y))) =>
@@ -3916,6 +3971,14 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
         }
 
         (lhs, rhs) match {
+          case (PreTransLit(LongLiteral(l)), PreTransLit(LongLiteral(r))) =>
+            booleanLit((op: @switch) match {
+              case Long_<  => l < r
+              case Long_<= => l <= r
+              case Long_>  => l > r
+              case Long_>= => l >= r
+            })
+
           case (_, PreTransLit(LongLiteral(Long.MinValue))) =>
             if (op == Long_< || op == Long_>=) {
               Block(finishTransformStat(lhs),
@@ -4018,8 +4081,27 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case _ => default
         }
 
+      case Float_+ =>
+        (lhs, rhs) match {
+          case (PreTransLit(FloatLiteral(l)), PreTransLit(FloatLiteral(r))) =>
+            floatLit(l + r)
+
+          case _ => default
+        }
+
+      case Float_- =>
+        (lhs, rhs) match {
+          case (PreTransLit(FloatLiteral(l)), PreTransLit(FloatLiteral(r))) =>
+            floatLit(l - r)
+
+          case _ => default
+        }
+
       case Float_* =>
         (lhs, rhs) match {
+          case (PreTransLit(FloatLiteral(l)), PreTransLit(FloatLiteral(r))) =>
+            floatLit(l * r)
+
           case (_, PreTransLit(FloatLiteral(_))) =>
             foldBinaryOp(Float_*, rhs, lhs)
 
@@ -4034,6 +4116,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Float_/ =>
         (lhs, rhs) match {
+          case (PreTransLit(FloatLiteral(l)), PreTransLit(FloatLiteral(r))) =>
+            floatLit(l / r)
+
           case (_, PreTransLit(FloatLiteral(1))) =>
             lhs
           case (_, PreTransLit(FloatLiteral(-1))) =>
@@ -4044,11 +4129,33 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Float_% =>
         (lhs, rhs) match {
+          case (PreTransLit(FloatLiteral(l)), PreTransLit(FloatLiteral(r))) =>
+            floatLit(l % r)
+
+          case _ => default
+        }
+
+      case Double_+ =>
+        (lhs, rhs) match {
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            doubleLit(l + r)
+
+          case _ => default
+        }
+
+      case Double_- =>
+        (lhs, rhs) match {
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            doubleLit(l - r)
+
           case _ => default
         }
 
       case Double_* =>
         (lhs, rhs) match {
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            doubleLit(l * r)
+
           case (_, PreTransLit(DoubleLiteral(_))) =>
             foldBinaryOp(Double_*, rhs, lhs)
 
@@ -4063,6 +4170,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Double_/ =>
         (lhs, rhs) match {
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            doubleLit(l / r)
+
           case (_, PreTransLit(DoubleLiteral(1))) =>
             lhs
           case (_, PreTransLit(DoubleLiteral(-1))) =>
@@ -4073,104 +4183,70 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
 
       case Double_% =>
         (lhs, rhs) match {
-          case _ => default
-        }
-
-      case Boolean_== | Boolean_!= =>
-        val positive = (op == Boolean_==)
-        (lhs, rhs) match {
-          case (PreTransLit(_), _) =>
-            foldBinaryOp(op, rhs, lhs)
-
-          case (PreTransLit(BooleanLiteral(l)), _) =>
-            if (l == positive) rhs
-            else foldUnaryOp(UnaryOp.Boolean_!, rhs)
-
-          case _ =>
-            default
-        }
-
-      case Boolean_| =>
-        (lhs, rhs) match {
-          case (_, PreTransLit(BooleanLiteral(false))) => lhs
-          case (PreTransLit(BooleanLiteral(false)), _) => rhs
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            doubleLit(l % r)
 
           case _ => default
         }
 
-      case Boolean_& =>
+      case Double_== =>
         (lhs, rhs) match {
-          case (_, PreTransLit(BooleanLiteral(true))) => lhs
-          case (PreTransLit(BooleanLiteral(true)), _) => rhs
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            booleanLit(l == r)
 
           case _ => default
         }
 
-      case Int_== | Int_!= =>
+      case Double_!= =>
         (lhs, rhs) match {
-          case (PreTransBinaryOp(Int_+, PreTransLit(IntLiteral(x)), y),
-              PreTransLit(IntLiteral(z))) =>
-            foldBinaryOp(op, y, PreTransLit(IntLiteral(z - x)))
-
-          case (PreTransBinaryOp(Int_-, PreTransLit(IntLiteral(x)), y),
-              PreTransLit(IntLiteral(z))) =>
-            foldBinaryOp(op, y, PreTransLit(IntLiteral(x - z)))
-
-          case (PreTransBinaryOp(Int_^, PreTransLit(IntLiteral(x)), y),
-              PreTransLit(IntLiteral(z))) =>
-            foldBinaryOp(op, y, PreTransLit(IntLiteral(x ^ z)))
-
-          case (PreTransLit(_), _) => foldBinaryOp(op, rhs, lhs)
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            booleanLit(l != r)
 
           case _ => default
         }
 
-      case Int_< | Int_<= | Int_> | Int_>= =>
-        def flippedOp = (op: @switch) match {
-          case Int_<  => Int_>
-          case Int_<= => Int_>=
-          case Int_>  => Int_<
-          case Int_>= => Int_<=
-        }
-
+      case Double_< =>
         (lhs, rhs) match {
-          case (_, PreTransLit(IntLiteral(y))) =>
-            y match {
-              case Int.MinValue =>
-                if (op == Int_< || op == Int_>=) {
-                  Block(finishTransformStat(lhs),
-                      BooleanLiteral(op == Int_>=)).toPreTransform
-                } else {
-                  foldBinaryOp(if (op == Int_<=) Int_== else Int_!=, lhs, rhs)
-                }
-
-              case Int.MaxValue =>
-                if (op == Int_> || op == Int_<=) {
-                  Block(finishTransformStat(lhs),
-                      BooleanLiteral(op == Int_<=)).toPreTransform
-                } else {
-                  foldBinaryOp(if (op == Int_>=) Int_== else Int_!=, lhs, rhs)
-                }
-
-              case _ if y == Int.MinValue + 1 && (op == Int_< || op == Int_>=) =>
-                foldBinaryOp(if (op == Int_<) Int_== else Int_!=, lhs,
-                    PreTransLit(IntLiteral(Int.MinValue)))
-
-              case _ if y == Int.MaxValue - 1 && (op == Int_> || op == Int_<=) =>
-                foldBinaryOp(if (op == Int_>) Int_== else Int_!=, lhs,
-                    PreTransLit(IntLiteral(Int.MaxValue)))
-
-              case _ => default
-            }
-
-          case (PreTransLit(IntLiteral(_)), _) =>
-            foldBinaryOp(flippedOp, rhs, lhs)
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            booleanLit(l < r)
 
           case _ => default
         }
 
-      case _ =>
-        default
+      case Double_<= =>
+        (lhs, rhs) match {
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            booleanLit(l <= r)
+
+          case _ => default
+        }
+
+      case Double_> =>
+        (lhs, rhs) match {
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            booleanLit(l > r)
+
+          case _ => default
+        }
+
+      case Double_>= =>
+        (lhs, rhs) match {
+          case (PreTransLit(DoubleLiteral(l)), PreTransLit(DoubleLiteral(r))) =>
+            booleanLit(l >= r)
+
+          case _ => default
+        }
+
+      case String_charAt =>
+        (lhs, rhs) match {
+          case (PreTransLit(StringLiteral(l)), PreTransLit(IntLiteral(r))) =>
+            if (r < 0 || r >= l.length())
+              default
+            else
+              charLit(l.charAt(r))
+
+          case _ => default
+        }
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3172,6 +3172,16 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
             default
         }
 
+      // String.length
+
+      case String_length =>
+        arg match {
+          case PreTransLit(StringLiteral(s)) =>
+            PreTransLit(IntLiteral(s.length()))
+          case _ =>
+            default
+        }
+
       case _ =>
         default
     }

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 145210,
-      expectedFullLinkSizeWithoutClosure = 134353,
-      expectedFullLinkSizeWithClosure = 21671,
+      expectedFastLinkSize = 144813,
+      expectedFullLinkSizeWithoutClosure = 133956,
+      expectedFullLinkSizeWithClosure = 21669,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 144813,
-      expectedFullLinkSizeWithoutClosure = 133956,
-      expectedFullLinkSizeWithClosure = 21669,
+      expectedFastLinkSize = 145003,
+      expectedFullLinkSizeWithoutClosure = 133198,
+      expectedFullLinkSizeWithClosure = 21338,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -60,9 +60,10 @@ class MainGenericRunner {
 
     compliantSems.foldLeft(Semantics.Defaults) { (prev, compliantSem) =>
       compliantSem match {
-        case "asInstanceOfs"         => prev.withAsInstanceOfs(Compliant)
-        case "arrayIndexOutOfBounds" => prev.withArrayIndexOutOfBounds(Compliant)
-        case "moduleInit"            => prev.withModuleInit(Compliant)
+        case "asInstanceOfs"          => prev.withAsInstanceOfs(Compliant)
+        case "arrayIndexOutOfBounds"  => prev.withArrayIndexOutOfBounds(Compliant)
+        case "stringIndexOutOfBounds" => prev.withStringIndexOutOfBounds(Compliant)
+        case "moduleInit"             => prev.withModuleInit(Compliant)
       }
     }
   }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -15,6 +15,8 @@ object BinaryIncompatibilities {
   )
 
   val LinkerInterface = Seq(
+    // private, not an issue
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.interface.Semantics.this"),
   )
 
   val SbtPlugin = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,6 +45,7 @@ object ExposedValues extends AutoPlugin {
         semantics
           .withAsInstanceOfs(CheckedBehavior.Compliant)
           .withArrayIndexOutOfBounds(CheckedBehavior.Compliant)
+          .withStringIndexOutOfBounds(CheckedBehavior.Compliant)
           .withModuleInit(CheckedBehavior.Compliant)
       }
     }
@@ -1712,15 +1713,15 @@ object Build {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 515000 to 516000,
+                fastLink = 516500 to 517500,
                 fullLink = 107000 to 108000,
-                fastLinkGz = 65000 to 66000,
+                fastLinkGz = 65500 to 66500,
                 fullLinkGz = 28000 to 29000,
             ))
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 777000 to 778000,
+                fastLink = 778000 to 779000,
                 fullLink = 148000 to 149000,
                 fastLinkGz = 90000 to 91000,
                 fullLinkGz = 36000 to 37000,
@@ -1731,7 +1732,7 @@ object Build {
                 fastLink = 727000 to 728000,
                 fullLink = 155000 to 156000,
                 fastLinkGz = 91000 to 92000,
-                fullLinkGz = 40000 to 41000,
+                fullLinkGz = 39000 to 40000,
             ))
 
           case _ =>
@@ -2011,6 +2012,7 @@ object Build {
           "isFullOpt" -> (stage == Stage.FullOpt),
           "compliantAsInstanceOfs" -> (sems.asInstanceOfs == CheckedBehavior.Compliant),
           "compliantArrayIndexOutOfBounds" -> (sems.arrayIndexOutOfBounds == CheckedBehavior.Compliant),
+          "compliantStringIndexOutOfBounds" -> (sems.stringIndexOutOfBounds == CheckedBehavior.Compliant),
           "compliantModuleInit" -> (sems.moduleInit == CheckedBehavior.Compliant),
           "strictFloats" -> sems.strictFloats,
           "productionMode" -> sems.productionMode,

--- a/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
+++ b/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
@@ -25,6 +25,7 @@ private[utils] object BuildInfo {
   final val isFullOpt = false
   final val compliantAsInstanceOfs = false
   final val compliantArrayIndexOutOfBounds = false
+  final val compliantStringIndexOutOfBounds = false
   final val compliantModuleInit = false
   final val strictFloats = false
   final val productionMode = false

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -72,6 +72,9 @@ object Platform {
   def hasCompliantArrayIndexOutOfBounds: Boolean =
     BuildInfo.compliantArrayIndexOutOfBounds
 
+  def hasCompliantStringIndexOutOfBounds: Boolean =
+    BuildInfo.compliantStringIndexOutOfBounds
+
   def hasCompliantModuleInit: Boolean = BuildInfo.compliantModuleInit
 
   def hasDirectBuffers: Boolean = typedArrays

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -40,6 +40,7 @@ object Platform {
 
   def hasCompliantAsInstanceOfs: Boolean = true
   def hasCompliantArrayIndexOutOfBounds: Boolean = true
+  def hasCompliantStringIndexOutOfBounds: Boolean = true
   def hasCompliantModule: Boolean = true
   def hasDirectBuffers: Boolean = true
   def hasStrictFloats: Boolean = true

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
@@ -103,6 +103,8 @@ class FormatterTest {
       assertF("nul", "%.3" + conversion, null)
       assertF("  nul", "%5.3" + conversion, null)
       assertF("nul  ", "%-5.3" + conversion, null)
+      assertF("null", "%.4" + conversion, null)
+      assertF("null", "%.10" + conversion, null)
     }
 
     if (acceptUpperCase) {
@@ -190,6 +192,9 @@ class FormatterTest {
     assertF("     tru", "%8.3b", true)
     assertF("fal", "%.3b", null)
     assertF("     fal", "%8.3b", null)
+    assertF("true", "%.7b", true)
+    assertF("false", "%.7b", false)
+    assertF("false", "%.7b", null)
 
     expectFormatFlagsConversionMismatch('b', "#+ 0,(", true)
     expectFormatFlagsConversionMismatch('b', "#+ 0,(", null)
@@ -203,6 +208,7 @@ class FormatterTest {
     assertF("  f1e2a3", "%8h", x)
 
     assertF("f1e2a", "%.5h", x)
+    assertF("f1e2a3", "%.10h", x)
 
     testWithNull('h', "")
 
@@ -222,6 +228,7 @@ class FormatterTest {
 
     assertF("hel", "%.3s", "hello")
     assertF("    HEL", "%7.3S", "hello")
+    assertF("hello", "%.10s", "hello")
 
     testWithNull('s', "")
 


### PR DESCRIPTION
Fundamentally, the primitive operation that causes language-mandated `StringIndexOutOfBoundsException`s is `String.charAt`. In order for the linker to recognize it and conditionally apply checked behavior semantics to it, we introduce a new IR `BinaryOp.String_charAt` for that operation.

We use a compiler back-end hack to inject that IR node as the body of `String.charAt`. Using a dedicated primitive method in `scalajs.runtime`, like we did for `identityHashCode`, would not work so well here, as we want the binary operator to manipulate a *primitive* `StringType`, not a `ClassType(BoxedStringClass)`.

For derived methods that are implemented on top of JS primitives, namely `codePointAt` and `substring`, we use a trick similar to what we did in `j.u.Arrays`: we introduce carefully-chosen no-op calls to `charAt`, with the only purpose of checking bounds, before delegating to the JS methods. Since `s.length()` is not known to be pure by the optimizer, we use clever tricks not to call it in the bounds checks of `substring`.

---

We then also introduce an IR `UnaryOp.String_length`.

This is done mostly for consistency with String.charAt. Together with `String_+`, those two operations are the only primitives required to implement any manipulation on strings, so they make a coherent whole.

In practice, this allows the optimizer to reason about that operation, in terms of constant-folding and purity. With that, we need not be afraid of using `length()` in bounds checks, which allows them to be clearer and more efficient.