### PR TITLE
Reduce the memory pressure of BackwardsCompatTest.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -402,10 +402,18 @@ def Tasks = [
     npm install &&
     sbtnoretry ++$scala linker$v/test &&
     sbtnoretry linkerPrivateLibrary/test &&
-    sbtnoretry ++$scala irJS$v/test linkerJS$v/test linkerInterfaceJS$v/test &&
+    sbtnoretry ++$scala irJS$v/test &&
+    sbtnoretry ++$scala linkerInterfaceJS$v/test &&
+    sbtnoretry ++$scala linkerJS$v/test &&
     sbtnoretry 'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSStage in testSuite.v$v := FastOptStage' \
-        ++$scala irJS$v/test linkerJS$v/test linkerInterfaceJS$v/test &&
+        ++$scala irJS$v/test &&
+    sbtnoretry 'set scalaJSStage in Global := FullOptStage' \
+        'set scalaJSStage in testSuite.v$v := FastOptStage' \
+        ++$scala linkerInterfaceJS$v/test &&
+    sbtnoretry 'set scalaJSStage in Global := FullOptStage' \
+        'set scalaJSStage in testSuite.v$v := FastOptStage' \
+        ++$scala linkerJS$v/test &&
     sbtnoretry ++$scala testSuite$v/bootstrap:test &&
     sbtnoretry 'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSStage in testSuite.v$v := FastOptStage' \

--- a/linker/shared/src/test/scala/org/scalajs/linker/BackwardsCompatTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/BackwardsCompatTest.scala
@@ -80,18 +80,17 @@ class BackwardsCompatTest {
     val classDefFiles = classDefs.map(MemClassDefIRFile(_))
     val logger = new ScalaConsoleLogger(Level.Error)
 
-    Future.traverse(TestIRRepo.previousLibs.toSeq) { case (version, libFuture) =>
-      libFuture.flatMap { lib =>
-        val config = StandardConfig().withCheckIR(true)
-        val linker = StandardImpl.linker(config)
-        val out = MemOutputDirectory()
+    TestIRRepo.sequentiallyForEachPreviousLib { (version, lib) =>
+      val config = StandardConfig().withCheckIR(true)
+      val linker = StandardImpl.linker(config)
+      val out = MemOutputDirectory()
 
-        linker.link(lib ++ classDefFiles, moduleInitializers, out, logger)
-      }.recover {
-        case e: Throwable =>
-          throw new AssertionError(
-              s"linking stdlib $version failed: ${e.getMessage()}", e)
-      }
+      linker.link(lib ++ classDefFiles, moduleInitializers, out, logger)
+        .recover {
+          case e: Throwable =>
+            throw new AssertionError(
+                s"linking stdlib $version failed: ${e.getMessage()}", e)
+        }
     }
   }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRRepo.scala
@@ -13,7 +13,6 @@
 package org.scalajs.linker.testutils
 
 import scala.concurrent._
-import scala.concurrent.ExecutionContext.Implicits.global
 
 import org.scalajs.linker.StandardImpl
 import org.scalajs.linker.interface.IRFile
@@ -21,14 +20,54 @@ import org.scalajs.linker.interface.IRFile
 object TestIRRepo {
   private val globalIRCache = StandardImpl.irFileCache()
 
-  val minilib: Future[Seq[IRFile]] = load(StdlibHolder.minilib)
-  val javalib: Future[Seq[IRFile]] = load(StdlibHolder.javalib)
+  val minilib: Future[Seq[IRFile]] = loadGlobal(StdlibHolder.minilib)
+  val javalib: Future[Seq[IRFile]] = loadGlobal(StdlibHolder.javalib)
   val empty: Future[Seq[IRFile]] = Future.successful(Nil)
-  val previousLibs: Map[String, Future[Seq[IRFile]]] =
-    StdlibHolder.previousLibs.map(x => x._1 -> load(x._2))
 
-  private def load(stdlibPath: String) = {
+  private def loadGlobal(stdlibPath: String): Future[Seq[IRFile]] = {
+    import scala.concurrent.ExecutionContext.Implicits.global
+
     Platform.loadJar(stdlibPath)
       .flatMap(globalIRCache.newCache.cached _)
+  }
+
+  /** For each previous lib, calls `f(version, irFiles)`, and combines the result.
+   *
+   *  This method applies `f` *sequentially*. It waits until the returned
+   *  `Future` completes before moving on to the next iteration.
+   */
+  def sequentiallyForEachPreviousLib[A](f: (String, Seq[IRFile]) => Future[A])(
+      implicit ec: ExecutionContext): Future[List[A]] = {
+
+    // sort for determinism
+    val sortedPreviousLibs = StdlibHolder.previousLibs.toList.sortBy(_._1)
+
+    sequentialFutureTraverse(sortedPreviousLibs) { case (version, path) =>
+      Platform.loadJar(path).flatMap { files =>
+        val cache = globalIRCache.newCache
+        cache
+          .cached(files)
+          .flatMap(f(version, _))
+          .andThen { case _ => cache.free() }
+      }
+    }
+  }
+
+  /** Like `Future.traverse`, but waits until each `Future` has completed
+   *  before starting the next one.
+   */
+  private def sequentialFutureTraverse[A, B](items: List[A])(f: A => Future[B])(
+      implicit ec: ExecutionContext): Future[List[B]] = {
+    items match {
+      case Nil =>
+        Future.successful(Nil)
+      case head :: tail =>
+        for {
+          headResult <- f(head)
+          tailResult <- sequentialFutureTraverse(tail)(f)
+        } yield {
+          headResult :: tailResult
+        }
+    }
   }
 }


### PR DESCRIPTION
Previously, we were running the tests for *all* previous versions in parallel, because of the behavior of `Future.traverse`. While it can reduce the wall clock time of running that test, it comes at a huge memory consumption cost, increasing with every new release.

It seems we have recently hit the limit of what is reasonable, especially on JS. Even JS retains things in parallel in memory because the IO handling concurrently overlaps.

We now ensure a completely sequential behavior for this test. For each previous version, in sequence, we

1. create a new cache for the IR files of the version,
2. load the IR files,
3. execute the test,
4. free the cache.

Additionally, in the CI, we decompose the `ir`/`linkerInterface`/`linker` JS tests in separate processes.

This PR hopefully fixes #4961.