### PR TITLE
Preallocate the final buffers with 110% the size of the previous run.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/ByteArrayWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/ByteArrayWriter.scala
@@ -20,6 +20,11 @@ private[backend] final class ByteArrayWriter extends OutputStream {
   private var buffer: Array[Byte] = new Array[Byte](1024)
   private var size: Int = 0
 
+  def currentSize: Int = size
+
+  def sizeHint(capacity: Int): Unit =
+    ensureCapacity(capacity)
+
   private def ensureCapacity(capacity: Int): Unit = {
     if (buffer.length < capacity)
       buffer = java.util.Arrays.copyOf(buffer, powerOfTwoAtLeast(capacity))


### PR DESCRIPTION
This means that in the common case, we will only need 0 or 1 `grow()` of the buffer.

This speeds up the back-end by about 10% in the incremental case.