### PR TITLE
Move `undefOr2jsAny` implicit conversion to `js.Any` companion

### DIFF
--- a/library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-new-collections/scala/scalajs/js/Any.scala
@@ -79,6 +79,16 @@ object Any extends LowPrioAnyImplicits {
   @inline implicit def fromString(s: String): js.Any =
     s.asInstanceOf[js.Any]
 
+  /* This one is not very "in the spirit" of the union type, but it used to be
+   * available for `js.UndefOr[A]`, so we keep it for backward source
+   * compatibility. It is not really harmful, and has some perks in certain
+   * interoperability scenarios.
+   */
+  implicit def undefOr2jsAny[A](value: js.UndefOr[A])(
+      implicit ev: A => js.Any): js.Any = {
+    value.map(ev).asInstanceOf[js.Any]
+  }
+
   /* The following overload makes sure that the developer does not
    * inadvertently convert a Long to a Double to fit it in a js.Any.
    */

--- a/library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
+++ b/library/src/main/scala-old-collections/scala/scalajs/js/Any.scala
@@ -77,6 +77,16 @@ object Any extends js.LowPrioAnyImplicits {
   @inline implicit def fromString(s: String): js.Any =
     s.asInstanceOf[js.Any]
 
+  /* This one is not very "in the spirit" of the union type, but it used to be
+   * available for `js.UndefOr[A]`, so we keep it for backward source
+   * compatibility. It is not really harmful, and has some perks in certain
+   * interoperability scenarios.
+   */
+  implicit def undefOr2jsAny[A](value: js.UndefOr[A])(
+      implicit ev: A => js.Any): js.Any = {
+    value.map(ev).asInstanceOf[js.Any]
+  }
+
   /* The following overload makes sure that the developer does not
    * inadvertently convert a Long to a Double to fit it in a js.Any.
    */

--- a/library/src/main/scala/scala/scalajs/js/Union.scala
+++ b/library/src/main/scala/scala/scalajs/js/Union.scala
@@ -113,7 +113,8 @@ object | { // scalastyle:ignore
    * compatibility. It is not really harmful, and has some perks in certain
    * interoperability scenarios.
    */
-  implicit def undefOr2jsAny[A](value: js.UndefOr[A])(
+  @deprecated("Relocated to js.Any.undefOr2jsAny", "1.14.0")
+  def undefOr2jsAny[A](value: js.UndefOr[A])(
       implicit ev: A => js.Any): js.Any = {
     value.map(ev).asInstanceOf[js.Any]
   }

--- a/sbt-plugin/src/sbt-test/scala3/basic/Main.scala
+++ b/sbt-plugin/src/sbt-test/scala3/basic/Main.scala
@@ -22,5 +22,8 @@ object Main {
 
     // Testing the library resolved with %%% + withDottyCompat
     assert(Types.IntType.show() == "int")
+
+    // Testing the undefOr2jsAny implicit conversion
+    val x: js.Any = js.defined("")
   }
 }


### PR DESCRIPTION
As discussed on [Discord](https://discord.com/channels/632150470000902164/635668814956068864/1153429743740403803). Sorry, I did the minimal thing, and will appreciate hints for what else to do 😅 

The motivation for this change is that this implicit conversion will automatically be in scope on Scala 3 (as well as Scala 2), which is not currently the case. This forces the use of casts in user code as can be seen in the scala-js-dom Scala 3 PR in https://github.com/scala-js/scala-js-dom/pull/450.