### PR TITLE
Make j.l.Class extend j.io.Serializable and j.l.constant.Constable.

### DIFF
--- a/javalib/src/main/scala/java/lang/Class.scala
+++ b/javalib/src/main/scala/java/lang/Class.scala
@@ -12,6 +12,9 @@
 
 package java.lang
 
+import java.lang.constant.Constable
+import java.io.Serializable
+
 import scala.scalajs.js
 
 @js.native
@@ -31,7 +34,9 @@ private trait ScalaJSClassData[A] extends js.Object {
   def newArrayOfThisClass(dimensions: js.Array[Int]): AnyRef = js.native
 }
 
-final class Class[A] private (data0: Object) extends Object {
+final class Class[A] private (data0: Object)
+    extends Object with Serializable with Constable {
+
   private[this] val data: ScalaJSClassData[A] =
     data0.asInstanceOf[ScalaJSClassData[A]]
 

--- a/test-suite/shared/src/test/require-jdk15/org/scalajs/testsuite/javalib/lang/ConstableTest.scala
+++ b/test-suite/shared/src/test/require-jdk15/org/scalajs/testsuite/javalib/lang/ConstableTest.scala
@@ -33,6 +33,7 @@ class ConstableTest {
     test(true, 1.5f)
     test(true, 1.4)
     test(true, "foo")
+    test(true, classOf[Product])
 
     test(false, null)
     test(false, ())

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
@@ -47,6 +47,15 @@ class ClassTest {
       classOf[java.lang.Double]
   )
 
+  @Test def hierarchy(): Unit = {
+    def cls: Class[Product] = classOf[Product]
+
+    def serializable: java.io.Serializable = cls
+
+    // prevent DCE with trivial tests
+    assertSame(cls, serializable)
+  }
+
   @Test def getPrimitiveTypeName(): Unit = {
     @noinline
     def testNoInline(expected: String, cls: Class[_]): Unit =


### PR DESCRIPTION
This commit addresses https://github.com/lampepfl/dotty/issues/17542.