### PR TITLE
Reachability analysis: optimize resolution of reflective proxies.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -743,18 +743,13 @@ private final class Analyzer(config: CommonPhaseConfig,
         tryLookupMethod(proxyName).foreach(onSuccess)
       } else {
         publicMethodInfos.get(proxyName).fold {
-          workQueue.enqueue(findReflectiveTarget(proxyName)) { maybeTarget =>
-            maybeTarget.foreach { reflectiveTarget =>
-              val proxy = createReflProxy(proxyName, reflectiveTarget.methodName)
-              onSuccess(proxy)
-            }
-          }
+          findReflectiveTarget(proxyName)(onSuccess)
         } (onSuccess)
       }
     }
 
     private def findReflectiveTarget(proxyName: MethodName)(
-        implicit from: From): Future[Option[MethodInfo]] = {
+        onSuccess: MethodInfo => Unit)(implicit from: From): Unit = {
       /* The lookup for a target method in this code implements the
        * algorithm defining `java.lang.Class.getMethod`. This mimics how
        * reflective calls are implemented on the JVM, at link time.
@@ -776,9 +771,16 @@ private final class Analyzer(config: CommonPhaseConfig,
 
       val candidates = superClassesThenAncestors.map(_.findProxyMatch(proxyName))
 
-      locally {
+      val targetFuture = locally {
         implicit val iec = ec
         Future.sequence(candidates).map(_.collectFirst { case Some(m) => m })
+      }
+
+      workQueue.enqueue(targetFuture) { maybeTarget =>
+        maybeTarget.foreach { reflectiveTarget =>
+          val proxy = createReflProxy(proxyName, reflectiveTarget.methodName)
+          onSuccess(proxy)
+        }
       }
     }
 


### PR DESCRIPTION
There are several major changes, contributing together to a 20x speedup (!) of the reachability analysis time on our test suite. The speedup may not be representative of more standard codebases, which we expect not to have so many reflective calls in the first place.

---

1. Compute ancestors for reflective lookup once per class.

We extract the computation of all the ancestors, in the correct lookup order, in a private `lazy val` of type `List[ClassInfo]`.

---

2. Compute all the proxy target candidates for a class at once.

Iterating over all the public methods every time we need the candidates for a proxy is expensive. In the worst case, it can lead to a O(NxM) factor where N is the number of reflective calls, and M the number of methods in a class.

We now build a map of all the possible candidates for a class the first time one proxy is requested. Building the map is in theory O(M), and then each lookup becomes O(1). This turns the overall worst-case complexity from O(NxM) to O(N+M).

---

3. Fast, synchronous path for 0 and 1 proxy candidates.

When there is 0 or 1 proxy candidates, we can avoid all the complicated machinery to compute the most specific one. This is significant because that machinery involves Future computations.

We even push the call to `workQueue.enqueue` in the case with more than one candidate. This avoids most uses of `workQueue.enqueue` for reflective proxy reasons.

---

These optimizations were guided by a flame graph analysis.