### PR TITLE
Fix #5014: Implement java.io.BufferedWriter

### DIFF
--- a/javalib/src/main/scala/java/io/BufferedWriter.scala
+++ b/javalib/src/main/scala/java/io/BufferedWriter.scala
@@ -1,3 +1,17 @@
+// Ported from Scala-native
+
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package java.io
 
 class BufferedWriter(out: Writer, sz: Int) extends Writer {
@@ -6,9 +20,9 @@ class BufferedWriter(out: Writer, sz: Int) extends Writer {
 
   def this(out: Writer) = this(out, 4096)
 
-  private val buffer: Array[Char] = new Array[Char](sz)
-  private var pos: Int = 0
-  private var closed: Boolean = false
+  private[this] val buffer: Array[Char] = new Array[Char](sz)
+  private[this] var pos: Int = 0
+  private[this] var closed: Boolean = false
 
   def close(): Unit = if (!closed) {
     flush()
@@ -18,30 +32,38 @@ class BufferedWriter(out: Writer, sz: Int) extends Writer {
 
   def flush(): Unit = {
     ensureOpen()
-    out.write(buffer, 0, pos)
-    out.flush()
-    pos = 0
+    if (pos > 0) {
+      out.write(buffer, 0, pos)
+      out.flush()
+      pos = 0
+    }
   }
 
   def newLine(): Unit =
-    write(System.lineSeparator(), 0, System.lineSeparator().length)
+    write(System.lineSeparator())
 
-  override def write(c: Int): Unit =
-    write(Array(c.toChar), 0, 1)
+  override def write(c: Int): Unit = {
+    buffer.update(pos, c.toChar)
+    pos += 1
+    if (pos == sz)
+      flush()
+  }
 
   override def write(s: String, off: Int, len: Int): Unit =
     write(s.toCharArray, off, len)
 
   def write(cbuf: Array[Char], off: Int, len: Int): Unit = {
     ensureOpen()
-    val available = sz - pos
-    if (available >= len) {
-      System.arraycopy(cbuf, off, buffer, pos, len)
-      pos += len
-      if (pos == sz) flush()
-    } else {
-      write(cbuf, off, available)
-      write(cbuf, off + available, len - available)
+    if (len > 0 || off + len > 0) {
+      val available = sz - pos
+      if (available > len) {
+        System.arraycopy(cbuf, off, buffer, pos, len)
+        pos += len
+      } else {
+        flush()
+        out.write(cbuf, off, len)
+        out.flush()
+      }
     }
   }
 

--- a/javalib/src/main/scala/java/io/BufferedWriter.scala
+++ b/javalib/src/main/scala/java/io/BufferedWriter.scala
@@ -1,0 +1,50 @@
+package java.io
+
+class BufferedWriter(out: Writer, sz: Int) extends Writer {
+
+  if (sz <= 0) throw new IllegalArgumentException("Buffer size <= 0")
+
+  def this(out: Writer) = this(out, 4096)
+
+  private val buffer: Array[Char] = new Array[Char](sz)
+  private var pos: Int = 0
+  private var closed: Boolean = false
+
+  def close(): Unit = if (!closed) {
+    flush()
+    out.close()
+    closed = true
+  }
+
+  def flush(): Unit = {
+    ensureOpen()
+    out.write(buffer, 0, pos)
+    out.flush()
+    pos = 0
+  }
+
+  def newLine(): Unit =
+    write(System.lineSeparator(), 0, System.lineSeparator().length)
+
+  override def write(c: Int): Unit =
+    write(Array(c.toChar), 0, 1)
+
+  override def write(s: String, off: Int, len: Int): Unit =
+    write(s.toCharArray, off, len)
+
+  def write(cbuf: Array[Char], off: Int, len: Int): Unit = {
+    ensureOpen()
+    val available = sz - pos
+    if (available >= len) {
+      System.arraycopy(cbuf, off, buffer, pos, len)
+      pos += len
+      if (pos == sz) flush()
+    } else {
+      write(cbuf, off, available)
+      write(cbuf, off + available, len - available)
+    }
+  }
+
+  private def ensureOpen(): Unit =
+    if (closed) throw new IOException("Stream closed")
+}

--- a/javalib/src/main/scala/java/io/BufferedWriter.scala
+++ b/javalib/src/main/scala/java/io/BufferedWriter.scala
@@ -54,7 +54,7 @@ class BufferedWriter(out: Writer, sz: Int) extends Writer {
 
   def write(cbuf: Array[Char], off: Int, len: Int): Unit = {
     ensureOpen()
-    if (len > 0 || off + len > 0) {
+    if (len > 0 && off + len > 0) {
       val available = sz - pos
       if (available > len) {
         System.arraycopy(cbuf, off, buffer, pos, len)

--- a/javalib/src/main/scala/java/io/BufferedWriter.scala
+++ b/javalib/src/main/scala/java/io/BufferedWriter.scala
@@ -54,6 +54,11 @@ class BufferedWriter(out: Writer, sz: Int) extends Writer {
 
   def write(cbuf: Array[Char], off: Int, len: Int): Unit = {
     ensureOpen()
+
+    val cbufLength = cbuf.length
+    if (off < 0 || off + len > cbufLength)
+      throw new IndexOutOfBoundsException(s"Range [${off}, ${off + len}) out of bounds for length $cbufLength")
+
     if (len > 0 && off + len > 0) {
       val available = sz - pos
       if (available > len) {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/BufferedWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/BufferedWriterTest.scala
@@ -36,6 +36,7 @@ class BufferedWriterTest {
     val writer = new BufferedWriter(stringWriter)
     val string = "Hello, world!"
     writer.write(string)
+    assertTrue(stringWriter.toString == "")
     writer.flush()
     assertTrue(stringWriter.toString == string)
   }
@@ -45,8 +46,49 @@ class BufferedWriterTest {
     val writer = new BufferedWriter(stringWriter, 1)
     val string = "Hello, world!"
     writer.write(string)
+    assertTrue(stringWriter.toString == string)
     writer.flush()
     assertTrue(stringWriter.toString == string)
+  }
+
+  @Test def canWriteInMultiplePartsToBufferedWriter(): Unit = {
+    val stringWriter = new StringWriter()
+    val writer = new BufferedWriter(stringWriter, 5)
+    writer.write("Hell")
+    assertTrue(stringWriter.toString == "")
+    writer.write("o,")
+    assertTrue(stringWriter.toString == "Hello,")
+    writer.write(" w")
+    assertTrue(stringWriter.toString == "Hello,")
+    writer.flush()
+    assertTrue(stringWriter.toString == "Hello, w")
+    writer.write("orld!")
+    assertTrue(stringWriter.toString == "Hello, world!")
+  }
+
+  @Test def writeNegativeLengthWritesNothing(): Unit = {
+    val stringWriter = new StringWriter()
+    val writer = new BufferedWriter(stringWriter)
+    val string = "Hello, world!"
+    writer.write(string, 0, -1)
+    writer.flush()
+    assertTrue(stringWriter.toString == "")
+  }
+
+  @Test def writeNegativeOffsetPlusLengthWritesNothing(): Unit = {
+    val stringWriter = new StringWriter()
+    val writer = new BufferedWriter(stringWriter)
+    val string = "Hello, world!"
+    writer.write(string, -2, 1)
+    writer.flush()
+    assertTrue(stringWriter.toString == "")
+  }
+
+  @Test def closedWritersThrow(): Unit = {
+    val stream = new ByteArrayOutputStream
+    val writer = new BufferedWriter(new OutputStreamWriter(stream))
+    writer.close()
+    assertThrows(classOf[IOException], writer.write("Hello, world!"))
   }
 
   @Test def closingTwiceIsHarmless(): Unit = {
@@ -54,5 +96,16 @@ class BufferedWriterTest {
     val writer = new BufferedWriter(new OutputStreamWriter(stream))
     writer.close()
     writer.close()
+  }
+
+  @Test def canWriteNewLineSeparator(): Unit = {
+    val stringWriter = new StringWriter()
+    val writer = new BufferedWriter(stringWriter)
+    writer.write("Hello")
+    writer.newLine()
+    writer.write("world!")
+    writer.flush()
+    val expectedResult = "Hello" + System.lineSeparator() + "world!"
+    assertTrue(stringWriter.toString == expectedResult)
   }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/BufferedWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/BufferedWriterTest.scala
@@ -16,6 +16,7 @@ package org.scalajs.testsuite.javalib.io
 
 import java.io._
 
+import org.junit.Ignore
 import org.junit.Test
 import org.junit.Assert._
 
@@ -54,14 +55,14 @@ class BufferedWriterTest {
   @Test def canWriteInMultiplePartsToBufferedWriter(): Unit = {
     val stringWriter = new StringWriter()
     val writer = new BufferedWriter(stringWriter, 5)
-    writer.write("Hell")
-    assertTrue(stringWriter.toString == "")
-    writer.write("o,")
+    writer.write("Hello,")
     assertTrue(stringWriter.toString == "Hello,")
-    writer.write(" w")
+    writer.write(" ")
     assertTrue(stringWriter.toString == "Hello,")
     writer.flush()
-    assertTrue(stringWriter.toString == "Hello, w")
+    assertTrue(stringWriter.toString == "Hello, ")
+    writer.write("w")
+    assertTrue(stringWriter.toString == "Hello, ")
     writer.write("orld!")
     assertTrue(stringWriter.toString == "Hello, world!")
   }
@@ -75,13 +76,27 @@ class BufferedWriterTest {
     assertTrue(stringWriter.toString == "")
   }
 
-  @Test def writeNegativeOffsetPlusLengthWritesNothing(): Unit = {
+  @Ignore @Test def writeNegativeLengthThrowsIndexOutOfBound(): Unit = {
+    val stringWriter = new StringWriter()
+    val writer = new BufferedWriter(stringWriter)
+    val string = "Hello, world!"
+    assertThrows(classOf[IndexOutOfBoundsException], writer.write(string, 0, -1))
+  }
+
+  @Ignore @Test def writeNegativeOffsetPlusLengthWritesNothing(): Unit = {
     val stringWriter = new StringWriter()
     val writer = new BufferedWriter(stringWriter)
     val string = "Hello, world!"
     writer.write(string, -2, 1)
     writer.flush()
     assertTrue(stringWriter.toString == "")
+  }
+
+  @Test def writeNegativeOffsetPlusLengthThrowsIndexOutOfBound(): Unit = {
+    val stringWriter = new StringWriter()
+    val writer = new BufferedWriter(stringWriter)
+    val string = "Hello, world!"
+    assertThrows(classOf[IndexOutOfBoundsException], writer.write(string, -2, 1))
   }
 
   @Test def closedWritersThrow(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/BufferedWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/BufferedWriterTest.scala
@@ -1,0 +1,44 @@
+package org.scalajs.testsuite.javalib.io
+
+import java.io._
+
+import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+
+class BufferedWriterTest {
+
+  @Test def creatingBufferedWriterWithBufferSizeZeroThrowsException(): Unit = {
+    val writer = new OutputStreamWriter(new ByteArrayOutputStream)
+    assertThrows(
+      classOf[IllegalArgumentException],
+      new BufferedWriter(writer, -1)
+    )
+  }
+
+  @Test def canWriteSmallChunksToBufferedWriter(): Unit = {
+    val stream = new ByteArrayOutputStream
+    val writer = new BufferedWriter(new OutputStreamWriter(stream))
+    val string = "Hello, world!"
+    writer.write(string)
+    writer.flush()
+    assertTrue(stream.toString == string)
+  }
+
+  @Test def canWriteChunkLargerThanBufferSizeToBufferedWriter(): Unit = {
+    val stream = new ByteArrayOutputStream
+    val writer = new BufferedWriter(new OutputStreamWriter(stream), 1)
+    val string = "Hello, world!"
+    writer.write(string)
+    writer.flush()
+    assertTrue(stream.toString == string)
+  }
+
+  @Test def closingTwiceIsHarmless(): Unit = {
+    val stream = new ByteArrayOutputStream
+    val writer = new BufferedWriter(new OutputStreamWriter(stream))
+    writer.close()
+    writer.close()
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/BufferedWriterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/io/BufferedWriterTest.scala
@@ -1,3 +1,17 @@
+// Ported from Scala-native
+
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
 package org.scalajs.testsuite.javalib.io
 
 import java.io._
@@ -18,21 +32,21 @@ class BufferedWriterTest {
   }
 
   @Test def canWriteSmallChunksToBufferedWriter(): Unit = {
-    val stream = new ByteArrayOutputStream
-    val writer = new BufferedWriter(new OutputStreamWriter(stream))
+    val stringWriter = new StringWriter()
+    val writer = new BufferedWriter(stringWriter)
     val string = "Hello, world!"
     writer.write(string)
     writer.flush()
-    assertTrue(stream.toString == string)
+    assertTrue(stringWriter.toString == string)
   }
 
   @Test def canWriteChunkLargerThanBufferSizeToBufferedWriter(): Unit = {
-    val stream = new ByteArrayOutputStream
-    val writer = new BufferedWriter(new OutputStreamWriter(stream), 1)
+    val stringWriter = new StringWriter()
+    val writer = new BufferedWriter(stringWriter, 1)
     val string = "Hello, world!"
     writer.write(string)
     writer.flush()
-    assertTrue(stream.toString == string)
+    assertTrue(stringWriter.toString == string)
   }
 
   @Test def closingTwiceIsHarmless(): Unit = {


### PR DESCRIPTION
Implementation copied from Scala-native

I excluded any copyright headers Scala-js uses in all files because this code comes from Scala-native