### PR TITLE
Add LinkedClass.hasDirectInstances.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -826,7 +826,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
 
   def genTypeData(className: ClassName, kind: ClassKind,
       superClass: Option[ClassIdent], ancestors: List[ClassName],
-      jsNativeLoadSpec: Option[JSNativeLoadSpec], hasInstances: Boolean)(
+      jsNativeLoadSpec: Option[JSNativeLoadSpec], hasDirectInstances: Boolean)(
       implicit moduleContext: ModuleContext,
       globalKnowledge: GlobalKnowledge, pos: Position): WithGlobals[List[js.Tree]] = {
     import TreeDSL._
@@ -847,7 +847,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     val kindOrCtorParam = {
       if (isJSType) js.IntLiteral(2)
       else if (kind == ClassKind.Interface) js.IntLiteral(1)
-      else if (kind.isClass && hasInstances) globalVar(VarField.c, className)
+      else if (kind.isClass && hasDirectInstances) globalVar(VarField.c, className)
       else js.IntLiteral(0)
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -716,14 +716,14 @@ final class Emitter[E >: Null <: js.Tree](
 
       if (linkedClass.hasRuntimeTypeInfo) {
         main ++= extractWithGlobals(classTreeCache.typeData.getOrElseUpdate(
-            linkedClass.hasInstances,
+            linkedClass.hasDirectInstances,
             classEmitter.genTypeData(
               className, // invalidated by overall class cache (part of ancestors)
               kind, // invalidated by class version
               linkedClass.superClass, // invalidated by class version
               linkedClass.ancestors, // invalidated by overall class cache (identity)
               linkedClass.jsNativeLoadSpec, // invalidated by class version
-              linkedClass.hasInstances // invalidated directly (it is the input to `getOrElseUpdate`)
+              linkedClass.hasDirectInstances // invalidated directly (it is the input to `getOrElseUpdate`)
             )(moduleContext, classCache, linkedClass.pos).map(postTransform(_, 0))))
       }
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -166,6 +166,7 @@ private[frontend] object BaseLinker {
         classDef.pos,
         ancestors.toList,
         hasInstances = classInfo.isAnySubclassInstantiated,
+        hasDirectInstances = classInfo.isInstantiated,
         hasInstanceTests = classInfo.areInstanceTestsUsed,
         hasRuntimeTypeInfo = classInfo.isDataAccessed,
         fieldsRead = classInfo.fieldsRead.toSet,

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkedClass.scala
@@ -55,6 +55,7 @@ final class LinkedClass(
     // Actual Linking info
     val ancestors: List[ClassName],
     val hasInstances: Boolean,
+    val hasDirectInstances: Boolean,
     val hasInstanceTests: Boolean,
     val hasRuntimeTypeInfo: Boolean,
     val fieldsRead: Set[FieldName],

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -24,6 +24,9 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
+    // !!! Breaking, OK in minor release
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.LinkedClass.this"),
+
     // private, not an issue
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.CommonPhaseConfig.this"),
   )


### PR DESCRIPTION
Should be rebased on top of #4931 once it's merged, because of the second commit. Otherwise good to review.

---

It exposes whether the given class is directly instantiated. This is required for the WebAssembly backend, which needs to build vtables for concrete classes only.

The second commit only has a marginal impact, because the condition `&& linkedClass.hasRuntimeTypeInfo` almost entirely compensated for the former imprecision, but it is free lunch after the first one.