### PR TITLE
Address a new deprecation warning in Scala 2.13.9.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -445,7 +445,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         case ex: InterruptedException =>
           throw ex
         case ex: Throwable =>
-          if (settings.debug)
+          if (settings.debug.value)
             ex.printStackTrace()
           globalError(s"Error while emitting ${cunit.source}\n${ex.getMessage}")
       } finally {
@@ -1129,7 +1129,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
      *  static forwarders?
      */
     def isCandidateForForwarders(sym: Symbol): Boolean = {
-      !settings.noForwarders && sym.isStatic && !isImplClass(sym) && {
+      !settings.noForwarders.value && sym.isStatic && !isImplClass(sym) && {
         // Reject non-top-level objects unless opted in via the appropriate option
         scalaJSOpts.genStaticForwardersForNonTopLevelObjects ||
         !sym.name.containsChar('$') // this is the same test that scalac performs


### PR DESCRIPTION
In the compiler, using a `Setting[Boolean]` as a `Boolean` is now deprecated. We have to explicitly call `.value`.

---

Locally tested with:
```
> set Global / resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.13.9-bin-d578a02
> testSuite2_13/test
> testSuiteJVM2_13/test
> compiler2_13/test
> ir2_13/test
> linker2_13/test
```
and also with
```
> set Global / resolvers += "scala-integration" at "https://scala-ci.typesafe.com/artifactory/scala-integration/"
> ++2.12.17-bin-45183fa
> testSuite2_12/test
> testSuiteJVM2_12/test
> compiler2_12/test
> ir2_12/test
> linker2_12/test
```
The mentioned versions are the release candidates for Scala 2.13.9 and 2.12.17, respectively.