### PR TITLE
Intern unscoped global field name strings

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -262,7 +262,7 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
       origName: OriginalName = NoOriginalName)(
       implicit pos: Position): Ident = {
     val name =
-      if (subField == "") "$" + field
+      if (subField == "") ("$" + field).intern()
       else "$" + field + "_" + subField
 
     Ident(avoidClashWithGlobalRef(name), origName)


### PR DESCRIPTION
Memory profile analysis shows ~120k duplicates of the string "$n" amounting to ~6MB waste (on the test suite).

Further digging revealed that this happens through the "$n" call-helper (null check) via:
- SJSGen#genCallHelper
- VarGen#globalVar
- VarGen#globalVarIdent
- VarGen#genericIdent

A more invasive (but efficient) alternative would be to move the prefix to the call sites. As a result, no runtime interning would have to be performed as the strings would end up being part ot the static constant pool.

Discovered while working on #4906.