### PR TITLE
Reachability: Avoid dispatching the same method on the same interface.

### DIFF
--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -246,6 +246,8 @@ class AnalyzerTest {
 
   @Test
   def missingMethod(): AsyncResult = await {
+    val fooMethodName = m("foo", Nil, V)
+
     val classDefs = Seq(
         classDef("A", superClass = Some(ObjectClass),
             methods = List(trivialCtor("A")))
@@ -253,10 +255,10 @@ class AnalyzerTest {
 
     val analysis = computeAnalysis(classDefs,
         reqsFactory.instantiateClass("A", NoArgConstructorName) ++
-        reqsFactory.callMethod("A", m("foo", Nil, V)))
+        reqsFactory.callMethod("A", fooMethodName))
 
     assertContainsError("MissingMethod(A.foo;V)", analysis) {
-      case MissingMethod(MethInfo("A", "foo;V"), `fromUnitTest`) => true
+      case MissingMethod(MethInfo("A", "foo;V"), FromDispatch(ClsInfo("A"), `fooMethodName`)) => true
     }
   }
 
@@ -279,7 +281,7 @@ class AnalyzerTest {
         reqsFactory.callMethod("A", fooMethodName))
 
     assertContainsError("MissingMethod(A.foo;I)", analysis) {
-      case MissingMethod(MethInfo("A", "foo;I"), `fromUnitTest`) => true
+      case MissingMethod(MethInfo("A", "foo;I"), FromDispatch(ClsInfo("A"), `fooMethodName`)) => true
     }
   }
 


### PR DESCRIPTION
When we find a regular call to some (virtual) method `C.m`, we have to reach the implementations of `m` in all the instantiated subclasses of `C`. We do it immediately for the already known subclasses, and maintain a log for subclasses that will be found to be instantiated later.

Previously, we did this dispatch for every call site of `C.m`. If M methods call `C.m` and `C` has N instantiated subclasses, this would result in M*N resolutions. This was not strictly unnecessary work, since the `from` argument is different in each case. However, this makes the analysis non-linear, which is bad.

One might argue that M*N never gets arbitrarily big for any given `C.m`, so this is not *so* bad. But there is at least one case where M and N typically each grow linearly with the size of the codebase: the `apply` method of `FunctionN` traits.

Therefore, this commit changes the approach to make it linear, without losing `from` information. We introduce one indirection in the from-chain: a `FromDispatch(C, m)` represents a dispatch from a virtual call of `C.m`. The first time we call `C.m`, we actually do the resolutions and use `FromDispatch(C, m)` as `from`. We also store the previous `from` in the `dispatchCalledFrom` of `C.m`. For subsequent calls, we enrich `dispatchCalledFrom` but we do not redo the resolutions.

The indirection with `FromDispatch` allows to recover all the callers of an actual method, without requiring O(M*N) amount of information.

The generated .js files are unchanged.

---

On the test suite, this reduces the time spent in
"Compute reachability" by approximately 17% (from around 5.2s to around 4.3s on my machine).

---

For an unlinkable call to `Await.result`, a typical log output is now:

    Referring to non-existent class java.util.concurrent.locks.AbstractQueuedSynchronizer
      called from scala.concurrent.impl.Promise$CompletionLatch
      called from scala.concurrent.impl.Promise$DefaultPromise.tryAwait(scala.concurrent.duration.Duration)boolean
      called from scala.concurrent.impl.Promise$DefaultPromise.ready(scala.concurrent.duration.Duration,scala.concurrent.CanAwait)scala.concurrent.impl.Promise$DefaultPromise
      called from scala.concurrent.impl.Promise$DefaultPromise.result(scala.concurrent.duration.Duration,scala.concurrent.CanAwait)java.lang.Object
      dispatched from scala.concurrent.Awaitable.result(scala.concurrent.duration.Duration,scala.concurrent.CanAwait)java.lang.Object
      called from private scala.concurrent.Await$.$anonfun$result$1(scala.concurrent.Awaitable,scala.concurrent.duration.Duration)java.lang.Object
      called from scala.concurrent.Await$.result(scala.concurrent.Awaitable,scala.concurrent.duration.Duration)java.lang.Object
      called from helloworld.HelloWorld$.main([java.lang.String)void
      called from static helloworld.HelloWorld.main([java.lang.String)void
      called from core module module initializers