### PR TITLE
Fuse emitting and printing of trees in the backend

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -106,7 +106,8 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
       sjsModule <- moduleSet.modules.headOption
     } yield {
       val closureChunk = logger.time("Closure: Create trees)") {
-        buildChunk(emitterResult.body(sjsModule.id))
+        val (trees, _) = emitterResult.body(sjsModule.id)
+        buildChunk(trees)
       }
 
       logger.time("Closure: Compiler pass") {

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -60,7 +60,7 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
       .withTrackAllGlobalRefs(true)
       .withInternalModulePattern(m => OutputPatternsImpl.moduleName(config.outputPatterns, m.id))
 
-    new Emitter(emitterConfig)
+    new Emitter(emitterConfig, ClosureLinkerBackend.PostTransformer)
   }
 
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements
@@ -295,4 +295,11 @@ private object ClosureLinkerBackend {
     Function.prototype.apply;
     var NaN = 0.0/0.0, Infinity = 1.0/0.0, undefined = void 0;
     """
+
+  private object PostTransformer extends Emitter.PostTransformer[js.Tree] {
+    // Do not apply ClosureAstTransformer eagerly:
+    // The ASTs used by closure are highly mutable, so re-using them is non-trivial.
+    // Since closure is slow anyways, we haven't built the optimization.
+    def transformStats(trees: List[js.Tree], indent: Int): List[js.Tree] = trees
+  }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -17,6 +17,8 @@ import scala.concurrent._
 import java.nio.ByteBuffer
 import java.nio.charset.StandardCharsets
 
+import java.util.concurrent.atomic.AtomicInteger
+
 import org.scalajs.logging.Logger
 
 import org.scalajs.linker.interface.{IRFile, OutputDirectory, Report}
@@ -36,12 +38,19 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
 
   import BasicLinkerBackend._
 
+  private[this] var totalModules = 0
+  private[this] val rewrittenModules = new AtomicInteger(0)
+
   private[this] val emitter = {
     val emitterConfig = Emitter.Config(config.commonConfig.coreSpec)
       .withJSHeader(config.jsHeader)
       .withInternalModulePattern(m => OutputPatternsImpl.moduleName(config.outputPatterns, m.id))
 
-    new Emitter(emitterConfig)
+    val postTransformer =
+      if (config.sourceMap) PostTransformerWithSourceMap
+      else PostTransformerWithoutSourceMap
+
+    new Emitter(emitterConfig, postTransformer)
   }
 
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements
@@ -61,6 +70,11 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
       implicit ec: ExecutionContext): Future[Report] = {
     verifyModuleSet(moduleSet)
 
+    // Reset stats.
+
+    totalModules = moduleSet.modules.size
+    rewrittenModules.set(0)
+
     val emitterResult = logger.time("Emitter") {
       emitter.emit(moduleSet, logger)
     }
@@ -68,24 +82,25 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
     val skipContentCheck = !isFirstRun
     isFirstRun = false
 
-    printedModuleSetCache.startRun(moduleSet)
     val allChanged =
       printedModuleSetCache.updateGlobal(emitterResult.header, emitterResult.footer)
 
     val writer = new OutputWriter(output, config, skipContentCheck) {
       protected def writeModuleWithoutSourceMap(moduleID: ModuleID, force: Boolean): Option[ByteBuffer] = {
         val cache = printedModuleSetCache.getModuleCache(moduleID)
-        val changed = cache.update(emitterResult.body(moduleID))
+        val printedTrees = emitterResult.body(moduleID)
+
+        val changed = cache.update(printedTrees)
 
         if (force || changed || allChanged) {
-          printedModuleSetCache.incRewrittenModules()
+          rewrittenModules.incrementAndGet()
 
           val jsFileWriter = new ByteArrayWriter(sizeHintFor(cache.getPreviousFinalJSFileSize()))
 
           jsFileWriter.write(printedModuleSetCache.headerBytes)
           jsFileWriter.writeASCIIString("'use strict';\n")
 
-          for (printedTree <- cache.printedTrees)
+          for (printedTree <- printedTrees)
             jsFileWriter.write(printedTree.jsCode)
 
           jsFileWriter.write(printedModuleSetCache.footerBytes)
@@ -99,10 +114,12 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
 
       protected def writeModuleWithSourceMap(moduleID: ModuleID, force: Boolean): Option[(ByteBuffer, ByteBuffer)] = {
         val cache = printedModuleSetCache.getModuleCache(moduleID)
-        val changed = cache.update(emitterResult.body(moduleID))
+        val printedTrees = emitterResult.body(moduleID)
+
+        val changed = cache.update(printedTrees)
 
         if (force || changed || allChanged) {
-          printedModuleSetCache.incRewrittenModules()
+          rewrittenModules.incrementAndGet()
 
           val jsFileWriter = new ByteArrayWriter(sizeHintFor(cache.getPreviousFinalJSFileSize()))
           val sourceMapWriter = new ByteArrayWriter(sizeHintFor(cache.getPreviousFinalSourceMapSize()))
@@ -120,7 +137,7 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
           jsFileWriter.writeASCIIString("'use strict';\n")
           smWriter.nextLine()
 
-          for (printedTree <- cache.printedTrees) {
+          for (printedTree <- printedTrees) {
             jsFileWriter.write(printedTree.jsCode)
             smWriter.insertFragment(printedTree.sourceMapFragment)
           }
@@ -145,8 +162,14 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
       writer.write(moduleSet)
     }.andThen { case _ =>
       printedModuleSetCache.cleanAfterRun()
-      printedModuleSetCache.logStats(logger)
+      logStats(logger)
     }
+  }
+
+  private def logStats(logger: Logger): Unit = {
+    // Message extracted in BasicLinkerBackendTest
+    logger.debug(
+        s"BasicBackend: total modules: $totalModules; re-written: ${rewrittenModules.get()}")
   }
 }
 
@@ -160,20 +183,6 @@ private object BasicLinkerBackend {
     private var _headerNewLineCountCache: Int = 0
 
     private val modules = new java.util.concurrent.ConcurrentHashMap[ModuleID, PrintedModuleCache]
-
-    private var totalModules = 0
-    private val rewrittenModules = new java.util.concurrent.atomic.AtomicInteger(0)
-
-    private var totalTopLevelTrees = 0
-    private var recomputedTopLevelTrees = 0
-
-    def startRun(moduleSet: ModuleSet): Unit = {
-      totalModules = moduleSet.modules.size
-      rewrittenModules.set(0)
-
-      totalTopLevelTrees = 0
-      recomputedTopLevelTrees = 0
-    }
 
     def updateGlobal(header: String, footer: String): Boolean = {
       if (header == lastHeader && footer == lastFooter) {
@@ -193,61 +202,32 @@ private object BasicLinkerBackend {
     def headerNewLineCount: Int = _headerNewLineCountCache
 
     def getModuleCache(moduleID: ModuleID): PrintedModuleCache = {
-      val result = modules.computeIfAbsent(moduleID, { _ =>
-        if (withSourceMaps) new PrintedModuleCacheWithSourceMaps
-        else new PrintedModuleCache
-      })
-
+      val result = modules.computeIfAbsent(moduleID, _ => new PrintedModuleCache)
       result.startRun()
       result
     }
-
-    def incRewrittenModules(): Unit =
-      rewrittenModules.incrementAndGet()
 
     def cleanAfterRun(): Unit = {
       val iter = modules.entrySet().iterator()
       while (iter.hasNext()) {
         val moduleCache = iter.next().getValue()
-        if (moduleCache.cleanAfterRun()) {
-          totalTopLevelTrees += moduleCache.getTotalTopLevelTrees
-          recomputedTopLevelTrees += moduleCache.getRecomputedTopLevelTrees
-        } else {
+        if (!moduleCache.cleanAfterRun()) {
           iter.remove()
         }
       }
     }
-
-    def logStats(logger: Logger): Unit = {
-      /* These messages are extracted in BasicLinkerBackendTest to assert that
-       * we do not invalidate anything in a no-op second run.
-       */
-      logger.debug(
-          s"BasicBackend: total top-level trees: $totalTopLevelTrees; re-computed: $recomputedTopLevelTrees")
-      logger.debug(
-          s"BasicBackend: total modules: $totalModules; re-written: ${rewrittenModules.get()}")
-    }
-  }
-
-  private final class PrintedTree(val jsCode: Array[Byte], val sourceMapFragment: SourceMapWriter.Fragment) {
-    var cachedUsed: Boolean = false
   }
 
   private sealed class PrintedModuleCache {
     private var cacheUsed = false
     private var changed = false
-    private var lastJSTrees: List[js.Tree] = Nil
-    private var printedTreesCache: List[PrintedTree] = Nil
-    private val cache = new java.util.IdentityHashMap[js.Tree, PrintedTree]
+    private var lastPrintedTrees: List[js.PrintedTree] = Nil
 
     private var previousFinalJSFileSize: Int = 0
     private var previousFinalSourceMapSize: Int = 0
 
-    private var recomputedTopLevelTrees = 0
-
     def startRun(): Unit = {
       cacheUsed = true
-      recomputedTopLevelTrees = 0
     }
 
     def getPreviousFinalJSFileSize(): Int = previousFinalJSFileSize
@@ -259,72 +239,51 @@ private object BasicLinkerBackend {
       previousFinalSourceMapSize = finalSourceMapSize
     }
 
-    def update(newJSTrees: List[js.Tree]): Boolean = {
-      val changed = !newJSTrees.corresponds(lastJSTrees)(_ eq _)
+    def update(newPrintedTrees: List[js.PrintedTree]): Boolean = {
+      val changed = !newPrintedTrees.corresponds(lastPrintedTrees)(_ eq _)
       this.changed = changed
       if (changed) {
-        printedTreesCache = newJSTrees.map(getOrComputePrintedTree(_))
-        lastJSTrees = newJSTrees
+        lastPrintedTrees = newPrintedTrees
       }
       changed
     }
 
-    private def getOrComputePrintedTree(tree: js.Tree): PrintedTree = {
-      val result = cache.computeIfAbsent(tree, { (tree: js.Tree) =>
-        recomputedTopLevelTrees += 1
-        computePrintedTree(tree)
-      })
-
-      result.cachedUsed = true
-      result
-    }
-
-    protected def computePrintedTree(tree: js.Tree): PrintedTree = {
-      val jsCodeWriter = new ByteArrayWriter()
-      val printer = new Printers.JSTreePrinter(jsCodeWriter)
-
-      printer.printStat(tree)
-
-      new PrintedTree(jsCodeWriter.toByteArray(), SourceMapWriter.Fragment.Empty)
-    }
-
-    def printedTrees: List[PrintedTree] = printedTreesCache
-
     def cleanAfterRun(): Boolean = {
-      if (cacheUsed) {
-        cacheUsed = false
-
-        if (changed) {
-          val iter = cache.entrySet().iterator()
-          while (iter.hasNext()) {
-            val printedTree = iter.next().getValue()
-            if (printedTree.cachedUsed)
-              printedTree.cachedUsed = false
-            else
-              iter.remove()
-          }
-        }
-
-        true
-      } else {
-        false
-      }
+      val wasUsed = cacheUsed
+      cacheUsed = false
+      wasUsed
     }
-
-    def getTotalTopLevelTrees: Int = lastJSTrees.size
-    def getRecomputedTopLevelTrees: Int = recomputedTopLevelTrees
   }
 
-  private final class PrintedModuleCacheWithSourceMaps extends PrintedModuleCache {
-    override protected def computePrintedTree(tree: js.Tree): PrintedTree = {
-      val jsCodeWriter = new ByteArrayWriter()
-      val smFragmentBuilder = new SourceMapWriter.FragmentBuilder()
-      val printer = new Printers.JSTreePrinterWithSourceMap(jsCodeWriter, smFragmentBuilder)
+  private object PostTransformerWithoutSourceMap extends Emitter.PostTransformer[js.PrintedTree] {
+    def transformStats(trees: List[js.Tree], indent: Int): List[js.PrintedTree] = {
+      if (trees.isEmpty) {
+        Nil // Fast path
+      } else {
+        val jsCodeWriter = new ByteArrayWriter()
+        val printer = new Printers.JSTreePrinter(jsCodeWriter, indent)
 
-      printer.printStat(tree)
-      smFragmentBuilder.complete()
+        trees.map(printer.printStat(_))
 
-      new PrintedTree(jsCodeWriter.toByteArray(), smFragmentBuilder.result())
+        js.PrintedTree(jsCodeWriter.toByteArray(), SourceMapWriter.Fragment.Empty) :: Nil
+      }
+    }
+  }
+
+  private object PostTransformerWithSourceMap extends Emitter.PostTransformer[js.PrintedTree] {
+    def transformStats(trees: List[js.Tree], indent: Int): List[js.PrintedTree] = {
+      if (trees.isEmpty) {
+        Nil // Fast path
+      } else {
+        val jsCodeWriter = new ByteArrayWriter()
+        val smFragmentBuilder = new SourceMapWriter.FragmentBuilder()
+        val printer = new Printers.JSTreePrinterWithSourceMap(jsCodeWriter, smFragmentBuilder, indent)
+
+        trees.map(printer.printStat(_))
+        smFragmentBuilder.complete()
+
+        js.PrintedTree(jsCodeWriter.toByteArray(), smFragmentBuilder.result()) :: Nil
+      }
     }
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -45,7 +45,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
 
   def buildClass(className: ClassName, isJSClass: Boolean, jsClassCaptures: Option[List[ParamDef]],
       hasClassInitializer: Boolean,
-      superClass: Option[ClassIdent], storeJSSuperClass: Option[js.Tree], useESClass: Boolean,
+      superClass: Option[ClassIdent], storeJSSuperClass: List[js.Tree], useESClass: Boolean,
       members: List[js.Tree])(
       implicit moduleContext: ModuleContext,
       globalKnowledge: GlobalKnowledge, pos: Position): WithGlobals[List[js.Tree]] = {
@@ -75,7 +75,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       val createClassValueVar = genEmptyMutableLet(classValueIdent)
 
       val entireClassDefWithGlobals = if (useESClass) {
-        genJSSuperCtor(superClass, storeJSSuperClass.isDefined).map { jsSuperClass =>
+        genJSSuperCtor(superClass, storeJSSuperClass.nonEmpty).map { jsSuperClass =>
           List(classValueVar := js.ClassDef(Some(classValueIdent), Some(jsSuperClass), members))
         }
       } else {
@@ -86,7 +86,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
         entireClassDef <- entireClassDefWithGlobals
         createStaticFields <- genCreateStaticFieldsOfJSClass(className)
       } yield {
-        storeJSSuperClass.toList ::: entireClassDef ::: createStaticFields
+        storeJSSuperClass ::: entireClassDef ::: createStaticFields
       }
 
       jsClassCaptures.fold {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -499,4 +499,22 @@ object Trees {
       from: StringLiteral)(
       implicit val pos: Position)
       extends Tree
+
+  /** An already printed tree.
+   *
+   *  This is a special purpose node to store partially transformed trees.
+   *
+   *  A cleaner abstraction would be to have something like ir.Tree.Transient
+   *  (for different output formats), but for now, we do not need this.
+   */
+  sealed case class PrintedTree(jsCode: Array[Byte],
+      sourceMapFragment: SourceMapWriter.Fragment) extends Tree {
+    val pos: Position = Position.NoPosition
+
+    override def show: String = new String(jsCode, StandardCharsets.UTF_8)
+  }
+
+  object PrintedTree {
+    def empty: PrintedTree = PrintedTree(Array(), SourceMapWriter.Fragment.Empty)
+  }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/BasicLinkerBackendTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/BasicLinkerBackendTest.scala
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalajs.ir.Trees._
+import org.scalajs.ir.Version
 
 import org.scalajs.junit.async._
 
@@ -33,17 +34,17 @@ import org.scalajs.logging._
 class BasicLinkerBackendTest {
   import scala.concurrent.ExecutionContext.Implicits.global
 
-  private val BackendInvalidatedTopLevelTreesStatsMessage =
-    raw"""BasicBackend: total top-level trees: (\d+); re-computed: (\d+)""".r
+  private val BackendInvalidatedPrintedTreesStatsMessage =
+    raw"""BasicBackend: total top-level printed trees: (\d+); re-computed: (\d+)""".r
 
   private val BackendInvalidatedModulesStatsMessage =
     raw"""BasicBackend: total modules: (\d+); re-written: (\d+)""".r
 
   /** Makes sure that linking a "substantial" program (using `println`) twice
-   *  does not invalidate any top-level tree nor module in the second run.
+   *  does not invalidate any module in the second run.
    */
   @Test
-  def noInvalidatedTopLevelTreeOrModuleInSecondRun(): AsyncResult = await {
+  def noInvalidatedModuleInSecondRun(): AsyncResult = await {
     import ModuleSplitStyle._
 
     val classDefs = List(
@@ -60,7 +61,7 @@ class BasicLinkerBackendTest {
         .withModuleSplitStyle(splitStyle)
 
       val linker = StandardImpl.linker(config)
-      val classDefsFiles = classDefs.map(MemClassDefIRFile(_))
+      val classDefsFiles = classDefs.map(MemClassDefIRFile(_, Version.fromInt(0)))
 
       val initializers = MainTestModuleInitializers
       val outputDir = MemOutputDirectory()
@@ -73,25 +74,6 @@ class BasicLinkerBackendTest {
       } yield {
         val lines1 = logger1.allLogLines
         val lines2 = logger2.allLogLines
-
-        // Top-level trees
-
-        val Seq(totalTrees1, recomputedTrees1) =
-          lines1.assertContainsMatch(BackendInvalidatedTopLevelTreesStatsMessage).map(_.toInt)
-
-        val Seq(totalTrees2, recomputedTrees2) =
-          lines2.assertContainsMatch(BackendInvalidatedTopLevelTreesStatsMessage).map(_.toInt)
-
-        // At the time of writing this test, totalTrees1 reports 382 trees
-        assertTrue(
-            s"Not enough total top-level trees (got $totalTrees1); extraction must have gone wrong",
-            totalTrees1 > 300)
-
-        assertEquals("First run must invalidate every top-level tree", totalTrees1, recomputedTrees1)
-        assertEquals("Second run must have the same total top-level trees as first run", totalTrees1, totalTrees2)
-        assertEquals("Second run must not invalidate any top-level tree", 0, recomputedTrees2)
-
-        // Modules
 
         val Seq(totalModules1, rewrittenModules1) =
           lines1.assertContainsMatch(BackendInvalidatedModulesStatsMessage).map(_.toInt)

--- a/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
@@ -208,18 +208,21 @@ class EmitterTest {
 
       // Post transforms
 
-      val Seq(postTransforms1, _, _) =
+      val Seq(postTransforms1, nestedPostTransforms1, _) =
         lines1.assertContainsMatch(EmitterPostTransformStatsMessage).map(_.toInt)
 
-      val Seq(postTransforms2, _, _) =
+      val Seq(postTransforms2, nestedPostTransforms2, _) =
         lines2.assertContainsMatch(EmitterPostTransformStatsMessage).map(_.toInt)
 
-      // At the time of writing this test, postTransformsTotal1 reports 216
+      // At the time of writing this test, postTransforms1 reports 216
       assertTrue(
           s"Not enough post transforms (got $postTransforms1); extraction must have gone wrong",
           postTransforms1 > 200)
 
-      assertEquals("Second run must not have any post transforms", 0, postTransforms2)
+      assertEquals("Second run must only have nested post transforms",
+          nestedPostTransforms2, postTransforms2)
+      assertEquals("Both runs must have the same number of nested post transforms",
+          nestedPostTransforms1, nestedPostTransforms2)
     }
   }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
@@ -14,7 +14,7 @@ package org.scalajs.linker.backend.javascript
 
 import scala.language.implicitConversions
 
-import java.nio.charset.StandardCharsets
+import java.nio.charset.StandardCharsets.UTF_8
 
 import org.junit.Test
 import org.junit.Assert._
@@ -35,7 +35,7 @@ class PrintersTest {
     val printer = new Printers.JSTreePrinter(out)
     printer.printStat(tree)
     assertEquals(expected.stripMargin.trim + "\n",
-        new String(out.toByteArray(), StandardCharsets.UTF_8))
+        new String(out.toByteArray(), UTF_8))
   }
 
   @Test def printFunctionDef(): Unit = {
@@ -156,6 +156,26 @@ class PrintersTest {
         """,
         If(BooleanLiteral(false), IntLiteral(1),
             If(BooleanLiteral(true), IntLiteral(2), IntLiteral(3)))
+    )
+  }
+
+  @Test def showPrintedTree(): Unit = {
+    val tree = PrintedTree("test".getBytes(UTF_8), SourceMapWriter.Fragment.Empty)
+
+    assertEquals("test", tree.show)
+  }
+
+  @Test def showNestedPrintedTree(): Unit = {
+    val tree = PrintedTree("  test\n".getBytes(UTF_8), SourceMapWriter.Fragment.Empty)
+
+    val str = While(BooleanLiteral(false), tree).show
+    assertEquals(
+      """
+        |while (false) {
+        |  test
+        |}
+      """.stripMargin.trim,
+      str
     )
   }
 }


### PR DESCRIPTION
This allows us to use the Emitter's powerful caching mechanism to
directly cache printed trees (as byte buffers) and not cache
JavaScript trees anymore at all.

This reduces in-between run memory usage on the test suite from
1.13 GB (not GiB) to 1.01 GB on my machine (roughly 10%).

Runtime performance (both batch and incremental) is unaffected.

It is worth pointing out, that in order to avoid duplicate caching, we do not cache full class trees anymore.