### PR TITLE
Optimize memory consumption of Infos

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1448,25 +1448,21 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
         }
 
         if (!dataInClass.staticFieldsRead.isEmpty) {
-          moduleUnit.addStaticDependency(className)
           dataInClass.staticFieldsRead.foreach(
               clazz._staticFieldsRead.update(_, ()))
         }
 
         if (!dataInClass.staticFieldsWritten.isEmpty) {
-          moduleUnit.addStaticDependency(className)
           dataInClass.staticFieldsWritten.foreach(
               clazz._staticFieldsWritten.update(_, ()))
         }
 
         if (!dataInClass.methodsCalled.isEmpty) {
-          // Do not add to staticDependencies: We call these on the object.
           for (methodName <- dataInClass.methodsCalled)
             clazz.callMethod(methodName)
         }
 
         if (!dataInClass.methodsCalledStatically.isEmpty) {
-          moduleUnit.addStaticDependency(className)
           for (methodName <- dataInClass.methodsCalledStatically)
             clazz.callMethodStatically(methodName)
         }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1432,6 +1432,13 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
           if ((flags & ReachabilityInfoInClass.FlagStaticallyReferenced) != 0) {
             moduleUnit.addStaticDependency(className)
           }
+
+          if ((flags & ReachabilityInfoInClass.FlagDynamicallyReferenced) != 0) {
+            if (isNoModule)
+              _errors ::= DynamicImportWithoutModuleSupport(from)
+            else
+              moduleUnit.addDynamicDependency(className)
+          }
         }
 
         /* Since many of the lists below are likely to be empty, we always
@@ -1465,17 +1472,6 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
         if (!dataInClass.methodsCalledStatically.isEmpty) {
           for (methodName <- dataInClass.methodsCalledStatically)
             clazz.callMethodStatically(methodName)
-        }
-
-        if (!dataInClass.methodsCalledDynamicImport.isEmpty) {
-          if (isNoModule) {
-            _errors ::= DynamicImportWithoutModuleSupport(from)
-          } else {
-            moduleUnit.addDynamicDependency(className)
-            // In terms of reachability, a dynamic import call is just a static call.
-            for (methodName <- dataInClass.methodsCalledDynamicImport)
-              clazz.callMethodStatically(methodName)
-          }
         }
 
         if (!dataInClass.jsNativeMembersUsed.isEmpty) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -115,7 +115,6 @@ object Infos {
       val staticFieldsWritten: List[FieldName],
       val methodsCalled: List[MethodName],
       val methodsCalledStatically: List[NamespacedMethodName],
-      val methodsCalledDynamicImport: List[NamespacedMethodName],
       val jsNativeMembersUsed: List[MethodName],
       val flags: ReachabilityInfoInClass.Flags
   )
@@ -132,6 +131,7 @@ object Infos {
     final val FlagInstanceTestsUsed = 1 << 2
     final val FlagClassDataAccessed = 1 << 3
     final val FlagStaticallyReferenced = 1 << 4
+    final val FlagDynamicallyReferenced = 1 << 5
   }
 
   final class ClassInfoBuilder(
@@ -384,7 +384,6 @@ object Infos {
     private val staticFieldsWritten = mutable.Set.empty[FieldName]
     private val methodsCalled = mutable.Set.empty[MethodName]
     private val methodsCalledStatically = mutable.Set.empty[NamespacedMethodName]
-    private val methodsCalledDynamicImport = mutable.Set.empty[NamespacedMethodName]
     private val jsNativeMembersUsed = mutable.Set.empty[MethodName]
     private var flags: ReachabilityInfoInClass.Flags = 0
 
@@ -423,7 +422,9 @@ object Infos {
     }
 
     def addMethodCalledDynamicImport(method: NamespacedMethodName): this.type = {
-      methodsCalledDynamicImport += method
+      // In terms of reachability, a dynamic import call is just a static call.
+      methodsCalledStatically += method
+      setFlag(ReachabilityInfoInClass.FlagDynamicallyReferenced)
       this
     }
 
@@ -461,7 +462,6 @@ object Infos {
           staticFieldsWritten = toLikelyEmptyList(staticFieldsWritten),
           methodsCalled = toLikelyEmptyList(methodsCalled),
           methodsCalledStatically = toLikelyEmptyList(methodsCalledStatically),
-          methodsCalledDynamicImport = toLikelyEmptyList(methodsCalledDynamicImport),
           jsNativeMembersUsed = toLikelyEmptyList(jsNativeMembersUsed),
           flags = flags
       )

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -93,7 +93,7 @@ object Infos {
   )
 
   final class ReachabilityInfo private[Infos] (
-      val byClass: List[ReachabilityInfoInClass],
+      val byClass: Array[ReachabilityInfoInClass],
       val globalFlags: ReachabilityInfo.Flags
   )
 
@@ -374,7 +374,7 @@ object Infos {
       setFlag(ReachabilityInfo.FlagUsedExponentOperator)
 
     def result(): ReachabilityInfo =
-      new ReachabilityInfo(byClass.valuesIterator.map(_.result()).toList, flags)
+      new ReachabilityInfo(byClass.valuesIterator.map(_.result()).toArray, flags)
   }
 
   final class ReachabilityInfoInClassBuilder(val className: ClassName) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -400,21 +400,25 @@ object Infos {
 
     def addStaticFieldRead(field: FieldName): this.type = {
       staticFieldsRead += field
+      setStaticallyReferenced()
       this
     }
 
     def addStaticFieldWritten(field: FieldName): this.type = {
       staticFieldsWritten += field
+      setStaticallyReferenced()
       this
     }
 
     def addMethodCalled(method: MethodName): this.type = {
       methodsCalled += method
+      // Do not call setStaticallyReferenced: We call these methods on the object.
       this
     }
 
     def addMethodCalledStatically(method: NamespacedMethodName): this.type = {
       methodsCalledStatically += method
+      setStaticallyReferenced()
       this
     }
 


### PR DESCRIPTION
This reduces the retained size on the test suite for the infos as
follows:

| Component  | Before [MB] | After [MB] |
|------------|------------:|-----------:|
| BaseLinker |          26 |         20 |
| Refiner    |          22 |         17 |

The (incremental) runtime of the Analysis is unaffected.