### PR TITLE
Fix #4686: Take the envVars sbt setting into account.

### DIFF
--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -25,6 +25,8 @@ object BinaryIncompatibilities {
   )
 
   val TestAdapter = Seq(
+    // private[adapter], not an issue
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.testing.adapter.JSEnvRPC.this"),
   )
 
   val Library = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1011,8 +1011,8 @@ object Build {
       libraryDependencies ++= Seq(
           "com.google.javascript" % "closure-compiler" % "v20220202",
           "com.google.jimfs" % "jimfs" % "1.1" % "test",
-          "org.scala-js" %% "scalajs-env-nodejs" % "1.3.0" % "test",
-          "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.3.0" % "test"
+          "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0" % "test",
+          "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.4.0" % "test"
       ) ++ (
           parallelCollectionsDependencies(scalaVersion.value)
       ),
@@ -1084,7 +1084,7 @@ object Build {
       name := "Scala.js sbt test adapter",
       libraryDependencies ++= Seq(
           "org.scala-sbt" % "test-interface" % "1.0",
-          "org.scala-js" %% "scalajs-js-envs" % "1.3.0",
+          "org.scala-js" %% "scalajs-js-envs" % "1.4.0",
           "com.google.jimfs" % "jimfs" % "1.1" % "test",
       ),
       libraryDependencies ++= JUnitDeps,
@@ -1113,8 +1113,8 @@ object Build {
       mimaBinaryIssueFilters ++= BinaryIncompatibilities.SbtPlugin,
 
       addSbtPlugin("org.portable-scala" % "sbt-platform-deps" % "1.0.1"),
-      libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.3.0",
-      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.3.0",
+      libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.4.0",
+      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0",
 
       scriptedLaunchOpts += "-Dplugin.version=" + version.value,
 
@@ -2270,7 +2270,7 @@ object Build {
 
       resolvers += Resolver.typesafeIvyRepo("releases"),
 
-      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.3.0",
+      libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0",
 
       artifactPath in fetchScalaSource :=
         baseDirectory.value.getParentFile / "fetchedSources" / scalaVersion.value,

--- a/project/build.sbt
+++ b/project/build.sbt
@@ -12,8 +12,8 @@ libraryDependencies += "com.google.jimfs" % "jimfs" % "1.1"
 
 libraryDependencies += "org.eclipse.jgit" % "org.eclipse.jgit.pgm" % "3.2.0.201312181205-r"
 
-libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.3.0"
-libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.3.0"
+libraryDependencies += "org.scala-js" %% "scalajs-js-envs" % "1.4.0"
+libraryDependencies += "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0"
 
 Compile / unmanagedSourceDirectories ++= {
   val root = baseDirectory.value.getParentFile

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -593,6 +593,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
          */
         val config = RunConfig()
           .withLogger(sbtLogger2ToolsLogger(log))
+          .withEnv((envVars in run).value)
           .withInheritOut(false)
           .withInheritErr(false)
           .withOnOutputStream { (out, err) =>
@@ -696,6 +697,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
         val log = streams.value.log
         val config = TestAdapter.Config()
           .withLogger(sbtLogger2ToolsLogger(log))
+          .withEnv(envVars.value)
 
         val adapter = newTestAdapter(env, input, config)
         val frameworkAdapters = enhanceNotInstalledException(resolvedScoped.value, log) {

--- a/sbt-plugin/src/sbt-test/settings/env-vars/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/build.sbt
@@ -1,0 +1,38 @@
+inThisBuild(Def.settings(
+  scalaVersion := "2.12.16",
+))
+
+lazy val sharedSettings = Def.settings(
+  Compile / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "shared/src/main/scala",
+  Test / unmanagedSourceDirectories += baseDirectory.value.getParentFile / "shared/src/test/scala",
+
+  Test / testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s", "-v"),
+
+  envVars += "PROJECT_ENV_VAR" -> "scoped in project",
+  run / envVars += "RUN_ENV_VAR" -> "scoped in project/run", // has no effect
+  Compile / envVars += "COMPILE_ENV_VAR" -> "scoped in project/Compile",
+  Compile / run / envVars += "COMPILE_RUN_ENV_VAR" -> "scoped in project/Compile/run",
+  Test / envVars += "TEST_ENV_VAR" -> "scoped in project/Test",
+  Test / test / envVars += "TEST_TEST_ENV_VAR" -> "scoped in project/Test/test", // has no effect
+)
+
+// Confidence tests on the JVM
+lazy val jvmReference = project
+  .in(file("jvm"))
+  .settings(
+    sharedSettings,
+    libraryDependencies ++= Seq(
+      "com.novocode" % "junit-interface" % "0.11" % "test",
+      "junit" % "junit" % "4.13.2" % "test",
+    ),
+    fork := true,
+  )
+
+// Actual tests on JS
+lazy val jsTests = project
+  .in(file("js"))
+  .enablePlugins(ScalaJSPlugin, ScalaJSJUnitPlugin)
+  .settings(
+    sharedSettings,
+    scalaJSUseMainModuleInitializer := true,
+  )

--- a/sbt-plugin/src/sbt-test/settings/env-vars/js/src/main/scala/envvars/Platform.scala
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/js/src/main/scala/envvars/Platform.scala
@@ -1,0 +1,15 @@
+package envvars
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+object Platform {
+  def getEnvVarOpt(envVar: String): Option[String] =
+    process.env.get(envVar)
+
+  @js.native
+  @JSGlobal("process")
+  private object process extends js.Object {
+    val env: js.Dictionary[String] = js.native
+  }
+}

--- a/sbt-plugin/src/sbt-test/settings/env-vars/jvm/src/main/scala/envvars/Platform.scala
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/jvm/src/main/scala/envvars/Platform.scala
@@ -1,0 +1,6 @@
+package envvars
+
+object Platform {
+  def getEnvVarOpt(envVar: String): Option[String] =
+    Option(System.getenv(envVar))
+}

--- a/sbt-plugin/src/sbt-test/settings/env-vars/project/build.properties
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.2.8

--- a/sbt-plugin/src/sbt-test/settings/env-vars/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/project/build.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/settings/env-vars/shared/src/main/scala/envvars/Main.scala
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/shared/src/main/scala/envvars/Main.scala
@@ -1,0 +1,23 @@
+package envvars
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    assertEnvVar("scoped in project", "PROJECT_ENV_VAR")
+    assertNoEnvVar("RUN_ENV_VAR")
+    assertEnvVar("scoped in project/Compile", "COMPILE_ENV_VAR")
+    assertEnvVar("scoped in project/Compile/run", "COMPILE_RUN_ENV_VAR")
+    assertNoEnvVar("TEST_ENV_VAR")
+    assertNoEnvVar("TEST_TEST_ENV_VAR")
+  }
+
+  private def assertNoEnvVar(envVar: String): Unit =
+    assertEnvVar(None, envVar)
+
+  private def assertEnvVar(expected: String, envVar: String): Unit =
+    assertEnvVar(Some(expected), envVar)
+
+  private def assertEnvVar(expected: Option[String], envVar: String): Unit = {
+    val value = Platform.getEnvVarOpt(envVar)
+    assert(value == expected, s"for $envVar, expected: $expected, but got: $value")
+  }
+}

--- a/sbt-plugin/src/sbt-test/settings/env-vars/shared/src/test/scala/envvars/TestSuite.scala
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/shared/src/test/scala/envvars/TestSuite.scala
@@ -1,0 +1,27 @@
+package envvars
+
+import org.junit.Test
+import org.junit.Assert._
+
+class TestSuite {
+  @Test
+  def testEnvVars(): Unit = {
+    assertEnvVar("scoped in project", "PROJECT_ENV_VAR")
+    assertNoEnvVar("RUN_ENV_VAR")
+    assertEnvVar("scoped in project/Compile", "COMPILE_ENV_VAR") // because Test "extends" Compile
+    assertNoEnvVar("COMPILE_RUN_ENV_VAR")
+    assertEnvVar("scoped in project/Test", "TEST_ENV_VAR")
+    assertNoEnvVar("TEST_TEST_ENV_VAR") // always ignored
+  }
+
+  private def assertNoEnvVar(envVar: String): Unit =
+    assertEnvVar(None, envVar)
+
+  private def assertEnvVar(expected: String, envVar: String): Unit =
+    assertEnvVar(Some(expected), envVar)
+
+  private def assertEnvVar(expected: Option[String], envVar: String): Unit = {
+    val value = Platform.getEnvVarOpt(envVar)
+    assertEquals(s"for $envVar", expected, value)
+  }
+}

--- a/sbt-plugin/src/sbt-test/settings/env-vars/test
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/test
@@ -1,0 +1,6 @@
+> show jvmReference/Compile/run/envVars
+> jvmReference/run
+> show jvmReference/Test/envVars
+> jvmReference/test
+> jsTests/run
+> jsTests/test

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/JSEnvRPC.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/JSEnvRPC.scala
@@ -20,7 +20,7 @@ import org.scalajs.testing.common._
 
 /** RPC Core for use with a [[JSEnv]]. */
 private[adapter] final class JSEnvRPC(
-    jsenv: JSEnv, input: Seq[Input], logger: Logger)(
+    jsenv: JSEnv, input: Seq[Input], logger: Logger, env: Map[String, String])(
     implicit ec: ExecutionContext) extends RPCCore {
 
   private val run: JSComRun = {
@@ -35,6 +35,7 @@ private[adapter] final class JSEnvRPC(
      */
     val runConfig = RunConfig()
       .withLogger(logger)
+      .withEnv(env)
       .withInheritOut(false)
       .withInheritErr(false)
       .withOnOutputStream { (out, err) =>

--- a/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
+++ b/test-adapter/src/main/scala/org/scalajs/testing/adapter/TestAdapter.scala
@@ -125,7 +125,7 @@ final class TestAdapter(jsEnv: JSEnv, input: Seq[Input], config: TestAdapter.Con
     // Otherwise we might leak runners.
     require(!closed, "We are closed. Cannot create new runner.")
 
-    val com = new JSEnvRPC(jsEnv, input, config.logger)
+    val com = new JSEnvRPC(jsEnv, input, config.logger, config.env)
     val mux = new RunMuxRPC(com)
 
     new ManagedRunner(threadId, com, mux)
@@ -134,21 +134,27 @@ final class TestAdapter(jsEnv: JSEnv, input: Seq[Input], config: TestAdapter.Con
 
 object TestAdapter {
   final class Config private (
-      val logger: Logger
+      val logger: Logger,
+      val env: Map[String, String]
   ) {
     private def this() = {
       this(
-          logger = NullLogger
+          logger = NullLogger,
+          env = Map.empty
       )
     }
 
     def withLogger(logger: Logger): Config =
       copy(logger = logger)
 
+    def withEnv(env: Map[String, String]): Config =
+      copy(env = env)
+
     private def copy(
-        logger: Logger = logger
+        logger: Logger = logger,
+        env: Map[String, String] = env
     ): Config = {
-      new Config(logger)
+      new Config(logger, env)
     }
   }
 


### PR DESCRIPTION
For `run`, it is read in the scope `project/Config/run`. For test tasks, it is read in the scope `project/Test` (and not `project/Test/test`). This is consistent with the JVM, as ensured by the new scripted test.

We pass it down to the `RunConfig` of `JSEnv`s. If a `JSEnv `does not support environment variables, and `envVars.value` is non-empty, the `JSEnv` validator will report an error.

---

As I expected, it took way more time to test than to implement, on this side of the JSEnv interface. :sweat_smile: The real work was done in scalajs-js-envs.