### PR TITLE
Fix #4831: Structurally compare field defs in KnowledgeGuardian.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/OriginalName.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/OriginalName.scala
@@ -90,4 +90,12 @@ object OriginalName {
 
   def apply(name: String): OriginalName =
     apply(UTF8String(name))
+
+  def equals(x: OriginalName, y: OriginalName): Boolean =
+    if (x.isEmpty) y.isEmpty
+    else y.isDefined && java.util.Arrays.equals(x.bytes, y.bytes)
+
+  def hashCode(x: OriginalName): Int =
+    if (x.isEmpty) 0
+    else scala.util.hashing.MurmurHash3.bytesHash(x.bytes)
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -339,7 +339,8 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     implicit val pos = tree.pos
 
     val superCtorCallAndFieldDefs = if (forESClass) {
-      val fieldDefs = genFieldDefsOfScalaClass(tree.className, tree.fields)
+      val directFields = globalKnowledge.getFieldDefs(tree.className)
+      val fieldDefs = genFieldDefsOfScalaClass(tree.className, directFields)
       if (tree.superClass.isEmpty)
         fieldDefs
       else

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -794,7 +794,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
             }
 
             val enclosingClassFieldDefs =
-              globalKnowledge.getJSClassFieldDefs(enclosingClassName)
+              globalKnowledge.getFieldDefs(enclosingClassName)
 
             val fieldDefs = for {
               field <- enclosingClassFieldDefs

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -28,6 +28,9 @@ private[emitter] trait GlobalKnowledge {
   /** Tests whether the specified class name refers to an `Interface`. */
   def isInterface(className: ClassName): Boolean
 
+  /** The `FieldDef`s directly defined in a class. */
+  def getFieldDefs(className: ClassName): List[AnyFieldDef]
+
   /** All the `FieldDef`s, included inherited ones, of a Scala class.
    *
    *  It is invalid to call this method with anything but a `Class` or
@@ -77,13 +80,6 @@ private[emitter] trait GlobalKnowledge {
    *  JS class.
    */
   def getSuperClassOfJSClass(className: ClassName): ClassName
-
-  /** The `FieldDef`s of a non-native JS class.
-   *
-   *  It is invalid to call this method with a class that is not a non-native
-   *  JS class.
-   */
-  def getJSClassFieldDefs(className: ClassName): List[AnyFieldDef]
 
   /** The global variables that mirror a given static field. */
   def getStaticFieldMirrors(className: ClassName, field: FieldName): List[String]

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -179,6 +179,9 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
     def isInterface(className: ClassName): Boolean =
       classes(className).askIsInterface(this)
 
+    def getFieldDefs(className: ClassName): List[AnyFieldDef] =
+      classes(className).askFieldDefs(this)
+
     def getAllScalaClassFieldDefs(className: ClassName): List[(ClassName, List[AnyFieldDef])] =
       classes(className).askAllScalaClassFieldDefs(this)
 
@@ -202,9 +205,6 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
 
     def getSuperClassOfJSClass(className: ClassName): ClassName =
       classes(className).askJSSuperClass(this)
-
-    def getJSClassFieldDefs(className: ClassName): List[AnyFieldDef] =
-      classes(className).askJSClassFieldDefs(this)
 
     def getStaticFieldMirrors(className: ClassName, field: FieldName): List[String] =
       classes(className).askStaticFieldMirrors(this, field)
@@ -437,6 +437,12 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
       isInterface
     }
 
+    def askFieldDefs(invalidatable: Invalidatable): List[AnyFieldDef] = {
+      invalidatable.registeredTo(this)
+      fieldDefsAskers += invalidatable
+      fieldDefs
+    }
+
     def askAllScalaClassFieldDefs(
         invalidatable: Invalidatable): List[(ClassName, List[AnyFieldDef])] = {
       invalidatable.registeredTo(this)
@@ -488,12 +494,6 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
       invalidatable.registeredTo(this)
       superClassAskers += invalidatable
       superClass
-    }
-
-    def askJSClassFieldDefs(invalidatable: Invalidatable): List[AnyFieldDef] = {
-      invalidatable.registeredTo(this)
-      fieldDefsAskers += invalidatable
-      fieldDefs
     }
 
     def askStaticFieldMirrors(invalidatable: Invalidatable,


### PR DESCRIPTION
For `JSFieldDef`s, which have a `name: Tree`, this gets ugly. See the comment in the source for details.

To properly address this, we would probably need to add a `version` to `AnyFieldDef`s.