### PR TITLE
More minification.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -716,20 +716,15 @@ final class Emitter[E >: Null <: js.Tree](
 
       if (linkedClass.hasRuntimeTypeInfo) {
         main ++= extractWithGlobals(classTreeCache.typeData.getOrElseUpdate(
+            linkedClass.hasInstances,
             classEmitter.genTypeData(
               className, // invalidated by overall class cache (part of ancestors)
               kind, // invalidated by class version
               linkedClass.superClass, // invalidated by class version
               linkedClass.ancestors, // invalidated by overall class cache (identity)
-              linkedClass.jsNativeLoadSpec // invalidated by class version
+              linkedClass.jsNativeLoadSpec, // invalidated by class version
+              linkedClass.hasInstances // invalidated directly (it is the input to `getOrElseUpdate`)
             )(moduleContext, classCache, linkedClass.pos).map(postTransform(_, 0))))
-      }
-
-      if (linkedClass.hasInstances && kind.isClass && linkedClass.hasRuntimeTypeInfo) {
-        main ++= classTreeCache.setTypeData.getOrElseUpdate({
-          val tree = classEmitter.genSetTypeData(className)(moduleContext, classCache, linkedClass.pos)
-          postTransform(tree, 0)
-        })
       }
     }
 
@@ -1198,7 +1193,7 @@ object Emitter {
     val privateJSFields = new OneTimeCache[WithGlobals[E]]
     val storeJSSuperClass = new OneTimeCache[WithGlobals[E]]
     val instanceTests = new OneTimeCache[WithGlobals[E]]
-    val typeData = new OneTimeCache[WithGlobals[E]]
+    val typeData = new InputEqualityCache[Boolean, WithGlobals[E]]
     val setTypeData = new OneTimeCache[E]
     val moduleAccessor = new OneTimeCache[WithGlobals[E]]
     val staticInitialization = new OneTimeCache[E]
@@ -1219,6 +1214,24 @@ object Emitter {
     def getOrElseUpdate(v: => A): A = {
       if (value == null)
         value = v
+      value
+    }
+  }
+
+  /** A cache that depends on an `input: I`, testing with `==`.
+   *
+   *  @tparam I
+   *    the type of input, for which `==` must meaningful
+   */
+  private final class InputEqualityCache[I, A >: Null] {
+    private[this] var lastInput: Option[I] = None
+    private[this] var value: A = null
+
+    def getOrElseUpdate(input: I, v: => A): A = {
+      if (!lastInput.contains(input)) {
+        value = v
+        lastInput = Some(input)
+      }
       value
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -64,6 +64,11 @@ final class Emitter[E >: Null <: js.Tree](
 
     val classEmitter: ClassEmitter = new ClassEmitter(sjsGen)
 
+    val everyFileStart: List[E] = {
+      // This postTransform does not count in the statistics
+      postTransformer.transformStats(sjsGen.declarePrototypeVar, 0)
+    }
+
     val coreJSLibCache: CoreJSLibCache = new CoreJSLibCache
 
     val moduleCaches: mutable.Map[ModuleID, ModuleCache] = mutable.Map.empty
@@ -293,6 +298,11 @@ final class Emitter[E >: Null <: js.Tree](
          * it is crucial that we verify it.
          */
         val defTrees: List[E] = (
+            /* The declaration of the `$p` variable that temporarily holds
+             * prototypes.
+             */
+            state.everyFileStart.iterator ++
+
             /* The definitions of the CoreJSLib that come before the definition
              * of `j.l.Object`. They depend on nothing else.
              */

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
@@ -40,7 +40,10 @@ private[emitter] object VarField {
   /** Scala class initializers (<clinit>). */
   final val sct = mk("$sct")
 
-  /** Private (instance) methods. */
+  /** Private (instance) methods.
+   *
+   *  Also used for the `prototype` of the current class when minifying.
+   */
   final val p = mk("$p")
 
   /** Public static methods. */

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
@@ -175,8 +175,6 @@ private[emitter] object VarField {
 
   final val valueDescription = mk("$valueDescription")
 
-  final val propertyName = mk("$propertyName")
-
   // ID hash subsystem
 
   final val systemIdentityHashCode = mk("$systemIdentityHashCode")

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/CommonPhaseConfig.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/CommonPhaseConfig.scala
@@ -18,6 +18,8 @@ import org.scalajs.linker.interface._
 final class CommonPhaseConfig private (
     /** Core specification. */
     val coreSpec: CoreSpec,
+    /** Apply Scala.js-specific minification of the produced .js files. */
+    val minify: Boolean,
     /** Whether things that can be parallelized should be parallelized.
      *  On the JavaScript platform, this setting is typically ignored.
      */
@@ -37,6 +39,7 @@ final class CommonPhaseConfig private (
   private def this() = {
     this(
         coreSpec = CoreSpec.Defaults,
+        minify = false,
         parallel = true,
         batchMode = false)
   }
@@ -47,6 +50,6 @@ private[linker] object CommonPhaseConfig {
 
   private[linker] def fromStandardConfig(config: StandardConfig): CommonPhaseConfig = {
     val coreSpec = CoreSpec(config.semantics, config.moduleKind, config.esFeatures)
-    new CommonPhaseConfig(coreSpec, config.parallel, config.batchMode)
+    new CommonPhaseConfig(coreSpec, config.minify, config.parallel, config.batchMode)
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -29,6 +29,11 @@ import org.scalajs.ir.Names.{ClassName, FieldName}
  *  P+1. The converse is not true. This guarantees that versions can be used
  *  reliably to determine at phase P+1 whether a linked class coming from phase
  *  P must be reprocessed.
+ *
+ *  @param ancestors
+ *    List of all the ancestor classes and interfaces of this class. It always
+ *    contains this class name and `java.lang.Object`. This class name is
+ *    always the first element of the list.
  */
 final class LinkedClass(
     // Stuff from Tree
@@ -60,6 +65,9 @@ final class LinkedClass(
     val dynamicDependencies: Set[ClassName],
 
     val version: Version) {
+
+  require(ancestors.headOption.contains(name.name),
+      s"ancestors for ${name.name.nameString} must start with itself: $ancestors")
 
   def className: ClassName = name.name
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -71,8 +71,8 @@ class LibrarySizeTest {
 
     testLinkedSizes(
       expectedFastLinkSize = 147707,
-      expectedFullLinkSizeWithoutClosure = 88733,
-      expectedFullLinkSizeWithClosure = 21802,
+      expectedFullLinkSizeWithoutClosure = 86729,
+      expectedFullLinkSizeWithClosure = 21768,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -71,7 +71,7 @@ class LibrarySizeTest {
 
     testLinkedSizes(
       expectedFastLinkSize = 150205,
-      expectedFullLinkSizeWithoutClosure = 92762,
+      expectedFullLinkSizeWithoutClosure = 90108,
       expectedFullLinkSizeWithClosure = 21325,
       classDefs,
       moduleInitializers = MainTestModuleInitializers

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 150205,
-      expectedFullLinkSizeWithoutClosure = 90108,
-      expectedFullLinkSizeWithClosure = 21325,
+      expectedFastLinkSize = 148754,
+      expectedFullLinkSizeWithoutClosure = 89358,
+      expectedFullLinkSizeWithClosure = 22075,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 148754,
-      expectedFullLinkSizeWithoutClosure = 89358,
-      expectedFullLinkSizeWithClosure = 22075,
+      expectedFastLinkSize = 147707,
+      expectedFullLinkSizeWithoutClosure = 88733,
+      expectedFullLinkSizeWithClosure = 21802,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -24,6 +24,8 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
+    // private, not an issue
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.CommonPhaseConfig.this"),
   )
 
   val LinkerInterface = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1998,34 +1998,34 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 641000 to 642000,
-                  fullLink = 101000 to 102000,
-                  fastLinkGz = 77000 to 78000,
+                  fastLink = 634000 to 635000,
+                  fullLink = 102000 to 103000,
+                  fastLinkGz = 76000 to 77000,
                   fullLinkGz = 26000 to 27000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 454000 to 455000,
-                  fullLink = 306000 to 307000,
+                  fastLink = 450000 to 451000,
+                  fullLink = 303000 to 304000,
                   fastLinkGz = 65000 to 66000,
-                  fullLinkGz = 47000 to 48000,
+                  fullLinkGz = 46000 to 47000,
               ))
             }
 
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 463000 to 464000,
-                  fullLink = 99000 to 100000,
-                  fastLinkGz = 60000 to 61000,
-                  fullLinkGz = 26000 to 27000,
+                  fastLink = 458000 to 459000,
+                  fullLink = 100000 to 101000,
+                  fastLinkGz = 59000 to 60000,
+                  fullLinkGz = 27000 to 28000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 325000 to 326000,
-                  fullLink = 285000 to 286000,
+                  fastLink = 322000 to 323000,
+                  fullLink = 282000 to 283000,
                   fastLinkGz = 51000 to 52000,
-                  fullLinkGz = 47000 to 48000,
+                  fullLinkGz = 46000 to 47000,
               ))
             }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1998,16 +1998,16 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 634000 to 635000,
-                  fullLink = 102000 to 103000,
-                  fastLinkGz = 76000 to 77000,
-                  fullLinkGz = 26000 to 27000,
+                  fastLink = 626000 to 627000,
+                  fullLink = 98000 to 99000,
+                  fastLinkGz = 75000 to 79000,
+                  fullLinkGz = 25000 to 26000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 450000 to 451000,
-                  fullLink = 303000 to 304000,
-                  fastLinkGz = 65000 to 66000,
+                  fastLink = 442000 to 443000,
+                  fullLink = 297000 to 298000,
+                  fastLinkGz = 64000 to 65000,
                   fullLinkGz = 46000 to 47000,
               ))
             }
@@ -2015,16 +2015,16 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 458000 to 459000,
-                  fullLink = 100000 to 101000,
-                  fastLinkGz = 59000 to 60000,
-                  fullLinkGz = 27000 to 28000,
+                  fastLink = 452000 to 453000,
+                  fullLink = 96000 to 97000,
+                  fastLinkGz = 58000 to 59000,
+                  fullLinkGz = 26000 to 27000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 322000 to 323000,
-                  fullLink = 282000 to 283000,
-                  fastLinkGz = 51000 to 52000,
+                  fastLink = 316000 to 317000,
+                  fullLink = 276000 to 277000,
+                  fastLinkGz = 50000 to 51000,
                   fullLinkGz = 46000 to 47000,
               ))
             }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2005,10 +2005,10 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 495000 to 496000,
-                  fullLink = 337000 to 338000,
-                  fastLinkGz = 69000 to 70000,
-                  fullLinkGz = 50000 to 51000,
+                  fastLink = 454000 to 455000,
+                  fullLink = 306000 to 307000,
+                  fastLinkGz = 65000 to 66000,
+                  fullLinkGz = 47000 to 48000,
               ))
             }
 
@@ -2022,10 +2022,10 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 348000 to 349000,
-                  fullLink = 308000 to 309000,
-                  fastLinkGz = 54000 to 55000,
-                  fullLinkGz = 49000 to 50000,
+                  fastLink = 325000 to 326000,
+                  fullLink = 285000 to 286000,
+                  fastLinkGz = 51000 to 52000,
+                  fullLinkGz = 47000 to 48000,
               ))
             }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1999,16 +1999,16 @@ object Build {
             if (!useMinifySizes) {
               Some(ExpectedSizes(
                   fastLink = 626000 to 627000,
-                  fullLink = 98000 to 99000,
+                  fullLink = 97000 to 98000,
                   fastLinkGz = 75000 to 79000,
                   fullLinkGz = 25000 to 26000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 442000 to 443000,
-                  fullLink = 297000 to 298000,
-                  fastLinkGz = 64000 to 65000,
-                  fullLinkGz = 46000 to 47000,
+                  fastLink = 433000 to 434000,
+                  fullLink = 288000 to 289000,
+                  fastLinkGz = 62000 to 63000,
+                  fullLinkGz = 44000 to 45000,
               ))
             }
 
@@ -2016,16 +2016,16 @@ object Build {
             if (!useMinifySizes) {
               Some(ExpectedSizes(
                   fastLink = 452000 to 453000,
-                  fullLink = 96000 to 97000,
+                  fullLink = 94000 to 95000,
                   fastLinkGz = 58000 to 59000,
-                  fullLinkGz = 26000 to 27000,
+                  fullLinkGz = 25000 to 26000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 316000 to 317000,
-                  fullLink = 276000 to 277000,
-                  fastLinkGz = 50000 to 51000,
-                  fullLinkGz = 46000 to 47000,
+                  fastLink = 309000 to 310000,
+                  fullLink = 265000 to 266000,
+                  fastLinkGz = 49000 to 50000,
+                  fullLinkGz = 43000 to 44000,
               ))
             }
 


### PR DESCRIPTION
Based on #4945.

All together, this brings a 17% code size reduction in a Vite full build, compared to what we get at the end of #4945. We're still 14% bigger than what we get with GCC, but that's a lot more acceptable than the status quo.