### PR TITLE
Keep the analyzer alive over incremental runs

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -29,24 +29,32 @@ import org.scalajs.ir.Trees.{MemberNamespace, JSNativeLoadSpec}
 import org.scalajs.ir.Types.ClassRef
 
 import org.scalajs.linker._
+import org.scalajs.linker.frontend.IRLoader
 import org.scalajs.linker.interface.{ESVersion, ModuleKind, ModuleInitializer}
 import org.scalajs.linker.interface.unstable.ModuleInitializerImpl
 import org.scalajs.linker.standard._
 import org.scalajs.linker.standard.ModuleSet.ModuleID
 
+import org.scalajs.logging.Logger
+
 import Analysis._
 import Infos.{NamespacedMethodName, ReachabilityInfo, ReachabilityInfoInClass}
 
-private final class Analyzer(config: CommonPhaseConfig,
-    moduleInitializers: Seq[ModuleInitializer],
-    symbolRequirements: SymbolRequirement,
-    allowAddingSyntheticMethods: Boolean,
-    checkAbstractReachability: Boolean,
-    infoLoader: InfoLoader,
-    ec: ExecutionContext)
-    extends Analysis {
+final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
+    checkIR: Boolean, irLoader: IRLoader) {
 
   import Analyzer._
+
+  private val allowAddingSyntheticMethods = initial
+  private val checkAbstractReachability = initial
+
+  private val infoLoader: InfoLoader = {
+    new InfoLoader(irLoader,
+        if (!checkIR) InfoLoader.NoIRCheck
+        else if (initial) InfoLoader.InitialIRCheck
+        else InfoLoader.InternalIRCheck
+    )
+  }
 
   private val isNoModule = config.coreSpec.moduleKind == ModuleKind.NoModule
 
@@ -55,28 +63,34 @@ private final class Analyzer(config: CommonPhaseConfig,
 
   private[this] val _errors = mutable.Buffer.empty[Error]
 
-  private val workQueue = new WorkQueue(ec)
+  private var workQueue: WorkQueue = _
 
   private val fromAnalyzer = FromCore("analyzer")
 
-  private[this] var _loadedClassInfos: scala.collection.Map[ClassName, ClassInfo] = _
-
-  def classInfos: scala.collection.Map[ClassName, Analysis.ClassInfo] =
-    _loadedClassInfos
-
   private[this] val _topLevelExportInfos = mutable.Map.empty[(ModuleID, String), TopLevelExportInfo]
 
-  def topLevelExportInfos: scala.collection.Map[(ModuleID, String), Analysis.TopLevelExportInfo] =
-    _topLevelExportInfos
+  def computeReachability(moduleInitializers: Seq[ModuleInitializer],
+      symbolRequirements: SymbolRequirement, logger: Logger)(implicit ec: ExecutionContext): Future[Analysis] = {
 
-  def errors: scala.collection.Seq[Error] = _errors
+    resetState()
 
-  def computeReachability(): Future[Unit] = {
-    require(_classInfos.isEmpty, "Cannot run the same Analyzer multiple times")
+    infoLoader.update(logger)
 
-    loadObjectClass(() => loadEverything())
+    workQueue = new WorkQueue(ec)
 
-    workQueue.join().map(_ => postLoad())(ec)
+    loadObjectClass(() => loadEverything(moduleInitializers, symbolRequirements))
+
+    workQueue.join()
+      .map(_ => postLoad(moduleInitializers))(ec)
+      .andThen { case _ => infoLoader.cleanAfterRun() }
+  }
+
+  private def resetState(): Unit = {
+    objectClassInfo = null
+    workQueue = null
+    _errors.clear()
+    _classInfos.clear()
+    _topLevelExportInfos.clear()
   }
 
   private def loadObjectClass(onSuccess: () => Unit): Unit = {
@@ -85,7 +99,7 @@ private final class Analyzer(config: CommonPhaseConfig,
     /* Load the java.lang.Object class, and validate it
      * If it is missing or invalid, we're in deep trouble, and cannot continue.
      */
-    infoLoader.loadInfo(ObjectClass)(ec) match {
+    infoLoader.loadInfo(ObjectClass)(workQueue.ec) match {
       case None =>
         _errors += MissingJavaLangObjectClass(fromAnalyzer)
 
@@ -101,7 +115,8 @@ private final class Analyzer(config: CommonPhaseConfig,
     }
   }
 
-  private def loadEverything(): Unit = {
+  private def loadEverything(moduleInitializers: Seq[ModuleInitializer],
+      symbolRequirements: SymbolRequirement): Unit = {
     assert(objectClassInfo != null)
 
     implicit val from = fromAnalyzer
@@ -135,11 +150,11 @@ private final class Analyzer(config: CommonPhaseConfig,
     reachInitializers(moduleInitializers)
   }
 
-  private def postLoad(): Unit = {
+  private def postLoad(moduleInitializers: Seq[ModuleInitializer]): Analysis = {
     if (isNoModule) {
       // Check there is only a single module.
       val publicModuleIDs = (
-         topLevelExportInfos.keys.map(_._1).toList ++
+         _topLevelExportInfos.keys.map(_._1).toList ++
          moduleInitializers.map(i => ModuleID(i.moduleID))
       ).distinct
 
@@ -153,10 +168,14 @@ private final class Analyzer(config: CommonPhaseConfig,
     assert(_errors.nonEmpty || infos.size == _classInfos.size,
         "unloaded classes in post load phase")
 
-    _loadedClassInfos = infos
-
     // Reach additional data, based on reflection methods used
     reachDataThroughReflection(infos)
+
+    new Analysis {
+      val classInfos = infos
+      val topLevelExportInfos = _topLevelExportInfos
+      val errors = _errors
+    }
   }
 
   private def reachSymbolRequirement(requirement: SymbolRequirement,
@@ -350,7 +369,7 @@ private final class Analyzer(config: CommonPhaseConfig,
 
     _classInfos(className) = this
 
-    infoLoader.loadInfo(className)(ec) match {
+    infoLoader.loadInfo(className)(workQueue.ec) match {
       case Some(future) =>
         workQueue.enqueue(future)(link(_, nonExistent = false))
 
@@ -858,7 +877,7 @@ private final class Analyzer(config: CommonPhaseConfig,
 
       // Starting here, we just do data juggling, so it can run on any thread.
       locally {
-        implicit val iec = ec
+        implicit val iec = workQueue.ec
 
         val hasMoreSpecific = Future.traverse(specificityChecks)(
             checks => Future.sequence(checks).map(_.contains(true)))
@@ -1476,18 +1495,7 @@ object Analyzer {
   private val getSuperclassMethodName =
     MethodName("getSuperclass", Nil, ClassRef(ClassClass))
 
-  def computeReachability(config: CommonPhaseConfig,
-      moduleInitializers: Seq[ModuleInitializer],
-      symbolRequirements: SymbolRequirement,
-      allowAddingSyntheticMethods: Boolean,
-      checkAbstractReachability: Boolean,
-      infoLoader: InfoLoader)(implicit ec: ExecutionContext): Future[Analysis] = {
-    val analyzer = new Analyzer(config, moduleInitializers, symbolRequirements,
-        allowAddingSyntheticMethods, checkAbstractReachability, infoLoader, ec)
-    analyzer.computeReachability().map(_ => analyzer)
-  }
-
-  private class WorkQueue(ec: ExecutionContext) {
+  private class WorkQueue(val ec: ExecutionContext) {
     private val queue = new ConcurrentLinkedQueue[() => Unit]()
     private val working = new AtomicBoolean(false)
     private val pending = new AtomicInteger(0)

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -27,7 +27,7 @@ import org.scalajs.linker.frontend.IRLoader
 import org.scalajs.linker.interface.LinkingException
 import org.scalajs.linker.CollectionsCompat.MutableMapCompatOps
 
-final class InfoLoader(irLoader: IRLoader, irCheckMode: InfoLoader.IRCheckMode) {
+private[analyzer] final class InfoLoader(irLoader: IRLoader, irCheckMode: InfoLoader.IRCheckMode) {
   private var logger: Logger = _
   private val cache = mutable.Map.empty[ClassName, InfoLoader.ClassInfoCache]
 
@@ -55,7 +55,7 @@ final class InfoLoader(irLoader: IRLoader, irCheckMode: InfoLoader.IRCheckMode) 
   }
 }
 
-object InfoLoader {
+private[analyzer] object InfoLoader {
   sealed trait IRCheckMode
 
   case object NoIRCheck extends IRCheckMode

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -13,7 +13,6 @@
 package org.scalajs.linker.frontend
 
 import scala.concurrent._
-import scala.util.Try
 
 import org.scalajs.logging._
 
@@ -38,7 +37,7 @@ final class BaseLinker(config: CommonPhaseConfig, checkIR: Boolean) {
 
   private val irLoader = new FileIRLoader
   private val analyzer =
-    new Analyzer(config, initial = true, checkIR = checkIR, irLoader)
+    new Analyzer(config, initial = true, checkIR = checkIR, failOnError = true, irLoader)
   private val methodSynthesizer = new MethodSynthesizer(irLoader)
 
   def link(irInput: Seq[IRFile],
@@ -49,7 +48,7 @@ final class BaseLinker(config: CommonPhaseConfig, checkIR: Boolean) {
     val result = for {
       _ <- irLoader.update(irInput)
       analysis <- logger.timeFuture("Linker: Compute reachability") {
-        analyze(moduleInitializers, symbolRequirements, logger)
+        analyzer.computeReachability(moduleInitializers, symbolRequirements, logger)
       }
       linkResult <- logger.timeFuture("Linker: Assemble LinkedClasses") {
         assemble(moduleInitializers, analysis)
@@ -70,39 +69,6 @@ final class BaseLinker(config: CommonPhaseConfig, checkIR: Boolean) {
 
     result.andThen { case _ =>
       irLoader.cleanAfterRun()
-    }
-  }
-
-  private def analyze(moduleInitializers: Seq[ModuleInitializer],
-      symbolRequirements: SymbolRequirement, logger: Logger)(
-      implicit ec: ExecutionContext): Future[Analysis] = {
-    def reportErrors(errors: scala.collection.Seq[Analysis.Error]) = {
-      require(errors.nonEmpty)
-
-      val maxDisplayErrors = {
-        val propName = "org.scalajs.linker.maxlinkingerrors"
-        Try(System.getProperty(propName, "20").toInt).getOrElse(20).max(1)
-      }
-
-      errors
-        .take(maxDisplayErrors)
-        .foreach(logError(_, logger, Level.Error))
-
-      val skipped = errors.size - maxDisplayErrors
-      if (skipped > 0)
-        logger.log(Level.Error, s"Not showing $skipped more linking errors")
-
-      throw new LinkingException("There were linking errors")
-    }
-
-    for {
-      analysis <- analyzer.computeReachability(moduleInitializers, symbolRequirements, logger)
-    } yield {
-      if (analysis.errors.nonEmpty) {
-        reportErrors(analysis.errors)
-      }
-
-      analysis
     }
   }
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
@@ -101,17 +101,14 @@ object LinkingUtils {
     val injectedIRFiles = StandardLinkerBackend(config).injectedIRFiles
 
     val irLoader = new FileIRLoader
-    val infoLoader = new InfoLoader(irLoader, InfoLoader.InitialIRCheck)
+    val analyzer = new Analyzer(CommonPhaseConfig.fromStandardConfig(config),
+        initial = true, checkIR = true, irLoader)
     val logger = new ScalaConsoleLogger(Level.Error)
 
     for {
       baseFiles <- stdlib
       _ <- irLoader.update(classDefIRFiles ++ baseFiles ++ injectedIRFiles)
-      _ = infoLoader.update(logger)
-      analysis <- Analyzer.computeReachability(
-          CommonPhaseConfig.fromStandardConfig(config), moduleInitializers,
-          symbolRequirements, allowAddingSyntheticMethods = true,
-          checkAbstractReachability = true, infoLoader)
+      analysis <- analyzer.computeReachability(moduleInitializers, symbolRequirements, logger)
     } yield {
       analysis
     }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
@@ -102,7 +102,7 @@ object LinkingUtils {
 
     val irLoader = new FileIRLoader
     val analyzer = new Analyzer(CommonPhaseConfig.fromStandardConfig(config),
-        initial = true, checkIR = true, irLoader)
+        initial = true, checkIR = true, failOnError = false, irLoader)
     val logger = new ScalaConsoleLogger(Level.Error)
 
     for {


### PR DESCRIPTION
- Prepares for incremental analysis.
- Allows us to move the InfoLoader into the Analyzer.
- Overall more consistent.