### PR TITLE
Address a new Scala 2.13.2 compiler warning in the compiler's tests.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/util/DirectTest.scala
@@ -38,14 +38,14 @@ abstract class DirectTest {
   }
 
   def newScalaJSCompiler(args: String*): Global = {
-    val settings = newSettings(
+    val settings0 = newSettings(
         List(
             "-d", testOutputPath,
             "-bootclasspath", scalaLibPath,
             "-classpath", classpath.mkString(File.pathSeparator)) ++
         extraArgs ++ args.toList)
 
-    lazy val global: Global = new Global(settings, newReporter(settings)) {
+    lazy val global: Global = new Global(settings0, newReporter(settings0)) {
       private implicit class PluginCompat(val plugin: Plugin) {
         def options: List[String] = {
           val prefix = plugin.name + ":"


### PR DESCRIPTION
Usage of `settings` inside `PluginCompat.options` collided with the `val settings` in the outer scope. We rename the latter to `settings0` to avoid the collision.

---

Locally tested with `compiler2_13/test` using `2.13.12-bin-49d5507`.