### PR TITLE
Disallow abstract methods in non-public namespaces

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1646,30 +1646,12 @@ object Serializers {
       val memberDefs = List.fill(readInt())(readMemberDef(owner, ownerKind))
 
       // #4409: Filter out abstract methods in non-native JS classes for version < 1.5
-      if (ownerKind.isJSClass) {
-        if (hacks.use4) {
-          memberDefs.filter { m =>
-            m match {
-              case MethodDef(_, _, _, _, _, None) => false
-              case _                              => true
-            }
+      if (ownerKind.isJSClass && hacks.use4) {
+        memberDefs.filter { m =>
+          m match {
+            case MethodDef(_, _, _, _, _, None) => false
+            case _                              => true
           }
-        } else {
-          /* #4388 This check should be moved to a link-time check dependent on
-           * `checkIR`, but currently we only have the post-BaseLinker IR
-           * checker, at which points those methods have already been
-           * eliminated.
-           */
-          for (m <- memberDefs) {
-            m match {
-              case MethodDef(_, _, _, _, _, None) =>
-                throw new InvalidIRException(m,
-                    "Invalid abstract method in non-native JS class")
-              case _ =>
-                // ok
-            }
-          }
-          memberDefs
         }
       } else {
         memberDefs

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -231,6 +231,9 @@ private final class ClassDefChecker(classDef: ClassDef, reporter: ErrorReporter)
     if (!methods(namespace.ordinal).add(name))
       reportError(i"duplicate ${namespace.prefixString}method '$name'")
 
+    if (body.isEmpty && namespace != MemberNamespace.Public)
+      reportError("Abstract methods may only be in the public namespace")
+
     // ClassInitializer
     if (name.isClassInitializer) {
       if (!classDef.kind.isJSClass) {

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -141,6 +141,22 @@ class ClassDefCheckerTest {
   }
 
   @Test
+  def noStaticAbstractMethods(): Unit = {
+    val fooMethodName = MethodName("foo", Nil, IntRef)
+
+    assertError(
+        classDef("A",
+            kind = ClassKind.Interface,
+            memberDefs = List(
+              MethodDef(EMF.withNamespace(MemberNamespace.PublicStatic),
+                  fooMethodName, NON, Nil, IntType, None)(EOH, UNV),
+              MethodDef(EMF, fooMethodName, NON, Nil, IntType, None)(EOH, UNV) // OK
+            )
+        ),
+        "Abstract methods may only be in the public namespace")
+  }
+
+  @Test
   def noDuplicateVarDef(): Unit = {
     val body = Block(
       VarDef("x", NoOriginalName, IntType, mutable = false, int(1)),


### PR DESCRIPTION
We remove a similar, less strict check in Serializers that predates the ClassDefChecker.