### PR TITLE
Deprecate broken SymbolRequirement.optional

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
@@ -79,13 +79,8 @@ object SymbolRequirement {
       CallStaticMethod(origin, className, methodName)
     }
 
-    def optional(requirement: SymbolRequirement): SymbolRequirement = {
-      requirement match {
-        case NoRequirement      => NoRequirement
-        case optional: Optional => optional
-        case _                  => requirement
-      }
-    }
+    @deprecated("broken (not actually optional), do not use", "1.13.2")
+    def optional(requirement: SymbolRequirement): SymbolRequirement = requirement
 
     def multiple(requirements: SymbolRequirement*): SymbolRequirement =
       multipleInternal(requirements.toList)
@@ -122,8 +117,6 @@ object SymbolRequirement {
         extends SymbolRequirement
     final case class CallStaticMethod(origin: String, className: ClassName,
         methodName: MethodName)
-        extends SymbolRequirement
-    final case class Optional(requirement: SymbolRequirement)
         extends SymbolRequirement
     final case class Multiple(requirements: List[SymbolRequirement])
         extends SymbolRequirement

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -8,6 +8,11 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
+    // private[linker], not an issue
+    exclude[MissingClassProblem](
+        "org.scalajs.linker.standard.SymbolRequirement$Nodes$Optional"),
+    exclude[MissingClassProblem](
+        "org.scalajs.linker.standard.SymbolRequirement$Nodes$Optional$"),
   )
 
   val LinkerInterface = Seq(


### PR DESCRIPTION
Optional requirements would be much harder to get to work in an incremental analysis scenario.

Luckily, the implementation was always broken (observe how Nodes.Optional is never instantiated).

Therefore, we simply deprecate the broken factory and remove the unreachable implementation.