### PR TITLE
Backend: Avoid doing any I/O for modules that have not changed.

### DIFF
--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/OutputDirectoryImpl.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/unstable/OutputDirectoryImpl.scala
@@ -26,9 +26,32 @@ abstract class OutputDirectoryImpl extends OutputDirectory {
    *  Writing should only result in a file write if the contents of the file
    *  actually changed. Further, if the underlying filesystem allows it, the
    *  file should be written atomically.
+   *
+   *  Calling this method is equivalent to calling
+   *  `writeFull(name, buf, skipContentCheck = false)`.
    */
   def writeFull(name: String, buf: ByteBuffer)(
       implicit ec: ExecutionContext): Future[Unit]
+
+  /** Writes to the given file.
+   *
+   *  - If `skipContentCheck` is `false`, writing should only result in a file
+   *    write if the contents of the file actually changed.
+   *  - If it is `true`, the implementation is encouraged not to check for the
+   *    file contents, and always write it; however, this not mandatory for
+   *    backward compatibility reasons.
+   *
+   *  If the underlying filesystem allows it, the file should be written
+   *  atomically.
+   *
+   *  The default implementation of this method calls `writeFull` without the
+   *  `skipContentCheck`, which is suboptimal. Therefore, it is encouraged to
+   *  override it.
+   */
+  def writeFull(name: String, buf: ByteBuffer, skipContentCheck: Boolean)(
+      implicit ec: ExecutionContext): Future[Unit] = {
+    writeFull(name, buf)
+  }
 
   /** Fully read the given file into a new ByteBuffer. */
   def readFull(name: String)(

--- a/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputDirectory.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/PathOutputDirectory.scala
@@ -43,6 +43,14 @@ object PathOutputDirectory {
       }
     }
 
+    override def writeFull(name: String, buf: ByteBuffer, skipContentCheck: Boolean)(
+        implicit ec: ExecutionContext): Future[Unit] = {
+      if (skipContentCheck)
+        writeAtomic(name, buf)
+      else
+        writeFull(name, buf)
+    }
+
     def readFull(name: String)(implicit ec: ExecutionContext): Future[ByteBuffer] =
       withChannel(getPath(name), StandardOpenOption.READ)(readFromChannel(_))
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -14,6 +14,7 @@ package org.scalajs.linker.backend
 
 import scala.concurrent._
 
+import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
 import org.scalajs.logging.Logger
@@ -45,6 +46,8 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
 
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements
 
+  private var isFirstRun: Boolean = true
+
   private val printedModuleSetCache = new PrintedModuleSetCache(config.sourceMap)
 
   override def injectedIRFiles: Seq[IRFile] = emitter.injectedIRFiles
@@ -62,64 +65,81 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
       emitter.emit(moduleSet, logger)
     }
 
-    val writer = new OutputWriter(output, config) {
-      protected def writeModule(moduleID: ModuleID, jsFileWriter: ByteArrayWriter): Unit = {
-        val printedModuleCache = printedModuleSetCache.getModuleCache(moduleID)
+    val skipContentCheck = !isFirstRun
+    isFirstRun = false
 
-        jsFileWriter.sizeHint(sizeHintFor(printedModuleCache.getPreviousFinalJSFileSize()))
+    printedModuleSetCache.startRun(moduleSet)
+    val allChanged =
+      printedModuleSetCache.updateGlobal(emitterResult.header, emitterResult.footer)
 
-        jsFileWriter.write(emitterResult.header.getBytes(StandardCharsets.UTF_8))
-        jsFileWriter.writeASCIIString("'use strict';\n")
+    val writer = new OutputWriter(output, config, skipContentCheck) {
+      protected def writeModuleWithoutSourceMap(moduleID: ModuleID, force: Boolean): Option[ByteBuffer] = {
+        val cache = printedModuleSetCache.getModuleCache(moduleID)
+        val changed = cache.update(emitterResult.body(moduleID))
 
-        for (topLevelTree <- emitterResult.body(moduleID)) {
-          val printedTree = printedModuleCache.getPrintedTree(topLevelTree)
-          jsFileWriter.write(printedTree.jsCode)
+        if (force || changed || allChanged) {
+          printedModuleSetCache.incRewrittenModules()
+
+          val jsFileWriter = new ByteArrayWriter(sizeHintFor(cache.getPreviousFinalJSFileSize()))
+
+          jsFileWriter.write(printedModuleSetCache.headerBytes)
+          jsFileWriter.writeASCIIString("'use strict';\n")
+
+          for (printedTree <- cache.printedTrees)
+            jsFileWriter.write(printedTree.jsCode)
+
+          jsFileWriter.write(printedModuleSetCache.footerBytes)
+
+          cache.recordFinalSizes(jsFileWriter.currentSize, 0)
+          Some(jsFileWriter.toByteBuffer())
+        } else {
+          None
         }
-
-        jsFileWriter.write(emitterResult.footer.getBytes(StandardCharsets.UTF_8))
-
-        printedModuleCache.recordFinalSizes(jsFileWriter.currentSize, 0)
       }
 
-      protected def writeModule(moduleID: ModuleID, jsFileWriter: ByteArrayWriter,
-          sourceMapWriter: ByteArrayWriter): Unit = {
-        val printedModuleCache = printedModuleSetCache.getModuleCache(moduleID)
+      protected def writeModuleWithSourceMap(moduleID: ModuleID, force: Boolean): Option[(ByteBuffer, ByteBuffer)] = {
+        val cache = printedModuleSetCache.getModuleCache(moduleID)
+        val changed = cache.update(emitterResult.body(moduleID))
 
-        jsFileWriter.sizeHint(sizeHintFor(printedModuleCache.getPreviousFinalJSFileSize()))
-        sourceMapWriter.sizeHint(sizeHintFor(printedModuleCache.getPreviousFinalSourceMapSize()))
+        if (force || changed || allChanged) {
+          printedModuleSetCache.incRewrittenModules()
 
-        val jsFileURI = OutputPatternsImpl.jsFileURI(config.outputPatterns, moduleID.id)
-        val sourceMapURI = OutputPatternsImpl.sourceMapURI(config.outputPatterns, moduleID.id)
+          val jsFileWriter = new ByteArrayWriter(sizeHintFor(cache.getPreviousFinalJSFileSize()))
+          val sourceMapWriter = new ByteArrayWriter(sizeHintFor(cache.getPreviousFinalSourceMapSize()))
 
-        val smWriter = new SourceMapWriter(sourceMapWriter, jsFileURI,
-            config.relativizeSourceMapBase)
+          val jsFileURI = OutputPatternsImpl.jsFileURI(config.outputPatterns, moduleID.id)
+          val sourceMapURI = OutputPatternsImpl.sourceMapURI(config.outputPatterns, moduleID.id)
 
-        jsFileWriter.write(emitterResult.header.getBytes(StandardCharsets.UTF_8))
-        for (_ <- 0 until emitterResult.header.count(_ == '\n'))
+          val smWriter = new SourceMapWriter(sourceMapWriter, jsFileURI,
+              config.relativizeSourceMapBase)
+
+          jsFileWriter.write(printedModuleSetCache.headerBytes)
+          for (_ <- 0 until printedModuleSetCache.headerNewLineCount)
+            smWriter.nextLine()
+
+          jsFileWriter.writeASCIIString("'use strict';\n")
           smWriter.nextLine()
 
-        jsFileWriter.writeASCIIString("'use strict';\n")
-        smWriter.nextLine()
+          for (printedTree <- cache.printedTrees) {
+            jsFileWriter.write(printedTree.jsCode)
+            smWriter.insertFragment(printedTree.sourceMapFragment)
+          }
 
-        for (topLevelTree <- emitterResult.body(moduleID)) {
-          val printedTree = printedModuleCache.getPrintedTree(topLevelTree)
-          jsFileWriter.write(printedTree.jsCode)
-          smWriter.insertFragment(printedTree.sourceMapFragment)
+          jsFileWriter.write(printedModuleSetCache.footerBytes)
+          jsFileWriter.write(("//# sourceMappingURL=" + sourceMapURI + "\n").getBytes(StandardCharsets.UTF_8))
+
+          smWriter.complete()
+
+          cache.recordFinalSizes(jsFileWriter.currentSize, sourceMapWriter.currentSize)
+          Some((jsFileWriter.toByteBuffer(), sourceMapWriter.toByteBuffer()))
+        } else {
+          None
         }
-
-        jsFileWriter.write(emitterResult.footer.getBytes(StandardCharsets.UTF_8))
-        jsFileWriter.write(("//# sourceMappingURL=" + sourceMapURI + "\n").getBytes(StandardCharsets.UTF_8))
-
-        smWriter.complete()
-
-        printedModuleCache.recordFinalSizes(jsFileWriter.currentSize, sourceMapWriter.currentSize)
       }
 
       private def sizeHintFor(previousSize: Int): Int =
         previousSize + (previousSize / 10)
     }
-
-    printedModuleSetCache.startRun()
 
     logger.timeFuture("BasicBackend: Write result") {
       writer.write(moduleSet)
@@ -132,15 +152,45 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
 
 private object BasicLinkerBackend {
   private final class PrintedModuleSetCache(withSourceMaps: Boolean) {
+    private var lastHeader: String = null
+    private var lastFooter: String = null
+
+    private var _headerBytesCache: Array[Byte] = null
+    private var _footerBytesCache: Array[Byte] = null
+    private var _headerNewLineCountCache: Int = 0
+
     private val modules = new java.util.concurrent.ConcurrentHashMap[ModuleID, PrintedModuleCache]
+
+    private var totalModules = 0
+    private val rewrittenModules = new java.util.concurrent.atomic.AtomicInteger(0)
 
     private var totalTopLevelTrees = 0
     private var recomputedTopLevelTrees = 0
 
-    def startRun(): Unit = {
+    def startRun(moduleSet: ModuleSet): Unit = {
+      totalModules = moduleSet.modules.size
+      rewrittenModules.set(0)
+
       totalTopLevelTrees = 0
       recomputedTopLevelTrees = 0
     }
+
+    def updateGlobal(header: String, footer: String): Boolean = {
+      if (header == lastHeader && footer == lastFooter) {
+        false
+      } else {
+        _headerBytesCache = header.getBytes(StandardCharsets.UTF_8)
+        _footerBytesCache = footer.getBytes(StandardCharsets.UTF_8)
+        _headerNewLineCountCache = _headerBytesCache.count(_ == '\n')
+        lastHeader = header
+        lastFooter = footer
+        true
+      }
+    }
+
+    def headerBytes: Array[Byte] = _headerBytesCache
+    def footerBytes: Array[Byte] = _footerBytesCache
+    def headerNewLineCount: Int = _headerNewLineCountCache
 
     def getModuleCache(moduleID: ModuleID): PrintedModuleCache = {
       val result = modules.computeIfAbsent(moduleID, { _ =>
@@ -151,6 +201,9 @@ private object BasicLinkerBackend {
       result.startRun()
       result
     }
+
+    def incRewrittenModules(): Unit =
+      rewrittenModules.incrementAndGet()
 
     def cleanAfterRun(): Unit = {
       val iter = modules.entrySet().iterator()
@@ -166,11 +219,13 @@ private object BasicLinkerBackend {
     }
 
     def logStats(logger: Logger): Unit = {
-      /* This message is extracted in BasicLinkerBackendTest to assert that we
-       * do not invalidate anything in a no-op second run.
+      /* These messages are extracted in BasicLinkerBackendTest to assert that
+       * we do not invalidate anything in a no-op second run.
        */
       logger.debug(
           s"BasicBackend: total top-level trees: $totalTopLevelTrees; re-computed: $recomputedTopLevelTrees")
+      logger.debug(
+          s"BasicBackend: total modules: $totalModules; re-written: ${rewrittenModules.get()}")
     }
   }
 
@@ -180,17 +235,18 @@ private object BasicLinkerBackend {
 
   private sealed class PrintedModuleCache {
     private var cacheUsed = false
+    private var changed = false
+    private var lastJSTrees: List[js.Tree] = Nil
+    private var printedTreesCache: List[PrintedTree] = Nil
     private val cache = new java.util.IdentityHashMap[js.Tree, PrintedTree]
 
     private var previousFinalJSFileSize: Int = 0
     private var previousFinalSourceMapSize: Int = 0
 
-    private var totalTopLevelTrees = 0
     private var recomputedTopLevelTrees = 0
 
     def startRun(): Unit = {
       cacheUsed = true
-      totalTopLevelTrees = 0
       recomputedTopLevelTrees = 0
     }
 
@@ -203,9 +259,17 @@ private object BasicLinkerBackend {
       previousFinalSourceMapSize = finalSourceMapSize
     }
 
-    def getPrintedTree(tree: js.Tree): PrintedTree = {
-      totalTopLevelTrees += 1
+    def update(newJSTrees: List[js.Tree]): Boolean = {
+      val changed = !newJSTrees.corresponds(lastJSTrees)(_ eq _)
+      this.changed = changed
+      if (changed) {
+        printedTreesCache = newJSTrees.map(getOrComputePrintedTree(_))
+        lastJSTrees = newJSTrees
+      }
+      changed
+    }
 
+    private def getOrComputePrintedTree(tree: js.Tree): PrintedTree = {
       val result = cache.computeIfAbsent(tree, { (tree: js.Tree) =>
         recomputedTopLevelTrees += 1
         computePrintedTree(tree)
@@ -224,17 +288,21 @@ private object BasicLinkerBackend {
       new PrintedTree(jsCodeWriter.toByteArray(), SourceMapWriter.Fragment.Empty)
     }
 
+    def printedTrees: List[PrintedTree] = printedTreesCache
+
     def cleanAfterRun(): Boolean = {
       if (cacheUsed) {
         cacheUsed = false
 
-        val iter = cache.entrySet().iterator()
-        while (iter.hasNext()) {
-          val printedTree = iter.next().getValue()
-          if (printedTree.cachedUsed)
-            printedTree.cachedUsed = false
-          else
-            iter.remove()
+        if (changed) {
+          val iter = cache.entrySet().iterator()
+          while (iter.hasNext()) {
+            val printedTree = iter.next().getValue()
+            if (printedTree.cachedUsed)
+              printedTree.cachedUsed = false
+            else
+              iter.remove()
+          }
         }
 
         true
@@ -243,7 +311,7 @@ private object BasicLinkerBackend {
       }
     }
 
-    def getTotalTopLevelTrees: Int = totalTopLevelTrees
+    def getTotalTopLevelTrees: Int = lastJSTrees.size
     def getRecomputedTopLevelTrees: Int = recomputedTopLevelTrees
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/ByteArrayWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/ByteArrayWriter.scala
@@ -16,14 +16,15 @@ import java.io.OutputStream
 import java.nio.ByteBuffer
 
 /** Like a `java.io.ByteArrayOutputStream` but with more control. */
-private[backend] final class ByteArrayWriter extends OutputStream {
-  private var buffer: Array[Byte] = new Array[Byte](1024)
+private[backend] final class ByteArrayWriter(originalCapacity: Int) extends OutputStream {
+  private var buffer: Array[Byte] =
+    new Array[Byte](powerOfTwoAtLeast(Math.max(originalCapacity, 1024)))
+
   private var size: Int = 0
 
-  def currentSize: Int = size
+  def this() = this(0)
 
-  def sizeHint(capacity: Int): Unit =
-    ensureCapacity(capacity)
+  def currentSize: Int = size
 
   private def ensureCapacity(capacity: Int): Unit = {
     if (buffer.length < capacity)


### PR DESCRIPTION
Based on #4821. Only the last commit belongs to this PR.

Otherwise ready for review, although I'm not super happy with the new internal `OutputWriter` API.

---

Previously, we had to read the file to check whether the bytes would be the same. Now, we can tell that a module has not changed since the previous incremental run without opening the file, avoiding any useless I/O.

We cache the list of `js.Tree`s emitted for each module, in addition to the map from those `js.Tree`s to their printed output. When re-emitting a module, we test whether the list of new JS trees is the same, and if it is, we entirely bypass the rewriting of modules.

This has no real effect on single-module outputs. However, for multi-module outputs, the perfomance improvement is massive: about a 50x (!) speedup for the back-end when changing only one source file, resulting in two output modules being re-emitted.