### PR TITLE
Generalize the side-effect-free analysis of constructors to all classes.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1967,17 +1967,17 @@ object Build {
         scalaVersion.value match {
           case `default212Version` =>
             Some(ExpectedSizes(
-                fastLink = 768000 to 769000,
+                fastLink = 682000 to 683000,
                 fullLink = 144000 to 145000,
-                fastLinkGz = 90000 to 91000,
+                fastLinkGz = 82000 to 83000,
                 fullLinkGz = 35000 to 36000,
             ))
 
           case `default213Version` =>
             Some(ExpectedSizes(
-                fastLink = 478000 to 479000,
+                fastLink = 476000 to 477000,
                 fullLink = 101000 to 102000,
-                fastLinkGz = 62000 to 63000,
+                fastLinkGz = 61000 to 62000,
                 fullLinkGz = 27000 to 28000,
             ))
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/NullPointersTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/NullPointersTest.scala
@@ -23,7 +23,8 @@ class NullPointersTest {
   import NullPointersTest._
 
   // Instantiate Tester somewhere, otherwise plenty of tests are moot
-  new Tester(0)
+  @noinline def keep(x: Any): Unit = ()
+  keep(new Tester(0))
 
   @noinline
   private def nullOf[T >: Null]: T = null


### PR DESCRIPTION
Previously, we only analyzed *module* class constructors for side-effect-freedom. This allowed us to get rid of unused `LoadModule`s.

We now generalize the same analysis to all Scala classes. We take a little shortcut by bundling *all* the constructors of a class together as being side-effect-free or not. This is an over-approximation in theory, but in practice it is unlikely that it will make a difference. This shortcut allows our analysis to be straightforward even in the presence of constructor delegation chains.