### PR TITLE
Separate the javalib into its own artifact.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,7 @@ val linkerJS = Build.linkerJS
 val testAdapter = Build.testAdapter
 val sbtPlugin = Build.plugin
 val javalibintf = Build.javalibintf
+val javalibInternal = Build.javalibInternal
 val javalib = Build.javalib
 val scalalib = Build.scalalib
 val libraryAux = Build.libraryAux

--- a/linker/shared/src/test/scala-ide-stubs/org/scalajs/linker/testutils/StdlibHolder.scala
+++ b/linker/shared/src/test/scala-ide-stubs/org/scalajs/linker/testutils/StdlibHolder.scala
@@ -18,6 +18,6 @@ package org.scalajs.linker.testutils
 
 private[testutils] object StdlibHolder {
   final val minilib = ""
-  final val fulllib = ""
+  final val javalib = ""
   final val previousLibs: Map[String, String] = Map.empty
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/BackwardsCompatTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/BackwardsCompatTest.scala
@@ -40,7 +40,7 @@ class BackwardsCompatTest {
   @Test
   def testHelloWorld(): AsyncResult = await {
     val classDefs = Seq(
-      mainTestClassDef(predefPrintln(str("Hello world!")))
+      mainTestClassDef(systemOutPrintln(str("Hello world!")))
     )
 
     test(classDefs, MainTestModuleInitializers)
@@ -50,8 +50,8 @@ class BackwardsCompatTest {
   def testSystemIdentityHashCode(): AsyncResult = await {
     val classDefs = Seq(
       mainTestClassDef(
-          predefPrintln(Apply(EAF,
-              LoadModule("java.lang.System$"),
+          systemOutPrintln(ApplyStatic(EAF,
+              "java.lang.System",
               m("identityHashCode", List(O), I),
               List(JSObjectConstr(Nil)))(IntType)))
     )
@@ -67,7 +67,7 @@ class BackwardsCompatTest {
           interfaces = List(CloneableClass),
           memberDefs = List(trivialCtor("A"))),
       mainTestClassDef(
-          predefPrintln(Apply(EAF,
+          systemOutPrintln(Apply(EAF,
               New("A", NoArgConstructorName, Nil),
               m("clone", Nil, O), Nil)(AnyType)))
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
@@ -87,7 +87,7 @@ class EmitterTest {
   @Test
   def linkNoSecondAttemptInEmitter(): AsyncResult = await {
     val classDefs = List(
-      mainTestClassDef(predefPrintln(str("Hello world!")))
+      mainTestClassDef(systemOutPrintln(str("Hello world!")))
     )
 
     val logger = new CapturingLogger
@@ -97,8 +97,8 @@ class EmitterTest {
     val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
 
     for {
-      fulllib <- TestIRRepo.fulllib
-      report <- linker.link(fulllib ++ classDefsFiles,
+      javalib <- TestIRRepo.javalib
+      report <- linker.link(javalib ++ classDefsFiles,
           MainTestModuleInitializers, MemOutputDirectory(), logger)
     } yield {
       logger.allLogLines.assertNotContains(EmitterSetOfDangerousGlobalRefsChangedMessage)
@@ -111,7 +111,7 @@ class EmitterTest {
   @Test
   def linkYesSecondAttemptInEmitter(): AsyncResult = await {
     val classDefs = List(
-      mainTestClassDef(predefPrintln(JSGlobalRef("$dangerousGlobalRef")))
+      mainTestClassDef(systemOutPrintln(JSGlobalRef("$dangerousGlobalRef")))
     )
 
     val logger = new CapturingLogger
@@ -121,8 +121,8 @@ class EmitterTest {
     val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
 
     for {
-      fulllib <- TestIRRepo.fulllib
-      report <- linker.link(fulllib ++ classDefsFiles,
+      javalib <- TestIRRepo.javalib
+      report <- linker.link(javalib ++ classDefsFiles,
           MainTestModuleInitializers, MemOutputDirectory(), logger)
     } yield {
       logger.allLogLines.assertContains(EmitterSetOfDangerousGlobalRefsChangedMessage)

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibraryReachabilityTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibraryReachabilityTest.scala
@@ -106,7 +106,7 @@ object LibraryReachabilityTest {
       implicit ec: ExecutionContext): Future[Analysis] = {
     for {
       analysis <- LinkingUtils.computeAnalysis(classDefs, symbolRequirements,
-          moduleInitializers, config, stdlib = TestIRRepo.fulllib)
+          moduleInitializers, config, stdlib = TestIRRepo.javalib)
     } yield {
       if (analysis.errors.nonEmpty)
         fail(analysis.errors.mkString("Unexpected errors:\n", "\n", ""))

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -108,8 +108,8 @@ object LibrarySizeTest {
     val fullOutput = MemOutputDirectory()
 
     for {
-      fulllib <- TestIRRepo.fulllib
-      irFiles = fulllib ++ classDefsFiles
+      javalib <- TestIRRepo.javalib
+      irFiles = javalib ++ classDefsFiles
       fastLinkReport <- fastLinker.link(irFiles, moduleInitializers, fastOutput, logger)
       fullLinkReport <- fullLinker.link(irFiles, moduleInitializers, fullOutput, logger)
     } yield {

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -179,13 +179,13 @@ class OptimizerTest {
   def testHelloWorldDoesNotNeedClassClass(): AsyncResult = await {
     val classDefs = Seq(
         mainTestClassDef({
-          predefPrintln(str("Hello world!"))
+          systemOutPrintln(str("Hello world!"))
         })
     )
 
     for {
       moduleSet <- linkToModuleSet(classDefs, MainTestModuleInitializers,
-          stdlib = TestIRRepo.fulllib)
+          stdlib = TestIRRepo.javalib)
     } yield {
       assertFalse(findClass(moduleSet, ClassClass).isDefined)
     }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
@@ -97,12 +97,15 @@ object LinkingUtils {
       stdlib: Future[Seq[IRFile]] = TestIRRepo.minilib)(
       implicit ec: ExecutionContext): Future[Analysis] = {
 
+    val classDefIRFiles = classDefs.map(MemClassDefIRFile(_))
+    val injectedIRFiles = StandardLinkerBackend(config).injectedIRFiles
+
     val loader = new IRLoader(checkIR = true)
     val logger = new ScalaConsoleLogger(Level.Error)
 
     for {
       baseFiles <- stdlib
-      irLoader <- loader.update(classDefs.map(MemClassDefIRFile(_)) ++ baseFiles, logger)
+      irLoader <- loader.update(classDefIRFiles ++ baseFiles ++ injectedIRFiles, logger)
       analysis <- Analyzer.computeReachability(
           CommonPhaseConfig.fromStandardConfig(config), moduleInitializers,
           symbolRequirements, allowAddingSyntheticMethods = true,

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -108,12 +108,13 @@ object TestIRBuilder {
   def consoleLog(expr: Tree): Tree =
     JSMethodApply(JSGlobalRef("console"), str("log"), List(expr))
 
-  def predefPrintln(expr: Tree): Tree = {
-    val PredefModuleClass = ClassName("scala.Predef$")
+  def systemOutPrintln(expr: Tree): Tree = {
+    val PrintStreamClass = ClassName("java.io.PrintStream")
+    val outMethodName = m("out", Nil, ClassRef(PrintStreamClass))
     val printlnMethodName = m("println", List(O), VoidRef)
 
-    Apply(EAF, LoadModule(PredefModuleClass), printlnMethodName, List(expr))(
-        NoType)
+    val out = ApplyStatic(EAF, "java.lang.System", outMethodName, Nil)(ClassType(PrintStreamClass))
+    Apply(EAF, out, printlnMethodName, List(expr))(NoType)
   }
 
   def paramDef(name: LocalName, ptpe: Type): ParamDef =

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
@@ -20,7 +20,7 @@ import org.scalajs.linker.interface.IRFile
 
 object TestIRRepo {
   val minilib: Future[Seq[IRFile]] = load(StdlibHolder.minilib)
-  val fulllib: Future[Seq[IRFile]] = load(StdlibHolder.fulllib)
+  val javalib: Future[Seq[IRFile]] = load(StdlibHolder.javalib)
   val empty: Future[Seq[IRFile]] = Future.successful(Nil)
   val previousLibs: Map[String, Future[Seq[IRFile]]] =
     StdlibHolder.previousLibs.map(x => x._1 -> load(x._2))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -536,10 +536,10 @@ object Build {
    *  - `"semver-spec"` for artifacts whose public API can only break in major releases (e.g., `library`)
    *
    *  At the moment, we only set the version scheme for artifacts in the
-   *  "library ecosystem", i.e., scalajs-library, scalajs-test-interface,
-   *  scalajs-junit-runtime and scalajs-test-bridge. Artifacts of the "tools
-   *  ecosystem" do not have a version scheme set, as the jury is still out on
-   *  what is the best way to specify them.
+   *  "library ecosystem", i.e., scalajs-javalib scalajs-library,
+   *  scalajs-test-interface, scalajs-junit-runtime and scalajs-test-bridge.
+   *  Artifacts of the "tools ecosystem" do not have a version scheme set, as
+   *  the jury is still out on what is the best way to specify them.
    *
    *  See also https://www.scala-sbt.org/1.x/docs/Publishing.html#Version+scheme
    */
@@ -648,6 +648,32 @@ object Build {
       }
     }
 
+    /** Depends on library and, by artificial transitivity, on the javalib. */
+    def dependsOnLibrary2_12: Project = {
+      val library = LocalProject("library2_12")
+
+      // Add a real dependency on the library
+      val project1 = project
+        .dependsOn(library)
+
+      /* Because the javalib's exportsJar is false, but its actual products are
+       * only in its jar, we must manually add the jar on the internal
+       * classpath.
+       * Once published, only jars are ever used, so this is fine.
+       */
+      if (isGeneratingForIDE) {
+        project1
+      } else {
+        project1
+          .settings(
+            Compile / internalDependencyClasspath +=
+              (javalib / Compile / packageBin).value,
+            Test / internalDependencyClasspath +=
+              (javalib / Compile / packageBin).value,
+          )
+      }
+    }
+
     def withScalaJSJUnitPlugin2_12: Project = {
       project.settings(
           scalacOptions in Test ++= {
@@ -691,6 +717,31 @@ object Build {
       }
     }
 
+    /** Depends on library and, by transitivity, on the javalib. */
+    def dependsOnLibrary: MultiScalaProject = {
+      // Add a real dependency on the library
+      val project1 = project
+        .dependsOn(library)
+
+      /* Because the javalib's exportsJar is false, but its actual products are
+       * only in its jar, we must manually add the jar on the internal
+       * classpath.
+       * Once published, only jars are ever used, so this is fine.
+       */
+      if (isGeneratingForIDE) {
+        project1
+      } else {
+        // Actually add classpath dependencies on the javalib jar
+        project1
+          .settings(
+            Compile / internalDependencyClasspath +=
+              (javalib / Compile / packageBin).value,
+            Test / internalDependencyClasspath +=
+              (javalib / Compile / packageBin).value,
+          )
+      }
+    }
+
     /** Depends on the sources of another project. */
     def dependsOnSource(dependency: MultiScalaProject): MultiScalaProject = {
       if (isGeneratingForIDE) {
@@ -730,7 +781,7 @@ object Build {
             linkerInterface, linkerInterfaceJS, linker, linkerJS,
             testAdapter,
             javalibintf,
-            javalib, scalalib, libraryAux, library,
+            javalibInternal, javalib, scalalib, libraryAux, library,
             testInterface, jUnitRuntime, testBridge, jUnitPlugin, jUnitAsyncJS,
             jUnitAsyncJVM, jUnitTestOutputsJS, jUnitTestOutputsJVM,
             helloworld, reversi, testingExample, testSuite, testSuiteJVM,
@@ -792,8 +843,8 @@ object Build {
       MyScalaJSPlugin
   ).settings(
       commonIrProjectSettings,
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      library, jUnitRuntime % "test", testBridge % "test"
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
+      jUnitRuntime % "test", testBridge % "test"
   )
 
   lazy val compiler: MultiScalaProject = MultiScalaProject(
@@ -923,8 +974,8 @@ object Build {
 
         fileSet.toSeq.filter(_.getPath().endsWith(".scala"))
       }.taskValue,
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      library, irProjectJS, jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test",
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
+      irProjectJS, jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test",
   )
 
   lazy val linkerPrivateLibrary: Project = (project in file("linker-private-library")).enablePlugins(
@@ -937,8 +988,8 @@ object Build {
       publishArtifact in Compile := false,
       delambdafySetting,
       cleanIRSettings
-  ).withScalaJSCompiler2_12.withScalaJSJUnitPlugin2_12.dependsOn(
-      library.v2_12, jUnitRuntime.v2_12 % "test", testBridge.v2_12 % "test",
+  ).withScalaJSCompiler2_12.withScalaJSJUnitPlugin2_12.dependsOnLibrary2_12.dependsOn(
+      jUnitRuntime.v2_12 % "test", testBridge.v2_12 % "test",
   )
 
   def commonLinkerSettings: Seq[Setting[_]] = Def.settings(
@@ -959,6 +1010,7 @@ object Build {
       buildInfoPackage in Test := "org.scalajs.linker.testutils",
       buildInfoObject in Test := "StdlibHolder",
       buildInfoOptions in Test += BuildInfoOption.PackagePrivate,
+
       buildInfoKeys in Test := {
         val previousLibsTask = Def.task {
           val s = streams.value
@@ -969,7 +1021,13 @@ object Build {
           val retrieveDir = s.cacheDirectory / "previous-stdlibs"
 
           previousVersions.map { version =>
-            val jars = lm.retrieve("org.scala-js" % s"scalajs-library_$binVer" % version intransitive(),
+            // Prior to Scala.js 1.11.0, the javalib IR files were in scalajs-library
+            val artifactName = CrossVersion.partialVersion(version) match {
+              case Some((1L, minor)) if minor < 11 => s"scalajs-library_$binVer"
+              case _                               => "scalajs-javalib"
+            }
+
+            val jars = lm.retrieve("org.scala-js" % artifactName % version intransitive(),
                 scalaModuleInfo = None, retrieveDir, log)
               .fold(w => throw w.resolveException, _.distinct)
             assert(jars.size == 1, jars.toString())
@@ -1079,8 +1137,8 @@ object Build {
       },
 
       scalaJSLinkerConfig in Test ~= (_.withModuleKind(ModuleKind.CommonJSModule))
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      linkerInterfaceJS, library, irProjectJS, jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test"
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
+      linkerInterfaceJS, irProjectJS, jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test"
   )
 
   lazy val testAdapter: MultiScalaProject = MultiScalaProject(
@@ -1149,6 +1207,8 @@ object Build {
             publishLocal in jUnitPlugin.v2_13,
 
             // JS libs
+            publishLocal in javalib,
+
             publishLocal in library.v2_11,
             publishLocal in testInterface.v2_11,
             publishLocal in testBridge.v2_11,
@@ -1215,15 +1275,20 @@ object Build {
       autoScalaLibrary := false,
   )
 
-  lazy val javalib: Project = Project(
-      id = "javalib", base = file("javalib")
+  /** The project that actually compiles the `javalib`, but which is not
+   *  exposed.
+   *
+   *  Instead, its products are copied in `javalib`.
+   */
+  lazy val javalibInternal: Project = Project(
+      id = "javalibInternal", base = file("javalib")
   ).enablePlugins(
       MyScalaJSPlugin
   ).settings(
       commonSettings,
       scalaVersion := DefaultScalaVersion,
       fatalWarningsSettings,
-      name := "scalajs-javalib",
+      name := "scalajs-javalib-internal",
       publishArtifact in Compile := false,
       delambdafySetting,
 
@@ -1253,6 +1318,12 @@ object Build {
 
       cleanIRSettings,
 
+      Compile / doc := {
+        val dir = (Compile / doc / target).value
+        IO.createDirectory(dir)
+        dir
+      },
+
       headerSources in Compile ~= { srcs =>
         srcs.filter { src =>
           val path = src.getPath.replace('\\', '/')
@@ -1260,6 +1331,27 @@ object Build {
           !path.endsWith("/java/util/concurrent/ThreadLocalRandom.scala")
         }
       },
+  ).withScalaJSCompiler2_12.dependsOnLibraryNoJar2_12
+
+  /** An empty project, without source nor dependencies, whose products are
+   *  copied from `javalibInternal`.
+   *
+   *  This the "public" version of the javalib, as depended on by the `library`
+   *  and published on Maven.
+   */
+  lazy val javalib: Project = Project(
+      id = "javalib", base = file("javalib-public")
+  ).settings(
+      commonSettings,
+      name := "scalajs-javalib",
+      publishSettings(Some(VersionScheme.BreakOnMajor)),
+
+      crossPaths := false,
+      autoScalaLibrary := false,
+      crossVersion := CrossVersion.disabled,
+
+      Compile / packageBin / mappings := (javalibInternal / Compile / packageBin / mappings).value,
+      exportJars := false, // very important, otherwise there's a cycle with the `library`
 
       Compile / packageMinilib := {
         val sources = (Compile / packageBin / mappings).value.filter { mapping =>
@@ -1271,7 +1363,7 @@ object Build {
         sbt.Package(config, s.cacheStoreFactory, s.log)
         jar
       },
-  ).withScalaJSCompiler2_12.dependsOnLibraryNoJar2_12
+  )
 
   lazy val scalalib: MultiScalaProject = MultiScalaProject(
       id = "scalalib", base = file("scalalib")
@@ -1441,7 +1533,7 @@ object Build {
   ).enablePlugins(
       MyScalaJSPlugin
   ).dependsOn(
-      javalibintf % Provided,
+      javalibintf % Provided, javalib,
   ).settings(
       commonSettings,
       publishSettings(Some(VersionScheme.BreakOnMajor)),
@@ -1527,8 +1619,7 @@ object Build {
 
             val otherProducts = (
                 (products in localProjects(0)).value ++
-                (products in localProjects(1)).value ++
-                (products in LocalProject("javalib")).value)
+                (products in localProjects(1)).value)
             val otherMappings =
               otherProducts.flatMap(base => Path.selectSubpaths(base, filter))
 
@@ -1551,7 +1642,7 @@ object Build {
       delambdafySetting,
       previousArtifactSetting,
       mimaBinaryIssueFilters ++= BinaryIncompatibilities.TestInterface
-  ).withScalaJSCompiler.dependsOn(library)
+  ).withScalaJSCompiler.dependsOnLibrary
 
   lazy val testBridge: MultiScalaProject = MultiScalaProject(
       id = "testBridge", base = file("test-bridge")
@@ -1574,8 +1665,8 @@ object Build {
         baseDirectory.value.getParentFile.getParentFile / "test-common/src/main/scala",
       unmanagedSourceDirectories in Test +=
         baseDirectory.value.getParentFile.getParentFile / "test-common/src/test/scala"
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      library, testInterface, jUnitRuntime % "test", jUnitAsyncJS % "test"
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
+      testInterface, jUnitRuntime % "test", jUnitAsyncJS % "test"
   )
 
   lazy val jUnitRuntime: MultiScalaProject = MultiScalaProject(
@@ -1597,7 +1688,7 @@ object Build {
           !path.contains("/org/junit/") && !path.contains("/org/hamcrest/")
         }
       }
-  ).withScalaJSCompiler.dependsOn(testInterface)
+  ).withScalaJSCompiler.dependsOnLibrary.dependsOn(testInterface)
 
   val commonJUnitTestOutputsSettings = Def.settings(
       commonSettings,
@@ -1618,7 +1709,7 @@ object Build {
   ).settings(
       commonJUnitTestOutputsSettings,
       name := "Tests for Scala.js JUnit output in JS."
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
       jUnitRuntime % "test", testBridge % "test", jUnitAsyncJS % "test"
   )
 
@@ -1657,7 +1748,7 @@ object Build {
       fatalWarningsSettings,
       name := "Scala.js internal JUnit async JS support",
       publishArtifact in Compile := false
-  ).dependsOn(library)
+  ).dependsOnLibrary
 
   lazy val jUnitAsyncJVM: MultiScalaProject = MultiScalaProject(
       id = "jUnitAsyncJVM", base = file("junit-async/jvm")
@@ -1684,7 +1775,7 @@ object Build {
       name := "Hello World - Scala.js example",
       moduleName := "helloworld",
       scalaJSUseMainModuleInitializer := true
-  ).withScalaJSCompiler.dependsOn(library)
+  ).withScalaJSCompiler.dependsOnLibrary
 
   lazy val reversi: MultiScalaProject = MultiScalaProject(
       id = "reversi", base = file("examples") / "reversi"
@@ -1735,7 +1826,7 @@ object Build {
             None
         }
       }
-  ).withScalaJSCompiler.dependsOn(library)
+  ).withScalaJSCompiler.dependsOnLibrary
 
   lazy val testingExample: MultiScalaProject = MultiScalaProject(
       id = "testingExample", base = file("examples") / "testing"
@@ -1751,8 +1842,8 @@ object Build {
             "testingExample/test is not supported because it requires DOM " +
             "support. Use testingExample/testHtml instead.")
       }
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      library, jUnitRuntime % "test", testBridge % "test"
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
+      jUnitRuntime % "test", testBridge % "test"
   )
 
   // Testing
@@ -2096,8 +2187,8 @@ object Build {
       },
   ).zippedSettings(testSuiteLinker)(
       l => inConfig(Bootstrap)(testSuiteBootstrapSetting(l))
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      library, jUnitRuntime, testBridge % "test", jUnitAsyncJS % "test"
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
+      jUnitRuntime, testBridge % "test", jUnitAsyncJS % "test"
   )
 
   lazy val testSuiteJVM: MultiScalaProject = MultiScalaProject(
@@ -2158,9 +2249,7 @@ object Build {
       scalacOptions += "-Yno-predef",
       // We implement JDK classes, so we emit static forwarders for all static objects
       scalacOptions ++= scalaJSCompilerOption("genStaticForwardersForNonTopLevelObjects"),
-  ).withScalaJSCompiler.dependsOn(
-      library
-  )
+  ).withScalaJSCompiler.dependsOnLibrary
 
   def testSuiteExCommonSettings(isJSTest: Boolean): Seq[Setting[_]] = Def.settings(
       publishArtifact in Compile := false,
@@ -2194,8 +2283,8 @@ object Build {
       testSuiteExCommonSettings(isJSTest = true),
       name := "Scala.js test suite ex",
       publishArtifact in Compile := false,
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(
-      library, javalibExtDummies, jUnitRuntime, testBridge % "test", testSuite
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
+      javalibExtDummies, jUnitRuntime, testBridge % "test", testSuite
   )
 
   lazy val testSuiteExJVM: MultiScalaProject = MultiScalaProject(
@@ -2233,7 +2322,7 @@ object Build {
         baseDirectory.value.getParentFile.getParentFile /
           "project/TestSuiteLinkerOptions.scala"
       }
-  ).withScalaJSCompiler.dependsOn(linkerJS)
+  ).withScalaJSCompiler.dependsOnLibrary.dependsOn(linkerJS)
 
   def shouldPartestSetting(partestSuite: LocalProject) = Def.settings(
       shouldPartest := {
@@ -2374,7 +2463,7 @@ object Build {
       }.value
   ).zippedSettings("partestSuite")(partestSuite =>
       shouldPartestSetting(partestSuite)
-  ).dependsOn(partest % "test", library)
+  ).dependsOnLibrary.dependsOn(partest % "test")
 
   lazy val scalaTestSuite: MultiScalaProject = MultiScalaProject(
       id = "scalaTestSuite", base = file("scala-test-suite")
@@ -2432,6 +2521,8 @@ object Build {
           case (rel, file) if !blacklist.contains(rel) => file
         }
       }
-  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOn(jUnitRuntime, testBridge % "test")
+  ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
+      jUnitRuntime, testBridge % "test"
+  )
 
 }

--- a/scripts/publish.sh
+++ b/scripts/publish.sh
@@ -9,7 +9,7 @@ fi
 
 SUFFIXES="2_11 2_12 2_13"
 
-JAVA_LIBS="javalibintf"
+JAVA_LIBS="javalibintf javalib"
 COMPILER="compiler jUnitPlugin"
 JS_LIBS="library irJS linkerInterfaceJS linkerJS testInterface testBridge jUnitRuntime"
 JVM_LIBS="ir linkerInterface linker testAdapter"


### PR DESCRIPTION
Previously, the .sjsir files produced for the `javalib` were included in the `scalajs-library`. Now, instead, we publish the `javalib` as its own artifact, and we make the `scalajs-library` depend on it.

The dependency is tricky to set up, because, at *compile*-time, the `javalib` depends on `library2_12` and `scala-library` 2.12.x.

The former means that we cannot simply do `dependsOn(javalib)` for the `library`, as it would create a cycle. We must add the dependency only in the published POM and Ivy files.

Likewise, the latter means that we must *remove* the dependency on `scala-library` from the `javalib`, again only in the POM and Ivy files.

I did not find a way to affect both the POM and Ivy files in a single way without also breaking other parts of the build. The only way I found required to do it separately for the POM and Ivy files.

Having a unique, independent `scalajs-javalib` artifact would allow other languages to target the Scala.js IR and the `javalib`, without depending on a particular version of the Scala library. There are currently no concrete plan like this, but it opens the door to such a plan.

---

In addition to the tests performed by the `scripted` tests of the sbt plugin, I manually checked that the published POM and Ivy files are as intended. They can be seen here:
https://gist.github.com/sjrd/79627000afa7f0e0116a71197d66122f