### PR TITLE
Use `def`s for `hashCode` in 2.13.x Manifests, like in 2.12.x.

### DIFF
--- a/scalalib/overrides-2.13/scala/reflect/Manifest.scala
+++ b/scalalib/overrides-2.13/scala/reflect/Manifest.scala
@@ -152,8 +152,7 @@ abstract class AnyValManifest[T <: AnyVal](override val toString: String) extend
     case _                    => false
   }
   override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
-  @transient
-  override val hashCode = System.identityHashCode(this)
+  override def hashCode = System.identityHashCode(this)
 }
 
 /** `ManifestFactory` defines factory methods for manifests.
@@ -402,8 +401,7 @@ object ManifestFactory {
   private abstract class PhantomManifest[T](_runtimeClass: Predef.Class[_],
                                             override val toString: String) extends ClassTypeManifest[T](None, _runtimeClass, Nil) {
     override def equals(that: Any): Boolean = this eq that.asInstanceOf[AnyRef]
-    @transient
-    override val hashCode = System.identityHashCode(this)
+    override def hashCode = System.identityHashCode(this)
   }
 
   /** Manifest for the class type `clazz[args]`, where `clazz` is


### PR DESCRIPTION
Originally we made the change from the upstream `val`s to `def`s in 7865a5d48776198fa205d882de48f930ade43e41. We then accidentally reverted that change in the 2.13.x in 1a7f013641edd77dd427e05a50f9d38462fbd154.

This commit aligns the 2.13.x overrides with 2.12.x again.