### PR TITLE
Introduce non-nullable reference types in the IR.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -154,7 +154,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
 
     def currentThisType: jstpe.Type = {
       encodeClassType(currentClassSym) match {
-        case tpe @ jstpe.ClassType(cls) =>
+        case tpe @ jstpe.ClassType(cls, _) =>
           jstpe.BoxedClassToPrimType.getOrElse(cls, tpe)
         case tpe =>
           tpe
@@ -1259,7 +1259,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
            * Anyway, scalac also has problems with uninitialized value
            * class values, if they come from a generic context.
            */
-          jstpe.ClassType(encodeClassName(tpe.valueClazz))
+          jstpe.ClassType(encodeClassName(tpe.valueClazz), nullable = true)
 
         case _ =>
           /* Other types are not boxed, so we can initialize them to
@@ -3622,7 +3622,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       val newMethodIdent = js.MethodIdent(newName)
 
       js.ApplyStatic(flags, className, newMethodIdent, args)(
-          jstpe.ClassType(className))
+          jstpe.ClassType(className, nullable = true))
     }
 
     /** Gen JS code for creating a new Array: new Array[T](length)
@@ -4562,8 +4562,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
               def genAnyEquality(eqeq: Boolean, not: Boolean): js.Tree = {
                 // Arrays, Null, Nothing never have a custom equals() method
                 def canHaveCustomEquals(tpe: jstpe.Type): Boolean = tpe match {
-                  case jstpe.AnyType | jstpe.ClassType(_) => true
-                  case _                                  => false
+                  case jstpe.AnyType | _:jstpe.ClassType => true
+                  case _                                 => false
                 }
                 if (eqeq &&
                     // don't call equals if we have a literal null at either side
@@ -6334,7 +6334,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       }
       val className = encodeClassName(currentClassSym).withSuffix(suffix)
 
-      val classType = jstpe.ClassType(className)
+      val classType = jstpe.ClassType(className, nullable = true)
 
       // val f: Any
       val fFieldIdent = js.FieldIdent(FieldName(className, SimpleFieldName("f")))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -152,12 +152,19 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
     private val fieldsMutatedInCurrentClass = new ScopedVar[mutable.Set[Name]]
     private val generatedSAMWrapperCount = new ScopedVar[VarBox[Int]]
 
+    def currentThisTypeNullable: jstpe.Type =
+      encodeClassType(currentClassSym)
+
     def currentThisType: jstpe.Type = {
-      encodeClassType(currentClassSym) match {
+      currentThisTypeNullable match {
         case tpe @ jstpe.ClassType(cls, _) =>
-          jstpe.BoxedClassToPrimType.getOrElse(cls, tpe)
-        case tpe =>
+          jstpe.BoxedClassToPrimType.getOrElse(cls, tpe.toNonNullable)
+        case tpe @ jstpe.AnyType =>
+          // We are in a JS class, in which even `this` is nullable
           tpe
+        case tpe =>
+          throw new AssertionError(
+              s"Unexpected IR this type $tpe for class ${currentClassSym.get}")
       }
     }
 
@@ -2124,8 +2131,13 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           if (thisSym.isMutable)
             mutableLocalVars += thisSym
 
+          /* The `thisLocalIdent` must be nullable. Even though we initially
+           * assign it to `this`, which is non-nullable, tail-recursive calls
+           * may reassign it to a different value, which in general will be
+           * nullable.
+           */
           val thisLocalIdent = encodeLocalSym(thisSym)
-          val thisLocalType = currentThisType
+          val thisLocalType = currentThisTypeNullable
 
           val genRhs = {
             /* #3267 In default methods, scalac will type its _$this
@@ -2222,7 +2234,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
      *  @param tree
      *    The tree to adapt.
      *  @param tpe
-     *    The target type, which must be either `AnyType` or `ClassType(_)`.
+     *    The target type, which must be either `AnyType` or `ClassType`.
      */
     private def forceAdapt(tree: js.Tree, tpe: jstpe.Type): js.Tree = {
       if (tree.tpe == tpe || tpe == jstpe.AnyType) {
@@ -2670,7 +2682,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         js.This()(currentThisType)
       } { thisLocalIdent =>
         // .copy() to get the correct position
-        js.VarRef(thisLocalIdent.copy())(currentThisType)
+        js.VarRef(thisLocalIdent.copy())(currentThisTypeNullable)
       }
     }
 
@@ -3333,7 +3345,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           val isTailJumpThisLocalVar = formalArgSym.name == nme.THIS
 
           val tpe =
-            if (isTailJumpThisLocalVar) currentThisType
+            if (isTailJumpThisLocalVar) currentThisTypeNullable
             else toIRType(formalArgSym.tpe)
 
           val fixedActualArg =
@@ -3561,7 +3573,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         // The Scala type system prevents x.isInstanceOf[Null] and ...[Nothing]
         assert(sym != NullClass && sym != NothingClass,
             s"Found a .isInstanceOf[$sym] at $pos")
-        js.IsInstanceOf(value, toIRType(to))
+        js.IsInstanceOf(value, toIRType(to).toNonNullable)
       }
     }
 
@@ -6334,7 +6346,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       }
       val className = encodeClassName(currentClassSym).withSuffix(suffix)
 
-      val classType = jstpe.ClassType(className, nullable = true)
+      val thisType = jstpe.ClassType(className, nullable = false)
 
       // val f: Any
       val fFieldIdent = js.FieldIdent(FieldName(className, SimpleFieldName("f")))
@@ -6353,10 +6365,10 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
             jstpe.NoType,
             Some(js.Block(List(
                 js.Assign(
-                    js.Select(js.This()(classType), fFieldIdent)(jstpe.AnyType),
+                    js.Select(js.This()(thisType), fFieldIdent)(jstpe.AnyType),
                     fParamDef.ref),
                 js.ApplyStatically(js.ApplyFlags.empty.withConstructor(true),
-                    js.This()(classType),
+                    js.This()(thisType),
                     ir.Names.ObjectClass,
                     js.MethodIdent(ir.Names.NoArgConstructorName),
                     Nil)(jstpe.NoType)))))(
@@ -6404,7 +6416,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         }.map((ensureBoxed _).tupled)
 
         val call = js.JSFunctionApply(
-            js.Select(js.This()(classType), fFieldIdent)(jstpe.AnyType),
+            js.Select(js.This()(thisType), fFieldIdent)(jstpe.AnyType),
             actualParams)
 
         val body = fromAny(call, enteringPhase(currentRun.posterasurePhase) {

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -930,7 +930,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
 
   private sealed abstract class RTTypeTest
 
-  private case class PrimitiveTypeTest(tpe: jstpe.Type, rank: Int)
+  private case class PrimitiveTypeTest(tpe: jstpe.PrimType, rank: Int)
       extends RTTypeTest
 
   // scalastyle:off equals.hash.code

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -973,7 +973,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
         import org.scalajs.ir.Names
 
         (toIRType(tpe): @unchecked) match {
-          case jstpe.AnyType => NoTypeTest
+          case jstpe.AnyType | jstpe.AnyNotNullType => NoTypeTest
 
           case jstpe.NoType      => PrimitiveTypeTest(jstpe.UndefType, 0)
           case jstpe.BooleanType => PrimitiveTypeTest(jstpe.BooleanType, 1)
@@ -985,11 +985,11 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
           case jstpe.FloatType   => PrimitiveTypeTest(jstpe.FloatType, 7)
           case jstpe.DoubleType  => PrimitiveTypeTest(jstpe.DoubleType, 8)
 
-          case jstpe.ClassType(Names.BoxedUnitClass)   => PrimitiveTypeTest(jstpe.UndefType, 0)
-          case jstpe.ClassType(Names.BoxedStringClass) => PrimitiveTypeTest(jstpe.StringType, 9)
-          case jstpe.ClassType(_)                      => InstanceOfTypeTest(tpe)
+          case jstpe.ClassType(Names.BoxedUnitClass, _)   => PrimitiveTypeTest(jstpe.UndefType, 0)
+          case jstpe.ClassType(Names.BoxedStringClass, _) => PrimitiveTypeTest(jstpe.StringType, 9)
+          case jstpe.ClassType(_, _)                      => InstanceOfTypeTest(tpe)
 
-          case jstpe.ArrayType(_) => InstanceOfTypeTest(tpe)
+          case jstpe.ArrayType(_, _) => InstanceOfTypeTest(tpe)
         }
     }
   }

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSEncoding.scala
@@ -275,7 +275,7 @@ trait JSEncoding[G <: Global with Singleton] extends SubComponent {
     else {
       assert(sym != definitions.ArrayClass,
           "encodeClassType() cannot be called with ArrayClass")
-      jstpe.ClassType(encodeClassName(sym))
+      jstpe.ClassType(encodeClassName(sym), nullable = true)
     }
   }
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
@@ -60,7 +60,7 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
     if (arrayDepth == 0)
       primitiveIRTypeMap.getOrElse(base, encodeClassType(base))
     else
-      Types.ArrayType(makeArrayTypeRef(base, arrayDepth))
+      Types.ArrayType(makeArrayTypeRef(base, arrayDepth), nullable = true)
   }
 
   def toTypeRef(t: Type): Types.TypeRef = {

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -605,27 +605,28 @@ object Hashers {
     }
 
     def mixType(tpe: Type): Unit = tpe match {
-      case AnyType     => mixTag(TagAnyType)
-      case NothingType => mixTag(TagNothingType)
-      case UndefType   => mixTag(TagUndefType)
-      case BooleanType => mixTag(TagBooleanType)
-      case CharType    => mixTag(TagCharType)
-      case ByteType    => mixTag(TagByteType)
-      case ShortType   => mixTag(TagShortType)
-      case IntType     => mixTag(TagIntType)
-      case LongType    => mixTag(TagLongType)
-      case FloatType   => mixTag(TagFloatType)
-      case DoubleType  => mixTag(TagDoubleType)
-      case StringType  => mixTag(TagStringType)
-      case NullType    => mixTag(TagNullType)
-      case NoType      => mixTag(TagNoType)
+      case AnyType        => mixTag(TagAnyType)
+      case AnyNotNullType => mixTag(TagAnyNotNullType)
+      case NothingType    => mixTag(TagNothingType)
+      case UndefType      => mixTag(TagUndefType)
+      case BooleanType    => mixTag(TagBooleanType)
+      case CharType       => mixTag(TagCharType)
+      case ByteType       => mixTag(TagByteType)
+      case ShortType      => mixTag(TagShortType)
+      case IntType        => mixTag(TagIntType)
+      case LongType       => mixTag(TagLongType)
+      case FloatType      => mixTag(TagFloatType)
+      case DoubleType     => mixTag(TagDoubleType)
+      case StringType     => mixTag(TagStringType)
+      case NullType       => mixTag(TagNullType)
+      case NoType         => mixTag(TagNoType)
 
-      case ClassType(className) =>
-        mixTag(TagClassType)
+      case ClassType(className, nullable) =>
+        mixTag(if (nullable) TagClassType else TagNonNullClassType)
         mixName(className)
 
-      case ArrayType(arrayTypeRef) =>
-        mixTag(TagArrayType)
+      case ArrayType(arrayTypeRef, nullable) =>
+        mixTag(if (nullable) TagArrayType else TagNonNullArrayType)
         mixArrayTypeRef(arrayTypeRef)
 
       case RecordType(fields) =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -1066,24 +1066,31 @@ object Printers {
     }
 
     def print(tpe: Type): Unit = tpe match {
-      case AnyType              => print("any")
-      case NothingType          => print("nothing")
-      case UndefType            => print("void")
-      case BooleanType          => print("boolean")
-      case CharType             => print("char")
-      case ByteType             => print("byte")
-      case ShortType            => print("short")
-      case IntType              => print("int")
-      case LongType             => print("long")
-      case FloatType            => print("float")
-      case DoubleType           => print("double")
-      case StringType           => print("string")
-      case NullType             => print("null")
-      case ClassType(className) => print(className)
-      case NoType               => print("<notype>")
+      case AnyType        => print("any")
+      case AnyNotNullType => print("any!")
+      case NothingType    => print("nothing")
+      case UndefType      => print("void")
+      case BooleanType    => print("boolean")
+      case CharType       => print("char")
+      case ByteType       => print("byte")
+      case ShortType      => print("short")
+      case IntType        => print("int")
+      case LongType       => print("long")
+      case FloatType      => print("float")
+      case DoubleType     => print("double")
+      case StringType     => print("string")
+      case NullType       => print("null")
+      case NoType         => print("<notype>")
 
-      case ArrayType(arrayTypeRef) =>
+      case ClassType(className, nullable) =>
+        print(className)
+        if (!nullable)
+          print("!")
+
+      case ArrayType(arrayTypeRef, nullable) =>
         print(arrayTypeRef)
+        if (!nullable)
+          print("!")
 
       case RecordType(fields) =>
         print('(')

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -18,7 +18,7 @@ import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
     current = "1.17.0-SNAPSHOT",
-    binaryEmitted = "1.16"
+    binaryEmitted = "1.17-SNAPSHOT"
 )
 
 /** Helper class to allow for testing of logic. */

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1234,7 +1234,7 @@ object Serializers {
         case TagIsInstanceOf =>
           val expr = readTree()
           val testType0 = readType()
-          val testType = if (true /* hacks.use16 */) { // scalastyle:ignore
+          val testType = if (hacks.use16) {
             testType0 match {
               case ClassType(className, true)    => ClassType(className, nullable = false)
               case ArrayType(arrayTypeRef, true) => ArrayType(arrayTypeRef, nullable = false)
@@ -1414,7 +1414,7 @@ object Serializers {
       val originalName = readOriginalName()
       val kind = ClassKind.fromByte(readByte())
 
-      if (true /* hacks.use16 */) { // scalastyle:ignore
+      if (hacks.use16) {
         thisTypeForHack = kind match {
           case ClassKind.Class | ClassKind.ModuleClass | ClassKind.Interface =>
             Some(ClassType(cls, nullable = false))

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -851,27 +851,28 @@ object Serializers {
 
     def writeType(tpe: Type): Unit = {
       tpe match {
-        case AnyType     => buffer.write(TagAnyType)
-        case NothingType => buffer.write(TagNothingType)
-        case UndefType   => buffer.write(TagUndefType)
-        case BooleanType => buffer.write(TagBooleanType)
-        case CharType    => buffer.write(TagCharType)
-        case ByteType    => buffer.write(TagByteType)
-        case ShortType   => buffer.write(TagShortType)
-        case IntType     => buffer.write(TagIntType)
-        case LongType    => buffer.write(TagLongType)
-        case FloatType   => buffer.write(TagFloatType)
-        case DoubleType  => buffer.write(TagDoubleType)
-        case StringType  => buffer.write(TagStringType)
-        case NullType    => buffer.write(TagNullType)
-        case NoType      => buffer.write(TagNoType)
+        case AnyType        => buffer.write(TagAnyType)
+        case AnyNotNullType => buffer.write(TagAnyNotNullType)
+        case NothingType    => buffer.write(TagNothingType)
+        case UndefType      => buffer.write(TagUndefType)
+        case BooleanType    => buffer.write(TagBooleanType)
+        case CharType       => buffer.write(TagCharType)
+        case ByteType       => buffer.write(TagByteType)
+        case ShortType      => buffer.write(TagShortType)
+        case IntType        => buffer.write(TagIntType)
+        case LongType       => buffer.write(TagLongType)
+        case FloatType      => buffer.write(TagFloatType)
+        case DoubleType     => buffer.write(TagDoubleType)
+        case StringType     => buffer.write(TagStringType)
+        case NullType       => buffer.write(TagNullType)
+        case NoType         => buffer.write(TagNoType)
 
-        case ClassType(className) =>
-          buffer.write(TagClassType)
+        case ClassType(className, nullable) =>
+          buffer.write(if (nullable) TagClassType else TagNonNullClassType)
           writeName(className)
 
-        case ArrayType(arrayTypeRef) =>
-          buffer.write(TagArrayType)
+        case ArrayType(arrayTypeRef, nullable) =>
+          buffer.write(if (nullable) TagArrayType else TagNonNullArrayType)
           writeArrayTypeRef(arrayTypeRef)
 
         case RecordType(fields) =>
@@ -1035,7 +1036,7 @@ object Serializers {
     private[this] var lastPosition: Position = Position.NoPosition
 
     private[this] var enclosingClassName: ClassName = _
-    private[this] var thisTypeForHack8: Type = NoType
+    private[this] var thisTypeForHack: Option[Type] = None
 
     def deserializeEntryPointsInfo(): EntryPointsInfo = {
       hacks = new Hacks(sourceVersion = readHeader())
@@ -1229,7 +1230,22 @@ object Serializers {
         case TagArrayLength      => ArrayLength(readTree())
         case TagArraySelect      => ArraySelect(readTree(), readTree())(readType())
         case TagRecordValue      => RecordValue(readType().asInstanceOf[RecordType], readTrees())
-        case TagIsInstanceOf     => IsInstanceOf(readTree(), readType())
+
+        case TagIsInstanceOf =>
+          val expr = readTree()
+          val testType0 = readType()
+          val testType = if (true /* hacks.use16 */) { // scalastyle:ignore
+            testType0 match {
+              case ClassType(className, true)    => ClassType(className, nullable = false)
+              case ArrayType(arrayTypeRef, true) => ArrayType(arrayTypeRef, nullable = false)
+              case AnyType                       => AnyNotNullType
+              case _                             => testType0
+            }
+          } else {
+            testType0
+          }
+          IsInstanceOf(expr, testType)
+
         case TagAsInstanceOf     => AsInstanceOf(readTree(), readType())
         case TagGetClass         => GetClass(readTree())
         case TagClone            => Clone(readTree())
@@ -1282,24 +1298,22 @@ object Serializers {
 
         case TagThis =>
           val tpe = readType()
-          if (hacks.use8)
-            This()(thisTypeForHack8)
-          else
-            This()(tpe)
+          This()(thisTypeForHack.getOrElse(tpe))
 
         case TagClosure =>
           val arrow = readBoolean()
           val captureParams = readParamDefs()
           val (params, restParam) = readParamDefsWithRest()
-          val body = if (!hacks.use8) {
+          val body = if (thisTypeForHack.isEmpty) {
+            // Fast path; always taken for IR >= 1.17
             readTree()
           } else {
-            val prevThisTypeForHack8 = thisTypeForHack8
-            thisTypeForHack8 = if (arrow) NoType else AnyType
+            val prevThisTypeForHack = thisTypeForHack
+            thisTypeForHack = None
             try {
               readTree()
             } finally {
-              thisTypeForHack8 = prevThisTypeForHack8
+              thisTypeForHack = prevThisTypeForHack
             }
           }
           val captureValues = readTrees()
@@ -1358,7 +1372,7 @@ object Serializers {
           // Evaluate the expression then definitely run into an NPE UB
           UnwrapFromThrowable(expr)
 
-        case ClassType(_) =>
+        case ClassType(_, _) =>
           expr match {
             case New(_, _, _) =>
               // Common case (`throw new SomeException(...)`) that is known not to be `null`
@@ -1400,14 +1414,15 @@ object Serializers {
       val originalName = readOriginalName()
       val kind = ClassKind.fromByte(readByte())
 
-      if (hacks.use8) {
-        thisTypeForHack8 = {
-          if (kind.isJSType)
-            AnyType
-          else if (kind == ClassKind.HijackedClass)
-            BoxedClassToPrimType.getOrElse(cls, ClassType(cls)) // getOrElse as safety guard
-          else
-            ClassType(cls)
+      if (true /* hacks.use16 */) { // scalastyle:ignore
+        thisTypeForHack = kind match {
+          case ClassKind.Class | ClassKind.ModuleClass | ClassKind.Interface =>
+            Some(ClassType(cls, nullable = false))
+          case ClassKind.HijackedClass if hacks.use8 =>
+            // Use getOrElse as safety guard for otherwise invalid inputs
+            Some(BoxedClassToPrimType.getOrElse(cls, ClassType(cls, nullable = false)))
+          case _ =>
+            None
         }
       }
 
@@ -1599,11 +1614,11 @@ object Serializers {
          */
         assert(args.isEmpty)
 
-        val thisValue = This()(ClassType(ObjectClass))
-        val cloneableClassType = ClassType(CloneableClass)
+        val thisValue = This()(ClassType(ObjectClass, nullable = false))
+        val cloneableClassType = ClassType(CloneableClass, nullable = true)
 
         val patchedBody = Some {
-          If(IsInstanceOf(thisValue, cloneableClassType),
+          If(IsInstanceOf(thisValue, cloneableClassType.toNonNullable),
               Clone(AsInstanceOf(thisValue, cloneableClassType)),
               Throw(New(
                   HackNames.CloneNotSupportedExceptionClass,
@@ -1844,23 +1859,27 @@ object Serializers {
     def readType(): Type = {
       val tag = readByte()
       (tag: @switch) match {
-        case TagAnyType     => AnyType
-        case TagNothingType => NothingType
-        case TagUndefType   => UndefType
-        case TagBooleanType => BooleanType
-        case TagCharType    => CharType
-        case TagByteType    => ByteType
-        case TagShortType   => ShortType
-        case TagIntType     => IntType
-        case TagLongType    => LongType
-        case TagFloatType   => FloatType
-        case TagDoubleType  => DoubleType
-        case TagStringType  => StringType
-        case TagNullType    => NullType
-        case TagNoType      => NoType
+        case TagAnyType        => AnyType
+        case TagAnyNotNullType => AnyNotNullType
+        case TagNothingType    => NothingType
+        case TagUndefType      => UndefType
+        case TagBooleanType    => BooleanType
+        case TagCharType       => CharType
+        case TagByteType       => ByteType
+        case TagShortType      => ShortType
+        case TagIntType        => IntType
+        case TagLongType       => LongType
+        case TagFloatType      => FloatType
+        case TagDoubleType     => DoubleType
+        case TagStringType     => StringType
+        case TagNullType       => NullType
+        case TagNoType         => NoType
 
-        case TagClassType => ClassType(readClassName())
-        case TagArrayType => ArrayType(readArrayTypeRef())
+        case TagClassType => ClassType(readClassName(), nullable = true)
+        case TagArrayType => ArrayType(readArrayTypeRef(), nullable = true)
+
+        case TagNonNullClassType => ClassType(readClassName(), nullable = false)
+        case TagNonNullArrayType => ArrayType(readArrayTypeRef(), nullable = false)
 
         case TagRecordType =>
           RecordType(List.fill(readInt()) {
@@ -2127,6 +2146,11 @@ object Serializers {
     val use12: Boolean = use11 || sourceVersion == "1.12"
 
     val use13: Boolean = use12 || sourceVersion == "1.13"
+
+    assert(sourceVersion != "1.14", "source version 1.14 does not exist")
+    assert(sourceVersion != "1.15", "source version 1.15 does not exist")
+
+    val use16: Boolean = use13 || sourceVersion == "1.16"
   }
 
   /** Names needed for hacks. */

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -170,6 +170,12 @@ private[ir] object Tags {
   final val TagRecordType = TagArrayType + 1
   final val TagNoType = TagRecordType + 1
 
+  // New in 1.17
+
+  final val TagAnyNotNullType = TagNoType + 1
+  final val TagNonNullClassType = TagAnyNotNullType + 1
+  final val TagNonNullArrayType = TagNonNullClassType + 1
+
   // Tags for TypeRefs
 
   final val TagVoidRef = 1

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -50,6 +50,7 @@ class PrintersTest {
 
   @Test def printType(): Unit = {
     assertPrintEquals("any", AnyType)
+    assertPrintEquals("any!", AnyNotNullType)
     assertPrintEquals("nothing", NothingType)
     assertPrintEquals("void", UndefType)
     assertPrintEquals("boolean", BooleanType)
@@ -64,10 +65,14 @@ class PrintersTest {
     assertPrintEquals("null", NullType)
     assertPrintEquals("<notype>", NoType)
 
-    assertPrintEquals("java.lang.Object", ClassType(ObjectClass))
+    assertPrintEquals("java.lang.Object", ClassType(ObjectClass, nullable = true))
+    assertPrintEquals("java.lang.String!",
+        ClassType(BoxedStringClass, nullable = false))
 
     assertPrintEquals("java.lang.Object[]", arrayType(ObjectClass, 1))
     assertPrintEquals("int[][]", arrayType(IntRef, 2))
+    assertPrintEquals("java.lang.String[]!",
+        ArrayType(ArrayTypeRef(BoxedStringClass, 1), nullable = false))
 
     assertPrintEquals("(x: int, var y: any)",
         RecordType(List(
@@ -570,13 +575,15 @@ class PrintersTest {
   }
 
   @Test def printIsInstanceOf(): Unit = {
-    assertPrintEquals("x.isInstanceOf[java.lang.String]",
-        IsInstanceOf(ref("x", AnyType), ClassType(BoxedStringClass)))
+    assertPrintEquals("x.isInstanceOf[java.lang.String!]",
+        IsInstanceOf(ref("x", AnyType), ClassType(BoxedStringClass, nullable = false)))
+    assertPrintEquals("x.isInstanceOf[int]",
+        IsInstanceOf(ref("x", AnyType), IntType))
   }
 
   @Test def printAsInstanceOf(): Unit = {
     assertPrintEquals("x.asInstanceOf[java.lang.String]",
-        AsInstanceOf(ref("x", AnyType), ClassType(BoxedStringClass)))
+        AsInstanceOf(ref("x", AnyType), ClassType(BoxedStringClass, nullable = true)))
     assertPrintEquals("x.asInstanceOf[int]",
         AsInstanceOf(ref("x", AnyType), IntType))
   }
@@ -599,7 +606,7 @@ class PrintersTest {
 
   @Test def printUnwrapFromThrowable(): Unit = {
     assertPrintEquals("<unwrapFromThrowable>(e)",
-        UnwrapFromThrowable(ref("e", ClassType(ThrowableClass))))
+        UnwrapFromThrowable(ref("e", ClassType(ThrowableClass, nullable = true))))
   }
 
   @Test def printJSNew(): Unit = {

--- a/ir/shared/src/test/scala/org/scalajs/ir/TestIRBuilder.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/TestIRBuilder.scala
@@ -54,7 +54,7 @@ object TestIRBuilder {
 
   // String -> Type and TypeRef conversions
   implicit def string2classType(className: String): ClassType =
-    ClassType(ClassName(className))
+    ClassType(ClassName(className), nullable = true)
   implicit def string2classRef(className: String): ClassRef =
     ClassRef(ClassName(className))
 
@@ -82,6 +82,6 @@ object TestIRBuilder {
   def ref(ident: LocalIdent, tpe: Type): VarRef = VarRef(ident)(tpe)
 
   def arrayType(base: NonArrayTypeRef, dimensions: Int): ArrayType =
-    ArrayType(ArrayTypeRef(base, dimensions))
+    ArrayType(ArrayTypeRef(base, dimensions), nullable = true)
 
 }

--- a/linker/jvm/src/test/scala/org/scalajs/linker/RunTest.scala
+++ b/linker/jvm/src/test/scala/org/scalajs/linker/RunTest.scala
@@ -66,14 +66,15 @@ class RunTest {
 
     val getMessage = MethodName("getMessage", Nil, T)
 
-    val e = VarRef("e")(ClassType(ThrowableClass))
+    val e = VarRef("e")(ClassType(ThrowableClass, nullable = true))
 
     val classDefs = Seq(
       mainTestClassDef(Block(
-        VarDef("e", NON, ClassType(ThrowableClass), mutable = false,
+        VarDef("e", NON, ClassType(ThrowableClass, nullable = true), mutable = false,
             WrapAsThrowable(JSNew(JSGlobalRef("RangeError"), List(str("boom"))))),
-        genAssert(IsInstanceOf(e, ClassType("java.lang.Exception"))),
-        genAssertEquals(str("RangeError: boom"), Apply(EAF, e, getMessage, Nil)(ClassType(BoxedStringClass)))
+        genAssert(IsInstanceOf(e, ClassType("java.lang.Exception", nullable = false))),
+        genAssertEquals(str("RangeError: boom"),
+            Apply(EAF, e, getMessage, Nil)(ClassType(BoxedStringClass, nullable = true)))
       ))
     )
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -180,9 +180,9 @@ object Infos {
       case FieldDef(flags, FieldIdent(name), _, ftpe) =>
         if (!flags.namespace.isStatic) {
           ftpe match {
-            case ClassType(cls) =>
+            case ClassType(cls, _) =>
               builder += name -> cls
-            case ArrayType(ArrayTypeRef(ClassRef(cls), _)) =>
+            case ArrayType(ArrayTypeRef(ClassRef(cls), _), _) =>
               builder += name -> cls
             case _ =>
           }
@@ -223,20 +223,20 @@ object Infos {
 
     def addMethodCalled(receiverTpe: Type, method: MethodName): this.type = {
       receiverTpe match {
-        case ClassType(cls) => addMethodCalled(cls, method)
-        case AnyType        => addMethodCalled(ObjectClass, method)
-        case UndefType      => addMethodCalled(BoxedUnitClass, method)
-        case BooleanType    => addMethodCalled(BoxedBooleanClass, method)
-        case CharType       => addMethodCalled(BoxedCharacterClass, method)
-        case ByteType       => addMethodCalled(BoxedByteClass, method)
-        case ShortType      => addMethodCalled(BoxedShortClass, method)
-        case IntType        => addMethodCalled(BoxedIntegerClass, method)
-        case LongType       => addMethodCalled(BoxedLongClass, method)
-        case FloatType      => addMethodCalled(BoxedFloatClass, method)
-        case DoubleType     => addMethodCalled(BoxedDoubleClass, method)
-        case StringType     => addMethodCalled(BoxedStringClass, method)
+        case ClassType(cls, _)        => addMethodCalled(cls, method)
+        case AnyType | AnyNotNullType => addMethodCalled(ObjectClass, method)
+        case UndefType                => addMethodCalled(BoxedUnitClass, method)
+        case BooleanType              => addMethodCalled(BoxedBooleanClass, method)
+        case CharType                 => addMethodCalled(BoxedCharacterClass, method)
+        case ByteType                 => addMethodCalled(BoxedByteClass, method)
+        case ShortType                => addMethodCalled(BoxedShortClass, method)
+        case IntType                  => addMethodCalled(BoxedIntegerClass, method)
+        case LongType                 => addMethodCalled(BoxedLongClass, method)
+        case FloatType                => addMethodCalled(BoxedFloatClass, method)
+        case DoubleType               => addMethodCalled(BoxedDoubleClass, method)
+        case StringType               => addMethodCalled(BoxedStringClass, method)
 
-        case ArrayType(_) =>
+        case ArrayType(_, _) =>
           /* The pseudo Array class is not reified in our analyzer/analysis,
            * so we need to cheat here. Since the Array[T] classes do not define
            * any method themselves--they are all inherited from j.l.Object--,
@@ -297,9 +297,9 @@ object Infos {
 
     def maybeAddUsedInstanceTest(tpe: Type): this.type = {
       tpe match {
-        case ClassType(className) =>
+        case ClassType(className, _) =>
           addUsedInstanceTest(className)
-        case ArrayType(ArrayTypeRef(ClassRef(baseClassName), _)) =>
+        case ArrayType(ArrayTypeRef(ClassRef(baseClassName), _), _) =>
           addUsedInstanceTest(baseClassName)
         case _ =>
       }
@@ -354,9 +354,9 @@ object Infos {
 
     def maybeAddReferencedClass(tpe: Type): this.type = {
       tpe match {
-        case ClassType(cls) =>
+        case ClassType(cls, _) =>
           addReferencedClass(cls)
-        case ArrayType(ArrayTypeRef(ClassRef(cls), _)) =>
+        case ArrayType(ArrayTypeRef(ClassRef(cls), _), _) =>
           addReferencedClass(cls)
         case _ =>
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -937,8 +937,6 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       globalKnowledge: GlobalKnowledge, pos: Position): WithGlobals[List[js.Tree]] = {
     import TreeDSL._
 
-    val tpe = ClassType(className)
-
     val moduleInstance = fileLevelVarIdent(VarField.n, genName(className))
 
     val createModuleInstanceField = genEmptyMutableLet(moduleInstance)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -591,8 +591,8 @@ final class Emitter(config: Emitter.Config, prePrinter: Emitter.PrePrinter) {
 
           val methodName = methodDef.name
           val newBody = ApplyStatically(ApplyFlags.empty,
-              This()(ClassType(className)), ObjectClass, methodName,
-              methodDef.args.map(_.ref))(
+              This()(ClassType(className, nullable = false)),
+              ObjectClass, methodName, methodDef.args.map(_.ref))(
               methodDef.resultType)
           MethodDef(MemberFlags.empty, methodName,
               methodDef.originalName, methodDef.args, methodDef.resultType,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -1149,7 +1149,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
       else if (isHijackedClass)
         Some(transformPrimType(BoxedClassToPrimType(className)))
       else
-        Some(transformClassType(className).toNonNullable)
+        Some(transformClassType(className, nullable = false))
 
     val body = method.body.getOrElse(throw new Exception("abstract method cannot be transformed"))
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -311,7 +311,7 @@ object CoreWasmLib {
         case DoubleRef => Float64
         case _         => Int32
       }
-      addHelperImport(genFunctionID.box(primRef), List(wasmType), List(anyref))
+      addHelperImport(genFunctionID.box(primRef), List(wasmType), List(RefType.any))
       addHelperImport(genFunctionID.unbox(primRef), List(anyref), List(wasmType))
       addHelperImport(genFunctionID.typeTest(primRef), List(anyref), List(Int32))
     }
@@ -383,18 +383,18 @@ object CoreWasmLib {
     addHelperImport(genFunctionID.jsGlobalRefGet, List(RefType.any), List(anyref))
     addHelperImport(genFunctionID.jsGlobalRefSet, List(RefType.any, anyref), Nil)
     addHelperImport(genFunctionID.jsGlobalRefTypeof, List(RefType.any), List(RefType.any))
-    addHelperImport(genFunctionID.jsNewArray, Nil, List(anyref))
-    addHelperImport(genFunctionID.jsArrayPush, List(anyref, anyref), List(anyref))
+    addHelperImport(genFunctionID.jsNewArray, Nil, List(RefType.any))
+    addHelperImport(genFunctionID.jsArrayPush, List(RefType.any, anyref), List(RefType.any))
     addHelperImport(
       genFunctionID.jsArraySpreadPush,
-      List(anyref, anyref),
-      List(anyref)
+      List(RefType.any, anyref),
+      List(RefType.any)
     )
-    addHelperImport(genFunctionID.jsNewObject, Nil, List(anyref))
+    addHelperImport(genFunctionID.jsNewObject, Nil, List(RefType.any))
     addHelperImport(
       genFunctionID.jsObjectPush,
-      List(anyref, anyref, anyref),
-      List(anyref)
+      List(RefType.any, anyref, anyref),
+      List(RefType.any)
     )
     addHelperImport(genFunctionID.jsSelect, List(anyref, anyref), List(anyref))
     addHelperImport(genFunctionID.jsSelectSet, List(anyref, anyref, anyref), Nil)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
@@ -85,7 +85,7 @@ object DerivedClasses {
     val className = clazz.className
     val derivedClassName = className.withSuffix("Box")
     val primType = BoxedClassToPrimType(className).asInstanceOf[PrimTypeWithRef]
-    val derivedClassType = ClassType(derivedClassName)
+    val derivedThisType = ClassType(derivedClassName, nullable = false)
 
     val fieldName = FieldName(derivedClassName, valueFieldSimpleName)
     val fieldIdent = FieldIdent(fieldName)
@@ -94,7 +94,7 @@ object DerivedClasses {
       FieldDef(EMF, fieldIdent, NON, primType)
     )
 
-    val selectField = Select(This()(derivedClassType), fieldIdent)(primType)
+    val selectField = Select(This()(derivedThisType), fieldIdent)(primType)
 
     val ctorParamDef =
       ParamDef(LocalIdent(fieldName.simpleName.toLocalName), NON, primType, mutable = false)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
@@ -279,7 +279,7 @@ object Preprocessor {
       tree match {
         case Apply(flags, receiver, MethodIdent(methodName), _) if !methodName.isReflectiveProxy =>
           receiver.tpe match {
-            case ClassType(className) =>
+            case ClassType(className, _) =>
               registerCall(className, methodName)
             case AnyType =>
               registerCall(ObjectClass, methodName)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -35,10 +35,11 @@ object SWasmGen {
       case StringType => GlobalGet(genGlobalID.emptyString)
       case UndefType  => GlobalGet(genGlobalID.undef)
 
-      case AnyType | ClassType(_) | ArrayType(_) | NullType =>
+      case AnyType | ClassType(_, true) | ArrayType(_, true) | NullType =>
         RefNull(Types.HeapType.None)
 
-      case NoType | NothingType | _: RecordType =>
+      case NothingType | NoType | ClassType(_, false) | ArrayType(_, false) |
+          AnyNotNullType | _:RecordType =>
         throw new AssertionError(s"Unexpected type for field: ${tpe.show()}")
     }
   }
@@ -53,10 +54,11 @@ object SWasmGen {
         GlobalGet(genGlobalID.bZero)
       case LongType =>
         GlobalGet(genGlobalID.bZeroLong)
-      case AnyType | ClassType(_) | ArrayType(_) | StringType | UndefType | NullType =>
+      case AnyType | ClassType(_, true) | ArrayType(_, true) | StringType | UndefType | NullType =>
         RefNull(Types.HeapType.None)
 
-      case NoType | NothingType | _: RecordType =>
+      case NothingType | NoType | ClassType(_, false) | ArrayType(_, false) |
+          AnyNotNullType | _:RecordType =>
         throw new AssertionError(s"Unexpected type for field: ${tpe.show()}")
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
@@ -85,9 +85,9 @@ final class WasmContext(
       if (className == ObjectClass || getClassInfo(className).kind.isJSType)
         AnyType
       else
-        ClassType(className)
+        ClassType(className, nullable = true)
     case typeRef: ArrayTypeRef =>
-      ArrayType(typeRef)
+      ArrayType(typeRef, nullable = true)
   }
 
   /** Retrieves a unique identifier for a reflective proxy with the given name.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Types.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Types.scala
@@ -56,6 +56,8 @@ object Types {
   }
 
   object RefType {
+    def apply(nullable: Boolean, typeID: TypeID): RefType =
+      RefType(nullable, HeapType(typeID))
 
     /** Builds a non-nullable `(ref heapType)` for the given `heapType`. */
     def apply(heapType: HeapType): RefType = RefType(false, heapType)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/MethodSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/MethodSynthesizer.scala
@@ -66,8 +66,8 @@ private[frontend] final class MethodSynthesizer(
       val targetIdent = targetMDef.name.copy() // for the new pos
       val proxyIdent = MethodIdent(methodName)
       val params = targetMDef.args.map(_.copy()) // for the new pos
-      val instanceThisType =
-        BoxedClassToPrimType.getOrElse(classInfo.className, ClassType(classInfo.className))
+      val instanceThisType = BoxedClassToPrimType.getOrElse(classInfo.className,
+          ClassType(classInfo.className, nullable = false))
 
       val call = Apply(ApplyFlags.empty, This()(instanceThisType),
           targetIdent, params.map(_.ref))(targetMDef.resultType)
@@ -101,8 +101,8 @@ private[frontend] final class MethodSynthesizer(
       val targetIdent = targetMDef.name.copy() // for the new pos
       val bridgeIdent = targetIdent
       val params = targetMDef.args.map(_.copy()) // for the new pos
-      val instanceThisType =
-        BoxedClassToPrimType.getOrElse(classInfo.className, ClassType(classInfo.className))
+      val instanceThisType = BoxedClassToPrimType.getOrElse(classInfo.className,
+          ClassType(classInfo.className, nullable = false))
 
       val body = ApplyStatically(
           ApplyFlags.empty, This()(instanceThisType), targetInterface,

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -1491,7 +1491,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
     private def computeInstanceThisType(linkedClass: LinkedClass): Type = {
       if (linkedClass.kind.isJSType) AnyType
       else if (linkedClass.kind == ClassKind.HijackedClass) BoxedClassToPrimType(className)
-      else ClassType(className)
+      else ClassType(className, nullable = false)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -1127,6 +1127,8 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
 
     val className: ClassName = linkedClass.className
 
+    override def toString(): String = className.nameString
+
     private[this] val exportedMembers = mutable.ArrayBuffer.empty[JSMethodImpl]
     private[this] var jsConstructorDef: Option[JSCtorImpl] = None
     private[this] var _jsClassCaptures: List[ParamDef] = Nil
@@ -1202,6 +1204,8 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
 
     val untrackedJSClassCaptures: List[ParamDef] = Nil
     def untrackedThisType(namespace: MemberNamespace): Type = NoType
+
+    override def toString(): String = "<top-level>"
 
     def updateWith(topLevelExports: List[LinkedTopLevelExport]): Unit = {
       val newMethods = topLevelExports.map(_.tree).collect {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3195,7 +3195,7 @@ private[optimizer] abstract class OptimizerCore(
       case ArrayNewInstance =>
         val List(tcomponentType, tlength) = targs
         tcomponentType match {
-          case PreTransTree(ClassOf(elementTypeRef), _) =>
+          case PreTransTree(ClassOf(elementTypeRef), _) if elementTypeRef != VoidRef =>
             val arrayTypeRef = ArrayTypeRef.of(elementTypeRef)
             contTree(NewArray(arrayTypeRef, List(finishTransformExpr(tlength))))
           case _ =>

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -316,7 +316,7 @@ class AnalyzerTest {
             methods = List(
                 trivialCtor("A"),
                 MethodDef(EMF, barMethodName, NON, Nil, NoType, Some(Block(
-                  Apply(EAF, This()(ClassType("A")), fooMethodName, Nil)(NoType),
+                  Apply(EAF, thisFor("A"), fooMethodName, Nil)(NoType),
                   Apply(EAF, New("B", NoArgConstructorName, Nil), fooMethodName, Nil)(NoType)
                 )))(EOH, UNV)
             )),
@@ -725,9 +725,9 @@ class AnalyzerTest {
         classDef("X", superClass = Some(ObjectClass),
             methods = List(
                 trivialCtor("X"),
-                MethodDef(EMF, fooAMethodName, NON, Nil, ClassType("A"),
+                MethodDef(EMF, fooAMethodName, NON, Nil, ClassType("A", nullable = true),
                     Some(Null()))(EOH, UNV),
-                MethodDef(EMF, fooBMethodName, NON, Nil, ClassType("B"),
+                MethodDef(EMF, fooBMethodName, NON, Nil, ClassType("B", nullable = true),
                     Some(Null()))(EOH, UNV)
             )
         )

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -63,7 +63,7 @@ class IRCheckerTest {
                  * instances of `Bar`. It will therefore not make `Foo` reachable.
                  */
                 MethodDef(EMF, methMethodName, NON,
-                    List(paramDef("foo", ClassType("Foo"))), NoType,
+                    List(paramDef("foo", ClassType("Foo", nullable = true))), NoType,
                     Some(Skip()))(
                     EOH, UNV)
             )
@@ -74,12 +74,12 @@ class IRCheckerTest {
             methods = List(
                 trivialCtor(MainTestClassName),
                 MethodDef(EMF.withNamespace(MemberNamespace.PublicStatic),
-                    nullBarMethodName, NON, Nil, ClassType("Bar"),
+                    nullBarMethodName, NON, Nil, ClassType("Bar", nullable = true),
                     Some(Null()))(
                     EOH, UNV),
                 mainMethodDef(Block(
                     callMethOn(ApplyStatic(EAF, MainTestClassName,
-                        nullBarMethodName, Nil)(ClassType("Bar"))),
+                        nullBarMethodName, Nil)(ClassType("Bar", nullable = true))),
                     callMethOn(Null()),
                     callMethOn(Throw(Null()))
                 ))
@@ -101,7 +101,7 @@ class IRCheckerTest {
 
     val results = for (receiverClassName <- List(A, B, C, D)) yield {
       val receiverClassRef = ClassRef(receiverClassName)
-      val receiverType = ClassType(receiverClassName)
+      val receiverType = ClassType(receiverClassName, nullable = true)
 
       val testMethodName = m("test", List(receiverClassRef, ClassRef(C), ClassRef(D)), V)
 
@@ -114,7 +114,8 @@ class IRCheckerTest {
           interfaces = Nil,
           methods = List(
             MethodDef(EMF, fooMethodName, NON,
-                List(paramDef("x", ClassType(B))), NoType, Some(Skip()))(EOH, UNV)
+                List(paramDef("x", ClassType(B, nullable = true))), NoType, Some(Skip()))(
+                EOH, UNV)
           )
         ),
         classDef("B", kind = ClassKind.Interface, interfaces = List("A")),
@@ -137,11 +138,17 @@ class IRCheckerTest {
               EMF.withNamespace(MemberNamespace.PublicStatic),
               testMethodName,
               NON,
-              List(paramDef("x", receiverType), paramDef("c", ClassType(C)), paramDef("d", ClassType(D))),
+              List(
+                paramDef("x", receiverType),
+                paramDef("c", ClassType(C, nullable = true)),
+                paramDef("d", ClassType(D, nullable = true))
+              ),
               NoType,
               Some(Block(
-                Apply(EAF, VarRef("x")(receiverType), fooMethodName, List(VarRef("c")(ClassType(C))))(NoType),
-                Apply(EAF, VarRef("x")(receiverType), fooMethodName, List(VarRef("d")(ClassType(D))))(NoType)
+                Apply(EAF, VarRef("x")(receiverType), fooMethodName,
+                    List(VarRef("c")(ClassType(C, nullable = true))))(NoType),
+                Apply(EAF, VarRef("x")(receiverType), fooMethodName,
+                    List(VarRef("d")(ClassType(D, nullable = true))))(NoType)
               ))
             )(EOH, UNV)
           )

--- a/linker/shared/src/test/scala/org/scalajs/linker/IncrementalTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IncrementalTest.scala
@@ -137,9 +137,8 @@ class IncrementalTest {
     val Foo1Class = ClassName("Foo1")
     val Foo2Class = ClassName("Foo2")
 
-    val BarType = ClassType(BarInterface)
-    val Foo1Type = ClassType(Foo1Class)
-    val Foo2Type = ClassType(Foo2Class)
+    val BarType = ClassType(BarInterface, nullable = true)
+    val Foo1Type = ClassType(Foo1Class, nullable = true)
 
     val meth = m("meth", List(ClassRef(Foo1Class), I), I)
 
@@ -180,7 +179,7 @@ class IncrementalTest {
             methods = List(
               trivialCtor(Foo1Class),
               MethodDef(EMF, meth, NON, methParamDefs, IntType, Some({
-                ApplyStatically(EAF, if (pre) This()(Foo1Type) else foo1Ref,
+                ApplyStatically(EAF, if (pre) thisFor(Foo1Class) else foo1Ref,
                     BarInterface, meth, List(foo1Ref, xRef))(IntType)
               }))(EOH, UNV)
             )
@@ -190,7 +189,7 @@ class IncrementalTest {
         v0 -> classDef(Foo2Class, superClass = Some(ObjectClass), interfaces = List(BarInterface), methods = List(
             trivialCtor(Foo2Class),
             MethodDef(EMF, meth, NON, methParamDefs, IntType, Some({
-              ApplyStatically(EAF, This()(Foo2Type), BarInterface, meth, List(foo1Ref, xRef))(IntType)
+              ApplyStatically(EAF, thisFor(Foo2Class), BarInterface, meth, List(foo1Ref, xRef))(IntType)
             }))(EOH, UNV)
         ))
     )
@@ -316,7 +315,7 @@ class IncrementalTest {
     def fooCtor(pre: Boolean) = {
       val superCtor = {
         ApplyStatically(EAF.withConstructor(true),
-            This()(ClassType(FooModule)),
+            thisFor(FooModule),
             ObjectClass, MethodIdent(NoArgConstructorName),
             Nil)(NoType)
       }

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibraryReachabilityTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibraryReachabilityTest.scala
@@ -38,7 +38,7 @@ class LibraryReachabilityTest {
   def juPropertiesNotReachableWhenUsingGetSetClearProperty(): AsyncResult = await {
     val systemMod = LoadModule("java.lang.System$")
     val emptyStr = str("")
-    val StringType = ClassType(BoxedStringClass)
+    val StringType = ClassType(BoxedStringClass, nullable = true)
 
     val classDefs = Seq(
         classDef("A", superClass = Some(ObjectClass), methods = List(
@@ -66,7 +66,7 @@ class LibraryReachabilityTest {
 
   @Test
   def jmBigNumbersNotInstantiatedWhenUsingStringFormat(): AsyncResult = await {
-    val StringType = ClassType(BoxedStringClass)
+    val StringType = ClassType(BoxedStringClass, nullable = true)
     val formatMethod = m("format", List(T, ArrayTypeRef(O, 1)), T)
 
     val classDefs = Seq(

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -52,12 +52,12 @@ class LibrarySizeTest {
       val compiledPattern = ApplyStatic(EAF, PatternClass,
           m("compile", List(T, I), ClassRef(PatternClass)),
           List(str(pattern), int(flags)))(
-          ClassType(PatternClass))
+          ClassType(PatternClass, nullable = true))
 
       val matcher = Apply(EAF, compiledPattern,
           m("matcher", List(ClassRef("java.lang.CharSequence")), ClassRef(MatcherClass)),
           List(str(input)))(
-          ClassType(MatcherClass))
+          ClassType(MatcherClass, nullable = true))
 
       consoleLog(Apply(EAF, matcher, m("matches", Nil, Z), Nil)(BooleanType))
     }

--- a/linker/shared/src/test/scala/org/scalajs/linker/SmallModulesForSplittingTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/SmallModulesForSplittingTest.scala
@@ -38,7 +38,7 @@ class SmallModulesForSplittingTest {
     /* Test splitting in the degenerate case, where dependencies traverse the
      * split boundary multiple times.
      */
-    val strClsType = ClassType(BoxedStringClass)
+    val strClsType = ClassType(BoxedStringClass, nullable = true)
 
     val methodName = m("get", Nil, T)
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/SmallestModulesSplittingTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/SmallestModulesSplittingTest.scala
@@ -33,7 +33,7 @@ class SmallestModulesSplittingTest {
   /** Smoke test to ensure modules do not get merged too much. */
   @Test
   def splitsModules(): AsyncResult = await {
-    val strClsType = ClassType(BoxedStringClass)
+    val strClsType = ClassType(BoxedStringClass, nullable = true)
 
     val greetMethodName = m("greet", Nil, T)
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -90,7 +90,7 @@ object TestIRBuilder {
     val flags = MemberFlags.empty.withNamespace(MemberNamespace.Constructor)
     MethodDef(flags, MethodIdent(NoArgConstructorName), NON, Nil, NoType,
         Some(ApplyStatically(EAF.withConstructor(true),
-            This()(ClassType(enclosingClassName)),
+            thisFor(enclosingClassName),
             parentClassName, MethodIdent(NoArgConstructorName),
             Nil)(NoType)))(
         EOH, UNV)
@@ -105,7 +105,7 @@ object TestIRBuilder {
   val MainMethodName: MethodName = m("main", List(AT), VoidRef)
 
   def mainMethodDef(body: Tree): MethodDef = {
-    val argsParamDef = paramDef("args", ArrayType(AT))
+    val argsParamDef = paramDef("args", ArrayType(AT, nullable = true))
     MethodDef(MemberFlags.empty.withNamespace(MemberNamespace.PublicStatic),
         MainMethodName, NON, List(argsParamDef), NoType, Some(body))(
         EOH, UNV)
@@ -119,7 +119,8 @@ object TestIRBuilder {
     val outMethodName = m("out", Nil, ClassRef(PrintStreamClass))
     val printlnMethodName = m("println", List(O), VoidRef)
 
-    val out = ApplyStatic(EAF, "java.lang.System", outMethodName, Nil)(ClassType(PrintStreamClass))
+    val out = ApplyStatic(EAF, "java.lang.System", outMethodName, Nil)(
+        ClassType(PrintStreamClass, nullable = true))
     Apply(EAF, out, printlnMethodName, List(expr))(NoType)
   }
 
@@ -150,6 +151,9 @@ object TestIRBuilder {
     if (classKind.isJSClass) Some(trivialJSCtor)
     else None
   }
+
+  def thisFor(cls: ClassName): This =
+    This()(ClassType(cls, nullable = false))
 
   implicit def string2LocalName(name: String): LocalName =
     LocalName(name)

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -5,6 +5,22 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val IR = Seq(
+    // !!! Breaking, OK in minor release
+
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.scalajs.ir.Trees#*.tpe"),
+
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ClassType.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ClassType.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ClassType.copy"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ArrayType.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ArrayType.apply"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ArrayType.copy"),
+
+    ProblemFilters.exclude[MissingTypesProblem]("org.scalajs.ir.Types$ClassType$"),
+    ProblemFilters.exclude[MissingTypesProblem]("org.scalajs.ir.Types$ArrayType$"),
+
+    // New abstract member in sealed hierarchy, not an issue
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.scalajs.ir.Types#Type.toNonNullable"),
   )
 
   val Linker = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2064,10 +2064,10 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 433000 to 434000,
-                  fullLink = 283000 to 284000,
-                  fastLinkGz = 62000 to 63000,
-                  fullLinkGz = 44000 to 45000,
+                  fastLink = 425000 to 426000,
+                  fullLink = 282000 to 283000,
+                  fastLinkGz = 61000 to 62000,
+                  fullLinkGz = 43000 to 44000,
               ))
             }
 
@@ -2081,9 +2081,9 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 309000 to 310000,
-                  fullLink = 263000 to 264000,
-                  fastLinkGz = 49000 to 50000,
+                  fastLink = 306000 to 307000,
+                  fullLink = 262000 to 263000,
+                  fastLinkGz = 48000 to 49000,
                   fullLinkGz = 43000 to 44000,
               ))
             }

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -26,7 +26,7 @@ object JavaLangObject {
     implicit val DummyPos = NoPosition
 
     // ClassType(Object) is normally invalid, but not in this class def
-    val ThisType = ClassType(ObjectClass, nullable = true) // temp to test deserialization hack
+    val ThisType = ClassType(ObjectClass, nullable = false)
 
     val ObjectClassRef = ClassRef(ObjectClass)
     val ClassClassRef = ClassRef(ClassClass)
@@ -101,8 +101,7 @@ object JavaLangObject {
           Nil,
           AnyType,
           Some {
-            // temporarily use nullable in IsInstanceOf to test deserialization hack
-            If(IsInstanceOf(This()(ThisType), ClassType(CloneableClass, nullable = true)), {
+            If(IsInstanceOf(This()(ThisType), ClassType(CloneableClass, nullable = false)), {
               Clone(AsInstanceOf(This()(ThisType), ClassType(CloneableClass, nullable = true)))
             }, {
               Throw(New(ClassName("java.lang.CloneNotSupportedException"),

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -26,7 +26,7 @@ object JavaLangObject {
     implicit val DummyPos = NoPosition
 
     // ClassType(Object) is normally invalid, but not in this class def
-    val ThisType = ClassType(ObjectClass)
+    val ThisType = ClassType(ObjectClass, nullable = true) // temp to test deserialization hack
 
     val ObjectClassRef = ClassRef(ObjectClass)
     val ClassClassRef = ClassRef(ClassClass)
@@ -60,7 +60,7 @@ object JavaLangObject {
           MethodIdent(MethodName("getClass", Nil, ClassClassRef)),
           NoOriginalName,
           Nil,
-          ClassType(ClassClass),
+          ClassType(ClassClass, nullable = true),
           Some {
             GetClass(This()(ThisType))
           })(OptimizerHints.empty.withInline(true), Unversioned),
@@ -101,8 +101,9 @@ object JavaLangObject {
           Nil,
           AnyType,
           Some {
-            If(IsInstanceOf(This()(ThisType), ClassType(CloneableClass)), {
-              Clone(AsInstanceOf(This()(ThisType), ClassType(CloneableClass)))
+            // temporarily use nullable in IsInstanceOf to test deserialization hack
+            If(IsInstanceOf(This()(ThisType), ClassType(CloneableClass, nullable = true)), {
+              Clone(AsInstanceOf(This()(ThisType), ClassType(CloneableClass, nullable = true)))
             }, {
               Throw(New(ClassName("java.lang.CloneNotSupportedException"),
                 MethodIdent(NoArgConstructorName), Nil))
@@ -117,15 +118,16 @@ object JavaLangObject {
           MethodIdent(MethodName("toString", Nil, StringClassRef)),
           NoOriginalName,
           Nil,
-          ClassType(BoxedStringClass),
+          ClassType(BoxedStringClass, nullable = true),
           Some {
             BinaryOp(BinaryOp.String_+, BinaryOp(BinaryOp.String_+,
               Apply(
                 EAF,
                 Apply(EAF, This()(ThisType),
                   MethodIdent(MethodName("getClass", Nil, ClassClassRef)), Nil)(
-                  ClassType(ClassClass)),
-                MethodIdent(MethodName("getName", Nil, StringClassRef)), Nil)(ClassType(BoxedStringClass)),
+                  ClassType(ClassClass, nullable = true)),
+                MethodIdent(MethodName("getName", Nil, StringClassRef)), Nil)(
+                ClassType(BoxedStringClass, nullable = true)),
               // +
               StringLiteral("@")),
               // +
@@ -134,7 +136,7 @@ object JavaLangObject {
                 LoadModule(ClassName("java.lang.Integer$")),
                 MethodIdent(MethodName("toHexString", List(IntRef), StringClassRef)),
                 List(Apply(EAF, This()(ThisType), MethodIdent(MethodName("hashCode", Nil, IntRef)), Nil)(IntType)))(
-                ClassType(BoxedStringClass)))
+                ClassType(BoxedStringClass, nullable = true)))
           })(OptimizerHints.empty, Unversioned),
 
         /* Since wait() is not supported in any way, a correct implementation
@@ -178,7 +180,7 @@ object JavaLangObject {
           {
             Apply(EAF, This()(ThisType),
                 MethodIdent(MethodName("toString", Nil, StringClassRef)),
-                Nil)(ClassType(BoxedStringClass))
+                Nil)(ClassType(BoxedStringClass, nullable = true))
           })(OptimizerHints.empty, Unversioned)
       ),
       jsNativeMembers = Nil,

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -567,16 +567,16 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
 
     private def transformType(tpe: Type)(implicit pos: Position): Type = {
       tpe match {
-        case ClassType(ObjectClass) =>
+        case ClassType(ObjectClass, _) =>
           // In java.lang.Object iself, there are ClassType(ObjectClass) that must be preserved as is.
           tpe
-        case ClassType(cls) =>
+        case ClassType(cls, nullable) =>
           transformClassName(cls) match {
-            case ObjectClass => AnyType
-            case newCls      => ClassType(newCls)
+            case ObjectClass => if (nullable) AnyType else AnyNotNullType
+            case newCls      => ClassType(newCls, nullable)
           }
-        case ArrayType(arrayTypeRef) =>
-          ArrayType(transformArrayTypeRef(arrayTypeRef))
+        case ArrayType(arrayTypeRef, nullable) =>
+          ArrayType(transformArrayTypeRef(arrayTypeRef), nullable)
         case _ =>
           tpe
       }
@@ -724,7 +724,7 @@ object JavalibIRCleaner {
   }
 
   private def isFunctionNType(n: Int, tpe: Type): Boolean = tpe match {
-    case ClassType(cls) =>
+    case ClassType(cls, _) =>
       cls == FunctionNClasses(n) || cls == AnonFunctionNClasses(n)
     case _ =>
       false


### PR DESCRIPTION
~~Based on #4993 to abuse the optimizer+Wasm backend as validation that the optimizer is type-preserving, including wrt. nullability. Otherwise ready to review. The last 5 commits belong to this PR.~~

---

`ClassType`s and `ArrayType`s now carry a `nullable: Boolean` flag. When `nullable` is false, the type does not admit `null` values. We also introduce `AnyNotNullType` to be the non-nullable variant of `AnyType`.

This way, every non-void type `tpe` has a non-nullable variant, which we can get with `tpe.toNonNullable`.

There are a few sources of non-nullable values, such as `New` nodes, and, most importantly, `This` nodes.

Since non-nullable reference types have no corresponding `TypeRef`, they cannot appear in the signature of methods. They only live locally within method bodies.

---

The optimizer already had dedicated tracking of non-nullable `PreTransform`s. We now replace that tracking by the actual `tpe` of the trees.

In order to be type-preserving, we must now insert most `Cast`s, to non-nullable types. Before, at the IR level everything became nullable again, so even if the optimizer had determined that a tree could not be null, that did not influence the produced IR.

On the plus side, since IR nodes track their nullability, we do not need `AssumeNotNull` anymore. The `Cast`s to non-nullable types achieve the same result in a more consistent way.

In fact, the new non-nullable types allow the optimizer to better keep track of nullability, resulting in fewer `$n` calls to check for nulls. This is the main source of code side reduction.

---

Since we now have non-nullable reference types, we change `IsInstanceOf` to require non-nullable test types. This makes more sense, since `IsInstanceOf` always answers `false` when the value is `null`.

---

We introduce deserialization hacks to:

* adapt the type of `This` nodes, and
* adapt the test type of `IsInstanceOf` nodes.

In the first major commit, we do not change the compiler nor the hard-coded IR of `jl.Object` yet, in order to test the deserialization hacks.

In the last commit, we adapt the compiler and `jl.Object`, and only enable the deserialization hacks when reading IR < 1.17.