### PR TITLE
Checks for ArrayStoreExceptions and NegativeArraySizeExceptions. (combined)

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -501,6 +501,10 @@ object Names {
   val ArrayIndexOutOfBoundsExceptionClass: ClassName =
     ClassName("java.lang.ArrayIndexOutOfBoundsException")
 
+  /** The exception thrown by an `Assign(ArraySelect, ...)` where the value cannot be stored. */
+  val ArrayStoreExceptionClass: ClassName =
+    ClassName("java.lang.ArrayStoreException")
+
   /** The exception thrown by a `BinaryOp.String_charAt` that is out of bounds. */
   val StringIndexOutOfBoundsExceptionClass: ClassName =
     ClassName("java.lang.StringIndexOutOfBoundsException")

--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -505,6 +505,10 @@ object Names {
   val ArrayStoreExceptionClass: ClassName =
     ClassName("java.lang.ArrayStoreException")
 
+  /** The exception thrown by a `NewArray(...)` with a negative size. */
+  val NegativeArraySizeExceptionClass: ClassName =
+    ClassName("java.lang.NegativeArraySizeException")
+
   /** The exception thrown by a `BinaryOp.String_charAt` that is out of bounds. */
   val StringIndexOutOfBoundsExceptionClass: ClassName =
     ClassName("java.lang.StringIndexOutOfBoundsException")

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.11.1-SNAPSHOT",
+    current = "1.12.0-SNAPSHOT",
     binaryEmitted = "1.11"
 )
 

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
@@ -17,7 +17,7 @@ import Fingerprint.FingerprintBuilder
 
 final class Semantics private (
     val asInstanceOfs: CheckedBehavior,
-    val arrayIndexOutOfBounds: CheckedBehavior,
+    val arrayErrors: CheckedBehavior,
     val stringIndexOutOfBounds: CheckedBehavior,
     val moduleInit: CheckedBehavior,
     val strictFloats: Boolean,
@@ -26,11 +26,18 @@ final class Semantics private (
 
   import Semantics._
 
+  @deprecated("Use arrayErrors instead", "1.11.0")
+  val arrayIndexOutOfBounds: CheckedBehavior = arrayErrors
+
   def withAsInstanceOfs(behavior: CheckedBehavior): Semantics =
     copy(asInstanceOfs = behavior)
 
+  def withArrayErrors(behavior: CheckedBehavior): Semantics =
+    copy(arrayErrors = behavior)
+
+  @deprecated("Use withArrayErrors instead", "1.11.0")
   def withArrayIndexOutOfBounds(behavior: CheckedBehavior): Semantics =
-    copy(arrayIndexOutOfBounds = behavior)
+    withArrayErrors(behavior)
 
   def withStringIndexOutOfBounds(behavior: CheckedBehavior): Semantics =
     copy(stringIndexOutOfBounds = behavior)
@@ -56,7 +63,7 @@ final class Semantics private (
 
   def optimized: Semantics = {
     copy(asInstanceOfs = this.asInstanceOfs.optimized,
-        arrayIndexOutOfBounds = this.arrayIndexOutOfBounds.optimized,
+        arrayErrors = this.arrayErrors.optimized,
         stringIndexOutOfBounds = this.stringIndexOutOfBounds.optimized,
         moduleInit = this.moduleInit.optimized,
         productionMode = true)
@@ -65,7 +72,7 @@ final class Semantics private (
   override def equals(that: Any): Boolean = that match {
     case that: Semantics =>
       this.asInstanceOfs == that.asInstanceOfs &&
-      this.arrayIndexOutOfBounds == that.arrayIndexOutOfBounds &&
+      this.arrayErrors == that.arrayErrors &&
       this.stringIndexOutOfBounds == that.stringIndexOutOfBounds &&
       this.moduleInit == that.moduleInit &&
       this.strictFloats == that.strictFloats &&
@@ -79,7 +86,7 @@ final class Semantics private (
     import scala.util.hashing.MurmurHash3._
     var acc = HashSeed
     acc = mix(acc, asInstanceOfs.##)
-    acc = mix(acc, arrayIndexOutOfBounds.##)
+    acc = mix(acc, arrayErrors.##)
     acc = mix(acc, stringIndexOutOfBounds.##)
     acc = mix(acc, moduleInit.##)
     acc = mix(acc, strictFloats.##)
@@ -91,7 +98,7 @@ final class Semantics private (
   override def toString(): String = {
     s"""Semantics(
        |  asInstanceOfs          = $asInstanceOfs,
-       |  arrayIndexOutOfBounds  = $arrayIndexOutOfBounds,
+       |  arrayErrors            = $arrayErrors,
        |  stringIndexOutOfBounds = $stringIndexOutOfBounds,
        |  moduleInit             = $moduleInit,
        |  strictFloats           = $strictFloats,
@@ -101,7 +108,7 @@ final class Semantics private (
 
   private def copy(
       asInstanceOfs: CheckedBehavior = this.asInstanceOfs,
-      arrayIndexOutOfBounds: CheckedBehavior = this.arrayIndexOutOfBounds,
+      arrayErrors: CheckedBehavior = this.arrayErrors,
       stringIndexOutOfBounds: CheckedBehavior = this.stringIndexOutOfBounds,
       moduleInit: CheckedBehavior = this.moduleInit,
       strictFloats: Boolean = this.strictFloats,
@@ -110,7 +117,7 @@ final class Semantics private (
         this.runtimeClassNameMapper): Semantics = {
     new Semantics(
         asInstanceOfs = asInstanceOfs,
-        arrayIndexOutOfBounds = arrayIndexOutOfBounds,
+        arrayErrors = arrayErrors,
         stringIndexOutOfBounds = stringIndexOutOfBounds,
         moduleInit = moduleInit,
         strictFloats = strictFloats,
@@ -226,7 +233,7 @@ object Semantics {
     override def fingerprint(semantics: Semantics): String = {
       new FingerprintBuilder("Semantics")
         .addField("asInstanceOfs", semantics.asInstanceOfs)
-        .addField("arrayIndexOutOfBounds", semantics.arrayIndexOutOfBounds)
+        .addField("arrayErrors", semantics.arrayErrors)
         .addField("stringIndexOutOfBounds", semantics.stringIndexOutOfBounds)
         .addField("moduleInit", semantics.moduleInit)
         .addField("strictFloats", semantics.strictFloats)
@@ -238,7 +245,7 @@ object Semantics {
 
   val Defaults: Semantics = new Semantics(
       asInstanceOfs = Fatal,
-      arrayIndexOutOfBounds = Fatal,
+      arrayErrors = Fatal,
       stringIndexOutOfBounds = Fatal,
       moduleInit = Unchecked,
       strictFloats = true,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -582,11 +582,49 @@ private[emitter] object CoreJSLib {
     }
 
     private def defineRuntimeFunctions(): Tree = Block(
+      condTree(asInstanceOfs != CheckedBehavior.Unchecked || arrayErrors != CheckedBehavior.Unchecked)(
+        /* Returns a safe string description of a value.
+         * This helper is never called for `value === null`. As implemented,
+         * it would return `"object"` if it were.
+         */
+        defineFunction1("valueDescription") { value =>
+          Return {
+            If(typeof(value) === str("number"), {
+              If((value === 0) && (int(1) / value < 0), {
+                str("number(-0)")
+              }, {
+                str("number(") + value + str(")")
+              })
+            }, {
+              val longOrBigIntTest =
+                if (useBigIntForLongs) typeof(value) === str("bigint")
+                else genIsInstanceOfHijackedClass(value, BoxedLongClass)
+              If(longOrBigIntTest, {
+                if (useBigIntForLongs)
+                  str("bigint(") + value + str(")")
+                else
+                  str("long")
+              }, {
+                If(genIsInstanceOfHijackedClass(value, BoxedCharacterClass), {
+                  str("char")
+                }, {
+                  If(genIsScalaJSObject(value), {
+                    genIdentBracketSelect(value DOT classData, "name")
+                  }, {
+                    typeof(value)
+                  })
+                })
+              })
+            })
+          }
+        }
+      ),
+
       condTree(asInstanceOfs != CheckedBehavior.Unchecked)(Block(
         defineFunction2("throwClassCastException") { (instance, classFullName) =>
           Throw(maybeWrapInUBE(asInstanceOfs, {
             genScalaClassNew(ClassCastExceptionClass, StringArgConstructorName,
-                instance + str(" is not an instance of ") + classFullName)
+                genCallHelper("valueDescription", instance) + str(" cannot be cast to ") + classFullName)
           }))
         },
 
@@ -600,15 +638,23 @@ private[emitter] object CoreJSLib {
         }
       )),
 
-      condTree(arrayErrors != CheckedBehavior.Unchecked)(
+      condTree(arrayErrors != CheckedBehavior.Unchecked)(Block(
         defineFunction1("throwArrayIndexOutOfBoundsException") { i =>
           Throw(maybeWrapInUBE(arrayErrors, {
             genScalaClassNew(ArrayIndexOutOfBoundsExceptionClass,
                 StringArgConstructorName,
                 If(i === Null(), Null(), str("") + i))
           }))
+        },
+
+        defineFunction1("throwArrayStoreException") { v =>
+          Throw(maybeWrapInUBE(arrayErrors, {
+            genScalaClassNew(ArrayStoreExceptionClass,
+                StringArgConstructorName,
+                If(v === Null(), Null(), genCallHelper("valueDescription", v)))
+          }))
         }
-      ),
+      )),
 
       condTree(moduleInit == CheckedBehavior.Fatal)(
         defineFunction1("throwModuleInitError") { name =>
@@ -1077,6 +1123,61 @@ private[emitter] object CoreJSLib {
         }
       ),
 
+      condTree(arrayErrors != CheckedBehavior.Unchecked)(Block(
+        defineFunction5("systemArraycopyRefs") { (src, srcPos, dest, destPos, length) =>
+          If(Apply(genIdentBracketSelect(dest DOT classData, "isAssignableFrom"), List(src DOT classData)), {
+            /* Fast-path, no need for array store checks. This always applies
+             * for arrays of the same type, and a fortiori, when `src eq dest`.
+             */
+            genCallHelper("arraycopyGeneric", src.u, srcPos, dest.u, destPos, length)
+          }, {
+            /* Slow copy with "set" calls for every element. By construction,
+             * we have `src ne dest` in this case.
+             */
+            val srcArray = varRef("srcArray")
+            val i = varRef("i")
+            Block(
+              const(srcArray, src.u),
+              genCallHelper("arraycopyCheckBounds",
+                  srcArray.length, srcPos, dest.u.length, destPos, length),
+              For(let(i, 0), i < length, i := ((i + 1) | 0), {
+                Apply(dest DOT "set", List((destPos + i) | 0, BracketSelect(srcArray, (srcPos + i) | 0)))
+              })
+            )
+          })
+        },
+
+        defineFunction5("systemArraycopyFull") { (src, srcPos, dest, destPos, length) =>
+          val ObjectArray = globalVar("ac", ObjectClass)
+          val srcData = varRef("srcData")
+
+          Block(
+            const(srcData, src && (src DOT classData)),
+            If(srcData === (dest && (dest DOT classData)), {
+              // Both values have the same "data" (could also be falsy values)
+              If(srcData && genIdentBracketSelect(srcData, "isArrayClass"), {
+                // Fast path: the values are array of the same type
+                if (esVersion >= ESVersion.ES2015)
+                  Apply(src DOT "copyTo", List(srcPos, dest, destPos, length))
+                else
+                  genCallHelper("systemArraycopy", src, srcPos, dest, destPos, length)
+              }, {
+                genCallHelper("throwArrayStoreException", Null())
+              })
+            }, {
+              /* src and dest are of different types; the only situation that
+               * can still be valid is if they are two reference array types.
+               */
+              If((src instanceof ObjectArray) && (dest instanceof ObjectArray), {
+                genCallHelper("systemArraycopyRefs", src, srcPos, dest, destPos, length)
+              }, {
+                genCallHelper("throwArrayStoreException", Null())
+              })
+            })
+          )
+        }
+      )),
+
       // systemIdentityHashCode
       locally {
         val WeakMapRef = globalRef("WeakMap")
@@ -1463,12 +1564,12 @@ private[emitter] object CoreJSLib {
               privateFieldSet("isAssignableFromFun", Undefined()),
 
               privateFieldSet("wrapArray", Undefined()),
+              privateFieldSet("isJSType", bool(false)),
 
               publicFieldSet("name", str("")),
               publicFieldSet("isPrimitive", bool(false)),
               publicFieldSet("isInterface", bool(false)),
               publicFieldSet("isArrayClass", bool(false)),
-              publicFieldSet("isJSClass", bool(false)),
               publicFieldSet("isInstance", Undefined())
           )
         })
@@ -1634,6 +1735,34 @@ private[emitter] object CoreJSLib {
               })
             }
 
+            val set = if (arrayErrors != CheckedBehavior.Unchecked) {
+              val i = varRef("i")
+              val v = varRef("v")
+
+              val boundsCheck = {
+                If((i < 0) || (i >= This().u.length),
+                    genCallHelper("throwArrayIndexOutOfBoundsException", i))
+              }
+
+              val storeCheck = {
+                If((v !== Null()) && !(componentData DOT "isJSType") &&
+                    !Apply(genIdentBracketSelect(componentData, "isInstance"), v :: Nil),
+                    genCallHelper("throwArrayStoreException", v))
+              }
+
+              List(
+                MethodDef(static = false, Ident("set"), paramList(i, v), None, {
+                  Block(
+                      boundsCheck,
+                      storeCheck,
+                      BracketSelect(This().u, i) := v
+                  )
+                })
+              )
+            } else {
+              Nil
+            }
+
             val copyTo = if (esVersion >= ESVersion.ES2015) {
               val srcPos = varRef("srcPos")
               val dest = varRef("dest")
@@ -1654,7 +1783,7 @@ private[emitter] object CoreJSLib {
                   Apply(genIdentBracketSelect(This().u, "slice"), Nil) :: Nil))
             })
 
-            val members = copyTo ::: clone :: Nil
+            val members = set ::: copyTo ::: clone :: Nil
 
             if (useClassesForRegularClasses) {
               ClassDef(Some(ArrayClass.ident), Some(globalVar("ac", ObjectClass)),
@@ -1810,6 +1939,10 @@ private[emitter] object CoreJSLib {
                 getSuperclass,
                 getComponentType,
                 newArrayOfThisClass
+            )
+          } else if (arrayErrors != CheckedBehavior.Unchecked) {
+            List(
+              isAssignableFrom
             )
           } else {
             Nil

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -600,9 +600,9 @@ private[emitter] object CoreJSLib {
         }
       )),
 
-      condTree(arrayIndexOutOfBounds != CheckedBehavior.Unchecked)(
+      condTree(arrayErrors != CheckedBehavior.Unchecked)(
         defineFunction1("throwArrayIndexOutOfBoundsException") { i =>
-          Throw(maybeWrapInUBE(arrayIndexOutOfBounds, {
+          Throw(maybeWrapInUBE(arrayErrors, {
             genScalaClassNew(ArrayIndexOutOfBoundsExceptionClass,
                 StringArgConstructorName,
                 If(i === Null(), Null(), str("") + i))
@@ -1040,7 +1040,7 @@ private[emitter] object CoreJSLib {
     }
 
     private def defineIntrinsics(): Tree = Block(
-      condTree(arrayIndexOutOfBounds != CheckedBehavior.Unchecked)(
+      condTree(arrayErrors != CheckedBehavior.Unchecked)(
         defineFunction5("arraycopyCheckBounds") { (srcLen, srcPos, destLen, destPos, length) =>
           If((srcPos < 0) || (destPos < 0) || (length < 0) ||
               (srcPos > ((srcLen - length) | 0)) ||
@@ -1053,7 +1053,7 @@ private[emitter] object CoreJSLib {
       defineFunction5("arraycopyGeneric") { (srcArray, srcPos, destArray, destPos, length) =>
         val i = varRef("i")
         Block(
-          if (arrayIndexOutOfBounds != CheckedBehavior.Unchecked) {
+          if (arrayErrors != CheckedBehavior.Unchecked) {
             genCallHelper("arraycopyCheckBounds", srcArray.length,
                 srcPos, destArray.length, destPos, length)
           } else {
@@ -1320,7 +1320,7 @@ private[emitter] object CoreJSLib {
           })
         }
 
-        val getAndSet = if (arrayIndexOutOfBounds != CheckedBehavior.Unchecked) {
+        val getAndSet = if (arrayErrors != CheckedBehavior.Unchecked) {
           val i = varRef("i")
           val v = varRef("v")
 
@@ -1356,7 +1356,7 @@ private[emitter] object CoreJSLib {
               paramList(srcPos, dest, destPos, length), None, {
             if (isTypedArray) {
               Block(
-                  if (semantics.arrayIndexOutOfBounds != CheckedBehavior.Unchecked) {
+                  if (semantics.arrayErrors != CheckedBehavior.Unchecked) {
                     genCallHelper("arraycopyCheckBounds", This().u.length,
                         srcPos, dest.u.length, destPos, length)
                   } else {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -823,7 +823,7 @@ object Emitter {
           instantiateClass(ClassCastExceptionClass, StringArgConstructorName)
         },
 
-        cond(arrayIndexOutOfBounds != Unchecked) {
+        cond(arrayErrors != Unchecked) {
           instantiateClass(ArrayIndexOutOfBoundsExceptionClass,
               StringArgConstructorName)
         },
@@ -833,7 +833,7 @@ object Emitter {
               IntArgConstructorName)
         },
 
-        cond(asInstanceOfs == Fatal || arrayIndexOutOfBounds == Fatal || stringIndexOutOfBounds == Fatal) {
+        cond(asInstanceOfs == Fatal || arrayErrors == Fatal || stringIndexOutOfBounds == Fatal) {
           instantiateClass(UndefinedBehaviorErrorClass,
               ThrowableArgConsructorName)
         },

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -824,8 +824,12 @@ object Emitter {
         },
 
         cond(arrayErrors != Unchecked) {
-          instantiateClass(ArrayIndexOutOfBoundsExceptionClass,
-              StringArgConstructorName)
+          multiple(
+            instantiateClass(ArrayIndexOutOfBoundsExceptionClass,
+                StringArgConstructorName),
+            instantiateClass(ArrayStoreExceptionClass,
+                StringArgConstructorName)
+          )
         },
 
         cond(stringIndexOutOfBounds != Unchecked) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -828,7 +828,9 @@ object Emitter {
             instantiateClass(ArrayIndexOutOfBoundsExceptionClass,
                 StringArgConstructorName),
             instantiateClass(ArrayStoreExceptionClass,
-                StringArgConstructorName)
+                StringArgConstructorName),
+            instantiateClass(NegativeArraySizeExceptionClass,
+                NoArgConstructorName)
           )
         },
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1332,8 +1332,6 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           test(obj) // may NPE but that is UB.
 
         // Expressions preserving side-effect freedom
-        case NewArray(tpe, lengths) =>
-          allowUnpure && (lengths forall test)
         case ArrayValue(tpe, elems) =>
           allowUnpure && (elems forall test)
         case Clone(arg) =>
@@ -1373,7 +1371,10 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case Transient(TypedArrayToArray(expr, primRef)) =>
           allowSideEffects && test(expr) // may TypeError
 
-        // Array access can throw ArrayIndexOutOfBounds exception
+        // Array operations with conditional exceptions
+        case NewArray(tpe, lengths) =>
+          (allowSideEffects || semantics.arrayErrors == Unchecked && allowUnpure) &&
+          (lengths forall test)
         case ArraySelect(array, index) =>
           (allowSideEffects || semantics.arrayErrors == Unchecked && allowUnpure) &&
           test(array) && test(index)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -617,7 +617,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                 val genArray = transformExprNoChar(newArray)
                 val genIndex = transformExprNoChar(newIndex)
                 val genRhs = transformExpr(newRhs, lhs.tpe)
-                semantics.arrayIndexOutOfBounds match {
+                semantics.arrayErrors match {
                   case CheckedBehavior.Compliant | CheckedBehavior.Fatal =>
                     js.Apply(js.DotSelect(genArray, js.Ident("set")),
                         List(genIndex, genRhs))
@@ -1342,7 +1342,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
 
         // Array access can throw ArrayIndexOutOfBounds exception
         case ArraySelect(array, index) =>
-          (allowSideEffects || semantics.arrayIndexOutOfBounds == Unchecked && allowUnpure) &&
+          (allowSideEffects || semantics.arrayErrors == Unchecked && allowUnpure) &&
           test(array) && test(index)
 
         // Casts
@@ -2657,7 +2657,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case ArraySelect(array, index) =>
           val newArray = transformExprNoChar(array)
           val newIndex = transformExprNoChar(index)
-          semantics.arrayIndexOutOfBounds match {
+          semantics.arrayErrors match {
             case CheckedBehavior.Compliant | CheckedBehavior.Fatal =>
               js.Apply(js.DotSelect(newArray, js.Ident("get")), List(newIndex))
             case CheckedBehavior.Unchecked =>

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,7 +70,7 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 144857,
+      expectedFastLinkSize = 146276,
       expectedFullLinkSizeWithoutClosure = 129956,
       expectedFullLinkSizeWithClosure = 21210,
       classDefs,

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 142501,
+      expectedFastLinkSize = 144857,
       expectedFullLinkSizeWithoutClosure = 129956,
-      expectedFullLinkSizeWithClosure = 21225,
+      expectedFullLinkSizeWithClosure = 21210,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -61,7 +61,7 @@ class MainGenericRunner {
     compliantSems.foldLeft(Semantics.Defaults) { (prev, compliantSem) =>
       compliantSem match {
         case "asInstanceOfs"          => prev.withAsInstanceOfs(Compliant)
-        case "arrayIndexOutOfBounds"  => prev.withArrayIndexOutOfBounds(Compliant)
+        case "arrayErrors"            => prev.withArrayErrors(Compliant)
         case "stringIndexOutOfBounds" => prev.withStringIndexOutOfBounds(Compliant)
         case "moduleInit"             => prev.withModuleInit(Compliant)
       }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1805,7 +1805,7 @@ object Build {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 380000 to 381000,
+                fastLink = 382000 to 383000,
                 fullLink = 79000 to 80000,
                 fastLinkGz = 49000 to 50000,
                 fullLinkGz = 21000 to 22000,
@@ -1813,7 +1813,7 @@ object Build {
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 756000 to 757000,
+                fastLink = 759000 to 760000,
                 fullLink = 145000 to 146000,
                 fastLinkGz = 88000 to 89000,
                 fullLinkGz = 35000 to 36000,
@@ -1821,7 +1821,7 @@ object Build {
 
           case Default2_13ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 443000 to 444000,
+                fastLink = 446000 to 447000,
                 fullLink = 97000 to 98000,
                 fastLinkGz = 57000 to 58000,
                 fullLinkGz = 26000 to 27000,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -44,7 +44,7 @@ object ExposedValues extends AutoPlugin {
       _.withSemantics { semantics =>
         semantics
           .withAsInstanceOfs(CheckedBehavior.Compliant)
-          .withArrayIndexOutOfBounds(CheckedBehavior.Compliant)
+          .withArrayErrors(CheckedBehavior.Compliant)
           .withStringIndexOutOfBounds(CheckedBehavior.Compliant)
           .withModuleInit(CheckedBehavior.Compliant)
       }
@@ -2103,7 +2103,7 @@ object Build {
           "isCommonJSModule" -> (moduleKind == ModuleKind.CommonJSModule),
           "isFullOpt" -> (stage == Stage.FullOpt),
           "compliantAsInstanceOfs" -> (sems.asInstanceOfs == CheckedBehavior.Compliant),
-          "compliantArrayIndexOutOfBounds" -> (sems.arrayIndexOutOfBounds == CheckedBehavior.Compliant),
+          "compliantArrayErrors" -> (sems.arrayErrors == CheckedBehavior.Compliant),
           "compliantStringIndexOutOfBounds" -> (sems.stringIndexOutOfBounds == CheckedBehavior.Compliant),
           "compliantModuleInit" -> (sems.moduleInit == CheckedBehavior.Compliant),
           "strictFloats" -> sems.strictFloats,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1805,7 +1805,7 @@ object Build {
         scalaVersion.value match {
           case Default2_11ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 382000 to 383000,
+                fastLink = 383000 to 384000,
                 fullLink = 79000 to 80000,
                 fastLinkGz = 49000 to 50000,
                 fullLinkGz = 21000 to 22000,
@@ -1813,15 +1813,15 @@ object Build {
 
           case Default2_12ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 759000 to 760000,
+                fastLink = 760000 to 761000,
                 fullLink = 145000 to 146000,
-                fastLinkGz = 88000 to 89000,
+                fastLinkGz = 89000 to 90000,
                 fullLinkGz = 35000 to 36000,
             ))
 
           case Default2_13ScalaVersion =>
             Some(ExpectedSizes(
-                fastLink = 446000 to 447000,
+                fastLink = 447000 to 448000,
                 fullLink = 97000 to 98000,
                 fastLinkGz = 57000 to 58000,
                 fullLinkGz = 26000 to 27000,

--- a/project/MiniLib.scala
+++ b/project/MiniLib.scala
@@ -36,6 +36,7 @@ object MiniLib {
         "ClassCastException",
         "CloneNotSupportedException",
         "IndexOutOfBoundsException",
+        "NegativeArraySizeException",
         "StringIndexOutOfBoundsException"
     ).map("java/lang/" + _)
 

--- a/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
+++ b/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
@@ -24,7 +24,7 @@ private[utils] object BuildInfo {
   final val isCommonJSModule = false
   final val isFullOpt = false
   final val compliantAsInstanceOfs = false
-  final val compliantArrayIndexOutOfBounds = false
+  final val compliantArrayErrors = false
   final val compliantStringIndexOutOfBounds = false
   final val compliantModuleInit = false
   final val strictFloats = false

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -71,8 +71,8 @@ object Platform {
 
   def hasCompliantAsInstanceOfs: Boolean = BuildInfo.compliantAsInstanceOfs
 
-  def hasCompliantArrayIndexOutOfBounds: Boolean =
-    BuildInfo.compliantArrayIndexOutOfBounds
+  def hasCompliantArrayErrors: Boolean =
+    BuildInfo.compliantArrayErrors
 
   def hasCompliantStringIndexOutOfBounds: Boolean =
     BuildInfo.compliantStringIndexOutOfBounds

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ArrayJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ArrayJSTest.scala
@@ -1,0 +1,72 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.compiler
+
+import scala.scalajs.js
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.Platform._
+
+class ArrayJSTest {
+
+  private def covariantUpcast[A <: AnyRef](array: Array[_ <: A]): Array[A] =
+    array.asInstanceOf[Array[A]]
+
+  @Test
+  def setArrayStoreWithJSElems(): Unit = {
+    val jsObj = new js.Object
+    val obj = new AnyRef
+    val str = "foo"
+    val list = List(1, 2)
+
+    // Array of JS class
+    val a: Array[AnyRef] = covariantUpcast(new Array[js.Object](5))
+    a(1) = jsObj
+    assertSame(jsObj, a(1))
+    a(2) = obj
+    assertSame(obj, a(2))
+    a(3) = str
+    assertEquals(str, a(3))
+    a(4) = list
+    assertSame(list, a(4))
+    a(1) = null
+    assertNull(a(1))
+
+    // Array of JS trait
+    val b: Array[AnyRef] = covariantUpcast(new Array[js.Iterator[Any]](5))
+    b(1) = jsObj
+    assertSame(jsObj, b(1))
+    b(2) = obj
+    assertSame(obj, b(2))
+    b(3) = str
+    assertEquals(str, b(3))
+    b(4) = list
+    assertSame(list, b(4))
+    b(1) = null
+    assertNull(b(1))
+  }
+
+  @Test
+  def setArrayStoreExceptionsWithJSElems(): Unit = {
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    val jsObj = new js.Object
+
+    val a: Array[AnyRef] = covariantUpcast(new Array[List[Any]](5))
+    assertThrows(classOf[ArrayStoreException], a(1) = jsObj)
+  }
+}

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -41,7 +41,7 @@ object Platform {
   def isInFullOpt: Boolean = false
 
   def hasCompliantAsInstanceOfs: Boolean = true
-  def hasCompliantArrayIndexOutOfBounds: Boolean = true
+  def hasCompliantArrayErrors: Boolean = true
   def hasCompliantStringIndexOutOfBounds: Boolean = true
   def hasCompliantModule: Boolean = true
   def hasDirectBuffers: Boolean = true

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
@@ -147,4 +147,37 @@ class ArrayTest {
 
     assertThrows(classOf[ArrayIndexOutOfBoundsException], testAccess(Array()))
   }
+
+  @Test def negativeArraySizes(): Unit = {
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    @noinline def getNegValue(): Int = -5
+    val negValue = getNegValue()
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[Int](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[Int](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[Boolean](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[Boolean](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[AnyRef](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[AnyRef](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[String](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[String](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], new Array[Array[AnyRef]](-5))
+    assertThrows(classOf[NegativeArraySizeException], new Array[Array[AnyRef]](negValue))
+
+    assertThrows(classOf[NegativeArraySizeException], Array.ofDim[Int](-5, 5))
+    assertThrows(classOf[NegativeArraySizeException], Array.ofDim[Int](negValue, 5))
+    assertThrows(classOf[NegativeArraySizeException], Array.ofDim[Int](5, -5))
+    assertThrows(classOf[NegativeArraySizeException], Array.ofDim[Int](5, negValue))
+
+    // Force unit result type to tempt the optimizer and emtiter into getting rid of the expression
+    @noinline
+    def testCreateNegativeSizeArray(): Unit = new Array[Int](-1)
+
+    assertThrows(classOf[NegativeArraySizeException], testCreateNegativeSizeArray())
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
@@ -17,14 +17,13 @@ import org.junit.Assert._
 import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
-import org.scalajs.testsuite.utils.Platform.hasCompliantArrayIndexOutOfBounds
+import org.scalajs.testsuite.utils.Platform._
 
 class ArrayTest {
 
   @Test
   def getArrayIndexOutOfBounds(): Unit = {
-    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
-        hasCompliantArrayIndexOutOfBounds)
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
 
     val a = new Array[Int](5)
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(-1))
@@ -35,8 +34,7 @@ class ArrayTest {
 
   @Test
   def setArrayIndexOutOfBounds(): Unit = {
-    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
-        hasCompliantArrayIndexOutOfBounds)
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
 
     val a = new Array[Int](5)
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(-1) = 1)
@@ -47,8 +45,7 @@ class ArrayTest {
 
   @Test
   def arraySelectSideEffecting_Issue3848(): Unit = {
-    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
-        hasCompliantArrayIndexOutOfBounds)
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
 
     // Force unit return type so the Emitter tries to get rid of the expression.
     @noinline

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemArraycopyTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemArraycopyTest.scala
@@ -1,0 +1,411 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.Platform._
+
+/** Tests for `System.arraycopy`.
+ *
+ *  We test with Arrays of Ints, Booleans, Objects and Strings:
+ *
+ *  - `Array[Int]` is a specialized primitive array type backed by a TypedArray
+ *  - `Array[Boolean]` is a specialized primitive array type backed by an Array
+ *  - `Array[Object]` is a specialized reference array type (backed by an Array)
+ *  - `Array[String]` is a generic reference array type (backed by an Array)
+ */
+class SystemArraycopyTest {
+  import SystemArraycopyTest._
+
+  import System.arraycopy
+
+  private def covariantUpcast[A <: AnyRef](array: Array[_ <: A]): Array[A] =
+    array.asInstanceOf[Array[A]]
+
+  @noinline
+  private def assertArrayRefEquals[A <: AnyRef](expected: Array[A], actual: Array[A]): Unit =
+    assertArrayEquals(expected.asInstanceOf[Array[AnyRef]], actual.asInstanceOf[Array[AnyRef]])
+
+  @noinline
+  private def assertThrowsAIOOBE[U](code: => U): ArrayIndexOutOfBoundsException =
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], code)
+
+  @noinline
+  private def assertThrowsASE[U](code: => U): ArrayStoreException =
+    assertThrows(classOf[ArrayStoreException], code)
+
+  @Test def simpleTests(): Unit = {
+    val object0 = Array[Any]("[", "b", "c", "d", "e", "f", "]")
+    val object1 = Array[Any](() => true, 1, "2", '3', 4.0, true, object0)
+
+    System.arraycopy(object1, 1, object0, 1, 5)
+    if (executingInJVM) {
+      assertEquals("[1234.0true]", object0.mkString)
+    } else {
+      assertEquals("[1234true]", object0.mkString)
+    }
+
+    val string0 = Array("a", "b", "c", "d", "e", "f")
+    val string1 = Array("1", "2", "3", "4")
+
+    System.arraycopy(string1, 0, string0, 3, 3)
+    assertEquals("abc123", string0.mkString)
+
+    val ab01Chars = Array("ab".toCharArray, "01".toCharArray)
+    val chars = new Array[Array[Char]](32)
+    System.arraycopy(ab01Chars, 0, chars, 0, 2)
+    for (i <- Seq(0, 2, 4, 8, 16)) {
+      System.arraycopy(chars, i / 4, chars, i, i)
+    }
+
+    assertEquals(12, chars.filter(_ == null).length)
+    assertEquals("ab01ab0101ab01ab0101ab0101ab01ab0101ab01",
+        chars.filter(_ != null).map(_.mkString).mkString)
+  }
+
+  @Test def arraycopyWithRangeOverlapsForTheSameArrayInt(): Unit = {
+    val array = new Array[Int](10)
+
+    for (i <- 1 to 6)
+      array(i) = i
+
+    assertArrayEquals(Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0), array)
+    arraycopy(array, 0, array, 3, 7)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6), array)
+
+    arraycopy(array, 0, array, 1, 0)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6), array)
+
+    arraycopy(array, 0, array, 1, 9)
+    assertArrayEquals(Array(0, 0, 1, 2, 0, 1, 2, 3, 4, 5), array)
+
+    arraycopy(array, 1, array, 0, 9)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5), array)
+
+    arraycopy(array, 0, array, 0, 10)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5), array)
+
+    val reversed = array.reverse
+    arraycopy(reversed, 5, array, 5, 5)
+    assertArrayEquals(Array(0, 1, 2, 0, 1, 1, 0, 2, 1, 0), array)
+  }
+
+  @Test def arraycopyWithRangeOverlapsForTheSameArrayBoolean(): Unit = {
+    val array = new Array[Boolean](10)
+
+    for (i <- 1 to 6)
+      array(i) = (i % 2) == 1
+
+    assertArrayEquals(Array(false, true, false, true, false, true, false, false, false, false), array)
+    arraycopy(array, 0, array, 3, 7)
+    assertArrayEquals(Array(false, true, false, false, true, false, true, false, true, false), array)
+
+    arraycopy(array, 0, array, 1, 0)
+    assertArrayEquals(Array(false, true, false, false, true, false, true, false, true, false), array)
+
+    arraycopy(array, 0, array, 1, 9)
+    assertArrayEquals(Array(false, false, true, false, false, true, false, true, false, true), array)
+
+    arraycopy(array, 1, array, 0, 9)
+    assertArrayEquals(Array(false, true, false, false, true, false, true, false, true, true), array)
+
+    arraycopy(array, 0, array, 0, 10)
+    assertArrayEquals(Array(false, true, false, false, true, false, true, false, true, true), array)
+
+    val reversed = array.reverse
+    arraycopy(reversed, 5, array, 5, 5)
+    assertArrayEquals(Array(false, true, false, false, true, true, false, false, true, false), array)
+  }
+
+  @Test def arraycopyWithRangeOverlapsForTheSameArrayObject(): Unit = {
+    val array = new Array[AnyRef](10)
+
+    for (i <- 1 to 6)
+      array(i) = O(i)
+
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), O(3), O(4), O(5), O(6), null, null, null), array)
+    arraycopy(array, 0, array, 3, 7)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5), O(6)), array)
+
+    arraycopy(array, 0, array, 1, 0)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5), O(6)), array)
+
+    arraycopy(array, 0, array, 1, 9)
+    assertArrayEquals(Array[AnyRef](null, null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5)), array)
+
+    arraycopy(array, 1, array, 0, 9)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5), O(5)), array)
+
+    arraycopy(array, 0, array, 0, 10)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(2), O(3), O(4), O(5), O(5)), array)
+
+    val reversed = array.reverse
+    arraycopy(reversed, 5, array, 5, 5)
+    assertArrayEquals(Array[AnyRef](null, O(1), O(2), null, O(1), O(1), null, O(2), O(1), null), array)
+  }
+
+  @Test def arraycopyWithRangeOverlapsForTheSameArrayString(): Unit = {
+    val array = new Array[String](10)
+
+    for (i <- 1 to 6)
+      array(i) = i.toString()
+
+    assertArrayRefEquals(Array(null, "1", "2", "3", "4", "5", "6", null, null, null), array)
+    arraycopy(array, 0, array, 3, 7)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "2", "3", "4", "5", "6"), array)
+
+    arraycopy(array, 0, array, 1, 0)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "2", "3", "4", "5", "6"), array)
+
+    arraycopy(array, 0, array, 1, 9)
+    assertArrayRefEquals(Array(null, null, "1", "2", null, "1", "2", "3", "4", "5"), array)
+
+    arraycopy(array, 1, array, 0, 9)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "2", "3", "4", "5", "5"), array)
+
+    arraycopy(array, 0, array, 0, 10)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "2", "3", "4", "5", "5"), array)
+
+    val reversed = array.reverse
+    arraycopy(reversed, 5, array, 5, 5)
+    assertArrayRefEquals(Array(null, "1", "2", null, "1", "1", null, "2", "1", null), array)
+  }
+
+  @Test def arraycopyIndexOutOfBoundsInt(): Unit = {
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    val src = Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0)
+    val dest = Array(11, 12, 13, 15, 15, 16)
+    val original = Array(11, 12, 13, 15, 15, 16)
+
+    assertThrowsAIOOBE(arraycopy(src, -1, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 8, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, -1, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 4, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 11, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 13, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 3, Int.MaxValue))
+    assertArrayEquals(original, dest)
+  }
+
+  @Test def arraycopyIndexOutOfBoundsBoolean(): Unit = {
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    val src = Array(false, true, false, true, false, true, false, false, false, false)
+    val dest = Array(true, true, true, true, true, true)
+    val original = Array(true, true, true, true, true, true)
+
+    assertThrowsAIOOBE(arraycopy(src, -1, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 8, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, -1, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 4, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 11, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 13, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 3, Int.MaxValue))
+    assertArrayEquals(original, dest)
+  }
+
+  @Test def arraycopyIndexOutOfBoundsObject(): Unit = {
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    val src = Array[AnyRef](O(0), O(1), O(2), O(3), O(4), O(5), O(6), O(0), O(0), O(0))
+    val dest = Array[AnyRef](O(11), O(12), O(13), O(15), O(15), O(16))
+    val original = Array[AnyRef](O(11), O(12), O(13), O(15), O(15), O(16))
+
+    assertThrowsAIOOBE(arraycopy(src, -1, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 8, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, -1, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 4, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 11, dest, 3, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 13, 4))
+    assertArrayEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 3, Int.MaxValue))
+    assertArrayEquals(original, dest)
+  }
+
+  @Test def arraycopyIndexOutOfBoundsString(): Unit = {
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    val src = Array("0", "1", "2", "3", "4", "5", "6", "0", "0", "0")
+    val dest = Array("11", "12", "13", "15", "15", "16")
+    val original = Array("11", "12", "13", "15", "15", "16")
+
+    assertThrowsAIOOBE(arraycopy(src, -1, dest, 3, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 8, dest, 3, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, -1, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 4, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 11, dest, 3, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 13, 4))
+    assertArrayRefEquals(original, dest)
+
+    assertThrowsAIOOBE(arraycopy(src, 1, dest, 3, Int.MaxValue))
+    assertArrayRefEquals(original, dest)
+  }
+
+  @Test def earlyArrayStoreException(): Unit = {
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    val ints = Array(1, 2, 3, 4, 5)
+    val bools = Array(true, false, true, false)
+    val objs = Array[AnyRef](O(1), O(2), O(3), O(4), O(5))
+    val strs = Array("0", "1", "2", "3", "4")
+
+    val allArrays: List[AnyRef] = List(ints, bools, objs, strs)
+    val notAnArray: AnyRef = Some("not an array")
+    val undefined: AnyRef = ().asInstanceOf[AnyRef]
+
+    /* Copying to/from notAnArray or undefined
+     * (undefined has dedicated code paths because `undefined.$classData`
+     * throws, unlike any other non-null value).
+     */
+
+    for (a <- notAnArray :: allArrays) {
+      assertThrowsASE(arraycopy(notAnArray, 1, a, 1, 2))
+      assertThrowsASE(arraycopy(notAnArray, 1, a, 1, 0))
+
+      assertThrowsASE(arraycopy(undefined, 1, a, 1, 2))
+      assertThrowsASE(arraycopy(undefined, 1, a, 1, 0))
+
+      assertThrowsASE(arraycopy(a, 1, notAnArray, 1, 2))
+      assertThrowsASE(arraycopy(a, 1, notAnArray, 1, 0))
+
+      assertThrowsASE(arraycopy(a, 1, undefined, 1, 2))
+      assertThrowsASE(arraycopy(a, 1, undefined, 1, 0))
+    }
+
+    // Also test a few cases where the optimizer sees through everything
+    assertThrowsASE(arraycopy(notAnArray, 1, objs, 1, 2))
+    assertThrowsASE(arraycopy(objs, 1, notAnArray, 1, 2))
+
+    // Copying between different primitive array types, or between primitive and ref array types
+
+    for (len <- List(2, 0, -1)) {
+      assertThrowsASE(arraycopy(ints, 1, bools, 1, 2))
+      assertThrowsASE(arraycopy(ints, 1, objs, 1, 2))
+      assertThrowsASE(arraycopy(ints, 1, strs, 1, 2))
+
+      assertThrowsASE(arraycopy(bools, 1, ints, 1, 2))
+      assertThrowsASE(arraycopy(bools, 1, objs, 1, 2))
+      assertThrowsASE(arraycopy(bools, 1, strs, 1, 2))
+
+      assertThrowsASE(arraycopy(objs, 1, ints, 1, 2))
+      assertThrowsASE(arraycopy(objs, 1, bools, 1, 2))
+
+      assertThrowsASE(arraycopy(strs, 1, ints, 1, 2))
+      assertThrowsASE(arraycopy(strs, 1, bools, 1, 2))
+    }
+
+    // Also test a few cases where the optimizer sees through everything
+    assertThrowsASE(arraycopy(ints, 1, bools, 1, 2))
+    assertThrowsASE(arraycopy(ints, 1, objs, 1, 2))
+    assertThrowsASE(arraycopy(objs, 1, ints, 1, 2))
+  }
+
+  @Test def lateArrayStoreException(): Unit = {
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    // From Array[Object] to Array[O]
+
+    val src1: Array[AnyRef] = Array[AnyRef](O(1), O(2), "3", O(4), "5", O(6))
+    val dest1: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8))
+    assertThrowsASE(arraycopy(src1, 0, dest1, 0, 6))
+    assertArrayRefEquals(Array[O](O(1), O(2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8)), dest1)
+
+    val src2 = src1
+    val dest2: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8))
+    assertThrowsASE(arraycopy(src2, 1, dest2, 3, 3))
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(-5), O(-6), O(-7), O(-8)), dest2)
+
+    arraycopy(src2, 2, dest2, 0, 0)
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(-5), O(-6), O(-7), O(-8)), dest2)
+
+    // From Array[SuperClass] to Array[O]
+
+    val src3: Array[AnyRef] = covariantUpcast(Array[SuperClass](O(1), O(2), P(3), O(4), P(5), O(6)))
+    val dest3: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8))
+    assertThrowsASE(arraycopy(src3, 0, dest3, 0, 6))
+    assertArrayRefEquals(Array[O](O(1), O(2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8)), dest3)
+
+    val src4 = src3
+    val dest4: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5), O(-6), O(-7), O(-8))
+    assertThrowsASE(arraycopy(src4, 1, dest4, 3, 3))
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(-5), O(-6), O(-7), O(-8)), dest4)
+
+    arraycopy(src4, 2, dest4, 0, 0)
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(2), O(-5), O(-6), O(-7), O(-8)), dest2)
+
+    // From Array[P] to Array[O], succeeds with 0 elements to copy
+
+    val src5: Array[AnyRef] = covariantUpcast(Array[P](P(1), P(2), P(3)))
+    val dest5: Array[O] = Array[O](O(-1), O(-2), O(-3), O(-4), O(-5))
+    arraycopy(src5, 2, dest5, 1, 0)
+    assertArrayRefEquals(Array[O](O(-1), O(-2), O(-3), O(-4), O(-5)), dest5)
+  }
+}
+
+object SystemArraycopyTest {
+  abstract class SuperClass
+
+  private final case class O(x: Int) extends SuperClass
+
+  private final case class P(x: Int) extends SuperClass
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -14,7 +14,6 @@ package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test
 import org.junit.Assert._
-import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
@@ -52,99 +51,6 @@ class SystemTest {
     } finally {
       System.setErr(savedErr)
     }
-  }
-
-  @Test def arraycopy(): Unit = {
-    val object0 = Array[Any]("[", "b", "c", "d", "e", "f", "]")
-    val object1 = Array[Any](() => true, 1, "2", '3', 4.0, true, object0)
-
-    System.arraycopy(object1, 1, object0, 1, 5)
-    if (executingInJVM) {
-      assertEquals("[1234.0true]", object0.mkString)
-    } else {
-      assertEquals("[1234true]", object0.mkString)
-    }
-
-    val string0 = Array("a", "b", "c", "d", "e", "f")
-    val string1 = Array("1", "2", "3", "4")
-
-    System.arraycopy(string1, 0, string0, 3, 3)
-    assertEquals("abc123", string0.mkString)
-
-    val ab01Chars = Array("ab".toCharArray, "01".toCharArray)
-    val chars = new Array[Array[Char]](32)
-    System.arraycopy(ab01Chars, 0, chars, 0, 2)
-    for (i <- Seq(0, 2, 4, 8, 16)) {
-      System.arraycopy(chars, i / 4, chars, i, i)
-    }
-
-    assertEquals(12, chars.filter(_ == null).length)
-    assertEquals("ab01ab0101ab01ab0101ab0101ab01ab0101ab01",
-        chars.filter(_ != null).map(_.mkString).mkString)
-  }
-
-  @Test def arraycopyWithRangeOverlapsForTheSameArray(): Unit = {
-    val array = new Array[Int](10)
-
-    for (i <- 1 to 6) {
-      array(i) = i
-    }
-
-    assertArrayEquals(Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0), array)
-    System.arraycopy(array, 0, array, 3, 7)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6), array)
-
-    System.arraycopy(array, 0, array, 1, 0)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 6), array)
-
-    System.arraycopy(array, 0, array, 1, 9)
-    assertArrayEquals(Array(0, 0, 1, 2, 0, 1, 2, 3, 4, 5), array)
-
-    System.arraycopy(array, 1, array, 0, 9)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5), array)
-
-    System.arraycopy(array, 0, array, 0, 10)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 2, 3, 4, 5, 5), array)
-
-    val reversed = array.reverse
-    System.arraycopy(reversed, 5, array, 5, 5)
-    assertArrayEquals(Array(0, 1, 2, 0, 1, 1, 0, 2, 1, 0), array)
-  }
-
-  @Test def arraycopyIndexOutOfBounds(): Unit = {
-    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
-
-    val src = Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0)
-    val dest = Array(11, 12, 13, 15, 15, 16)
-    val original = Array(11, 12, 13, 15, 15, 16)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, -1, dest, 3, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 8, dest, 3, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 1, dest, -1, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 1, dest, 4, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 11, dest, 3, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 1, dest, 13, 4))
-    assertArrayEquals(original, dest)
-
-    assertThrows(classOf[ArrayIndexOutOfBoundsException],
-        System.arraycopy(src, 1, dest, 3, Int.MaxValue))
-    assertArrayEquals(original, dest)
   }
 
   @Test def identityHashCode(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/SystemTest.scala
@@ -112,8 +112,7 @@ class SystemTest {
   }
 
   @Test def arraycopyIndexOutOfBounds(): Unit = {
-    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
-        hasCompliantArrayIndexOutOfBounds)
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
 
     val src = Array(0, 1, 2, 3, 4, 5, 6, 0, 0, 0)
     val dest = Array(11, 12, 13, 15, 15, 16)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
@@ -16,6 +16,10 @@ import scala.runtime.BoxedUnit
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.Platform._
 
 class ReflectArrayTest {
 
@@ -64,5 +68,29 @@ class ReflectArrayTest {
     testNewInstance(classOf[Array[Object]], classOf[Array[Array[Object]]], null)
     testNewInstance(classOf[Array[Int]], classOf[Array[Array[Int]]], null)
     testNewInstance(classOf[Array[String]], classOf[Array[Array[String]]], null)
+  }
+
+  @Test def newInstanceNegativeArraySize(): Unit = {
+    import java.lang.{reflect => jlr}
+
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
+
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Int], -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Boolean], -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[AnyRef], -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[String], -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Array[AnyRef]], -5))
+
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Int], -5, 5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Boolean], -5, 5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[AnyRef], -5, 5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[String], -5, 5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Array[AnyRef]], -5, 5))
+
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Int], 5, -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Boolean], 5, -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[AnyRef], 5, -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[String], 5, -5))
+    assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Array[AnyRef]], 5, -5))
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArraysTest.scala
@@ -156,8 +156,7 @@ class ArraysTest {
   }
 
   @Test def sortArrayIndexOutOfBoundsException(): Unit = {
-    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
-        hasCompliantArrayIndexOutOfBounds)
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
 
     val array = Array(0, 1, 3, 4)
 
@@ -609,8 +608,7 @@ class ArraysTest {
   }
 
   @Test def binarySearchArrayIndexOutOfBoundsException(): Unit = {
-    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
-        hasCompliantArrayIndexOutOfBounds)
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
 
     val array = Array(0, 1, 3, 4)
 
@@ -713,8 +711,7 @@ class ArraysTest {
   }
 
   @Test def copyOfRangeAnyRefArrayIndexOutOfBoundsException(): Unit = {
-    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
-        hasCompliantArrayIndexOutOfBounds)
+    assumeTrue("Assuming compliant array errors", hasCompliantArrayErrors)
 
     val anyrefs: Array[AnyRef] = Array("a", "b", "c", "d", "e")
     assertThrows(classOf[ArrayIndexOutOfBoundsException],


### PR DESCRIPTION
Alternative to #4711. We rename `Semantics.arrayIndexOutOfBounds` to `arrayErrors`, then implement checks for `ArrayStoreException`s and `NegativeArraySizeException`s under that unique semantics config.