### PR TITLE
Better codegen for the null check on outer pointers in constructors.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -2791,7 +2791,9 @@ private[optimizer] abstract class OptimizerCore(
        *   if (cond) throw e
        *   else value
        *
-       * Typical shape of initialization of outer pointer of inner classes.
+       * Typical shape of initialization of outer pointer of inner classes
+       * coming from Scala.js < 1.15.1 (since 1.15.1, we intercept that shape
+       * already in the compiler back-end).
        */
       case If(cond, th: Throw, Assign(Select(This(), _, _), value)) :: rest =>
         // work around a bug of the compiler (these should be @-bindings)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1967,15 +1967,15 @@ object Build {
         scalaVersion.value match {
           case `default212Version` =>
             Some(ExpectedSizes(
-                fastLink = 682000 to 683000,
-                fullLink = 144000 to 145000,
+                fastLink = 681000 to 682000,
+                fullLink = 142000 to 143000,
                 fastLinkGz = 82000 to 83000,
                 fullLinkGz = 35000 to 36000,
             ))
 
           case `default213Version` =>
             Some(ExpectedSizes(
-                fastLink = 476000 to 477000,
+                fastLink = 475000 to 476000,
                 fullLink = 101000 to 102000,
                 fastLinkGz = 61000 to 62000,
                 fullLinkGz = 27000 to 28000,


### PR DESCRIPTION
When introducing outer pointers, scalac generates a null check in the constructor of nested classes. The null check looks like this:

    if ($outer.eq(null))
      throw null
    else
      this.$outer = $outer

This is a bad shape for our optimizations, notably because the explicit null check cannot be considered UB at the IR level if we compile it as is, although in the original *language*, that would clearly fall into UB.

Therefore, we now intercept that shape and rewrite it as follows instead:

    <getClass>($outer)   // null check subject to UB
    this.$outer = $outer // the `else` branch in general

---

On its own, this does not look like much (although it does reduce code size even for fastLink, just not a lot). However, when combined with other optimizations I have in the pipeline, it will make a significant difference.