### PR TITLE
Optimize `String_+` for `char` at the emitter level.

### DIFF
--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -118,7 +118,7 @@ object Character {
   @inline def hashCode(value: Char): Int = value.toInt
 
   @inline def toString(c: Char): String =
-    js.Dynamic.global.String.fromCharCode(c.toInt).asInstanceOf[String]
+    "" + c
 
   def toString(codePoint: Int): String = {
     if (isBmpCodePoint(codePoint)) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -947,6 +947,9 @@ private[emitter] object CoreJSLib {
       defineFunction1(VarField.doubleToInt) { x =>
         Return(If(x > 2147483647, 2147483647, If(x < -2147483648, -2147483648, x | 0)))
       } :::
+      defineFunction1(VarField.charToString) { x =>
+        Return(Apply(genIdentBracketSelect(StringRef, "fromCharCode"), x :: Nil))
+      } :::
       condDefs(semantics.stringIndexOutOfBounds != CheckedBehavior.Unchecked)(
         defineFunction2(VarField.charAt) { (s, i) =>
           val r = varRef("r")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
@@ -154,6 +154,8 @@ private[emitter] object VarField {
   /** Box char. */
   final val bC = mk("$bC")
 
+  final val charToString = mk("$cToS")
+
   final val charAt = mk("$charAt")
 
   // Object helpers


### PR DESCRIPTION
Previously, our implementation of `Character.toString(c)` used JS interop itself to produce `String.fromCharCode(c)`. This was the only hijacked class to do so, as the other ones use `"" + c` instead. The reason was that the function emitter used to box chars in string concatenation to get the behavior of `$Char.toString()`, and we wanted to avoid the boxing.

We now make `FunctionEmitter` smarter about primitive `char`s in `String_+`: it does not box anymore, and instead calls a dedicated helper that calls `String.fromCharCode(c)`. We replace the user-space implementation of `Character.toString(c)` with `"" + c`, which aligns it with the other hijacked classes.

This is better because the optimization is more widely applicable: it applies to all string concatenations, including those generated by string interpolators, instead of only explicit `toString()` calls.

Moreover, it automatically allows to constant-fold `c.toString()` when `c` is a constant character.

---

I originally thought about doing this to help the wip Wasm back-end, but it turned out to be beneficial for JS as well.