### PR TITLE
Hash all js.ClassDefs generated by the compiler.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -67,8 +67,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
   val phaseName: String = "jscode"
   override val description: String = "generate JavaScript code from ASTs"
 
-  /** testing: this will be called when ASTs are generated */
-  def generatedJSAST(clDefs: List[js.ClassDef]): Unit
+  /** testing: this will be called for each generated `ClassDef`. */
+  def generatedJSAST(clDef: js.ClassDef): Unit
 
   /** Implicit conversion from nsc Position to ir.Position. */
   implicit def pos2irPos(pos: Position): ir.Position = {
@@ -423,9 +423,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           regularClasses ::: staticForwarderClasses
         }
 
-        generatedJSAST(clDefs)
-
         for (tree <- clDefs) {
+          generatedJSAST(tree)
           genIRFile(cunit, tree)
         }
       } catch {

--- a/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
@@ -40,8 +40,8 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
     }
   }
 
-  /** Called when the JS ASTs are generated. Override for testing */
-  def generatedJSAST(clDefs: List[Trees.ClassDef]): Unit = {}
+  /** Called for each generated `ClassDef`. Override for testing. */
+  def generatedJSAST(clDef: Trees.ClassDef): Unit = {}
 
   /** A trick to avoid early initializers while still enforcing that `global`
    *  is initialized early.
@@ -98,8 +98,8 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
     override val runsAfter = List("mixin")
     override val runsBefore = List("delambdafy", "cleanup", "terminal")
 
-    def generatedJSAST(clDefs: List[Trees.ClassDef]): Unit =
-      ScalaJSPlugin.this.generatedJSAST(clDefs)
+    def generatedJSAST(clDef: Trees.ClassDef): Unit =
+      ScalaJSPlugin.this.generatedJSAST(clDef)
   }
 
   override def init(options: List[String], error: String => Unit): Boolean = {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Version.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Version.scala
@@ -48,6 +48,17 @@ final class Version private (private val v: Array[Byte]) extends AnyVal {
 
   @inline
   private def isVersioned: Boolean = v != null
+
+  // For debugging purposes
+  override def toString(): String = {
+    if (v == null) {
+      "Unversioned"
+    } else {
+      val typeByte = v(0)
+      val otherBytesStr = v.iterator.drop(1).map(b => "%02x".format(b & 0xff)).mkString
+      s"Version($typeByte, $otherBytesStr)"
+    }
+  }
 }
 
 object Version {


### PR DESCRIPTION
Some `js.ClassDef`s did not go through `Hashers.hashClassDef`, notably LMF-generated classes and static forwarder classes. This caused their content to be reoptimized and re-emitted on every run.

We now hash *all* class defs in one centralized way, so that this problem does not appear in the future anymore.