### PR TITLE
FF ONLY Towards 1.11.1.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -171,6 +171,7 @@ def Tasks = [
     sbtretry ++$scala headerCheck &&
     sbtretry ++$scala partest$v/fetchScalaSource &&
     sbtretry ++$scala \
+        javalibintf/mimaReportBinaryIssues \
         library$v/mimaReportBinaryIssues \
         testInterface$v/mimaReportBinaryIssues \
         jUnitRuntime$v/mimaReportBinaryIssues

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,7 +17,7 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.11.0",
+    current = "1.11.1-SNAPSHOT",
     binaryEmitted = "1.11"
 )
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -5,33 +5,21 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val IR = Seq(
-    // private, not an issue
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Serializers#Hacks.*"),
   )
 
   val Linker = Seq(
-    // Breaking (minor change)
-    exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.LinkedClass.this"),
-    // private[linker], not an issue.
-    exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.LinkedClass.refined"),
   )
 
   val LinkerInterface = Seq(
-    // private, not an issue
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.interface.Semantics.this"),
   )
 
   val SbtPlugin = Seq(
   )
 
   val TestAdapter = Seq(
-    // private[adapter], not an issue
-    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.testing.adapter.JSEnvRPC.this"),
   )
 
   val Library = Seq(
-    // Static initializer (2.11 only), not an issue
-    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.scalajs.js.JavaScriptException.<clinit>"),
   )
 
   val TestInterface = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -245,7 +245,7 @@ object Build {
 
   val previousVersions = List("1.0.0", "1.0.1", "1.1.0", "1.1.1", "1.2.0",
       "1.3.0", "1.3.1", "1.4.0", "1.5.0", "1.5.1", "1.6.0", "1.7.0", "1.7.1",
-      "1.8.0", "1.9.0", "1.10.0", "1.10.1")
+      "1.8.0", "1.9.0", "1.10.0", "1.10.1", "1.11.0")
   val previousVersion = previousVersions.last
 
   val previousBinaryCrossVersion = CrossVersion.binaryWith("sjs1_", "")
@@ -1270,6 +1270,11 @@ object Build {
       commonSettings,
       publishSettings(Some(VersionScheme.BreakOnMajor)),
       name := "scalajs-javalib-intf",
+
+      mimaPreviousArtifacts += {
+        val thisProjectID = projectID.value
+        thisProjectID.organization % thisProjectID.name % previousVersion
+      },
 
       crossPaths := false,
       autoScalaLibrary := false,


### PR DESCRIPTION
Set up MiMa for the javalibintf.

---

I locally tested that, if I remove a method from the javalibintf, then `javalibintf/mimaReportBinaryIssues` fails.