### PR TITLE
RFC: Move symbolRequirements to the linker frontend constructor

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/StandardImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/StandardImpl.scala
@@ -23,8 +23,10 @@ object StandardImpl {
     new StandardIRFileCache(config)
 
   def linker(config: StandardConfig): Linker = {
-    StandardLinkerImpl(StandardLinkerFrontend(config),
-        StandardLinkerBackend(config))
+    val backend = StandardLinkerBackend(config)
+    val frontend = StandardLinkerFrontend(config, backend.symbolRequirements)
+
+    StandardLinkerImpl(frontend, backend)
   }
 
   def clearableLinker(config: StandardConfig): ClearableLinker =

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -41,7 +41,7 @@ import Analysis._
 import Infos.{NamespacedMethodName, ReachabilityInfo, ReachabilityInfoInClass}
 
 final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
-    checkIR: Boolean, failOnError: Boolean, irLoader: IRLoader) {
+    checkIR: Boolean, failOnError: Boolean, irLoader: IRLoader, symbolRequirements: SymbolRequirement) {
 
   import Analyzer._
 
@@ -69,8 +69,8 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
 
   private[this] val _topLevelExportInfos = mutable.Map.empty[(ModuleID, String), TopLevelExportInfo]
 
-  def computeReachability(moduleInitializers: Seq[ModuleInitializer],
-      symbolRequirements: SymbolRequirement, logger: Logger)(implicit ec: ExecutionContext): Future[Analysis] = {
+  def computeReachability(moduleInitializers: Seq[ModuleInitializer], logger: Logger)(
+      implicit ec: ExecutionContext): Future[Analysis] = {
 
     resetState()
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -26,22 +26,21 @@ import org.scalajs.linker.standard.ModuleSet.ModuleID
 import org.scalajs.linker.analyzer._
 
 /** Does a dead code elimination pass on a [[LinkingUnit]]. */
-final class Refiner(config: CommonPhaseConfig, checkIR: Boolean) {
+final class Refiner(config: CommonPhaseConfig, checkIR: Boolean, symbolRequirements: SymbolRequirement) {
   import Refiner._
 
   private val irLoader = new ClassDefIRLoader
   private val analyzer =
-    new Analyzer(config, initial = false, checkIR = checkIR, failOnError = true, irLoader)
+    new Analyzer(config, initial = false, checkIR = checkIR, failOnError = true, irLoader, symbolRequirements)
 
   def refine(classDefs: Seq[(ClassDef, Version)],
-      moduleInitializers: List[ModuleInitializer],
-      symbolRequirements: SymbolRequirement, logger: Logger)(
+      moduleInitializers: List[ModuleInitializer], logger: Logger)(
       implicit ec: ExecutionContext): Future[LinkingUnit] = {
 
     irLoader.update(classDefs)
 
     val analysis = logger.timeFuture("Refiner: Compute reachability") {
-      analyzer.computeReachability(moduleInitializers, symbolRequirements, logger)
+      analyzer.computeReachability(moduleInitializers, logger)
     }
 
     for {

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerFrontend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerFrontend.scala
@@ -34,7 +34,6 @@ abstract class LinkerFrontend {
 
   /** Link and optionally optimize the given IR to a [[ModuleSet]]. */
   def link(irFiles: Seq[IRFile],
-      moduleInitializers: Seq[ModuleInitializer],
-      symbolRequirements: SymbolRequirement, logger: Logger)(
+      moduleInitializers: Seq[ModuleInitializer], logger: Logger)(
       implicit ec: ExecutionContext): Future[ModuleSet]
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerFrontend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerFrontend.scala
@@ -16,13 +16,13 @@ import org.scalajs.linker.interface.StandardConfig
 import org.scalajs.linker.frontend.LinkerFrontendImpl
 
 object StandardLinkerFrontend {
-  def apply(config: StandardConfig): LinkerFrontend = {
+  def apply(config: StandardConfig, backendRequirements: SymbolRequirement): LinkerFrontend = {
     val frontendConfig = LinkerFrontendImpl.Config()
       .withCommonConfig(CommonPhaseConfig.fromStandardConfig(config))
       .withModuleSplitStyle(config.moduleSplitStyle)
       .withCheckIR(config.checkIR)
       .withOptimizer(config.optimizer)
 
-    LinkerFrontendImpl(frontendConfig)
+    LinkerFrontendImpl(frontendConfig, backendRequirements)
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerImpl.scala
@@ -42,8 +42,7 @@ private final class StandardLinkerImpl private (
 
     checkValid()
       .flatMap(_ => frontend.link(
-          irFiles ++ backend.injectedIRFiles, moduleInitializers,
-          backend.symbolRequirements, logger))
+          irFiles ++ backend.injectedIRFiles, moduleInitializers, logger))
       .flatMap(linkingUnit => backend.emit(linkingUnit, output, logger))
       .andThen { case t if t.isFailure => _valid = false }
       .andThen { case t => _linking.set(false) }

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -201,11 +201,12 @@ object IRCheckerTest {
     val config = StandardConfig()
       .withCheckIR(true)
       .withOptimizer(false)
-    val linkerFrontend = StandardLinkerFrontend(config)
 
     val noSymbolRequirements = SymbolRequirement
       .factory("IRCheckerTest")
       .none()
+
+    val linkerFrontend = StandardLinkerFrontend(config, noSymbolRequirements)
 
     TestIRRepo.minilib.flatMap { stdLibFiles =>
       val irFiles = (
@@ -213,7 +214,7 @@ object IRCheckerTest {
           classDefs.map(MemClassDefIRFile(_))
       )
 
-      linkerFrontend.link(irFiles, moduleInitializers, noSymbolRequirements, logger)
+      linkerFrontend.link(irFiles, moduleInitializers, logger)
     }.map(_ => ())
   }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -47,15 +47,16 @@ class ClassDefCheckerTest {
     val config = StandardConfig()
       .withCheckIR(true)
       .withOptimizer(false)
-    val linkerFrontend = StandardLinkerFrontend(config)
 
     val loadASymbolRequirements = SymbolRequirement
       .factory("ClassDefCheckerTest")
       .classData("A")
 
+    val linkerFrontend = StandardLinkerFrontend(config, loadASymbolRequirements)
+
     TestIRRepo.minilib.flatMap { stdLibFiles =>
       val irFiles = stdLibFiles :+ MemClassDefIRFile(wrongClassDef)
-      linkerFrontend.link(irFiles, Nil, loadASymbolRequirements, NullLogger)
+      linkerFrontend.link(irFiles, Nil, NullLogger)
     }.failed.map { th =>
       assertTrue(th.toString(), th.isInstanceOf[LinkingException])
     }


### PR DESCRIPTION
It has always been the case that symbolRequirements cannot change over incremental linker runs. However, the current API does not make this explicit in the inner components (notably the Analyzer).

We move the symbolRequirements from the relevant method calls to the constructors to make this explicit.