### PR TITLE
Embed enough information in the IR for NPE semantics of `throw null`.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/special/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/special/package.scala
@@ -175,6 +175,9 @@ package object special {
    *
    *  Instances of [[js.JavaScriptException]] are unwrapped to return the
    *  underlying value. Other values are returned as is.
+   *
+   *  @throws java.lang.NullPointerException
+   *    If `th` is `null`. Subject to Undefined Behaviors.
    */
   def unwrapFromThrowable(th: Throwable): scala.Any =
     throw new java.lang.Error("stub")

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/SpecialTest.scala
@@ -225,8 +225,7 @@ class SpecialTest {
     val th = new IllegalArgumentException
     assertSame(th, js.special.unwrapFromThrowable(th))
 
-    // Does not unwrap null
-    assertNull(null, js.special.unwrapFromThrowable(null))
+    // unwrapFromThrowable(null) is UB (as NullPointerException) and is therefore not tested
   }
 
   // js.special.fileLevelThis


### PR DESCRIPTION
In Scala, as in Java, `throw (null: Throwable)` throws a `NullPointerException`. Since NPEs are Undefined Behaviors in Scala.js, we previously did not care about this pattern, and assume it would not happen in the codegen.

If we want to have a checked behavior for NPEs, we need enough information in the IR for the linker to be able to conditionally throw accurate `NullPointerException`s in that case.

We do this with a combination of:

* Make `UnwrapFromThrowable(null)` "throw" an NPE, subject to undefined behavior (and potentially a checked behavior in the future), and
* Emit `Throw(UnwrapFromThrowable(e))` when `e` is nullable, even if it cannot be a `JavaScriptException`.

We fix up the non-null-aware IR from previous versions of the compiler via a deserialization hack.

The produced JavaScript code is basically unchanged after this commit, since the optimizer can remove the `UnwrapFromThrowable` in all the cases where the compiler previously omitted them. Some local variables have different names, and outer pointer checks in inner JS classes have a worse error path, but that is negligible.

---

This is extracted from my wip branch for checked NPEs at https://github.com/sjrd/scala-js/tree/checked-behavior-npe. This commit is the minimum amount of changes that need to go in 1.11.0 for the proper semantics of `throw null` to be doable later. We can do this in 1.11.0 because we introduced `js.special.throw` and `UnwrapFromThrowable` in this version. But we wouldn't be able to do it later without breaking existing code using `js.special.throw` and/or `js.special.unwrapFromThrowable`.

---

I locally tested the changes for the deserialization hack. I locally published using v1.10.1 a small library with the following code:
```scala
package testlib

import scala.scalajs.js

object TestLib {
  def throwThrowable(th: Throwable): Nothing =
    throw th

  def throwIllegalArg(th: IllegalArgumentException): Nothing =
    throw th

  def throwJSException(th: js.JavaScriptException): Nothing =
    throw th

  def throwNull(): Nothing =
    throw (null: Throwable)

  def throwNewIllegalArg(): Nothing =
    throw new IllegalArgumentException("boom")

  def throwOne(x: Boolean, th1: IllegalArgumentException, th2: IllegalArgumentException): Nothing = {
    def th: IllegalArgumentException = if (x) th1 else th2
    throw th
  }

  def tryCatchNoJSException(body: => Unit): Unit = {
    try {
      body
    } catch {
      case th: IllegalArgumentException =>
        throw th
    }
  }

  def tryCatchMaybeJSException(body: => Unit): Unit = {
    try {
      body
    } catch {
      case th: Exception =>
        throw th
    }
  }

  def tryCatchThrowable(body: => Unit): Unit = {
    try {
      body
    } catch {
      case th: Throwable =>
        throw th
    }
  }
}
```
I then inspected the patched IR using `scalajsp` from this branch, so that it prints
```scala
module class testlib.TestLib$ extends java.lang.Object {
  def throwThrowable;Ljava.lang.Throwable;E(th: java.lang.Throwable): nothing = {
    throw mod:scala.scalajs.runtime.package$.unwrapJavaScriptException;Ljava.lang.Throwable;Ljava.lang.Object(th)
  }
  def throwIllegalArg;Ljava.lang.IllegalArgumentException;E(th: java.lang.IllegalArgumentException): nothing = {
    throw if ((th === null)) {
      <unwrapFromThrowable>(null)
    } else {
      th
    }
  }
  def throwJSException;Lscala.scalajs.js.JavaScriptException;E(th: scala.scalajs.js.JavaScriptException): nothing = {
    throw mod:scala.scalajs.runtime.package$.unwrapJavaScriptException;Ljava.lang.Throwable;Ljava.lang.Object(th)
  }
  def throwNull;E(): nothing = {
    throw <unwrapFromThrowable>(null)
  }
  def throwNewIllegalArg;E(): nothing = {
    throw new java.lang.IllegalArgumentException().<init>;Ljava.lang.String;V("boom")
  }
  def throwOne;Z;Ljava.lang.IllegalArgumentException;Ljava.lang.IllegalArgumentException;E(x: boolean, th1: java.lang.IllegalArgumentException, th2: java.lang.IllegalArgumentException): nothing = {
    throw (arrow-lambda<>(x: any): any = {
      if ((x === null)) {
        <unwrapFromThrowable>(null)
      } else {
        x
      }
    })(this.testlib.TestLib$::private::th$1;Z;Ljava.lang.IllegalArgumentException;Ljava.lang.IllegalArgumentException;Ljava.lang.IllegalArgumentException(x, th1, th2))
  }
  def tryCatchNoJSException;Lscala.Function0;V(body: scala.Function0) {
    try {
      body.apply$mcV$sp;V()
    } catch (e) {
      if (e.isInstanceOf[java.lang.IllegalArgumentException]) {
        val th: java.lang.IllegalArgumentException = e.asInstanceOf[java.lang.IllegalArgumentException];
        throw if ((th === null)) {
          <unwrapFromThrowable>(null)
        } else {
          th
        }
      } else {
        throw e
      }
    }
  }
  def tryCatchMaybeJSException;Lscala.Function0;V(body: scala.Function0) {
    try {
      body.apply$mcV$sp;V()
    } catch (e) {
      val e$2: java.lang.Throwable = mod:scala.scalajs.runtime.package$.wrapJavaScriptException;Ljava.lang.Object;Ljava.lang.Throwable(e);
      if (e$2.isInstanceOf[java.lang.Exception]) {
        val th: java.lang.Exception = e$2.asInstanceOf[java.lang.Exception];
        throw mod:scala.scalajs.runtime.package$.unwrapJavaScriptException;Ljava.lang.Throwable;Ljava.lang.Object(th)
      } else {
        throw e
      }
    }
  }
  def tryCatchThrowable;Lscala.Function0;V(body: scala.Function0) {
    try {
      body.apply$mcV$sp;V()
    } catch (e) {
      val e$2: java.lang.Throwable = mod:scala.scalajs.runtime.package$.wrapJavaScriptException;Ljava.lang.Object;Ljava.lang.Throwable(e);
      if (e$2.isInstanceOf[java.lang.Throwable]) {
        val th: java.lang.Throwable = e$2.asInstanceOf[java.lang.Throwable];
        throw mod:scala.scalajs.runtime.package$.unwrapJavaScriptException;Ljava.lang.Throwable;Ljava.lang.Object(th)
      } else {
        throw e
      }
    }
  }
  private def th$1;Z;Ljava.lang.IllegalArgumentException;Ljava.lang.IllegalArgumentException;Ljava.lang.IllegalArgumentException(x$1: boolean, th1$1: java.lang.IllegalArgumentException, th2$1: java.lang.IllegalArgumentException): java.lang.IllegalArgumentException = {
    if (x$1) {
      th1$1
    } else {
      th2$1
    }
  }
  constructor def <init>;V() {
    this.java.lang.Object::<init>;V();
    mod:testlib.TestLib$<-this
  }
}
```
In addition, as part of my larger branch with checked NPEs, I verified that the following test passes with compliant NPEs and depending on the above library:
```scala
  @noinline
  private def assertNPE[U](body: => U): Unit =
    assertThrows(classOf[NullPointerException], body)

  @noinline
  private def assertThrowsNull[U](body: => U): Unit = {
    val errorMessage = js.special.tryCatch { () =>
      body
      "No exception was thrown"
    } { e =>
      if (e == null) null
      else "Wrong exception thrown: " + e
    }
    if (errorMessage != null)
      throw new AssertionError(errorMessage)
  }

  def backwardCompat(): Unit = {
    import testlib.TestLib

    assumeCompliantNPEs()

    assertNPE(TestLib.throwThrowable(null))

    assertNPE(TestLib.throwIllegalArg(null))

    assertNPE(TestLib.throwJSException(null))
    assertNPE(TestLib.throwNull())

    assertNPE(TestLib.throwOne(true, null, new IllegalArgumentException))

    assertThrowsNull(TestLib.throwThrowable(js.JavaScriptException(null)))
    assertThrowsNull(TestLib.throwJSException(js.JavaScriptException(null)))

    assertThrowsNull(TestLib.tryCatchNoJSException(js.special.`throw`(null)))
    assertThrowsNull(TestLib.tryCatchMaybeJSException(js.special.`throw`(null)))
    assertThrowsNull(TestLib.tryCatchThrowable(js.special.`throw`(null)))

    assertThrows(classOf[IllegalArgumentException], TestLib.throwNewIllegalArg())
  }
```