### PR TITLE
Safer and fixed cache invalidation in Emitter

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -794,7 +794,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
             }
 
             val enclosingClassFieldDefs =
-              globalKnowledge.getJSClassFieldDefs(enclosingClassName)
+              globalKnowledge.getFieldDefs(enclosingClassName)
 
             val fieldDefs = for {
               field <- enclosingClassFieldDefs

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -78,12 +78,8 @@ private[emitter] trait GlobalKnowledge {
    */
   def getSuperClassOfJSClass(className: ClassName): ClassName
 
-  /** The `FieldDef`s of a non-native JS class.
-   *
-   *  It is invalid to call this method with a class that is not a non-native
-   *  JS class.
-   */
-  def getJSClassFieldDefs(className: ClassName): List[AnyFieldDef]
+  /** The `FieldDef`s of a class. */
+  def getFieldDefs(className: ClassName): List[AnyFieldDef]
 
   /** The global variables that mirror a given static field. */
   def getStaticFieldMirrors(className: ClassName, field: FieldName): List[String]

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -202,8 +202,8 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
     def getSuperClassOfJSClass(className: ClassName): ClassName =
       classes(className).askJSSuperClass(this)
 
-    def getJSClassFieldDefs(className: ClassName): List[AnyFieldDef] =
-      classes(className).askJSClassFieldDefs(this)
+    def getFieldDefs(className: ClassName): List[AnyFieldDef] =
+      classes(className).askFieldDefs(this)
 
     def getStaticFieldMirrors(className: ClassName, field: FieldName): List[String] =
       classes(className).askStaticFieldMirrors(this, field)
@@ -449,7 +449,7 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
       superClass
     }
 
-    def askJSClassFieldDefs(invalidatable: Invalidatable): List[AnyFieldDef] = {
+    def askFieldDefs(invalidatable: Invalidatable): List[AnyFieldDef] = {
       invalidatable.registeredTo(this)
       fieldDefsAskers += invalidatable
       fieldDefs


### PR DESCRIPTION
We never pass a full LinkedClass anymore to a generating function
under cache. This makes it possible to check (manually) at the call
boundary that the cache has the necessary invalidation.

In some places, this means we need to retrieve fields from
GlobalKnowledge (because they are non-trivial to check for equality,
we re-use the machinery).

We also fix the invalidation of FullClassCache surfaced by this
change.