### PR TITLE
Close #4850: Add regression tests for JS types kept only for their data.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -131,6 +131,21 @@ class ReflectionTest {
     if (hiddenJSObj.getClass() != null)
       fail("optimizer thought that hiddenJSObj.getClass() was non-null")
   }
+
+  @Test def jsTypesKeptOnlyForTheirData_Issue4850(): Unit = {
+    import JSTypesKeptOnlyForTheirData._
+
+    @noinline
+    def nameOf(cls: Class[_]): String = cls.getName()
+
+    val prefix = "org.scalajs.testsuite.compiler.ReflectionTest$JSTypesKeptOnlyForTheirData$"
+    assertEquals(prefix + "NativeClass", nameOf(classOf[NativeClass]))
+    assertEquals(prefix + "NativeObject$", nameOf(classOf[Array[NativeObject.type]].getComponentType()))
+    assertEquals(prefix + "NativeTrait", nameOf(classOf[NativeTrait]))
+    assertEquals(prefix + "NonNativeClass", nameOf(classOf[NonNativeClass]))
+    assertEquals(prefix + "NonNativeObject$", nameOf(classOf[Array[NonNativeObject.type]].getComponentType()))
+    assertEquals(prefix + "NonNativeTrait", nameOf(classOf[NonNativeTrait]))
+  }
 }
 
 object ReflectionTest {
@@ -143,4 +158,22 @@ object ReflectionTest {
 
   class OtherPrefixRenamedTestClass
 
+  object JSTypesKeptOnlyForTheirData {
+    @js.native
+    @JSGlobal("NativeClass")
+    class NativeClass extends js.Object
+
+    @js.native
+    @JSGlobal("NativeObject")
+    object NativeObject extends js.Object
+
+    @js.native
+    trait NativeTrait extends js.Object
+
+    class NonNativeClass extends js.Object
+
+    object NonNativeObject extends js.Object
+
+    trait NonNativeTrait extends js.Object
+  }
 }


### PR DESCRIPTION
The underlying issue was already fixed in ae17b935d1cd388e67c58744d69484d25e4ff78c.

On 1.13.1, those tests report three ClassDef checking errors:
```
[error] .../ReflectionTest.scala(168:12:ClassDef): Only native JS classes may have a jsNativeLoadSpec
[error] .../ReflectionTest.scala(173:11:ClassDef): JS classes and module classes must have a constructor
[error] .../ReflectionTest.scala(175:12:ClassDef): JS classes and module classes must have a constructor
```