### PR TITLE
Fix #4763: Bump sbt from 1.2.8 to 1.3.3 in our scripted tests.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -401,21 +401,14 @@ def Tasks = [
         testAdapter$v/compile:doc
   ''',
 
-  "tools-sbtplugin": '''
+  // These are agnostic to the Scala version
+  "sbt-plugin-and-scalastyle": '''
     setJavaVersion $java
     npm install &&
-    sbtnoretry ++$scala ir$v/test linkerInterface$v/compile \
-        linker$v/compile testAdapter$v/test \
-        sbtPlugin/package \
-        ir$v/mimaReportBinaryIssues \
-        linkerInterface$v/mimaReportBinaryIssues linker$v/mimaReportBinaryIssues \
-        testAdapter$v/mimaReportBinaryIssues \
-        sbtPlugin/mimaReportBinaryIssues &&
-    sbtnoretry ++$scala scalastyleCheck &&
-    sbtnoretry ++$scala ir$v/compile:doc \
-        linkerInterface$v/compile:doc linker$v/compile:doc \
-        testAdapter$v/compile:doc \
-        sbtPlugin/compile:doc &&
+    sbtnoretry \
+        sbtPlugin/compile:doc \
+        sbtPlugin/mimaReportBinaryIssues \
+        scalastyleCheck &&
     sbtnoretry sbtPlugin/scripted
   ''',
 
@@ -501,6 +494,7 @@ def quickMatrix = []
 mainScalaVersions.each { scalaVersion ->
   allJavaVersions.each { javaVersion ->
     quickMatrix.add([task: "main", scala: scalaVersion, java: javaVersion])
+    quickMatrix.add([task: "tools", scala: scalaVersion, java: javaVersion])
   }
   quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testSuite: "testSuite"])
   quickMatrix.add([task: "test-suite-custom-esversion", scala: scalaVersion, java: mainJavaVersion, esVersion: "ES5_1", testSuite: "testSuite"])
@@ -515,9 +509,9 @@ allESVersions.each { esVersion ->
 allJavaVersions.each { javaVersion ->
   if (javaVersion != "16") {
     // the sbt plugin tests fail on Java 16, filed as #4763
-    quickMatrix.add([task: "tools-sbtplugin", scala: "2.12.17", java: javaVersion])
+    // the `scala` version is irrelevant here
+    quickMatrix.add([task: "sbt-plugin-and-scalastyle", scala: mainScalaVersion, java: javaVersion])
   }
-  quickMatrix.add([task: "tools", scala: "2.13.10", java: javaVersion])
 }
 quickMatrix.add([task: "scala3-compat", scala: scala3Version, java: mainJavaVersion])
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -507,11 +507,8 @@ allESVersions.each { esVersion ->
   quickMatrix.add([task: "test-suite-custom-esversion-force-polyfills", scala: mainScalaVersion, java: mainJavaVersion, esVersion: esVersion, testSuite: "testSuite"])
 }
 allJavaVersions.each { javaVersion ->
-  if (javaVersion != "16") {
-    // the sbt plugin tests fail on Java 16, filed as #4763
-    // the `scala` version is irrelevant here
-    quickMatrix.add([task: "sbt-plugin-and-scalastyle", scala: mainScalaVersion, java: javaVersion])
-  }
+  // the `scala` version is irrelevant here
+  quickMatrix.add([task: "sbt-plugin-and-scalastyle", scala: mainScalaVersion, java: javaVersion])
 }
 quickMatrix.add([task: "scala3-compat", scala: scala3Version, java: mainJavaVersion])
 

--- a/sbt-plugin/src/sbt-test/cross-version/2.13/project/build.properties
+++ b/sbt-plugin/src/sbt-test/cross-version/2.13/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/incremental/change-config-and-source/project/build.properties
+++ b/sbt-plugin/src/sbt-test/incremental/change-config-and-source/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/incremental/change-config/project/build.properties
+++ b/sbt-plugin/src/sbt-test/incremental/change-config/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/incremental/fix-compile-error/project/build.properties
+++ b/sbt-plugin/src/sbt-test/incremental/fix-compile-error/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/linker/concurrent-linker-use/project/build.properties
+++ b/sbt-plugin/src/sbt-test/linker/concurrent-linker-use/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/linker/custom-linker/project/build.properties
+++ b/sbt-plugin/src/sbt-test/linker/custom-linker/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/project/build.properties
+++ b/sbt-plugin/src/sbt-test/linker/no-root-dependency-resolution/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/linker/non-existent-classpath/project/build.properties
+++ b/sbt-plugin/src/sbt-test/linker/non-existent-classpath/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/settings/cross-version/project/build.properties
+++ b/sbt-plugin/src/sbt-test/settings/cross-version/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/settings/env-vars/project/build.properties
+++ b/sbt-plugin/src/sbt-test/settings/env-vars/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/settings/legacy-link-empty/project/build.properties
+++ b/sbt-plugin/src/sbt-test/settings/legacy-link-empty/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/settings/legacy-link-tasks/project/build.properties
+++ b/sbt-plugin/src/sbt-test/settings/legacy-link-tasks/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/settings/module-init/project/build.properties
+++ b/sbt-plugin/src/sbt-test/settings/module-init/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/settings/source-map/project/build.properties
+++ b/sbt-plugin/src/sbt-test/settings/source-map/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3

--- a/sbt-plugin/src/sbt-test/testing/multi-framework/project/build.properties
+++ b/sbt-plugin/src/sbt-test/testing/multi-framework/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.2.8
+sbt.version=1.3.3


### PR DESCRIPTION
This allows us to run the sbt plugin scripted tests on JDK 16.

This does not necessarily drop support for sbt 1.2.8, although it will not be tested anymore.

This is a trade-off between:

* ensuring our plugin works with sbt 1.2.8, and
* ensuring it works on JDK 16.

Nowadays, the value of the latter should far exceed the value of the former.