### PR TITLE
Add Symbol.asyncIterator

### DIFF
--- a/library/src/main/scala/scala/scalajs/js/Symbol.scala
+++ b/library/src/main/scala/scala/scalajs/js/Symbol.scala
@@ -67,6 +67,13 @@ object Symbol extends js.Object {
    */
   def keyFor(sym: js.Symbol): js.UndefOr[String] = js.native
 
+  /** <span class="badge badge-ecma2018" style="float: right;">ECMAScript 2018</span>
+   *  The well-known symbol `@@asyncIterator`.
+   *
+   *  @group wellknownsyms
+   */
+  val asyncIterator: js.Symbol = js.native
+
   /** The well-known symbol `@@hasInstance`.
    *
    *  @group wellknownsyms


### PR DESCRIPTION
Hi!

This symbol returns an object conforming to the async iterator protocol. This protocol is effectively the same as the regular iterator protocol, except the methods on the iterator return values wrapped in promises. Any and all feedback is welcome.

This is a follow-up of [my message in the Scala.js discord](https://discord.com/channels/632150470000902164/635668814956068864/1218993100530126848), where I mentioned I was interested in adding facades for working with the OPFS to scala-js-dom. In particular, `Symbol.asyncIterator` is required for a complete implementation of the `FileSystemDirectoryHandle` facade. Assuming I'm going about this the right way, my next step after this PR would be to take a look at adding an `AsyncIterator` facade to this repo.

Doc links:
- [ES2018 - Symbol.asyncIterator](https://262.ecma-international.org/9.0/#sec-symbol.asynciterator)
- [MDN - Async iterable protocol](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols#the_async_iterator_and_async_iterable_protocols)
- [MDN - Symbol.asyncIterator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Symbol/asyncIterator)
- [MDN - FileSystemDirectoryHandle](https://developer.mozilla.org/en-US/docs/Web/API/FileSystemDirectoryHandle)
- [MDN - OPFS](https://developer.mozilla.org/en-US/docs/Web/API/File_System_API/Origin_private_file_system)