### PR TITLE
Upgrade to sbt-header 5.9.0.

### DIFF
--- a/project/build.sbt
+++ b/project/build.sbt
@@ -1,4 +1,4 @@
-addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.0.0")
+addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.9.0")
 
 addSbtPlugin("com.typesafe" % "sbt-mima-plugin" % "0.8.1")
 


### PR DESCRIPTION
sbt-header was the only dependency for which we relied on the old Bintray/JFrog repositories. The latest version is published on Maven Central, like the rest of our dependencies.