### PR TITLE
Cleanups to Emitter post transforms

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -61,12 +61,10 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
       .withTrackAllGlobalRefs(true)
       .withInternalModulePattern(m => OutputPatternsImpl.moduleName(config.outputPatterns, m.id))
 
-    // Do not apply ClosureAstTransformer eagerly:
-    // The ASTs used by closure are highly mutable, so re-using them is non-trivial.
-    // Since closure is slow anyways, we haven't built the optimization.
-    val postTransformer = Emitter.PostTransformer.Identity
+    // Do not pre-print trees: We do not want the printed form.
+    val prePrinter = Emitter.PrePrinter.Off
 
-    new Emitter(emitterConfig, postTransformer)
+    new Emitter(emitterConfig, prePrinter)
   }
 
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -43,19 +43,19 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
 
   private[this] val fragmentIndex = new SourceMapWriter.Index
 
-  private[this] val bodyPrinter: BodyPrinter = {
-    if (config.minify) IdentityPostTransformerBasedBodyPrinter
-    else if (config.sourceMap) new PrintedTreeWithSourceMapBodyPrinter(fragmentIndex)
-    else PrintedTreeWithoutSourceMapBodyPrinter
-  }
+  private[this] val emitter: Emitter = {
+    val postTransformer = {
+      if (config.minify) Emitter.PostTransformer.Identity
+      else if (config.sourceMap) new PostTransformerWithSourceMap(fragmentIndex)
+      else PostTransformerWithoutSourceMap
+    }
 
-  private[this] val emitter: Emitter[bodyPrinter.TreeType] = {
     val emitterConfig = Emitter.Config(config.commonConfig.coreSpec)
       .withJSHeader(config.jsHeader)
       .withInternalModulePattern(m => OutputPatternsImpl.moduleName(config.outputPatterns, m.id))
       .withMinify(config.minify)
 
-    new Emitter(emitterConfig, bodyPrinter.postTransformer)
+    new Emitter(emitterConfig, postTransformer)
   }
 
   val symbolRequirements: SymbolRequirement = emitter.symbolRequirements
@@ -104,7 +104,9 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
           jsFileWriter.write(printedModuleSetCache.headerBytes)
           jsFileWriter.writeASCIIString("'use strict';\n")
 
-          bodyPrinter.printWithoutSourceMap(trees, jsFileWriter)
+          val printer = new Printers.JSTreePrinter(jsFileWriter)
+          for (tree <- trees)
+            printer.printStat(tree)
 
           jsFileWriter.write(printedModuleSetCache.footerBytes)
 
@@ -138,7 +140,9 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
           jsFileWriter.writeASCIIString("'use strict';\n")
           smWriter.nextLine()
 
-          bodyPrinter.printWithSourceMap(trees, jsFileWriter, smWriter)
+          val printer = new Printers.JSTreePrinterWithSourceMap(jsFileWriter, smWriter, initIndent = 0)
+          for (tree <- trees)
+            printer.printStat(tree)
 
           jsFileWriter.write(printedModuleSetCache.footerBytes)
           jsFileWriter.write(("//# sourceMappingURL=" + sourceMapURI + "\n").getBytes(StandardCharsets.UTF_8))
@@ -242,58 +246,7 @@ private object BasicLinkerBackend {
     }
   }
 
-  private abstract class BodyPrinter {
-    type TreeType >: Null <: js.Tree
-
-    val postTransformer: Emitter.PostTransformer[TreeType]
-
-    def printWithoutSourceMap(trees: List[TreeType], jsFileWriter: ByteArrayWriter): Unit
-    def printWithSourceMap(trees: List[TreeType], jsFileWriter: ByteArrayWriter, smWriter: SourceMapWriter): Unit
-  }
-
-  private object IdentityPostTransformerBasedBodyPrinter extends BodyPrinter {
-    type TreeType = js.Tree
-
-    val postTransformer: Emitter.PostTransformer[TreeType] = Emitter.PostTransformer.Identity
-
-    def printWithoutSourceMap(trees: List[TreeType], jsFileWriter: ByteArrayWriter): Unit = {
-      val printer = new Printers.JSTreePrinter(jsFileWriter)
-      for (tree <- trees)
-        printer.printStat(tree)
-    }
-
-    def printWithSourceMap(trees: List[TreeType], jsFileWriter: ByteArrayWriter, smWriter: SourceMapWriter): Unit = {
-      val printer = new Printers.JSTreePrinterWithSourceMap(jsFileWriter, smWriter, initIndent = 0)
-      for (tree <- trees)
-        printer.printStat(tree)
-    }
-  }
-
-  private abstract class PrintedTreeBasedBodyPrinter(
-    val postTransformer: Emitter.PostTransformer[js.PrintedTree]
-  ) extends BodyPrinter {
-    type TreeType = js.PrintedTree
-
-    def printWithoutSourceMap(trees: List[TreeType], jsFileWriter: ByteArrayWriter): Unit = {
-      for (tree <- trees)
-        jsFileWriter.write(tree.jsCode)
-    }
-
-    def printWithSourceMap(trees: List[TreeType], jsFileWriter: ByteArrayWriter, smWriter: SourceMapWriter): Unit = {
-      for (tree <- trees) {
-        jsFileWriter.write(tree.jsCode)
-        smWriter.insertFragment(tree.sourceMapFragment)
-      }
-    }
-  }
-
-  private object PrintedTreeWithoutSourceMapBodyPrinter
-      extends PrintedTreeBasedBodyPrinter(PostTransformerWithoutSourceMap)
-
-  private class PrintedTreeWithSourceMapBodyPrinter(fragmentIndex: SourceMapWriter.Index)
-      extends PrintedTreeBasedBodyPrinter(new PostTransformerWithSourceMap(fragmentIndex))
-
-  private object PostTransformerWithoutSourceMap extends Emitter.PostTransformer[js.PrintedTree] {
+  private object PostTransformerWithoutSourceMap extends Emitter.PostTransformer {
     def transformStats(trees: List[js.Tree], indent: Int): List[js.PrintedTree] = {
       if (trees.isEmpty) {
         Nil // Fast path
@@ -309,7 +262,7 @@ private object BasicLinkerBackend {
   }
 
   private class PostTransformerWithSourceMap(fragmentIndex: SourceMapWriter.Index)
-      extends Emitter.PostTransformer[js.PrintedTree] {
+      extends Emitter.PostTransformer {
     def transformStats(trees: List[js.Tree], indent: Int): List[js.PrintedTree] = {
       if (trees.isEmpty) {
         Nil // Fast path

--- a/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
@@ -137,7 +137,7 @@ class EmitterTest {
     raw"""Emitter: Method tree cache stats: reused: (\d+) -- invalidated: (\d+)""".r
 
   private val EmitterPostTransformStatsMessage =
-    raw"""Emitter: Post transforms: total: (\d+) -- nested: (\d+) -- nested avoided: (\d+)""".r
+    raw"""Emitter: Post transforms: (\d+)""".r
 
   /** Makes sure that linking a "substantial" program (using `println`) twice
    *  does not invalidate any cache or top-level tree in the second run.
@@ -208,21 +208,18 @@ class EmitterTest {
 
       // Post transforms
 
-      val Seq(postTransforms1, nestedPostTransforms1, _) =
+      val Seq(postTransforms1) =
         lines1.assertContainsMatch(EmitterPostTransformStatsMessage).map(_.toInt)
 
-      val Seq(postTransforms2, nestedPostTransforms2, _) =
+      val Seq(postTransforms2) =
         lines2.assertContainsMatch(EmitterPostTransformStatsMessage).map(_.toInt)
 
-      // At the time of writing this test, postTransforms1 reports 216
+      // At the time of writing this test, postTransforms1 reports 188
       assertTrue(
           s"Not enough post transforms (got $postTransforms1); extraction must have gone wrong",
-          postTransforms1 > 200)
+          postTransforms1 > 180)
 
-      assertEquals("Second run must only have nested post transforms",
-          nestedPostTransforms2, postTransforms2)
-      assertEquals("Both runs must have the same number of nested post transforms",
-          nestedPostTransforms1, nestedPostTransforms2)
+      assertEquals("Second run may not have post transforms", 0, postTransforms2)
     }
   }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
@@ -136,8 +136,8 @@ class EmitterTest {
   private val EmitterMethodTreeCacheStatsMessage =
     raw"""Emitter: Method tree cache stats: reused: (\d+) -- invalidated: (\d+)""".r
 
-  private val EmitterPostTransformStatsMessage =
-    raw"""Emitter: Post transforms: (\d+)""".r
+  private val EmitterPrePrintsStatsMessage =
+    raw"""Emitter: Pre prints: (\d+)""".r
 
   /** Makes sure that linking a "substantial" program (using `println`) twice
    *  does not invalidate any cache or top-level tree in the second run.
@@ -206,20 +206,20 @@ class EmitterTest {
       assertEquals("Second run must reuse all method caches", methodCacheReused2, methodCacheInvalidated1)
       assertEquals("Second run must not invalidate any method cache", 0, methodCacheInvalidated2)
 
-      // Post transforms
+      // Pre prints
 
-      val Seq(postTransforms1) =
-        lines1.assertContainsMatch(EmitterPostTransformStatsMessage).map(_.toInt)
+      val Seq(prePrints1) =
+        lines1.assertContainsMatch(EmitterPrePrintsStatsMessage).map(_.toInt)
 
-      val Seq(postTransforms2) =
-        lines2.assertContainsMatch(EmitterPostTransformStatsMessage).map(_.toInt)
+      val Seq(prePrints2) =
+        lines2.assertContainsMatch(EmitterPrePrintsStatsMessage).map(_.toInt)
 
-      // At the time of writing this test, postTransforms1 reports 188
+      // At the time of writing this test, prePrints1 reports 188
       assertTrue(
-          s"Not enough post transforms (got $postTransforms1); extraction must have gone wrong",
-          postTransforms1 > 180)
+          s"Not enough pre prints (got $prePrints1); extraction must have gone wrong",
+          prePrints1 > 180)
 
-      assertEquals("Second run may not have post transforms", 0, postTransforms2)
+      assertEquals("Second run may not have pre prints", 0, prePrints2)
     }
   }
 }


### PR DESCRIPTION
The changes in #4945 made me realize that the post transform concept is more general than we actually need: we do not need general purpose post transformation, just pre-printing.

This PR aligns the code with this notion.