### PR TITLE
Make the JS AST -> source step of the linker incremental.

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -127,8 +127,8 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
     }
   }
 
-  private def buildChunk(tree: js.Tree): JSChunk = {
-    val root = ClosureAstTransformer.transformScript(tree,
+  private def buildChunk(topLevelTrees: List[js.Tree]): JSChunk = {
+    val root = ClosureAstTransformer.transformScript(topLevelTrees,
         languageMode.toFeatureSet(), config.relativizeSourceMapBase)
 
     val chunk = new JSChunk("Scala.js")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -63,7 +63,10 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
         val printer = new Printers.JSTreePrinter(jsFileWriter)
         jsFileWriter.write(emitterResult.header)
         jsFileWriter.write("'use strict';\n")
-        printer.printTopLevelTree(emitterResult.body(moduleID))
+
+        for (topLevelTree <- emitterResult.body(moduleID))
+          printer.printTopLevelTree(topLevelTree)
+
         jsFileWriter.write(emitterResult.footer)
       }
 
@@ -84,7 +87,8 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
         jsFileWriter.write("'use strict';\n")
         smWriter.nextLine()
 
-        printer.printTopLevelTree(emitterResult.body(moduleID))
+        for (topLevelTree <- emitterResult.body(moduleID))
+          printer.printTopLevelTree(topLevelTree)
 
         jsFileWriter.write(emitterResult.footer)
         jsFileWriter.write("//# sourceMappingURL=" + sourceMapURI + "\n")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -726,7 +726,7 @@ object Printers {
   }
 
   class JSTreePrinterWithSourceMap(_out: Writer,
-      sourceMap: SourceMapWriter) extends JSTreePrinter(_out) {
+      sourceMap: SourceMapWriter.Builder) extends JSTreePrinter(_out) {
 
     private var column = 0
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/BasicLinkerBackendTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/BasicLinkerBackendTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker
+
+import java.nio.charset.StandardCharsets
+
+import scala.concurrent.{ExecutionContext, Future}
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.ir.Trees._
+
+import org.scalajs.junit.async._
+
+import org.scalajs.linker.interface._
+import org.scalajs.linker.standard._
+import org.scalajs.linker.testutils._
+import org.scalajs.linker.testutils.TestIRBuilder._
+
+import org.scalajs.logging._
+
+class BasicLinkerBackendTest {
+  import scala.concurrent.ExecutionContext.Implicits.global
+
+  private val BackendInvalidatedTopLevelTreesStatsMessage =
+    raw"""BasicBackend: total top-level trees: (\d+); re-computed: (\d+)""".r
+
+  /** Makes sure that linking a "substantial" program (using `println`) twice
+   *  does not invalidate any top-level tree in the second run.
+   */
+  @Test
+  def linkNoSecondAttemptInEmitter(): AsyncResult = await {
+    val classDefs = List(
+      mainTestClassDef(systemOutPrintln(str("Hello world!")))
+    )
+
+    val logger1 = new CapturingLogger
+    val logger2 = new CapturingLogger
+
+    val config = StandardConfig().withCheckIR(true)
+    val linker = StandardImpl.linker(config)
+    val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
+
+    val initializers = MainTestModuleInitializers
+    val outputDir = MemOutputDirectory()
+
+    for {
+      javalib <- TestIRRepo.javalib
+      allIRFiles = javalib ++ classDefsFiles
+      _ <- linker.link(allIRFiles, initializers, outputDir, logger1)
+      _ <- linker.link(allIRFiles, initializers, outputDir, logger2)
+    } yield {
+      val lines1 = logger1.allLogLines
+      val Seq(total1, recomputed1) =
+        lines1.assertContainsMatch(BackendInvalidatedTopLevelTreesStatsMessage).map(_.toInt)
+
+      val lines2 = logger2.allLogLines
+      val Seq(total2, recomputed2) =
+        lines2.assertContainsMatch(BackendInvalidatedTopLevelTreesStatsMessage).map(_.toInt)
+
+      // At the time of writing this test, total1 reports 382 trees
+      assertTrue(
+          s"Not enough total top-level trees (got $total1); extraction must have gone wrong",
+          total1 > 300)
+
+      assertEquals("First run must invalidate every top-level tree", total1, recomputed1)
+      assertEquals("Second run must have the same total as first run", total1, total2)
+
+      assertEquals(
+          "Second run must not invalidate any top-level tree beside the module initializer",
+          1, recomputed2)
+    }
+  }
+}


### PR DESCRIPTION
~~Based on #4815 for the purposes of performance analysis; the first two commits do not belong to this PR. But otherwise can be reviewed independently.~~

In `BasicLinkerBackend`, we now cache the JavaScript source code produced by each top-level tree, as well as the corresponding source map `Fragment`. Trees are identified with their reference identity.

The caches are stored per-`ModuleID`, since

* several modules can be written in parallel, and
* the emitter throws caches away across `ModuleID`s anyway.

This makes the tree-to-source step of our linker truly incremental.

The source maps building is incremental up to a `Fragment`. We cannot avoid a full pass for actually emitting the content, because the `name` table and `source` table are inherently global and cannot be incrementalized.

These changes bring about a 2x speedup to the "BasicBackend: Write result" step of the linker. This can be improved later by:

* caching more trees (some "rare, small" trees such as top-level exports, static initialization calls and some module-related trees
  are not cached in the `Emitter`), and
* caching the UTF-8-encoded bytes instead of the yet-to-be-encoded Strings.