### PR TITLE
Fix #4831: Correctly compare fieldDefs in KnowledgeGuardian.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Version.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Version.scala
@@ -108,6 +108,16 @@ object Version {
     new Version(buf.array())
   }
 
+  /** Create a non-hash version from the given [[UTF8String]].
+   *
+   *  Strictly equivalent to (but potentially more efficient):
+   *  {{{
+   *  fromBytes(Array.tabulate(utf8String.length)(utf8String(_)))
+   *  }}}
+   */
+  def fromUTF8String(utf8String: UTF8String): Version =
+    make(Type.Ephemeral, utf8String.bytes)
+
   /** Create a combined, non-hash version from the given bytes.
    *
    *  Returns [[Unversioned]] if at least one of versions is [[Unversioned]].


### PR DESCRIPTION
Previously, we compared the essentially compared the nodes for identity, which causes spurious invalidations in some cases.

We cannot completely compare them structurally, because the name of `JSFieldDef`s can be arbitrary `Tree`s, which we cannot efficiently compare. Therefore, we use an elaborate combination of the version of the class, a flag for whether there is any JS field, and the list of non-JS field names. See the comment for the new method `computeFieldDefsVersion` for details.