### PR TITLE
Exclude files from Scala's `library-aux` to prepare for 2.13.14.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1681,6 +1681,12 @@ object Build {
 
         val s = streams.value
 
+        /* Exclude files coming from Scala's `library-aux` directory, as they are not
+         * meant to be compiled. They are part of the source jar since Scala 2.13.14.
+         */
+        val excludeFiles =
+          Set("Any.scala", "AnyRef.scala", "Nothing.scala", "Null.scala", "Singleton.scala")
+
         for {
           srcDir <- sourceDirectories
           normSrcDir = normPath(srcDir)
@@ -1688,10 +1694,10 @@ object Build {
         } {
           val normSrc = normPath(src)
           val path = normSrc.substring(normSrcDir.length)
-          val useless =
+          val exclude =
             path.contains("/scala/collection/parallel/") ||
-            path.contains("/scala/util/parsing/")
-          if (!useless) {
+            (src.getParentFile().getName() == "scala" && excludeFiles.contains(src.getName()))
+          if (!exclude) {
             if (paths.add(path))
               sources += src
             else


### PR DESCRIPTION
Since Scala 2.13.14, the stdlib's source jar contains the files of their `library-aux` directory. These files are not meant to be processed by the regular compiler (only by Scaladoc). We must therefore exclude them from the compilation of the scalalib.

In the process, we remove the exclusion of `/scala/util/parsing/` which has been dead code since we dropped support for Scala 2.11.

---

Locally tested with the "RC" 2.13.14-bin-a527019.