### PR TITLE
Hard-code `scala.package$` as having elidable constructors.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -1476,7 +1476,7 @@ object IncOptimizer {
     new IncOptimizer(config, SeqCollOps)
 
   private val isAdHocElidableConstructors: Set[ClassName] =
-    Set(ClassName("scala.Predef$"))
+    Set(ClassName("scala.Predef$"), ClassName("scala.package$"))
 
   sealed abstract class ElidableConstructorsInfo {
     import ElidableConstructorsInfo._

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1967,9 +1967,9 @@ object Build {
         scalaVersion.value match {
           case `default212Version` =>
             Some(ExpectedSizes(
-                fastLink = 676000 to 677000,
-                fullLink = 103000 to 104000,
-                fastLinkGz = 82000 to 83000,
+                fastLink = 642000 to 643000,
+                fullLink = 102000 to 103000,
+                fastLinkGz = 77000 to 78000,
                 fullLinkGz = 26000 to 27000,
             ))
 


### PR DESCRIPTION
Like `scala.Predef$`.

Not much good for 2.13, but it's an easy win for 2.12.