### PR TITLE
Refactor: Make FieldName a composite of ClassName and SimpleFieldName.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -18,7 +18,7 @@ import scala.tools.nsc._
 
 import org.scalajs.ir
 import org.scalajs.ir.{Trees => js, Types => jstpe}
-import org.scalajs.ir.Names.{LocalName, LabelName, FieldName, SimpleMethodName, MethodName, ClassName}
+import org.scalajs.ir.Names.{LocalName, LabelName, SimpleFieldName, FieldName, SimpleMethodName, MethodName, ClassName}
 import org.scalajs.ir.OriginalName
 import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.UTF8String
@@ -178,8 +178,9 @@ trait JSEncoding[G <: Global with Singleton] extends SubComponent {
 
   def encodeFieldSym(sym: Symbol)(implicit pos: Position): js.FieldIdent = {
     requireSymIsField(sym)
-    val name = sym.name.dropLocal
-    js.FieldIdent(FieldName(name.toString()))
+    val className = encodeClassName(sym.owner)
+    val simpleName = SimpleFieldName(sym.name.dropLocal.toString())
+    js.FieldIdent(FieldName(className, simpleName))
   }
 
   def encodeFieldSymAsStringLiteral(sym: Symbol)(

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -262,16 +262,14 @@ object Hashers {
         case StoreModule() =>
           mixTag(TagStoreModule)
 
-        case Select(qualifier, className, field) =>
+        case Select(qualifier, field) =>
           mixTag(TagSelect)
           mixTree(qualifier)
-          mixName(className)
           mixFieldIdent(field)
           mixType(tree.tpe)
 
-        case SelectStatic(className, field) =>
+        case SelectStatic(field) =>
           mixTag(TagSelectStatic)
-          mixName(className)
           mixFieldIdent(field)
           mixType(tree.tpe)
 
@@ -351,7 +349,7 @@ object Hashers {
         case RecordSelect(record, field) =>
           mixTag(TagRecordSelect)
           mixTree(record)
-          mixFieldIdent(field)
+          mixSimpleFieldIdent(field)
           mixType(tree.tpe)
 
         case IsInstanceOf(expr, testType) =>
@@ -389,10 +387,9 @@ object Hashers {
           mixTree(ctor)
           mixTreeOrJSSpreads(args)
 
-        case JSPrivateSelect(qualifier, className, field) =>
+        case JSPrivateSelect(qualifier, field) =>
           mixTag(TagJSPrivateSelect)
           mixTree(qualifier)
-          mixName(className)
           mixFieldIdent(field)
 
         case JSSelect(qualifier, item) =>
@@ -651,9 +648,16 @@ object Hashers {
       mixName(ident.name)
     }
 
-    def mixFieldIdent(ident: FieldIdent): Unit = {
+    def mixSimpleFieldIdent(ident: SimpleFieldIdent): Unit = {
       mixPos(ident.pos)
       mixName(ident.name)
+    }
+
+    def mixFieldIdent(ident: FieldIdent): Unit = {
+      // For historical reasons, the className comes *before* the position
+      mixName(ident.name.className)
+      mixPos(ident.pos)
+      mixName(ident.name.simpleName)
     }
 
     def mixMethodIdent(ident: MethodIdent): Unit = {

--- a/ir/shared/src/main/scala/org/scalajs/ir/OriginalName.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/OriginalName.scala
@@ -53,6 +53,10 @@ final class OriginalName private (private val bytes: Array[Byte])
     if (isDefined) this
     else OriginalName(name)
 
+  // new in 1.16.0; added as last overload to preserve binary compatibility
+  def orElse(name: FieldName): OriginalName =
+    orElse(name.simpleName)
+
   def getOrElse(name: Name): UTF8String =
     getOrElse(name.encoded)
 
@@ -70,6 +74,10 @@ final class OriginalName private (private val bytes: Array[Byte])
     if (isDefined) unsafeGet
     else UTF8String(name)
   }
+
+  // new in 1.16.0; added as last overload to preserve binary compatibility
+  def getOrElse(name: FieldName): UTF8String =
+    getOrElse(name.simpleName)
 
   override def toString(): String =
     if (isDefined) s"OriginalName($unsafeGet)"

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -123,6 +123,7 @@ object Printers {
       node match {
         case node: LocalIdent        => print(node)
         case node: LabelIdent        => print(node)
+        case node: SimpleFieldIdent  => print(node)
         case node: FieldIdent        => print(node)
         case node: MethodIdent       => print(node)
         case node: ClassIdent        => print(node)
@@ -299,16 +300,12 @@ object Printers {
         case StoreModule() =>
           print("<storeModule>")
 
-        case Select(qualifier, className, field) =>
+        case Select(qualifier, field) =>
           print(qualifier)
           print('.')
-          print(className)
-          print("::")
           print(field)
 
-        case SelectStatic(className, field) =>
-          print(className)
-          print("::")
+        case SelectStatic(field) =>
           print(field)
 
         case SelectJSNativeMember(className, member) =>
@@ -572,11 +569,11 @@ object Printers {
 
         case JSNew(ctor, args) =>
           def containsOnlySelectsFromAtom(tree: Tree): Boolean = tree match {
-            case JSPrivateSelect(qual, _, _) => containsOnlySelectsFromAtom(qual)
-            case JSSelect(qual, _)           => containsOnlySelectsFromAtom(qual)
-            case VarRef(_)                   => true
-            case This()                      => true
-            case _                           => false // in particular, Apply
+            case JSPrivateSelect(qual, _) => containsOnlySelectsFromAtom(qual)
+            case JSSelect(qual, _)        => containsOnlySelectsFromAtom(qual)
+            case VarRef(_)                => true
+            case This()                   => true
+            case _                        => false // in particular, Apply
           }
           if (containsOnlySelectsFromAtom(ctor)) {
             print("new ")
@@ -588,11 +585,9 @@ object Printers {
           }
           printArgs(args)
 
-        case JSPrivateSelect(qualifier, className, field) =>
+        case JSPrivateSelect(qualifier, field) =>
           print(qualifier)
           print('.')
-          print(className)
-          print("::")
           print(field)
 
         case JSSelect(qualifier, item) =>
@@ -1113,6 +1108,9 @@ object Printers {
     def print(ident: LabelIdent): Unit =
       print(ident.name)
 
+    def print(ident: SimpleFieldIdent): Unit =
+      print(ident.name)
+
     def print(ident: FieldIdent): Unit =
       print(ident.name)
 
@@ -1123,6 +1121,9 @@ object Printers {
       print(ident.name)
 
     def print(name: Name): Unit =
+      printEscapeJS(name.nameString, out)
+
+    def print(name: FieldName): Unit =
       printEscapeJS(name.nameString, out)
 
     def print(name: MethodName): Unit =

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -91,8 +91,8 @@ object Transformers {
         case New(className, ctor, args) =>
           New(className, ctor, args map transformExpr)
 
-        case Select(qualifier, className, field) =>
-          Select(transformExpr(qualifier), className, field)(tree.tpe)
+        case Select(qualifier, field) =>
+          Select(transformExpr(qualifier), field)(tree.tpe)
 
         case Apply(flags, receiver, method, args) =>
           Apply(flags, transformExpr(receiver), method,
@@ -158,8 +158,8 @@ object Transformers {
         case JSNew(ctor, args) =>
           JSNew(transformExpr(ctor), args.map(transformExprOrJSSpread))
 
-        case JSPrivateSelect(qualifier, className, field) =>
-          JSPrivateSelect(transformExpr(qualifier), className, field)
+        case JSPrivateSelect(qualifier, field) =>
+          JSPrivateSelect(transformExpr(qualifier), field)
 
         case JSSelect(qualifier, item) =>
           JSSelect(transformExpr(qualifier), transformExpr(item))

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -77,7 +77,7 @@ object Traversers {
       case New(_, _, args) =>
         args foreach traverse
 
-      case Select(qualifier, _, _) =>
+      case Select(qualifier, _) =>
         traverse(qualifier)
 
       case Apply(_, receiver, _, args) =>
@@ -147,7 +147,7 @@ object Traversers {
         traverse(ctor)
         args.foreach(traverseTreeOrJSSpread)
 
-      case JSPrivateSelect(qualifier, _, _) =>
+      case JSPrivateSelect(qualifier, _) =>
         traverse(qualifier)
 
       case JSSelect(qualifier, item) =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -59,6 +59,9 @@ object Trees {
   sealed case class LabelIdent(name: LabelName)(implicit val pos: Position)
       extends IRNode
 
+  sealed case class SimpleFieldIdent(name: SimpleFieldName)(implicit val pos: Position)
+      extends IRNode
+
   sealed case class FieldIdent(name: FieldName)(implicit val pos: Position)
       extends IRNode
 
@@ -241,13 +244,10 @@ object Trees {
     val tpe = NoType // cannot be in expression position
   }
 
-  sealed case class Select(qualifier: Tree, className: ClassName,
-      field: FieldIdent)(
-      val tpe: Type)(
+  sealed case class Select(qualifier: Tree, field: FieldIdent)(val tpe: Type)(
       implicit val pos: Position) extends AssignLhs
 
-  sealed case class SelectStatic(className: ClassName, field: FieldIdent)(
-      val tpe: Type)(
+  sealed case class SelectStatic(field: FieldIdent)(val tpe: Type)(
       implicit val pos: Position) extends AssignLhs
 
   sealed case class SelectJSNativeMember(className: ClassName, member: MethodIdent)(
@@ -465,7 +465,7 @@ object Trees {
   sealed case class RecordValue(tpe: RecordType, elems: List[Tree])(
       implicit val pos: Position) extends Tree
 
-  sealed case class RecordSelect(record: Tree, field: FieldIdent)(
+  sealed case class RecordSelect(record: Tree, field: SimpleFieldIdent)(
       val tpe: Type)(
       implicit val pos: Position)
       extends AssignLhs
@@ -512,8 +512,7 @@ object Trees {
     val tpe = AnyType
   }
 
-  sealed case class JSPrivateSelect(qualifier: Tree, className: ClassName,
-      field: FieldIdent)(
+  sealed case class JSPrivateSelect(qualifier: Tree, field: FieldIdent)(
       implicit val pos: Position) extends AssignLhs {
     val tpe = AnyType
   }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Types.scala
@@ -143,12 +143,12 @@ object Types {
    *  The compiler itself never generates record types.
    */
   final case class RecordType(fields: List[RecordType.Field]) extends Type {
-    def findField(name: FieldName): RecordType.Field =
+    def findField(name: SimpleFieldName): RecordType.Field =
       fields.find(_.name == name).get
   }
 
   object RecordType {
-    final case class Field(name: FieldName, originalName: OriginalName,
+    final case class Field(name: SimpleFieldName, originalName: OriginalName,
         tpe: Type, mutable: Boolean)
   }
 

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -307,12 +307,12 @@ class PrintersTest {
 
   @Test def printSelect(): Unit = {
     assertPrintEquals("x.test.Test::f",
-        Select(ref("x", "test.Test"), "test.Test", "f")(IntType))
+        Select(ref("x", "test.Test"), FieldName("test.Test", "f"))(IntType))
   }
 
   @Test def printSelectStatic(): Unit = {
     assertPrintEquals("test.Test::f",
-        SelectStatic("test.Test", "f")(IntType))
+        SelectStatic(FieldName("test.Test", "f"))(IntType))
   }
 
   @Test def printApply(): Unit = {
@@ -606,21 +606,21 @@ class PrintersTest {
     assertPrintEquals("new C()", JSNew(ref("C", AnyType), Nil))
     assertPrintEquals("new C(4, 5)", JSNew(ref("C", AnyType), List(i(4), i(5))))
     assertPrintEquals("new x.test.Test::C(4, 5)",
-        JSNew(JSPrivateSelect(ref("x", AnyType), "test.Test", "C"), List(i(4), i(5))))
+        JSNew(JSPrivateSelect(ref("x", AnyType), FieldName("test.Test", "C")), List(i(4), i(5))))
     assertPrintEquals("""new x["C"]()""",
         JSNew(JSSelect(ref("x", AnyType), StringLiteral("C")), Nil))
 
     val fApplied = JSFunctionApply(ref("f", AnyType), Nil)
     assertPrintEquals("new (f())()", JSNew(fApplied, Nil))
     assertPrintEquals("new (f().test.Test::C)(4, 5)",
-        JSNew(JSPrivateSelect(fApplied, "test.Test", "C"), List(i(4), i(5))))
+        JSNew(JSPrivateSelect(fApplied, FieldName("test.Test", "C")), List(i(4), i(5))))
     assertPrintEquals("""new (f()["C"])()""",
         JSNew(JSSelect(fApplied, StringLiteral("C")), Nil))
   }
 
   @Test def printJSPrivateSelect(): Unit = {
     assertPrintEquals("x.test.Test::f",
-        JSPrivateSelect(ref("x", AnyType), "test.Test", "f"))
+        JSPrivateSelect(ref("x", AnyType), FieldName("test.Test", "f")))
   }
 
   @Test def printJSSelect(): Unit = {
@@ -634,12 +634,12 @@ class PrintersTest {
         JSFunctionApply(ref("f", AnyType), List(i(3), i(4))))
 
     assertPrintEquals("(0, x.test.Test::f)()",
-        JSFunctionApply(JSPrivateSelect(ref("x", AnyType), "test.Test", "f"), Nil))
+        JSFunctionApply(JSPrivateSelect(ref("x", AnyType), FieldName("test.Test", "f")), Nil))
     assertPrintEquals("""(0, x["f"])()""",
         JSFunctionApply(JSSelect(ref("x", AnyType), StringLiteral("f")),
             Nil))
     assertPrintEquals("(0, x.test.Test::f)()",
-        JSFunctionApply(Select(ref("x", "test.Test"), "test.Test", "f")(AnyType),
+        JSFunctionApply(Select(ref("x", "test.Test"), FieldName("test.Test", "f"))(AnyType),
             Nil))
   }
 
@@ -1137,7 +1137,7 @@ class PrintersTest {
     assertPrintEquals(
         """
           |module class Test extends java.lang.Object {
-          |  val x: int
+          |  val Test::x: int
           |  def m;I(): int = <abstract>
           |  constructor def constructor(): any = {
           |    super()
@@ -1151,7 +1151,7 @@ class PrintersTest {
         """,
         ClassDef("Test", NON, ClassKind.ModuleClass, None, Some(ObjectClass),
             Nil, None, None,
-            List(FieldDef(MemberFlags.empty, "x", NON, IntType)),
+            List(FieldDef(MemberFlags.empty, FieldName("Test", "x"), NON, IntType)),
             List(MethodDef(MemberFlags.empty, MethodName("m", Nil, I), NON, Nil, IntType, None)(NoOptHints, UNV)),
             Some(JSConstructorDef(MemberFlags.empty.withNamespace(Constructor), Nil, None,
                 JSConstructorBody(Nil, JSSuperConstructorCall(Nil), Nil))(NoOptHints, UNV)),
@@ -1163,12 +1163,12 @@ class PrintersTest {
   }
 
   @Test def printFieldDef(): Unit = {
-    assertPrintEquals("val x: int",
-        FieldDef(MemberFlags.empty, "x", NON, IntType))
-    assertPrintEquals("var y: any",
-        FieldDef(MemberFlags.empty.withMutable(true), "y", NON, AnyType))
-    assertPrintEquals("val x{orig name}: int",
-        FieldDef(MemberFlags.empty, "x", TestON, IntType))
+    assertPrintEquals("val Test::x: int",
+        FieldDef(MemberFlags.empty, FieldName("Test", "x"), NON, IntType))
+    assertPrintEquals("var Test::y: any",
+        FieldDef(MemberFlags.empty.withMutable(true), FieldName("Test", "y"), NON, AnyType))
+    assertPrintEquals("val Test::x{orig name}: int",
+        FieldDef(MemberFlags.empty, FieldName("Test", "x"), TestON, IntType))
   }
 
   @Test def printJSFieldDef(): Unit = {
@@ -1428,8 +1428,8 @@ class PrintersTest {
   @Test def printTopLevelFieldExportDef(): Unit = {
     assertPrintEquals(
         """
-          |export top[moduleID="main"] static field x$1 as "x"
+          |export top[moduleID="main"] static field Test::x$1 as "x"
         """,
-        TopLevelFieldExportDef("main", "x", "x$1"))
+        TopLevelFieldExportDef("main", "x", FieldName("Test", "x$1")))
   }
 }

--- a/ir/shared/src/test/scala/org/scalajs/ir/TestIRBuilder.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/TestIRBuilder.scala
@@ -37,8 +37,8 @@ object TestIRBuilder {
   val NoOptHints = OptimizerHints.empty
 
   // String -> Name conversions
-  implicit def string2fieldName(name: String): FieldName =
-    FieldName(name)
+  implicit def string2simpleFieldName(name: String): SimpleFieldName =
+    SimpleFieldName(name)
   implicit def string2className(name: String): ClassName =
     ClassName(name)
 
@@ -47,8 +47,8 @@ object TestIRBuilder {
     LocalIdent(LocalName(name))
   implicit def string2labelIdent(name: String): LabelIdent =
     LabelIdent(LabelName(name))
-  implicit def string2fieldIdent(name: String): FieldIdent =
-    FieldIdent(FieldName(name))
+  implicit def string2simpleFieldIdent(name: String): SimpleFieldIdent =
+    SimpleFieldIdent(SimpleFieldName(name))
   implicit def string2classIdent(name: String): ClassIdent =
     ClassIdent(ClassName(name))
 
@@ -59,6 +59,8 @@ object TestIRBuilder {
     ClassRef(ClassName(className))
 
   // Name -> Ident conversions
+  implicit def fieldName2fieldIdent(name: FieldName): FieldIdent =
+    FieldIdent(name)
   implicit def methodName2methodIdent(name: MethodName): MethodIdent =
     MethodIdent(name)
   implicit def className2classRef(className: ClassName): ClassRef =

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterNames.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/EmitterNames.scala
@@ -26,8 +26,8 @@ private[emitter] object EmitterNames {
 
   // Field names
 
-  val dataFieldName = FieldName("data")
-  val exceptionFieldName = FieldName("exception")
+  val dataFieldName = FieldName(ClassClass, SimpleFieldName("data"))
+  val exceptionFieldName = FieldName(JavaScriptExceptionClass, SimpleFieldName("exception"))
 
   // Method names
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -33,8 +33,7 @@ private[emitter] trait GlobalKnowledge {
    *  It is invalid to call this method with anything but a `Class` or
    *  `ModuleClass`.
    */
-  def getAllScalaClassFieldDefs(
-      className: ClassName): List[(ClassName, List[AnyFieldDef])]
+  def getAllScalaClassFieldDefs(className: ClassName): List[AnyFieldDef]
 
   /** Tests whether the specified class uses an inlineable init.
    *
@@ -82,7 +81,7 @@ private[emitter] trait GlobalKnowledge {
   def getFieldDefs(className: ClassName): List[AnyFieldDef]
 
   /** The global variables that mirror a given static field. */
-  def getStaticFieldMirrors(className: ClassName, field: FieldName): List[String]
+  def getStaticFieldMirrors(field: FieldName): List[String]
 
   /** The module containing this class definition.
    *

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
@@ -47,8 +47,8 @@ private[emitter] final class NameGen {
     cache
   }
 
-  private val genFieldNameCache =
-    mutable.Map.empty[FieldName, String]
+  private val genSimpleFieldNameCache =
+    mutable.Map.empty[SimpleFieldName, String]
 
   private val genMethodNameCache =
     mutable.Map.empty[MethodName, String]
@@ -107,7 +107,10 @@ private[emitter] final class NameGen {
   }
 
   def genName(name: LabelName): String = genNameGeneric(name, genLabelNameCache)
-  def genName(name: FieldName): String = genNameGeneric(name, genFieldNameCache)
+  def genName(name: SimpleFieldName): String = genNameGeneric(name, genSimpleFieldNameCache)
+
+  def genName(name: FieldName): String =
+    genName(name.className) + "__f_" + genName(name.simpleName)
 
   def genName(name: MethodName): String = {
     genMethodNameCache.getOrElseUpdate(name, {
@@ -208,6 +211,11 @@ private[emitter] final class NameGen {
   def genOriginalName(name: Name, originalName: OriginalName,
       jsName: String): OriginalName = {
     genOriginalName(name.encoded, originalName, jsName)
+  }
+
+  def genOriginalName(name: FieldName, originalName: OriginalName,
+      jsName: String): OriginalName = {
+    genOriginalName(name.simpleName, originalName, jsName)
   }
 
   def genOriginalName(name: MethodName, originalName: OriginalName,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -163,21 +163,18 @@ private[emitter] final class SJSGen(
       genCallHelper(VarField.systemArraycopy, args: _*)
   }
 
-  def genSelect(receiver: Tree, className: ClassName, field: irt.FieldIdent)(
+  def genSelect(receiver: Tree, field: irt.FieldIdent)(
       implicit pos: Position): Tree = {
-    DotSelect(receiver, Ident(genFieldJSName(className, field))(field.pos))
+    DotSelect(receiver, Ident(genName(field.name))(field.pos))
   }
 
-  def genSelect(receiver: Tree, className: ClassName, field: irt.FieldIdent,
+  def genSelect(receiver: Tree, field: irt.FieldIdent,
       originalName: OriginalName)(
       implicit pos: Position): Tree = {
-    val jsName = genFieldJSName(className, field)
+    val jsName = genName(field.name)
     val jsOrigName = genOriginalName(field.name, originalName, jsName)
     DotSelect(receiver, Ident(jsName, jsOrigName)(field.pos))
   }
-
-  private def genFieldJSName(className: ClassName, field: irt.FieldIdent): String =
-    genName(className) + "__f_" + genName(field.name)
 
   def genApply(receiver: Tree, methodName: MethodName, args: List[Tree])(
       implicit pos: Position): Tree = {
@@ -192,13 +189,12 @@ private[emitter] final class SJSGen(
   def genMethodName(methodName: MethodName): String =
     genName(methodName)
 
-  def genJSPrivateSelect(receiver: Tree, className: ClassName,
-      field: irt.FieldIdent)(
+  def genJSPrivateSelect(receiver: Tree, field: irt.FieldIdent)(
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
       pos: Position): Tree = {
     val fieldName = {
       implicit val pos = field.pos
-      globalVar(VarField.r, (className, field.name))
+      globalVar(VarField.r, field.name)
     }
 
     BracketSelect(receiver, fieldName)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -350,11 +350,11 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
       def reprClass(x: ClassName): ClassName = x
     }
 
-    implicit object FieldScope extends Scope[(ClassName, FieldName)] {
-      def subField(x: (ClassName, FieldName)): String =
-        genName(x._1) + "__" + genName(x._2)
+    implicit object FieldScope extends Scope[FieldName] {
+      def subField(x: FieldName): String =
+        genName(x.className) + "__" + genName(x.simpleName)
 
-      def reprClass(x: (ClassName, FieldName)): ClassName = x._1
+      def reprClass(x: FieldName): ClassName = x.className
     }
 
     implicit object MethodScope extends Scope[(ClassName, MethodName)] {

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -214,6 +214,8 @@ private final class ClassDefChecker(classDef: ClassDef,
       case FieldDef(_, FieldIdent(name), _, ftpe) =>
         if (!classDef.kind.isAnyNonNativeClass)
           reportError("illegal FieldDef (only non native classes may contain fields)")
+        if (name.className != classDef.className)
+          reportError(i"illegal FieldDef with name $name in class ${classDef.className}")
         if (fields(namespace.ordinal).put(name, ftpe).isDefined)
           reportError(i"duplicate ${namespace.prefixString}field '$name'")
 
@@ -620,7 +622,7 @@ private final class ClassDefChecker(classDef: ClassDef,
         if (env.thisType == NoType) // can happen before JSSuperConstructorCall in JSModuleClass
           reportError(i"Cannot find `this` in scope for StoreModule()")
 
-      case Select(qualifier, _, _) =>
+      case Select(qualifier, _) =>
         checkTree(qualifier, env)
 
       case _: SelectStatic =>
@@ -714,7 +716,7 @@ private final class ClassDefChecker(classDef: ClassDef,
         checkTree(ctor, env)
         checkTreeOrSpreads(args, env)
 
-      case JSPrivateSelect(qualifier, className, field) =>
+      case JSPrivateSelect(qualifier, _) =>
         checkTree(qualifier, env)
 
       case JSSelect(qualifier, item) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ErrorReporter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ErrorReporter.scala
@@ -36,6 +36,7 @@ private[checker] object ErrorReporter {
     private def format(arg: Any): String = {
       arg match {
         case arg: Name       => arg.nameString
+        case arg: FieldName  => arg.nameString
         case arg: MethodName => arg.displayName
         case arg: IRNode     => arg.show
         case arg: TypeRef    => arg.displayName

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -645,7 +645,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
           field = anyField.asInstanceOf[FieldDef]
           if parent.fieldsRead.contains(field.name.name)
         } yield {
-          parent.className -> field
+          field
         }
 
         Some(new OptimizerCore.InlineableClassStructure(allFields))
@@ -717,8 +717,8 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
       }
 
       def isElidableStat(tree: Tree): Boolean = tree match {
-        case Block(stats)                      => stats.forall(isElidableStat)
-        case Assign(Select(This(), _, _), rhs) => isTriviallySideEffectFree(rhs)
+        case Block(stats)                   => stats.forall(isElidableStat)
+        case Assign(Select(This(), _), rhs) => isTriviallySideEffectFree(rhs)
 
         // Mixin constructor -- test whether its body is entirely empty
         case ApplyStatically(flags, This(), className, methodName, Nil)
@@ -1462,11 +1462,11 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
       }
     }
 
-    protected def isFieldRead(className: ClassName, fieldName: FieldName): Boolean =
-      getInterface(className).askFieldRead(fieldName, asker)
+    protected def isFieldRead(fieldName: FieldName): Boolean =
+      getInterface(fieldName.className).askFieldRead(fieldName, asker)
 
-    protected def isStaticFieldRead(className: ClassName, fieldName: FieldName): Boolean =
-      getInterface(className).askStaticFieldRead(fieldName, asker)
+    protected def isStaticFieldRead(fieldName: FieldName): Boolean =
+      getInterface(fieldName.className).askStaticFieldRead(fieldName, asker)
   }
 
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -123,14 +123,46 @@ class ClassDefCheckerTest {
   }
 
   @Test
+  def fieldDefClassName(): Unit = {
+    assertError(
+      classDef(
+        "A",
+        superClass = Some(ObjectClass),
+        fields = List(
+          FieldDef(EMF, FieldName("B", "foo"), NON, IntType)
+        ),
+        methods = List(trivialCtor("A"))
+      ),
+      "illegal FieldDef with name B::foo in class A"
+    )
+
+    // evidence that we do not need an explicit check for top-level field exports
+    assertError(
+      classDef(
+        "A",
+        kind = ClassKind.ModuleClass,
+        superClass = Some(ObjectClass),
+        fields = List(
+          FieldDef(EMF.withNamespace(MemberNamespace.PublicStatic), FieldName("A", "foo"), NON, IntType)
+        ),
+        methods = List(trivialCtor("A")),
+        topLevelExportDefs = List(
+          TopLevelFieldExportDef("main", "foo", FieldName("B", "foo"))
+        )
+      ),
+      "Cannot export non-existent static field 'B::foo'"
+    )
+  }
+
+  @Test
   def noDuplicateFields(): Unit = {
     assertError(
         classDef("A", superClass = Some(ObjectClass),
             fields = List(
-              FieldDef(EMF, "foobar", NON, IntType),
-              FieldDef(EMF, "foobar", NON, BooleanType)
+              FieldDef(EMF, FieldName("A", "foobar"), NON, IntType),
+              FieldDef(EMF, FieldName("A", "foobar"), NON, BooleanType)
             )),
-        "duplicate field 'foobar'")
+        "duplicate field 'A::foobar'")
   }
 
   @Test

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -155,8 +155,8 @@ object TestIRBuilder {
     LocalName(name)
   implicit def string2LabelName(name: String): LabelName =
     LabelName(name)
-  implicit def string2FieldName(name: String): FieldName =
-    FieldName(name)
+  implicit def string2SimpleFieldName(name: String): SimpleFieldName =
+    SimpleFieldName(name)
   implicit def string2ClassName(name: String): ClassName =
     ClassName(name)
 
@@ -164,13 +164,13 @@ object TestIRBuilder {
     LocalIdent(LocalName(name))
   implicit def string2LabelIdent(name: String): LabelIdent =
     LabelIdent(LabelName(name))
-  implicit def string2FieldIdent(name: String): FieldIdent =
-    FieldIdent(FieldName(name))
   implicit def string2ClassIdent(name: String): ClassIdent =
     ClassIdent(ClassName(name))
 
   implicit def localName2LocalIdent(name: LocalName): LocalIdent =
     LocalIdent(name)
+  implicit def fieldName2FieldIdent(name: FieldName): FieldIdent =
+    FieldIdent(name)
   implicit def methodName2MethodIdent(name: MethodName): MethodIdent =
     MethodIdent(name)
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -6,8 +6,21 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 object BinaryIncompatibilities {
   val IR = Seq(
     // !!! Breaking, OK in minor release
+
+    ProblemFilters.exclude[MissingTypesProblem]("org.scalajs.ir.Names$FieldName"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Names#FieldName.*"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Names#LocalName.fromFieldName"),
+
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.scalajs.ir.Types#RecordType.findField"),
+    ProblemFilters.exclude[MemberProblem]("org.scalajs.ir.Types#RecordType#Field.*"),
+
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#StoreModule.*"),
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.scalajs.ir.Trees#StoreModule.unapply"),
+
+    ProblemFilters.exclude[MemberProblem]("org.scalajs.ir.Trees#JSPrivateSelect.*"),
+    ProblemFilters.exclude[MemberProblem]("org.scalajs.ir.Trees#RecordSelect.*"),
+    ProblemFilters.exclude[MemberProblem]("org.scalajs.ir.Trees#Select.*"),
+    ProblemFilters.exclude[MemberProblem]("org.scalajs.ir.Trees#SelectStatic.*"),
   )
 
   val Linker = Seq(

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -439,8 +439,9 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
 
         case New(className, ctor, args) =>
           New(transformNonJSClassName(className), transformMethodIdent(ctor), args)
-        case Select(qualifier, className, field) =>
-          Select(qualifier, transformNonJSClassName(className), field)(transformType(tree.tpe))
+        case Select(qualifier, field @ FieldIdent(fieldName)) =>
+          val newFieldName = FieldName(transformNonJSClassName(fieldName.className), fieldName.simpleName)
+          Select(qualifier, FieldIdent(newFieldName)(field.pos))(transformType(tree.tpe))
 
         case t: Apply =>
           Apply(t.flags, t.receiver, transformMethodIdent(t.method), t.args)(


### PR DESCRIPTION
Previously, `FieldName` only represented the *simple* name of a field. It was complemented everywhere with the enclosing `ClassName`, for namespacing purposes.

We now make `FieldName` a composite, like `MethodName`. It contains a `ClassName` and a `SimpleFieldName`. Structurally, `SimpleFieldName` is the same as the old `FieldName`.

This removes the need to pass additional, out-of-band `ClassName`s everywhere a `FieldName` or `FieldIdent` was used.

In addition to the readability improvements, this might improve performance. We previously often had to create (temporary) pairs of `(ClassName, FieldName)` as keys of maps. Now, we can directly use the `FieldName`s instead.

While the IR names, types and trees are significantly impacted by this change, the `.sjsir` format is unchanged.