### PR TITLE
Fix #4850: Adapt kind and jsNativeLoadSpec of non-instantiated JS types.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/ClassKind.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ClassKind.scala
@@ -50,6 +50,7 @@ sealed abstract class ClassKind {
     case _                                             => false
   }
 
+  @deprecated("not a meaningful operation", since = "1.13.2")
   def withoutModuleAccessor: ClassKind = this match {
     case ModuleClass         => Class
     case JSModuleClass       => JSClass

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/ReflectionTest.scala
@@ -131,6 +131,69 @@ class ReflectionTest {
     if (hiddenJSObj.getClass() != null)
       fail("optimizer thought that hiddenJSObj.getClass() was non-null")
   }
+
+  @Test def jsTypesKeptOnlyForTheirData_Issue4850(): Unit = {
+    import JSTypesKeptOnlyForTheirData._
+
+    @noinline
+    def nameOf(cls: Class[_]): String = cls.getName()
+
+    @inline
+    def testName(expectedShortName: String, cls: Class[_]): Unit = {
+      val prefix = "org.scalajs.testsuite.compiler.ReflectionTest$JSTypesKeptOnlyForTheirData$"
+      val expectedName = prefix + expectedShortName
+
+      assertEquals(expectedName, cls.getName()) // constant-folded
+      assertEquals(expectedName, nameOf(cls)) // evaluated at run-time
+    }
+
+    testName("NativeClass", classOf[NativeClass])
+    testName("NativeObject$", classOf[Array[NativeObject.type]].getComponentType())
+    testName("NativeTrait", classOf[NativeTrait])
+    testName("NonNativeClass", classOf[NonNativeClass])
+    testName("NonNativeObject$", classOf[Array[NonNativeObject.type]].getComponentType())
+    testName("NonNativeTrait", classOf[NonNativeTrait])
+
+    @noinline
+    def isInterfaceOf(cls: Class[_]): Boolean = cls.isInterface()
+
+    @inline
+    def testIsInterface(expected: Boolean, cls: Class[_]): Unit = {
+      assertEquals(expected, cls.isInterface()) // could be constant-folded in the future
+      assertEquals(expected, isInterfaceOf(cls)) // evaluated at run-time
+    }
+
+    // Consistent with isInterfaceForInstantiatedJSTypes()
+    testIsInterface(false, classOf[NativeClass])
+    testIsInterface(false, classOf[Array[NativeObject.type]].getComponentType())
+    testIsInterface(false, classOf[NativeTrait])
+    testIsInterface(false, classOf[NonNativeClass])
+    testIsInterface(false, classOf[Array[NonNativeObject.type]].getComponentType())
+    testIsInterface(false, classOf[NonNativeTrait])
+  }
+
+  @Test def isInterfaceForInstantiatedJSTypes(): Unit = {
+    // Make sure the instantiated non-native things are actually instantiated
+    assertEquals("function", js.typeOf(js.constructorOf[InstantiatedNonNativeClass]))
+    assertEquals("object", js.typeOf(InstantiatedNonNativeObject))
+
+    @noinline
+    def isInterfaceOf(cls: Class[_]): Boolean = cls.isInterface()
+
+    @inline
+    def testIsInterface(expected: Boolean, cls: Class[_]): Unit = {
+      assertEquals(expected, cls.isInterface()) // could be constant-folded in the future
+      assertEquals(expected, isInterfaceOf(cls)) // evaluated at run-time
+    }
+
+    // Consistent with jsTypesKeptOnlyForTheirData_Issue4850()
+    testIsInterface(false, classOf[js.Date]) // native class
+    testIsInterface(false, classOf[Array[js.Math.type]].getComponentType()) // native object
+    testIsInterface(false, classOf[js.Function0[Any]]) // native trait
+    testIsInterface(false, classOf[InstantiatedNonNativeClass])
+    testIsInterface(false, classOf[Array[InstantiatedNonNativeObject.type]].getComponentType())
+    testIsInterface(false, classOf[PseudoInstantiatedNonNativeTrait])
+  }
 }
 
 object ReflectionTest {
@@ -143,4 +206,28 @@ object ReflectionTest {
 
   class OtherPrefixRenamedTestClass
 
+  object JSTypesKeptOnlyForTheirData {
+    @js.native
+    @JSGlobal("NativeClass")
+    class NativeClass extends js.Object
+
+    @js.native
+    @JSGlobal("NativeObject")
+    object NativeObject extends js.Object
+
+    @js.native
+    trait NativeTrait extends js.Object
+
+    class NonNativeClass extends js.Object
+
+    object NonNativeObject extends js.Object
+
+    trait NonNativeTrait extends js.Object
+  }
+
+  trait PseudoInstantiatedNonNativeTrait extends js.Object
+
+  class InstantiatedNonNativeClass extends js.Object with PseudoInstantiatedNonNativeTrait
+
+  object InstantiatedNonNativeObject extends js.Object with PseudoInstantiatedNonNativeTrait
 }


### PR DESCRIPTION
When a JS type is not instantiated, it loses its constructor, which makes it invalid from the ClassDef checker's perspective. We now turn such JS types into `AbstractJSType`s, which do not need any constructor.

For native JS types, this also means that they should get rid of their `jsNativeLoadSpec`, since abstract JS types must not have one.