### PR TITLE
Fix #4949: Wrap all `{}` *starting* a statement in parens.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -34,7 +34,7 @@ object Trees {
     def show: String = {
       val writer = new ByteArrayWriter()
       val printer = new Printers.JSTreePrinter(writer)
-      printer.printTree(this, isStat = true)
+      printer.printTree(this, isStat = true, isAtStartOfStat = true)
       new String(writer.toByteArray(), StandardCharsets.US_ASCII)
     }
   }

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
@@ -159,6 +159,33 @@ class PrintersTest {
     )
   }
 
+  @Test def objectLitAtStartOfStatement_Issue4949(): Unit = {
+    val fooStringLit = StringLiteral("foo")
+
+    val emptyObjLit = ObjectConstr(Nil)
+    val emptyObjLitStr = "{}"
+
+    val foo1ObjLit = ObjectConstr(List(fooStringLit -> IntLiteral(1)))
+    val foo1ObjLitStr =
+      """{
+        |  "foo": 1
+        |}"""
+
+    for ((objLit, objLitStr) <- List(emptyObjLit -> emptyObjLitStr, foo1ObjLit -> foo1ObjLitStr)) {
+      // baseline: no wrapping ()
+      assertPrintEquals(s"""var x = $objLitStr;""", VarDef("x", Some(objLit)))
+
+      assertPrintEquals(s"""($objLitStr);""", objLit)
+      assertPrintEquals(s"""($objLitStr).foo;""", DotSelect(objLit, "foo"))
+      assertPrintEquals(s"""($objLitStr).foo = 2;""", Assign(DotSelect(objLit, "foo"), IntLiteral(2)))
+      assertPrintEquals(s"""($objLitStr).foo();""", Apply(DotSelect(objLit, "foo"), Nil))
+      assertPrintEquals(s"""($objLitStr)["foo"];""", BracketSelect(objLit, fooStringLit))
+      assertPrintEquals(s"""($objLitStr)["foo"] = 2;""", Assign(BracketSelect(objLit, fooStringLit), IntLiteral(2)))
+      assertPrintEquals(s"""($objLitStr)["foo"]();""", Apply(BracketSelect(objLit, fooStringLit), Nil))
+      assertPrintEquals(s"""($objLitStr + $objLitStr);""", BinaryOp(ir.Trees.JSBinaryOp.+, objLit, objLit))
+    }
+  }
+
   @Test def showPrintedTree(): Unit = {
     val tree = PrintedTree("test".getBytes(UTF_8), SourceMapWriter.Fragment.Empty)
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/jsinterop/DynamicTest.scala
@@ -109,11 +109,19 @@ class DynamicTest {
     assertJSUndefined(obj_anything)
   }
 
-  @Test def objectLiteralInStatementPosition_Issue1627(): Unit = {
-    // Just make sure it does not cause a SyntaxError
+  @Test def objectLiteralInStatementPosition_Issue1627_Issue4949(): Unit = {
+    @noinline def dynProp(): String = "foo"
+
+    // Just make sure those statements do not cause a SyntaxError
     js.Dynamic.literal(foo = "bar")
-    // and also test the case without param (different code path in Printers)
     js.Dynamic.literal()
+    js.Dynamic.literal(foo = "bar").foo
+    js.Dynamic.literal(foo = () => "bar").foo()
+    js.Dynamic.literal(foo = "bar").foo = "babar"
+    js.Dynamic.literal(foo = "foo").selectDynamic(dynProp())
+    js.Dynamic.literal(foo = "foo").updateDynamic(dynProp())("babar")
+    js.Dynamic.literal(foo = () => "bar").applyDynamic(dynProp())()
+    js.Dynamic.literal(foo = "bar") + js.Dynamic.literal(foobar = "babar")
   }
 
   @Test def objectLiteralConstructionWithDynamicNaming(): Unit = {


### PR DESCRIPTION
Alternative to #4950.