### PR TITLE
Do not put `O` (`jl.Object`) in the `ancestors` dictionaries.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -865,7 +865,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     }
 
     val ancestorsRecord = js.ObjectConstr(
-        ancestors.map(ancestor => (js.Ident(genName(ancestor)), js.IntLiteral(1))))
+        ancestors.withFilter(_ != ObjectClass).map(ancestor => (js.Ident(genName(ancestor)), js.IntLiteral(1))))
 
     val isInstanceFunWithGlobals: WithGlobals[js.Tree] = {
       if (globalKnowledge.isAncestorOfHijackedClass(className)) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -1687,7 +1687,6 @@ private[emitter] object CoreJSLib {
             else
               Skip(),
             privateFieldSet("ancestors", ObjectConstr(List(
-                Ident(genName(ObjectClass)) -> 1,
                 Ident(genName(CloneableClass)) -> 1,
                 Ident(genName(SerializableClass)) -> 1
             ))),
@@ -2066,7 +2065,7 @@ private[emitter] object CoreJSLib {
         extractWithGlobals(
             globalVarDef(VarField.d, ObjectClass, New(globalVar(VarField.TypeData, CoreVar), Nil))) :::
         List(
-          privateFieldSet("ancestors", ObjectConstr(List((Ident(genName(ObjectClass)) -> 1)))),
+          privateFieldSet("ancestors", ObjectConstr(Nil)),
           privateFieldSet("arrayEncodedName", str("L" + fullName + ";")),
           privateFieldSet("isAssignableFromFun", {
             genArrowFunction(paramList(that), {

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 150339,
-      expectedFullLinkSizeWithoutClosure = 130884,
-      expectedFullLinkSizeWithClosure = 21394,
+      expectedFastLinkSize = 150063,
+      expectedFullLinkSizeWithoutClosure = 130664,
+      expectedFullLinkSizeWithClosure = 21325,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1967,16 +1967,16 @@ object Build {
         scalaVersion.value match {
           case `default212Version` =>
             Some(ExpectedSizes(
-                fastLink = 770000 to 771000,
-                fullLink = 145000 to 146000,
+                fastLink = 768000 to 769000,
+                fullLink = 144000 to 145000,
                 fastLinkGz = 90000 to 91000,
                 fullLinkGz = 35000 to 36000,
             ))
 
           case `default213Version` =>
             Some(ExpectedSizes(
-                fastLink = 479000 to 480000,
-                fullLink = 102000 to 103000,
+                fastLink = 478000 to 479000,
+                fullLink = 101000 to 102000,
                 fastLinkGz = 62000 to 63000,
                 fullLinkGz = 27000 to 28000,
             ))


### PR DESCRIPTION
It is never read, because all the functions that would read it are special-cased, so these are wasted bytes.

---

Extracted from #4930 as suggested.