### PR TITLE
Use standard loading mechanism for jl.Object in Analyzer

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -165,7 +165,6 @@ object Analysis {
     def from: From
   }
 
-  final case class MissingJavaLangObjectClass(from: From) extends Error
   final case class CycleInInheritanceChain(encodedClassNames: List[ClassName], from: From) extends Error
   final case class MissingClass(info: ClassInfo, from: From) extends Error
 
@@ -216,8 +215,6 @@ object Analysis {
 
   def logError(error: Error, logger: Logger, level: Level): Unit = {
     val headMsg = error match {
-      case MissingJavaLangObjectClass(_) =>
-        "Fatal error: java.lang.Object is missing"
       case CycleInInheritanceChain(encodedClassNames, _) =>
         ("Fatal error: cycle in inheritance chain involving " +
             encodedClassNames.map(_.nameString).mkString(", "))

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -461,15 +461,11 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
     val isNativeJSClass =
       kind == ClassKind.NativeJSClass || kind == ClassKind.NativeJSModuleClass
 
-    // Note: j.l.Object is special and is validated upfront
-
     val superClass: Option[ClassInfo] =
-      if (className == ObjectClass) unvalidatedSuperClass
-      else validateSuperClass(unvalidatedSuperClass)
+      validateSuperClass(unvalidatedSuperClass)
 
     val interfaces: List[ClassInfo] =
-      if (className == ObjectClass) unvalidatedInterfaces
-      else validateInterfaces(unvalidatedInterfaces)
+      validateInterfaces(unvalidatedInterfaces)
 
     /** Ancestors of this class or interface.
      *
@@ -497,6 +493,11 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
       def from = FromClass(this)
 
       kind match {
+        case _ if className == ObjectClass =>
+          assert(superClass.isEmpty)
+
+          None
+
         case ClassKind.Class | ClassKind.ModuleClass | ClassKind.HijackedClass =>
           val superCl = superClass.get // checked by ClassDef checker.
           if (superCl.kind != ClassKind.Class) {

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -51,7 +51,10 @@ class AnalyzerTest {
   @Test
   def missingJavaLangObject(): AsyncResult = await {
     val analysis = computeAnalysis(Nil, stdlib = TestIRRepo.empty)
-    assertExactErrors(analysis, MissingJavaLangObjectClass(fromAnalyzer))
+    assertContainsError("MissingClass(jlObject)", analysis) {
+      case MissingClass(ClsInfo(name), fromAnalyzer) =>
+        name == ObjectClass.nameString
+    }
   }
 
   @Test
@@ -61,7 +64,10 @@ class AnalyzerTest {
     val analysis = computeAnalysis(classDefs,
         reqsFactory.classData("A"), stdlib = TestIRRepo.empty)
 
-    assertExactErrors(analysis, MissingJavaLangObjectClass(fromAnalyzer))
+    assertContainsError("MissingClass(jlObject)", analysis) {
+      case MissingClass(ClsInfo(name), fromAnalyzer) =>
+        name == ObjectClass.nameString
+    }
   }
 
   @Test

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -55,6 +55,16 @@ class AnalyzerTest {
   }
 
   @Test
+  def missingJavaLangObjectButOthers(): AsyncResult = await {
+    val classDefs = Seq(classDef("A", superClass = Some(ObjectClass)))
+
+    val analysis = computeAnalysis(classDefs,
+        reqsFactory.classData("A"), stdlib = TestIRRepo.empty)
+
+    assertExactErrors(analysis, MissingJavaLangObjectClass(fromAnalyzer))
+  }
+
+  @Test
   def cycleInInheritanceChainThroughParentClasses(): AsyncResult = await {
     val classDefs = Seq(
         classDef("A", superClass = Some("B")),


### PR DESCRIPTION
Discovered as a simplification while working on https://github.com/scala-js/scala-js/issues/1626.

This also exposes a latent bug in the class loading sequence: the
Analyzer is built with the assumption that pending tasks never drop to
zero until the whole analysis is completed.

However, our loading sequence violated this assumption: since the
constructor of LoadingClass scheduled info loading immediately, it was
possible for info loading to complete before linking is requested on
the class. If this condition happens on the initial calling
thread (which itself is not tracked as a "task"), the pending task
count would drop to zero.