### PR TITLE
Fix #4726: Use parseFloat(toString()) for BigDecimal.floatValue().

### DIFF
--- a/javalib/src/main/scala/java/math/Conversion.scala
+++ b/javalib/src/main/scala/java/math/Conversion.scala
@@ -282,37 +282,4 @@ private[math] object Conversion {
       else result
     }
   }
-
-  def bigInteger2Double(bi: BigInteger): Double = {
-    if (bi.numberLength < 2 || ((bi.numberLength == 2) && (bi.digits(1) > 0))) {
-      bi.longValue().toDouble
-    } else if (bi.numberLength > 32) {
-      if (bi.sign > 0) Double.PositiveInfinity
-      else Double.NegativeInfinity
-    } else {
-      val bitLen = bi.abs().bitLength()
-      var exponent: Long = bitLen - 1
-      val delta = bitLen - 54
-      val lVal = bi.abs().shiftRight(delta).longValue()
-      var mantissa = lVal & 0x1FFFFFFFFFFFFFL
-
-      if (exponent == 1023 && mantissa == 0X1FFFFFFFFFFFFFL) {
-        if (bi.sign > 0) Double.PositiveInfinity
-        else Double.NegativeInfinity
-      } else if (exponent == 1023 && mantissa == 0x1FFFFFFFFFFFFEL) {
-        if (bi.sign > 0) Double.MaxValue
-        else -Double.MaxValue
-      } else {
-        val droppedBits = BitLevel.nonZeroDroppedBits(delta, bi.digits)
-        if (((mantissa & 1) == 1) && (((mantissa & 2) == 2) || droppedBits))
-          mantissa += 2
-
-        mantissa >>= 1
-        val resSign = if (bi.sign < 0) 0x8000000000000000L else 0
-        exponent = ((1023 + exponent) << 52) & 0x7FF0000000000000L
-        val result = resSign | exponent | mantissa
-        java.lang.Double.longBitsToDouble(result)
-      }
-    }
-  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -201,7 +201,7 @@ class FloatTest {
 
     // the limit between MaxValue and PositiveInfinity
     test(Float.MaxValue, "0x1.fffffefp127")
-    //test(Float.MaxValue, "0x1.fffffeffffffffffffffffffffffffffp127")
+    test(Float.MaxValue, "0x1.fffffeffffffffffffffffffffffffffp127")
     test(Float.PositiveInfinity, "0x1.ffffff00000000000000p127")
     test(Float.PositiveInfinity, "0x1.ffffff00000000000001p127")
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConvertTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConvertTest.scala
@@ -21,7 +21,7 @@ package org.scalajs.testsuite.javalib.math
 
 import java.math.BigInteger
 
-import org.junit.{Test, Ignore}
+import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
@@ -253,14 +253,18 @@ class BigIntegerConvertTest {
     assertEquals(Float.NegativeInfinity, aNumber, 0.0f)
   }
 
-  @Ignore @Test def testFloatValueNegativeInfinity2(): Unit = {
+  @Test def testFloatValueNegativeInfinity2(): Unit = {
+    assumeTrue("requires accurate floats", hasAccurateFloats)
+
     val a = Array[Byte](0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
     val aSign = -1
     val aNumber = new BigInteger(aSign, a).floatValue()
     assertEquals(Float.NegativeInfinity, aNumber, 0.0f)
   }
 
-  @Ignore @Test def testFloatValueNegMantissaIsZero(): Unit = {
+  @Test def testFloatValueNegMantissaIsZero(): Unit = {
+    assumeTrue("requires accurate floats", hasAccurateFloats)
+
     val a = Array[Byte](1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     val aSign = -1
     val aNumber = new BigInteger(aSign, a).floatValue()
@@ -294,14 +298,18 @@ class BigIntegerConvertTest {
     assertTrue(aNumber - result < delta)
   }
 
-  @Ignore @Test def testFloatValuePastNegMaxValue(): Unit = {
+  @Test def testFloatValuePastNegMaxValue(): Unit = {
+    assumeTrue("requires accurate floats", hasAccurateFloats)
+
     val a = Array[Byte](0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
     val aSign = -1
     val aNumber = new BigInteger(aSign, a).floatValue()
     assertEquals(Float.NegativeInfinity, aNumber, 0.0f)
   }
 
-  @Ignore @Test def testFloatValuePastPosMaxValue(): Unit = {
+  @Test def testFloatValuePastPosMaxValue(): Unit = {
+    assumeTrue("requires accurate floats", hasAccurateFloats)
+
     val a = Array[Byte](0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
     val aSign = 1
     val aNumber = new BigInteger(aSign, a).floatValue()
@@ -323,7 +331,9 @@ class BigIntegerConvertTest {
     assertTrue(aNumber - result < delta)
   }
 
-  @Ignore @Test def testFloatValuePositiveInfinity1(): Unit = {
+  @Test def testFloatValuePositiveInfinity1(): Unit = {
+    assumeTrue("requires accurate floats", hasAccurateFloats)
+
     val a = Array[Byte](0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
     val aSign = 1
     val aNumber: Float = new BigInteger(aSign, a).floatValue()


### PR DESCRIPTION
Or rather, a faster version thereof, which does not rescale the value to follow the public spec of `toString()`.

Similarly, we simplify `doubleValue()` to use `parseDouble()` of the same `toString()`.

`parseDouble` is provided by the JS engine. We don't have any evidence either way, but it is not impossible that its native speed compensates for the conversion to string. `parseFloat`, in turn, is implemented on top of `parseDouble`, and only has a fallback for corner cases.

Using `parseDouble` and `parseFloat` for `toString()` is already what `BigInteger` does. This is one more reason not to bother to do something cleverer in `BigDecimal`.