### PR TITLE
Clean up the internal APIs used for stack trace construction.

### DIFF
--- a/javalib/src/main/scala/java/lang/StackTrace.scala
+++ b/javalib/src/main/scala/java/lang/StackTrace.scala
@@ -24,79 +24,72 @@ import Utils._
 private[lang] object StackTrace {
 
   /* !!! Note that in this unit, we go to great lengths *not* to use anything
-   * from the Scala collections library.
+   * from the collections library, and in general to use as little non-JS APIs
+   * as possible.
    *
-   * This minimizes the risk of runtime errors during the process of decoding
+   * This minimizes the risk of run-time errors during the process of decoding
    * errors, which would be very bad if it happened.
    */
 
   /** Returns the current stack trace.
-   *  If the stack trace cannot be analyzed in meaningful way (because we don't
-   *  know the browser), an empty array is returned.
+   *
+   *  If the stack trace cannot be analyzed in a meaningful way (normally,
+   *  only in case we don't know the engine's format for stack traces), an
+   *  empty array is returned.
    */
   def getCurrentStackTrace(): Array[StackTraceElement] =
-    extract(createException().asInstanceOf[js.Dynamic])
+    extract(new js.Error())
 
-  /** Captures browser-specific state recording the current stack trace.
+  /** Captures a JavaScript error object recording the stack trace of the given
+   *  `Throwable`.
+   *
    *  The state is stored as a magic field of the throwable, and will be used
    *  by `extract()` to create an Array[StackTraceElement].
    */
-  @inline def captureState(throwable: Throwable): Unit = {
-    val throwableAsJSAny = throwable.asInstanceOf[js.Any]
+  @inline def captureJSError(throwable: Throwable): Any = {
+    val reference = js.special.unwrapFromThrowable(throwable)
     val identifyingString: Any = {
       js.constructorOf[js.Object].prototype
         .selectDynamic("toString")
-        .call(throwableAsJSAny)
+        .call(reference.asInstanceOf[js.Any])
     }
     if ("[object Error]" == identifyingString) {
-      /* The `throwable` has an `[[ErrorData]]` internal slot, which is as good
+      /* The `reference` has an `[[ErrorData]]` internal slot, which is as good
        * a guarantee as any that it contains stack trace data itself. In
        * practice, this happens when we emit ES 2015 classes, and no other
        * compiler down the line has compiled them away as ES 5.1 functions and
        * prototypes.
        */
-      captureState(throwable, throwable)
+      reference
     } else if (js.constructorOf[js.Error].captureStackTrace eq ().asInstanceOf[AnyRef]) {
-      captureState(throwable, createException())
+      // Create a JS Error with the current stack trace.
+      new js.Error()
     } else {
       /* V8-specific.
-       * The Error.captureStackTrace(e) method records the current stack trace
-       * on `e` as would do `new Error()`, thereby turning `e` into a proper
-       * exception. This avoids creating a dummy exception, but is mostly
-       * important so that Node.js will show stack traces if the exception
-       * is never caught and reaches the global event queue.
+       *
+       * The `Error.captureStackTrace(e)` method records the current stack
+       * trace on `e` as would do `new Error()`, thereby turning `e` into a
+       * proper exception. This avoids creating a dummy exception, but is
+       * mostly important so that Node.js will show stack traces if the
+       * exception is never caught and reaches the global event queue.
+       *
+       * We use the `throwable` itself instead of the `reference` in this case,
+       * since the latter is not under our control, and could even be a
+       * primitive value which cannot be passed to `captureStackTrace`.
        */
-      js.constructorOf[js.Error].captureStackTrace(throwableAsJSAny)
-      captureState(throwable, throwable)
+      js.constructorOf[js.Error].captureStackTrace(throwable.asInstanceOf[js.Any])
+      throwable
     }
   }
 
-  /** Creates a JS Error with the current stack trace state. */
-  @inline private def createException(): Any =
-    new js.Error()
-
-  /** Captures browser-specific state recording the stack trace of a JS error.
-   *  The state is stored as a magic field of the throwable, and will be used
-   *  by `extract()` to create an Array[StackTraceElement].
+  /** Extracts a stack trace from a JavaScript error object.
+   *  If the provided error is not a JavaScript object, or if its stack data
+   *  otherwise cannot be analyzed in a meaningful way (normally, only in case
+   *  we don't know the engine's format for stack traces), an empty array is
+   *  returned.
    */
-  @inline def captureState(throwable: Throwable, e: Any): Unit =
-    throwable.setStackTraceStateInternal(e)
-
-  /** Extracts a throwable's stack trace from captured browser-specific state.
-   *  If no stack trace state has been recorded, or if the state cannot be
-   *  analyzed in meaningful way (because we don't know the browser), an
-   *  empty array is returned.
-   */
-  def extract(throwable: Throwable): Array[StackTraceElement] =
-    extract(throwable.getStackTraceStateInternal())
-
-  /** Extracts a stack trace from captured browser-specific stackdata.
-   *  If no stack trace state has been recorded, or if the state cannot be
-   *  analyzed in meaningful way (because we don't know the browser), an
-   *  empty array is returned.
-   */
-  private def extract(stackdata: Any): Array[StackTraceElement] = {
-    val lines = normalizeStackTraceLines(stackdata.asInstanceOf[js.Dynamic])
+  def extract(jsError: Any): Array[StackTraceElement] = {
+    val lines = normalizeStackTraceLines(jsError.asInstanceOf[js.Dynamic])
     normalizedLinesToStackTrace(lines)
   }
 

--- a/javalib/src/main/scala/java/lang/StackTrace.scala
+++ b/javalib/src/main/scala/java/lang/StackTrace.scala
@@ -119,14 +119,14 @@ private[lang] object StackTrace {
         if (mtch ne null) {
           val classAndMethodName =
             extractClassMethod(undefOrForceGet(mtch(1)))
-          val elem = new StackTraceElement(classAndMethodName(0),
+          trace.push(new StackTraceElement(classAndMethodName(0),
               classAndMethodName(1), undefOrForceGet(mtch(2)),
-              parseInt(undefOrForceGet(mtch(3))))
-          undefOrForeach(mtch(4))(c => elem.setColumnNumber(parseInt(c)))
-          trace.push(elem)
+              parseInt(undefOrForceGet(mtch(3))),
+              undefOrFold(mtch(4))(-1)(parseInt(_))))
         } else {
           // just in case
-          trace.push(new StackTraceElement("<jscode>", line, null, -1))
+          // (explicitly use the constructor with column number so that STE has an inlineable init)
+          trace.push(new StackTraceElement("<jscode>", line, null, -1, -1))
         }
       }
       i += 1

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -44,6 +44,7 @@ final class StackTraceElement(declaringClass: String, methodName: String,
     case that: StackTraceElement =>
       (getFileName() == that.getFileName()) &&
       (getLineNumber() == that.getLineNumber()) &&
+      (getColumnNumber() == that.getColumnNumber()) &&
       (getClassName() == that.getClassName()) &&
       (getMethodName() == that.getMethodName())
     case _ =>
@@ -73,6 +74,10 @@ final class StackTraceElement(declaringClass: String, methodName: String,
   }
 
   override def hashCode(): Int = {
-    declaringClass.hashCode() ^ methodName.hashCode()
+    declaringClass.hashCode() ^
+    methodName.hashCode() ^
+    fileName.hashCode() ^
+    lineNumber ^
+    columnNumber
   }
 }

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -15,10 +15,16 @@ package java.lang
 import scala.scalajs.js
 import js.annotation.JSExport
 
+/* The primary constructor, taking a `columnNumber`, is not part of the JDK
+ * API. It is used internally in `java.lang.StackTrace`, and could be accessed
+ * by third-party libraries with a bit of IR manipulation.
+ */
 final class StackTraceElement(declaringClass: String, methodName: String,
-    fileName: String, lineNumber: Int) extends AnyRef with java.io.Serializable {
+    fileName: String, lineNumber: Int, private[this] var columnNumber: Int)
+    extends AnyRef with java.io.Serializable {
 
-  private[this] var columnNumber: Int = -1
+  def this(declaringClass: String, methodName: String, fileName: String, lineNumber: Int) =
+    this(declaringClass, methodName, fileName, lineNumber, -1)
 
   def getFileName(): String = fileName
   def getLineNumber(): Int = lineNumber
@@ -26,14 +32,11 @@ final class StackTraceElement(declaringClass: String, methodName: String,
   def getMethodName(): String = methodName
   def isNativeMethod(): scala.Boolean = false
 
-  /* Not part of the JDK API, used internally in java.lang and accessible
-   * through reflection.
-   */
+  // Not part of the JDK API, accessible through reflection.
   def getColumnNumber(): Int = columnNumber
 
-  /* Not part of the JDK API, used internally in java.lang and accessible
-   * through reflection.
-   */
+  // Not part of the JDK API, accessible through reflection.
+  @deprecated("old internal API; use the constructor with a column number instead", "1.11.0")
   def setColumnNumber(columnNumber: Int): Unit =
     this.columnNumber = columnNumber
 

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -24,7 +24,7 @@ class Throwable protected (s: String, private var e: Throwable,
   def this(s: String) = this(s, null)
   def this(e: Throwable) = this(if (e == null) null else e.toString, e)
 
-  private[this] var stackTraceStateInternal: Any = _
+  private[this] var jsErrorForStackTrace: Any = _
   private[this] var stackTrace: Array[StackTraceElement] = _
 
   /* We use an Array rather than, say, a List, so that Throwable does not
@@ -45,26 +45,14 @@ class Throwable protected (s: String, private var e: Throwable,
   def getLocalizedMessage(): String = getMessage()
 
   def fillInStackTrace(): Throwable = {
-    StackTrace.captureState(this)
+    jsErrorForStackTrace = StackTrace.captureJSError(this)
     this
   }
-
-  /* Not part of the JDK API, used internally in java.lang and accessible
-   * through reflection.
-   */
-  def getStackTraceStateInternal(): Any =
-    stackTraceStateInternal
-
-  /* Not part of the JDK API, used internally in java.lang and accessible
-   * through reflection.
-   */
-  def setStackTraceStateInternal(e: Any): Unit =
-    stackTraceStateInternal = e
 
   def getStackTrace(): Array[StackTraceElement] = {
     if (stackTrace eq null) {
       if (writableStackTrace)
-        stackTrace = StackTrace.extract(this)
+        stackTrace = StackTrace.extract(jsErrorForStackTrace)
       else
         stackTrace = new Array[StackTraceElement](0)
     }

--- a/library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
+++ b/library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
@@ -20,12 +20,4 @@ final case class JavaScriptException(exception: scala.Any)
     extends RuntimeException {
 
   override def getMessage(): String = exception.toString()
-
-  override def fillInStackTrace(): Throwable = {
-    type JSExceptionEx = JavaScriptException {
-      def setStackTraceStateInternal(e: scala.Any): Unit
-    }
-    this.asInstanceOf[JSExceptionEx].setStackTraceStateInternal(exception)
-    this
-  }
 }

--- a/linker-private-library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
+++ b/linker-private-library/src/main/scala/scala/scalajs/js/JavaScriptException.scala
@@ -18,12 +18,4 @@ final class JavaScriptException(val exception: scala.Any)
     extends RuntimeException {
 
   override def getMessage(): String = exception.toString()
-
-  override def fillInStackTrace(): Throwable = {
-    type JSExceptionEx = JavaScriptException {
-      def setStackTraceStateInternal(e: scala.Any): Unit
-    }
-    this.asInstanceOf[JSExceptionEx].setStackTraceStateInternal(exception)
-    this
-  }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,7 +70,7 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 141677,
+      expectedFastLinkSize = 142501,
       expectedFullLinkSizeWithoutClosure = 129956,
       expectedFullLinkSizeWithClosure = 21225,
       classDefs,

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -28,6 +28,8 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+    // Static initializer (2.11 only), not an issue
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.scalajs.js.JavaScriptException.<clinit>"),
   )
 
   val TestInterface = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1713,7 +1713,7 @@ object Build {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 379000 to 380000,
+                fastLink = 380000 to 381000,
                 fullLink = 79000 to 80000,
                 fastLinkGz = 49000 to 50000,
                 fullLinkGz = 21000 to 22000,


### PR DESCRIPTION
Prompted by #4710.

--

If #4721 is merged before this PR, we should also change the code in `javalibintf/StackTraceElement.scala` to use the new constructor of `java.lang.StackTraceElement`.