### PR TITLE
Wasm: Use dedicated helpers to support some operations of the core lib.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -177,6 +177,24 @@ const scalaJSHelpers = {
   idHashCodeGet: (map, obj) => map.get(obj) | 0, // undefined becomes 0
   idHashCodeSet: (map, obj, value) => map.set(obj, value),
 
+  // Some support functions for CoreWasmLib
+  genJSTypeMetaData: (typeData, name, isPrimitive, isArrayClass, isInterface, isInstanceFun,
+      isAssignableFromFun, checkCastFun, getComponentTypeFun, newArrayOfThisClassFun) => ({
+    __typeData: typeData, // (TODO hide this better? although nobody will notice anyway)
+    "name": name,
+    "isPrimitive": isPrimitive !== 0,
+    "isArrayClass": isArrayClass !== 0,
+    "isInterface": isInterface !== 0,
+    "isInstance": (value) => isInstanceFun(typeData, value) !== 0,
+    "isAssignableFrom": (that) => isAssignableFromFun(typeData, that.__typeData) !== 0,
+    "checkCast": (value) => checkCastFun(typeData, value),
+    "getComponentType": () => getComponentTypeFun(typeData),
+    "newArrayOfThisClass": (lengths) => newArrayOfThisClassFun(typeData, lengths),
+  }),
+  makeTypeError: (msg) => new TypeError(msg),
+  jsArrayLength: (array) => array.length,
+  jsArrayGetInt: (array, index) => array[index],
+
   // JS interop
   jsGlobalRefGet: (globalRefName) => (new Function("return " + globalRefName))(),
   jsGlobalRefSet: (globalRefName, v) => {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -156,6 +156,11 @@ object VarGen {
     case object idHashCodeGet extends JSHelperFunctionID
     case object idHashCodeSet extends JSHelperFunctionID
 
+    case object genJSTypeMetaData extends JSHelperFunctionID
+    case object makeTypeError extends JSHelperFunctionID
+    case object jsArrayLength extends JSHelperFunctionID
+    case object jsArrayGetInt extends JSHelperFunctionID
+
     case object jsGlobalRefGet extends JSHelperFunctionID
     case object jsGlobalRefSet extends JSHelperFunctionID
     case object jsGlobalRefTypeof extends JSHelperFunctionID
@@ -247,9 +252,7 @@ object VarGen {
     case object throwNullPointerException extends FunctionID
     case object checkedStringCharAt extends FunctionID
     case object throwModuleInitError extends FunctionID
-    case object isInstanceExternal extends FunctionID
     case object isInstance extends FunctionID
-    case object isAssignableFromExternal extends FunctionID
     case object isAssignableFrom extends FunctionID
     case object checkCast extends FunctionID
     case object getComponentType extends FunctionID


### PR DESCRIPTION
Previously, the core lib itself used the general-purpose JS interop helpers. That was fine, but required several round-trips for no good reason. We now use dedicated helpers instead.

---

This used to be the first commit of #5023.