### PR TITLE
Fix a compiler warning coming in 2.13.11.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/MemOutputFile.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/MemOutputFile.scala
@@ -26,12 +26,12 @@ sealed trait MemOutputFile extends LinkerOutput.File {
 
 @deprecated("Part of old Linker interface. Use MemOutputDirectory instead.", "1.3.0")
 object MemOutputFile {
-  private final val name = "mem-file.js"
+  private final val MemFileName = "mem-file.js"
 
   def apply(): MemOutputFile = new Impl(MemOutputDirectory())
 
   private final class Impl(dir: MemOutputDirectory)
-      extends OutputFileImpl(name, dir) with MemOutputFile {
+      extends OutputFileImpl(MemFileName, dir) with MemOutputFile {
     def content: Array[Byte] = {
       dir.content(name).getOrElse {
         throw new IllegalStateException("content hasn't been written yet")


### PR DESCRIPTION
`name` was both inherited from the superclass, and accessible in the outer scope. Such bindings become ambiguous in Scala 3, and Scala 2.13.11 will warn about them.

---

Locally test with the latest nightlies of 2.12.18 and 2.13.11.