### PR TITLE
Upgrade to sbt 1.9.0.

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.8
+sbt.version=1.9.0


### PR DESCRIPTION
sbt 1.9.0 contains the new sbt plugin publishing mechanism. It dual-publishes sbt plugins with Ivy-style paths (invalid in Maven, although it works out when released from sbt) and valid Maven paths.

See https://github.com/sbt/sbt/issues/3410 and https://github.com/sbt/sbt/pull/7096.