### PR TITLE
Printer improvements to fuse JS emitting and printing

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -283,7 +283,7 @@ private object BasicLinkerBackend {
       val jsCodeWriter = new ByteArrayWriter()
       val printer = new Printers.JSTreePrinter(jsCodeWriter)
 
-      printer.printTopLevelTree(tree)
+      printer.printStat(tree)
 
       new PrintedTree(jsCodeWriter.toByteArray(), SourceMapWriter.Fragment.Empty)
     }
@@ -321,7 +321,7 @@ private object BasicLinkerBackend {
       val smFragmentBuilder = new SourceMapWriter.FragmentBuilder()
       val printer = new Printers.JSTreePrinterWithSourceMap(jsCodeWriter, smFragmentBuilder)
 
-      printer.printTopLevelTree(tree)
+      printer.printStat(tree)
       smFragmentBuilder.complete()
 
       new PrintedTree(jsCodeWriter.toByteArray(), smFragmentBuilder.result())

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -683,12 +683,12 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
 
   def genInstanceTests(className: ClassName, kind: ClassKind)(
       implicit moduleContext: ModuleContext,
-      globalKnowledge: GlobalKnowledge, pos: Position): WithGlobals[js.Tree] = {
+      globalKnowledge: GlobalKnowledge, pos: Position): WithGlobals[List[js.Tree]] = {
     for {
       single <- genSingleInstanceTests(className, kind)
       array <- genArrayInstanceTests(className)
     } yield {
-      js.Block(single ::: array)
+      single ::: array
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -595,7 +595,7 @@ final class Emitter(config: Emitter.Config) {
        */
 
       if (classEmitter.needInstanceTests(linkedClass)(classCache)) {
-        main += extractWithGlobals(classTreeCache.instanceTests.getOrElseUpdate(
+        main ++= extractWithGlobals(classTreeCache.instanceTests.getOrElseUpdate(
             classEmitter.genInstanceTests(className, kind)(moduleContext, classCache, linkedClass.pos)))
       }
 
@@ -1035,7 +1035,7 @@ object Emitter {
 
   private final class DesugaredClassCache {
     val privateJSFields = new OneTimeCache[WithGlobals[List[js.Tree]]]
-    val instanceTests = new OneTimeCache[WithGlobals[js.Tree]]
+    val instanceTests = new OneTimeCache[WithGlobals[List[js.Tree]]]
     val typeData = new OneTimeCache[WithGlobals[List[js.Tree]]]
     val setTypeData = new OneTimeCache[js.Tree]
     val moduleAccessor = new OneTimeCache[WithGlobals[List[js.Tree]]]

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -90,19 +90,21 @@ object Printers {
     }
 
     protected def printBlock(tree: Tree): Unit = {
-      print('{'); indent(); println()
+      print('{'); indent();
       tree match {
+        case Skip() =>
+          // do not print anything
+
         case tree: Block =>
           var rest = tree.stats
           while (rest.nonEmpty) {
-            val x = rest.head
+            println()
+            printStat(rest.head)
             rest = rest.tail
-            printStat(x)
-            if (rest.nonEmpty)
-              println()
           }
 
         case _ =>
+          println()
           printStat(tree)
       }
       undent(); println(); print('}')

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -62,19 +62,8 @@ object Printers {
     }
 
     def printTopLevelTree(tree: Tree): Unit = {
-      tree match {
-        case Skip() =>
-          // do not print anything
-        case tree: Block =>
-          var rest = tree.stats
-          while (rest.nonEmpty) {
-            printTopLevelTree(rest.head)
-            rest = rest.tail
-          }
-        case _ =>
-          printStat(tree)
-          println()
-      }
+      printStat(tree)
+      println()
     }
 
     protected def printRow(ts: List[Tree], start: Char, end: Char): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -64,10 +64,6 @@ object Printers {
       newIndentArray
     }
 
-    def printTopLevelTree(tree: Tree): Unit = {
-      printStat(tree)
-    }
-
     private def printRow(ts: List[Tree], start: Char, end: Char): Unit = {
       print(start)
       var rest = ts
@@ -121,7 +117,7 @@ object Printers {
       printRow(args, '(', ')')
 
     /** Prints a stat including leading indent and trailing newline. */
-    private def printStat(tree: Tree): Unit = {
+    final def printStat(tree: Tree): Unit = {
       printIndent()
       printTree(tree, isStat = true)
       println()

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -66,7 +66,7 @@ object Printers {
       println()
     }
 
-    protected def printRow(ts: List[Tree], start: Char, end: Char): Unit = {
+    private def printRow(ts: List[Tree], start: Char, end: Char): Unit = {
       print(start)
       var rest = ts
       while (rest.nonEmpty) {
@@ -78,7 +78,7 @@ object Printers {
       print(end)
     }
 
-    protected def printBlock(tree: Tree): Unit = {
+    private def printBlock(tree: Tree): Unit = {
       print('{'); indent();
       tree match {
         case Skip() =>
@@ -99,7 +99,7 @@ object Printers {
       undent(); println(); print('}')
     }
 
-    protected def printSig(args: List[ParamDef], restParam: Option[ParamDef]): Unit = {
+    private def printSig(args: List[ParamDef], restParam: Option[ParamDef]): Unit = {
       print("(")
       var rem = args
       while (rem.nonEmpty) {
@@ -117,13 +117,13 @@ object Printers {
       print(") ")
     }
 
-    protected def printArgs(args: List[Tree]): Unit =
+    private def printArgs(args: List[Tree]): Unit =
       printRow(args, '(', ')')
 
-    protected def printStat(tree: Tree): Unit =
+    private def printStat(tree: Tree): Unit =
       printTree(tree, isStat = true)
 
-    protected def print(tree: Tree): Unit =
+    private def print(tree: Tree): Unit =
       printTree(tree, isStat = false)
 
     def printTree(tree: Tree, isStat: Boolean): Unit = {
@@ -760,7 +760,7 @@ object Printers {
         print("]")
     }
 
-    protected def print(exportName: ExportName): Unit =
+    private def print(exportName: ExportName): Unit =
       printEscapeJS(exportName.name)
 
     /** Prints an ASCII string -- use for syntax strings, not for user strings. */

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,8 +70,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 150031,
-      expectedFullLinkSizeWithoutClosure = 130655,
+      expectedFastLinkSize = 150534,
+      expectedFullLinkSizeWithoutClosure = 131079,
       expectedFullLinkSizeWithClosure = 21394,
       classDefs,
       moduleInitializers = MainTestModuleInitializers

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,8 +70,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 150534,
-      expectedFullLinkSizeWithoutClosure = 131079,
+      expectedFastLinkSize = 150339,
+      expectedFullLinkSizeWithoutClosure = 130884,
       expectedFullLinkSizeWithClosure = 21394,
       classDefs,
       moduleInitializers = MainTestModuleInitializers

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
@@ -1,0 +1,164 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.javascript
+
+import scala.language.implicitConversions
+
+import java.nio.charset.StandardCharsets
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.ir
+
+import Trees._
+
+class PrintersTest {
+
+  private implicit val pos: ir.Position = ir.Position.NoPosition
+
+  private implicit def str2ident(name: String): Ident =
+    Ident(name, ir.OriginalName.NoOriginalName)
+
+  private def assertPrintEquals(expected: String, tree: Tree): Unit = {
+    val out = new ByteArrayWriter
+    val printer = new Printers.JSTreePrinter(out)
+    printer.printTopLevelTree(tree)
+    assertEquals(expected.stripMargin.trim + "\n",
+        new String(out.toByteArray(), StandardCharsets.UTF_8))
+  }
+
+  @Test def printFunctionDef(): Unit = {
+    assertPrintEquals(
+        """
+          |function test() {
+          |  const x = 2;
+          |  return x
+          |}
+        """,
+        FunctionDef("test", Nil, None, Block(
+          Let("x", mutable = false, Some(IntLiteral(2))),
+          Return(VarRef("x"))))
+    )
+
+    assertPrintEquals(
+        """
+          |function test() {
+          |  /*<skip>*/
+          |}
+        """,
+        FunctionDef("test", Nil, None, Skip())
+    )
+  }
+
+  @Test def printClassDef(): Unit = {
+    assertPrintEquals(
+        """
+          |class MyClass extends foo.Other {
+          |}
+        """,
+        ClassDef(Some("MyClass"), Some(DotSelect(VarRef("foo"), "Other")), Nil)
+    )
+
+    assertPrintEquals(
+        """
+          |class MyClass {
+          |  foo() {
+          |    /*<skip>*/
+          |  };
+          |  get a() {
+          |    return 1
+          |  };
+          |  set a(x) {
+          |    /*<skip>*/
+          |  };
+          |}
+        """,
+        ClassDef(Some("MyClass"), None, List(
+          MethodDef(false, "foo", Nil, None, Skip()),
+          GetterDef(false, "a", Return(IntLiteral(1))),
+          SetterDef(false, "a", ParamDef("x"), Skip())
+        ))
+    )
+  }
+
+  @Test def printDocComment(): Unit = {
+    assertPrintEquals(
+      """
+        | /** test */
+      """,
+      DocComment("test")
+    )
+  }
+
+  @Test def printFor(): Unit = {
+    assertPrintEquals(
+      """
+        |for (let x = 1; (x < 15); x = (x + 1)) {
+        |  /*<skip>*/
+        |};
+      """,
+      For(Let("x", true, Some(IntLiteral(1))),
+          BinaryOp(ir.Trees.JSBinaryOp.<, VarRef("x"), IntLiteral(15)),
+          Assign(VarRef("x"), BinaryOp(ir.Trees.JSBinaryOp.+, VarRef("x"), IntLiteral(1))),
+          Skip())
+    )
+  }
+
+  @Test def printForIn(): Unit = {
+    assertPrintEquals(
+      """
+        |for (var x in foo) {
+        |  /*<skip>*/
+        |};
+      """,
+      ForIn(VarDef("x", None), VarRef("foo"), Skip())
+    )
+  }
+
+  @Test def printIf(): Unit = {
+    assertPrintEquals(
+        """
+          |if (false) {
+          |  1
+          |};
+        """,
+        If(BooleanLiteral(false), IntLiteral(1), Skip())
+    )
+
+    assertPrintEquals(
+        """
+          |if (false) {
+          |  1
+          |} else {
+          |  2
+          |};
+        """,
+        If(BooleanLiteral(false), IntLiteral(1), IntLiteral(2))
+    )
+
+    assertPrintEquals(
+        """
+          |if (false) {
+          |  1
+          |} else if (true) {
+          |  2
+          |} else {
+          |  3
+          |};
+        """,
+        If(BooleanLiteral(false), IntLiteral(1),
+            If(BooleanLiteral(true), IntLiteral(2), IntLiteral(3)))
+    )
+  }
+}

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
@@ -43,7 +43,7 @@ class PrintersTest {
         """
           |function test() {
           |  const x = 2;
-          |  return x
+          |  return x;
           |}
         """,
         FunctionDef("test", Nil, None, Block(
@@ -75,13 +75,13 @@ class PrintersTest {
           |class MyClass {
           |  foo() {
           |    /*<skip>*/
-          |  };
+          |  }
           |  get a() {
-          |    return 1
-          |  };
+          |    return 1;
+          |  }
           |  set a(x) {
           |    /*<skip>*/
-          |  };
+          |  }
           |}
         """,
         ClassDef(Some("MyClass"), None, List(
@@ -106,7 +106,7 @@ class PrintersTest {
       """
         |for (let x = 1; (x < 15); x = (x + 1)) {
         |  /*<skip>*/
-        |};
+        |}
       """,
       For(Let("x", true, Some(IntLiteral(1))),
           BinaryOp(ir.Trees.JSBinaryOp.<, VarRef("x"), IntLiteral(15)),
@@ -120,7 +120,7 @@ class PrintersTest {
       """
         |for (var x in foo) {
         |  /*<skip>*/
-        |};
+        |}
       """,
       ForIn(VarDef("x", None), VarRef("foo"), Skip())
     )
@@ -130,8 +130,8 @@ class PrintersTest {
     assertPrintEquals(
         """
           |if (false) {
-          |  1
-          |};
+          |  1;
+          |}
         """,
         If(BooleanLiteral(false), IntLiteral(1), Skip())
     )
@@ -139,10 +139,10 @@ class PrintersTest {
     assertPrintEquals(
         """
           |if (false) {
-          |  1
+          |  1;
           |} else {
-          |  2
-          |};
+          |  2;
+          |}
         """,
         If(BooleanLiteral(false), IntLiteral(1), IntLiteral(2))
     )
@@ -150,12 +150,12 @@ class PrintersTest {
     assertPrintEquals(
         """
           |if (false) {
-          |  1
+          |  1;
           |} else if (true) {
-          |  2
+          |  2;
           |} else {
-          |  3
-          |};
+          |  3;
+          |}
         """,
         If(BooleanLiteral(false), IntLiteral(1),
             If(BooleanLiteral(true), IntLiteral(2), IntLiteral(3)))

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
@@ -33,7 +33,7 @@ class PrintersTest {
   private def assertPrintEquals(expected: String, tree: Tree): Unit = {
     val out = new ByteArrayWriter
     val printer = new Printers.JSTreePrinter(out)
-    printer.printTopLevelTree(tree)
+    printer.printStat(tree)
     assertEquals(expected.stripMargin.trim + "\n",
         new String(out.toByteArray(), StandardCharsets.UTF_8))
   }

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
@@ -54,7 +54,6 @@ class PrintersTest {
     assertPrintEquals(
         """
           |function test() {
-          |  /*<skip>*/
           |}
         """,
         FunctionDef("test", Nil, None, Skip())
@@ -74,13 +73,11 @@ class PrintersTest {
         """
           |class MyClass {
           |  foo() {
-          |    /*<skip>*/
           |  }
           |  get a() {
           |    return 1;
           |  }
           |  set a(x) {
-          |    /*<skip>*/
           |  }
           |}
         """,
@@ -105,7 +102,6 @@ class PrintersTest {
     assertPrintEquals(
       """
         |for (let x = 1; (x < 15); x = (x + 1)) {
-        |  /*<skip>*/
         |}
       """,
       For(Let("x", true, Some(IntLiteral(1))),
@@ -119,7 +115,6 @@ class PrintersTest {
     assertPrintEquals(
       """
         |for (var x in foo) {
-        |  /*<skip>*/
         |}
       """,
       ForIn(VarDef("x", None), VarRef("foo"), Skip())

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1967,15 +1967,15 @@ object Build {
         scalaVersion.value match {
           case `default212Version` =>
             Some(ExpectedSizes(
-                fastLink = 775000 to 776000,
+                fastLink = 770000 to 771000,
                 fullLink = 145000 to 146000,
-                fastLinkGz = 91000 to 92000,
+                fastLinkGz = 90000 to 91000,
                 fullLinkGz = 35000 to 36000,
             ))
 
           case `default213Version` =>
             Some(ExpectedSizes(
-                fastLink = 481000 to 483000,
+                fastLink = 479000 to 480000,
                 fullLink = 102000 to 103000,
                 fastLinkGz = 62000 to 63000,
                 fullLinkGz = 27000 to 28000,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1967,7 +1967,7 @@ object Build {
         scalaVersion.value match {
           case `default212Version` =>
             Some(ExpectedSizes(
-                fastLink = 772000 to 773000,
+                fastLink = 775000 to 776000,
                 fullLink = 145000 to 146000,
                 fastLinkGz = 91000 to 92000,
                 fullLinkGz = 35000 to 36000,
@@ -1975,7 +1975,7 @@ object Build {
 
           case `default213Version` =>
             Some(ExpectedSizes(
-                fastLink = 480000 to 481000,
+                fastLink = 481000 to 483000,
                 fullLink = 102000 to 103000,
                 fastLinkGz = 62000 to 63000,
                 fullLinkGz = 27000 to 28000,


### PR DESCRIPTION
The core of the change is to print semicolons and newlines as part of a statement.

This is necessary for a subsequent change, where we pre-print
statements into byte buffers. When we later assemble the statement
into the surrounding block, we do not have type information
anymore (and hence cannot judge whether a semicolon is necessary).

Note that this now prints a semicolon after the last statement in a
block (which we didn't previously). This does increase fastopt
size (somewhat artificially), but more closely corresponds:

- to what a human would write
- the ECMAScript spec (e.g. https://tc39.es/ecma262/#sec-expression-statement)