### PR TITLE
Remove the parameters to StoreModule IR nodes.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -3191,10 +3191,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         if (isStaticModule(currentClassSym) && !isModuleInitialized.value &&
             currentMethodSym.isClassConstructor) {
           isModuleInitialized.value = true
-          val className = encodeClassName(currentClassSym)
-          val initModule =
-            js.StoreModule(className, js.This()(jstpe.ClassType(className)))
-          js.Block(superCall, initModule)
+          js.Block(superCall, js.StoreModule())
         } else {
           superCall
         }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -259,10 +259,8 @@ object Hashers {
           mixTag(TagLoadModule)
           mixName(className)
 
-        case StoreModule(className, value) =>
+        case StoreModule() =>
           mixTag(TagStoreModule)
-          mixName(className)
-          mixTree(value)
 
         case Select(qualifier, className, field) =>
           mixTag(TagSelect)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -296,11 +296,8 @@ object Printers {
           print("mod:")
           print(className)
 
-        case StoreModule(className, value) =>
-          print("mod:")
-          print(className)
-          print("<-")
-          print(value)
+        case StoreModule() =>
+          print("<storeModule>")
 
         case Select(qualifier, className, field) =>
           print(qualifier)

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,8 +17,8 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.15.1-SNAPSHOT",
-    binaryEmitted = "1.13"
+    current = "1.16.0-SNAPSHOT",
+    binaryEmitted = "1.16-SNAPSHOT"
 )
 
 /** Helper class to allow for testing of logic. */

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -91,9 +91,6 @@ object Transformers {
         case New(className, ctor, args) =>
           New(className, ctor, args map transformExpr)
 
-        case StoreModule(className, value) =>
-          StoreModule(className, transformExpr(value))
-
         case Select(qualifier, className, field) =>
           Select(transformExpr(qualifier), className, field)(tree.tpe)
 
@@ -223,9 +220,10 @@ object Transformers {
 
         // Trees that need not be transformed
 
-        case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic | _:SelectJSNativeMember |
-            _:LoadJSConstructor | _:LoadJSModule | _:JSNewTarget | _:JSImportMeta |
-            _:JSLinkingInfo | _:Literal | _:VarRef | _:This | _:JSGlobalRef  =>
+        case _:Skip | _:Debugger | _:LoadModule | _:StoreModule |
+            _:SelectStatic | _:SelectJSNativeMember | _:LoadJSConstructor |
+            _:LoadJSModule | _:JSNewTarget | _:JSImportMeta | _:JSLinkingInfo |
+            _:Literal | _:VarRef | _:This | _:JSGlobalRef  =>
           tree
       }
     }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -77,9 +77,6 @@ object Traversers {
       case New(_, _, args) =>
         args foreach traverse
 
-      case StoreModule(_, value) =>
-        traverse(value)
-
       case Select(qualifier, _, _) =>
         traverse(qualifier)
 
@@ -222,9 +219,10 @@ object Traversers {
 
       // Trees that need not be traversed
 
-      case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic | _:SelectJSNativeMember |
-          _:LoadJSConstructor | _:LoadJSModule | _:JSNewTarget | _:JSImportMeta |
-          _:JSLinkingInfo | _:Literal | _:VarRef | _:This | _:JSGlobalRef =>
+      case _:Skip | _:Debugger | _:LoadModule | _:StoreModule |
+          _:SelectStatic | _:SelectJSNativeMember | _:LoadJSConstructor |
+          _:LoadJSModule | _:JSNewTarget | _:JSImportMeta | _:JSLinkingInfo |
+          _:Literal | _:VarRef | _:This | _:JSGlobalRef =>
     }
 
     def traverseClassDef(tree: ClassDef): Unit = {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -237,8 +237,7 @@ object Trees {
     val tpe = ClassType(className)
   }
 
-  sealed case class StoreModule(className: ClassName, value: Tree)(
-      implicit val pos: Position) extends Tree {
+  sealed case class StoreModule()(implicit val pos: Position) extends Tree {
     val tpe = NoType // cannot be in expression position
   }
 

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -302,8 +302,7 @@ class PrintersTest {
   }
 
   @Test def printStoreModule(): Unit = {
-    assertPrintEquals("mod:scala.Predef$<-this",
-        StoreModule("scala.Predef$", This()("scala.Predef$")))
+    assertPrintEquals("<storeModule>", StoreModule())
   }
 
   @Test def printSelect(): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -693,11 +693,12 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               pushLhsInto(Lhs.Assign(lhs), rhs, tailPosLabels)
           }
 
-        case StoreModule(className, value) =>
-          unnest(value) { (newValue, env0) =>
-            implicit val env = env0
-            js.Assign(globalVar(VarField.n, className), transformExprNoChar(newValue))
+        case StoreModule() =>
+          val enclosingClassName = env.enclosingClassName.getOrElse {
+            throw new AssertionError(
+                "Need enclosing class for StoreModule().")
           }
+          js.Assign(globalVar(VarField.n, enclosingClassName), js.This())
 
         case While(cond, body) =>
           val loopEnv = env.withInLoopForVarCapture(true)

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -319,14 +319,9 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
         if (clazz.kind != ClassKind.ModuleClass)
           reportError("LoadModule of non-module class $className")
 
-      case StoreModule(className, value) =>
-        val clazz = lookupClass(className)
-        if (!clazz.kind.hasModuleAccessor)
-          reportError("StoreModule of non-module class $className")
-        val expectedType =
-          if (clazz.kind == ClassKind.JSModuleClass) AnyType
-          else ClassType(className)
-        typecheckExpect(value, env, expectedType)
+      case StoreModule() =>
+        // Nothing to check; everything is checked in ClassDefChecker
+        ()
 
       case Select(qualifier, className, FieldIdent(item)) =>
         val c = lookupClass(className)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -748,8 +748,8 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
         case ApplyStatically(flags, This(), _, _, args) if flags.isConstructor =>
           args.forall(isTriviallySideEffectFree)
 
-        case StoreModule(_, _) => true
-        case _                 => isTriviallySideEffectFree(tree)
+        case StoreModule() => true
+        case _             => isTriviallySideEffectFree(tree)
       }
 
       impl.originalDef.body.fold {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -171,7 +171,7 @@ private[optimizer] abstract class OptimizerCore(
   private def tryElimStoreModule(body: Tree): Tree = {
     implicit val pos = body.pos
     body match {
-      case StoreModule(_, _) =>
+      case StoreModule() =>
         Skip()
       case Block(stats) =>
         val (before, from) = stats.span(!_.isInstanceOf[StoreModule])
@@ -458,9 +458,6 @@ private[optimizer] abstract class OptimizerCore(
       case New(className, ctor, args) =>
         New(className, ctor, args map transformExpr)
 
-      case StoreModule(className, value) =>
-        StoreModule(className, transformExpr(value))
-
       case tree: Select =>
         trampoline {
           pretransformSelectCommon(tree, isLhsOfAssign = false)(
@@ -656,8 +653,8 @@ private[optimizer] abstract class OptimizerCore(
 
       // Trees that need not be transformed
 
-      case _:Skip | _:Debugger | _:LoadModule | _:SelectStatic |
-          _:JSNewTarget | _:JSImportMeta | _:JSLinkingInfo |
+      case _:Skip | _:Debugger | _:LoadModule | _:StoreModule |
+          _:SelectStatic | _:JSNewTarget | _:JSImportMeta | _:JSLinkingInfo |
           _:JSGlobalRef | _:JSTypeOfGlobalRef | _:Literal =>
         tree
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -5,6 +5,9 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val IR = Seq(
+    // !!! Breaking, OK in minor release
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#StoreModule.*"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.scalajs.ir.Trees#StoreModule.unapply"),
   )
 
   val Linker = Seq(


### PR DESCRIPTION
`StoreModule` was always implicitly assumed to be used only in the constructor of the corresponding module class, and with a `This()` rhs.

We now include that assumption as a core truth of `StoreModule()`, and therefore remove its two arguments.

A deserialization hack reads they old arguments but throws them away. In theory this could change the meaning of existing IR, but nothing that would have been emitted by our compilers.