### PR TITLE
Fix #4850: Handle JS classes that survive only for their data.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/ClassKind.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ClassKind.scala
@@ -50,6 +50,7 @@ sealed abstract class ClassKind {
     case _                                             => false
   }
 
+  @deprecated("not a meaningful operation", since = "1.13.2")
   def withoutModuleAccessor: ClassKind = this match {
     case ModuleClass         => Class
     case JSModuleClass       => JSClass

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -57,11 +57,11 @@ object Analysis {
     def nonExistent: Boolean
     /** For a Scala class, it is instantiated with a `New`; for a JS class,
      *  its constructor is accessed with a `JSLoadConstructor` or because it
-     *  is needed for a subclass.
+     *  is needed for a subclass. For modules (Scala or JS), the module is
+     *  accessed.
      */
     def isInstantiated: Boolean
     def isAnySubclassInstantiated: Boolean
-    def isModuleAccessed: Boolean
     def areInstanceTestsUsed: Boolean
     def isDataAccessed: Boolean
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -582,7 +582,7 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
 
     var isInstantiated: Boolean = false
     var isAnySubclassInstantiated: Boolean = false
-    var isModuleAccessed: Boolean = false
+    private var isModuleAccessed: Boolean = false
     var areInstanceTestsUsed: Boolean = false
     var isDataAccessed: Boolean = false
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -88,7 +88,7 @@ private[analyzer] object InfoLoader {
 
               case InfoLoader.InitialIRCheck =>
                 val errorCount = ClassDefChecker.check(tree,
-                    allowReflectiveProxies = false, allowTransients = false, logger)
+                    postBaseLinker = false, postOptimizer = false, logger)
                 if (errorCount != 0) {
                   throw new LinkingException(
                       s"There were $errorCount ClassDef checking errors.")
@@ -96,7 +96,7 @@ private[analyzer] object InfoLoader {
 
               case InfoLoader.InternalIRCheck =>
                 val errorCount = ClassDefChecker.check(tree,
-                    allowReflectiveProxies = true, allowTransients = true, logger)
+                    postBaseLinker = true, postOptimizer = true, logger)
                 if (errorCount != 0) {
                   throw new LinkingException(
                       s"There were $errorCount ClassDef checking errors after optimizing. " +

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -629,9 +629,10 @@ final class Emitter(config: Emitter.Config) {
       }
     }
 
-    if (linkedClass.kind.hasModuleAccessor)
+    if (linkedClass.kind.hasModuleAccessor && linkedClass.hasInstances) {
       addToMain(classTreeCache.moduleAccessor.getOrElseUpdate(
           classEmitter.genModuleAccessor(className, kind)(moduleContext, classCache, linkedClass.pos)))
+    }
 
     // Static fields
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -147,15 +147,11 @@ private[frontend] object BaseLinker {
 
     val allMethods = methods ++ syntheticMethodDefs
 
-    val kind =
-      if (classInfo.isModuleAccessed) classDef.kind
-      else classDef.kind.withoutModuleAccessor
-
     val ancestors = classInfo.ancestors.map(_.className)
 
     val linkedClass = new LinkedClass(
         classDef.name,
-        kind,
+        classDef.kind,
         classDef.jsClassCaptures,
         classDef.superClass,
         classDef.interfaces,


### PR DESCRIPTION
There were several interleaved issues with JS classes (native or not, module or not) that survived the base linker only for their class data:

- Non-native classes lose their `jsConstructorDef` (which is what caused the symptoms in the issue).
- Non-native non-module classes generate a `Class.isInstance` test that tries to access a never-declared `$a_C()` accessor.
- Module classes lose their module status, triggering the wrong conditions for the `Class.isInstance` tests later on.

Some related issues about module accessors were previously handled by patching `ClassKind`s. For module classes whose module accessor was not used, we patched the kind to a corresponding kind without module accessor. This was problematic as well: it caused the third issue above, as well as making the kind unstable over incremental runs (although we tend to assume that the kind is covered by the class version).

We solve all these issues at once, by taking a much more principled approach:

- We never change the kind of classes.
- After base linking, we tolerate `ClassDef`s without constructors even if they are module classes and/or non-native JS classes.
- In the emitter, we adjust the generation of module accessors and `Class.isInstance` tests to whether the class effectively has instances.

---

This is a revisit of #4854.