### PR TITLE
Fix #4796: Don't use the canonical natural comparator in TreeSet

### DIFF
--- a/javalib/src/main/scala/java/util/Comparator.scala
+++ b/javalib/src/main/scala/java/util/Comparator.scala
@@ -86,7 +86,16 @@ object Comparator {
    */
   @inline
   def naturalOrder[T <: Comparable[T]](): Comparator[T] =
-    NaturalComparator.asInstanceOf[Comparator[T]]
+    ReusableNaturalComparator.asInstanceOf[Comparator[T]]
+
+  /* Not the same object as NaturalComparator.
+   *
+   * Otherwise we'll get null back from TreeSet#comparator() (see #4796).
+   */
+  private object ReusableNaturalComparator extends Comparator[Any] {
+    def compare(o1: Any, o2: Any): Int =
+      o1.asInstanceOf[Comparable[Any]].compareTo(o2)
+  }
 
   @inline
   def nullsFirst[T](comparator: Comparator[_ >: T]): Comparator[T] = new Comparator[T] with Serializable {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/TreeSetTest.scala
@@ -27,6 +27,16 @@ import ju.Comparator
 
 import scala.reflect.ClassTag
 
+class TreeSetComparatorTest {
+
+  @Test def naturalComparator_issue4796(): Unit = {
+    val cmp = ju.Comparator.naturalOrder[String]()
+
+    assertSame(cmp, new TreeSet[String](cmp).comparator())
+  }
+
+}
+
 class TreeSetWithoutNullTest extends TreeSetTest(new TreeSetFactory) {
 
   @Test def comparatorNull(): Unit = {


### PR DESCRIPTION
Otherwise we cannot determine anymore whether it originated from null.