### PR TITLE
Wasm: Avoid JS interop when possible.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -1299,10 +1299,10 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
             else SpecialNames.LongBoxClass
           val structTypeID = genTypeID.forClass(boxClass)
 
-          fb.block(RefType.anyref) { castFailLabel =>
+          fb.block(RefType.any) { castFailLabel =>
             fb += LocalGet(objParam)
             fb += BrOnNull(objIsNullLabel)
-            fb += BrOnCastFail(castFailLabel, RefType.anyref, RefType(structTypeID))
+            fb += BrOnCastFail(castFailLabel, RefType.any, RefType(structTypeID))
 
             // Extract the `value` field if unboxing
             if (isUnbox) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -634,6 +634,8 @@ private class FunctionEmitter private (
         primType match {
           case NullType =>
             ()
+          case ByteType | ShortType =>
+            fb += wa.RefI31
           case CharType =>
             /* `char` and `long` are opaque to JS in the Scala.js semantics.
              * We implement them with real Wasm classes following the correct

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1518,19 +1518,73 @@ private class FunctionEmitter private (
     val BinaryOp(op, lhs, rhs) = tree
     assert(op == === || op == !==)
 
-    // TODO Optimize this when the operands have a better type than `any`
+    def maybeGenInvert(): Unit = {
+      if (op == BinaryOp.!==)
+        fb += wa.I32Eqz
+    }
 
-    genTree(lhs, AnyType)
-    genTree(rhs, AnyType)
+    /* Can we use `ref.eq` for the given type?
+     *
+     * This is the case if the Wasm encoding of the given type a subtype of
+     * `eqref`, i.e., `(ref null eq)`.
+     *
+     * This requires that it be a ref type of the form `(ref null? heapType)`
+     * and that the `heapType` be a sub-heap-type of `eq`.
+     *
+     * Note that all the `HeapType.Type(_)`s returned by `transformSingleType`
+     * point to struct types, which are sub-heap-types of `eq`. (In general
+     * this is not true, since they could also point to `func` heap types,
+     * which are not sub-heap-types of `eq`.)
+     *
+     * Therefore, in practice, the only heap type we can observe and that is
+     * *not* a sub-heap-type of `eq` is `any`.
+     */
+    def canUseRefEq(tpe: Type): Boolean = transformSingleType(tpe) match {
+      case watpe.RefType(_, heapType) => heapType != watpe.HeapType.Any
+      case _                          => false
+    }
 
-    markPosition(tree)
+    val lhsType = lhs.tpe
+    val rhsType = rhs.tpe
 
-    fb += wa.Call(genFunctionID.is)
-
-    if (op == !==)
-      fb += wa.I32Eqz
-
-    BooleanType
+    if (lhsType == NothingType) {
+      genTree(lhs, NothingType)
+      NothingType
+    } else if (rhsType == NothingType) {
+      genTree(lhs, NoType)
+      genTree(rhs, NothingType)
+      NothingType
+    } else if (rhsType == NullType) {
+      /* Note that the optimizer normalizes Literals on the right of `===`,
+       * so testing for the `lhsType == NullType` is not as useful.
+       */
+      genTree(lhs, AnyType)
+      genTree(rhs, NoType) // no-op if it is actually a Null() literal
+      markPosition(tree)
+      fb += wa.RefIsNull
+      maybeGenInvert()
+      BooleanType
+    } else if (canUseRefEq(lhsType) && canUseRefEq(rhsType)) {
+      /* When both types translate to Wasm types that are subtypes of `eqref`,
+       * we can use `ref.eq`. Note that for all possible `eqref`s (in all of
+       * Wasm, not just the subset that we use), `Object.is` coincides with
+       * `ref.eq`. So this is a sound optimization over using `Object.is`.
+       */
+      genTree(lhs, lhsType)
+      genTree(rhs, rhsType)
+      markPosition(tree)
+      fb += wa.RefEq
+      maybeGenInvert()
+      BooleanType
+    } else {
+      // Otherwise, fall back on the `Object.is` helper
+      genTree(lhs, AnyType)
+      genTree(rhs, AnyType)
+      markPosition(tree)
+      fb += wa.Call(genFunctionID.is)
+      maybeGenInvert()
+      BooleanType
+    }
   }
 
   private def getElementaryBinaryOpInstr(op: BinaryOp.Code): wa.Instr = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -88,12 +88,12 @@ const scalaJSHelpers = {
   undef: void 0,
   isUndef: (x) => x === (void 0),
 
-  // Zero boxes
+  // Constant boxes
   bFalse: false,
+  bTrue: true,
   bZero: 0,
 
   // Boxes (upcast) -- most are identity at the JS level but with different types in Wasm
-  bZ: (x) => x !== 0,
   bIFallback: (x) => x,
   bF: (x) => x,
   bD: (x) => x,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -94,24 +94,18 @@ const scalaJSHelpers = {
 
   // Boxes (upcast) -- most are identity at the JS level but with different types in Wasm
   bZ: (x) => x !== 0,
-  bB: (x) => x,
-  bS: (x) => x,
   bIFallback: (x) => x,
   bF: (x) => x,
   bD: (x) => x,
 
   // Unboxes (downcast, null is converted to the zero of the type as part of ToWebAssemblyValue)
   uZ: (x) => x, // ToInt32 turns false into 0 and true into 1, so this is also an identity
-  uB: (x) => x,
-  uS: (x) => x,
   uIFallback: (x) => x,
   uF: (x) => x,
   uD: (x) => x,
 
   // Type tests
   tZ: (x) => typeof x === 'boolean',
-  tB: (x) => typeof x === 'number' && Object.is((x << 24) >> 24, x),
-  tS: (x) => typeof x === 'number' && Object.is((x << 16) >> 16, x),
   tI: (x) => typeof x === 'number' && Object.is(x | 0, x),
   tF: (x) => typeof x === 'number' && (Math.fround(x) === x || x !== x),
   tD: (x) => typeof x === 'number',

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -96,7 +96,7 @@ const scalaJSHelpers = {
   bZ: (x) => x !== 0,
   bB: (x) => x,
   bS: (x) => x,
-  bI: (x) => x,
+  bIFallback: (x) => x,
   bF: (x) => x,
   bD: (x) => x,
 
@@ -104,7 +104,7 @@ const scalaJSHelpers = {
   uZ: (x) => x, // ToInt32 turns false into 0 and true into 1, so this is also an identity
   uB: (x) => x,
   uS: (x) => x,
-  uI: (x) => x,
+  uIFallback: (x) => x,
   uF: (x) => x,
   uD: (x) => x,
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -127,6 +127,9 @@ object VarGen {
       override def toString(): String = "t" + primRef.charCode
     }
 
+    case object bIFallback extends JSHelperFunctionID
+    case object uIFallback extends JSHelperFunctionID
+
     case object fmod extends JSHelperFunctionID
 
     case object closure extends JSHelperFunctionID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -56,6 +56,7 @@ object VarGen {
     case object jsLinkingInfo extends JSHelperGlobalID
     case object undef extends JSHelperGlobalID
     case object bFalse extends JSHelperGlobalID
+    case object bTrue extends JSHelperGlobalID
     case object bZero extends JSHelperGlobalID
     case object emptyString extends JSHelperGlobalID
     case object idHashCodeMap extends JSHelperGlobalID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/BinaryWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/BinaryWriter.scala
@@ -440,6 +440,9 @@ private sealed class BinaryWriter(module: Module, emitDebugInfo: Boolean) {
       case F32Const(v) => buf.f32(v)
       case F64Const(v) => buf.f64(v)
 
+      case Select(resultTypes) =>
+        buf.vec(resultTypes)(writeType(_))
+
       case BrTable(labelIdxVector, defaultLabelIdx) =>
         buf.vec(labelIdxVector)(writeLabelIdx(_))
         writeLabelIdx(defaultLabelIdx)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
@@ -156,6 +156,9 @@ object Instructions {
 
   case object Drop extends SimpleInstr("drop", 0x1A)
 
+  final case class Select(resultTypes: List[Type])
+      extends Instr("select", if (resultTypes.isEmpty) 0x1B else 0x1C)
+
   final case class TryTable(i: BlockType, cs: List[CatchClause], label: Option[LabelID] = None)
       extends Instr("try_table", 0x1F) with StructuredLabeledInstr
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/TextWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/TextWriter.scala
@@ -470,6 +470,9 @@ private class TextWriter(module: Module) {
       case F32Const(v) => writeFloatString(v.toDouble)
       case F64Const(v) => writeFloatString(v)
 
+      case Select(resultTypes) =>
+        resultTypes.foreach(writeType(_))
+
       case BrTable(labelIdxVector, defaultLabelIdx) =>
         labelIdxVector.foreach(appendName(_))
         appendName(defaultLabelIdx)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Types.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Types.scala
@@ -83,6 +83,9 @@ object Types {
     /** `(ref null func)`, i.e., `funcref`. */
     val funcref: RefType = nullable(HeapType.Func)
 
+    /** `(ref i31)`. */
+    val i31: RefType = apply(HeapType.I31)
+
     /** `(ref extern)`. */
     val extern: RefType = apply(HeapType.Extern)
 
@@ -119,6 +122,7 @@ object Types {
     case object Extern extends AbsHeapType("extern", "externref", 0x6F)
     case object Any extends AbsHeapType("any", "anyref", 0x6E)
     case object Eq extends AbsHeapType("eq", "eqref", 0x6D)
+    case object I31 extends AbsHeapType("i31", "i31ref", 0x6C)
     case object Struct extends AbsHeapType("struct", "structref", 0x6B)
     case object Array extends AbsHeapType("array", "arrayref", 0x6A)
     case object Exn extends AbsHeapType("exn", "exnref", 0x69)


### PR DESCRIPTION
Benchmarks and profiling showed that using JS interop in tight loops is quite bad for performance. When we can, it is better to spend more operations on the Wasm side to avoid JS interop entirely.

Review by @tanishiking in addition to @gzm0.