### PR TITLE
Check that constructor calls follow a chaining discipline.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSInterop.scala
@@ -475,7 +475,7 @@ abstract class PrepJSInterop[G <: Global with Singleton](val global: G)
                */
               val superCtorCall = gen.mkMethodCall(
                   Super(clsSym, tpnme.EMPTY),
-                  ObjectClass.primaryConstructor, Nil, Nil)
+                  DynamicImportThunkClass.primaryConstructor, Nil, Nil)
 
               // class $anon extends DynamicImportThunk
               val clsDef = ClassDef(clsSym, List(

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1530,7 +1530,7 @@ object Serializers {
       val superClass = readOptClassIdent()
       val parents = readClassIdents()
 
-      if (/* hacks.use17 &&*/ kind.isClass) { // scalastyle:ignore
+      if (hacks.use17 && kind.isClass) {
         /* In 1.18, we started enforcing the constructor chaining discipline.
          * Unfortunately, we used to generate a wrong super constructor call in
          * synthetic classes extending `DynamicImportThunk`, so we patch them.

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -192,7 +192,7 @@ class AnalyzerTest {
         val classDefs = Seq(
             classDef("A", kind = kindSub,
                 superClass = Some("B"),
-                methods = requiredMethods("A", kindSub),
+                methods = requiredMethods("A", kindSub, "B"),
                 jsConstructor = requiredJSConstructor(kindSub)),
             classDef("B", kind = kindBase,
                 superClass = validParentForKind(kindBase),
@@ -321,7 +321,7 @@ class AnalyzerTest {
                 )))(EOH, UNV)
             )),
         classDef("B", superClass = Some("A"),
-            methods = List(trivialCtor("B")))
+            methods = List(trivialCtor("B", "A")))
     )
 
     val analysis = computeAnalysis(classDefs,
@@ -350,7 +350,7 @@ class AnalyzerTest {
             methods = List(trivialCtor("A"))),
         classDef("B", superClass = Some("A"),
             methods = List(
-                trivialCtor("B"),
+                trivialCtor("B", "A"),
                 MethodDef(EMF, fooMethodName, NON, Nil, IntType, Some(int(5)))(EOH, UNV)
             ))
     )
@@ -771,12 +771,12 @@ class AnalyzerTest {
             )),
         classDef("B", superClass = Some("A"), interfaces = List("I2"),
             methods = List(
-                trivialCtor("B"),
+                trivialCtor("B", "A"),
                 MethodDef(EMF, fooMethodName, NON, Nil, IntType, Some(int(5)))(EOH, UNV)
             )),
         classDef("C", superClass = Some("B"),
             methods = List(
-                trivialCtor("C"),
+                trivialCtor("C", "B"),
                 MethodDef(EMF, barMethodName, NON, Nil, IntType, Some(int(5)))(EOH, UNV)
             ))
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/BaseLinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/BaseLinkerTest.scala
@@ -55,7 +55,7 @@ class BaseLinkerTest {
           "Sub",
           kind = ClassKind.Class,
           superClass = Some("Base"),
-          methods = List(trivialCtor("Sub"))
+          methods = List(trivialCtor("Sub", "Base"))
       ),
       mainTestClassDef(
         consoleLog(Apply(EAF, New("Sub", NoArgConstructorName, Nil), fooName, Nil)(IntType))

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -133,7 +133,7 @@ class IRCheckerTest {
           superClass = Some("C"),
           interfaces = List("B"),
           methods = List(
-            trivialCtor("D"),
+            trivialCtor("D", "C"),
             MethodDef(
               EMF.withNamespace(MemberNamespace.PublicStatic),
               testMethodName,

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -503,10 +503,12 @@ class OptimizerTest {
             // def this() = {
             //   this.x = null
             //   this.y = 5
+            //   this.jl.Object::<init>()
             // }
             MethodDef(EMF.withNamespace(Constructor), NoArgConstructorName, NON, Nil, NoType, Some(Block(
               Assign(Select(thisFor("Foo"), FieldName("Foo", "x"))(witnessType), Null()),
-              Assign(Select(thisFor("Foo"), FieldName("Foo", "y"))(IntType), int(5))
+              Assign(Select(thisFor("Foo"), FieldName("Foo", "y"))(IntType), int(5)),
+              trivialSuperCtorCall("Foo")
             )))(EOH, UNV),
 
             // def method(): Int = this.y

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -89,11 +89,16 @@ object TestIRBuilder {
   def trivialCtor(enclosingClassName: ClassName, parentClassName: ClassName = ObjectClass): MethodDef = {
     val flags = MemberFlags.empty.withNamespace(MemberNamespace.Constructor)
     MethodDef(flags, MethodIdent(NoArgConstructorName), NON, Nil, NoType,
-        Some(ApplyStatically(EAF.withConstructor(true),
-            thisFor(enclosingClassName),
-            parentClassName, MethodIdent(NoArgConstructorName),
-            Nil)(NoType)))(
+        Some(trivialSuperCtorCall(enclosingClassName, parentClassName)))(
         EOH, UNV)
+  }
+
+  def trivialSuperCtorCall(enclosingClassName: ClassName,
+      parentClassName: ClassName = ObjectClass): ApplyStatically = {
+    ApplyStatically(EAF.withConstructor(true),
+        thisFor(enclosingClassName),
+        parentClassName, MethodIdent(NoArgConstructorName),
+        Nil)(NoType)
   }
 
   def trivialJSCtor: JSConstructorDef = {
@@ -141,10 +146,12 @@ object TestIRBuilder {
     )
   }
 
-  def requiredMethods(className: ClassName,
-      classKind: ClassKind): List[MethodDef] = {
-    if (classKind == ClassKind.ModuleClass) List(trivialCtor(className))
-    else Nil
+  def requiredMethods(className: ClassName, classKind: ClassKind,
+      parentClassName: ClassName = ObjectClass): List[MethodDef] = {
+    if (classKind == ClassKind.ModuleClass)
+      List(trivialCtor(className, parentClassName))
+    else
+      Nil
   }
 
   def requiredJSConstructor(classKind: ClassKind): Option[JSConstructorDef] = {


### PR DESCRIPTION
(Toned down my ambitions compared to #5019. This PR only checks the constructor chaining discipline as a first easier step.)

---

* The constructor of `jl.Object` cannot call any other constructor.
* Every other constructor must call exactly one other constructor, on `this`, either from the same class or the direct superclass.

There cannot be any other call to constructors.

These restrictions are also enforced by the JVM. Technically we are more restrictive because the JVM allows different code paths, each having a single constructor call, whereas we require exactly one at the top level. This is fine because both Scala and Java, as languages, enforce that more restrictive property.

Unfortunately, we used to generate an illegal super constructor call in the synthetic classes that extend `DynamicImportThunk`. We patch them with a deserialization hack.

In the first commit, we do not yet change the compiler to fix the above. In the second commit, we fix the compiler and only enable the deserialization hack on IR < 1.17.