### PR TITLE
Fix #4949: Wrap statements starting with a `{}` in parens.

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
@@ -109,11 +109,19 @@ class DynamicTest {
     assertJSUndefined(obj_anything)
   }
 
-  @Test def objectLiteralInStatementPosition_Issue1627(): Unit = {
-    // Just make sure it does not cause a SyntaxError
+  @Test def objectLiteralInStatementPosition_Issue1627_Issue4949(): Unit = {
+    @noinline def dynProp(): String = "foo"
+
+    // Just make sure those statements do not cause a SyntaxError
     js.Dynamic.literal(foo = "bar")
-    // and also test the case without param (different code path in Printers)
     js.Dynamic.literal()
+    js.Dynamic.literal(foo = "bar").foo
+    js.Dynamic.literal(foo = () => "bar").foo()
+    js.Dynamic.literal(foo = "bar").foo = "babar"
+    js.Dynamic.literal(foo = "foo").selectDynamic(dynProp())
+    js.Dynamic.literal(foo = "foo").updateDynamic(dynProp())("babar")
+    js.Dynamic.literal(foo = () => "bar").applyDynamic(dynProp())()
+    js.Dynamic.literal(foo = "bar") + js.Dynamic.literal(foobar = "babar")
   }
 
   @Test def objectLiteralConstructionWithDynamicNaming(): Unit = {


### PR DESCRIPTION
An alternative would be to pass down through `printTree` whether we are textually at the start of a statement, and still handle the parens only in `ObjectConstr`. Not sure which is more efficient.