### PR TITLE
Force the `tpe` of `This` nodes to have the most precise type.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -151,7 +151,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
     private val fieldsMutatedInCurrentClass = new ScopedVar[mutable.Set[Name]]
     private val generatedSAMWrapperCount = new ScopedVar[VarBox[Int]]
 
-    private def currentThisType: jstpe.Type = {
+    def currentThisType: jstpe.Type = {
       encodeClassType(currentClassSym) match {
         case tpe @ jstpe.ClassType(cls) =>
           jstpe.BoxedClassToPrimType.getOrElse(cls, tpe)

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -624,7 +624,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
         }
       }
 
-      val receiver = js.This()(jstpe.AnyType)
+      val receiver = js.This()(currentThisType)
       val nameString = genExpr(jsNameOf(sym))
 
       if (jsInterop.isJSGetter(sym)) {
@@ -708,7 +708,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
            * dispatchers, we know the default getter is on `this`. This applies
            * to both top-level and nested classes.
            */
-          (owner, js.This()(encodeClassType(owner)))
+          (owner, js.This()(currentThisType))
         } else if (isNested) {
           assert(captures.size == 1,
               s"expected exactly one capture got $captures ($sym at $pos)")
@@ -816,10 +816,8 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
       def receiver = {
         if (static)
           genLoadModule(sym.owner)
-        else if (sym.owner == ObjectClass)
-          js.This()(jstpe.ClassType(ir.Names.ObjectClass))
         else
-          js.This()(encodeClassType(sym.owner))
+          js.This()(currentThisType)
       }
 
       if (isNonNativeJSClass(currentClassSym)) {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1000,6 +1000,8 @@ object Serializers {
 
     private[this] var lastPosition: Position = Position.NoPosition
 
+    private[this] var thisTypeForHack8: Type = NoType
+
     def deserializeEntryPointsInfo(): EntryPointsInfo = {
       hacks = new Hacks(sourceVersion = readHeader())
       readEntryPointsInfo()
@@ -1224,13 +1226,32 @@ object Serializers {
 
         case TagVarRef =>
           VarRef(readLocalIdent())(readType())
+
         case TagThis =>
-          This()(readType())
+          val tpe = readType()
+          if (/*hacks.use8*/ true) // scalastyle:ignore
+            This()(thisTypeForHack8)
+          else
+            This()(tpe)
+
         case TagClosure =>
           val arrow = readBoolean()
           val captureParams = readParamDefs()
           val (params, restParam) = readParamDefsWithRest()
-          Closure(arrow, captureParams, params, restParam, readTree(), readTrees())
+          val body = if (/*!hacks.use8*/ false) { // scalastyle:ignore
+            readTree()
+          } else {
+            val prevThisTypeForHack8 = thisTypeForHack8
+            thisTypeForHack8 = if (arrow) NoType else AnyType
+            try {
+              readTree()
+            } finally {
+              thisTypeForHack8 = prevThisTypeForHack8
+            }
+          }
+          val captureValues = readTrees()
+          Closure(arrow, captureParams, params, restParam, body, captureValues)
+
         case TagCreateJSClass =>
           CreateJSClass(readClassName(), readTrees())
       }
@@ -1319,8 +1340,21 @@ object Serializers {
     def readClassDef(): ClassDef = {
       implicit val pos = readPosition()
       val name = readClassIdent()
+      val cls = name.name
       val originalName = readOriginalName()
       val kind = ClassKind.fromByte(readByte())
+
+      if (/*hacks.use8*/ true) { // scalastyle:ignore
+        thisTypeForHack8 = {
+          if (kind.isJSType)
+            AnyType
+          else if (kind == ClassKind.HijackedClass)
+            BoxedClassToPrimType.getOrElse(cls, ClassType(cls)) // getOrElse as safety guard
+          else
+            ClassType(cls)
+        }
+      }
+
       val hasJSClassCaptures = readBoolean()
       val jsClassCaptures =
         if (!hasJSClassCaptures) None
@@ -1335,8 +1369,8 @@ object Serializers {
       val jsSuperClass = readOptTree()
 
       val jsNativeLoadSpec = readJSNativeLoadSpec()
-      val memberDefs0 = readMemberDefs(name.name, kind)
-      val topLevelExportDefs = readTopLevelExportDefs(name.name, kind)
+      val memberDefs0 = readMemberDefs(cls, kind)
+      val topLevelExportDefs = readTopLevelExportDefs(cls, kind)
       val optimizerHints = OptimizerHints.fromBits(readInt())
 
       val memberDefs =

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1229,7 +1229,7 @@ object Serializers {
 
         case TagThis =>
           val tpe = readType()
-          if (/*hacks.use8*/ true) // scalastyle:ignore
+          if (hacks.use8)
             This()(thisTypeForHack8)
           else
             This()(tpe)
@@ -1238,7 +1238,7 @@ object Serializers {
           val arrow = readBoolean()
           val captureParams = readParamDefs()
           val (params, restParam) = readParamDefsWithRest()
-          val body = if (/*!hacks.use8*/ false) { // scalastyle:ignore
+          val body = if (!hacks.use8) {
             readTree()
           } else {
             val prevThisTypeForHack8 = thisTypeForHack8
@@ -1344,7 +1344,7 @@ object Serializers {
       val originalName = readOriginalName()
       val kind = ClassKind.fromByte(readByte())
 
-      if (/*hacks.use8*/ true) { // scalastyle:ignore
+      if (hacks.use8) {
         thisTypeForHack8 = {
           if (kind.isJSType)
             AnyType

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2229,7 +2229,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                * not already a CharType, we must introduce a cast to unbox the
                * value.
                */
-              if (realTreeType(receiver) == CharType)
+              if (receiver.tpe == CharType)
                 transformExpr(receiver, preserveChar = true)
               else
                 transformExpr(AsInstanceOf(receiver, CharType), preserveChar = true)
@@ -2981,25 +2981,10 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               tree.getClass)
       }
 
-      if (preserveChar || realTreeType(tree) != CharType)
+      if (preserveChar || tree.tpe != CharType)
         baseResult
       else
         genCallHelper("bC", baseResult)
-    }
-
-    private def realTreeType(tree: Tree)(implicit env: Env): Type = {
-      val tpe = tree.tpe
-      tree match {
-        case This() if tpe.isInstanceOf[ClassType] =>
-          env.enclosingClassName match {
-            case Some(enclosingClassName) =>
-              BoxedClassToPrimType.getOrElse(enclosingClassName, ClassType(enclosingClassName))
-            case None =>
-              tpe
-          }
-        case _ =>
-          tpe
-      }
     }
 
     private def transformApplyDynamicImport(tree: ApplyDynamicImport)(

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -100,8 +100,17 @@ private final class ClassDefChecker(classDef: ClassDef, reporter: ErrorReporter)
   }
 
   private def checkKind()(implicit ctx: ErrorContext): Unit = {
-    if (isJLObject && classDef.kind != ClassKind.Class)
+    val className = classDef.name.name
+
+    if (isJLObject && classDef.kind != ClassKind.Class) {
       reportError("java.lang.Object must be a Class")
+    } else {
+      val isHijacked = HijackedClasses.contains(className)
+      if (isHijacked && classDef.kind != ClassKind.HijackedClass)
+        reportError(i"$className must be a HijackedClass")
+      else if (!isHijacked && classDef.kind == ClassKind.HijackedClass)
+        reportError(i"$className must not be a HijackedClass")
+    }
   }
 
   private def checkJSClassCaptures()(implicit ctx: ErrorContext): Unit = {

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -211,7 +211,7 @@ class AnalyzerTest {
                 memberDefs = requiredMemberDefs("A", kindCls)),
             classDef("B", kind = kindIntf,
                 superClass = validParentForKind(kindIntf),
-                memberDefs = requiredMemberDefs("A", kindIntf))
+                memberDefs = requiredMemberDefs("B", kindIntf))
         )
 
         val analysis = computeAnalysis(classDefs,

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -128,7 +128,6 @@ class AnalyzerTest {
     val kindsSub = Seq(
         ClassKind.Class,
         ClassKind.ModuleClass,
-        ClassKind.HijackedClass,
         ClassKind.JSClass,
         ClassKind.JSModuleClass,
         ClassKind.NativeJSClass,
@@ -139,7 +138,7 @@ class AnalyzerTest {
     def kindsBaseFor(kindSub: ClassKind): Seq[ClassKind] = {
       import ClassKind._
       kindSub match {
-        case Class | ModuleClass | HijackedClass =>
+        case Class | ModuleClass =>
           Seq(Interface, ModuleClass, JSClass, NativeJSClass)
         case Interface =>
           // interfaces are checked in the ClassDefChecker.
@@ -147,6 +146,8 @@ class AnalyzerTest {
         case JSClass | JSModuleClass | NativeJSClass | NativeJSModuleClass |
             AbstractJSType =>
           Seq(Class, Interface, AbstractJSType, JSModuleClass)
+        case HijackedClass =>
+          throw new AssertionError("Cannot test HijackedClass because it fails earlier")
       }
     }
 
@@ -179,7 +180,6 @@ class AnalyzerTest {
     val kindsCls = Seq(
         ClassKind.Class,
         ClassKind.ModuleClass,
-        ClassKind.HijackedClass,
         ClassKind.Interface,
         ClassKind.JSClass,
         ClassKind.JSModuleClass,
@@ -191,12 +191,14 @@ class AnalyzerTest {
     def kindsIntfFor(kindCls: ClassKind): Seq[ClassKind] = {
       import ClassKind._
       kindCls match {
-        case Class | ModuleClass | HijackedClass | Interface =>
+        case Class | ModuleClass | Interface =>
           Seq(Class, ModuleClass, JSClass, NativeJSClass, AbstractJSType)
         case JSClass | JSModuleClass | NativeJSClass | NativeJSModuleClass |
             AbstractJSType =>
-          Seq(Class, ModuleClass, HijackedClass, Interface, JSClass,
+          Seq(Class, ModuleClass, Interface, JSClass,
               JSModuleClass, NativeJSClass, NativeJSModuleClass)
+        case HijackedClass =>
+          throw new AssertionError("Cannot test HijackedClass because it fails earlier")
       }
     }
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -180,6 +180,62 @@ class ClassDefCheckerTest {
         "Duplicate local variable name x."
     )
   }
+
+  @Test
+  def thisType(): Unit = {
+    def testThisTypeError(static: Boolean, expr: Tree, expectedMsg: String): Unit = {
+      val methodFlags =
+        if (static) EMF.withNamespace(MemberNamespace.PublicStatic)
+        else EMF
+
+      assertError(
+          classDef(
+            "Foo", superClass = Some(ObjectClass),
+            memberDefs = List(
+              MethodDef(methodFlags, m("bar", Nil, V), NON, Nil, NoType, Some({
+                consoleLog(expr)
+              }))(EOH, None)
+            )
+          ),
+          expectedMsg)
+    }
+
+    testThisTypeError(static = true,
+        This()(NoType),
+        "Cannot find `this` in scope")
+
+    testThisTypeError(static = true,
+        This()(ClassType("Foo")),
+        "Cannot find `this` in scope")
+
+    testThisTypeError(static = false,
+        This()(NoType),
+        "`this` of type Foo typed as <notype>")
+
+    testThisTypeError(static = false,
+        This()(AnyType),
+        "`this` of type Foo typed as any")
+
+    testThisTypeError(static = false,
+        This()(ClassType("Bar")),
+        "`this` of type Foo typed as Bar")
+
+    testThisTypeError(static = false,
+        Closure(arrow = true, Nil, Nil, None, This()(NoType), Nil),
+        "Cannot find `this` in scope")
+
+    testThisTypeError(static = false,
+        Closure(arrow = true, Nil, Nil, None, This()(AnyType), Nil),
+        "Cannot find `this` in scope")
+
+    testThisTypeError(static = false,
+        Closure(arrow = false, Nil, Nil, None, This()(NoType), Nil),
+        "`this` of type any typed as <notype>")
+
+    testThisTypeError(static = false,
+        Closure(arrow = false, Nil, Nil, None, This()(ClassType("Foo")), Nil),
+        "`this` of type any typed as Foo")
+  }
 }
 
 private object ClassDefCheckerTest {

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -48,6 +48,17 @@ class ClassDefCheckerTest {
   }
 
   @Test
+  def hijackedClassesKinds(): Unit = {
+    assertError(
+        classDef(BoxedIntegerClass, kind = ClassKind.Class, superClass = Some(ObjectClass)),
+        "java.lang.Integer must be a HijackedClass")
+
+    assertError(
+        classDef("A", kind = ClassKind.HijackedClass, superClass = Some(ObjectClass)),
+        "A must not be a HijackedClass")
+  }
+
+  @Test
   def missingSuperClass(): Unit = {
     val kinds = Seq(
         ClassKind.Class,
@@ -60,8 +71,9 @@ class ClassDefCheckerTest {
     )
 
     for (kind <- kinds) {
+      val name = if (kind == ClassKind.HijackedClass) BoxedIntegerClass else ClassName("A")
       assertError(
-          classDef("A", kind = kind, memberDefs = requiredMemberDefs("A", kind)),
+          classDef(name, kind = kind, memberDefs = requiredMemberDefs(name, kind)),
           "missing superClass")
     }
   }


### PR DESCRIPTION
Previously, for `This` nodes, we checked that their `tpe` was a *subtype* of the expected this type. Now, we force it to always be the most precise, i.e., the exact this type for the enclosing class.

This allows to move that check from the IR checker up to the ClassDef checker, as we do not need the subtyping relationships.

It also allows to remove a hack in the FunctionEmitter where we had to compute the exact type for `This` nodes for correct boxing and unboxing of `char` values.

At a fundamental level, this removes the only occurrence of *subsumption* for terms in the type system of our IR. Every term must have the most precise type it can have (but can be *used* in contexts that demand a supertype, obviously).

We introduce a deserialization hack to patch up the `tpe` of `This` nodes coming from earlier versions of the IR, as the precise type was not enforced (and was indeed not always as precise as possible).

In the first commit, we apply the hack regardless of the IR version, and do not update the compiler yet, for testing purposes. In the second commit, we condition the hack on the IR version and fix the last places in the compiler back-end that emitted loose `this` types.