### PR TITLE
Remove `DoWhile` from the IR; deserialize it to `While` instead.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -219,11 +219,6 @@ object Hashers {
           mixTree(cond)
           mixTree(body)
 
-        case DoWhile(body, cond) =>
-          mixTag(TagDoWhile)
-          mixTree(body)
-          mixTree(cond)
-
         case ForIn(obj, keyVar, keyVarOriginalName, body) =>
           mixTag(TagForIn)
           mixTree(obj)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -223,13 +223,6 @@ object Printers {
           print(") ")
           printBlock(body)
 
-        case DoWhile(body, cond) =>
-          print("do ")
-          printBlock(body)
-          print(" while (")
-          print(cond)
-          print(')')
-
         case ForIn(obj, keyVar, keyVarOriginalName, body) =>
           print("for (val ")
           print(keyVar)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -31,7 +31,7 @@ private[ir] object Tags {
   final val TagReturn = TagAssign + 1
   final val TagIf = TagReturn + 1
   final val TagWhile = TagIf + 1
-  final val TagDoWhile = TagWhile + 1
+  final val TagDoWhile = TagWhile + 1 // removed in 1.13
   final val TagForIn = TagDoWhile + 1
   final val TagTryCatch = TagForIn + 1
   final val TagTryFinally = TagTryCatch + 1

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -66,9 +66,6 @@ object Transformers {
         case While(cond, body) =>
           While(transformExpr(cond), transformStat(body))
 
-        case DoWhile(body, cond) =>
-          DoWhile(transformStat(body), transformExpr(cond))
-
         case ForIn(obj, keyVar, keyVarOriginalName, body) =>
           ForIn(transformExpr(obj), keyVar, keyVarOriginalName,
               transformStat(body))

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -52,10 +52,6 @@ object Traversers {
         traverse(cond)
         traverse(body)
 
-      case DoWhile(body, cond) =>
-        traverse(body)
-        traverse(cond)
-
       case ForIn(obj, _, _, body) =>
         traverse(obj)
         traverse(body)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -174,11 +174,6 @@ object Trees {
     }
   }
 
-  sealed case class DoWhile(body: Tree, cond: Tree)(
-      implicit val pos: Position) extends Tree {
-    val tpe = NoType // cannot be in expression position
-  }
-
   sealed case class ForIn(obj: Tree, keyVar: LocalIdent,
       keyVarOriginalName: OriginalName, body: Tree)(
       implicit val pos: Position) extends Tree {

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -199,16 +199,6 @@ class PrintersTest {
         While(b(true), i(5)))
   }
 
-  @Test def printDoWhile(): Unit = {
-    assertPrintEquals(
-        """
-          |do {
-          |  5
-          |} while (true)
-        """,
-        DoWhile(i(5), b(true)))
-  }
-
   @Test def printForIn(): Unit = {
     assertPrintEquals(
         """

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -551,10 +551,6 @@ private final class ClassDefChecker(classDef: ClassDef, reporter: ErrorReporter)
         checkTree(cond, env)
         checkTree(body, env)
 
-      case DoWhile(body, cond) =>
-        checkTree(body, env)
-        checkTree(cond, env)
-
       case ForIn(obj, keyVar, _, body) =>
         checkTree(obj, env)
         checkDeclareLocalVar(keyVar)

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -280,10 +280,6 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
         typecheckExpect(cond, env, BooleanType)
         typecheck(body, env)
 
-      case DoWhile(body, cond) =>
-        typecheck(body, env)
-        typecheckExpect(cond, env, BooleanType)
-
       case ForIn(obj, keyVar, _, body) =>
         typecheckExpr(obj, env)
         typecheck(body, env)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -413,14 +413,6 @@ private[optimizer] abstract class OptimizerCore(config: CommonPhaseConfig) {
           case _                     => While(newCond, transformStat(body))
         }
 
-      case DoWhile(body, cond) =>
-        val newBody = transformStat(body)
-        val newCond = transformExpr(cond)
-        newCond match {
-          case BooleanLiteral(false) => newBody
-          case _                     => DoWhile(newBody, newCond)
-        }
-
       case ForIn(obj, keyVar @ LocalIdent(name), originalName, body) =>
         val newObj = transformExpr(obj)
         val (newName, newOriginalName) =

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -9,6 +9,8 @@ object BinaryIncompatibilities {
     exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#JSPropertyDef.copy"),
     exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#JSPropertyDef.this"),
     exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#JSPropertyDef.apply"),
+    exclude[MissingClassProblem]("org.scalajs.ir.Trees$DoWhile"),
+    exclude[MissingClassProblem]("org.scalajs.ir.Trees$DoWhile$"),
   )
 
   val Linker = Seq(


### PR DESCRIPTION
The `DoWhile` loop was never used by the Scala 3 compiler, and has not been used in the Scala 2 compiler either since e1f353a0f8d57411cf9f92aabecd163f72f6c609.

We rewrite it to a `While` loop as a deserialization hack.

We do not remove `DoWhile` from the linker-internal `javascript/` ASTs at this time. They are now dead code, but could be used by the `FunctionEmitter` to compile some shapes of `While` loops.