### PR TITLE
Wasm: Use custom JS helpers for almost all JS interop.

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -180,7 +180,7 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
 
       case FunctionDef(name, args, restParam, body) =>
         val node = transformName(name)
-        val rhs = genFunction(name.name, args, restParam, body)
+        val rhs = genFunction(name.resolveName(), args, restParam, body)
         node.addChildToFront(rhs)
         new Node(Token.VAR, node)
 
@@ -390,7 +390,7 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
         node.setIsArrowFunction(arrow)
         node
       case FunctionDef(name, args, restParam, body) =>
-        genFunction(name.name, args, restParam, body)
+        genFunction(name.resolveName(), args, restParam, body)
 
       case classDef: ClassDef =>
         transformClassDef(classDef)
@@ -421,8 +421,8 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
     new Node(Token.FUNCTION, nameNode, paramList, transformBlock(body))
   }
 
-  def transformName(ident: Ident)(implicit parentPos: Position): Node =
-    setNodePosition(Node.newString(Token.NAME, ident.name),
+  def transformName(ident: MaybeDelayedIdent)(implicit parentPos: Position): Node =
+    setNodePosition(Node.newString(Token.NAME, ident.resolveName()),
         ident.pos orElse parentPos)
 
   def transformLabel(ident: Ident)(implicit parentPos: Position): Node =

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -92,17 +92,10 @@ private[emitter] final class JSGen(val config: Emitter.Config) {
   }
 
   def genBracketSelect(qual: Tree, item: Tree)(implicit pos: Position): Tree = {
-    item match {
-      case StringLiteral(name) if optimizeBracketSelects &&
-          Ident.isValidJSIdentifierName(name) && name != "eval" =>
-        /* We exclude "eval" because we do not want to rely too much on the
-         * strict mode peculiarities of eval(), so that we can keep running
-         * on VMs that do not support strict mode.
-         */
-        DotSelect(qual, Ident(name))
-      case _ =>
-        BracketSelect(qual, item)
-    }
+    if (optimizeBracketSelects)
+      BracketSelect.makeOptimized(qual, item)
+    else
+      BracketSelect(qual, item)
   }
 
   def genIdentBracketSelect(qual: Tree, item: String)(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -66,10 +66,10 @@ private[emitter] final class JSGen(val config: Emitter.Config) {
    */
   val useLets = esFeatures.esVersion >= ESVersion.ES2015 && !esFeatures.avoidLetsAndConsts
 
-  def genConst(name: Ident, rhs: Tree)(implicit pos: Position): LocalDef =
+  def genConst(name: MaybeDelayedIdent, rhs: Tree)(implicit pos: Position): LocalDef =
     genLet(name, mutable = false, rhs)
 
-  def genLet(name: Ident, mutable: Boolean, rhs: Tree)(
+  def genLet(name: MaybeDelayedIdent, mutable: Boolean, rhs: Tree)(
       implicit pos: Position): LocalDef = {
     if (useLets)
       Let(name, mutable, Some(rhs))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
@@ -24,7 +24,7 @@ import org.scalajs.ir.Types._
  *  - Converts IR names to JavaScript names.
  *  - Converts module names to JavaScript names.
  */
-private[emitter] final class NameGen {
+private[backend] final class NameGen {
   import NameGen._
 
   private val genLocalNameCache = {
@@ -259,49 +259,9 @@ private[emitter] final class NameGen {
     else if (sameName) NoOriginalName
     else OriginalName(name)
   }
-
-  def genModuleName(module: String): String = {
-    /* This is written so that the happy path, when `module` contains only
-     * valid characters, is fast.
-     */
-
-    def isValidChar(c: Char): Boolean =
-      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
-
-    def containsOnlyValidChars(): Boolean = {
-      // scalastyle:off return
-      val len = module.length
-      var i = 0
-      while (i != len) {
-        if (!isValidChar(module.charAt(i)))
-          return false
-        i += 1
-      }
-      true
-      // scalastyle:on return
-    }
-
-    def buildValidName(): String = {
-      val result = new java.lang.StringBuilder()
-      val len = module.length
-      var i = 0
-      while (i != len) {
-        val c = module.charAt(i)
-        if (isValidChar(c))
-          result.append(c)
-        else
-          result.append("$%04x".format(c.toInt))
-        i += 1
-      }
-      result.toString()
-    }
-
-    if (containsOnlyValidChars()) module
-    else buildValidName()
-  }
 }
 
-private[emitter] object NameGen {
+private[backend] object NameGen {
 
   private final val FullwidthSpacingUnderscore = '\uff3f'
   private final val GreekSmallLetterDelta = '\u03b4'
@@ -414,6 +374,46 @@ private[emitter] object NameGen {
     }
     true
     // scalastyle:on return
+  }
+
+  def genModuleName(module: String): String = {
+    /* This is written so that the happy path, when `module` contains only
+     * valid characters, is fast.
+     */
+
+    def isValidChar(c: Char): Boolean =
+      (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
+
+    def containsOnlyValidChars(): Boolean = {
+      // scalastyle:off return
+      val len = module.length
+      var i = 0
+      while (i != len) {
+        if (!isValidChar(module.charAt(i)))
+          return false
+        i += 1
+      }
+      true
+      // scalastyle:on return
+    }
+
+    def buildValidName(): String = {
+      val result = new java.lang.StringBuilder()
+      val len = module.length
+      var i = 0
+      while (i != len) {
+        val c = module.charAt(i)
+        if (isValidChar(c))
+          result.append(c)
+        else
+          result.append("$%04x".format(c.toInt))
+        i += 1
+      }
+      result.toString()
+    }
+
+    if (containsOnlyValidChars()) module
+    else buildValidName()
   }
 
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -258,10 +258,10 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
   }
 
   def externalModuleFieldIdent(moduleName: String)(implicit pos: Position): Ident =
-    fileLevelVarIdent(VarField.i, genModuleName(moduleName), OriginalName(moduleName))
+    fileLevelVarIdent(VarField.i, NameGen.genModuleName(moduleName), OriginalName(moduleName))
 
   def internalModuleFieldIdent(module: ModuleID)(implicit pos: Position): Ident =
-    fileLevelVarIdent(VarField.j, genModuleName(module.id), OriginalName(module.id))
+    fileLevelVarIdent(VarField.j, NameGen.genModuleName(module.id), OriginalName(module.id))
 
   private def genericIdent(field: VarField, subField: String,
       origName: OriginalName = NoOriginalName)(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -29,6 +29,7 @@ import org.scalajs.linker.backend.webassembly.Types._
 
 import EmbeddedConstants._
 import VarGen._
+import SWasmGen._
 import TypeTransformer._
 
 final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
@@ -314,7 +315,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     addGlobalHelperImport(genGlobalID.undef, RefType.any)
     addGlobalHelperImport(genGlobalID.bFalse, RefType.any)
     addGlobalHelperImport(genGlobalID.bTrue, RefType.any)
-    addGlobalHelperImport(genGlobalID.bZero, RefType.any)
     addGlobalHelperImport(genGlobalID.emptyString, RefType.extern)
     addGlobalHelperImport(genGlobalID.idHashCodeMap, RefType.extern)
   }
@@ -379,34 +379,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
 
     addHelperImport(genFunctionID.fmod, List(Float64, Float64), List(Float64))
 
-    addHelperImport(
-      genFunctionID.closure,
-      List(RefType.func, anyref),
-      List(RefType.any)
-    )
-    addHelperImport(
-      genFunctionID.closureThis,
-      List(RefType.func, anyref),
-      List(RefType.any)
-    )
-    addHelperImport(
-      genFunctionID.closureRest,
-      List(RefType.func, anyref, Int32),
-      List(RefType.any)
-    )
-    addHelperImport(
-      genFunctionID.closureThisRest,
-      List(RefType.func, anyref, Int32),
-      List(RefType.any)
-    )
-
-    addHelperImport(genFunctionID.makeExportedDef, List(RefType.func), List(RefType.any))
-    addHelperImport(
-      genFunctionID.makeExportedDefRest,
-      List(RefType.func, Int32),
-      List(RefType.any)
-    )
-
     addHelperImport(genFunctionID.jsValueToString, List(RefType.any), List(RefType.extern))
     addHelperImport(genFunctionID.jsValueToStringForConcat, List(anyref), List(RefType.extern))
     addHelperImport(genFunctionID.booleanToString, List(Int32), List(RefType.extern))
@@ -435,83 +407,18 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
 
     addHelperImport(genFunctionID.makeTypeError, List(RefType.extern), List(RefType.extern))
 
-    addHelperImport(genFunctionID.jsGlobalRefGet, List(RefType.extern), List(anyref))
-    addHelperImport(genFunctionID.jsGlobalRefSet, List(RefType.extern, anyref), Nil)
-    addHelperImport(genFunctionID.jsGlobalRefTypeof, List(RefType.extern), List(RefType.any))
     addHelperImport(genFunctionID.jsNewArray, Nil, List(RefType.any))
-    addHelperImport(genFunctionID.jsArrayPush, List(RefType.any, anyref), List(RefType.any))
-    addHelperImport(
-      genFunctionID.jsArraySpreadPush,
-      List(RefType.any, anyref),
-      List(RefType.any)
-    )
     addHelperImport(genFunctionID.jsNewObject, Nil, List(RefType.any))
-    addHelperImport(
-      genFunctionID.jsObjectPush,
-      List(RefType.any, anyref, anyref),
-      List(RefType.any)
-    )
     addHelperImport(genFunctionID.jsSelect, List(anyref, anyref), List(anyref))
     addHelperImport(genFunctionID.jsSelectSet, List(anyref, anyref, anyref), Nil)
-    addHelperImport(genFunctionID.jsNew, List(anyref, anyref), List(anyref))
-    addHelperImport(genFunctionID.jsFunctionApply, List(anyref, anyref), List(anyref))
-    addHelperImport(
-      genFunctionID.jsMethodApply,
-      List(anyref, anyref, anyref),
-      List(anyref)
-    )
+    addHelperImport(genFunctionID.jsNewNoArg, List(anyref), List(anyref))
     addHelperImport(genFunctionID.jsImportCall, List(anyref), List(anyref))
     addHelperImport(genFunctionID.jsImportMeta, Nil, List(anyref))
     addHelperImport(genFunctionID.jsDelete, List(anyref, anyref), Nil)
     addHelperImport(genFunctionID.jsForInSimple, List(anyref, anyref), Nil)
     addHelperImport(genFunctionID.jsIsTruthy, List(anyref), List(Int32))
 
-    for ((op, funcID) <- genFunctionID.jsUnaryOps)
-      addHelperImport(funcID, List(anyref), List(anyref))
-
-    for ((op, funcID) <- genFunctionID.jsBinaryOps) {
-      val resultType =
-        if (op == JSBinaryOp.=== || op == JSBinaryOp.!==) Int32
-        else anyref
-      addHelperImport(funcID, List(anyref, anyref), List(resultType))
-    }
-
     addHelperImport(genFunctionID.newSymbol, Nil, List(anyref))
-    addHelperImport(
-      genFunctionID.createJSClass,
-      List(anyref, anyref, RefType.func, RefType.func, RefType.func, anyref),
-      List(RefType.any)
-    )
-    addHelperImport(
-      genFunctionID.createJSClassRest,
-      List(anyref, anyref, RefType.func, RefType.func, RefType.func, anyref, Int32),
-      List(RefType.any)
-    )
-    addHelperImport(
-      genFunctionID.installJSField,
-      List(anyref, anyref, anyref),
-      Nil
-    )
-    addHelperImport(
-      genFunctionID.installJSMethod,
-      List(anyref, anyref, anyref, RefType.func, Int32),
-      Nil
-    )
-    addHelperImport(
-      genFunctionID.installJSStaticMethod,
-      List(anyref, anyref, anyref, RefType.func, Int32),
-      Nil
-    )
-    addHelperImport(
-      genFunctionID.installJSProperty,
-      List(anyref, anyref, anyref, RefType.funcref, RefType.funcref),
-      Nil
-    )
-    addHelperImport(
-      genFunctionID.installJSStaticProperty,
-      List(anyref, anyref, anyref, RefType.funcref, RefType.funcref),
-      Nil
-    )
     addHelperImport(
       genFunctionID.jsSuperSelect,
       List(anyref, anyref, anyref),
@@ -521,11 +428,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
       genFunctionID.jsSuperSelectSet,
       List(anyref, anyref, anyref, anyref),
       Nil
-    )
-    addHelperImport(
-      genFunctionID.jsSuperCall,
-      List(anyref, anyref, anyref, anyref),
-      List(anyref)
     )
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CustomJSHelperBuilder.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CustomJSHelperBuilder.scala
@@ -1,0 +1,284 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.wasmemitter
+
+import scala.collection.mutable
+
+import org.scalajs.ir.{ClassKind, OriginalName, Position, UTF8String}
+import org.scalajs.ir.Names._
+import org.scalajs.ir.OriginalName.NoOriginalName
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.Types._
+
+import org.scalajs.linker.backend.emitter.{NameGen => JSNameGen}
+
+import org.scalajs.linker.backend.javascript.{Trees => js}
+
+import org.scalajs.linker.backend.webassembly.FunctionBuilder
+import org.scalajs.linker.backend.webassembly.{Instructions => wa}
+import org.scalajs.linker.backend.webassembly.{Modules => wamod}
+import org.scalajs.linker.backend.webassembly.{Identitities => wanme}
+import org.scalajs.linker.backend.webassembly.{Types => watpe}
+
+import EmbeddedConstants._
+import SWasmGen._
+import VarGen._
+import TypeTransformer._
+import WasmContext._
+
+/** Toolkit to build custom JS helpers that take Wasm inputs, while trying to
+ *  optimize them directly as JavaScript trees.
+ *
+ *  The usage scenario for this class is as follows:
+ *
+ *  {{{
+ *  val builder = new CustomJSHelperBuilder()
+ *
+ *  // Add inputs that will be evaluated on the Wasm call site, and whose
+ *  // values are then available as `js.Tree`s in the JS helper:
+ *  val xRef = builder.addWasmInput(watpe.Int32) {
+ *    // Wasm code evaluated at call site
+ *    fb += wa.LocalGet(someLocal)
+ *  }
+ *  ...
+ *
+ *  // Build the body of the helper using the above inputs
+ *  val helperID = builder.build(watpe.Int32) {
+ *    js.Return(js.BinaryOp(JSBinaryOp.+, xRef, js.IntLiteral(5)))
+ *  }
+ *
+ *  // Call the helper, which consumes the declared inputs and leaves the result on the stack
+ *  fb += wa.Call(helperID)
+ *  }}}
+ *
+ *  The subclass [[CustomJSHelperBuilder.WithTreeEval]] provides even richer
+ *  capabilities, by allowing to evaluate arbitrary IR `Tree`s as inputs. The
+ *  builder will optimize the evaluation and transfer from Wasm to JS:
+ *
+ *  - Evaluate some trees entirely on the JS side instead of on the Wasm side.
+ *    This is notably the case for string literals, which commonly appear as
+ *    method names, and global refs/external imports, which commonly appear as
+ *    method receivers.
+ *  - For other trees, evaluate them on the Wasm side, but fuse their boxing
+ *    operation with the Wasm-to-JS interoperability layer, by choosing the
+ *    best possible Wasm type for the helper function.
+ *
+ *  When using the `WithTreeEval` subclass, the user must provide a concrete
+ *  method to evaluate `Tree`s at call site with a given expected type. In the
+ *  context of `FunctionEmitter`, that directly translates to the `genTree`
+ *  method.
+ *
+ *  A typical scenario looks like:
+ *
+ *  {{{
+ *  val builder = new CustomJSHelperBuilder.WithTreeEval() {
+ *    protected def evalTreeAtCallSite(tree: Tree, expectedType: Type): Unit = ???
+ *  }
+ *
+ *  // Add inputs that will be evaluated on the JS side if possible, otherwise
+ *  // evaluated on the Wasm call site, and whose values are then available as
+ *  // `js.Tree`s in the JS helper:
+ *  val xRef = builder.addInput(someIRTree)
+ *  ...
+ *  }}}
+ *
+ *  In addition to the input management, `CustomJSHelperBuilder` provides tools
+ *  for local name management, and generation of `js.ParamDef`s for inner
+ *  functions.
+ */
+class CustomJSHelperBuilder()(implicit ctx: WasmContext, pos: Position) {
+  import CustomJSHelperBuilder._
+
+  private val usedGlobalRefs = mutable.Set.empty[String]
+  private val allocatedLocalIdentResolvers = mutable.ListBuffer.empty[LocalResolver]
+
+  private val jsParamDefs = mutable.ListBuffer.empty[js.ParamDef]
+  private val wasmParamTypes = mutable.ListBuffer.empty[watpe.Type]
+
+  def newLocalIdent(origName: String): js.DelayedIdent = {
+    val resolver = new LocalResolver(origName)
+    allocatedLocalIdentResolvers += resolver
+    js.DelayedIdent(resolver)
+  }
+
+  def newLocalIdent(name: LocalName): js.DelayedIdent =
+    newLocalIdent(ctx.jsNameGen.genName(name))
+
+  private def addParamDef(origName: String, wasmType: watpe.Type): js.VarRef = {
+    val jsParamDef = js.ParamDef(newLocalIdent(origName))
+    jsParamDefs += jsParamDef
+    wasmParamTypes += wasmType
+    jsParamDef.ref
+  }
+
+  /** Adds an input of an arbitrary Wasm type, to be evaluated on the Wasm
+   *  stack.
+   *
+   *  The `evalValue` must add code to the call site context to evaluate the
+   *  value on the Wasm site. It is passed as by-name parameter to show
+   *  intent, but is in fact called immediately.
+   *
+   *  @return
+   *    A `js.VarRef` that can be used in the JS helper to read the input.
+   */
+  def addWasmInput(origName: String, wasmType: watpe.Type)(evalValue: => Unit): js.VarRef = {
+    evalValue
+    addParamDef(origName, wasmType)
+  }
+
+  def genGlobalRef(name: String): js.VarRef = {
+    usedGlobalRefs += name
+    js.VarRef(js.Ident(name))
+  }
+
+  def genJSNativeLoadSpec(jsNativeLoadSpec: JSNativeLoadSpec): js.Tree = {
+    def genFollowPath(owner: js.Tree, path: List[String]): js.Tree = {
+      path.foldLeft(owner) { (owner, item) =>
+        js.BracketSelect.makeOptimized(owner, js.StringLiteral(item))
+      }
+    }
+
+    jsNativeLoadSpec match {
+      case JSNativeLoadSpec.Global(globalRef, path) =>
+        genFollowPath(genGlobalRef(globalRef), path)
+      case JSNativeLoadSpec.Import(module, path) =>
+        genFollowPath(js.VarRef(js.Ident("imported" + JSNameGen.genModuleName(module))), path)
+      case JSNativeLoadSpec.ImportWithGlobalFallback(importSpec, _) =>
+        genJSNativeLoadSpec(importSpec)
+    }
+  }
+
+  def genJSParamDef(param: ParamDef): js.ParamDef =
+    js.ParamDef(newLocalIdent(param.name.name))
+
+  def genJSParamDefs(params: List[ParamDef],
+      restParam: Option[ParamDef]): (List[js.ParamDef], Option[js.ParamDef]) = {
+    (params.map(genJSParamDef(_)), restParam.map(genJSParamDef(_)))
+  }
+
+  def build(resultType: Type)(body: js.Tree): wanme.FunctionID = {
+    // Allocate names for the local ident resolvers
+    val usedLocalNames = usedGlobalRefs.clone()
+    for (resolver <- allocatedLocalIdentResolvers) {
+      var allocatedName = resolver.origName
+      var index = 0
+      while (!usedLocalNames.add(allocatedName)) {
+        index += 1
+        allocatedName = resolver.origName + index
+      }
+      resolver.setResolved(allocatedName)
+    }
+
+    val helperFun = js.Function(arrow = true, jsParamDefs.toList, None, body)
+    val wasmFunType = watpe.FunctionType(wasmParamTypes.toList, transformResultType(resultType))
+    ctx.addCustomJSHelper(helperFun, wasmFunType)
+  }
+}
+
+object CustomJSHelperBuilder {
+
+  private final class LocalResolver(val origName: String) extends js.DelayedIdent.Resolver {
+    private var resolved: Option[String] = None
+
+    def debugString: String = origName
+
+    def resolve(): String = {
+      resolved.getOrElse {
+        throw new IllegalStateException(s"Local JS ident '$origName' not resolved")
+      }
+    }
+
+    def setResolved(resolved: String): Unit = {
+      if (this.resolved.isDefined)
+        throw new IllegalStateException(s"Local JS ident '$origName' was already resolved")
+      this.resolved = Some(resolved)
+    }
+  }
+
+  abstract class WithTreeEval()(implicit ctx: WasmContext, pos: Position) extends CustomJSHelperBuilder {
+    /** Evaluates an arbitrary `Tree` with the given expected type and puts it
+     *  on the call site's stack.
+     *
+     *  Concrete subclasses must implement this method to evaluate trees in
+     *  their own call site context.
+     *
+     *  The given `tree` is guaranteed to be none of:
+     *
+     *  - `JSGlobalRef`
+     *  - `LoadJSConstructor` for a native JS class
+     *  - `LoadJSModule` for a native JS module class
+     *  - `SelectJSNativeMember`
+     */
+    protected def evalTreeAtCallSite(tree: Tree, expectedType: Type): Unit
+
+    def addInput(tree: TreeOrJSSpread): js.Tree = {
+      tree match {
+        case JSSpread(items) =>
+          js.Spread(addInput(items))
+
+        // Literals that we can directly constant-fold into the JS code
+        case Undefined()           => js.Undefined()
+        case Null()                => js.Null()
+        case BooleanLiteral(value) => js.BooleanLiteral(value)
+        case ByteLiteral(value)    => js.IntLiteral(value)
+        case ShortLiteral(value)   => js.IntLiteral(value)
+        case IntLiteral(value)     => js.IntLiteral(value)
+        case FloatLiteral(value)   => js.DoubleLiteral(value)
+        case DoubleLiteral(value)  => js.DoubleLiteral(value)
+        case StringLiteral(value)  => js.StringLiteral(value)
+
+        // Global refs and native load specs
+        case JSGlobalRef(name) =>
+          genGlobalRef(name)
+        case LoadJSConstructor(ClassNameWithJSNativeLoadSpec(jsNativeLoadSpec)) =>
+          genJSNativeLoadSpec(jsNativeLoadSpec)
+        case LoadJSModule(ClassNameWithJSNativeLoadSpec(jsNativeLoadSpec)) =>
+          genJSNativeLoadSpec(jsNativeLoadSpec)
+        case SelectJSNativeMember(className, MethodIdent(memberName)) =>
+          genJSNativeLoadSpec(ctx.getClassInfo(className).jsNativeMembers.getOrElse(memberName, {
+            throw new AssertionError(
+                s"Found $tree for non-existing JS native member at ${tree.pos}")
+          }))
+
+        // Other trees, which must be evaluated at the call site
+        case arg: Tree =>
+          def addInputAsType(expectedType: Type): js.Tree = {
+            addWasmInput("x", transformParamType(expectedType)) {
+              evalTreeAtCallSite(arg, expectedType)
+            }
+          }
+
+          arg.tpe match {
+            case BooleanType =>
+              // Pass in an i32; convert to boolean in the JS code
+              val input = addInputAsType(BooleanType)
+              js.BinaryOp(JSBinaryOp.!==, input, js.IntLiteral(0))
+
+            case CharType | LongType =>
+              // Box on the Wasm side; pass in an anyref
+              addInputAsType(AnyType)
+
+            case argTpe =>
+              // For all other types, we can rely on the Wasm-to-JS type conversions
+              addInputAsType(argTpe)
+          }
+      }
+    }
+  }
+
+  private object ClassNameWithJSNativeLoadSpec {
+    def unapply(className: ClassName)(implicit ctx: WasmContext): Option[JSNativeLoadSpec] =
+      ctx.getClassInfo(className).jsNativeLoadSpec
+  }
+
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -68,15 +68,6 @@ function superSelectSet(superClass, self, propName, value) {
   throw new TypeError("super has no setter '" + propName + "'.");
 }
 
-function installJSField(instance, name, value) {
-  Object.defineProperty(instance, name, {
-    value,
-    configurable: true,
-    enumerable: true,
-    writable: true,
-  });
-}
-
 const scalaJSHelpers = {
   // JSTag
   JSTag: WebAssembly.JSTag,
@@ -91,7 +82,6 @@ const scalaJSHelpers = {
   // Constant boxes
   bFalse: false,
   bTrue: true,
-  bZero: 0,
 
   // Boxes (upcast) -- most are identity at the JS level but with different types in Wasm
   bIFallback: (x) => x,
@@ -112,16 +102,6 @@ const scalaJSHelpers = {
 
   // fmod, to implement Float_% and Double_% (it is apparently quite hard to implement fmod otherwise)
   fmod: (x, y) => x % y,
-
-  // Closure
-  closure: (f, data) => f.bind(void 0, data),
-  closureThis: (f, data) => function(...args) { return f(data, this, ...args); },
-  closureRest: (f, data, n) => ((...args) => f(data, ...args.slice(0, n), args.slice(n))),
-  closureThisRest: (f, data, n) => function(...args) { return f(data, this, ...args.slice(0, n), args.slice(n)); },
-
-  // Top-level exported defs -- they must be `function`s but have no actual `this` nor `data`
-  makeExportedDef: (f) => function(...args) { return f(...args); },
-  makeExportedDefRest: (f, n) => function(...args) { return f(...args.slice(0, n), args.slice(n)); },
 
   // Strings
   emptyString: "",
@@ -170,127 +150,21 @@ const scalaJSHelpers = {
   makeTypeError: (msg) => new TypeError(msg),
 
   // JS interop
-  jsGlobalRefGet: (globalRefName) => (new Function("return " + globalRefName))(),
-  jsGlobalRefSet: (globalRefName, v) => {
-    var argName = globalRefName === 'v' ? 'w' : 'v';
-    (new Function(argName, globalRefName + " = " + argName))(v);
-  },
-  jsGlobalRefTypeof: (globalRefName) => (new Function("return typeof " + globalRefName))(),
   jsNewArray: () => [],
-  jsArrayPush: (a, v) => (a.push(v), a),
-  jsArraySpreadPush: (a, vs) => (a.push(...vs), a),
   jsNewObject: () => ({}),
-  jsObjectPush: (o, p, v) => (o[p] = v, o),
   jsSelect: (o, p) => o[p],
   jsSelectSet: (o, p, v) => o[p] = v,
-  jsNew: (constr, args) => new constr(...args),
-  jsFunctionApply: (f, args) => f(...args),
-  jsMethodApply: (o, m, args) => o[m](...args),
+  jsNewNoArg: (constr) => new constr(),
   jsImportCall: (s) => import(s),
   jsImportMeta: () => import.meta,
   jsDelete: (o, p) => { delete o[p]; },
   jsForInSimple: (o, f) => { for (var k in o) f(k); },
   jsIsTruthy: (x) => !!x,
 
-  // Excruciating list of all the JS operators
-  jsUnaryPlus: (a) => +a,
-  jsUnaryMinus: (a) => -a,
-  jsUnaryTilde: (a) => ~a,
-  jsUnaryBang: (a) => !a,
-  jsUnaryTypeof: (a) => typeof a,
-  jsStrictEquals: (a, b) => a === b,
-  jsNotStrictEquals: (a, b) => a !== b,
-  jsPlus: (a, b) => a + b,
-  jsMinus: (a, b) => a - b,
-  jsTimes: (a, b) => a * b,
-  jsDivide: (a, b) => a / b,
-  jsModulus: (a, b) => a % b,
-  jsBinaryOr: (a, b) => a | b,
-  jsBinaryAnd: (a, b) => a & b,
-  jsBinaryXor: (a, b) => a ^ b,
-  jsShiftLeft: (a, b) => a << b,
-  jsArithmeticShiftRight: (a, b) => a >> b,
-  jsLogicalShiftRight: (a, b) => a >>> b,
-  jsLessThan: (a, b) => a < b,
-  jsLessEqual: (a, b) => a <= b,
-  jsGreaterThan: (a, b) => a > b,
-  jsGreaterEqual: (a, b) => a >= b,
-  jsIn: (a, b) => a in b,
-  jsInstanceof: (a, b) => a instanceof b,
-  jsExponent: (a, b) => a ** b,
-
   // Non-native JS class support
   newSymbol: Symbol,
-  createJSClass: (data, superClass, preSuperStats, superArgs, postSuperStats, fields) => {
-    // fields is an array where even indices are field names and odd indices are initial values
-    return class extends superClass {
-      constructor(...args) {
-        var preSuperEnv = preSuperStats(data, new.target, ...args);
-        super(...superArgs(data, preSuperEnv, new.target, ...args));
-        for (var i = 0; i != fields.length; i = (i + 2) | 0)
-          installJSField(this, fields[i], fields[(i + 1) | 0]);
-        postSuperStats(data, preSuperEnv, new.target, this, ...args);
-      }
-    };
-  },
-  createJSClassRest: (data, superClass, preSuperStats, superArgs, postSuperStats, fields, n) => {
-    // fields is an array where even indices are field names and odd indices are initial values
-    return class extends superClass {
-      constructor(...args) {
-        var fixedArgs = args.slice(0, n);
-        var restArg = args.slice(n);
-        var preSuperEnv = preSuperStats(data, new.target, ...fixedArgs, restArg);
-        super(...superArgs(data, preSuperEnv, new.target, ...fixedArgs, restArg));
-        for (var i = 0; i != fields.length; i = (i + 2) | 0)
-          installJSField(this, fields[i], fields[(i + 1) | 0]);
-        postSuperStats(data, preSuperEnv, new.target, this, ...fixedArgs, restArg);
-      }
-    };
-  },
-  installJSField,
-  installJSMethod: (data, jsClass, name, func, fixedArgCount) => {
-    var closure = fixedArgCount < 0
-      ? (function(...args) { return func(data, this, ...args); })
-      : (function(...args) { return func(data, this, ...args.slice(0, fixedArgCount), args.slice(fixedArgCount))});
-    jsClass.prototype[name] = closure;
-  },
-  installJSStaticMethod: (data, jsClass, name, func, fixedArgCount) => {
-    var closure = fixedArgCount < 0
-      ? (function(...args) { return func(data, ...args); })
-      : (function(...args) { return func(data, ...args.slice(0, fixedArgCount), args.slice(fixedArgCount))});
-    jsClass[name] = closure;
-  },
-  installJSProperty: (data, jsClass, name, getter, setter) => {
-    var getterClosure = getter
-      ? (function() { return getter(data, this) })
-      : (void 0);
-    var setterClosure = setter
-      ? (function(arg) { setter(data, this, arg) })
-      : (void 0);
-    Object.defineProperty(jsClass.prototype, name, {
-      get: getterClosure,
-      set: setterClosure,
-      configurable: true,
-    });
-  },
-  installJSStaticProperty: (data, jsClass, name, getter, setter) => {
-    var getterClosure = getter
-      ? (function() { return getter(data) })
-      : (void 0);
-    var setterClosure = setter
-      ? (function(arg) { setter(data, arg) })
-      : (void 0);
-    Object.defineProperty(jsClass, name, {
-      get: getterClosure,
-      set: setterClosure,
-      configurable: true,
-    });
-  },
   jsSuperSelect: superSelect,
   jsSuperSelectSet: superSelectSet,
-  jsSuperCall: (superClass, receiver, method, args) => {
-    return superClass.prototype[method].apply(receiver, args);
-  },
 }
 
 const stringBuiltinPolyfills = {
@@ -305,7 +179,7 @@ const stringBuiltinPolyfills = {
   equals: (a, b) => a === b,
 };
 
-export async function load(wasmFileURL, linkingInfo, importedModules, exportSetters) {
+export async function load(wasmFileURL, linkingInfo, exportSetters, customJSHelpers) {
   const myScalaJSHelpers = {
     ...scalaJSHelpers,
     jsLinkingInfo: linkingInfo,
@@ -313,8 +187,8 @@ export async function load(wasmFileURL, linkingInfo, importedModules, exportSett
   };
   const importsObj = {
     "__scalaJSHelpers": myScalaJSHelpers,
-    "__scalaJSImports": importedModules,
     "__scalaJSExportSetters": exportSetters,
+    "__scalaJSCustomHelpers": customJSHelpers,
     "wasm:js-string": stringBuiltinPolyfills,
   };
   const options = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -25,7 +25,6 @@ import org.scalajs.linker.backend.webassembly.Identitities._
 object VarGen {
 
   object genGlobalID {
-    final case class forImportedModule(moduleName: String) extends GlobalID
     final case class forModuleInstance(className: ClassName) extends GlobalID
     final case class forModuleInitFlag(className: ClassName) extends GlobalID
     final case class forJSClassValue(className: ClassName) extends GlobalID
@@ -58,7 +57,6 @@ object VarGen {
     case object undef extends JSHelperGlobalID
     case object bFalse extends JSHelperGlobalID
     case object bTrue extends JSHelperGlobalID
-    case object bZero extends JSHelperGlobalID
     case object emptyString extends JSHelperGlobalID
     case object idHashCodeMap extends JSHelperGlobalID
   }
@@ -134,14 +132,6 @@ object VarGen {
 
     case object fmod extends JSHelperFunctionID
 
-    case object closure extends JSHelperFunctionID
-    case object closureThis extends JSHelperFunctionID
-    case object closureRest extends JSHelperFunctionID
-    case object closureThisRest extends JSHelperFunctionID
-
-    case object makeExportedDef extends JSHelperFunctionID
-    case object makeExportedDefRest extends JSHelperFunctionID
-
     case object jsValueToString extends JSHelperFunctionID // for actual toString() call
     case object jsValueToStringForConcat extends JSHelperFunctionID
     case object booleanToString extends JSHelperFunctionID
@@ -158,79 +148,20 @@ object VarGen {
 
     case object makeTypeError extends JSHelperFunctionID
 
-    case object jsGlobalRefGet extends JSHelperFunctionID
-    case object jsGlobalRefSet extends JSHelperFunctionID
-    case object jsGlobalRefTypeof extends JSHelperFunctionID
     case object jsNewArray extends JSHelperFunctionID
-    case object jsArrayPush extends JSHelperFunctionID
-    case object jsArraySpreadPush extends JSHelperFunctionID
     case object jsNewObject extends JSHelperFunctionID
-    case object jsObjectPush extends JSHelperFunctionID
     case object jsSelect extends JSHelperFunctionID
     case object jsSelectSet extends JSHelperFunctionID
-    case object jsNew extends JSHelperFunctionID
-    case object jsFunctionApply extends JSHelperFunctionID
-    case object jsMethodApply extends JSHelperFunctionID
+    case object jsNewNoArg extends JSHelperFunctionID
     case object jsImportCall extends JSHelperFunctionID
     case object jsImportMeta extends JSHelperFunctionID
     case object jsDelete extends JSHelperFunctionID
     case object jsForInSimple extends JSHelperFunctionID
     case object jsIsTruthy extends JSHelperFunctionID
 
-    final case class jsUnaryOp(name: String) extends JSHelperFunctionID {
-      override def toString(): String = name
-    }
-
-    val jsUnaryOps: Map[JSUnaryOp.Code, jsUnaryOp] = {
-      Map(
-        JSUnaryOp.+ -> jsUnaryOp("jsUnaryPlus"),
-        JSUnaryOp.- -> jsUnaryOp("jsUnaryMinus"),
-        JSUnaryOp.~ -> jsUnaryOp("jsUnaryTilde"),
-        JSUnaryOp.! -> jsUnaryOp("jsUnaryBang"),
-        JSUnaryOp.typeof -> jsUnaryOp("jsUnaryTypeof")
-      )
-    }
-
-    final case class jsBinaryOp(name: String) extends JSHelperFunctionID {
-      override def toString(): String = name
-    }
-
-    val jsBinaryOps: Map[JSBinaryOp.Code, jsBinaryOp] = {
-      Map(
-        JSBinaryOp.=== -> jsBinaryOp("jsStrictEquals"),
-        JSBinaryOp.!== -> jsBinaryOp("jsNotStrictEquals"),
-        JSBinaryOp.+ -> jsBinaryOp("jsPlus"),
-        JSBinaryOp.- -> jsBinaryOp("jsMinus"),
-        JSBinaryOp.* -> jsBinaryOp("jsTimes"),
-        JSBinaryOp./ -> jsBinaryOp("jsDivide"),
-        JSBinaryOp.% -> jsBinaryOp("jsModulus"),
-        JSBinaryOp.| -> jsBinaryOp("jsBinaryOr"),
-        JSBinaryOp.& -> jsBinaryOp("jsBinaryAnd"),
-        JSBinaryOp.^ -> jsBinaryOp("jsBinaryXor"),
-        JSBinaryOp.<< -> jsBinaryOp("jsShiftLeft"),
-        JSBinaryOp.>> -> jsBinaryOp("jsArithmeticShiftRight"),
-        JSBinaryOp.>>> -> jsBinaryOp("jsLogicalShiftRight"),
-        JSBinaryOp.< -> jsBinaryOp("jsLessThan"),
-        JSBinaryOp.<= -> jsBinaryOp("jsLessEqual"),
-        JSBinaryOp.> -> jsBinaryOp("jsGreaterThan"),
-        JSBinaryOp.>= -> jsBinaryOp("jsGreaterEqual"),
-        JSBinaryOp.in -> jsBinaryOp("jsIn"),
-        JSBinaryOp.instanceof -> jsBinaryOp("jsInstanceof"),
-        JSBinaryOp.** -> jsBinaryOp("jsExponent")
-      )
-    }
-
     case object newSymbol extends JSHelperFunctionID
-    case object createJSClass extends JSHelperFunctionID
-    case object createJSClassRest extends JSHelperFunctionID
-    case object installJSField extends JSHelperFunctionID
-    case object installJSMethod extends JSHelperFunctionID
-    case object installJSStaticMethod extends JSHelperFunctionID
-    case object installJSProperty extends JSHelperFunctionID
-    case object installJSStaticProperty extends JSHelperFunctionID
     case object jsSuperSelect extends JSHelperFunctionID
     case object jsSuperSelectSet extends JSHelperFunctionID
-    case object jsSuperCall extends JSHelperFunctionID
 
     // Wasm internal helpers
 


### PR DESCRIPTION
Previously, we used a small set of fixed JS helpers to implement all the Wasm-to-JS interop nodes. For example, there was a unique `jsMethodApply` helper, used for all `JSMethodApply` nodes. We also used a single entry point to read all `JSGlobalRef`s, using a JS `new Function("...")` to read global variables.

This strategy, while having the advantage of doing all the codebase-dependent work on the Wasm side, was extremely slow. Imagine that calling `Math.cos(x)` had to:

1. load the constant string `"Math"`,
2. use `jsGlobalRefGet("Math")`, using a `new Function` to read that,
3. load the constant string `"cos"`,
4. use `jsNewArray` and `jsArrayPush` to create a JS array with `x` as argument (plus a `bD` call to box `x`!),
5. use `jsMethodApply`, which uses a `...spread` operator to re-expand the one-element array of arguments.

A unique call like that in a more-or-less tight loop would destroy any hope of good performance.

---

We now use a completely different strategy. For every Wasm-to-JS interop node, `FunctionEmitter` creates a dedicated JS helper. It is registered in the context and will be inserted in the generated `main.js` file.

We build on a unified toolkit to generate efficient JS helpers and managing their inputs: `CustomJSHelperBuilder`. It manages the evaluatation of Wasm values on one side, then gives them to a dedicated JS function body. Boxing is fused into the JS function call through the built-in Wasm-to-JS interop features when possible. Moreover, literals and JS global refs are "constant-folded" into the JS function altogether.

For the above example scenario, we end up with a helper of the form `(x) => Math.cos(x)`, typed in Wasm as a `[f64] -> [anyref]`. We can call it directly with a `double` value, without explicit call to `bD`, without JS array, and without string values representing `"Math"` nor `"cos"`. This is almost as good as it gets. The only non-optimal aspect is that we still return an `anyref`, which we have to unbox later with a call to `uD`. Improving that last point is left for future work.

---

We use the same mechanism to build dedicated helpers for `Closure`s and for non-native JS classes.

---

There are two things that we can still improve in the future without too much effort:

* Handling of the arguments to the super constructor calls in non-native JS classes, for which we could leverage Wasm functions with multiple return values.
* Move the management of the `Symbol`s for private JS fields to the JS side of things, instead of passing them from Wasm every time.