### PR TITLE
Limit partest to use at most 8 threads.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2444,6 +2444,12 @@ object Build {
 
       fork in Test := true,
       javaOptions in Test += "-Xmx3G",
+      javaOptions in Test += {
+        // Use maximum 8 threads in partest (avoid saturating the memory on machines with lots of processors)
+        val availableProcs = java.lang.Runtime.getRuntime().availableProcessors()
+        val numThreads = if (availableProcs < 1) 1 else if (availableProcs > 8) 8 else availableProcs
+        s"-Dpartest.threads=$numThreads"
+      },
 
       // Override the dependency of partest - see #1889
       dependencyOverrides += "org.scala-lang" % "scala-library" % scalaVersion.value % "test",


### PR DESCRIPTION
On big machines with lots of cores, running partest on all available cores consumes a lot more memory.

---

One more step towards getting the CI back to a reliable state.