### PR TITLE
Make the optimizer type-preserving by inserting Casts when necessary.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -976,7 +976,7 @@ private[optimizer] abstract class OptimizerCore(
           } else if (baseTpe == NullType) {
             cont(checkNotNull(texpr))
           } else if (isSubtype(baseTpe, JavaScriptExceptionClassType)) {
-            pretransformSelectCommon(AnyType, texpr,
+            pretransformSelectCommon(AnyType, texpr, optQualDeclaredType = None,
                 FieldIdent(exceptionFieldName), isLhsOfAssign = false)(cont)
           } else {
             if (texpr.tpe.isExact || !isSubtype(JavaScriptExceptionClassType, baseTpe))
@@ -1182,13 +1182,14 @@ private[optimizer] abstract class OptimizerCore(
       implicit scope: Scope): TailRec[Tree] = {
     val Select(qualifier, field) = tree
     pretransformExpr(qualifier) { preTransQual =>
-      pretransformSelectCommon(tree.tpe, preTransQual, field, isLhsOfAssign)(
+      pretransformSelectCommon(tree.tpe, preTransQual, optQualDeclaredType = None, field, isLhsOfAssign)(
           cont)(scope, tree.pos)
     }
   }
 
   private def pretransformSelectCommon(expectedType: Type,
-      preTransQual: PreTransform, field: FieldIdent, isLhsOfAssign: Boolean)(
+      preTransQual: PreTransform, optQualDeclaredType: Option[Type],
+      field: FieldIdent, isLhsOfAssign: Boolean)(
       cont: PreTransCont)(
       implicit scope: Scope, pos: Position): TailRec[Tree] = {
     /* Note: Callers are expected to have already removed writes to fields that
@@ -1249,7 +1250,13 @@ private[optimizer] abstract class OptimizerCore(
 
             case PreTransTree(newQual, newQualType) =>
               val newQual1 = maybeAssumeNotNull(newQual, newQualType)
-              cont(PreTransTree(Select(newQual1, field)(expectedType),
+              val newQual2 = optQualDeclaredType match {
+                case Some(qualDeclaredType) if !isSubtype(newQual1.tpe, qualDeclaredType) =>
+                  Transient(Cast(newQual1, qualDeclaredType))
+                case _ =>
+                  newQual1
+              }
+              cont(PreTransTree(Select(newQual2, field)(expectedType),
                   RefinedType(expectedType)))
           }
         }
@@ -1707,6 +1714,11 @@ private[optimizer] abstract class OptimizerCore(
       keepOnlySideEffects(expr)
     case UnwrapFromThrowable(expr) =>
       checkNotNullStatement(expr)(stat.pos)
+
+    // By definition, a failed cast is always UB, so it cannot have side effects
+    case Transient(Cast(expr, _)) =>
+      keepOnlySideEffects(expr)
+
     case _ =>
       stat
   }
@@ -1937,6 +1949,9 @@ private[optimizer] abstract class OptimizerCore(
         case AsInstanceOf(expr, tpe) =>
           rec(expr).mapOrFailed(AsInstanceOf(_, tpe))
 
+        case Transient(Cast(expr, tpe)) =>
+          rec(expr).mapOrKeepGoing(newExpr => Transient(Cast(newExpr, tpe)))
+
         case GetClass(expr) =>
           rec(expr).mapOrKeepGoingIf(GetClass(_))(keepGoingIf = isNotNull(expr))
 
@@ -2063,24 +2078,16 @@ private[optimizer] abstract class OptimizerCore(
           } else {
             val allocationSites =
               (treceiver :: targs).map(_.tpe.allocationSite)
-            val shouldMultiInline = {
+            val shouldTryMultiInline = {
               impls.nonEmpty && // will fail at runtime.
-              !impls.exists(impl => scope.implsBeingInlined((allocationSites, impl))) &&
-              canMultiInline(impls)
+              impls.forall(impl => impl.attributes.isForwarder && impl.attributes.inlineable) &&
+              !impls.exists(impl => scope.implsBeingInlined((allocationSites, impl)))
             }
 
-            if (shouldMultiInline) {
-              /* When multi-inlining, we cannot use the enclosing class of the
-               * target method as the declared type of the receiver, since we
-               * have no guarantee that the receiver is in fact of that
-               * particular class. It could be of any of the classes that the
-               * targets belong to. Therefore, we have to keep the receiver's
-               * static type as a declared type, which is our only safe choice.
-               */
-              val representative = impls.minBy(_.enclosingClassName) // for stability
-              val receiverType = treceiver.tpe.base
-              inline(allocationSites, Some((receiverType, treceiver)), targs,
-                  representative, isStat, usePreTransform)(cont)
+            if (shouldTryMultiInline) {
+              tryMultiInline(impls, treceiver, targs, isStat, usePreTransform)(cont) {
+                treeNotInlined
+              }
             } else {
               treeNotInlined
             }
@@ -2089,22 +2096,55 @@ private[optimizer] abstract class OptimizerCore(
     }
   }
 
-  private def canMultiInline(impls: List[MethodID]): Boolean = {
-    // TODO? Inline multiple non-forwarders with the exact same body?
-    impls.forall(impl => impl.attributes.isForwarder && impl.attributes.inlineable) &&
-    (getMethodBody(impls.head).body.get match {
-      // Shape of forwards to default methods
-      case ApplyStatically(flags, This(), className, MethodIdent(methodName), args) =>
-        impls.tail.forall(getMethodBody(_).body.get match {
+  private def tryMultiInline(impls: List[MethodID], treceiver: PreTransform,
+      targs: List[PreTransform], isStat: Boolean, usePreTransform: Boolean)(
+      cont: PreTransCont)(
+      treeNotInlined: => TailRec[Tree])(
+      implicit scope: Scope, pos: Position): TailRec[Tree] = {
+
+    val referenceMethodDef = getMethodBody(impls.head)
+
+    (referenceMethodDef.body.get match {
+      // Shape of forwarders to default methods
+      case body @ ApplyStatically(flags, This(), className, MethodIdent(methodName), args) =>
+        val allTheSame = impls.tail.forall(getMethodBody(_).body.get match {
           case ApplyStatically(`flags`, This(), `className`, MethodIdent(`methodName`), _) =>
             true
           case _ =>
             false
         })
 
+        if (!allTheSame) {
+          treeNotInlined
+        } else {
+          /* In this case, we can directly "splice in" the treceiver and targs
+           * into a made-up ApplyStatically, as evaluation order is always
+           * preserved. This potentially avoids useless bindings and keeps
+           * things simple.
+           *
+           * We only need to cast the receiver after checking that it is not null,
+           * since we need to pass it as the receiver of the `ApplyStatically`,
+           * which expects a known type.
+           */
+          val treceiverCast = foldCast(checkNotNull(treceiver), ClassType(className))
+
+          val target = staticCall(className,
+              MemberNamespace.forNonStaticCall(flags), methodName)
+
+          pretransformSingleDispatch(flags, target, Some(treceiverCast), targs,
+              isStat, usePreTransform)(cont) {
+            val newTree = ApplyStatically(flags,
+                finishTransformExprMaybeAssumeNotNull(treceiverCast),
+                className, MethodIdent(methodName),
+                targs.map(finishTransformExpr))(
+                body.tpe)
+            cont(newTree.toPreTransform)
+          }
+        }
+
       // Bridge method
-      case Apply(flags, This(), MethodIdent(methodName), referenceArgs) =>
-        impls.tail.forall(getMethodBody(_).body.get match {
+      case body @ Apply(flags, This(), MethodIdent(methodName), referenceArgs) =>
+        val allTheSame = impls.tail.forall(getMethodBody(_).body.get match {
           case Apply(`flags`, This(), MethodIdent(`methodName`), implArgs) =>
             referenceArgs.zip(implArgs) forall {
               case (MaybeUnbox(_, unboxID1), MaybeUnbox(_, unboxID2)) =>
@@ -2113,6 +2153,71 @@ private[optimizer] abstract class OptimizerCore(
           case _ =>
             false
         })
+
+        if (!allTheSame) {
+          treeNotInlined
+        } else {
+          /* Interestingly, for this shape of multi-inlining, we do not need to
+           * cast the receiver. We can keep it as is. Virtual dispatch and
+           * reachability analysis will be happy to compute the possible targets
+           * of the generated Apply given the type of our receiver.
+           *
+           * It's a good thing too, because it would be quite hard to figure out
+           * what type to cast the receiver to!
+           */
+
+          if (!referenceArgs.exists(_.isInstanceOf[AsInstanceOf])) {
+            // Common case where where we can splice in; evaluation order is preserved
+            pretransformApply(flags, treceiver, MethodIdent(methodName), targs,
+                body.tpe, isStat, usePreTransform)(cont)
+          } else {
+            /* If there is at least one unbox, we cannot splice in; we need to
+             * use actual bindings and resolve the actual Apply tree to apply
+             * the unboxes in the correct evaluation order.
+             */
+
+            /* Generate a new, fake body that we will inline. For
+             * type-preservation, the type of its `This()` node is the type of
+             * our receiver. For stability, the parameter names are normalized
+             * (taking them from `body` would make the result depend on which
+             * method came up first in the list of targets).
+             */
+            val normalizedParams: List[(LocalName, Type)] = {
+              referenceMethodDef.args.zipWithIndex.map {
+                case (referenceParam, i) => (LocalName("x" + i), referenceParam.ptpe)
+              }
+            }
+            val normalizedBody = Apply(
+              flags,
+              This()(treceiver.tpe.base),
+              MethodIdent(methodName),
+              normalizedParams.zip(referenceArgs).map {
+                case ((name, ptpe), AsInstanceOf(_, castTpe)) =>
+                  AsInstanceOf(VarRef(LocalIdent(name))(ptpe), castTpe)
+                case ((name, ptpe), _) =>
+                  VarRef(LocalIdent(name))(ptpe)
+              }
+            )(body.tpe)
+
+            // Construct bindings; need to check null for the receiver to preserve evaluation order
+            val receiverBinding =
+              Binding(Binding.This, treceiver.tpe.base, mutable = false, checkNotNull(treceiver))
+            val argsBindings = normalizedParams.zip(targs).map {
+              case ((name, ptpe), targ) =>
+                Binding(Binding.Local(name, NoOriginalName), ptpe, mutable = false, targ)
+            }
+
+            withBindings(receiverBinding :: argsBindings) { (bodyScope, cont1) =>
+              implicit val scope = bodyScope
+              if (usePreTransform) {
+                assert(!isStat, "Cannot use pretransform in statement position")
+                pretransformExpr(normalizedBody)(cont1)
+              } else {
+                cont1(PreTransTree(transform(normalizedBody, isStat)))
+              }
+            } (cont) (scope.withEnv(OptEnv.Empty))
+          }
+        }
 
       case body =>
         throw new AssertionError("Invalid forwarder shape: " + body)
@@ -2546,13 +2651,14 @@ private[optimizer] abstract class OptimizerCore(
       case This() if args.isEmpty =>
         assert(optReceiver.isDefined,
             "There was a This(), there should be a receiver")
-        cont(checkNotNull(optReceiver.get._2))
+        cont(foldCast(checkNotNull(optReceiver.get._2), optReceiver.get._1))
 
       case Select(This(), field) if formals.isEmpty =>
         assert(optReceiver.isDefined,
             "There was a This(), there should be a receiver")
-        pretransformSelectCommon(body.tpe, optReceiver.get._2, field,
-            isLhsOfAssign = false)(cont)
+        pretransformSelectCommon(body.tpe, optReceiver.get._2,
+            optQualDeclaredType = Some(optReceiver.get._1),
+            field, isLhsOfAssign = false)(cont)
 
       case Assign(lhs @ Select(This(), field), VarRef(LocalIdent(rhsName)))
           if formals.size == 1 && formals.head.name.name == rhsName =>
@@ -2567,8 +2673,9 @@ private[optimizer] abstract class OptimizerCore(
           // Field is never read, discard assign, keep side effects only.
           cont(PreTransTree(finishTransformArgsAsStat(), RefinedType.NoRefinedType))
         } else {
-          pretransformSelectCommon(lhs.tpe, treceiver, field,
-              isLhsOfAssign = true) { tlhs =>
+          pretransformSelectCommon(lhs.tpe, treceiver,
+              optQualDeclaredType = Some(optReceiver.get._1),
+              field, isLhsOfAssign = true) { tlhs =>
             pretransformAssign(tlhs, args.head)(cont)
           }
         }
@@ -2588,17 +2695,14 @@ private[optimizer] abstract class OptimizerCore(
       implicit scope: Scope, pos: Position): TailRec[Tree] = tailcall {
 
     val optReceiverBinding = optReceiver map { receiver =>
-      /* If the declaredType is CharType, we must introduce a cast, because we
-       * must communicate to the emitter that it has to unbox the value.
-       * For other primitive types, unboxes/casts are not necessary, because
-       * they would only convert `null` to the zero value of the type. However,
-       * `null` is ruled out by `checkNotNull` (or because it is UB).
+      /* Introduce an explicit null check that would be part of the semantics
+       * of `Apply` or `ApplyStatically`.
+       * Then, cast the non-null receiver to the expected receiver type. This
+       * may be required because we found a single potential call target in a
+       * subclass of the static type of the receiver.
        */
       val (declaredType, value0) = receiver
-      val value1 = checkNotNull(value0)
-      val value =
-        if (declaredType == CharType) foldAsInstanceOf(value1, declaredType)
-        else value1
+      val value = foldCast(checkNotNull(value0), declaredType)
       Binding(Binding.This, declaredType, false, value)
     }
 
@@ -4746,10 +4850,50 @@ private[optimizer] abstract class OptimizerCore(
 
   private def foldAsInstanceOf(arg: PreTransform, tpe: Type)(
       implicit pos: Position): PreTransform = {
-    if (isSubtype(arg.tpe.base, tpe))
+    def mayRequireUnboxing: Boolean =
+      arg.tpe.isNullable && !isNullableType(tpe)
+
+    if (semantics.asInstanceOfs == CheckedBehavior.Unchecked && !mayRequireUnboxing)
+      foldCast(arg, tpe)
+    else if (isSubtype(arg.tpe.base, tpe))
       arg
     else
       AsInstanceOf(finishTransformExpr(arg), tpe).toPreTransform
+  }
+
+  private def foldCast(arg: PreTransform, tpe: Type)(
+      implicit pos: Position): PreTransform = {
+    def default(arg: PreTransform, newTpe: RefinedType): PreTransform =
+      PreTransTree(Transient(Cast(finishTransformExpr(arg), tpe)), newTpe)
+
+    def castLocalDef(arg: PreTransform, newTpe: RefinedType): PreTransform = arg match {
+      case PreTransMaybeBlock(bindingsAndStats, PreTransLocalDef(localDef)) =>
+        val refinedLocalDef = localDef.tryWithRefinedType(newTpe)
+        if (refinedLocalDef ne localDef)
+          PreTransBlock(bindingsAndStats, PreTransLocalDef(refinedLocalDef))
+        else
+          default(arg, newTpe)
+
+      case _ =>
+        default(arg, newTpe)
+    }
+
+    if (isSubtype(arg.tpe.base, tpe)) {
+      arg
+    } else {
+      val castTpe = RefinedType(tpe, isExact = false,
+          isNullable = arg.tpe.isNullable && isNullableType(tpe),
+          arg.tpe.allocationSite)
+
+      val isCastFreeAtRunTime = tpe != CharType
+
+      if (isCastFreeAtRunTime) {
+        // Try to push the cast down to usages of LocalDefs, in order to preserve aliases
+        castLocalDef(arg, castTpe)
+      } else {
+        default(arg, castTpe)
+      }
+    }
   }
 
   private def foldJSSelect(qualifier: Tree, item: Tree)(
@@ -4973,16 +5117,31 @@ private[optimizer] abstract class OptimizerCore(
   }
 
   private def checkNotNull(texpr: PreTransform)(implicit pos: Position): PreTransform = {
-    val tpe = texpr.tpe
-
-    if (!tpe.isNullable || semantics.nullPointers == CheckedBehavior.Unchecked) {
+    if (!texpr.tpe.isNullable) {
       texpr
-    } else {
-      val refinedType: RefinedType = tpe.base match {
-        case NullType => RefinedType.Nothing
-        case baseType => RefinedType(baseType, isExact = tpe.isExact, isNullable = false)
+    } else if (semantics.nullPointers == CheckedBehavior.Unchecked) {
+      // If possible, improve the type of the expression to be non-nullable
+
+      val nonNullType = texpr.tpe.toNonNullable
+
+      def rec(texpr: PreTransform): PreTransform = texpr match {
+        case PreTransBlock(bindingsAndStats, result) =>
+          PreTransBlock(bindingsAndStats, rec(result).asInstanceOf[PreTransResult])
+        case PreTransLocalDef(localDef) =>
+          PreTransLocalDef(localDef.tryWithRefinedType(nonNullType))(texpr.pos)
+        case PreTransTree(tree, tpe) =>
+          PreTransTree(tree, nonNullType)
+        case _:PreTransUnaryOp | _:PreTransBinaryOp | _:PreTransJSBinaryOp | _:PreTransRecordTree =>
+          // We cannot improve the type of those
+          texpr
       }
-      PreTransTree(Transient(CheckNotNull(finishTransformExpr(texpr))), refinedType)
+
+      if (nonNullType.isNothingType)
+        texpr // things blow up otherwise
+      else
+        rec(texpr)
+    } else {
+      PreTransTree(Transient(CheckNotNull(finishTransformExpr(texpr))), texpr.tpe.toNonNullable)
     }
   }
 
@@ -5023,18 +5182,20 @@ private[optimizer] abstract class OptimizerCore(
     }
   }
 
+  private def isNullableType(tpe: Type): Boolean = tpe match {
+    case NullType    => true
+    case _: PrimType => false
+    case _           => true
+  }
+
   private def isNotNull(tree: Tree): Boolean = {
     // !!! Duplicate code with FunctionEmitter.isNotNull
-
-    def isNullableType(tpe: Type): Boolean = tpe match {
-      case NullType    => true
-      case _: PrimType => false
-      case _           => true
-    }
 
     def isShapeNotNull(tree: Tree): Boolean = tree match {
       case Transient(CheckNotNull(_) | AssumeNotNull(_)) =>
         true
+      case Transient(Cast(expr, _)) =>
+        isShapeNotNull(expr)
       case _: This =>
         tree.tpe != AnyType
       case _:New | _:LoadModule | _:NewArray | _:ArrayValue | _:Clone | _:ClassOf =>
@@ -5178,48 +5339,6 @@ private[optimizer] abstract class OptimizerCore(
     } else if (mutable) {
       withDedicatedVar(RefinedType(declaredType))
     } else {
-      def computeRefinedType(): RefinedType = bindingName match {
-        case _ if value.tpe.isExact || declaredType == AnyType =>
-          /* If the value's type is exact, or if the declared type is `AnyType`,
-           * the declared type cannot have any new information to give us, so
-           * we directly return `value.tpe`. This avoids a useless `isSubtype`
-           * call, which creates dependencies for incremental optimization.
-           *
-           * In addition, for the case `declaredType == AnyType` there is a
-           * stronger reason: we don't actually know that `this` is non-null in
-           * that case, since it could be the `this` value of a JavaScript
-           * function, which can accept `null`. (As of this writing, this is
-           * theoretical, because the only place where we use a declared type
-           * of `AnyType` is in `JSFunctionApply`, where the actual value for
-           * `this` is always `undefined`.)
-           */
-          value.tpe
-
-        case _: Binding.Local =>
-          /* When binding a something else than `this`, we do not receive the
-           * non-null information. Moreover, there is no situation where the
-           * declared type would bring any new information, since that would
-           * not be valid IR in the first place. Therefore, to avoid a useless
-           * call to `isSubtype`, we directly return `value.tpe`.
-           */
-          value.tpe
-
-        case Binding.This =>
-          /* When binding to `this`, if the declared type is not `AnyType`,
-           * we are in a situation where
-           * a) we know the value must be non-null, and
-           * b) the declaredType may bring more precise information than
-           *    value.tpe.base (typically when inlining a polymorphic method
-           *    that ends up having only one target in a subclass).
-           * We can refine the type here based on that knowledge.
-           */
-          val improvedBaseType =
-            if (isSubtype(value.tpe.base, declaredType)) value.tpe.base
-            else declaredType
-          val isExact = false // We catch the case value.tpe.isExact earlier
-          RefinedType(improvedBaseType, isExact, isNullable = false)
-      }
-
       value match {
         case PreTransBlock(bindingsAndStats, result) =>
           withNewLocalDef(binding.copy(value = result))(buildInner) { tresult =>
@@ -5230,41 +5349,19 @@ private[optimizer] abstract class OptimizerCore(
           /* Attention: the same-name optimization in transformCapturingBody
            * relies on immutable bindings to var refs not being renamed.
            */
-
-          val refinedType = computeRefinedType()
-          val newLocalDef = if (refinedType == value.tpe) {
-            localDef
-          } else {
-            /* Only adjust if the replacement if ReplaceWithThis or
-             * ReplaceWithVarRef, because other types have nothing to gain
-             * (e.g., ReplaceWithConstant) or we want to keep them unwrapped
-             * because they are examined in optimizations (notably all the
-             * types with virtualized objects).
-             */
-            localDef.replacement match {
-              case _:ReplaceWithThis | _:ReplaceWithVarRef =>
-                LocalDef(refinedType, mutable = false,
-                    ReplaceWithOtherLocalDef(localDef))
-              case _ =>
-                localDef
-            }
-          }
-          buildInner(newLocalDef, cont)
+          buildInner(localDef, cont)
 
         case PreTransTree(literal: Literal, _) =>
-          /* A `Literal` always has the most precise type it could ever have.
-           * There is no point using `computeRefinedType()`.
-           */
           buildInner(LocalDef(value.tpe, false,
               ReplaceWithConstant(literal)), cont)
 
         case PreTransTree(VarRef(LocalIdent(refName)), _)
             if !localIsMutable(refName) =>
-          buildInner(LocalDef(computeRefinedType(), false,
+          buildInner(LocalDef(value.tpe, false,
               ReplaceWithVarRef(refName, newSimpleState(UsedAtLeastOnce), None)), cont)
 
         case _ =>
-          withDedicatedVar(computeRefinedType())
+          withDedicatedVar(value.tpe)
       }
     }
   }
@@ -5535,6 +5632,12 @@ private[optimizer] object OptimizerCore {
       isNullable: Boolean)(val allocationSite: AllocationSite, dummy: Int = 0) {
 
     def isNothingType: Boolean = base == NothingType
+
+    def toNonNullable: RefinedType = {
+      if (!isNullable) this
+      else if (base == NullType) RefinedType.Nothing
+      else RefinedType(base, isExact, isNullable = false, allocationSite)
+    }
   }
 
   private object RefinedType {
@@ -5643,7 +5746,11 @@ private[optimizer] object OptimizerCore {
          * notably because it allows us to run the ClassDefChecker after the
          * optimizer.
          */
-        localDef.newReplacement
+        val underlying = localDef.newReplacement
+        if (underlying.tpe == tpe.base)
+          underlying
+        else
+          Transient(Cast(underlying, tpe.base))
 
       case ReplaceWithConstant(value) =>
         value
@@ -5689,6 +5796,23 @@ private[optimizer] object OptimizerCore {
              _:ReplaceWithThis | _:ReplaceWithConstant =>
           false
       })
+    }
+
+    def tryWithRefinedType(refinedType: RefinedType): LocalDef = {
+      /* Only adjust if the replacement if ReplaceWithThis or
+       * ReplaceWithVarRef, because other types have nothing to gain
+       * (e.g., ReplaceWithConstant) or we want to keep them unwrapped
+       * because they are examined in optimizations (notably all the
+       * types with virtualized objects).
+       */
+      replacement match {
+        case _:ReplaceWithThis | _:ReplaceWithVarRef =>
+          LocalDef(refinedType, mutable, ReplaceWithOtherLocalDef(this))
+        case replacement: ReplaceWithOtherLocalDef =>
+          LocalDef(refinedType, mutable, replacement)
+        case _ =>
+          this
+      }
     }
   }
 
@@ -6411,6 +6535,7 @@ private[optimizer] object OptimizerCore {
 
         // Shape of bridges for generic methods
         case Apply(_, This(), method, args) =>
+          !method.name.isReflectiveProxy &&
           (args.size == params.size) &&
           args.zip(params).forall {
             case (MaybeUnbox(VarRef(LocalIdent(aname)), _),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2021,15 +2021,15 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 626000 to 627000,
+                  fastLink = 625000 to 626000,
                   fullLink = 97000 to 98000,
                   fastLinkGz = 75000 to 79000,
                   fullLinkGz = 25000 to 26000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 433000 to 434000,
-                  fullLink = 288000 to 289000,
+                  fastLink = 432000 to 433000,
+                  fullLink = 283000 to 284000,
                   fastLinkGz = 62000 to 63000,
                   fullLinkGz = 44000 to 45000,
               ))
@@ -2039,14 +2039,14 @@ object Build {
             if (!useMinifySizes) {
               Some(ExpectedSizes(
                   fastLink = 451000 to 452000,
-                  fullLink = 94000 to 95000,
+                  fullLink = 95000 to 96000,
                   fastLinkGz = 58000 to 59000,
                   fullLinkGz = 25000 to 26000,
               ))
             } else {
               Some(ExpectedSizes(
                   fastLink = 308000 to 309000,
-                  fullLink = 265000 to 266000,
+                  fullLink = 263000 to 264000,
                   fastLinkGz = 49000 to 50000,
                   fullLinkGz = 43000 to 44000,
               ))


### PR DESCRIPTION
Previously, the optimizer generated IR that was ill-typed, in the sense that it would not pass the IR checker (even if it were generalized to understand intrinsics and record types).

This happened when the receiver of a method call had a more generic type than an inlined method. That can be the case when only there is effectively only one possible target method for a virtual call, or when there are multiple targets but we can apply multi-inlining.

Producing ill-typed IR is not a big deal for JavaScript, although we had to care about some details like proper unboxing of chars. In order to apply the optimizer to the Wasm backend, however, we need well-typed IR to be able to produce well-typed Wasm.

In this commit, we fix the issue by introducing a new transient, `Cast`. It performs a true, unchecked cast, doing nothing but reassigning another type to an expression. It behaves like an unchecked `AsInstanceOf`, except it does not convert `null` to the zero of primitive types.

When inlining, we now introduce casts (along with explicit null checks) to adapt the receiver to the target method. For single inlining, it is straightforward. For multi-inlining, choosing a correct target type, and generally producing well-typed IR, required to significantly change the logic. Previously, we picked an arbitrary target among the possible candidates and inlined it in the normal way. We cannot do this anymore, since the `This` type of any one possible target may not represent what is valid for all the targets. Instead, we now deeply inspect the shapes we know how to multi-inlining, and recreate calls on the fly for the method that they call.

The explicit introduction of casts at the inlining level, along with explicit null checks, made the logic to refine receiver types in `withBindings` redundant. In order to completely get rid of it without any regression, we had to make `checkNotNull` more powerful to preserve the "it is now not-null" information even when `nullPointers` are unchecked.

Interestingly, making the above changes retains more information even within the optimizer. That results in fewer useless temporary variables in the generated code. The changes are therefore beneficial even for the JavaScript backend.

Finally, since we have proper casts, we can simplify `AsInstanceOf`s that never require unboxing into `Cast`s, when `asInstanceOfs` are unchecked. This changes almost nothing to the generated code, except replacing some `$uC(expr)` by `expr.c`.

---

Gists with diffs on the suite before->after in 3 configurations:

* [Default fastLinkJS](https://gist.github.com/sjrd/0b464a29ff7edf3fb743bfb51c58184a)
* [fastLinkJS with `optimized` semantics](https://gist.github.com/sjrd/2fbf0a8d4888ad999f88b8331c89a029): see the effect of having no null checks nor asInstanceOf checks
* [fullLinkJS with `enableMinifyEverywhere`](https://gist.github.com/sjrd/e128eadd35713b4c1b4fc90825c3f133): notice that even with the "inline local vals" of `minify`, we also have fewer useless aliases (although the diff is polluted by minified ancestor names being changed)