### PR TITLE
Fix #4789: Make the support level of `js.timers` clearer.

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/timers/RawTimers.scala
+++ b/library/src/main/scala/scala/scalajs/js/timers/RawTimers.scala
@@ -22,6 +22,11 @@ import js.annotation.JSGlobalScope
  *  The methods on this object expose the raw JavaScript methods for timers. In
  *  general it is more advisable to use the methods directly defined on
  *  [[timers]] as they are more Scala-like.
+ *
+ *  The methods exposed by this object are not standard in ECMAScript.
+ *  Different JavaScript environments support all, some or none of them.
+ *
+ *  Browsers support all those methods as part the of the DOM standard.
  */
 @js.native
 @JSGlobalScope

--- a/library/src/main/scala/scala/scalajs/js/timers/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/timers/package.scala
@@ -16,11 +16,17 @@ import scala.concurrent.duration.FiniteDuration
 
 /**
  *  <span class="badge badge-non-std" style="float: right;">Non-Standard</span>
- *  Non-standard, but in general well supported methods to schedule asynchronous
+ *  Non-standard, although often supported methods to schedule asynchronous
  *  execution.
  *
- *  The methods in this package work in all JavaScript virtual machines
- *  supporting `setTimeout` and `setInterval`.
+ *  The methods in this package are not supported in all JavaScript
+ *  environments. Each relies on the global JavaScript function with the same
+ *  name.
+ *
+ *  The corresponding methods are not standard in ECMAScript.
+ *  Different JavaScript environments support all, some or none of them.
+ *
+ *  Browsers support all those methods as part the of the DOM standard.
  */
 package object timers {
 


### PR DESCRIPTION
In particular, make it clear that some methods can be supported while others are not.

/cc @armanbilge 