### PR TITLE
 Add sbt-vspp for publishing the Scala.js SBT plug-in in a Maven-valid format

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -8,6 +8,8 @@ addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.1")
 
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.11.0")
 
+addSbtPlugin("com.scalawilliam.esbeetee" % "sbt-vspp" % "0.4.11")
+
 libraryDependencies += "com.google.jimfs" % "jimfs" % "1.1"
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.2.0.201312181205-r"


### PR DESCRIPTION
 This is to enable the usage of Scala.js in Enterprise environments where only the valid-POM format is accepted for JAR downloads, meaning Scala.js is hard to access in organizations with stricter security policies. Adding this would make Scala.js possible in many enterprise environments where it is in fact a very appropriate fit for rapid application development.
 
 This plug-in does not modify or remove any existing files, it only adds additional files (POM+JAR) alongside the existing deployment; for example, sbt-bloop 1.5.3 now looks like this:
 - https://mvnrepository.com/artifact/ch.epfl.scala/sbt-bloop_2.12_1.0/1.5.3
 - https://repo1.maven.org/maven2/ch/epfl/scala/sbt-bloop_2.12_1.0/1.5.3/
 This means that SBT can access the plug-in through invalid POM (as is currently) and also through valid POM (for where invalid artifact is not supported).

 Full background here in this README: https://github.com/esbeetee/sbt-vspp - would be hugely appreciated to have this merged in - in case you have any questions I am more than happy to set up a call.