### PR TITLE
Explicitly validate the capacity in `nio.*Buffer.allocate`.

### DIFF
--- a/javalib/src/main/scala/java/nio/ByteBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ByteBuffer.scala
@@ -17,11 +17,15 @@ import scala.scalajs.js.typedarray._
 object ByteBuffer {
   private final val HashSeed = -547316498 // "java.nio.ByteBuffer".##
 
-  def allocate(capacity: Int): ByteBuffer =
+  def allocate(capacity: Int): ByteBuffer = {
+    GenBuffer.validateAllocateCapacity(capacity)
     wrap(new Array[Byte](capacity))
+  }
 
-  def allocateDirect(capacity: Int): ByteBuffer =
+  def allocateDirect(capacity: Int): ByteBuffer = {
+    GenBuffer.validateAllocateCapacity(capacity)
     TypedArrayByteBuffer.allocate(capacity)
+  }
 
   def wrap(array: Array[Byte], offset: Int, length: Int): ByteBuffer =
     HeapByteBuffer.wrap(array, 0, array.length, offset, length, false)

--- a/javalib/src/main/scala/java/nio/CharBuffer.scala
+++ b/javalib/src/main/scala/java/nio/CharBuffer.scala
@@ -17,8 +17,10 @@ import scala.scalajs.js.typedarray._
 object CharBuffer {
   private final val HashSeed = -182887236 // "java.nio.CharBuffer".##
 
-  def allocate(capacity: Int): CharBuffer =
+  def allocate(capacity: Int): CharBuffer = {
+    GenBuffer.validateAllocateCapacity(capacity)
     wrap(new Array[Char](capacity))
+  }
 
   def wrap(array: Array[Char], offset: Int, length: Int): CharBuffer =
     HeapCharBuffer.wrap(array, 0, array.length, offset, length, false)

--- a/javalib/src/main/scala/java/nio/DoubleBuffer.scala
+++ b/javalib/src/main/scala/java/nio/DoubleBuffer.scala
@@ -17,8 +17,10 @@ import scala.scalajs.js.typedarray._
 object DoubleBuffer {
   private final val HashSeed = 2140173175 // "java.nio.DoubleBuffer".##
 
-  def allocate(capacity: Int): DoubleBuffer =
+  def allocate(capacity: Int): DoubleBuffer = {
+    GenBuffer.validateAllocateCapacity(capacity)
     wrap(new Array[Double](capacity))
+  }
 
   def wrap(array: Array[Double], offset: Int, length: Int): DoubleBuffer =
     HeapDoubleBuffer.wrap(array, 0, array.length, offset, length, false)

--- a/javalib/src/main/scala/java/nio/FloatBuffer.scala
+++ b/javalib/src/main/scala/java/nio/FloatBuffer.scala
@@ -17,8 +17,10 @@ import scala.scalajs.js.typedarray._
 object FloatBuffer {
   private final val HashSeed = 1920204022 // "java.nio.FloatBuffer".##
 
-  def allocate(capacity: Int): FloatBuffer =
+  def allocate(capacity: Int): FloatBuffer = {
+    GenBuffer.validateAllocateCapacity(capacity)
     wrap(new Array[Float](capacity))
+  }
 
   def wrap(array: Array[Float], offset: Int, length: Int): FloatBuffer =
     HeapFloatBuffer.wrap(array, 0, array.length, offset, length, false)

--- a/javalib/src/main/scala/java/nio/GenBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenBuffer.scala
@@ -17,6 +17,11 @@ import java.util.internal.GenericArrayOps._
 private[nio] object GenBuffer {
   def apply[B <: Buffer](self: B): GenBuffer[B] =
     new GenBuffer(self)
+
+  @inline def validateAllocateCapacity(capacity: Int): Unit = {
+    if (capacity < 0)
+      throw new IllegalArgumentException
+  }
 }
 
 /* The underlying `val self` is intentionally public because

--- a/javalib/src/main/scala/java/nio/IntBuffer.scala
+++ b/javalib/src/main/scala/java/nio/IntBuffer.scala
@@ -17,8 +17,10 @@ import scala.scalajs.js.typedarray._
 object IntBuffer {
   private final val HashSeed = 39599817 // "java.nio.IntBuffer".##
 
-  def allocate(capacity: Int): IntBuffer =
+  def allocate(capacity: Int): IntBuffer = {
+    GenBuffer.validateAllocateCapacity(capacity)
     wrap(new Array[Int](capacity))
+  }
 
   def wrap(array: Array[Int], offset: Int, length: Int): IntBuffer =
     HeapIntBuffer.wrap(array, 0, array.length, offset, length, false)

--- a/javalib/src/main/scala/java/nio/LongBuffer.scala
+++ b/javalib/src/main/scala/java/nio/LongBuffer.scala
@@ -15,8 +15,10 @@ package java.nio
 object LongBuffer {
   private final val HashSeed = -1709696158 // "java.nio.LongBuffer".##
 
-  def allocate(capacity: Int): LongBuffer =
+  def allocate(capacity: Int): LongBuffer = {
+    GenBuffer.validateAllocateCapacity(capacity)
     wrap(new Array[Long](capacity))
+  }
 
   def wrap(array: Array[Long], offset: Int, length: Int): LongBuffer =
     HeapLongBuffer.wrap(array, 0, array.length, offset, length, false)

--- a/javalib/src/main/scala/java/nio/ShortBuffer.scala
+++ b/javalib/src/main/scala/java/nio/ShortBuffer.scala
@@ -17,8 +17,10 @@ import scala.scalajs.js.typedarray._
 object ShortBuffer {
   private final val HashSeed = 383731478 // "java.nio.ShortBuffer".##
 
-  def allocate(capacity: Int): ShortBuffer =
+  def allocate(capacity: Int): ShortBuffer = {
+    GenBuffer.validateAllocateCapacity(capacity)
     wrap(new Array[Short](capacity))
+  }
 
   def wrap(array: Array[Short], offset: Int, length: Int): ShortBuffer =
     HeapShortBuffer.wrap(array, 0, array.length, offset, length, false)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
@@ -39,7 +39,9 @@ abstract class BaseBufferTest {
 
     assertEquals(0, allocBuffer(0).capacity)
 
-    assertThrows(classOf[Exception], allocBuffer(-1))
+    assertThrows(classOf[IllegalArgumentException], allocBuffer(-1))
+    assertThrows(classOf[IllegalArgumentException], allocBuffer(-100))
+
     assertThrows(classOf[Throwable], allocBuffer(0, -1, 1))
     assertThrows(classOf[Throwable], allocBuffer(1, 0, 1))
     assertThrows(classOf[Throwable], allocBuffer(0, 1, 0))


### PR DESCRIPTION
Giving a negative size should throw an `IllegalArgumentException`, which is well specified.

Extracted from #4711/#4715.