### PR TITLE
Fix name of pickler phase constraint

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/ScalaJSPlugin.scala
@@ -77,7 +77,7 @@ class ScalaJSPlugin(val global: Global) extends NscPlugin {
     val jsAddons: ScalaJSPlugin.this.jsAddons.type = ScalaJSPlugin.this.jsAddons
     val scalaJSOpts = ScalaJSPlugin.this.scalaJSOpts
     override val runsAfter = List("typer")
-    override val runsBefore = List("pickle")
+    override val runsBefore = List("pickler")
   }
 
   object ExplicitInnerJSComponent extends ExplicitInnerJS[global.type](global) {


### PR DESCRIPTION
Noticed at https://github.com/scala/scala/pull/10687#issuecomment-2185547660 which no longer ignores the bad phase name.

This is merely the minimal fix.