### PR TITLE
Expose the linker output *dir* as new tasks {fast,full}LinkJSOutput.

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -180,6 +180,12 @@ object ScalaJSPlugin extends AutoPlugin {
     val fullLinkJS = TaskKey[Attributed[Report]]("fullLinkJS",
         "Link all compiled JavaScript and fully optimize", APlusTask)
 
+    val fastLinkJSOutput = TaskKey[File]("fastLinkJSOutput",
+        "Quickly link all compiled JavaScript and return the output directory", AMinusTask)
+
+    val fullLinkJSOutput = TaskKey[File]("fullLinkJSOutput",
+        "Link all compiled JavaScript with full optimizations and return the output directory", AMinusTask)
+
     val testHtml = TaskKey[Attributed[File]]("testHtml",
         "Create an HTML test runner. Honors `scalaJSStage`.", AMinusTask)
 


### PR DESCRIPTION
The `fastLinkJSOutput` task runs `fastLinkJS` and extracts the output directory `File` from the `Attributed[Report]`. Likewise for `fullLinkJSOutput`.

In the generic implementations within sbt-scalajs, we prefer to get access to the full attributed `Report`. But in a typical user build, the knowledge inside the `Report` is superfluous, and the wrapping gets in the way of writing a simple build file.

The new task keys give a simpler access to what's relevant from a user point of view. It can also be directly used in a `print fastLinkJSOutput` command from an orchestrating tool (such as a JavaScript build tool calling sbt), since it prints as a bare string with the absolute path.