### PR TITLE
CI ONLY Wasm: Use the JS string builtins, with a polyfill.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -277,7 +277,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
         // componentType - always `null` since this method is not used for array types
         wa.RefNull(watpe.HeapType(genTypeID.typeData)),
         // name - initially `null`; filled in by the `typeDataName` helper
-        wa.RefNull(watpe.HeapType.Any),
+        wa.RefNull(watpe.HeapType.NoExtern),
         // the classOf instance - initially `null`; filled in by the `createClassOf` helper
         wa.RefNull(watpe.HeapType(genTypeID.ClassStruct)),
         // arrayOf, the typeData of an array of this type - initially `null`; filled in by the `arrayTypeData` helper
@@ -943,6 +943,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
           case StringLiteral(value) =>
             // Common shape for all the `nameTree` expressions
             fb ++= ctx.stringPool.getConstantStringInstr(value)
+            fb += wa.AnyConvertExtern
 
           case VarRef(LocalIdent(localName)) if classCaptureParamsOfTypeAny.contains(localName) =>
             /* Common shape for the `jsSuperClass` value

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -310,12 +310,9 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
     addHelperImport(genFunctionID.isUndef, List(anyref), List(Int32))
 
-    for (primRef <- List(BooleanRef, ByteRef, ShortRef, FloatRef, DoubleRef)) {
-      val wasmType = primRef match {
-        case FloatRef  => Float32
-        case DoubleRef => Float64
-        case _         => Int32
-      }
+    for (primType <- List(BooleanType, FloatType, DoubleType)) {
+      val primRef = primType.primRef
+      val wasmType = transformPrimType(primType)
       addHelperImport(genFunctionID.box(primRef), List(wasmType), List(RefType.any))
       addHelperImport(genFunctionID.unbox(primRef), List(anyref), List(wasmType))
       addHelperImport(genFunctionID.typeTest(primRef), List(anyref), List(Int32))
@@ -596,6 +593,10 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
   private def genHelperDefinitions()(implicit ctx: WasmContext): Unit = {
     genBoxInt()
     genUnboxInt()
+    genUnboxByteOrShort(ByteRef)
+    genUnboxByteOrShort(ShortRef)
+    genTestByteOrShort(ByteRef, I32Extend8S)
+    genTestByteOrShort(ShortRef, I32Extend16S)
     genStringLiteral()
     genCreateStringFromData()
     genTypeDataName()
@@ -711,6 +712,59 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
     // Otherwise, use the fallback helper
     fb += Call(genFunctionID.uIFallback)
+
+    fb.buildAndAddToModule()
+  }
+
+  private def genUnboxByteOrShort(typeRef: PrimRef)(implicit ctx: WasmContext): Unit = {
+    /* As long as we only support Unchecked asInstanceOfs, the unboxing
+     * functions for Byte and Short actually do exactly the same thing.
+     * We keep them separate so that the rest of the codebase is clearer.
+     */
+
+    val fb = newFunctionBuilder(genFunctionID.unbox(typeRef))
+    val xParam = fb.addParam("x", RefType.anyref)
+    fb.setResultType(Int32)
+
+    // If x is a (ref i31), extract it
+    fb.block(RefType.anyref) { xIsNotI31Label =>
+      fb += LocalGet(xParam)
+      fb += BrOnCastFail(xIsNotI31Label, RefType.anyref, RefType.i31)
+      fb += I31GetS
+      fb += Return
+    }
+
+    // Otherwise, it must be null, so return 0
+    fb += Drop
+    fb += I32Const(0)
+
+    fb.buildAndAddToModule()
+  }
+
+  private def genTestByteOrShort(typeRef: PrimRef, signExtend: SimpleInstr)(
+        implicit ctx: WasmContext): Unit = {
+
+    val fb = newFunctionBuilder(genFunctionID.typeTest(typeRef))
+    val xParam = fb.addParam("x", RefType.anyref)
+    fb.setResultType(Int32)
+
+    val intValueLocal = fb.addLocal("intValue", Int32)
+
+    // If x is a (ref i31), extract it and that it sign-extends to itself
+    fb.block(RefType.anyref) { xIsNotI31Label =>
+      fb += LocalGet(xParam)
+      fb += BrOnCastFail(xIsNotI31Label, RefType.anyref, RefType.i31)
+      fb += I31GetS
+      fb += LocalTee(intValueLocal)
+      fb += LocalGet(intValueLocal)
+      fb += signExtend
+      fb += I32Eq
+      fb += Return
+    }
+
+    // Otherwise, return false
+    fb += Drop
+    fb += I32Const(0)
 
     fb.buildAndAddToModule()
   }
@@ -1198,6 +1252,39 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
     fb.block() { objIsNullLabel =>
       primType match {
+        // For byte and short, use br_on_cast_fail with i31 then check the value
+        case ByteType | ShortType =>
+          val intValueLocal = fb.addLocal("intValue", Int32)
+
+          fb.block(RefType.anyref) { castFailLabel =>
+            fb += LocalGet(objParam)
+            fb += BrOnNull(objIsNullLabel)
+            fb += BrOnCastFail(castFailLabel, RefType.any, RefType.i31)
+
+            // Extract the i31 value
+            fb += I31GetS
+            fb += LocalTee(intValueLocal)
+
+            // if it sign-extends to itself
+            fb += LocalGet(intValueLocal)
+            if (primType == ByteType)
+              fb += I32Extend8S
+            else
+              fb += I32Extend16S
+            fb += I32Eq
+            fb.ifThen() {
+              // then success
+              if (isUnbox)
+                fb += LocalGet(intValueLocal)
+              else
+                fb += LocalGet(objParam)
+              fb += Return
+            }
+
+            // Fall through for CCE
+            fb += LocalGet(objParam)
+          }
+
         // For char and long, use br_on_cast_fail to test+cast to the box class
         case CharType | LongType =>
           val boxClass =
@@ -1205,10 +1292,10 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
             else SpecialNames.LongBoxClass
           val structTypeID = genTypeID.forClass(boxClass)
 
-          fb.block(RefType.anyref) { castFailLabel =>
+          fb.block(RefType.any) { castFailLabel =>
             fb += LocalGet(objParam)
             fb += BrOnNull(objIsNullLabel)
-            fb += BrOnCastFail(castFailLabel, RefType.anyref, RefType(structTypeID))
+            fb += BrOnCastFail(castFailLabel, RefType.any, RefType(structTypeID))
 
             // Extract the `value` field if unboxing
             if (isUnbox) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -256,6 +256,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
   private def genImports()(implicit ctx: WasmContext): Unit = {
     genTagImports()
     genGlobalImports()
+    genStringBuiltinImports()
     genHelperImports()
   }
 
@@ -293,6 +294,30 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     addGlobalHelperImport(genGlobalID.bZero, RefType.any)
     addGlobalHelperImport(genGlobalID.emptyString, RefType.extern)
     addGlobalHelperImport(genGlobalID.idHashCodeMap, RefType.extern)
+  }
+
+  private def genStringBuiltinImports()(implicit ctx: WasmContext): Unit = {
+    import RefType.{extern, externref}
+
+    def addHelperImport(id: genFunctionID.JSHelperFunctionID,
+        params: List[Type], results: List[Type]): Unit = {
+      val sig = FunctionType(params, results)
+      val typeID = ctx.moduleBuilder.functionTypeToTypeID(sig)
+      ctx.moduleBuilder.addImport(
+        Import(
+          "wasm:js-string",
+          id.toString(), // import name, guaranteed by JSHelperFunctionID
+          ImportDesc.Func(id, OriginalName(id.toString()), typeID)
+        )
+      )
+    }
+
+    addHelperImport(genFunctionID.stringBuiltins.test, List(externref), List(Int32))
+    addHelperImport(genFunctionID.stringBuiltins.fromCharCode, List(Int32), List(extern))
+    addHelperImport(genFunctionID.stringBuiltins.charCodeAt, List(externref, Int32), List(Int32))
+    addHelperImport(genFunctionID.stringBuiltins.length, List(externref), List(Int32))
+    addHelperImport(genFunctionID.stringBuiltins.concat, List(externref, externref), List(extern))
+    addHelperImport(genFunctionID.stringBuiltins.equals, List(externref, externref), List(Int32))
   }
 
   private def genHelperImports()(implicit ctx: WasmContext): Unit = {
@@ -356,21 +381,12 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       List(RefType.any)
     )
 
-    addHelperImport(genFunctionID.stringLength, List(RefType.extern), List(Int32))
-    addHelperImport(genFunctionID.stringCharAt, List(RefType.extern, Int32), List(Int32))
     addHelperImport(genFunctionID.jsValueToString, List(RefType.any), List(RefType.extern))
     addHelperImport(genFunctionID.jsValueToStringForConcat, List(anyref), List(RefType.extern))
     addHelperImport(genFunctionID.booleanToString, List(Int32), List(RefType.extern))
-    addHelperImport(genFunctionID.charToString, List(Int32), List(RefType.extern))
     addHelperImport(genFunctionID.intToString, List(Int32), List(RefType.extern))
     addHelperImport(genFunctionID.longToString, List(Int64), List(RefType.extern))
     addHelperImport(genFunctionID.doubleToString, List(Float64), List(RefType.extern))
-    addHelperImport(
-      genFunctionID.stringConcat,
-      List(RefType.extern, RefType.extern),
-      List(RefType.extern)
-    )
-    addHelperImport(genFunctionID.isString, List(anyref), List(Int32))
 
     addHelperImport(genFunctionID.jsValueType, List(RefType.any), List(Int32))
     addHelperImport(genFunctionID.jsValueDescription, List(anyref), List(RefType.extern))
@@ -861,8 +877,8 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       fb += LocalGet(dataParam)
       fb += LocalGet(iLocal)
       fb += ArrayGetU(genTypeID.i16Array)
-      fb += Call(genFunctionID.charToString)
-      fb += Call(genFunctionID.stringConcat)
+      fb += Call(genFunctionID.stringBuiltins.fromCharCode)
+      fb += Call(genFunctionID.stringBuiltins.concat)
       fb += LocalSet(resultLocal)
 
       // i := i + 1
@@ -922,7 +938,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
         // <top of stack> := "[", for the CALL to stringConcat near the end
         fb += I32Const('['.toInt)
-        fb += Call(genFunctionID.charToString)
+        fb += Call(genFunctionID.stringBuiltins.fromCharCode)
 
         // componentTypeData := ref_as_non_null(typeData.componentType)
         fb += LocalGet(typeDataParam)
@@ -942,35 +958,35 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
         }(
           List(KindBoolean) -> { () =>
             fb += I32Const('Z'.toInt)
-            fb += Call(genFunctionID.charToString)
+            fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           },
           List(KindChar) -> { () =>
             fb += I32Const('C'.toInt)
-            fb += Call(genFunctionID.charToString)
+            fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           },
           List(KindByte) -> { () =>
             fb += I32Const('B'.toInt)
-            fb += Call(genFunctionID.charToString)
+            fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           },
           List(KindShort) -> { () =>
             fb += I32Const('S'.toInt)
-            fb += Call(genFunctionID.charToString)
+            fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           },
           List(KindInt) -> { () =>
             fb += I32Const('I'.toInt)
-            fb += Call(genFunctionID.charToString)
+            fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           },
           List(KindLong) -> { () =>
             fb += I32Const('J'.toInt)
-            fb += Call(genFunctionID.charToString)
+            fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           },
           List(KindFloat) -> { () =>
             fb += I32Const('F'.toInt)
-            fb += Call(genFunctionID.charToString)
+            fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           },
           List(KindDouble) -> { () =>
             fb += I32Const('D'.toInt)
-            fb += Call(genFunctionID.charToString)
+            fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           },
           List(KindArray) -> { () =>
             // the component type is an array; get its own name
@@ -981,17 +997,17 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
           // default: the component type is neither a primitive nor an array;
           // concatenate "L" + <its own name> + ";"
           fb += I32Const('L'.toInt)
-          fb += Call(genFunctionID.charToString)
+          fb += Call(genFunctionID.stringBuiltins.fromCharCode)
           fb += LocalGet(componentTypeDataLocal)
           fb += Call(genFunctionID.typeDataName)
-          fb += Call(genFunctionID.stringConcat)
+          fb += Call(genFunctionID.stringBuiltins.concat)
           fb += I32Const(';'.toInt)
-          fb += Call(genFunctionID.charToString)
-          fb += Call(genFunctionID.stringConcat)
+          fb += Call(genFunctionID.stringBuiltins.fromCharCode)
+          fb += Call(genFunctionID.stringBuiltins.concat)
         }
 
         // At this point, the stack contains "[" and the string that must be concatenated with it
-        fb += Call(genFunctionID.stringConcat)
+        fb += Call(genFunctionID.stringBuiltins.concat)
       } {
         // it is not an array; its name is stored in nameData
         for (
@@ -1226,11 +1242,11 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
         fb += Call(genFunctionID.valueDescription)
 
         fb ++= ctx.stringPool.getConstantStringInstr(" cannot be cast to ")
-        fb += Call(genFunctionID.stringConcat)
+        fb += Call(genFunctionID.stringBuiltins.concat)
 
         fb += LocalGet(typeDataParam)
         fb += Call(genFunctionID.typeDataName)
-        fb += Call(genFunctionID.stringConcat)
+        fb += Call(genFunctionID.stringBuiltins.concat)
       }
     }
 
@@ -1357,7 +1373,8 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
             case UndefType =>
               fb += Call(genFunctionID.isUndef)
             case StringType =>
-              fb += Call(genFunctionID.isString)
+              fb += ExternConvertAny
+              fb += Call(genFunctionID.stringBuiltins.test)
             case primType: PrimTypeWithRef =>
               fb += Call(genFunctionID.typeTest(primType.primRef))
           }
@@ -1876,7 +1893,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     // if index unsigned_>= str.length
     fb += LocalGet(indexParam)
     fb += LocalGet(strParam)
-    fb += Call(genFunctionID.stringLength)
+    fb += Call(genFunctionID.stringBuiltins.length)
     fb += I32GeU // unsigned comparison makes negative values of index larger than the length
     fb.ifThen() {
       // then, throw a StringIndexOutOfBoundsException
@@ -1893,7 +1910,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     // otherwise, read the char
     fb += LocalGet(strParam)
     fb += LocalGet(indexParam)
-    fb += Call(genFunctionID.stringCharAt)
+    fb += Call(genFunctionID.stringBuiltins.charCodeAt)
 
     fb.buildAndAddToModule()
   }
@@ -1911,10 +1928,10 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       fb ++= ctx.stringPool.getConstantStringInstr("Initializer of ")
       fb += LocalGet(typeDataParam)
       fb += Call(genFunctionID.typeDataName)
-      fb += Call(genFunctionID.stringConcat)
+      fb += Call(genFunctionID.stringBuiltins.concat)
       fb ++= ctx.stringPool.getConstantStringInstr(
           " called before completion of its super constructor")
-      fb += Call(genFunctionID.stringConcat)
+      fb += Call(genFunctionID.stringBuiltins.concat)
     }
     fb += ExternConvertAny
     fb += Throw(genTagID.exception)
@@ -2020,7 +2037,8 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       },
       List(KindBoxedString) -> { () =>
         fb += LocalGet(valueParam)
-        fb += Call(genFunctionID.isString)
+        fb += ExternConvertAny
+        fb += Call(genFunctionID.stringBuiltins.test)
       },
       // case KindJSType => call typeData.isJSClassInstance(value) or throw if it is null
       List(KindJSType) -> { () =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -310,7 +310,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
     addHelperImport(genFunctionID.isUndef, List(anyref), List(Int32))
 
-    for (primRef <- List(BooleanRef, ByteRef, ShortRef, IntRef, FloatRef, DoubleRef)) {
+    for (primRef <- List(BooleanRef, ByteRef, ShortRef, FloatRef, DoubleRef)) {
       val wasmType = primRef match {
         case FloatRef  => Float32
         case DoubleRef => Float64
@@ -320,6 +320,10 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       addHelperImport(genFunctionID.unbox(primRef), List(anyref), List(wasmType))
       addHelperImport(genFunctionID.typeTest(primRef), List(anyref), List(Int32))
     }
+
+    addHelperImport(genFunctionID.bIFallback, List(Int32), List(RefType.any))
+    addHelperImport(genFunctionID.uIFallback, List(anyref), List(Int32))
+    addHelperImport(genFunctionID.typeTest(IntRef), List(anyref), List(Int32))
 
     addHelperImport(genFunctionID.fmod, List(Float64, Float64), List(Float64))
 
@@ -590,6 +594,8 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
   /** Generates all the helper function definitions of the core Wasm lib. */
   private def genHelperDefinitions()(implicit ctx: WasmContext): Unit = {
+    genBoxInt()
+    genUnboxInt()
     genStringLiteral()
     genCreateStringFromData()
     genTypeDataName()
@@ -660,6 +666,53 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
   private def newFunctionBuilder(functionID: FunctionID)(
       implicit ctx: WasmContext): FunctionBuilder = {
     newFunctionBuilder(functionID, OriginalName(functionID.toString()))
+  }
+
+  private def genBoxInt()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.box(IntRef))
+    val xParam = fb.addParam("x", Int32)
+    fb.setResultType(RefType.any)
+
+    // Test if the most significant bit is necessary: (x ^ (x << 1)) & 0x80000000
+    fb += LocalGet(xParam)
+    fb += LocalGet(xParam)
+    fb += I32Const(1)
+    fb += I32Shl
+    fb += I32Xor
+    fb += I32Const(0x80000000)
+    fb += I32And
+
+    // If non-zero,
+    fb.ifThenElse(RefType.any) {
+      // then call the fallback JS helper
+      fb += LocalGet(xParam)
+      fb += Call(genFunctionID.bIFallback)
+    } {
+      // else use ref.i31
+      fb += LocalGet(xParam)
+      fb += RefI31
+    }
+
+    fb.buildAndAddToModule()
+  }
+
+  private def genUnboxInt()(implicit ctx: WasmContext): Unit = {
+    val fb = newFunctionBuilder(genFunctionID.unbox(IntRef))
+    val xParam = fb.addParam("x", RefType.anyref)
+    fb.setResultType(Int32)
+
+    // If x is a (ref i31), extract it
+    fb.block(RefType.anyref) { xIsNotI31Label =>
+      fb += LocalGet(xParam)
+      fb += BrOnCastFail(xIsNotI31Label, RefType.anyref, RefType.i31)
+      fb += I31GetS
+      fb += Return
+    }
+
+    // Otherwise, use the fallback helper
+    fb += Call(genFunctionID.uIFallback)
+
+    fb.buildAndAddToModule()
   }
 
   private def genStringLiteral()(implicit ctx: WasmContext): Unit = {
@@ -1168,8 +1221,20 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
         // For all other types, use type test, and separately unbox if required
         case _ =>
-          fb += LocalGet(objParam)
-          fb += BrOnNull(objIsNullLabel)
+          // For Int, include a fast path for values that fit in i31
+          if (primType == IntType) {
+            fb.block(RefType.any) { notI31Label =>
+              fb += LocalGet(objParam)
+              fb += BrOnNull(objIsNullLabel)
+              fb += BrOnCastFail(notI31Label, RefType.any, RefType.i31)
+              if (isUnbox)
+                fb += I31GetS
+              fb += Return
+            }
+          } else {
+            fb += LocalGet(objParam)
+            fb += BrOnNull(objIsNullLabel)
+          }
 
           // if obj.isInstanceOf[primType]
           primType match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -77,7 +77,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       make(specialInstanceTypes, Int32, isMutable = false),
       make(strictAncestors, nullable(genTypeID.typeDataArray), isMutable = false),
       make(componentType, nullable(genTypeID.typeData), isMutable = false),
-      make(name, RefType.anyref, isMutable = true),
+      make(name, RefType.externref, isMutable = true),
       make(classOfValue, nullable(genTypeID.ClassStruct), isMutable = true),
       make(arrayOf, nullable(genTypeID.ObjectVTable), isMutable = true),
       make(cloneFunction, nullable(genTypeID.cloneFunctionType), isMutable = false),
@@ -138,6 +138,8 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     genUnderlyingArrayType(genTypeID.f32Array, Float32)
     genUnderlyingArrayType(genTypeID.f64Array, Float64)
     genUnderlyingArrayType(genTypeID.anyArray, anyref)
+
+    genUnderlyingArrayType(genTypeID.externrefArray, RefType.externref)
   }
 
   private def genCoreTypesInRecType()(implicit ctx: WasmContext): Unit = {
@@ -289,7 +291,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     addGlobalHelperImport(genGlobalID.bFalse, RefType.any)
     addGlobalHelperImport(genGlobalID.bTrue, RefType.any)
     addGlobalHelperImport(genGlobalID.bZero, RefType.any)
-    addGlobalHelperImport(genGlobalID.emptyString, RefType.any)
+    addGlobalHelperImport(genGlobalID.emptyString, RefType.extern)
     addGlobalHelperImport(genGlobalID.idHashCodeMap, RefType.extern)
   }
 
@@ -354,29 +356,29 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       List(RefType.any)
     )
 
-    addHelperImport(genFunctionID.stringLength, List(RefType.any), List(Int32))
-    addHelperImport(genFunctionID.stringCharAt, List(RefType.any, Int32), List(Int32))
-    addHelperImport(genFunctionID.jsValueToString, List(RefType.any), List(RefType.any))
-    addHelperImport(genFunctionID.jsValueToStringForConcat, List(anyref), List(RefType.any))
-    addHelperImport(genFunctionID.booleanToString, List(Int32), List(RefType.any))
-    addHelperImport(genFunctionID.charToString, List(Int32), List(RefType.any))
-    addHelperImport(genFunctionID.intToString, List(Int32), List(RefType.any))
-    addHelperImport(genFunctionID.longToString, List(Int64), List(RefType.any))
-    addHelperImport(genFunctionID.doubleToString, List(Float64), List(RefType.any))
+    addHelperImport(genFunctionID.stringLength, List(RefType.extern), List(Int32))
+    addHelperImport(genFunctionID.stringCharAt, List(RefType.extern, Int32), List(Int32))
+    addHelperImport(genFunctionID.jsValueToString, List(RefType.any), List(RefType.extern))
+    addHelperImport(genFunctionID.jsValueToStringForConcat, List(anyref), List(RefType.extern))
+    addHelperImport(genFunctionID.booleanToString, List(Int32), List(RefType.extern))
+    addHelperImport(genFunctionID.charToString, List(Int32), List(RefType.extern))
+    addHelperImport(genFunctionID.intToString, List(Int32), List(RefType.extern))
+    addHelperImport(genFunctionID.longToString, List(Int64), List(RefType.extern))
+    addHelperImport(genFunctionID.doubleToString, List(Float64), List(RefType.extern))
     addHelperImport(
       genFunctionID.stringConcat,
-      List(RefType.any, RefType.any),
-      List(RefType.any)
+      List(RefType.extern, RefType.extern),
+      List(RefType.extern)
     )
     addHelperImport(genFunctionID.isString, List(anyref), List(Int32))
 
     addHelperImport(genFunctionID.jsValueType, List(RefType.any), List(Int32))
-    addHelperImport(genFunctionID.jsValueDescription, List(anyref), List(RefType.any))
+    addHelperImport(genFunctionID.jsValueDescription, List(anyref), List(RefType.extern))
     addHelperImport(genFunctionID.bigintHashCode, List(RefType.any), List(Int32))
     addHelperImport(
       genFunctionID.symbolDescription,
       List(RefType.any),
-      List(RefType.anyref)
+      List(RefType.externref)
     )
     addHelperImport(
       genFunctionID.idHashCodeGet,
@@ -389,9 +391,9 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       Nil
     )
 
-    addHelperImport(genFunctionID.jsGlobalRefGet, List(RefType.any), List(anyref))
-    addHelperImport(genFunctionID.jsGlobalRefSet, List(RefType.any, anyref), Nil)
-    addHelperImport(genFunctionID.jsGlobalRefTypeof, List(RefType.any), List(RefType.any))
+    addHelperImport(genFunctionID.jsGlobalRefGet, List(RefType.extern), List(anyref))
+    addHelperImport(genFunctionID.jsGlobalRefSet, List(RefType.extern, anyref), Nil)
+    addHelperImport(genFunctionID.jsGlobalRefTypeof, List(RefType.extern), List(RefType.any))
     addHelperImport(genFunctionID.jsNewArray, Nil, List(RefType.any))
     addHelperImport(genFunctionID.jsArrayPush, List(RefType.any, anyref), List(RefType.any))
     addHelperImport(
@@ -511,7 +513,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       // componentType
       RefNull(HeapType.None),
       // name - initially `null`; filled in by the `typeDataName` helper
-      RefNull(HeapType.None),
+      RefNull(HeapType.NoExtern),
       // the classOf instance - initially `null`; filled in by the `createClassOf` helper
       RefNull(HeapType.None),
       // arrayOf, the typeData of an array of this type - initially `null`; filled in by the `arrayTypeData` helper
@@ -790,14 +792,14 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     val offsetParam = fb.addParam("offset", Int32)
     val sizeParam = fb.addParam("size", Int32)
     val stringIndexParam = fb.addParam("stringIndex", Int32)
-    fb.setResultType(RefType.any)
+    fb.setResultType(RefType.extern)
 
-    val str = fb.addLocal("str", RefType.any)
+    val str = fb.addLocal("str", RefType.extern)
 
-    fb.block(RefType.any) { cacheHit =>
+    fb.block(RefType.extern) { cacheHit =>
       fb += GlobalGet(genGlobalID.stringLiteralCache)
       fb += LocalGet(stringIndexParam)
-      fb += ArrayGet(genTypeID.anyArray)
+      fb += ArrayGet(genTypeID.externrefArray)
 
       fb += BrOnNonNull(cacheHit)
 
@@ -810,7 +812,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       fb += ArrayNewData(genTypeID.i16Array, genDataID.string)
       fb += Call(genFunctionID.createStringFromData)
       fb += LocalTee(str)
-      fb += ArraySet(genTypeID.anyArray)
+      fb += ArraySet(genTypeID.externrefArray)
 
       fb += LocalGet(str)
     }
@@ -818,17 +820,17 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     fb.buildAndAddToModule()
   }
 
-  /** `createStringFromData: (ref array u16) -> (ref any)` (representing a `string`). */
+  /** `createStringFromData: (ref array u16) -> (ref extern)` (representing a `string`). */
   private def genCreateStringFromData()(implicit ctx: WasmContext): Unit = {
     val dataType = RefType(genTypeID.i16Array)
 
     val fb = newFunctionBuilder(genFunctionID.createStringFromData)
     val dataParam = fb.addParam("data", dataType)
-    fb.setResultType(RefType.any)
+    fb.setResultType(RefType.extern)
 
     val lenLocal = fb.addLocal("len", Int32)
     val iLocal = fb.addLocal("i", Int32)
-    val resultLocal = fb.addLocal("result", RefType.any)
+    val resultLocal = fb.addLocal("result", RefType.extern)
 
     // len := data.length
     fb += LocalGet(dataParam)
@@ -877,7 +879,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     fb.buildAndAddToModule()
   }
 
-  /** `typeDataName: (ref typeData) -> (ref any)` (representing a `string`).
+  /** `typeDataName: (ref typeData) -> (ref extern)` (representing a `string`).
    *
    *  Initializes the `name` field of the given `typeData` if that was not done yet, and returns its
    *  value.
@@ -894,14 +896,14 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
     val fb = newFunctionBuilder(genFunctionID.typeDataName)
     val typeDataParam = fb.addParam("typeData", typeDataType)
-    fb.setResultType(RefType.any)
+    fb.setResultType(RefType.extern)
 
     val componentTypeDataLocal = fb.addLocal("componentTypeData", typeDataType)
     val componentNameDataLocal = fb.addLocal("componentNameData", nameDataType)
     val firstCharLocal = fb.addLocal("firstChar", Int32)
-    val nameLocal = fb.addLocal("name", RefType.any)
+    val nameLocal = fb.addLocal("name", RefType.extern)
 
-    fb.block(RefType.any) { alreadyInitializedLabel =>
+    fb.block(RefType.extern) { alreadyInitializedLabel =>
       // br_on_non_null $alreadyInitialized typeData.name
       fb += LocalGet(typeDataParam)
       fb += StructGet(genTypeID.typeData, genFieldID.typeData.name)
@@ -915,7 +917,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       fb += StructGet(genTypeID.typeData, genFieldID.typeData.kind)
       fb += I32Const(KindArray)
       fb += I32Eq
-      fb.ifThenElse(RefType.any) {
+      fb.ifThenElse(RefType.extern) {
         // it is an array; compute its name from the component type name
 
         // <top of stack> := "[", for the CALL to stringConcat near the end
@@ -933,7 +935,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
         // switch (componentTypeData.kind)
         // the result of this switch is the string that must come after "["
-        fb.switch(RefType.any) { () =>
+        fb.switch(RefType.extern) { () =>
           // scrutinee
           fb += LocalGet(componentTypeDataLocal)
           fb += StructGet(genTypeID.typeData, genFieldID.typeData.kind)
@@ -1044,15 +1046,19 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     // "__typeData": typeData (TODO hide this better? although nobody will notice anyway)
     // (this is used by `isAssignableFromExternal`)
     fb ++= ctx.stringPool.getConstantStringInstr("__typeData")
+    fb += AnyConvertExtern
     fb += LocalGet(typeDataParam)
     fb += Call(genFunctionID.jsObjectPush)
     // "name": typeDataName(typeData)
     fb ++= ctx.stringPool.getConstantStringInstr("name")
+    fb += AnyConvertExtern
     fb += LocalGet(typeDataParam)
     fb += Call(genFunctionID.typeDataName)
+    fb += AnyConvertExtern
     fb += Call(genFunctionID.jsObjectPush)
     // "isPrimitive": (typeData.kind <= KindLastPrimitive)
     fb ++= ctx.stringPool.getConstantStringInstr("isPrimitive")
+    fb += AnyConvertExtern
     fb += LocalGet(typeDataParam)
     fb += StructGet(genTypeID.typeData, genFieldID.typeData.kind)
     fb += I32Const(KindLastPrimitive)
@@ -1061,6 +1067,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     fb += Call(genFunctionID.jsObjectPush)
     // "isArrayClass": (typeData.kind == KindArray)
     fb ++= ctx.stringPool.getConstantStringInstr("isArrayClass")
+    fb += AnyConvertExtern
     fb += LocalGet(typeDataParam)
     fb += StructGet(genTypeID.typeData, genFieldID.typeData.kind)
     fb += I32Const(KindArray)
@@ -1069,6 +1076,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     fb += Call(genFunctionID.jsObjectPush)
     // "isInterface": (typeData.kind == KindInterface)
     fb ++= ctx.stringPool.getConstantStringInstr("isInterface")
+    fb += AnyConvertExtern
     fb += LocalGet(typeDataParam)
     fb += StructGet(genTypeID.typeData, genFieldID.typeData.kind)
     fb += I32Const(KindInterface)
@@ -1077,30 +1085,35 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     fb += Call(genFunctionID.jsObjectPush)
     // "isInstance": closure(isInstance, typeData)
     fb ++= ctx.stringPool.getConstantStringInstr("isInstance")
+    fb += AnyConvertExtern
     fb += ctx.refFuncWithDeclaration(genFunctionID.isInstanceExternal)
     fb += LocalGet(typeDataParam)
     fb += Call(genFunctionID.closure)
     fb += Call(genFunctionID.jsObjectPush)
     // "isAssignableFrom": closure(isAssignableFrom, typeData)
     fb ++= ctx.stringPool.getConstantStringInstr("isAssignableFrom")
+    fb += AnyConvertExtern
     fb += ctx.refFuncWithDeclaration(genFunctionID.isAssignableFromExternal)
     fb += LocalGet(typeDataParam)
     fb += Call(genFunctionID.closure)
     fb += Call(genFunctionID.jsObjectPush)
     // "checkCast": closure(checkCast, typeData)
     fb ++= ctx.stringPool.getConstantStringInstr("checkCast")
+    fb += AnyConvertExtern
     fb += ctx.refFuncWithDeclaration(genFunctionID.checkCast)
     fb += LocalGet(typeDataParam)
     fb += Call(genFunctionID.closure)
     fb += Call(genFunctionID.jsObjectPush)
     // "getComponentType": closure(getComponentType, typeData)
     fb ++= ctx.stringPool.getConstantStringInstr("getComponentType")
+    fb += AnyConvertExtern
     fb += ctx.refFuncWithDeclaration(genFunctionID.getComponentType)
     fb += LocalGet(typeDataParam)
     fb += Call(genFunctionID.closure)
     fb += Call(genFunctionID.jsObjectPush)
     // "newArrayOfThisClass": closure(newArrayOfThisClass, typeData)
     fb ++= ctx.stringPool.getConstantStringInstr("newArrayOfThisClass")
+    fb += AnyConvertExtern
     fb += ctx.refFuncWithDeclaration(genFunctionID.newArrayOfThisClass)
     fb += LocalGet(typeDataParam)
     fb += Call(genFunctionID.closure)
@@ -1151,7 +1164,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     fb.buildAndAddToModule()
   }
 
-  /** `valueDescription: anyref -> (ref any)` (a string).
+  /** `valueDescription: anyref -> (ref extern)` (a string).
    *
    *  Returns a safe string description of a value. This helper is never called
    *  for `value === null`. As implemented, it would return `"object"` if it were.
@@ -1161,7 +1174,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
     val fb = newFunctionBuilder(genFunctionID.valueDescription)
     val valueParam = fb.addParam("value", anyref)
-    fb.setResultType(RefType.any)
+    fb.setResultType(RefType.extern)
 
     fb.block(anyref) { notOurObjectLabel =>
       fb.block(objectType) { isCharLabel =>
@@ -1356,6 +1369,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
                   fb += GlobalGet(genGlobalID.undef)
                 case StringType =>
                   fb += LocalGet(objParam)
+                  fb += ExternConvertAny
                   fb += RefAsNonNull
                 case primType: PrimTypeWithRef =>
                   fb += LocalGet(objParam)
@@ -1363,6 +1377,8 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
               }
             } else {
               fb += LocalGet(objParam)
+              if (primType == StringType)
+                fb += ExternConvertAny
             }
 
             fb += Return
@@ -1765,7 +1781,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
         )
 
         fb += LocalGet(typeDataParam) // componentType
-        fb += RefNull(HeapType.None) // name
+        fb += RefNull(HeapType.NoExtern) // name
         fb += RefNull(HeapType.None) // classOf
         fb += RefNull(HeapType.None) // arrayOf
 
@@ -1846,14 +1862,14 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     fb.buildAndAddToModule()
   }
 
-  /** `checkedStringCharAt: (ref any), i32 -> i32`.
+  /** `checkedStringCharAt: (ref extern), i32 -> i32`.
    *
    *  Accesses a char of a string by index. Used when stringIndexOutOfBounds
    *  are checked.
    */
   private def genCheckedStringCharAt()(implicit ctx: WasmContext): Unit = {
     val fb = newFunctionBuilder(genFunctionID.checkedStringCharAt)
-    val strParam = fb.addParam("str", RefType.any)
+    val strParam = fb.addParam("str", RefType.extern)
     val indexParam = fb.addParam("index", Int32)
     fb.setResultType(Int32)
 
@@ -2030,6 +2046,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
         fb ++= ctx.stringPool.getConstantStringInstr(
           "Cannot call isInstance() on a Class representing a JS trait/object"
         )
+        fb += AnyConvertExtern
         fb += Call(genFunctionID.jsArrayPush)
         fb += Call(genFunctionID.jsNew)
         fb += ExternConvertAny
@@ -2134,6 +2151,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     // load ref.cast<typeData> from["__typeData"] (as a JS selection)
     fb += LocalGet(fromParam)
     fb ++= ctx.stringPool.getConstantStringInstr("__typeData")
+    fb += AnyConvertExtern
     fb += Call(genFunctionID.jsSelect)
     fb += RefCast(RefType(typeDataType.heapType))
 
@@ -2357,6 +2375,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     // lengthsLen := lengths.length // as a JS field access
     fb += LocalGet(lengthsParam)
     fb ++= ctx.stringPool.getConstantStringInstr("length")
+    fb += AnyConvertExtern
     fb += Call(genFunctionID.jsSelect)
     fb += Call(genFunctionID.unbox(IntRef))
     fb += LocalTee(lengthsLenLocal)
@@ -2430,7 +2449,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     fb.buildAndAddToModule()
   }
 
-  /** `anyGetClassName: (ref any) -> (ref any)` (a string).
+  /** `anyGetClassName: (ref any) -> (ref extern)` (a string).
    *
    *  This is the implementation of `value.getClass().getName()`, which comes
    *  to the backend as the `ObjectClassName` intrinsic.
@@ -2438,7 +2457,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
   private def genAnyGetClassName()(implicit ctx: WasmContext): Unit = {
     val fb = newFunctionBuilder(genFunctionID.anyGetClassName)
     val valueParam = fb.addParam("value", RefType.any)
-    fb.setResultType(RefType.any)
+    fb.setResultType(RefType.extern)
 
     if (semantics.nullPointers == CheckedBehavior.Unchecked) {
       fb += LocalGet(valueParam)
@@ -2854,6 +2873,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
         },
         List(JSValueTypeString) -> { () =>
           fb += LocalGet(objNonNullLocal)
+          fb += ExternConvertAny
           fb += Call(
             genFunctionID.forMethod(Public, BoxedStringClass, hashCodeMethodName)
           )
@@ -3038,6 +3058,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     // Originally, exception is thrown from JS saying e.g. "obj2.z1__ is not a function"
     // TODO Improve the error message to include some information about the missing method
     fb ++= ctx.stringPool.getConstantStringInstr("Method not found")
+    fb += AnyConvertExtern
     fb += Call(genFunctionID.jsArrayPush)
     fb += Call(genFunctionID.jsNew)
     fb += ExternConvertAny
@@ -3166,7 +3187,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     maybeWrapInUBE(fb, semantics.arrayIndexOutOfBounds) {
       genNewScalaClass(fb, ArrayIndexOutOfBoundsExceptionClass,
           SpecialNames.StringArgConstructorName) {
-        fb += RefNull(HeapType.None)
+        fb += RefNull(HeapType.NoExtern)
       }
     }
     fb += ExternConvertAny
@@ -3347,7 +3368,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       maybeWrapInUBE(fb, semantics.arrayStores) {
         genNewScalaClass(fb, ArrayStoreExceptionClass,
             SpecialNames.StringArgConstructorName) {
-          fb += RefNull(HeapType.None)
+          fb += RefNull(HeapType.NoExtern)
         }
       }
       fb += ExternConvertAny

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -231,7 +231,10 @@ final class Emitter(config: Emitter.Config) {
         case ModuleInitializerImpl.MainMethodWithArgs(className, encodedMainMethodName, args) =>
           val stringArrayTypeRef = ArrayTypeRef(ClassRef(BoxedStringClass), 1)
           SWasmGen.genArrayValue(fb, stringArrayTypeRef, args.size) {
-            args.foreach(arg => fb ++= ctx.stringPool.getConstantStringInstr(arg))
+            for (arg <- args) {
+              fb ++= ctx.stringPool.getConstantStringInstr(arg)
+              fb += wa.AnyConvertExtern
+            }
           }
           genCallStatic(className, encodedMainMethodName)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -634,6 +634,8 @@ private class FunctionEmitter private (
         primType match {
           case NullType =>
             ()
+          case ByteType | ShortType =>
+            fb += wa.RefI31
           case CharType =>
             /* `char` and `long` are opaque to JS in the Scala.js semantics.
              * We implement them with real Wasm classes following the correct

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1518,19 +1518,53 @@ private class FunctionEmitter private (
     val BinaryOp(op, lhs, rhs) = tree
     assert(op == === || op == !==)
 
-    // TODO Optimize this when the operands have a better type than `any`
+    def maybeGenInvert(): Unit = {
+      if (op == BinaryOp.!==)
+        fb += wa.I32Eqz
+    }
 
-    genTree(lhs, AnyType)
-    genTree(rhs, AnyType)
+    val lhsType = lhs.tpe
+    val rhsType = rhs.tpe
 
-    markPosition(tree)
+    if (lhsType == NothingType) {
+      genTree(lhs, NothingType)
+      NothingType
+    } else if (rhsType == NothingType) {
+      genTree(lhs, NoType)
+      genTree(rhs, NothingType)
+      NothingType
+    } else if (rhsType == NullType) {
+      /* Note that the optimizer normalizes Literals on the right of `===`,
+       * so testing for the `lhsType == NullType` is not as useful.
+       */
+      genTree(lhs, AnyType)
+      genTree(rhs, NoType) // no-op if it is actually a Null() literal
+      markPosition(tree)
+      fb += wa.RefIsNull
+      maybeGenInvert()
+      BooleanType
+    } else {
+      val lhsWasmType = transformSingleType(lhsType)
+      val rhsWasmType = transformSingleType(rhsType)
 
-    fb += wa.Call(genFunctionID.is)
+      (lhsWasmType, rhsWasmType) match {
+        case (watpe.RefType(_, lhsHeapType), watpe.RefType(_, rhsHeapType))
+            if lhsHeapType != watpe.HeapType.Any && rhsHeapType != watpe.HeapType.Any =>
+          genTree(lhs, lhsType)
+          genTree(rhs, rhsType)
+          markPosition(tree)
+          fb += wa.RefEq
 
-    if (op == !==)
-      fb += wa.I32Eqz
+        case _ =>
+          genTree(lhs, AnyType)
+          genTree(rhs, AnyType)
+          markPosition(tree)
+          fb += wa.Call(genFunctionID.is)
+      }
 
-    BooleanType
+      maybeGenInvert()
+      BooleanType
+    }
   }
 
   private def getElementaryBinaryOpInstr(op: BinaryOp.Code): wa.Instr = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1431,7 +1431,7 @@ private class FunctionEmitter private (
 
       // String.length
       case String_length =>
-        fb += wa.Call(genFunctionID.stringLength)
+        fb += wa.Call(genFunctionID.stringBuiltins.length)
     }
 
     tree.tpe
@@ -1524,7 +1524,7 @@ private class FunctionEmitter private (
         genTree(rhs, IntType)
         markPosition(tree)
         if (semantics.stringIndexOutOfBounds == CheckedBehavior.Unchecked)
-          fb += wa.Call(genFunctionID.stringCharAt)
+          fb += wa.Call(genFunctionID.stringBuiltins.charCodeAt)
         else
           fb += wa.Call(genFunctionID.checkedStringCharAt)
         CharType
@@ -1549,6 +1549,12 @@ private class FunctionEmitter private (
         fb += wa.I32Eqz
     }
 
+    def isStringType(tpe: Type): Boolean = tpe match {
+      case StringType                     => true
+      case ClassType(BoxedStringClass, _) => true
+      case _                              => false
+    }
+
     val lhsType = lhs.tpe
     val rhsType = rhs.tpe
 
@@ -1567,6 +1573,13 @@ private class FunctionEmitter private (
       genTree(rhs, NoType) // no-op if it is actually a Null() literal
       markPosition(tree)
       fb += wa.RefIsNull
+      maybeGenInvert()
+      BooleanType
+    } else if (isStringType(lhsType) && isStringType(rhsType)) {
+      genTree(lhs, ClassType(BoxedStringClass, nullable = lhs.tpe.isNullable))
+      genTree(rhs, ClassType(BoxedStringClass, nullable = rhs.tpe.isNullable))
+      markPosition(tree)
+      fb += wa.Call(genFunctionID.stringBuiltins.equals)
       maybeGenInvert()
       BooleanType
     } else {
@@ -1674,7 +1687,7 @@ private class FunctionEmitter private (
         genToStringForConcat(lhs)
         genToStringForConcat(rhs)
         markPosition(tree)
-        fb += wa.Call(genFunctionID.stringConcat)
+        fb += wa.Call(genFunctionID.stringBuiltins.concat)
     }
 
     StringType
@@ -1780,7 +1793,7 @@ private class FunctionEmitter private (
           case BooleanType =>
             fb += wa.Call(genFunctionID.booleanToString)
           case CharType =>
-            fb += wa.Call(genFunctionID.charToString)
+            fb += wa.Call(genFunctionID.stringBuiltins.fromCharCode)
           case ByteType | ShortType | IntType =>
             fb += wa.Call(genFunctionID.intToString)
           case LongType =>
@@ -1941,7 +1954,8 @@ private class FunctionEmitter private (
       case UndefType =>
         fb += wa.Call(genFunctionID.isUndef)
       case StringType =>
-        fb += wa.Call(genFunctionID.isString)
+        fb += wa.ExternConvertAny
+        fb += wa.Call(genFunctionID.stringBuiltins.test)
       case CharType =>
         val structTypeID = genTypeID.forClass(SpecialNames.CharBoxClass)
         fb += wa.RefTest(watpe.RefType(structTypeID))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -633,7 +633,10 @@ private class FunctionEmitter private (
         // box
         primType match {
           case NullType =>
-            ()
+            expectedType match {
+              case ClassType(BoxedStringClass, true) => fb += wa.ExternConvertAny
+              case _                                 => ()
+            }
           case ByteType | ShortType =>
             fb += wa.RefI31
           case CharType =>
@@ -655,6 +658,11 @@ private class FunctionEmitter private (
              * representation, which we can store in an `anyref`.
              */
             fb += wa.Call(genFunctionID.box(primType.primRef))
+        }
+      case (StringType | ClassType(BoxedStringClass, _), _) =>
+        expectedType match {
+          case ClassType(BoxedStringClass, _) => ()
+          case _                              => fb += wa.AnyConvertExtern
         }
       case _ =>
         ()
@@ -716,6 +724,14 @@ private class FunctionEmitter private (
 
             genCheckNonNullFor(array)
 
+            def genRhs(): Unit = {
+              genTree(rhs, lhs.tpe)
+              lhs.tpe match {
+                case ClassType(BoxedStringClass, _) => fb += wa.AnyConvertExtern
+                case _                              => ()
+              }
+            }
+
             if (semantics.arrayIndexOutOfBounds == CheckedBehavior.Unchecked &&
                 (semantics.arrayStores == CheckedBehavior.Unchecked || isPrimArray)) {
               // Get the underlying array
@@ -724,12 +740,12 @@ private class FunctionEmitter private (
                 genFieldID.objStruct.arrayUnderlying
               )
               genTree(index, IntType)
-              genTree(rhs, lhs.tpe)
+              genRhs()
               markPosition(tree)
               fb += wa.ArraySet(genTypeID.underlyingOf(arrayTypeRef))
             } else {
               genTree(index, IntType)
-              genTree(rhs, lhs.tpe)
+              genRhs()
               markPosition(tree)
               fb += wa.Call(genFunctionID.arraySetFor(arrayTypeRef))
             }
@@ -1065,7 +1081,8 @@ private class FunctionEmitter private (
           pushArgs(argsLocals)
           genHijackedClassCall(BoxedDoubleClass)
         } else if (receiverClassName == CharSequenceClass) {
-          // the value must be a `string`; it already has the right type
+          // the value must be a `string`
+          fb += wa.ExternConvertAny
           pushArgs(argsLocals)
           genHijackedClassCall(BoxedStringClass)
         } else if (methodName == compareToMethodName) {
@@ -1097,7 +1114,7 @@ private class FunctionEmitter private (
             // case JSValueTypeString =>
             List(JSValueTypeString) -> { () =>
               fb += wa.LocalGet(receiverLocal)
-              // no need to unbox for string
+              fb += wa.ExternConvertAny
               pushArgs(argsLocals)
               genHijackedClassCall(BoxedStringClass)
             }
@@ -1267,6 +1284,13 @@ private class FunctionEmitter private (
        * `Labeled` in statement position, since they must have a non-`void`
        * type in the IR but they get a `void` expected type.
        */
+      expectedType
+    } else if (tree.isInstanceOf[Null] && expectedType == ClassType(BoxedStringClass, true)) {
+      /* Directly emit a `ref.null noextern` instead of requiring an
+       * `extern.convert_from_any` in `genAdapt`.
+       */
+      markPosition(tree)
+      fb += wa.RefNull(watpe.HeapType.NoExtern)
       expectedType
     } else {
       markPosition(tree)
@@ -1549,9 +1573,19 @@ private class FunctionEmitter private (
       val lhsWasmType = transformSingleType(lhsType)
       val rhsWasmType = transformSingleType(rhsType)
 
+      def isSubEq(heapType: watpe.HeapType): Boolean = heapType match {
+        case watpe.HeapType.Any | watpe.HeapType.Extern =>
+          false
+        case _ =>
+          /* All other ref types *that we return from transformSingleType* are
+           * sub-heap-types of `eq`.
+           */
+          true
+      }
+
       (lhsWasmType, rhsWasmType) match {
         case (watpe.RefType(_, lhsHeapType), watpe.RefType(_, rhsHeapType))
-            if lhsHeapType != watpe.HeapType.Any && rhsHeapType != watpe.HeapType.Any =>
+            if isSubEq(lhsHeapType) && isSubEq(rhsHeapType) =>
           genTree(lhs, lhsType)
           genTree(rhs, rhsType)
           markPosition(tree)
@@ -1669,7 +1703,7 @@ private class FunctionEmitter private (
          *
          * The overall structure of the generated code is as follows:
          *
-         * block (ref any) $done
+         * block (ref extern) $done
          *   block $isNull
          *     load receiver as (ref null java.lang.Object)
          *     br_on_null $isNull
@@ -1680,7 +1714,7 @@ private class FunctionEmitter private (
          * end $done
          */
 
-        fb.block(watpe.RefType.any) { labelDone =>
+        fb.block(watpe.RefType.extern) { labelDone =>
           fb.block() { labelIsNull =>
             genTreeAuto(tree)
             markPosition(tree)
@@ -1697,7 +1731,7 @@ private class FunctionEmitter private (
          *
          * The overall structure of the generated code is as follows:
          *
-         * block (ref any) $done
+         * block (ref extern) $done
          *   block anyref $notOurObject
          *     load receiver
          *     br_on_cast_fail anyref (ref $java.lang.Object) $notOurObject
@@ -1709,7 +1743,7 @@ private class FunctionEmitter private (
          * end $done
          */
 
-        fb.block(watpe.RefType.any) { labelDone =>
+        fb.block(watpe.RefType.extern) { labelDone =>
           // First try the case where the value is one of our objects
           fb.block(watpe.RefType.anyref) { labelNotOurObject =>
             // Load receiver
@@ -1767,10 +1801,16 @@ private class FunctionEmitter private (
 
       case ClassType(BoxedStringClass, nullable) =>
         // Common case for which we want to avoid the hijacked class dispatch
-        genTreeAuto(tree)
-        markPosition(tree)
-        if (nullable)
-          fb += wa.Call(genFunctionID.jsValueToStringForConcat)
+        if (nullable) {
+          fb.block(watpe.RefType.extern) { notNullLabel =>
+            genTreeAuto(tree)
+            markPosition(tree)
+            fb += wa.BrOnNonNull(notNullLabel)
+            fb ++= ctx.stringPool.getConstantStringInstr("null")
+          }
+        } else {
+          genTreeAuto(tree)
+        }
 
       case ClassType(className, _) =>
         genWithDispatch(ctx.getClassInfo(className).isAncestorOfHijackedClass)
@@ -2093,6 +2133,10 @@ private class FunctionEmitter private (
               targetWasmType match {
                 case watpe.RefType(true, watpe.HeapType.Any) =>
                   () // nothing to do
+                case watpe.RefType(targetNullable, watpe.HeapType.Extern) =>
+                  fb += wa.ExternConvertAny
+                  if (!targetNullable)
+                    fb += wa.RefAsNonNull
                 case targetWasmType: watpe.RefType =>
                   fb += wa.RefCast(targetWasmType)
                 case _ =>
@@ -2118,7 +2162,8 @@ private class FunctionEmitter private (
         fb += wa.GlobalGet(genGlobalID.undef)
 
       case StringType =>
-        val sig = watpe.FunctionType(List(watpe.RefType.anyref), List(watpe.RefType.any))
+        fb += wa.ExternConvertAny
+        val sig = watpe.FunctionType(List(watpe.RefType.externref), List(watpe.RefType.extern))
         fb.block(sig) { nonNullLabel =>
           fb += wa.BrOnNonNull(nonNullLabel)
           fb += wa.GlobalGet(genGlobalID.emptyString)
@@ -2911,6 +2956,10 @@ private class FunctionEmitter private (
               case watpe.RefType.anyref =>
                 // nothing to do
                 ()
+              case watpe.RefType(nullable, watpe.HeapType.Extern) =>
+                fb += wa.ExternConvertAny
+                if (!nullable)
+                  fb += wa.RefAsNonNull
               case refType: watpe.RefType =>
                 fb += wa.RefCast(refType)
               case otherType =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -106,24 +106,18 @@ const scalaJSHelpers = {
 
   // Boxes (upcast) -- most are identity at the JS level but with different types in Wasm
   bZ: (x) => x !== 0,
-  bB: (x) => x,
-  bS: (x) => x,
   bIFallback: (x) => x,
   bF: (x) => x,
   bD: (x) => x,
 
   // Unboxes (downcast, null is converted to the zero of the type as part of ToWebAssemblyValue)
   uZ: (x) => x, // ToInt32 turns false into 0 and true into 1, so this is also an identity
-  uB: (x) => x,
-  uS: (x) => x,
   uIFallback: (x) => x,
   uF: (x) => x,
   uD: (x) => x,
 
   // Type tests
   tZ: (x) => typeof x === 'boolean',
-  tB: (x) => typeof x === 'number' && Object.is((x << 24) >> 24, x),
-  tS: (x) => typeof x === 'number' && Object.is((x << 16) >> 16, x),
   tI: (x) => typeof x === 'number' && Object.is(x | 0, x),
   tF: (x) => typeof x === 'number' && (Math.fround(x) === x || x !== x),
   tD: (x) => typeof x === 'number',

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -108,7 +108,7 @@ const scalaJSHelpers = {
   bZ: (x) => x !== 0,
   bB: (x) => x,
   bS: (x) => x,
-  bI: (x) => x,
+  bIFallback: (x) => x,
   bF: (x) => x,
   bD: (x) => x,
 
@@ -116,7 +116,7 @@ const scalaJSHelpers = {
   uZ: (x) => x, // ToInt32 turns false into 0 and true into 1, so this is also an identity
   uB: (x) => x,
   uS: (x) => x,
-  uI: (x) => x,
+  uIFallback: (x) => x,
   uF: (x) => x,
   uD: (x) => x,
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -137,17 +137,12 @@ const scalaJSHelpers = {
 
   // Strings
   emptyString: "",
-  stringLength: (s) => s.length,
-  stringCharAt: (s, i) => s.charCodeAt(i),
   jsValueToString: (x) => (x === void 0) ? "undefined" : x.toString(),
   jsValueToStringForConcat: (x) => "" + x,
   booleanToString: (b) => b ? "true" : "false",
-  charToString: (c) => String.fromCharCode(c),
   intToString: (i) => "" + i,
   longToString: (l) => "" + l, // l must be a bigint here
   doubleToString: (d) => "" + d,
-  stringConcat: (x, y) => ("" + x) + y, // the added "" is for the case where x === y === null
-  isString: (x) => typeof x === 'string',
 
   // Get the type of JS value of `x` in a single JS helper call, for the purpose of dispatch.
   jsValueType: (x) => {
@@ -308,12 +303,25 @@ const scalaJSHelpers = {
   },
 }
 
+const stringBuiltinPolyfills = {
+  test: (x) => typeof x === 'string',
+  fromCharCode: (c) => String.fromCharCode(c),
+  charCodeAt: (s, i) => s.charCodeAt(i),
+  length: (s) => s.length,
+  concat: (a, b) => "" + a + b,
+  equals: (a, b) => a === b,
+};
+
 export async function load(wasmFileURL, importedModules, exportSetters) {
   const myScalaJSHelpers = { ...scalaJSHelpers, idHashCodeMap: new WeakMap() };
   const importsObj = {
     "__scalaJSHelpers": myScalaJSHelpers,
     "__scalaJSImports": importedModules,
     "__scalaJSExportSetters": exportSetters,
+    "wasm:js-string": stringBuiltinPolyfills,
+  };
+  const options = {
+    builtins: ["js-string"],
   };
   const resolvedURL = new URL(wasmFileURL, import.meta.url);
   if (resolvedURL.protocol === 'file:') {
@@ -321,9 +329,9 @@ export async function load(wasmFileURL, importedModules, exportSetters) {
     const { readFile } = await import("node:fs/promises");
     const wasmPath = fileURLToPath(resolvedURL);
     const body = await readFile(wasmPath);
-    return WebAssembly.instantiate(body, importsObj);
+    return WebAssembly.instantiate(body, importsObj, options);
   } else {
-    return await WebAssembly.instantiateStreaming(fetch(resolvedURL), importsObj);
+    return await WebAssembly.instantiateStreaming(fetch(resolvedURL), importsObj, options);
   }
 }
     """

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -100,12 +100,12 @@ const scalaJSHelpers = {
   undef: void 0,
   isUndef: (x) => x === (void 0),
 
-  // Zero boxes
+  // Constant boxes
   bFalse: false,
+  bTrue: true,
   bZero: 0,
 
   // Boxes (upcast) -- most are identity at the JS level but with different types in Wasm
-  bZ: (x) => x !== 0,
   bIFallback: (x) => x,
   bF: (x) => x,
   bD: (x) => x,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -35,6 +35,9 @@ object SWasmGen {
       case StringType => GlobalGet(genGlobalID.emptyString)
       case UndefType  => GlobalGet(genGlobalID.undef)
 
+      case ClassType(BoxedStringClass, true) =>
+        RefNull(Types.HeapType.NoExtern)
+
       case AnyType | ClassType(_, true) | ArrayType(_, true) | NullType =>
         RefNull(Types.HeapType.None)
 
@@ -119,6 +122,7 @@ object SWasmGen {
     def genFollowPath(path: List[String]): Unit = {
       for (prop <- path) {
         fb ++= ctx.stringPool.getConstantStringInstr(prop)
+        fb += AnyConvertExtern
         fb += Call(genFunctionID.jsSelect)
       }
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/StringPool.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/StringPool.scala
@@ -90,11 +90,11 @@ private[wasmemitter] final class StringPool {
         genGlobalID.stringLiteralCache,
         OriginalName("stringLiteralCache"),
         isMutable = false,
-        RefType(genTypeID.anyArray),
+        RefType(genTypeID.externrefArray),
         Expr(
           List(
             I32Const(nextIndex), // number of entries in the pool
-            ArrayNewDefault(genTypeID.anyArray)
+            ArrayNewDefault(genTypeID.externrefArray)
           )
         )
       )

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
@@ -102,7 +102,9 @@ object TypeTransformer {
       implicit ctx: WasmContext): watpe.RefType = {
     val heapType: watpe.HeapType = ctx.getClassInfoOption(className) match {
       case Some(info) =>
-        if (info.isAncestorOfHijackedClass)
+        if (className == BoxedStringClass)
+          watpe.HeapType.Extern // for all the JS string builtin functions
+        else if (info.isAncestorOfHijackedClass)
           watpe.HeapType.Any
         else if (!info.hasInstances)
           watpe.HeapType.None
@@ -129,7 +131,7 @@ object TypeTransformer {
       case LongType    => watpe.Int64
       case FloatType   => watpe.Float32
       case DoubleType  => watpe.Float64
-      case StringType  => watpe.RefType.any
+      case StringType  => watpe.RefType.extern
       case NullType    => watpe.RefType.nullref
 
       case NoType | NothingType =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -127,6 +127,9 @@ object VarGen {
       override def toString(): String = "t" + primRef.charCode
     }
 
+    case object bIFallback extends JSHelperFunctionID
+    case object uIFallback extends JSHelperFunctionID
+
     case object fmod extends JSHelperFunctionID
 
     case object closure extends JSHelperFunctionID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -56,6 +56,7 @@ object VarGen {
     case object jsLinkingInfo extends JSHelperGlobalID
     case object undef extends JSHelperGlobalID
     case object bFalse extends JSHelperGlobalID
+    case object bTrue extends JSHelperGlobalID
     case object bZero extends JSHelperGlobalID
     case object emptyString extends JSHelperGlobalID
     case object idHashCodeMap extends JSHelperGlobalID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -141,17 +141,12 @@ object VarGen {
     case object makeExportedDef extends JSHelperFunctionID
     case object makeExportedDefRest extends JSHelperFunctionID
 
-    case object stringLength extends JSHelperFunctionID
-    case object stringCharAt extends JSHelperFunctionID
     case object jsValueToString extends JSHelperFunctionID // for actual toString() call
     case object jsValueToStringForConcat extends JSHelperFunctionID
     case object booleanToString extends JSHelperFunctionID
-    case object charToString extends JSHelperFunctionID
     case object intToString extends JSHelperFunctionID
     case object longToString extends JSHelperFunctionID
     case object doubleToString extends JSHelperFunctionID
-    case object stringConcat extends JSHelperFunctionID
-    case object isString extends JSHelperFunctionID
 
     case object jsValueType extends JSHelperFunctionID
     case object jsValueDescription extends JSHelperFunctionID
@@ -278,6 +273,17 @@ object VarGen {
     case object arrayCopyCheckBounds extends FunctionID
     case object slowRefArrayCopy extends FunctionID
     case object genericArrayCopy extends FunctionID
+
+    // String builtins
+
+    object stringBuiltins {
+      case object test extends JSHelperFunctionID
+      case object fromCharCode extends JSHelperFunctionID
+      case object charCodeAt extends JSHelperFunctionID
+      case object length extends JSHelperFunctionID
+      case object concat extends JSHelperFunctionID
+      case object equals extends JSHelperFunctionID
+    }
   }
 
   object genFieldID {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -461,6 +461,9 @@ object VarGen {
     case object f64Array extends TypeID
     case object anyArray extends TypeID
 
+    // for the array of cached string constants
+    case object externrefArray extends TypeID
+
     def underlyingOf(arrayTypeRef: ArrayTypeRef): TypeID = {
       if (arrayTypeRef.dimensions > 1) {
         anyArray

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/BinaryWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/BinaryWriter.scala
@@ -440,6 +440,9 @@ private sealed class BinaryWriter(module: Module, emitDebugInfo: Boolean) {
       case F32Const(v) => buf.f32(v)
       case F64Const(v) => buf.f64(v)
 
+      case Select(resultTypes) =>
+        buf.vec(resultTypes)(writeType(_))
+
       case BrTable(labelIdxVector, defaultLabelIdx) =>
         buf.vec(labelIdxVector)(writeLabelIdx(_))
         writeLabelIdx(defaultLabelIdx)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
@@ -156,6 +156,9 @@ object Instructions {
 
   case object Drop extends SimpleInstr("drop", 0x1A)
 
+  final case class Select(resultTypes: List[Type])
+      extends Instr("select", if (resultTypes.isEmpty) 0x1B else 0x1C)
+
   final case class TryTable(i: BlockType, cs: List[CatchClause], label: Option[LabelID] = None)
       extends Instr("try_table", 0x1F) with StructuredLabeledInstr
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/TextWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/TextWriter.scala
@@ -470,6 +470,9 @@ private class TextWriter(module: Module) {
       case F32Const(v) => writeFloatString(v.toDouble)
       case F64Const(v) => writeFloatString(v)
 
+      case Select(resultTypes) =>
+        resultTypes.foreach(writeType(_))
+
       case BrTable(labelIdxVector, defaultLabelIdx) =>
         labelIdxVector.foreach(appendName(_))
         appendName(defaultLabelIdx)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Types.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Types.scala
@@ -83,6 +83,9 @@ object Types {
     /** `(ref null func)`, i.e., `funcref`. */
     val funcref: RefType = nullable(HeapType.Func)
 
+    /** `(ref i31)`. */
+    val i31: RefType = apply(HeapType.I31)
+
     /** `(ref extern)`. */
     val extern: RefType = apply(HeapType.Extern)
 
@@ -119,6 +122,7 @@ object Types {
     case object Extern extends AbsHeapType("extern", "externref", 0x6F)
     case object Any extends AbsHeapType("any", "anyref", 0x6E)
     case object Eq extends AbsHeapType("eq", "eqref", 0x6D)
+    case object I31 extends AbsHeapType("i31", "i31ref", 0x6C)
     case object Struct extends AbsHeapType("struct", "structref", 0x6B)
     case object Array extends AbsHeapType("array", "arrayref", 0x6A)
     case object Exn extends AbsHeapType("exn", "exnref", 0x69)


### PR DESCRIPTION
JS string builtins are not yet at stage 4 of standardization, but they have been pretty stable recently, except for string literals.

We now use some of the builtins to implement our primitive operations on strings. We provide polyfills for Wasm engines that do not yet recognize string builtins.

Benchmarks showed that we get significant performance boosts from these builtins.