### PR TITLE
Parallelize the Analyzer

### DIFF
--- a/linker/js/src/main/scala/org/scalajs/linker/analyzer/Platform.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/analyzer/Platform.scala
@@ -1,0 +1,19 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.analyzer
+
+import scala.collection.mutable
+
+private[analyzer] object Platform {
+  def emptyThreadSafeMap[K, V]: mutable.Map[K, V] = mutable.Map.empty
+}

--- a/linker/js/src/main/scala/org/scalajs/linker/analyzer/Platform.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/analyzer/Platform.scala
@@ -13,7 +13,13 @@
 package org.scalajs.linker.analyzer
 
 import scala.collection.mutable
+import scala.concurrent.ExecutionContext
 
 private[analyzer] object Platform {
   def emptyThreadSafeMap[K, V]: mutable.Map[K, V] = mutable.Map.empty
+
+  def adjustExecutionContextForParallelism(ec: ExecutionContext,
+      parallel: Boolean): ExecutionContext = {
+    ec // we're never parallel on JS
+  }
 }

--- a/linker/jvm/src/main/scala/org/scalajs/linker/analyzer/Platform.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/analyzer/Platform.scala
@@ -14,7 +14,23 @@ package org.scalajs.linker.analyzer
 
 import scala.collection.mutable
 import scala.collection.concurrent.TrieMap
+import scala.concurrent.ExecutionContext
+
+import java.util.concurrent.Executors
 
 private[analyzer] object Platform {
   def emptyThreadSafeMap[K, V]: mutable.Map[K, V] = TrieMap.empty
+
+  def adjustExecutionContextForParallelism(ec: ExecutionContext,
+      parallel: Boolean): ExecutionContext = {
+    /* Parallel is the default. Parallelism is disabled (likely for debugging),
+     * we create our own single thread executor. This is for sure not the most
+     * efficient, but it is simpler than, say, attempting to build single thread
+     * execution on top of an arbitrary execution context.
+     * Further, if parallel is false, we do not expect that speed is the primary
+     * aim of the execution.
+     */
+    if (parallel) ec
+    else ExecutionContext.fromExecutorService(Executors.newSingleThreadExecutor())
+  }
 }

--- a/linker/jvm/src/main/scala/org/scalajs/linker/analyzer/Platform.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/analyzer/Platform.scala
@@ -1,0 +1,20 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.analyzer
+
+import scala.collection.mutable
+import scala.collection.concurrent.TrieMap
+
+private[analyzer] object Platform {
+  def emptyThreadSafeMap[K, V]: mutable.Map[K, V] = TrieMap.empty
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -78,7 +78,7 @@ object Analysis {
 
     def linkedFrom: scala.collection.Seq[From]
     def instantiatedFrom: scala.collection.Seq[From]
-    def dispatchCalledFrom: scala.collection.Map[MethodName, scala.collection.Seq[From]]
+    def dispatchCalledFrom(methodName: MethodName): Option[scala.collection.Seq[From]]
     def methodInfos(
         namespace: MemberNamespace): scala.collection.Map[MethodName, MethodInfo]
 
@@ -309,7 +309,7 @@ object Analysis {
         }
 
         def followDispatch(fromDispatch: FromDispatch): Option[From] =
-          fromDispatch.classInfo.dispatchCalledFrom.get(fromDispatch.methodName).flatMap(_.lastOption)
+          fromDispatch.classInfo.dispatchCalledFrom(fromDispatch.methodName).flatMap(_.lastOption)
 
         optFrom match {
           case None =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -69,7 +69,7 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
 
   private val fromAnalyzer = FromCore("analyzer")
 
-  private[this] val _topLevelExportInfos = mutable.Map.empty[(ModuleID, String), TopLevelExportInfo]
+  private[this] val _topLevelExportInfos: mutable.Map[(ModuleID, String), TopLevelExportInfo] = emptyThreadSafeMap
 
   def computeReachability(moduleInitializers: Seq[ModuleInitializer],
       symbolRequirements: SymbolRequirement, logger: Logger)(implicit ec: ExecutionContext): Future[Analysis] = {
@@ -1018,9 +1018,7 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
         val info = new TopLevelExportInfo(className, tle)
         info.reach()
 
-        _topLevelExportInfos.get(key).fold[Unit] {
-          _topLevelExportInfos.put(key, info)
-        } { other =>
+        _topLevelExportInfos.put(key, info).foreach { other =>
           _errors ::= ConflictingTopLevelExport(tle.moduleID, tle.exportName, List(info, other))
         }
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -618,7 +618,8 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
     val staticFieldsRead: mutable.Set[FieldName] = mutable.Set.empty
     val staticFieldsWritten: mutable.Set[FieldName] = mutable.Set.empty
 
-    val jsNativeMembersUsed: mutable.Set[MethodName] = mutable.Set.empty
+    private[this] val _jsNativeMembersUsed: mutable.Map[MethodName, Unit] = emptyThreadSafeMap
+    def jsNativeMembersUsed: scala.collection.Set[MethodName] = _jsNativeMembersUsed.keySet
 
     val jsNativeLoadSpec: Option[JSNativeLoadSpec] = data.jsNativeLoadSpec
 
@@ -1213,7 +1214,7 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
     def useJSNativeMember(name: MethodName)(
         implicit from: From): Option[JSNativeLoadSpec] = {
       val maybeJSNativeLoadSpec = data.jsNativeMembers.get(name)
-      if (jsNativeMembersUsed.add(name)) {
+      if (_jsNativeMembersUsed.put(name, ()).isEmpty) {
         maybeJSNativeLoadSpec match {
           case None =>
             _errors ::= MissingJSNativeMember(this, name, from)

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -37,7 +37,7 @@ import org.scalajs.linker.standard.ModuleSet.ModuleID
 
 import org.scalajs.logging._
 
-import Platform.emptyThreadSafeMap
+import Platform._
 
 import Analysis._
 import Infos.{NamespacedMethodName, ReachabilityInfo, ReachabilityInfoInClass}
@@ -72,6 +72,14 @@ final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
   private[this] val _topLevelExportInfos: mutable.Map[(ModuleID, String), TopLevelExportInfo] = emptyThreadSafeMap
 
   def computeReachability(moduleInitializers: Seq[ModuleInitializer],
+      symbolRequirements: SymbolRequirement, logger: Logger)(implicit ec: ExecutionContext): Future[Analysis] = {
+
+    computeInternal(moduleInitializers, symbolRequirements, logger)(
+        adjustExecutionContextForParallelism(ec, config.parallel))
+  }
+
+  /** Internal helper to isolate the execution context. */
+  private def computeInternal(moduleInitializers: Seq[ModuleInitializer],
       symbolRequirements: SymbolRequirement, logger: Logger)(implicit ec: ExecutionContext): Future[Analysis] = {
 
     resetState()

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -27,9 +27,11 @@ import org.scalajs.linker.frontend.IRLoader
 import org.scalajs.linker.interface.LinkingException
 import org.scalajs.linker.CollectionsCompat.MutableMapCompatOps
 
+import Platform.emptyThreadSafeMap
+
 private[analyzer] final class InfoLoader(irLoader: IRLoader, irCheckMode: InfoLoader.IRCheckMode) {
   private var logger: Logger = _
-  private val cache = mutable.Map.empty[ClassName, InfoLoader.ClassInfoCache]
+  private val cache = emptyThreadSafeMap[ClassName, InfoLoader.ClassInfoCache]
 
   def update(logger: Logger): Unit = {
     this.logger = logger


### PR DESCRIPTION
Leads to almost 2x speedup of "Compute Reachability".

```
> d %>% group_by(op, variant) %>% summarize(median(t_ns))
`summarise()` has grouped output by 'op'. You can override using the
`.groups` argument.
# A tibble: 6 × 3
# Groups:   op [2]
  op                            variant  `median(t_ns)`
  <fct>                         <fct>             <dbl>
1 Linker: Compute reachability  main         323617749 
2 Linker: Compute reachability  parallel     163542533 
3 Linker: Compute reachability  pr           165204962.
4 Refiner: Compute reachability main         255269676 
5 Refiner: Compute reachability parallel     170701844 
6 Refiner: Compute reachability pr           169508056.
```