### PR TITLE
Optimize Infos for caching in InfoLoader

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1507,10 +1507,13 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
       if (className == ObjectClass) None
       else Some(ObjectClass)
 
-    new Infos.ClassInfoBuilder(className, ClassKind.Class,
-        superClass = superClass, interfaces = Nil, jsNativeLoadSpec = None)
-      .addMethod(makeSyntheticMethodInfo(NoArgConstructorName, MemberNamespace.Constructor))
-      .result()
+    val methods =
+      List(makeSyntheticMethodInfo(NoArgConstructorName, MemberNamespace.Constructor))
+
+    new Infos.ClassInfo(className, ClassKind.Class,
+        superClass = superClass, interfaces = Nil, jsNativeLoadSpec = None,
+        referencedFieldClasses = Map.empty, methods = methods,
+        jsNativeMembers = Map.empty, jsMethodProps = Nil, topLevelExports = Nil)
   }
 
   private def makeSyntheticMethodInfo(

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1520,8 +1520,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
       methodName: MethodName,
       namespace: MemberNamespace,
       methodsCalled: List[(ClassName, MethodName)] = Nil,
-      methodsCalledStatically: List[(ClassName, NamespacedMethodName)] = Nil,
-      instantiatedClasses: List[ClassName] = Nil
+      methodsCalledStatically: List[(ClassName, NamespacedMethodName)] = Nil
   ): Infos.MethodInfo = {
     val reachabilityInfoBuilder = new Infos.ReachabilityInfoBuilder()
     for ((className, methodName) <- methodsCalled)


### PR DESCRIPTION
This allows us to use the previously calculated infos themselves as
the cached values, reducing memory consumption.

Further, we reduce memory consumption by using immutable maps: Because
a lot of the maps are empty, we do not spend unecessary memory on
empty mutable maps.

This reduces the retained size on the test suite for the infos as
follows:

| Component  | Before [MB] | After [MB] |
|------------|------------:|-----------:|
| BaseLinker |          20 |         15 |
| Refiner    |          17 |         13 |

As a nice side-effect, this allows us to simplify the InfoLoader. The
simplification mainly stems from the insight, that we do not need
active cache used tracking; control flow is sufficient.

Execution times are unaffected, in fact, the incremental case might
even be a bit faster (non-significant though).