### PR TITLE
Fix #4865: Synthesize non-existing constructor in the Constructor namespace.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -646,19 +646,19 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
       }
 
       if (candidatesIterator.isEmpty)
-        createNonExistentMethod(methodName)
+        createNonExistentPublicMethod(methodName)
       else
         candidatesIterator.next()
     }
 
     def lookupMethod(methodName: MethodName): MethodInfo = {
       tryLookupMethod(methodName).getOrElse {
-        createNonExistentMethod(methodName)
+        createNonExistentPublicMethod(methodName)
       }
     }
 
-    private def createNonExistentMethod(methodName: MethodName): MethodInfo = {
-      val syntheticData = makeSyntheticMethodInfo(methodName)
+    private def createNonExistentPublicMethod(methodName: MethodName): MethodInfo = {
+      val syntheticData = makeSyntheticMethodInfo(methodName, MemberNamespace.Public)
       val m = new MethodInfo(this, syntheticData)
       m.nonExistent = true
       publicMethodInfos += methodName -> m
@@ -757,6 +757,7 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
 
       val syntheticInfo = makeSyntheticMethodInfo(
           methodName = methodName,
+          namespace = MemberNamespace.Public,
           methodsCalledStatically = List(
               targetOwner.className -> NamespacedMethodName(MemberNamespace.Public, methodName)))
       val m = new MethodInfo(this, syntheticInfo)
@@ -951,6 +952,7 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
 
       val syntheticInfo = makeSyntheticMethodInfo(
           methodName = proxyName,
+          namespace = MemberNamespace.Public,
           methodsCalled = List(this.className -> targetName))
       val m = new MethodInfo(this, syntheticInfo)
       m.syntheticKind = MethodSyntheticKind.ReflectiveProxy(targetName)
@@ -1479,13 +1481,13 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
   private def createMissingClassInfo(className: ClassName): Infos.ClassInfo = {
     new Infos.ClassInfoBuilder(className, ClassKind.Class,
         superClass = Some(ObjectClass), interfaces = Nil, jsNativeLoadSpec = None)
-      .addMethod(makeSyntheticMethodInfo(NoArgConstructorName))
+      .addMethod(makeSyntheticMethodInfo(NoArgConstructorName, MemberNamespace.Constructor))
       .result()
   }
 
   private def makeSyntheticMethodInfo(
       methodName: MethodName,
-      namespace: MemberNamespace = MemberNamespace.Public,
+      namespace: MemberNamespace,
       methodsCalled: List[(ClassName, MethodName)] = Nil,
       methodsCalledStatically: List[(ClassName, NamespacedMethodName)] = Nil,
       instantiatedClasses: List[ClassName] = Nil

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -86,12 +86,12 @@ object TestIRBuilder {
     )
   }
 
-  def trivialCtor(enclosingClassName: ClassName): MethodDef = {
+  def trivialCtor(enclosingClassName: ClassName, parentClassName: ClassName = ObjectClass): MethodDef = {
     val flags = MemberFlags.empty.withNamespace(MemberNamespace.Constructor)
     MethodDef(flags, MethodIdent(NoArgConstructorName), NON, Nil, NoType,
         Some(ApplyStatically(EAF.withConstructor(true),
             This()(ClassType(enclosingClassName)),
-            ObjectClass, MethodIdent(NoArgConstructorName),
+            parentClassName, MethodIdent(NoArgConstructorName),
             Nil)(NoType)))(
         EOH, UNV)
   }


### PR DESCRIPTION
When we link a class extending a non-existing class, we generate a synthetic constructor to avoid follow-up errors. However, we mistakenly put it in the Public namespace, which is invalid. When combined with a reflective call somewhere in the codebase, this triggered the creation of a reflective proxy candidate name for the constructor. That is non-sensical, and was caught by an `IllegalArgumentException` in the `MethodName.reflectiveProxy` constructor.