### PR TITLE
Checks for ArrayStoreExceptions and NegativeArraySizeExceptions. (separate)

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -501,6 +501,10 @@ object Names {
   val ArrayIndexOutOfBoundsExceptionClass: ClassName =
     ClassName("java.lang.ArrayIndexOutOfBoundsException")
 
+  /** The exception thrown by an `Assign(ArraySelect, ...)` where the value cannot be stored. */
+  val ArrayStoreExceptionClass: ClassName =
+    ClassName("java.lang.ArrayStoreException")
+
   /** The exception thrown by a `BinaryOp.String_charAt` that is out of bounds. */
   val StringIndexOutOfBoundsExceptionClass: ClassName =
     ClassName("java.lang.StringIndexOutOfBoundsException")

--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -505,6 +505,10 @@ object Names {
   val ArrayStoreExceptionClass: ClassName =
     ClassName("java.lang.ArrayStoreException")
 
+  /** The exception thrown by a `NewArray(...)` with a negative size. */
+  val NegativeArraySizeExceptionClass: ClassName =
+    ClassName("java.lang.NegativeArraySizeException")
+
   /** The exception thrown by a `BinaryOp.String_charAt` that is out of bounds. */
   val StringIndexOutOfBoundsExceptionClass: ClassName =
     ClassName("java.lang.StringIndexOutOfBoundsException")

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.11.1-SNAPSHOT",
+    current = "1.12.0-SNAPSHOT",
     binaryEmitted = "1.11"
 )
 

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
@@ -18,6 +18,7 @@ import Fingerprint.FingerprintBuilder
 final class Semantics private (
     val asInstanceOfs: CheckedBehavior,
     val arrayIndexOutOfBounds: CheckedBehavior,
+    val arrayStores: CheckedBehavior,
     val stringIndexOutOfBounds: CheckedBehavior,
     val moduleInit: CheckedBehavior,
     val strictFloats: Boolean,
@@ -31,6 +32,9 @@ final class Semantics private (
 
   def withArrayIndexOutOfBounds(behavior: CheckedBehavior): Semantics =
     copy(arrayIndexOutOfBounds = behavior)
+
+  def withArrayStores(behavior: CheckedBehavior): Semantics =
+    copy(arrayStores = behavior)
 
   def withStringIndexOutOfBounds(behavior: CheckedBehavior): Semantics =
     copy(stringIndexOutOfBounds = behavior)
@@ -57,6 +61,7 @@ final class Semantics private (
   def optimized: Semantics = {
     copy(asInstanceOfs = this.asInstanceOfs.optimized,
         arrayIndexOutOfBounds = this.arrayIndexOutOfBounds.optimized,
+        arrayStores = this.arrayStores.optimized,
         stringIndexOutOfBounds = this.stringIndexOutOfBounds.optimized,
         moduleInit = this.moduleInit.optimized,
         productionMode = true)
@@ -66,6 +71,7 @@ final class Semantics private (
     case that: Semantics =>
       this.asInstanceOfs == that.asInstanceOfs &&
       this.arrayIndexOutOfBounds == that.arrayIndexOutOfBounds &&
+      this.arrayStores == that.arrayStores &&
       this.stringIndexOutOfBounds == that.stringIndexOutOfBounds &&
       this.moduleInit == that.moduleInit &&
       this.strictFloats == that.strictFloats &&
@@ -80,18 +86,20 @@ final class Semantics private (
     var acc = HashSeed
     acc = mix(acc, asInstanceOfs.##)
     acc = mix(acc, arrayIndexOutOfBounds.##)
+    acc = mix(acc, arrayStores.##)
     acc = mix(acc, stringIndexOutOfBounds.##)
     acc = mix(acc, moduleInit.##)
     acc = mix(acc, strictFloats.##)
     acc = mix(acc, productionMode.##)
     acc = mixLast(acc, runtimeClassNameMapper.##)
-    finalizeHash(acc, 7)
+    finalizeHash(acc, 8)
   }
 
   override def toString(): String = {
     s"""Semantics(
        |  asInstanceOfs          = $asInstanceOfs,
        |  arrayIndexOutOfBounds  = $arrayIndexOutOfBounds,
+       |  arrayStores            = $arrayStores,
        |  stringIndexOutOfBounds = $stringIndexOutOfBounds,
        |  moduleInit             = $moduleInit,
        |  strictFloats           = $strictFloats,
@@ -102,6 +110,7 @@ final class Semantics private (
   private def copy(
       asInstanceOfs: CheckedBehavior = this.asInstanceOfs,
       arrayIndexOutOfBounds: CheckedBehavior = this.arrayIndexOutOfBounds,
+      arrayStores: CheckedBehavior = this.arrayStores,
       stringIndexOutOfBounds: CheckedBehavior = this.stringIndexOutOfBounds,
       moduleInit: CheckedBehavior = this.moduleInit,
       strictFloats: Boolean = this.strictFloats,
@@ -111,6 +120,7 @@ final class Semantics private (
     new Semantics(
         asInstanceOfs = asInstanceOfs,
         arrayIndexOutOfBounds = arrayIndexOutOfBounds,
+        arrayStores = arrayStores,
         stringIndexOutOfBounds = stringIndexOutOfBounds,
         moduleInit = moduleInit,
         strictFloats = strictFloats,
@@ -227,6 +237,7 @@ object Semantics {
       new FingerprintBuilder("Semantics")
         .addField("asInstanceOfs", semantics.asInstanceOfs)
         .addField("arrayIndexOutOfBounds", semantics.arrayIndexOutOfBounds)
+        .addField("arrayStores", semantics.arrayStores)
         .addField("stringIndexOutOfBounds", semantics.stringIndexOutOfBounds)
         .addField("moduleInit", semantics.moduleInit)
         .addField("strictFloats", semantics.strictFloats)
@@ -239,6 +250,7 @@ object Semantics {
   val Defaults: Semantics = new Semantics(
       asInstanceOfs = Fatal,
       arrayIndexOutOfBounds = Fatal,
+      arrayStores = Fatal,
       stringIndexOutOfBounds = Fatal,
       moduleInit = Unchecked,
       strictFloats = true,

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
@@ -19,6 +19,7 @@ final class Semantics private (
     val asInstanceOfs: CheckedBehavior,
     val arrayIndexOutOfBounds: CheckedBehavior,
     val arrayStores: CheckedBehavior,
+    val negativeArraySizes: CheckedBehavior,
     val stringIndexOutOfBounds: CheckedBehavior,
     val moduleInit: CheckedBehavior,
     val strictFloats: Boolean,
@@ -35,6 +36,9 @@ final class Semantics private (
 
   def withArrayStores(behavior: CheckedBehavior): Semantics =
     copy(arrayStores = behavior)
+
+  def withNegativeArraySizes(behavior: CheckedBehavior): Semantics =
+    copy(negativeArraySizes = behavior)
 
   def withStringIndexOutOfBounds(behavior: CheckedBehavior): Semantics =
     copy(stringIndexOutOfBounds = behavior)
@@ -62,6 +66,7 @@ final class Semantics private (
     copy(asInstanceOfs = this.asInstanceOfs.optimized,
         arrayIndexOutOfBounds = this.arrayIndexOutOfBounds.optimized,
         arrayStores = this.arrayStores.optimized,
+        negativeArraySizes = this.negativeArraySizes.optimized,
         stringIndexOutOfBounds = this.stringIndexOutOfBounds.optimized,
         moduleInit = this.moduleInit.optimized,
         productionMode = true)
@@ -72,6 +77,7 @@ final class Semantics private (
       this.asInstanceOfs == that.asInstanceOfs &&
       this.arrayIndexOutOfBounds == that.arrayIndexOutOfBounds &&
       this.arrayStores == that.arrayStores &&
+      this.negativeArraySizes == that.negativeArraySizes &&
       this.stringIndexOutOfBounds == that.stringIndexOutOfBounds &&
       this.moduleInit == that.moduleInit &&
       this.strictFloats == that.strictFloats &&
@@ -87,12 +93,13 @@ final class Semantics private (
     acc = mix(acc, asInstanceOfs.##)
     acc = mix(acc, arrayIndexOutOfBounds.##)
     acc = mix(acc, arrayStores.##)
+    acc = mix(acc, negativeArraySizes.##)
     acc = mix(acc, stringIndexOutOfBounds.##)
     acc = mix(acc, moduleInit.##)
     acc = mix(acc, strictFloats.##)
     acc = mix(acc, productionMode.##)
     acc = mixLast(acc, runtimeClassNameMapper.##)
-    finalizeHash(acc, 8)
+    finalizeHash(acc, 9)
   }
 
   override def toString(): String = {
@@ -100,6 +107,7 @@ final class Semantics private (
        |  asInstanceOfs          = $asInstanceOfs,
        |  arrayIndexOutOfBounds  = $arrayIndexOutOfBounds,
        |  arrayStores            = $arrayStores,
+       |  negativeArraySizes     = $negativeArraySizes,
        |  stringIndexOutOfBounds = $stringIndexOutOfBounds,
        |  moduleInit             = $moduleInit,
        |  strictFloats           = $strictFloats,
@@ -111,6 +119,7 @@ final class Semantics private (
       asInstanceOfs: CheckedBehavior = this.asInstanceOfs,
       arrayIndexOutOfBounds: CheckedBehavior = this.arrayIndexOutOfBounds,
       arrayStores: CheckedBehavior = this.arrayStores,
+      negativeArraySizes: CheckedBehavior = this.negativeArraySizes,
       stringIndexOutOfBounds: CheckedBehavior = this.stringIndexOutOfBounds,
       moduleInit: CheckedBehavior = this.moduleInit,
       strictFloats: Boolean = this.strictFloats,
@@ -121,6 +130,7 @@ final class Semantics private (
         asInstanceOfs = asInstanceOfs,
         arrayIndexOutOfBounds = arrayIndexOutOfBounds,
         arrayStores = arrayStores,
+        negativeArraySizes = negativeArraySizes,
         stringIndexOutOfBounds = stringIndexOutOfBounds,
         moduleInit = moduleInit,
         strictFloats = strictFloats,
@@ -238,6 +248,7 @@ object Semantics {
         .addField("asInstanceOfs", semantics.asInstanceOfs)
         .addField("arrayIndexOutOfBounds", semantics.arrayIndexOutOfBounds)
         .addField("arrayStores", semantics.arrayStores)
+        .addField("negativeArraySizes", semantics.negativeArraySizes)
         .addField("stringIndexOutOfBounds", semantics.stringIndexOutOfBounds)
         .addField("moduleInit", semantics.moduleInit)
         .addField("strictFloats", semantics.strictFloats)
@@ -251,6 +262,7 @@ object Semantics {
       asInstanceOfs = Fatal,
       arrayIndexOutOfBounds = Fatal,
       arrayStores = Fatal,
+      negativeArraySizes = Fatal,
       stringIndexOutOfBounds = Fatal,
       moduleInit = Unchecked,
       strictFloats = true,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -818,6 +818,9 @@ object Emitter {
     def cond(p: Boolean)(v: => SymbolRequirement): SymbolRequirement =
       if (p) v else none()
 
+    def isAnyFatal(behaviors: CheckedBehavior*): Boolean =
+      behaviors.contains(Fatal)
+
     multiple(
         cond(asInstanceOfs != Unchecked) {
           instantiateClass(ClassCastExceptionClass, StringArgConstructorName)
@@ -828,12 +831,17 @@ object Emitter {
               StringArgConstructorName)
         },
 
+        cond(arrayStores != Unchecked) {
+          instantiateClass(ArrayStoreExceptionClass,
+              StringArgConstructorName)
+        },
+
         cond(stringIndexOutOfBounds != Unchecked) {
           instantiateClass(StringIndexOutOfBoundsExceptionClass,
               IntArgConstructorName)
         },
 
-        cond(asInstanceOfs == Fatal || arrayIndexOutOfBounds == Fatal || stringIndexOutOfBounds == Fatal) {
+        cond(isAnyFatal(asInstanceOfs, arrayIndexOutOfBounds, arrayStores, stringIndexOutOfBounds)) {
           instantiateClass(UndefinedBehaviorErrorClass,
               ThrowableArgConsructorName)
         },

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -836,12 +836,18 @@ object Emitter {
               StringArgConstructorName)
         },
 
+        cond(negativeArraySizes != Unchecked) {
+          instantiateClass(NegativeArraySizeExceptionClass,
+              NoArgConstructorName)
+        },
+
         cond(stringIndexOutOfBounds != Unchecked) {
           instantiateClass(StringIndexOutOfBoundsExceptionClass,
               IntArgConstructorName)
         },
 
-        cond(isAnyFatal(asInstanceOfs, arrayIndexOutOfBounds, arrayStores, stringIndexOutOfBounds)) {
+        cond(isAnyFatal(asInstanceOfs, arrayIndexOutOfBounds, arrayStores,
+            negativeArraySizes, stringIndexOutOfBounds)) {
           instantiateClass(UndefinedBehaviorErrorClass,
               ThrowableArgConsructorName)
         },

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -142,6 +142,20 @@ private[emitter] final class SJSGen(
     }
   }
 
+  def genUncheckedArraycopy(args: List[Tree])(
+      implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
+      pos: Position): Tree = {
+    import TreeDSL._
+
+    assert(args.lengthCompare(5) == 0,
+        s"wrong number of args for genUncheckedArrayCopy: $args")
+
+    if (esFeatures.esVersion >= ESVersion.ES2015)
+      Apply(args.head DOT "copyTo", args.tail)
+    else
+      genCallHelper("systemArraycopy", args: _*)
+  }
+
   def genSelect(receiver: Tree, className: ClassName, field: irt.FieldIdent)(
       implicit pos: Position): Tree = {
     DotSelect(receiver, Ident(genFieldJSName(className, field))(field.pos))

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1602,7 +1602,9 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
     case LoadModule(moduleClassName) =>
       if (hasElidableModuleAccessor(moduleClassName)) Skip()(stat.pos)
       else stat
-    case NewArray(_, lengths) =>
+    case NewArray(_, lengths) if lengths.forall(isNonNegativeIntLiteral(_)) =>
+      Skip()(stat.pos)
+    case NewArray(_, lengths) if semantics.negativeArraySizes == CheckedBehavior.Unchecked =>
       Block(lengths.map(keepOnlySideEffects))(stat.pos)
     case Select(qualifier, _, _) =>
       keepOnlySideEffects(qualifier)
@@ -1658,6 +1660,11 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
       keepOnlySideEffects(expr)
     case _ =>
       stat
+  }
+
+  private def isNonNegativeIntLiteral(tree: Tree): Boolean = tree match {
+    case IntLiteral(value) => value >= 0
+    case _                 => false
   }
 
   private def pretransformApply(tree: Apply, isStat: Boolean,

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,7 +70,7 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 144857,
+      expectedFastLinkSize = 146276,
       expectedFullLinkSizeWithoutClosure = 129956,
       expectedFullLinkSizeWithClosure = 21210,
       classDefs,

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 142501,
+      expectedFastLinkSize = 144857,
       expectedFullLinkSizeWithoutClosure = 129956,
-      expectedFullLinkSizeWithClosure = 21225,
+      expectedFullLinkSizeWithClosure = 21210,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -63,6 +63,7 @@ class MainGenericRunner {
         case "asInstanceOfs"          => prev.withAsInstanceOfs(Compliant)
         case "arrayIndexOutOfBounds"  => prev.withArrayIndexOutOfBounds(Compliant)
         case "arrayStores"            => prev.withArrayStores(Compliant)
+        case "negativeArraySizes"     => prev.withNegativeArraySizes(Compliant)
         case "stringIndexOutOfBounds" => prev.withStringIndexOutOfBounds(Compliant)
         case "moduleInit"             => prev.withModuleInit(Compliant)
       }

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -62,6 +62,7 @@ class MainGenericRunner {
       compliantSem match {
         case "asInstanceOfs"          => prev.withAsInstanceOfs(Compliant)
         case "arrayIndexOutOfBounds"  => prev.withArrayIndexOutOfBounds(Compliant)
+        case "arrayStores"            => prev.withArrayStores(Compliant)
         case "stringIndexOutOfBounds" => prev.withStringIndexOutOfBounds(Compliant)
         case "moduleInit"             => prev.withModuleInit(Compliant)
       }

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -11,6 +11,8 @@ object BinaryIncompatibilities {
   )
 
   val LinkerInterface = Seq(
+    // private, not an issue
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.interface.Semantics.this"),
   )
 
   val SbtPlugin = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -46,6 +46,7 @@ object ExposedValues extends AutoPlugin {
           .withAsInstanceOfs(CheckedBehavior.Compliant)
           .withArrayIndexOutOfBounds(CheckedBehavior.Compliant)
           .withArrayStores(CheckedBehavior.Compliant)
+          .withNegativeArraySizes(CheckedBehavior.Compliant)
           .withStringIndexOutOfBounds(CheckedBehavior.Compliant)
           .withModuleInit(CheckedBehavior.Compliant)
       }
@@ -1806,7 +1807,7 @@ object Build {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 382000 to 383000,
+                fastLink = 383000 to 384000,
                 fullLink = 79000 to 80000,
                 fastLinkGz = 49000 to 50000,
                 fullLinkGz = 21000 to 22000,
@@ -1814,15 +1815,15 @@ object Build {
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 759000 to 760000,
+                fastLink = 760000 to 761000,
                 fullLink = 145000 to 146000,
-                fastLinkGz = 88000 to 89000,
+                fastLinkGz = 89000 to 90000,
                 fullLinkGz = 35000 to 36000,
             ))
 
           case Default2_13ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 446000 to 447000,
+                fastLink = 447000 to 448000,
                 fullLink = 97000 to 98000,
                 fastLinkGz = 57000 to 58000,
                 fullLinkGz = 26000 to 27000,
@@ -2106,6 +2107,7 @@ object Build {
           "compliantAsInstanceOfs" -> (sems.asInstanceOfs == CheckedBehavior.Compliant),
           "compliantArrayIndexOutOfBounds" -> (sems.arrayIndexOutOfBounds == CheckedBehavior.Compliant),
           "compliantArrayStores" -> (sems.arrayStores == CheckedBehavior.Compliant),
+          "compliantNegativeArraySizes" -> (sems.negativeArraySizes == CheckedBehavior.Compliant),
           "compliantStringIndexOutOfBounds" -> (sems.stringIndexOutOfBounds == CheckedBehavior.Compliant),
           "compliantModuleInit" -> (sems.moduleInit == CheckedBehavior.Compliant),
           "strictFloats" -> sems.strictFloats,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -45,6 +45,7 @@ object ExposedValues extends AutoPlugin {
         semantics
           .withAsInstanceOfs(CheckedBehavior.Compliant)
           .withArrayIndexOutOfBounds(CheckedBehavior.Compliant)
+          .withArrayStores(CheckedBehavior.Compliant)
           .withStringIndexOutOfBounds(CheckedBehavior.Compliant)
           .withModuleInit(CheckedBehavior.Compliant)
       }
@@ -1805,7 +1806,7 @@ object Build {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 380000 to 381000,
+                fastLink = 382000 to 383000,
                 fullLink = 79000 to 80000,
                 fastLinkGz = 49000 to 50000,
                 fullLinkGz = 21000 to 22000,
@@ -1813,7 +1814,7 @@ object Build {
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 756000 to 757000,
+                fastLink = 759000 to 760000,
                 fullLink = 145000 to 146000,
                 fastLinkGz = 88000 to 89000,
                 fullLinkGz = 35000 to 36000,
@@ -1821,7 +1822,7 @@ object Build {
 
           case Default2_13ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 443000 to 444000,
+                fastLink = 446000 to 447000,
                 fullLink = 97000 to 98000,
                 fastLinkGz = 57000 to 58000,
                 fullLinkGz = 26000 to 27000,
@@ -2104,6 +2105,7 @@ object Build {
           "isFullOpt" -> (stage == Stage.FullOpt),
           "compliantAsInstanceOfs" -> (sems.asInstanceOfs == CheckedBehavior.Compliant),
           "compliantArrayIndexOutOfBounds" -> (sems.arrayIndexOutOfBounds == CheckedBehavior.Compliant),
+          "compliantArrayStores" -> (sems.arrayStores == CheckedBehavior.Compliant),
           "compliantStringIndexOutOfBounds" -> (sems.stringIndexOutOfBounds == CheckedBehavior.Compliant),
           "compliantModuleInit" -> (sems.moduleInit == CheckedBehavior.Compliant),
           "strictFloats" -> sems.strictFloats,

--- a/project/MiniLib.scala
+++ b/project/MiniLib.scala
@@ -36,6 +36,7 @@ object MiniLib {
         "ClassCastException",
         "CloneNotSupportedException",
         "IndexOutOfBoundsException",
+        "NegativeArraySizeException",
         "StringIndexOutOfBoundsException"
     ).map("java/lang/" + _)
 

--- a/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
+++ b/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
@@ -25,6 +25,7 @@ private[utils] object BuildInfo {
   final val isFullOpt = false
   final val compliantAsInstanceOfs = false
   final val compliantArrayIndexOutOfBounds = false
+  final val compliantArrayStores = false
   final val compliantStringIndexOutOfBounds = false
   final val compliantModuleInit = false
   final val strictFloats = false

--- a/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
+++ b/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
@@ -26,6 +26,7 @@ private[utils] object BuildInfo {
   final val compliantAsInstanceOfs = false
   final val compliantArrayIndexOutOfBounds = false
   final val compliantArrayStores = false
+  final val compliantNegativeArraySizes = false
   final val compliantStringIndexOutOfBounds = false
   final val compliantModuleInit = false
   final val strictFloats = false

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -77,6 +77,9 @@ object Platform {
   def hasCompliantArrayStores: Boolean =
     BuildInfo.compliantArrayStores
 
+  def hasCompliantNegativeArraySizes: Boolean =
+    BuildInfo.compliantNegativeArraySizes
+
   def hasCompliantStringIndexOutOfBounds: Boolean =
     BuildInfo.compliantStringIndexOutOfBounds
 

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -74,6 +74,9 @@ object Platform {
   def hasCompliantArrayIndexOutOfBounds: Boolean =
     BuildInfo.compliantArrayIndexOutOfBounds
 
+  def hasCompliantArrayStores: Boolean =
+    BuildInfo.compliantArrayStores
+
   def hasCompliantStringIndexOutOfBounds: Boolean =
     BuildInfo.compliantStringIndexOutOfBounds
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ArrayJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ArrayJSTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.compiler
+
+import scala.scalajs.js
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.Platform._
+
+class ArrayJSTest {
+
+  private def covariantUpcast[A <: AnyRef](array: Array[_ <: A]): Array[A] =
+    array.asInstanceOf[Array[A]]
+
+  @Test
+  def setArrayStoreWithJSElems(): Unit = {
+    val jsObj = new js.Object
+    val obj = new AnyRef
+    val str = "foo"
+    val list = List(1, 2)
+    val jsRangeError = new js.RangeError("foo")
+
+    // Array of JS class
+    val a: Array[AnyRef] = covariantUpcast(new Array[js.Object](5))
+    a(1) = jsObj
+    assertSame(jsObj, a(1))
+    a(2) = obj
+    assertSame(obj, a(2))
+    a(3) = str
+    assertEquals(str, a(3))
+    a(4) = list
+    assertSame(list, a(4))
+    a(1) = null
+    assertNull(a(1))
+
+    // Array of JS trait
+    val b: Array[AnyRef] = covariantUpcast(new Array[js.Iterator[Any]](5))
+    b(1) = jsObj
+    assertSame(jsObj, b(1))
+    b(2) = obj
+    assertSame(obj, b(2))
+    b(3) = str
+    assertEquals(str, b(3))
+    b(4) = list
+    assertSame(list, b(4))
+    b(1) = null
+    assertNull(b(1))
+
+    // Array of JS subclass
+    val c: Array[js.Object] = covariantUpcast(new Array[js.Error](5))
+    c(1) = jsRangeError
+    assertSame(jsRangeError, c(1))
+    c(2) = jsObj
+    assertSame(jsObj, c(2))
+    c(3) = str.asInstanceOf[js.Object]
+    assertEquals(str, c(3))
+    c(1) = null
+    assertNull(c(1))
+  }
+
+  @Test
+  def setArrayStoreExceptionsWithJSElems(): Unit = {
+    assumeTrue("Assuming compliant ArrayStores",
+        hasCompliantArrayStores)
+
+    val jsObj = new js.Object
+
+    val a: Array[AnyRef] = covariantUpcast(new Array[List[Any]](5))
+    assertThrows(classOf[ArrayStoreException], a(1) = jsObj)
+  }
+}

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -43,6 +43,7 @@ object Platform {
   def hasCompliantAsInstanceOfs: Boolean = true
   def hasCompliantArrayIndexOutOfBounds: Boolean = true
   def hasCompliantArrayStores: Boolean = true
+  def hasCompliantNegativeArraySizes: Boolean = true
   def hasCompliantStringIndexOutOfBounds: Boolean = true
   def hasCompliantModule: Boolean = true
   def hasDirectBuffers: Boolean = true

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -42,6 +42,7 @@ object Platform {
 
   def hasCompliantAsInstanceOfs: Boolean = true
   def hasCompliantArrayIndexOutOfBounds: Boolean = true
+  def hasCompliantArrayStores: Boolean = true
   def hasCompliantStringIndexOutOfBounds: Boolean = true
   def hasCompliantModule: Boolean = true
   def hasDirectBuffers: Boolean = true

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
@@ -17,9 +17,12 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
-import org.scalajs.testsuite.utils.Platform.hasCompliantArrayIndexOutOfBounds
+import org.scalajs.testsuite.utils.Platform._
 
 class ArrayTest {
+
+  private def covariantUpcast[A <: AnyRef](array: Array[_ <: A]): Array[A] =
+    array.asInstanceOf[Array[A]]
 
   @Test
   def getArrayIndexOutOfBounds(): Unit = {
@@ -31,6 +34,18 @@ class ArrayTest {
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(5))
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(Int.MinValue))
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(Int.MaxValue))
+
+    val b = new Array[AnyRef](5)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], b(-1))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], b(5))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], b(Int.MinValue))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], b(Int.MaxValue))
+
+    val c = new Array[Seq[_]](5)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], c(-1))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], c(5))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], c(Int.MinValue))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], c(Int.MaxValue))
   }
 
   @Test
@@ -43,6 +58,97 @@ class ArrayTest {
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(5) = 1)
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(Int.MinValue) = 1)
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(Int.MaxValue) = 1)
+
+    val b = new Array[AnyRef](5)
+    val obj = new AnyRef
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], b(-1) = obj)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], b(5) = obj)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], b(Int.MinValue) = obj)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], b(Int.MaxValue) = obj)
+
+    val c = new Array[Seq[_]](5)
+    val seq = List(1, 2)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], c(-1) = seq)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], c(5) = seq)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], c(Int.MinValue) = seq)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], c(Int.MaxValue) = seq)
+
+    /* IndexOutOfBoundsException is stronger than ArrayStoreException
+     * (whether the latter is compliant or not).
+     */
+    val d: Array[AnyRef] = covariantUpcast(c)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], d(-1) = obj)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], d(5) = obj)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], d(Int.MinValue) = obj)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], d(Int.MaxValue) = obj)
+  }
+
+  @Test
+  def setArrayStoreExceptions(): Unit = {
+    assumeTrue("Assuming compliant ArrayStores",
+        hasCompliantArrayStores)
+
+    val obj = new AnyRef
+    val str = "foo"
+    val list = List(1, 2)
+    val vector = Vector(3, 4)
+
+    val a: Array[AnyRef] = covariantUpcast(new Array[Seq[_]](5))
+    a(1) = list
+    assertSame(list, a(1))
+    assertThrows(classOf[ArrayStoreException], a(1) = obj)
+    assertSame(list, a(1))
+    assertThrows(classOf[ArrayStoreException], a(2) = str)
+    assertNull(a(2))
+    a(3) = vector
+    assertSame(vector, a(3))
+    a(1) = null
+    assertNull(a(1))
+
+    val b: Array[Seq[_]] = covariantUpcast(new Array[List[Any]](5))
+    b(1) = list
+    assertSame(list, b(1))
+    assertThrows(classOf[ArrayStoreException], b(1) = vector)
+    assertSame(list, b(1))
+
+    val c: Array[Number] = covariantUpcast(new Array[Integer](5))
+    c(1) = Integer.valueOf(5)
+    assertEquals(5, c(1))
+    assertThrows(classOf[ArrayStoreException], c(1) = java.lang.Double.valueOf(5.5))
+    assertEquals(5, c(1))
+    if (executingInJVM) {
+      assertThrows(classOf[ArrayStoreException], c(2) = java.lang.Double.valueOf(5.0))
+      assertNull(c(2))
+    } else {
+      c(2) = java.lang.Double.valueOf(5.0)
+      assertEquals(5.0, c(2))
+    }
+    val c2: Array[Object] = covariantUpcast(c)
+    c2(3) = Integer.valueOf(42)
+    assertThrows(classOf[ArrayStoreException], c2(3) = str)
+    assertEquals(42, c2(3))
+    assertEquals(42, c(3))
+
+    val x: Array[AnyRef] = covariantUpcast(new Array[Array[Seq[_]]](5))
+    x(1) = new Array[Seq[_]](1)
+    x(2) = new Array[List[Any]](1)
+    assertThrows(classOf[ArrayStoreException], x(3) = new Array[String](1))
+    assertThrows(classOf[ArrayStoreException], x(3) = new Array[AnyRef](1))
+    assertThrows(classOf[ArrayStoreException], x(3) = new Array[Int](1))
+    assertThrows(classOf[ArrayStoreException], x(3) = obj)
+    assertThrows(classOf[ArrayStoreException], x(3) = str)
+    x(1) = null
+    assertNull(x(1))
+
+    val y: Array[AnyRef] = covariantUpcast(new Array[Array[Int]](5))
+    y(1) = new Array[Int](1)
+    assertThrows(classOf[ArrayStoreException], y(3) = new Array[String](1))
+    assertThrows(classOf[ArrayStoreException], y(3) = new Array[AnyRef](1))
+    assertThrows(classOf[ArrayStoreException], y(3) = new Array[List[Any]](1))
+    assertThrows(classOf[ArrayStoreException], y(3) = obj)
+    assertThrows(classOf[ArrayStoreException], y(3) = str)
+    y(1) = null
+    assertNull(y(1))
   }
 
   @Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
@@ -162,4 +162,37 @@ class ArrayTest {
 
     assertThrows(classOf[ArrayIndexOutOfBoundsException], testAccess(Array()))
   }
+
+  @Test def negativeArraySizes(): Unit = {
+    assumeTrue("Assuming compliant negative array sizes", hasCompliantNegativeArraySizes)
+
+    @noinline def getNegValue(): Int = -5
+    val negValue = getNegValue()
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[Int](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[Int](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[Boolean](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[Boolean](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[AnyRef](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[AnyRef](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[String](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[String](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[Array[AnyRef]](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[Array[AnyRef]](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], Array.ofDim[Int](-5, 5))
+    assertThrows(classOf[NegativeArraySizeException], Array.ofDim[Int](negValue, 5))
+    assertThrows(classOf[NegativeArraySizeException], Array.ofDim[Int](5, -5))
+    assertThrows(classOf[NegativeArraySizeException], Array.ofDim[Int](5, negValue))
+
+    // Force unit result type to tempt the optimizer and emitter into getting rid of the expression
+    @noinline
+    def testCreateNegativeSizeArray(): Unit = new Array[Int](-1)
+
+    assertThrows(classOf[NegativeArraySizeException], testCreateNegativeSizeArray())
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemArraycopyTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemArraycopyTest.scala
@@ -1,0 +1,419 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.Platform._
+
+/** Tests for `System.arraycopy`.
+ *
+ *  We test with Arrays of Ints, Booleans, Objects and Strings:
+ *
+ *  - `Array[Int]` is a specialized primitive array type backed by a TypedArray
+ *  - `Array[Boolean]` is a specialized primitive array type backed by an Array
+ *  - `Array[Object]` is a specialized reference array type (backed by an Array)
+ *  - `Array[String]` is a generic reference array type (backed by an Array)
+ */
+class SystemArraycopyTest {
+  import SystemArraycopyTest._
+
+  import System.arraycopy
+
+  private def covariantUpcast[A <: AnyRef](array: Array[_ <: A]): Array[A] =
+    array.asInstanceOf[Array[A]]
+
+  @noinline
+  private def assertArrayRefEquals[A <: AnyRef](expected: Array[A], actual: Array[A]): Unit =
+    assertArrayEquals(expected.asInstanceOf[Array[AnyRef]], actual.asInstanceOf[Array[AnyRef]])
+
+  @noinline
+  private def assertThrowsAIOOBE[U](code: => U): ArrayIndexOutOfBoundsException =
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], code)
+
+  @noinline
+  private def assertThrowsASE[U](code: => U): ArrayStoreException =
+    assertThrows(classOf[ArrayStoreException], code)
+
+  @Test def simpleTests(): Unit = {
+    val object0 = Array[Any]("[", "b", "c", "d", "e", "f", "]")
+    val object1 = Array[Any](() => true, 1, "2", '3', 4.0, true, object0)
+
+    System.arraycopy(object1, 1, object0, 1, 5)
+    if (executingInJVM) {
+      assertEquals("[1234.0true]", object0.mkString)
+    } else {
+      assertEquals("[1234true]", object0.mkString)
+    }
+
+    val string0 = Array("a", "b", "c", "d", "e", "f")
+    val string1 = Array("1", "2", "3", "4")
+
+    System.arraycopy(string1, 0, string0, 3, 3)
+    assertEquals("abc123", string0.mkString)
+
+    val ab01Chars = Array("ab".toCharArray, "01".toCharArray)
+    val chars = new Array[Array[Char]](32)
+    System.arraycopy(ab01Chars, 0, chars, 0, 2)
+    for (i <- Seq(0, 2, 4, 8, 16)) {
+      System.arraycopy(chars, i / 4, chars, i, i)
+    }
+
+    assertEquals(12, chars.filter(_ == null).length)
+    assertEquals("ab01ab0101ab01ab0101ab0101ab01ab0101ab01",
+        chars.filter(_ != null).map(_.mkString).mkString)
+  }
+
+  @Test def arraycopyWithRangeOverlapsForTheSameArrayInt(): Unit = {
+    val array = new Array[Int](10)
+
+    for (i <- 1 to 6)
+      array(i) = i
+
+    assertArrayEquals(Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0), array)
+    arraycopy(array, 0, array, 3, 7)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6), array)
+
+    arraycopy(array, 0, array, 1, 0)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6), array)
+
+    arraycopy(array, 0, array, 1, 9)
+    assertArrayEquals(Array(0, 0, 1, 2, 0, 1, 2, 3, 4, 5), array)
+
+    arraycopy(array, 1, array, 0, 9)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5), array)
+
+    arraycopy(array, 0, array, 0, 10)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5), array)
+
+    val reversed = array.reverse
+    arraycopy(reversed, 5, array, 5, 5)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 1, 0, 2, 1, 0), array)
+  }
+
+  @Test def arraycopyWithRangeOverlapsForTheSameArrayBoolean(): Unit = {
+    val array = new Array[Boolean](10)
+
+    for (i <- 1 to 6)
+      array(i) = (i % 2) == 1
+
+    assertArrayEquals(Array(false, true, false, true, false, true, false, false, false, false), array)
+    arraycopy(array, 0, array, 3, 7)
+    assertArrayEquals(Array(false, true, false, false, true, false, true, false, true, false), array)
+
+    arraycopy(array, 0, array, 1, 0)
+    assertArrayEquals(Array(false, true, false, false, true, false, true, false, true, false), array)
+
+    arraycopy(array, 0, array, 1, 9)
+    assertArrayEquals(Array(false, false, true, false, false, true, false, true, false, true), array)
+
+    arraycopy(array, 1, array, 0, 9)
+    assertArrayEquals(Array(false, true, false, false, true, false, true, false, true, true), array)
+
+    arraycopy(array, 0, array, 0, 10)
+    assertArrayEquals(Array(false, true, false, false, true, false, true, false, true, true), array)
+
+    val reversed = array.reverse
+    arraycopy(reversed, 5, array, 5, 5)
+    assertArrayEquals(Array(false, true, false, false, true, true, false, false, true, false), array)
+  }
+
+  @Test def arraycopyWithRangeOverlapsForTheSameArrayObject(): Unit = {
+    val array = new Array[AnyRef](10)
+
+    for (i <- 1 to 6)
+      array(i) = O(i)
+
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), O(3), O(4), O(5), O(6), null, null, null), array)
+    arraycopy(array, 0, array, 3, 7)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5), O(6)), array)
+
+    arraycopy(array, 0, array, 1, 0)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5), O(6)), array)
+
+    arraycopy(array, 0, array, 1, 9)
+    assertArrayEquals(Array[AnyRef](null, null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5)), array)
+
+    arraycopy(array, 1, array, 0, 9)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5), O(5)), array)
+
+    arraycopy(array, 0, array, 0, 10)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5), O(5)), array)
+
+    val reversed = array.reverse
+    arraycopy(reversed, 5, array, 5, 5)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(1), null, O(2), O(1), null), array)
+  }
+
+  @Test def arraycopyWithRangeOverlapsForTheSameArrayString(): Unit = {
+    val array = new Array[String](10)
+
+    for (i <- 1 to 6)
+      array(i) = i.toString()
+
+    assertArrayRefEquals(Array(null, "1", "2", "3", "4", "5", "6", null, null, null), array)
+    arraycopy(array, 0, array, 3, 7)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "2", "3", "4", "5", "6"), array)
+
+    arraycopy(array, 0, array, 1, 0)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "2", "3", "4", "5", "6"), array)
+
+    arraycopy(array, 0, array, 1, 9)
+    assertArrayRefEquals(Array(null, null, "1", "2", null, "1", "2", "3", "4", "5"), array)
+
+    arraycopy(array, 1, array, 0, 9)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "2", "3", "4", "5", "5"), array)
+
+    arraycopy(array, 0, array, 0, 10)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "2", "3", "4", "5", "5"), array)
+
+    val reversed = array.reverse
+    arraycopy(reversed, 5, array, 5, 5)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "1", null, "2", "1", null), array)
+  }
+
+  @Test def arraycopyIndexOutOfBoundsInt(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+        hasCompliantArrayIndexOutOfBounds)
+
+    val src = Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0)
+    val dest = Array(11, 12, 13, 15, 15, 16)
+    val original = Array(11, 12, 13, 15, 15, 16)
+
+    assertThrowsAIOOBE(arraycopy(src, -1, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 8, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, -1, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 4, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 11, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 13, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 3, Int.MaxValue))
+    assertArrayEquals(original, dest)
+  }
+
+  @Test def arraycopyIndexOutOfBoundsBoolean(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+        hasCompliantArrayIndexOutOfBounds)
+
+    val src = Array(false, true, false, true, false, true, false, false, false, false)
+    val dest = Array(true, true, true, true, true, true)
+    val original = Array(true, true, true, true, true, true)
+
+    assertThrowsAIOOBE(arraycopy(src, -1, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 8, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, -1, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 4, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 11, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 13, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 3, Int.MaxValue))
+    assertArrayEquals(original, dest)
+  }
+
+  @Test def arraycopyIndexOutOfBoundsObject(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+        hasCompliantArrayIndexOutOfBounds)
+
+    val src = Array[AnyRef](O(0), O(1), O(2), O(3), O(4), O(5), O(6), O(0), O(0), O(0))
+    val dest = Array[AnyRef](O(11), O(12), O(13), O(15), O(15), O(16))
+    val original = Array[AnyRef](O(11), O(12), O(13), O(15), O(15), O(16))
+
+    assertThrowsAIOOBE(arraycopy(src, -1, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 8, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, -1, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 4, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 11, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 13, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 3, Int.MaxValue))
+    assertArrayEquals(original, dest)
+  }
+
+  @Test def arraycopyIndexOutOfBoundsString(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+        hasCompliantArrayIndexOutOfBounds)
+
+    val src = Array("0", "1", "2", "3", "4", "5", "6", "0", "0", "0")
+    val dest = Array("11", "12", "13", "15", "15", "16")
+    val original = Array("11", "12", "13", "15", "15", "16")
+
+    assertThrowsAIOOBE(arraycopy(src, -1, dest, 3, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 8, dest, 3, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, -1, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 4, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 11, dest, 3, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 13, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 3, Int.MaxValue))
+    assertArrayRefEquals(original, dest)
+  }
+
+  @Test def earlyArrayStoreException(): Unit = {
+    assumeTrue("Assuming compliant ArrayStores", hasCompliantArrayStores)
+
+    val ints = Array(1, 2, 3, 4, 5)
+    val bools = Array(true, false, true, false)
+    val objs = Array[AnyRef](O(1), O(2), O(3), O(4), O(5))
+    val strs = Array("0", "1", "2", "3", "4")
+
+    val allArrays: List[AnyRef] = List(ints, bools, objs, strs)
+    val notAnArray: AnyRef = Some("not an array")
+    val undefined: AnyRef = ().asInstanceOf[AnyRef]
+
+    /* Copying to/from notAnArray or undefined
+     * (undefined has dedicated code paths because `undefined.$classData`
+     * throws, unlike any other non-null value).
+     */
+
+    for (a <- notAnArray :: undefined :: allArrays) {
+      assertThrowsASE(arraycopy(notAnArray, 1, a, 1, 2))
+      assertThrowsASE(arraycopy(notAnArray, 1, a, 1, 0))
+
+      assertThrowsASE(arraycopy(undefined, 1, a, 1, 2))
+      assertThrowsASE(arraycopy(undefined, 1, a, 1, 0))
+
+      assertThrowsASE(arraycopy(a, 1, notAnArray, 1, 2))
+      assertThrowsASE(arraycopy(a, 1, notAnArray, 1, 0))
+
+      assertThrowsASE(arraycopy(a, 1, undefined, 1, 2))
+      assertThrowsASE(arraycopy(a, 1, undefined, 1, 0))
+    }
+
+    // Also test a few cases where the optimizer sees through everything
+    assertThrowsASE(arraycopy(notAnArray, 1, objs, 1, 2))
+    assertThrowsASE(arraycopy(objs, 1, notAnArray, 1, 2))
+
+    // Copying between different primitive array types, or between primitive and ref array types
+
+    for (len <- List(2, 0, -1)) {
+      assertThrowsASE(arraycopy(ints, 1, bools, 1, len))
+      assertThrowsASE(arraycopy(ints, 1, objs, 1, len))
+      assertThrowsASE(arraycopy(ints, 1, strs, 1, len))
+
+      assertThrowsASE(arraycopy(bools, 1, ints, 1, len))
+      assertThrowsASE(arraycopy(bools, 1, objs, 1, len))
+      assertThrowsASE(arraycopy(bools, 1, strs, 1, len))
+
+      assertThrowsASE(arraycopy(objs, 1, ints, 1, len))
+      assertThrowsASE(arraycopy(objs, 1, bools, 1, len))
+
+      assertThrowsASE(arraycopy(strs, 1, ints, 1, len))
+      assertThrowsASE(arraycopy(strs, 1, bools, 1, len))
+    }
+
+    // Also test a few cases where the optimizer sees through everything
+    assertThrowsASE(arraycopy(ints, 1, bools, 1, 2))
+    assertThrowsASE(arraycopy(ints, 1, objs, 1, 2))
+    assertThrowsASE(arraycopy(objs, 1, ints, 1, 2))
+  }
+
+  @Test def lateArrayStoreException(): Unit = {
+    assumeTrue("Assuming compliant ArrayStores", hasCompliantArrayStores)
+
+    // From Array[Object] to Array[O]
+
+    val src1: Array[AnyRef] = Array[AnyRef](O(1), O(2), "3", O(4), "5", O(6))
+    val dest1: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8))
+    assertThrowsASE(arraycopy(src1, 0, dest1, 0, 6))
+    assertArrayRefEquals(Array[O](O(1), O(2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8)), dest1)
+
+    val src2 = src1
+    val dest2: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8))
+    assertThrowsASE(arraycopy(src2, 1, dest2, 3, 3))
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(-5), O(-6), O(-7), O(-8)), dest2)
+
+    arraycopy(src2, 2, dest2, 0, 0)
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(-5), O(-6), O(-7), O(-8)), dest2)
+    arraycopy(src2, 0, dest2, 4, 2)
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(1), O(2), O(-7), O(-8)), dest2)
+
+    // From Array[SuperClass] to Array[O]
+
+    val src3: Array[AnyRef] = covariantUpcast(Array[SuperClass](O(1), O(2), P(3), O(4), P(5), O(6)))
+    val dest3: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8))
+    assertThrowsASE(arraycopy(src3, 0, dest3, 0, 6))
+    assertArrayRefEquals(Array[O](O(1), O(2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8)), dest3)
+
+    val src4 = src3
+    val dest4: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8))
+    assertThrowsASE(arraycopy(src4, 1, dest4, 3, 3))
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(-5), O(-6), O(-7), O(-8)), dest4)
+
+    arraycopy(src4, 2, dest4, 0, 0)
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(-5), O(-6), O(-7), O(-8)), dest4)
+    arraycopy(src4, 0, dest4, 4, 2)
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(1), O(2), O(-7), O(-8)), dest4)
+
+    // From Array[P] to Array[O], succeeds with 0 elements to copy
+
+    val src5: Array[AnyRef] = covariantUpcast(Array[P](P(1), P(2), P(3)))
+    val dest5: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5))
+    arraycopy(src5, 2, dest5, 1, 0)
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(-4), O(-5)), dest5)
+  }
+}
+
+object SystemArraycopyTest {
+  abstract class SuperClass
+
+  private final case class O(x: Int) extends SuperClass
+
+  private final case class P(x: Int) extends SuperClass
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -14,7 +14,6 @@ package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test
 import org.junit.Assert._
-import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
@@ -52,100 +51,6 @@ class SystemTest {
     } finally {
       System.setErr(savedErr)
     }
-  }
-
-  @Test def arraycopy(): Unit = {
-    val object0 = Array[Any]("[", "b", "c", "d", "e", "f", "]")
-    val object1 = Array[Any](() => true, 1, "2", '3', 4.0, true, object0)
-
-    System.arraycopy(object1, 1, object0, 1, 5)
-    if (executingInJVM) {
-      assertEquals("[1234.0true]", object0.mkString)
-    } else {
-      assertEquals("[1234true]", object0.mkString)
-    }
-
-    val string0 = Array("a", "b", "c", "d", "e", "f")
-    val string1 = Array("1", "2", "3", "4")
-
-    System.arraycopy(string1, 0, string0, 3, 3)
-    assertEquals("abc123", string0.mkString)
-
-    val ab01Chars = Array("ab".toCharArray, "01".toCharArray)
-    val chars = new Array[Array[Char]](32)
-    System.arraycopy(ab01Chars, 0, chars, 0, 2)
-    for (i <- Seq(0, 2, 4, 8, 16)) {
-      System.arraycopy(chars, i / 4, chars, i, i)
-    }
-
-    assertEquals(12, chars.filter(_ == null).length)
-    assertEquals("ab01ab0101ab01ab0101ab0101ab01ab0101ab01",
-        chars.filter(_ != null).map(_.mkString).mkString)
-  }
-
-  @Test def arraycopyWithRangeOverlapsForTheSameArray(): Unit = {
-    val array = new Array[Int](10)
-
-    for (i <- 1 to 6) {
-      array(i) = i
-    }
-
-    assertArrayEquals(Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0), array)
-    System.arraycopy(array, 0, array, 3, 7)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6), array)
-
-    System.arraycopy(array, 0, array, 1, 0)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6), array)
-
-    System.arraycopy(array, 0, array, 1, 9)
-    assertArrayEquals(Array(0, 0, 1, 2, 0, 1, 2, 3, 4, 5), array)
-
-    System.arraycopy(array, 1, array, 0, 9)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5), array)
-
-    System.arraycopy(array, 0, array, 0, 10)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5), array)
-
-    val reversed = array.reverse
-    System.arraycopy(reversed, 5, array, 5, 5)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 1, 0, 2, 1, 0), array)
-  }
-
-  @Test def arraycopyIndexOutOfBounds(): Unit = {
-    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
-        hasCompliantArrayIndexOutOfBounds)
-
-    val src = Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0)
-    val dest = Array(11, 12, 13, 15, 15, 16)
-    val original = Array(11, 12, 13, 15, 15, 16)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, -1, dest, 3, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 8, dest, 3, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 1, dest, -1, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 1, dest, 4, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 11, dest, 3, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 1, dest, 13, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 1, dest, 3, Int.MaxValue))
-    assertArrayEquals(original, dest)
   }
 
   @Test def identityHashCode(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
@@ -16,6 +16,10 @@ import scala.runtime.BoxedUnit
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.Platform._
 
 class ReflectArrayTest {
 
@@ -64,5 +68,29 @@ class ReflectArrayTest {
     testNewInstance(classOf[Array[Object]], classOf[Array[Array[Object]]], null)
     testNewInstance(classOf[Array[Int]], classOf[Array[Array[Int]]], null)
     testNewInstance(classOf[Array[String]], classOf[Array[Array[String]]], null)
+  }
+
+  @Test def newInstanceNegativeArraySize(): Unit = {
+    import java.lang.{reflect => jlr}
+
+    assumeTrue("Assuming compliant negative array sizes", hasCompliantNegativeArraySizes)
+
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Int], -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Boolean], -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[AnyRef], -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[String], -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Array[AnyRef]], -5))
+
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Int], -5, 5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Boolean], -5, 5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[AnyRef], -5, 5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[String], -5, 5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Array[AnyRef]], -5, 5))
+
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Int], 5, -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Boolean], 5, -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[AnyRef], 5, -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[String], 5, -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Array[AnyRef]], 5, -5))
   }
 }


### PR DESCRIPTION
The fundamental operation that can throw `ArrayStoreException`s is `Assign(ArraySelect(...), ...)` for a reference type array. We adapt the emitter to use a `set()` method for reference array types when either array index out of bounds or array stores are checked (or both). Assignments for primitive array types are left unchanged.

In addition to the language, the library function `System.arraycopy` throws `ArrayStoreException`s in various cases. The user-space implemention in `System.scala` was already conforming. We augment the intrinsic version to perform all the appropriate checks. In many common cases, it is possible to statically rule out the error cases (when both the `src` and `dest` arrays are statically known to be primitive arrays) or limit the error cases to a straightforward compatibility check (when both the arrays are reference arrays). The full checks are only necessary when one or both of the arrays are not statically known to be arrays.