### PR TITLE
Fix #4482: Minify property names ourselves in fullLink when we don't use GCC.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -185,6 +185,9 @@ def Tasks = [
         reversi$v/fastLinkJS \
         reversi$v/fullLinkJS \
         reversi$v/checksizes &&
+    sbtretry ++$scala \
+        'set Global/enableMinifyEverywhere := true' \
+        reversi$v/checksizes &&
     sbtretry ++$scala javalibintf/compile:doc compiler$v/compile:doc library$v/compile:doc \
         testInterface$v/compile:doc testBridge$v/compile:doc &&
     sbtretry ++$scala headerCheck &&
@@ -199,68 +202,83 @@ def Tasks = [
   "test-suite-default-esversion": '''
     setJavaVersion $java
     npm install &&
-    sbtretry ++$scala jUnitTestOutputsJVM$v/test jUnitTestOutputsJS$v/test testBridge$v/test \
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        jUnitTestOutputsJVM$v/test jUnitTestOutputsJS$v/test testBridge$v/test \
         'set scalaJSStage in Global := FullOptStage' jUnitTestOutputsJS$v/test testBridge$v/test &&
-    sbtretry ++$scala $testSuite$v/test $testSuite$v/testHtmlJSDom &&
-    sbtretry 'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test \
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        $testSuite$v/test $testSuite$v/testHtmlJSDom &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSStage in Global := FullOptStage' \
+        $testSuite$v/test \
         $testSuite$v/testHtmlJSDom &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
-        'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
-        'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withAllowBigIntsForLongs(true)))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withAllowBigIntsForLongs(true)).withOptimizer(false))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry \
+        'set scalaJSStage in Global := FullOptStage' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
+        'set scalaJSStage in Global := FullOptStage' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
+        'set scalaJSStage in Global := FullOptStage' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withAllowBigIntsForLongs(true)))' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withAllowBigIntsForLongs(true)).withOptimizer(false))' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withAvoidLetsAndConsts(false).withAvoidClasses(false)))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withAvoidLetsAndConsts(false).withAvoidClasses(false)))' \
         'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallestModules))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.CommonJSModule))' \
         'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test &&
-    sbtretry \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallestModules))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallModulesFor(List("org.scalajs.testsuite"))))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
         'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test
+        $testSuite$v/test
   ''',
 
   "test-suite-custom-esversion-force-polyfills": '''
@@ -504,9 +522,10 @@ mainScalaVersions.each { scalaVersion ->
     quickMatrix.add([task: "main", scala: scalaVersion, java: javaVersion])
     quickMatrix.add([task: "tools", scala: scalaVersion, java: javaVersion])
   }
-  quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testSuite: "testSuite"])
+  quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testMinify: "false", testSuite: "testSuite"])
+  quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testMinify: "true", testSuite: "testSuite"])
   quickMatrix.add([task: "test-suite-custom-esversion", scala: scalaVersion, java: mainJavaVersion, esVersion: "ES5_1", testSuite: "testSuite"])
-  quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testSuite: "scalaTestSuite"])
+  quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testMinify: "false", testSuite: "scalaTestSuite"])
   quickMatrix.add([task: "test-suite-custom-esversion", scala: scalaVersion, java: mainJavaVersion, esVersion: "ES5_1", testSuite: "scalaTestSuite"])
   quickMatrix.add([task: "bootstrap", scala: scalaVersion, java: mainJavaVersion])
   quickMatrix.add([task: "partest-fastopt", scala: scalaVersion, java: mainJavaVersion])
@@ -527,7 +546,7 @@ otherScalaVersions.each { scalaVersion ->
 }
 mainScalaVersions.each { scalaVersion ->
   otherJavaVersions.each { javaVersion ->
-    quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: javaVersion, testSuite: "testSuite"])
+    quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: javaVersion, testMinify: "false", testSuite: "testSuite"])
   }
   fullMatrix.add([task: "partest-noopt", scala: scalaVersion, java: mainJavaVersion])
   fullMatrix.add([task: "partest-fullopt", scala: scalaVersion, java: mainJavaVersion])

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -46,6 +46,19 @@ final class StandardConfig private (
     val relativizeSourceMapBase: Option[URI],
     /** Name patterns for output. */
     val outputPatterns: OutputPatterns,
+    /** Apply Scala.js-specific minification of the produced .js files.
+     *
+     *  When enabled, the linker more aggressively reduces the size of the
+     *  generated code, at the cost of readability and debuggability. It does
+     *  not perform size optimizations that would negatively impact run-time
+     *  performance.
+     *
+     *  The focus is on optimizations that general-purpose JavaScript minifiers
+     *  cannot do on their own. For the best results, we expect the Scala.js
+     *  minifier to be used in conjunction with a general-purpose JavaScript
+     *  minifier.
+     */
+    val minify: Boolean,
     /** Whether to use the Google Closure Compiler pass, if it is available.
      *  On the JavaScript platform, this does not have any effect.
      */
@@ -80,6 +93,7 @@ final class StandardConfig private (
         sourceMap = true,
         relativizeSourceMapBase = None,
         outputPatterns = OutputPatterns.Defaults,
+        minify = false,
         closureCompilerIfAvailable = false,
         prettyPrint = false,
         batchMode = false,
@@ -148,6 +162,9 @@ final class StandardConfig private (
   def withOutputPatterns(f: OutputPatterns => OutputPatterns): StandardConfig =
     copy(outputPatterns = f(outputPatterns))
 
+  def withMinify(minify: Boolean): StandardConfig =
+    copy(minify = minify)
+
   def withClosureCompilerIfAvailable(closureCompilerIfAvailable: Boolean): StandardConfig =
     copy(closureCompilerIfAvailable = closureCompilerIfAvailable)
 
@@ -173,6 +190,7 @@ final class StandardConfig private (
        |  sourceMap                  = $sourceMap,
        |  relativizeSourceMapBase    = $relativizeSourceMapBase,
        |  outputPatterns             = $outputPatterns,
+       |  minify                     = $minify,
        |  closureCompilerIfAvailable = $closureCompilerIfAvailable,
        |  prettyPrint                = $prettyPrint,
        |  batchMode                  = $batchMode,
@@ -192,6 +210,7 @@ final class StandardConfig private (
       sourceMap: Boolean = sourceMap,
       outputPatterns: OutputPatterns = outputPatterns,
       relativizeSourceMapBase: Option[URI] = relativizeSourceMapBase,
+      minify: Boolean = minify,
       closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
       prettyPrint: Boolean = prettyPrint,
       batchMode: Boolean = batchMode,
@@ -209,6 +228,7 @@ final class StandardConfig private (
         sourceMap,
         relativizeSourceMapBase,
         outputPatterns,
+        minify,
         closureCompilerIfAvailable,
         prettyPrint,
         batchMode,
@@ -237,6 +257,7 @@ object StandardConfig {
         .addField("relativizeSourceMapBase",
             config.relativizeSourceMapBase.map(_.toASCIIString()))
         .addField("outputPatterns", config.outputPatterns)
+        .addField("minify", config.minify)
         .addField("closureCompilerIfAvailable",
             config.closureCompilerIfAvailable)
         .addField("prettyPrint", config.prettyPrint)
@@ -264,6 +285,7 @@ object StandardConfig {
    *  - `sourceMap`: `true`
    *  - `relativizeSourceMapBase`: `None`
    *  - `outputPatterns`: [[OutputPatterns.Defaults]]
+   *  - `minify`: `false`
    *  - `closureCompilerIfAvailable`: `false`
    *  - `prettyPrint`: `false`
    *  - `batchMode`: `false`

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -54,6 +54,7 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
       s"Cannot use module kind $moduleKind with the Closure Compiler")
 
   private[this] val emitter = {
+    // Note that we do not transfer `minify` -- Closure will do its own thing anyway
     val emitterConfig = Emitter.Config(config.commonConfig.coreSpec)
       .withJSHeader(config.jsHeader)
       .withOptimizeBracketSelects(false)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -45,6 +45,7 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
     val emitterConfig = Emitter.Config(config.commonConfig.coreSpec)
       .withJSHeader(config.jsHeader)
       .withInternalModulePattern(m => OutputPatternsImpl.moduleName(config.outputPatterns, m.id))
+      .withMinify(config.minify)
 
     val postTransformer =
       if (config.sourceMap) PostTransformerWithSourceMap

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/LinkerBackendImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/LinkerBackendImpl.scala
@@ -53,6 +53,8 @@ object LinkerBackendImpl {
       val outputPatterns: OutputPatterns,
       /** Base path to relativize paths in the source map. */
       val relativizeSourceMapBase: Option[URI],
+      /** Whether to use Scala.js' minifier for property names. */
+      val minify: Boolean,
       /** Whether to use the Google Closure Compiler pass, if it is available.
        *  On the JavaScript platform, this does not have any effect.
        */
@@ -69,6 +71,7 @@ object LinkerBackendImpl {
           sourceMap = true,
           outputPatterns = OutputPatterns.Defaults,
           relativizeSourceMapBase = None,
+          minify = false,
           closureCompilerIfAvailable = false,
           prettyPrint = false,
           maxConcurrentWrites = 50)
@@ -91,6 +94,9 @@ object LinkerBackendImpl {
     def withRelativizeSourceMapBase(relativizeSourceMapBase: Option[URI]): Config =
       copy(relativizeSourceMapBase = relativizeSourceMapBase)
 
+    def withMinify(minify: Boolean): Config =
+      copy(minify = minify)
+
     def withClosureCompilerIfAvailable(closureCompilerIfAvailable: Boolean): Config =
       copy(closureCompilerIfAvailable = closureCompilerIfAvailable)
 
@@ -106,12 +112,21 @@ object LinkerBackendImpl {
         sourceMap: Boolean = sourceMap,
         outputPatterns: OutputPatterns = outputPatterns,
         relativizeSourceMapBase: Option[URI] = relativizeSourceMapBase,
+        minify: Boolean = minify,
         closureCompilerIfAvailable: Boolean = closureCompilerIfAvailable,
         prettyPrint: Boolean = prettyPrint,
         maxConcurrentWrites: Int = maxConcurrentWrites): Config = {
-      new Config(commonConfig, jsHeader, sourceMap, outputPatterns,
-          relativizeSourceMapBase, closureCompilerIfAvailable, prettyPrint,
-          maxConcurrentWrites)
+      new Config(
+        commonConfig,
+        jsHeader,
+        sourceMap,
+        outputPatterns,
+        relativizeSourceMapBase,
+        minify,
+        closureCompilerIfAvailable,
+        prettyPrint,
+        maxConcurrentWrites
+      )
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ArrayClassProperty.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ArrayClassProperty.scala
@@ -1,0 +1,42 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.emitter
+
+/** Represents a property of one of the special `ArrayClass`es.
+ *
+ *  These properties live in the same namespace as Scala field and method
+ *  names, because the `ArrayClass`es extend `j.l.Object`. Therefore, they
+ *  must take part in the global property minification algorithm.
+ */
+final class ArrayClassProperty(val nonMinifiedName: String)
+    extends Comparable[ArrayClassProperty] {
+
+  def compareTo(that: ArrayClassProperty): Int =
+    this.nonMinifiedName.compareTo(that.nonMinifiedName)
+
+  override def toString(): String = s"ArrayClassProperty($nonMinifiedName)"
+}
+
+object ArrayClassProperty {
+  /** `ArrayClass.u`: the underlying array of typed array. */
+  val u: ArrayClassProperty = new ArrayClassProperty("u")
+
+  /** `ArrayClass.get()`: gets one element. */
+  val get: ArrayClassProperty = new ArrayClassProperty("get")
+
+  /** `ArrayClass.set()`: sets one element. */
+  val set: ArrayClassProperty = new ArrayClassProperty("set")
+
+  /** `ArrayClass.copyTo()`: copies from that array to another array. */
+  val copyTo: ArrayClassProperty = new ArrayClassProperty("copyTo")
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -832,7 +832,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       ancestors: js.Tree)(
       implicit pos: Position): js.Tree = {
     import TreeDSL._
-    ancestors DOT genName(className)
+    ancestors DOT genAncestorName(className)
   }
 
   def genTypeData(className: ClassName, kind: ClassKind,
@@ -863,7 +863,10 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     }
 
     val ancestorsRecord = js.ObjectConstr(
-        ancestors.withFilter(_ != ObjectClass).map(ancestor => (js.Ident(genName(ancestor)), js.IntLiteral(1))))
+        ancestors
+          .withFilter(_ != ObjectClass)
+          .map(ancestor => (js.Ident(genAncestorName(ancestor)), js.IntLiteral(1)))
+    )
 
     val isInstanceFunWithGlobals: WithGlobals[js.Tree] = {
       if (globalKnowledge.isAncestorOfHijackedClass(className)) {
@@ -912,7 +915,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
 
     isInstanceFunWithGlobals.flatMap { isInstanceFun =>
       val allParams = List(
-          js.ObjectConstr(List(js.Ident(genName(className)) -> js.IntLiteral(0))),
+          js.ObjectConstr(List(js.Ident(genAncestorName(className)) -> js.IntLiteral(0))),
           js.BooleanLiteral(kind == ClassKind.Interface),
           js.StringLiteral(RuntimeClassNameMapperImpl.map(
               semantics.runtimeClassNameMapper, className.nameString)),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -716,7 +716,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
           !(!(
               genIsScalaJSObject(obj) &&
               genIsClassNameInAncestors(className,
-                  obj DOT "$classData" DOT "ancestors")
+                  obj DOT cpn.classData DOT cpn.ancestors)
           ))
         }
 
@@ -792,9 +792,9 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       globalFunctionDef(VarField.isArrayOf, className, List(objParam, depthParam), None, {
         js.Return(!(!({
           genIsScalaJSObject(obj) &&
-          ((obj DOT "$classData" DOT "arrayDepth") === depth) &&
+          ((obj DOT cpn.classData DOT cpn.arrayDepth) === depth) &&
           genIsClassNameInAncestors(className,
-              obj DOT "$classData" DOT "arrayBase" DOT "ancestors")
+              obj DOT cpn.classData DOT cpn.arrayBase DOT cpn.ancestors)
         })))
       })
     }
@@ -825,7 +825,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
 
   private def genIsScalaJSObject(obj: js.Tree)(implicit pos: Position): js.Tree = {
     import TreeDSL._
-    obj && (obj DOT "$classData")
+    obj && (obj DOT cpn.classData)
   }
 
   private def genIsClassNameInAncestors(className: ClassName,
@@ -928,7 +928,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       val prunedParams =
         allParams.reverse.dropWhile(_.isInstanceOf[js.Undefined]).reverse
 
-      val typeData = js.Apply(js.New(globalVar(VarField.TypeData, CoreVar), Nil) DOT "initClass",
+      val typeData = js.Apply(js.New(globalVar(VarField.TypeData, CoreVar), Nil) DOT cpn.initClass,
           prunedParams)
 
       globalVarDef(VarField.d, className, typeData)
@@ -940,7 +940,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       globalKnowledge: GlobalKnowledge, pos: Position): js.Tree = {
     import TreeDSL._
 
-    globalVar(VarField.c, className).prototype DOT "$classData" := globalVar(VarField.d, className)
+    globalVar(VarField.c, className).prototype DOT cpn.classData := globalVar(VarField.d, className)
   }
 
   def genModuleAccessor(className: ClassName, isJSClass: Boolean)(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -1704,8 +1704,8 @@ private[emitter] object CoreJSLib {
             else
               Skip(),
             privateFieldSet("ancestors", ObjectConstr(List(
-                Ident(genName(CloneableClass)) -> 1,
-                Ident(genName(SerializableClass)) -> 1
+                Ident(genAncestorName(CloneableClass)) -> 1,
+                Ident(genAncestorName(SerializableClass)) -> 1
             ))),
             privateFieldSet("componentData", componentData),
             privateFieldSet("arrayBase", arrayBase),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -1171,7 +1171,10 @@ private[emitter] object CoreJSLib {
               // Both values have the same "data" (could also be falsy values)
               If(srcData && genIdentBracketSelect(srcData, "isArrayClass"), {
                 // Fast path: the values are array of the same type
-                genUncheckedArraycopy(List(src, srcPos, dest, destPos, length))
+                if (esVersion >= ESVersion.ES2015 && nullPointers == CheckedBehavior.Unchecked)
+                  Apply(src DOT "copyTo", List(srcPos, dest, destPos, length))
+                else
+                  genCallHelper(VarField.systemArraycopy, src, srcPos, dest, destPos, length)
               }, {
                 genCallHelper(VarField.throwArrayStoreException, Null())
               })

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -100,8 +100,10 @@ final class Emitter[E >: Null <: js.Tree](
 
     val WithGlobals(body, globalRefs) = emitInternal(moduleSet, logger)
 
-    if (minify)
+    if (minify) {
+      state.nameCompressor.get.endRun(logger)
       state = null // let go of all the memory, since we will not use it anyway
+    }
 
     moduleKind match {
       case ModuleKind.NoModule =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2735,7 +2735,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
           js.DotSelect(
               genSelect(transformExprNoChar(checkNotNull(runtimeClass)),
                   FieldIdent(dataFieldName)),
-              js.Ident("zero"))
+              js.Ident(cpn.zero))
 
         case Transient(NativeArrayWrapper(elemClass, nativeArray)) =>
           val newNativeArray = transformExprNoChar(nativeArray)
@@ -2749,8 +2749,8 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
                   transformExprNoChar(checkNotNull(elemClass)),
                   FieldIdent(dataFieldName))
               val arrayClassData = js.Apply(
-                  js.DotSelect(elemClassData, js.Ident("getArrayOf")), Nil)
-              js.Apply(arrayClassData DOT "wrapArray", newNativeArray :: Nil)
+                  js.DotSelect(elemClassData, js.Ident(cpn.getArrayOf)), Nil)
+              js.Apply(arrayClassData DOT cpn.wrapArray, newNativeArray :: Nil)
           }
 
         case Transient(ObjectClassName(obj)) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameCompressor.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameCompressor.scala
@@ -1,0 +1,446 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.emitter
+
+import scala.annotation.{switch, tailrec}
+
+import java.util.Comparator
+
+import scala.collection.mutable
+
+import org.scalajs.ir._
+import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
+import org.scalajs.ir.Position._
+import org.scalajs.ir.Printers.IRTreePrinter
+import org.scalajs.ir.Transformers._
+import org.scalajs.ir.Traversers._
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
+
+import org.scalajs.linker.interface._
+import org.scalajs.linker.interface.CheckedBehavior._
+import org.scalajs.linker.backend.javascript.{Trees => js}
+import org.scalajs.linker.standard.{LinkedClass, ModuleSet}
+
+import org.scalajs.logging.Logger
+
+import EmitterNames._
+import PolyfillableBuiltin._
+import Transients._
+
+private[emitter] final class NameCompressor private (
+  entries: NameCompressor.EntryMap
+) {
+  import NameCompressor._
+
+  def allocatedFor(fieldName: FieldName): String =
+    entries(fieldName).allocatedName
+
+  def allocatedFor(methodName: MethodName): String =
+    entries(methodName).allocatedName
+
+  def allocatedFor(prop: ArrayClassProperty): String =
+    entries(prop).allocatedName
+}
+
+private[emitter] object NameCompressor {
+  def compress(config: Emitter.Config, moduleSet: ModuleSet,
+      logger: Logger): (NameCompressor, Set[String]) = {
+    val traverser = new Traverser(config, moduleSet)
+
+    logger.time("Name compressor: Collect names") {
+      traverser.traverseModuleSet()
+    }
+
+    val entries = traverser.entries
+    val dangerousGlobalRefs = traverser.dangerousGlobalRefs.toSet
+
+    logger.time("Name compressor: Allocate property names") {
+      allocatePropertyNames(entries, traverser.propertyNamesToAvoid)
+    }
+
+    val compressor = new NameCompressor(entries)
+    (compressor, dangerousGlobalRefs)
+  }
+
+  private def allocatePropertyNames(entries: EntryMap,
+      namesToAvoid: collection.Set[String]): Unit = {
+    val comparator: Comparator[PropertyNameEntry] =
+      Comparator.comparingInt[PropertyNameEntry](_.occurrences).reversed() // by decreasing order of occurrences
+        .thenComparing(Comparator.naturalOrder[PropertyNameEntry]()) // tie-break
+
+    val orderedEntries = entries.values.toArray
+    java.util.Arrays.sort(orderedEntries, comparator)
+
+    val generator = new NameGenerator(namesToAvoid)
+
+    for (entry <- orderedEntries)
+      entry.allocatedName = generator.nextString()
+  }
+
+  /** Keys of this map are `FieldName | MethodName | ArrayClassProperty`. */
+  private type EntryMap = mutable.AnyRefMap[AnyRef, PropertyNameEntry]
+
+  private sealed abstract class PropertyNameEntry extends Comparable[PropertyNameEntry] {
+    var occurrences: Int = 0
+    var allocatedName: String = null
+
+    def incOccurrences(): Unit =
+      occurrences += 1
+
+    def compareTo(that: PropertyNameEntry): Int = (this, that) match {
+      case (x: FieldNameEntry, y: FieldNameEntry) =>
+        x.fieldName.compareTo(y.fieldName)
+
+      case (x: MethodNameEntry, y: MethodNameEntry) =>
+        x.methodName.compareTo(y.methodName)
+
+      case (x: ArrayClassPropEntry, y: ArrayClassPropEntry) =>
+        x.property.compareTo(y.property)
+
+      case _ =>
+        def ordinalFor(x: PropertyNameEntry): Int = x match {
+          case _: FieldNameEntry      => 1
+          case _: MethodNameEntry     => 2
+          case _: ArrayClassPropEntry => 3
+        }
+        ordinalFor(this) - ordinalFor(that)
+    }
+  }
+
+  private final class FieldNameEntry(val fieldName: FieldName)
+      extends PropertyNameEntry {
+    override def toString(): String = s"FieldNameEntry(${fieldName.nameString})"
+  }
+
+  private final class MethodNameEntry(val methodName: MethodName)
+      extends PropertyNameEntry {
+    override def toString(): String = s"MethodNameEntry(${methodName.nameString})"
+  }
+
+  private final class ArrayClassPropEntry(val property: ArrayClassProperty)
+      extends PropertyNameEntry {
+    override def toString(): String = s"ArrayClassPropEntry(${property.nonMinifiedName})"
+  }
+
+  private final class Traverser(config: Emitter.Config, moduleSet: ModuleSet)
+      extends org.scalajs.ir.Traversers.Traverser {
+
+    import config.semantics._
+    import config.esFeatures.esVersion
+
+    private val useBigIntForLongs = config.esFeatures.allowBigIntsForLongs
+
+    private val interfaceClassNames: Set[ClassName] = {
+      (for {
+        module <- moduleSet.modules
+        linkedClass <- module.classDefs
+        if linkedClass.kind == ClassKind.Interface
+      } yield {
+        linkedClass.name.name
+      }).toSet
+    }
+
+    val dangerousGlobalRefs = mutable.Set.empty[String]
+
+    /** Names that should be avoided when allocating property names.
+     *
+     *  After traversing the module set, this set contains:
+     *
+     *  - the reserved JS identifiers (not technically invalid by spec, but JS
+     *    minifiers tend to avoid them anyway: `foo.if` is playing with fire),
+     *  - the `"then"` name, because it is used to identify `Thenable`s by
+     *    spec and therefore lives in the same namespace as the properties of
+     *    *all* objects,
+     *  - the `"name"` and `"cause"` names, because they are specified instance
+     *    properties of `Error` (which our `Throwable` extends) and are
+     *    short enough that they could in theory collide with generated names,
+     *  - the names of *exported* methods and properties in Scala classes,
+     *    because they live in the same namespace as the properties we will
+     *    rename, so we must avoid collisions with them.
+     */
+    val propertyNamesToAvoid: mutable.Set[String] =
+      mutable.Set.empty ++= NameGen.ReservedJSIdentifierNames ++= List("then", "name", "cause")
+
+    /** Keys are `FieldName`s, `MethodName`s or `ArrayClassProperty`s. */
+    val entries: EntryMap = mutable.AnyRefMap.empty
+
+    private def countPropertyName(fieldName: FieldName): Unit =
+      entries.getOrElseUpdate(fieldName, new FieldNameEntry(fieldName)).incOccurrences()
+
+    private def countPropertyName(methodName: MethodName): Unit =
+      entries.getOrElseUpdate(methodName, new MethodNameEntry(methodName)).incOccurrences()
+
+    private def countPropertyName(prop: ArrayClassProperty): Unit =
+      entries.getOrElseUpdate(prop, new ArrayClassPropEntry(prop)).incOccurrences()
+
+    private def countGlobalRef(name: String): Unit = {
+      if (GlobalRefUtils.isDangerousGlobalRef(name))
+        dangerousGlobalRefs += name
+    }
+
+    def traverseModuleSet(): Unit = {
+      countCoreJSLibPropertyNames()
+
+      for (module <- moduleSet.modules) {
+        for (linkedClass <- module.classDefs)
+          traverseLinkedClass(linkedClass)
+        for (topLevelExport <- module.topLevelExports)
+          traverseTopLevelExportDef(topLevelExport.tree)
+      }
+    }
+
+    private def countCoreJSLibPropertyNames(): Unit = {
+      countPropertyName(cloneMethodName)
+
+      if (nullPointers == CheckedBehavior.Unchecked) {
+        // See CoreJSLib.defineObjectGetClassFunctions()
+        countPropertyName(getClassMethodName)
+        countPropertyName(getNameMethodName)
+      }
+
+      // ArrayClass properties
+
+      countPropertyName(ArrayClassProperty.u)
+
+      if (arrayIndexOutOfBounds != CheckedBehavior.Unchecked) {
+        countPropertyName(ArrayClassProperty.get)
+        countPropertyName(ArrayClassProperty.set)
+      } else if (arrayStores != CheckedBehavior.Unchecked) {
+        countPropertyName(ArrayClassProperty.set)
+      }
+
+      if (esVersion >= ESVersion.ES2015)
+        countPropertyName(ArrayClassProperty.copyTo)
+    }
+
+    def traverseLinkedClass(linkedClass: LinkedClass): Unit = {
+      if (linkedClass.kind.isClass || linkedClass.kind == ClassKind.HijackedClass) {
+        /* For Scala classes, we need to register the definition names of
+         * fields and methods for allocation. We also need to register the
+         * definition names of member exports as names to avoid, in order to
+         * prevent collisions.
+         *
+         * Note: Methods of hijacked classes are referred to in a normal
+         * `genApply` from the dispatchers generated by
+         * `CoreJSLib.defineDispatchFunctions()`.
+         */
+        for (field <- linkedClass.fields)
+          traverseAnyFieldDefInScalaClass(field)
+        for (method <- linkedClass.methods)
+          traverseMethodDefInScalaClass(method)
+        for (exportedMember <- linkedClass.exportedMembers)
+          traverseJSMethodPropDefInScalaClass(exportedMember)
+      } else {
+        /* For all other types, including Scala interfaces, we only need to
+         * recurse inside the bodies. The definition names are not emitted.
+         */
+        for (field <- linkedClass.fields)
+          traverseAnyFieldDef(field)
+        for (method <- linkedClass.methods)
+          traverseMethodDef(method)
+        for (exportedMember <- linkedClass.exportedMembers)
+          traverseJSMethodPropDef(exportedMember)
+      }
+    }
+
+    def traverseAnyFieldDefInScalaClass(fieldDef: AnyFieldDef): Unit = {
+      traverseAnyFieldDef(fieldDef)
+
+      fieldDef match {
+        case fieldDef: FieldDef =>
+          if (!fieldDef.flags.namespace.isStatic)
+            countPropertyName(fieldDef.name.name)
+        case _: JSFieldDef =>
+          ()
+      }
+    }
+
+    def traverseMethodDefInScalaClass(methodDef: MethodDef): Unit = {
+      traverseMethodDef(methodDef)
+
+      if (methodDef.flags.namespace == MemberNamespace.Public)
+        countPropertyName(methodDef.name.name)
+    }
+
+    def traverseJSMethodPropDefInScalaClass(jsMethodPropDef: JSMethodPropDef): Unit = {
+      traverseJSMethodPropDef(jsMethodPropDef)
+
+      jsMethodPropDef match {
+        case JSMethodDef(_, StringLiteral(name), _, _, _) =>
+          propertyNamesToAvoid += name
+        case JSPropertyDef(_, StringLiteral(name), _, _) =>
+          propertyNamesToAvoid += name
+        case _ =>
+          ()
+      }
+    }
+
+    override def traverse(tree: Tree): Unit = {
+      // scalastyle:off return
+
+      tree match {
+        case Assign(ArraySelect(array, index), rhs) =>
+          if (FunctionEmitter.isArraySetChecked(config.semantics, array.tpe))
+            countPropertyName(ArrayClassProperty.set)
+          else
+            countPropertyName(ArrayClassProperty.u)
+          traverse(array)
+          traverse(index)
+          traverse(rhs)
+          return // prevent `super.traverse(tree)`
+
+        case Select(_, FieldIdent(fieldName)) =>
+          countPropertyName(fieldName)
+
+        case Apply(_, receiver, MethodIdent(methodName), _) =>
+          // Ideally we should also ignore hijacked method calls
+          if (receiver.tpe != AnyType || methodName.isReflectiveProxy)
+            countPropertyName(methodName)
+
+        case ApplyStatically(flags, _, className, MethodIdent(methodName), _) =>
+          if (!flags.isConstructor && !flags.isPrivate && !interfaceClassNames.contains(className))
+            countPropertyName(methodName)
+
+        case UnaryOp(op, _) if !useBigIntForLongs =>
+          import UnaryOp._
+          (op: @switch) match {
+            case IntToLong    => countPropertyName(LongImpl.fromInt)
+            case LongToInt    => countPropertyName(LongImpl.toInt)
+            case LongToDouble => countPropertyName(LongImpl.toDouble)
+            case DoubleToLong => countPropertyName(LongImpl.fromDouble)
+            case LongToFloat  => countPropertyName(LongImpl.toFloat)
+            case _            => ()
+          }
+
+        case BinaryOp(op, lhs, _) if !useBigIntForLongs =>
+          import BinaryOp._
+          (op: @switch) match {
+            case Long_+ => countPropertyName(LongImpl.+)
+            case Long_- =>
+              lhs match {
+                case LongLiteral(0L) => countPropertyName(LongImpl.UNARY_-)
+                case _               => countPropertyName(LongImpl.-)
+              }
+            case Long_* => countPropertyName(LongImpl.*)
+            case Long_/ => countPropertyName(LongImpl./)
+            case Long_% => countPropertyName(LongImpl.%)
+            case Long_| => countPropertyName(LongImpl.|)
+            case Long_& => countPropertyName(LongImpl.&)
+            case Long_^ =>
+              lhs match {
+                case LongLiteral(-1L) => countPropertyName(LongImpl.UNARY_~)
+                case _                => countPropertyName(LongImpl.^)
+              }
+            case Long_<<  => countPropertyName(LongImpl.<<)
+            case Long_>>> => countPropertyName(LongImpl.>>>)
+            case Long_>>  => countPropertyName(LongImpl.>>)
+            case Long_==  => countPropertyName(LongImpl.===)
+            case Long_!=  => countPropertyName(LongImpl.!==)
+            case Long_<   => countPropertyName(LongImpl.<)
+            case Long_<=  => countPropertyName(LongImpl.<=)
+            case Long_>   => countPropertyName(LongImpl.>)
+            case Long_>=  => countPropertyName(LongImpl.>=)
+            case _        => ()
+          }
+
+        case ArrayLength(_) =>
+          countPropertyName(ArrayClassProperty.u)
+
+        case ArraySelect(_, _) =>
+          if (arrayIndexOutOfBounds != CheckedBehavior.Unchecked)
+            countPropertyName(ArrayClassProperty.get)
+
+        case Clone(expr) =>
+          if (expr.tpe.isInstanceOf[ArrayType])
+            countPropertyName(cloneMethodName)
+
+        case UnwrapFromThrowable(expr) =>
+          countPropertyName(exceptionFieldName)
+
+        case JSGlobalRef(name) =>
+          countGlobalRef(name)
+
+        case Transient(SystemArrayCopy(src, srcPos, dest, destPos, length)) =>
+          if (esVersion >= ESVersion.ES2015 && nullPointers == CheckedBehavior.Unchecked) {
+            val useCopyTo = src.tpe match {
+              case _ if arrayStores == CheckedBehavior.Unchecked => true
+              case ArrayType(ArrayTypeRef(_: PrimRef, 1))        => src.tpe == dest.tpe
+              case _                                             => false
+            }
+            if (useCopyTo)
+              countPropertyName(ArrayClassProperty.copyTo)
+          }
+
+        case Transient(ZeroOf(_)) =>
+          countPropertyName(dataFieldName)
+
+        case Transient(NativeArrayWrapper(elemClass, _)) =>
+          if (!elemClass.isInstanceOf[ClassOf])
+            countPropertyName(dataFieldName)
+
+        case Transient(ArrayToTypedArray(_, _)) =>
+          countPropertyName(ArrayClassProperty.u)
+
+        case _ =>
+          ()
+      }
+
+      super.traverse(tree)
+
+      // scalastyle:on return
+    }
+  }
+
+  // private[emitter] for tests
+  private[emitter] final class NameGenerator(namesToAvoid: collection.Set[String]) {
+    /* 6 because 52 * (62**5) > Int.MaxValue
+     * i.e., to exceed this size we would need more than Int.MaxValue different names.
+     */
+    private val charArray = new Array[Char](6)
+    charArray(0) = 'a'
+    private var charCount = 1
+
+    @tailrec
+    private def incAtIndex(idx: Int): Unit = {
+      (charArray(idx): @switch) match {
+        case '9' =>
+          charArray(idx) = 'a'
+        case 'z' =>
+          charArray(idx) = 'A'
+        case 'Z' =>
+          if (idx > 0) {
+            charArray(idx) = '0'
+            incAtIndex(idx - 1)
+          } else {
+            java.util.Arrays.fill(charArray, '0')
+            charArray(0) = 'a'
+            charCount += 1
+          }
+        case c =>
+          charArray(idx) = (c + 1).toChar
+      }
+    }
+
+    @tailrec
+    final def nextString(): String = {
+      val s = new String(charArray, 0, charCount)
+      incAtIndex(charCount - 1)
+      if (namesToAvoid.contains(s))
+        nextString()
+      else
+        s
+    }
+  }
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
@@ -301,7 +301,7 @@ private[emitter] final class NameGen {
   }
 }
 
-private object NameGen {
+private[emitter] object NameGen {
 
   private final val FullwidthSpacingUnderscore = '\uff3f'
   private final val GreekSmallLetterDelta = '\u03b4'
@@ -371,7 +371,7 @@ private object NameGen {
    *    not actually mean `void 0`, and who knows what JS engine performance
    *    cliffs we can trigger with that.
    */
-  private final val ReservedJSIdentifierNames: Set[String] = Set(
+  private[emitter] final val ReservedJSIdentifierNames: Set[String] = Set(
       "arguments", "await", "break", "case", "catch", "class", "const",
       "continue", "debugger", "default", "delete", "do", "else", "enum",
       "eval", "export", "extends", "false", "finally", "for", "function", "if",

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -209,6 +209,13 @@ private[emitter] final class SJSGen(
     }
   }
 
+  def genAncestorName(ancestor: ClassName): String = {
+    nameCompressor match {
+      case None             => genName(ancestor)
+      case Some(compressor) => compressor.allocatedForAncestor(ancestor)
+    }
+  }
+
   def genJSPrivateSelect(receiver: Tree, field: irt.FieldIdent)(
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
       pos: Position): Tree = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -149,20 +149,6 @@ private[emitter] final class SJSGen(
     }
   }
 
-  def genUncheckedArraycopy(args: List[Tree])(
-      implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
-      pos: Position): Tree = {
-    import TreeDSL._
-
-    assert(args.lengthCompare(5) == 0,
-        s"wrong number of args for genUncheckedArrayCopy: $args")
-
-    if (esFeatures.esVersion >= ESVersion.ES2015 && semantics.nullPointers == CheckedBehavior.Unchecked)
-      Apply(args.head DOT "copyTo", args.tail)
-    else
-      genCallHelper(VarField.systemArraycopy, args: _*)
-  }
-
   def genSelect(receiver: Tree, field: irt.FieldIdent)(
       implicit pos: Position): Tree = {
     DotSelect(receiver, Ident(genName(field.name))(field.pos))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
@@ -112,7 +112,6 @@ private[emitter] object TreeDSL {
 
     def prototype(implicit pos: Position): Tree = self DOT "prototype"
     def length(implicit pos: Position): Tree = self DOT "length"
-    def u(implicit pos: Position): Tree = self DOT "u"
   }
 
   def typeof(expr: Tree)(implicit pos: Position): Tree =

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/StandardLinkerBackend.scala
@@ -23,6 +23,7 @@ object StandardLinkerBackend {
       .withSourceMap(config.sourceMap)
       .withOutputPatterns(config.outputPatterns)
       .withRelativizeSourceMapBase(config.relativizeSourceMapBase)
+      .withMinify(config.minify)
       .withClosureCompilerIfAvailable(config.closureCompilerIfAvailable)
       .withPrettyPrint(config.prettyPrint)
       .withMaxConcurrentWrites(config.maxConcurrentWrites)

--- a/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
@@ -63,7 +63,7 @@ class EmitterTest {
           config = config)
       fullContent <- linkToContent(classDefs,
           moduleInitializers = MainTestModuleInitializers,
-          config = config.withClosureCompilerIfAvailable(true))
+          config = config.withClosureCompilerIfAvailable(true).withMinify(true))
     } yield {
       def testContent(content: String): Unit = {
         if (!content.startsWith(header)) {

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -71,7 +71,7 @@ class LibrarySizeTest {
 
     testLinkedSizes(
       expectedFastLinkSize = 150063,
-      expectedFullLinkSizeWithoutClosure = 95734,
+      expectedFullLinkSizeWithoutClosure = 93922,
       expectedFullLinkSizeWithClosure = 21325,
       classDefs,
       moduleInitializers = MainTestModuleInitializers

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -71,7 +71,7 @@ class LibrarySizeTest {
 
     testLinkedSizes(
       expectedFastLinkSize = 150063,
-      expectedFullLinkSizeWithoutClosure = 93922,
+      expectedFullLinkSizeWithoutClosure = 92652,
       expectedFullLinkSizeWithClosure = 21325,
       classDefs,
       moduleInitializers = MainTestModuleInitializers

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -71,7 +71,7 @@ class LibrarySizeTest {
 
     testLinkedSizes(
       expectedFastLinkSize = 150063,
-      expectedFullLinkSizeWithoutClosure = 130664,
+      expectedFullLinkSizeWithoutClosure = 95734,
       expectedFullLinkSizeWithClosure = 21325,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
@@ -98,6 +98,7 @@ object LibrarySizeTest {
     val fullLinkConfig = config
       .withSemantics(_.optimized)
       .withClosureCompilerIfAvailable(true)
+      .withMinify(true)
 
     val fastLinker = StandardImpl.linker(config)
     val fullLinker = StandardImpl.linker(fullLinkConfig)

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/emitter/NameCompressorTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/emitter/NameCompressorTest.scala
@@ -1,0 +1,53 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.emitter
+
+import org.junit.Test
+import org.junit.Assert._
+
+class NameCompressorTest {
+  @Test def testNameGenerator(): Unit = {
+    // all the one-letter strings
+    val letterStrings = (('a' to 'z') ++ ('A' to 'Z')).map(_.toString())
+
+    // all the one-letter-or-digit strings
+    val letterOrDigitStrings = ('0' to '9').map(_.toString()) ++ letterStrings
+
+    val expectedOneCharIdents = letterStrings
+
+    val expectedTwoCharIdents = for {
+      firstChar <- letterStrings
+      secondChar <- letterOrDigitStrings
+      ident = firstChar + secondChar
+      if ident != "do" && ident != "if" && ident != "in" // reserved JS identifiers that will be avoided
+    } yield {
+      ident
+    }
+
+    val firstFewExpectedThreeCharIdents = {
+      letterOrDigitStrings.map("a0" + _) ++
+      letterOrDigitStrings.map("a1" + _)
+    }
+
+    val expectedSequenceStart =
+      expectedOneCharIdents ++ expectedTwoCharIdents ++ firstFewExpectedThreeCharIdents
+
+    // Now actually test
+
+    val namesToAvoid = NameGen.ReservedJSIdentifierNames
+    val generator = new NameCompressor.NameGenerator(namesToAvoid)
+
+    for (expected <- expectedSequenceStart)
+      assertEquals(expected, generator.nextString())
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2013,8 +2013,8 @@ object Build {
             Some(ExpectedSizes(
                 fastLink = 640000 to 641000,
                 fullLink = 101000 to 102000,
-                fastLinkMinify = 499000 to 500000,
-                fullLinkMinify = 341000 to 342000,
+                fastLinkMinify = 494000 to 495000,
+                fullLinkMinify = 337000 to 338000,
                 fastLinkGz = 77000 to 78000,
                 fullLinkGz = 26000 to 27000,
                 fastLinkMinifyGz = 69000 to 70000,
@@ -2025,8 +2025,8 @@ object Build {
             Some(ExpectedSizes(
                 fastLink = 462000 to 463000,
                 fullLink = 99000 to 100000,
-                fastLinkMinify = 352000 to 353000,
-                fullLinkMinify = 312000 to 313000,
+                fastLinkMinify = 347000 to 348000,
+                fullLinkMinify = 307000 to 308000,
                 fastLinkGz = 60000 to 61000,
                 fullLinkGz = 26000 to 27000,
                 fastLinkMinifyGz = 54000 to 55000,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2013,24 +2013,24 @@ object Build {
             Some(ExpectedSizes(
                 fastLink = 640000 to 641000,
                 fullLink = 101000 to 102000,
-                fastLinkMinify = 538000 to 539000,
-                fullLinkMinify = 371000 to 372000,
+                fastLinkMinify = 499000 to 500000,
+                fullLinkMinify = 341000 to 342000,
                 fastLinkGz = 77000 to 78000,
                 fullLinkGz = 26000 to 27000,
-                fastLinkMinifyGz = 71000 to 72000,
-                fullLinkMinifyGz = 51000 to 52000,
+                fastLinkMinifyGz = 69000 to 70000,
+                fullLinkMinifyGz = 50000 to 51000,
             ))
 
           case `default213Version` =>
             Some(ExpectedSizes(
                 fastLink = 462000 to 463000,
                 fullLink = 99000 to 100000,
-                fastLinkMinify = 373000 to 374000,
-                fullLinkMinify = 332000 to 333000,
+                fastLinkMinify = 352000 to 353000,
+                fullLinkMinify = 312000 to 313000,
                 fastLinkGz = 60000 to 61000,
                 fullLinkGz = 26000 to 27000,
-                fastLinkMinifyGz = 55000 to 56000,
-                fullLinkMinifyGz = 50000 to 51000,
+                fastLinkMinifyGz = 54000 to 55000,
+                fullLinkMinifyGz = 49000 to 50000,
             ))
 
           case _ =>

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -53,6 +53,9 @@ object ExposedValues extends AutoPlugin {
     val default213ScalaVersion: SettingKey[String] =
       settingKey("the default Scala 2.13.x version for this build (derived from cross213ScalaVersions)")
 
+    val enableMinifyEverywhere: SettingKey[Boolean] =
+      settingKey("force usage of the `minify` option of the linker in all contexts (fast and full)")
+
     // set scalaJSLinkerConfig in someProject ~= makeCompliant
     val makeCompliant: StandardConfig => StandardConfig = {
       _.withSemantics { semantics =>
@@ -102,8 +105,18 @@ object ExposedValues extends AutoPlugin {
   }
 }
 
-final case class ExpectedSizes(fastLink: Range, fullLink: Range,
-    fastLinkGz: Range, fullLinkGz: Range)
+import ExposedValues.autoImport.enableMinifyEverywhere
+
+final case class ExpectedSizes(
+  fastLink: Range,
+  fullLink: Range,
+  fastLinkMinify: Range,
+  fullLinkMinify: Range,
+  fastLinkGz: Range,
+  fullLinkGz: Range,
+  fastLinkMinifyGz: Range,
+  fullLinkMinifyGz: Range,
+)
 
 object MyScalaJSPlugin extends AutoPlugin {
   override def requires: Plugins = ScalaJSPlugin
@@ -143,6 +156,15 @@ object MyScalaJSPlugin extends AutoPlugin {
   }
 
   override def globalSettings: Seq[Setting[_]] = Def.settings(
+      // can be overridden with a 'set' command
+      enableMinifyEverywhere := false,
+
+      scalaJSLinkerConfig := {
+        scalaJSLinkerConfig.value
+          .withCheckIR(true)
+          .withMinify(enableMinifyEverywhere.value)
+      },
+
       fullClasspath in scalaJSLinkerImpl := {
         (fullClasspath in (Build.linker.v2_12, Runtime)).value
       },
@@ -201,9 +223,23 @@ object MyScalaJSPlugin extends AutoPlugin {
         libDeps.filterNot(dep => blacklist.contains(dep.name))
       },
 
-      scalaJSLinkerConfig ~= (_.withCheckIR(true)),
-
       wantSourceMaps := true,
+
+      // If `enableMinifyEverywhere` is used, make sure to deactive GCC in fullLinkJS
+      Compile / fullLinkJS / scalaJSLinkerConfig := {
+        val prev = (Compile / fullLinkJS / scalaJSLinkerConfig).value
+        if (enableMinifyEverywhere.value)
+          prev.withClosureCompiler(false)
+        else
+          prev
+      },
+      Test / fullLinkJS / scalaJSLinkerConfig := {
+        val prev = (Test / fullLinkJS / scalaJSLinkerConfig).value
+        if (enableMinifyEverywhere.value)
+          prev.withClosureCompiler(false)
+        else
+          prev
+      },
 
       jsEnv := new NodeJSEnv(
           NodeJSEnv.Config().withSourceMap(wantSourceMaps.value)),
@@ -231,6 +267,7 @@ object MyScalaJSPlugin extends AutoPlugin {
       checksizes := {
         val logger = streams.value.log
 
+        val useMinifySizes = enableMinifyEverywhere.value
         val maybeExpected = expectedSizes.value
 
         /* The deprecated tasks do exactly what we want in terms of module /
@@ -239,7 +276,7 @@ object MyScalaJSPlugin extends AutoPlugin {
         val fast = (fastOptJS in Compile).value.data
         val full = (fullOptJS in Compile).value.data
 
-        val desc = s"${thisProject.value.id} Scala ${scalaVersion.value}"
+        val desc = s"${thisProject.value.id} Scala ${scalaVersion.value}, useMinifySizes = $useMinifySizes"
 
         maybeExpected.fold {
           logger.info(s"Ignoring checksizes for " + desc)
@@ -255,17 +292,24 @@ object MyScalaJSPlugin extends AutoPlugin {
           val fastGzSize = fastGz.length()
           val fullGzSize = fullGz.length()
 
+          val (expectedFastLink, expectedFullLink, expectedFastLinkGz, expectedFullLinkGz) = {
+            if (useMinifySizes)
+              (expected.fastLinkMinify, expected.fullLinkMinify, expected.fastLinkMinifyGz, expected.fullLinkMinifyGz)
+            else
+              (expected.fastLink, expected.fullLink, expected.fastLinkGz, expected.fullLinkGz)
+          }
+
           logger.info(s"Checksizes: $desc")
-          logger.info(s"fastLink size = $fastSize (expected ${expected.fastLink})")
-          logger.info(s"fullLink size = $fullSize (expected ${expected.fullLink})")
-          logger.info(s"fastLink gzip size = $fastGzSize (expected ${expected.fastLinkGz})")
-          logger.info(s"fullLink gzip size = $fullGzSize (expected ${expected.fullLinkGz})")
+          logger.info(s"fastLink size = $fastSize (expected ${expectedFastLink})")
+          logger.info(s"fullLink size = $fullSize (expected ${expectedFullLink})")
+          logger.info(s"fastLink gzip size = $fastGzSize (expected ${expectedFastLinkGz})")
+          logger.info(s"fullLink gzip size = $fullGzSize (expected ${expectedFullLinkGz})")
 
           val ok = (
-              expected.fastLink.contains(fastSize) &&
-              expected.fullLink.contains(fullSize) &&
-              expected.fastLinkGz.contains(fastGzSize) &&
-              expected.fullLinkGz.contains(fullGzSize)
+              expectedFastLink.contains(fastSize) &&
+              expectedFullLink.contains(fullSize) &&
+              expectedFastLinkGz.contains(fastGzSize) &&
+              expectedFullLinkGz.contains(fullGzSize)
           )
 
           if (!ok)
@@ -1969,16 +2013,24 @@ object Build {
             Some(ExpectedSizes(
                 fastLink = 640000 to 641000,
                 fullLink = 101000 to 102000,
+                fastLinkMinify = 538000 to 539000,
+                fullLinkMinify = 371000 to 372000,
                 fastLinkGz = 77000 to 78000,
                 fullLinkGz = 26000 to 27000,
+                fastLinkMinifyGz = 71000 to 72000,
+                fullLinkMinifyGz = 51000 to 52000,
             ))
 
           case `default213Version` =>
             Some(ExpectedSizes(
                 fastLink = 462000 to 463000,
                 fullLink = 99000 to 100000,
+                fastLinkMinify = 373000 to 374000,
+                fullLinkMinify = 332000 to 333000,
                 fastLinkGz = 60000 to 61000,
                 fullLinkGz = 26000 to 27000,
+                fastLinkMinifyGz = 55000 to 56000,
+                fullLinkMinifyGz = 50000 to 51000,
             ))
 
           case _ =>
@@ -2227,7 +2279,8 @@ object Build {
           "isNoModule" -> (moduleKind == ModuleKind.NoModule),
           "isESModule" -> (moduleKind == ModuleKind.ESModule),
           "isCommonJSModule" -> (moduleKind == ModuleKind.CommonJSModule),
-          "isFullOpt" -> (stage == Stage.FullOpt),
+          "usesClosureCompiler" -> linkerConfig.closureCompiler,
+          "hasMinifiedNames" -> (linkerConfig.closureCompiler || linkerConfig.minify),
           "compliantAsInstanceOfs" -> (sems.asInstanceOfs == CheckedBehavior.Compliant),
           "compliantArrayIndexOutOfBounds" -> (sems.arrayIndexOutOfBounds == CheckedBehavior.Compliant),
           "compliantArrayStores" -> (sems.arrayStores == CheckedBehavior.Compliant),

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -470,6 +470,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
         prevConfig
           .withSemantics(_.optimized)
           .withClosureCompiler(useClosure)
+          .withMinify(true) // ignored if we actually use Closure
           .withCheckIR(true)  // for safety, fullOpt is slow anyways.
       },
 

--- a/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
+++ b/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
@@ -22,7 +22,8 @@ private[utils] object BuildInfo {
   final val isNoModule = false
   final val isESModule = false
   final val isCommonJSModule = false
-  final val isFullOpt = false
+  final val usesClosureCompiler = false
+  final val hasMinifiedNames = false
   final val compliantAsInstanceOfs = false
   final val compliantArrayIndexOutOfBounds = false
   final val compliantArrayStores = false

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -68,7 +68,10 @@ object Platform {
 
   def sourceMaps: Boolean = BuildInfo.hasSourceMaps && executingInNodeJS
 
-  def isInFullOpt: Boolean = BuildInfo.isFullOpt
+  def usesClosureCompiler: Boolean = BuildInfo.usesClosureCompiler
+
+  def hasMinifiedNames: Boolean = BuildInfo.hasMinifiedNames
+
   def isInProductionMode: Boolean = BuildInfo.productionMode
 
   def hasCompliantAsInstanceOfs: Boolean = BuildInfo.compliantAsInstanceOfs

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -321,19 +321,22 @@ class OptimizerTest {
   }
 
   @Test def foldingDoubleWithDecimalAndString(): Unit = {
-    assumeFalse("Assumed not executing in FullOpt", isInFullOpt)
+    assumeFalse("GCC wrongly optimizes this code", usesClosureCompiler)
+
     assertEquals("1.2323919403474454e+21hello", 1.2323919403474454E21 + "hello")
     assertEquals("hello1.2323919403474454e+21", "hello" + 1.2323919403474454E21)
   }
 
   @Test def foldingDoubleThatJVMWouldPrintInScientificNotationAndString(): Unit = {
-    assumeFalse("Assumed not executing in FullOpt", isInFullOpt)
+    assumeFalse("GCC wrongly optimizes this code", usesClosureCompiler)
+
     assertEquals("123456789012345hello", 123456789012345d + "hello")
     assertEquals("hello123456789012345", "hello" + 123456789012345d)
   }
 
   @Test def foldingDoublesToString(): Unit = {
-    assumeFalse("Assumed not executing in FullOpt", isInFullOpt)
+    assumeFalse("GCC wrongly optimizes this code", usesClosureCompiler)
+
     @noinline def toStringNoInline(v: Double): String = v.toString
     @inline def test(v: Double): Unit =
       assertEquals(toStringNoInline(v), v.toString)

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/MiscInteropTest.scala
@@ -42,7 +42,7 @@ class MiscInteropTest {
     assumeFalse(
         "GCC wrongly optimizes this code, " +
         "see https://github.com/google/closure-compiler/issues/3498",
-        isInFullOpt)
+        usesClosureCompiler)
 
     @noinline def nonExistentGlobalVarNoInline(): Any =
       js.Dynamic.global.thisGlobalVarDoesNotExist
@@ -197,7 +197,7 @@ class MiscInteropTest {
   // Emitted classes
 
   @Test def meaningfulNameProperty(): Unit = {
-    assumeFalse("Assumed not executing in FullOpt", isInFullOpt)
+    assumeFalse("Need non-minified names", hasMinifiedNames)
 
     def nameOf(obj: Any): js.Any =
       obj.asInstanceOf[js.Dynamic].constructor.name

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/StackTraceTest.scala
@@ -52,7 +52,7 @@ class StackTraceTest {
 
   @Test def decodeClassNameAndMethodName(): Unit = {
     assumeTrue("Assume Node.js", executingInNodeJS)
-    assumeFalse("Assume fullopt-stage", isInFullOpt)
+    assumeFalse("Assume non-minified names", hasMinifiedNames)
 
     val Error = js.constructorOf[js.Error]
     val oldStackTraceLimit = Error.stackTraceLimit

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -40,7 +40,9 @@ object Platform {
     else Integer.parseInt(v.takeWhile(_.isDigit))
   }
 
-  def isInFullOpt: Boolean = false
+  def usesClosureCompiler: Boolean = false
+
+  def hasMinifiedNames: Boolean = false
 
   def hasCompliantAsInstanceOfs: Boolean = true
   def hasCompliantArrayIndexOutOfBounds: Boolean = true

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -620,7 +620,7 @@ class LongTest {
     test(-1, lg(-1))
 
     // Closure seems to incorrectly rewrite the constant on the right :-(
-    val epsilon = if (isInFullOpt) 1E4f else 0.0f
+    val epsilon = if (usesClosureCompiler) 1E4f else 0.0f
     test(9.223372E18f, MaxVal, epsilon)
     test(-9.223372E18f, MinVal, epsilon)
 
@@ -674,7 +674,7 @@ class LongTest {
     test(-1, lg(-1))
 
     // Closure seems to incorrectly rewrite the constant on the right :-(
-    val epsilon = if (isInFullOpt) 1E4 else 0.0
+    val epsilon = if (usesClosureCompiler) 1E4 else 0.0
     test(9.223372036854776E18, MaxVal, epsilon)
     test(-9.223372036854776E18, MinVal, epsilon)
 
@@ -722,7 +722,7 @@ class LongTest {
     test(lg(0), -Double.MinPositiveValue)
     test(MaxVal, twoPow63)
     test(MaxVal, twoPow63NextUp)
-    if (!isInFullOpt) {
+    if (!usesClosureCompiler) {
       // GCC incorrectly rewrites the Double constants on the rhs
       test(lg(-1024, 2147483647), twoPow63NextDown)
       test(MinVal, -twoPow63)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ReflectiveCallTest.scala
@@ -346,7 +346,7 @@ class ReflectiveCallTest {
 
     assumeFalse(
         "GCC is a bit too eager in its optimizations in this error case",
-        Platform.isInFullOpt)
+        Platform.usesClosureCompiler)
 
     type ObjWithAnyRefPrimitives = Any {
       def eq(that: AnyRef): Boolean


### PR DESCRIPTION
When emitting ES modules, we cannot use Closure because it does not support ES modules the way we need it to. This results in files that are much larger than with other module kinds.

Off-the-shelf JavaScript bundlers/minifier can compensate for that to a large extent for local and file-local variables, but they do not have enough semantic information to do it on property names.

We therefore add our own property name compressor. When enabled, the emitter computes the frequency of every field and method name in the entire program. It then uses those frequencies to allocate short names to them, with the shortest ones allocated to the most used properties.

Obviously, this breaks any sort of incremental behavior, so we also invalidate all the emitter caches on every run when the new minifier is enabled. This should not be a problem as it is only intended to be used for fullLink.

Since we have to walk the entire codebase to compute property frequencies, we take the opportunity to also compute the set of dangerous global refs. This way, when we minify, we can avoid the optimistic first attempt, and always guarantee that a single attempt avoids all the referenced global refs.

We automatically enable the new minifier under fullLink when GCC is disabled. This can be overridden with a `scalaJSLinkerConfig` setting.

---

Overall, when used in the context of a Scala.js + Vite application, these change bring a 50% size to the `npm run build` output of Vite. So the size of the output is half that of before.

To be clear, this is comparing
* fullLink without GCC without Minify but with Vite's minification (through rollup), versus
* fullLink without GCC *with Minify* and also Vite's minification.

When comparing on our test suite without Vite's minification, the reduction is "only" of 20%. But this is not really the important measure; we definitely expect this feature to be used in conjunction with a JS-only minifier.