### PR TITLE
Fix #4835: Treat excluded classes for Tagger as special hops.

### DIFF
--- a/linker/shared/src/test/scala/org/scalajs/linker/SmallModulesForSplittingTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/SmallModulesForSplittingTest.scala
@@ -12,6 +12,7 @@
 
 package org.scalajs.linker
 
+import scala.collection.mutable
 import scala.concurrent._
 
 import org.junit.Test
@@ -25,6 +26,7 @@ import org.scalajs.ir.Types._
 import org.scalajs.junit.async._
 
 import org.scalajs.linker.interface._
+import org.scalajs.linker.standard.ModuleSet
 import org.scalajs.linker.testutils.LinkingUtils._
 import org.scalajs.linker.testutils.TestIRBuilder._
 
@@ -90,6 +92,144 @@ class SmallModulesForSplittingTest {
        * - bar.B
        */
       assertEquals(5, moduleSet.modules.size)
+    }
+  }
+
+  @Test
+  def noCircularDepsThroughFineGrainedClasses_Issue4835(): AsyncResult = await {
+    /* Test a particular shape of dependencies that used to produce modules
+     * with cyclic dependencies. Because of that, it used to fail when creating
+     * the ModuleSet with
+     *   "requirement failed: Must have exactly one root module".
+     * With that `require` statement disabled in the `ModuleSet` constructor,
+     * it used to then fail in `checkNoCyclicDependencies`.
+     */
+
+    val SMF = EMF.withNamespace(MemberNamespace.PublicStatic)
+
+    def methodHolder(name: ClassName, methodName: String, body: Tree): ClassDef = {
+      classDef(name,
+        kind = ClassKind.Interface,
+        methods = List(
+          MethodDef(SMF, m(methodName, Nil, I), NON, Nil, IntType, Some(body))(
+              EOH.withNoinline(true), UNV)
+        ))
+    }
+
+    def call(name: ClassName, methodName: String): Tree =
+      ApplyStatic(EAF, name, m(methodName, Nil, I), Nil)(IntType)
+
+    val EntryPointsClass = ClassName("lib.EntryPoints")
+    val entryPointsClassDef = classDef(
+      EntryPointsClass,
+      superClass = Some(ObjectClass),
+      methods = List(
+        trivialCtor(EntryPointsClass)
+      ),
+      topLevelExportDefs = List(
+        TopLevelMethodExportDef("moda",
+            JSMethodDef(SMF, str("expa"), Nil, None, call("lib.A", "baz"))(EOH, UNV)),
+        TopLevelMethodExportDef("modb",
+            JSMethodDef(SMF, str("expb"), Nil, None, call("lib.A", "baz"))(EOH, UNV))
+      )
+    )
+
+    val classDefs = Seq(
+      entryPointsClassDef,
+      methodHolder("lib.A", "baz", BinaryOp(BinaryOp.Int_+, call("app.C", "foo"), call("lib.B", "bar"))),
+      methodHolder("lib.B", "bar", int(1)),
+      methodHolder("app.C", "foo", BinaryOp(BinaryOp.Int_+, call("lib.B", "bar"), int(1)))
+    )
+
+    val linkerConfig = StandardConfig()
+      .withModuleKind(ModuleKind.ESModule)
+      .withModuleSplitStyle(ModuleSplitStyle.SmallModulesFor(List("app")))
+      .withSourceMap(false)
+
+    for {
+      moduleSet <- linkToModuleSet(classDefs, Nil, config = linkerConfig)
+    } yield {
+      checkNoCyclicDependencies(moduleSet)
+    }
+  }
+
+  @Test
+  def noCircularDepsThroughFineGrainedClasses2_Issue4835(): AsyncResult = await {
+    /* Another situation with potential circular dependencies, which was
+     * imagined while fixing #4835.
+     */
+
+    val SMF = EMF.withNamespace(MemberNamespace.PublicStatic)
+
+    def methodHolder(name: ClassName, methodName: String, body: Tree): ClassDef = {
+      classDef(name,
+        kind = ClassKind.Interface,
+        methods = List(
+          MethodDef(SMF, m(methodName, Nil, I), NON, Nil, IntType, Some(body))(
+              EOH.withNoinline(true), UNV)
+        ))
+    }
+
+    def call(name: ClassName, methodName: String): Tree =
+      ApplyStatic(EAF, name, m(methodName, Nil, I), Nil)(IntType)
+
+    val EntryPointsClass = ClassName("entry.EntryPoints")
+    val entryPointsClassDef = classDef(
+      EntryPointsClass,
+      superClass = Some(ObjectClass),
+      methods = List(
+        trivialCtor(EntryPointsClass)
+      ),
+      topLevelExportDefs = List(
+        TopLevelMethodExportDef("moda",
+            JSMethodDef(SMF, str("expa"), Nil, None, call("app.A", "baz"))(EOH, UNV)),
+        TopLevelMethodExportDef("modb",
+            JSMethodDef(SMF, str("expb"), Nil, None, call("app.A", "baz"))(EOH, UNV))
+      )
+    )
+
+    val classDefs = Seq(
+      entryPointsClassDef,
+      methodHolder("app.A", "baz", call("lib.B", "bar")),
+      methodHolder("lib.B", "bar", call("app.C", "foo")),
+      methodHolder("app.C", "foo", call("lib.D", "bar")),
+      methodHolder("lib.D", "bar", int(1))
+    )
+
+    val linkerConfig = StandardConfig()
+      .withModuleKind(ModuleKind.ESModule)
+      .withModuleSplitStyle(ModuleSplitStyle.SmallModulesFor(List("app")))
+      .withSourceMap(false)
+
+    for {
+      moduleSet <- linkToModuleSet(classDefs, Nil, config = linkerConfig)
+    } yield {
+      checkNoCyclicDependencies(moduleSet)
+    }
+  }
+
+  private def checkNoCyclicDependencies(moduleSet: ModuleSet): Unit = {
+    val processedModuleIDs = mutable.Set.empty[ModuleSet.ModuleID]
+    var remainingModules = moduleSet.modules
+
+    /* At each step of the loop, find all the modules in `remainingModules` for
+     * which all `internalDependencies` already belong to `processedModuleIDs`.
+     * Remove them from `remainingModules` and add them to `processedModuleIDs`
+     * instead.
+     * If no such module can be found, it means that there is a cycle within
+     * the remaining ones.
+     * When `remainingModules` is empty, we have shown that there is no cycle.
+     */
+    while (remainingModules.nonEmpty) {
+      val (newRoots, nextRemaining) = remainingModules.partition { m =>
+        m.internalDependencies.forall(processedModuleIDs.contains(_))
+      }
+      if (newRoots.isEmpty)
+        fail("Found cycle in modules: " + remainingModules.map(_.id).mkString(", "))
+
+      for (root <- newRoots)
+        processedModuleIDs += root.id
+      remainingModules = nextRemaining
     }
   }
 }


### PR DESCRIPTION
Previously, we more or less abused the concept of dynamic dependencies to handle them. This was based on the observation that we "must" split modules at those boundaries. See https://github.com/scala-js/scala-js/issues/4327#issuecomment-1059984564

However, as #4835 highlights, that observation ignored one aspect of dynamic dependencies: that when A--dyn-->B, A--static-->C and B--static-->C, by the time we load `B`, we know that `C` has already been loaded, and it is therefore OK to put A and C in the same module but not B.

For the excluded classes for `SmallModulesFor`, we cannot make that assumption. On the contrary, relying on it causes a circular dependency between the A-C module and the B module.

Instead, we now handle hops into excluded classes, from non-excluded classes, as special hops that need to be tracked. In the eventual tagging scheme of a class, we include the number of hops into excluded classes that are done to reach it from a root. If several paths have different hop counts, we track all of them (in a `BitSet`).

This commit also fixes #4833.