### PR TITLE
Fix #4794: Fix the stability of our compilation and linking pipeline.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -156,6 +156,13 @@ def Tasks = [
         ++$scala testingExample$v/testHtmlJSDom  &&
     sbtretry ++$scala testSuiteJVM$v/test testSuiteExJVM$v/test &&
     sbtretry ++$scala testSuite$v/test &&
+    sbtretry ++$scala \
+        testSuite$v/saveForStabilityTest \
+        testSuite$v/checkStability \
+        testSuite$v/forceRelinkForStabilityTest \
+        testSuite$v/checkStability \
+        testSuite$v/clean \
+        testSuite$v/checkStability &&
     sbtretry ++$scala testSuiteEx$v/test &&
     sbtretry 'set scalaJSStage in Global := FullOptStage' \
         ++$scala testSuiteEx$v/test &&

--- a/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
@@ -170,7 +170,29 @@ object Types {
    *  type refs that are used in method signatures, and which therefore dictate
    *  JVM/IR overloading.
    */
-  sealed abstract class TypeRef {
+  sealed abstract class TypeRef extends Comparable[TypeRef] {
+    final def compareTo(that: TypeRef): Int = this match {
+      case thiz: PrimRef =>
+        that match {
+          case that: PrimRef => Character.compare(thiz.charCode, that.charCode)
+          case _             => -1
+        }
+      case thiz: ClassRef =>
+        that match {
+          case that: ClassRef     => thiz.className.compareTo(that.className)
+          case that: PrimRef      => 1
+          case that: ArrayTypeRef => -1
+        }
+      case thiz: ArrayTypeRef =>
+        that match {
+          case that: ArrayTypeRef =>
+            if (thiz.dimensions != that.dimensions) thiz.dimensions - that.dimensions
+            else thiz.base.compareTo(that.base)
+          case _ =>
+            1
+        }
+    }
+
     def show(): String = {
       val writer = new java.io.StringWriter
       val printer = new Printers.IRTreePrinter(writer)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -135,7 +135,7 @@ private[frontend] object BaseLinker {
   /** Takes a ClassDef and DCE infos to construct a stripped down LinkedClass.
    */
   private[frontend] def linkClassDef(classDef: ClassDef, version: Version,
-      syntheticMethodDefs: Iterator[MethodDef],
+      syntheticMethodDefs: List[MethodDef],
       analysis: Analysis): (LinkedClass, List[LinkedTopLevelExport]) = {
     import ir.Trees._
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -56,7 +56,7 @@ final class Refiner(config: CommonPhaseConfig) {
           if analysis.classInfos.contains(classDef.className)
         } yield {
           BaseLinker.linkClassDef(classDef, version,
-              syntheticMethodDefs = Iterator.empty, analysis)
+              syntheticMethodDefs = Nil, analysis)
         }
 
         val (linkedClassDefs, linkedTopLevelExports) = assembled.unzip

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1741,9 +1741,10 @@ private[optimizer] abstract class OptimizerCore(
                * targets belong to. Therefore, we have to keep the receiver's
                * static type as a declared type, which is our only safe choice.
                */
+              val representative = impls.minBy(_.enclosingClassName) // for stability
               val receiverType = treceiver.tpe.base
               inline(allocationSites, Some((receiverType, treceiver)), targs,
-                  impls.head, isStat, usePreTransform)(cont)
+                  representative, isStat, usePreTransform)(cont)
             } else {
               treeNotInlined
             }


### PR DESCRIPTION
There were a few places where our compilation and linking pipeline made non-deterministic decisions that had an influence on the generated code. This is bad for multi-module output, which avoids rewriting files that have not changed. It is also bad for our development, when we want to precisely track the effect that our changes (to the library, code and/or linker) have on the generated code.

We fix the various sources of non-determinism, and add a smoke test for stability in the CI.