### PR TITLE
Complete methods of Character about code points in char sequences.

### DIFF
--- a/javalib/src/main/scala/java/lang/CharSequence.scala
+++ b/javalib/src/main/scala/java/lang/CharSequence.scala
@@ -18,3 +18,31 @@ trait CharSequence {
   def subSequence(start: scala.Int, end: scala.Int): CharSequence
   def toString(): String
 }
+
+private[lang] object CharSequence {
+  /** Wraps an `Array[Char]` as a `CharSequence` to reuse algorithms.
+   *
+   *  `subSequence` has an inefficient implementation. Avoid using this class
+   *  for algorithms that use that method.
+   */
+  @inline
+  private[lang] def ofArray(array: Array[Char]): OfArray = new OfArray(array)
+
+  /** Wraps an `Array[Char]` as a `CharSequence` to reuse algorithms.
+   *
+   *  `subSequence` has an inefficient implementation. Avoid using this class
+   *  for algorithms that use that method.
+   */
+  @inline
+  private[lang] final class OfArray(array: Array[Char]) extends CharSequence {
+    def length(): Int = array.length
+    def charAt(index: Int): Char = array(index)
+
+    // This is not efficient but we do not actually use it
+    def subSequence(start: Int, end: Int): CharSequence =
+      new OfArray(java.util.Arrays.copyOfRange(array, start, end))
+
+    override def toString(): String =
+      String.valueOf(array)
+  }
+}

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -59,73 +59,21 @@ final class _String private () // scalastyle:ignore
       charAt(index) // bounds check
       this.asInstanceOf[js.Dynamic].codePointAt(index).asInstanceOf[Int]
     } else {
-      val high = charAt(index)
-      if (index+1 < length()) {
-        val low = charAt(index+1)
-        if (Character.isSurrogatePair(high, low))
-          Character.toCodePoint(high, low)
-        else
-          high.toInt
-      } else {
-        high.toInt
-      }
+      Character.codePointAtImpl(this, index)
     }
   }
 
-  def codePointBefore(index: Int): Int = {
-    val low = charAt(index - 1)
-    if (index > 1) {
-      val high = charAt(index - 2)
-      if (Character.isSurrogatePair(high, low))
-        Character.toCodePoint(high, low)
-      else
-        low.toInt
-    } else {
-      low.toInt
-    }
-  }
+  @noinline
+  def codePointBefore(index: Int): Int =
+    Character.codePointBeforeImpl(this, index)
 
+  @noinline
   def codePointCount(beginIndex: Int, endIndex: Int): Int =
-    Character.codePointCount(this, beginIndex, endIndex)
+    Character.codePointCountImpl(this, beginIndex, endIndex)
 
-  def offsetByCodePoints(index: Int, codePointOffset: Int): Int = {
-    val len = length()
-    if (index < 0 || index > len)
-      throw new StringIndexOutOfBoundsException(index)
-
-    if (codePointOffset >= 0) {
-      var i = 0
-      var result = index
-      while (i != codePointOffset) {
-        if (result >= len)
-          throw new StringIndexOutOfBoundsException
-        if ((result < len - 1) &&
-            Character.isHighSurrogate(charAt(result)) &&
-            Character.isLowSurrogate(charAt(result + 1))) {
-          result += 2
-        } else {
-          result += 1
-        }
-        i += 1
-      }
-      result
-    } else {
-      var i = 0
-      var result = index
-      while (i != codePointOffset) {
-        if (result <= 0)
-          throw new StringIndexOutOfBoundsException
-        if ((result > 1) && Character.isLowSurrogate(charAt(result - 1)) &&
-            Character.isHighSurrogate(charAt(result - 2))) {
-          result -= 2
-        } else {
-          result -= 1
-        }
-        i -= 1
-      }
-      result
-    }
-  }
+  @noinline
+  def offsetByCodePoints(index: Int, codePointOffset: Int): Int =
+    Character.offsetByCodePointsImpl(this, index, codePointOffset)
 
   override def hashCode(): Int = {
     var res = 0
@@ -720,7 +668,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     val len = length()
     var j = i
     while (j != len) {
-      val cp = codePointAt(j)
+      val cp = this.codePointAt(j)
       if (combiningClassNoneOrAboveOrOther(cp) != CombiningClassIsOther)
         return j
       j += charCount(cp)
@@ -734,7 +682,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     import Character._
     var j = i
     while (j > 0) {
-      val cp = codePointBefore(j)
+      val cp = this.codePointBefore(j)
       if (combiningClassNoneOrAboveOrOther(cp) != CombiningClassIsOther)
         return j
       j -= charCount(cp)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
@@ -14,6 +14,7 @@ package org.scalajs.testsuite.javalib.lang
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
@@ -297,6 +298,164 @@ class CharacterTest {
     assertEquals('9', Character.forDigit(9, 10))
   }
 
+  @Test def codePointAtCharSequence(): Unit = {
+    assertEquals(0x61, Character.codePointAt("abc\ud834\udf06def", 0))
+    assertEquals(0x1d306, Character.codePointAt("abc\ud834\udf06def", 3))
+    assertEquals(0xdf06, Character.codePointAt("abc\ud834\udf06def", 4))
+    assertEquals(0x64, Character.codePointAt("abc\ud834\udf06def", 5))
+    assertEquals(0x1d306, Character.codePointAt("\ud834\udf06def", 0))
+    assertEquals(0xdf06, Character.codePointAt("\ud834\udf06def", 1))
+    assertEquals(0xd834, Character.codePointAt("\ud834abc", 0))
+    assertEquals(0xdf06, Character.codePointAt("\udf06abc", 0))
+    assertEquals(0xd834, Character.codePointAt("abc\ud834", 3))
+  }
+
+  @Test def codePointAtCharSequenceIndexOutOfBounds(): Unit = {
+    assumeTrue("Assuming compliant StringIndexOutOfBounds",
+        hasCompliantStringIndexOutOfBounds)
+
+    assertThrows(classOf[StringIndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def", -1))
+    assertThrows(classOf[StringIndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def", 8))
+    assertThrows(classOf[StringIndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def", 15))
+  }
+
+  @Test def codePointAtArray(): Unit = {
+    assertEquals(0x61, Character.codePointAt("abc\ud834\udf06def".toCharArray(), 0))
+    assertEquals(0x1d306, Character.codePointAt("abc\ud834\udf06def".toCharArray(), 3))
+    assertEquals(0xdf06, Character.codePointAt("abc\ud834\udf06def".toCharArray(), 4))
+    assertEquals(0x64, Character.codePointAt("abc\ud834\udf06def".toCharArray(), 5))
+    assertEquals(0x1d306, Character.codePointAt("\ud834\udf06def".toCharArray(), 0))
+    assertEquals(0xdf06, Character.codePointAt("\ud834\udf06def".toCharArray(), 1))
+    assertEquals(0xd834, Character.codePointAt("\ud834abc".toCharArray(), 0))
+    assertEquals(0xdf06, Character.codePointAt("\udf06abc".toCharArray(), 0))
+    assertEquals(0xd834, Character.codePointAt("abc\ud834".toCharArray(), 3))
+  }
+
+  @Test def codePointAtArrayIndexOutOfBounds(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+        hasCompliantArrayIndexOutOfBounds)
+
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), -1))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), 8))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), 15))
+  }
+
+  @Test def codePointAtArrayWithLimit(): Unit = {
+    assertEquals(0x61, Character.codePointAt("abc\ud834\udf06def".toCharArray(), 0, 3))
+    assertEquals(0x1d306, Character.codePointAt("abc\ud834\udf06def".toCharArray(), 3, 5))
+    assertEquals(0xdf06, Character.codePointAt("abc\ud834\udf06def".toCharArray(), 4, 5))
+    assertEquals(0x64, Character.codePointAt("abc\ud834\udf06def".toCharArray(), 5, 8))
+    assertEquals(0x1d306, Character.codePointAt("\ud834\udf06def".toCharArray(), 0, 2))
+    assertEquals(0xdf06, Character.codePointAt("\ud834\udf06def".toCharArray(), 1, 2))
+    assertEquals(0xd834, Character.codePointAt("\ud834\udf06def".toCharArray(), 0, 1))
+    assertEquals(0xdf06, Character.codePointAt("\ud834\udf06def".toCharArray(), 1, 2))
+    assertEquals(0xd834, Character.codePointAt("\ud834abc".toCharArray(), 0, 3))
+    assertEquals(0xdf06, Character.codePointAt("\udf06abc".toCharArray(), 0, 1))
+    assertEquals(0xd834, Character.codePointAt("abc\ud834".toCharArray(), 3, 4))
+  }
+
+  @Test def codePointAtArrayWithLimitIndexOutOfBounds(): Unit = {
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), -1, 3))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), 8, 8))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), 15, 5))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), 3, 1))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), 3, 3))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), -1, 0))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), -5, -2))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointAt("abc\ud834\udf06def".toCharArray(), 5, 10))
+  }
+
+  @Test def codePointBeforeCharSequence(): Unit = {
+    assertEquals(0x61, Character.codePointBefore("abc\ud834\udf06def", 1))
+    assertEquals(0x1d306, Character.codePointBefore("abc\ud834\udf06def", 5))
+    assertEquals(0xd834, Character.codePointBefore("abc\ud834\udf06def", 4))
+    assertEquals(0x64, Character.codePointBefore("abc\ud834\udf06def", 6))
+    assertEquals('f'.toInt, Character.codePointBefore("abc\ud834\udf06def", 8))
+    assertEquals(0x1d306, Character.codePointBefore("\ud834\udf06def", 2))
+    assertEquals(0xd834, Character.codePointBefore("\ud834\udf06def", 1))
+    assertEquals(0xd834, Character.codePointBefore("\ud834abc", 1))
+    assertEquals(0xdf06, Character.codePointBefore("\udf06abc", 1))
+  }
+
+  @Test def codePointBeforeCharSequenceIndexOutOfBounds(): Unit = {
+    assumeTrue("Assuming compliant StringIndexOutOfBounds",
+        hasCompliantStringIndexOutOfBounds)
+
+    assertThrows(classOf[StringIndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def", -5))
+    assertThrows(classOf[StringIndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def", 0))
+    assertThrows(classOf[StringIndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def", 9))
+    assertThrows(classOf[StringIndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def", 15))
+  }
+
+  @Test def codePointBeforeArray(): Unit = {
+    assertEquals(0x61, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 1))
+    assertEquals(0x1d306, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 5))
+    assertEquals(0xd834, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 4))
+    assertEquals(0x64, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 6))
+    assertEquals('f'.toInt, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 8))
+    assertEquals(0x1d306, Character.codePointBefore("\ud834\udf06def".toCharArray(), 2))
+    assertEquals(0xd834, Character.codePointBefore("\ud834\udf06def".toCharArray(), 1))
+    assertEquals(0xd834, Character.codePointBefore("\ud834abc".toCharArray(), 1))
+    assertEquals(0xdf06, Character.codePointBefore("\udf06abc".toCharArray(), 1))
+  }
+
+  @Test def codePointBeforeArrayIndexOutOfBounds(): Unit = {
+    assumeTrue("Assuming compliant ArrayIndexOutOfBounds",
+        hasCompliantArrayIndexOutOfBounds)
+
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), -5))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 0))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 9))
+    assertThrows(classOf[ArrayIndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 15))
+  }
+
+  @Test def codePointBeforeArrayWithStart(): Unit = {
+    assertEquals(0x61, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 1, 0))
+    assertEquals(0x1d306, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 5, 0))
+    assertEquals(0x1d306, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 5, 3))
+    assertEquals(0xdf06, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 5, 4))
+    assertEquals(0xd834, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 4, 2))
+    assertEquals(0xd834, Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 4, 3))
+    assertEquals(0xd834, Character.codePointBefore("\ud834\udf06def".toCharArray(), 1, 0))
+    assertEquals(0xd834, Character.codePointBefore("\ud834abc".toCharArray(), 1, 0))
+    assertEquals(0xdf06, Character.codePointBefore("\udf06abc".toCharArray(), 1, 0))
+  }
+
+  @Test def codePointBeforeArrayWithStartIndexOutOfBounds(): Unit = {
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), -5, 0))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 0, 0))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 2, 2))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 2, 5))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        Character.codePointBefore("abc\ud834\udf06def".toCharArray(), 15, 5))
+  }
+
   @Test def toChars(): Unit = {
     assertTrue(Character.toChars(0x61) sameElements Array('a'))
     assertTrue(Character.toChars(0x10000) sameElements Array('\uD800', '\uDC00'))
@@ -340,6 +499,112 @@ class CharacterTest {
     }
 
     assertThrows(classOf[IllegalArgumentException], Character.toChars(Integer.MAX_VALUE, new Array(2), 0))
+  }
+
+  @Test def offsetByCodePointsCharSequence(): Unit = {
+    val s: CharSequence = "abc\ud834\udf06de\ud834\udf06fgh\ud834ij\udf06\ud834kl\udf06"
+
+    assertEquals(s.length, Character.offsetByCodePoints(s, 0, 18))
+    assertEquals(5, Character.offsetByCodePoints(s, 3, 1))
+    assertEquals(3, Character.offsetByCodePoints(s, 2, 1))
+    assertEquals(5, Character.offsetByCodePoints(s, 2, 2))
+    assertEquals(6, Character.offsetByCodePoints(s, 2, 3))
+    assertEquals(17, Character.offsetByCodePoints(s, 12, 5))
+    assertEquals(10, Character.offsetByCodePoints(s, 8, 2))
+    assertEquals(10, Character.offsetByCodePoints(s, 7, 2))
+    assertEquals(7, Character.offsetByCodePoints(s, 7, 0))
+    assertEquals(s.length, Character.offsetByCodePoints(s, s.length - 1, 1))
+    assertEquals(s.length - 1, Character.offsetByCodePoints(s, s.length - 1, 0))
+    assertEquals(s.length, Character.offsetByCodePoints(s, s.length, 0))
+
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(s, -3, 0))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(s, -3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(s, 6, 18))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(s, 30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(s, 30, 0))
+  }
+
+  @Test def offsetByCodePointsCharSequenceBackwards(): Unit = {
+    val s: CharSequence = "abc\ud834\udf06de\ud834\udf06fgh\ud834ij\udf06\ud834kl\udf06"
+
+    assertEquals(0, Character.offsetByCodePoints(s, s.length, -18))
+    assertEquals(3, Character.offsetByCodePoints(s, 5, -1))
+    assertEquals(2, Character.offsetByCodePoints(s, 3, -1))
+    assertEquals(2, Character.offsetByCodePoints(s, 4, -2))
+    assertEquals(2, Character.offsetByCodePoints(s, 5, -2))
+    assertEquals(2, Character.offsetByCodePoints(s, 6, -3))
+    assertEquals(12, Character.offsetByCodePoints(s, 17, -5))
+    assertEquals(7, Character.offsetByCodePoints(s, 10, -2))
+    assertEquals(7, Character.offsetByCodePoints(s, 7, -0))
+    assertEquals(s.length - 1, Character.offsetByCodePoints(s, s.length, -1))
+    assertEquals(s.length - 1, Character.offsetByCodePoints(s, s.length - 1, -0))
+    assertEquals(s.length, Character.offsetByCodePoints(s, s.length, -0))
+
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(s, -3, -4))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(s, 6, -18))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(s, 30, -2))
+  }
+
+  @Test def offsetByCodePointsArray(): Unit = {
+    val a: Array[Char] =
+      "abc\ud834\udf06de\ud834\udf06fgh\ud834ij\udf06\ud834kl\udf06".toCharArray()
+    val len = a.length
+
+    assertEquals(len, Character.offsetByCodePoints(a, 0, len, 0, 18))
+    assertEquals(5, Character.offsetByCodePoints(a, 0, len, 3, 1))
+    assertEquals(3, Character.offsetByCodePoints(a, 0, 5, 2, 1))
+    assertEquals(5, Character.offsetByCodePoints(a, 0, 5, 2, 2))
+    assertEquals(6, Character.offsetByCodePoints(a, 0, len, 2, 3))
+    assertEquals(17, Character.offsetByCodePoints(a, 5, 12, 12, 5))
+
+    assertEquals(10, Character.offsetByCodePoints(a, 5, 8, 8, 2))
+    assertEquals(10, Character.offsetByCodePoints(a, 5, 8, 7, 2))
+
+    assertEquals(9, Character.offsetByCodePoints(a, 4, 5, 6, 2))
+    assertEquals(8, Character.offsetByCodePoints(a, 4, 4, 6, 2))
+
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, len, -3, 0))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, len, -3, 4))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, len, 6, 18))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, len, 30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, len, 30, 0))
+
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, 6, 2, 0))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, 6, 2, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, 6, 7, 5))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, 6, 10, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, 6, 10, 0))
+
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, -1, 6, 2, 0))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, 30, 2, 0))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, -2, 2, 0))
+  }
+
+  @Test def offsetByCodePointsArrayBackwards(): Unit = {
+    val a: Array[Char] =
+      "abc\ud834\udf06de\ud834\udf06fgh\ud834ij\udf06\ud834kl\udf06".toCharArray()
+    val len = a.length
+
+    assertEquals(0, Character.offsetByCodePoints(a, 0, len, len, -18))
+    assertEquals(3, Character.offsetByCodePoints(a, 0, len, 5, -1))
+    assertEquals(2, Character.offsetByCodePoints(a, 0, 5, 3, -1))
+    assertEquals(2, Character.offsetByCodePoints(a, 0, 5, 5, -2))
+    assertEquals(2, Character.offsetByCodePoints(a, 0, len, 6, -3))
+    assertEquals(12, Character.offsetByCodePoints(a, 5, 12, 17, -5))
+
+    assertEquals(6, Character.offsetByCodePoints(a, 5, 8, 8, -2))
+    assertEquals(6, Character.offsetByCodePoints(a, 5, 8, 9, -2))
+
+    assertEquals(3, Character.offsetByCodePoints(a, 3, 5, 6, -2))
+    assertEquals(4, Character.offsetByCodePoints(a, 4, 4, 6, -2))
+
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, len, -3, -4))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, len, 6, -18))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 0, len, 30, -2))
+
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, 6, 2, -2))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, 6, 7, -5))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.offsetByCodePoints(a, 3, 6, 10, -2))
   }
 
   @Test def isDigit(): Unit = {
@@ -1062,6 +1327,34 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, -3, 4))
     assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, 6, 2))
     assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(cs, 10, 30))
+  }
+
+  @Test def codePointCountArray(): Unit = {
+    /* Attention! The third argument is a count/length value, not an end/limit value.
+     * To keep consistency with the tests above, we use the same values and
+     * subtract the start offset.
+     */
+
+    val a: Array[Char] =
+      "abc\uD834\uDF06de\uD834\uDF06fgh\uD834ij\uDF06\uD834kl\uDF06".toCharArray()
+
+    assertEquals(18, Character.codePointCount(a, 0, a.length - 0))
+    assertEquals(1, Character.codePointCount(a, 3, 5 - 3))
+    assertEquals(1, Character.codePointCount(a, 2, 3 - 2))
+    assertEquals(2, Character.codePointCount(a, 2, 4 - 2))
+    assertEquals(2, Character.codePointCount(a, 2, 5 - 2))
+    assertEquals(3, Character.codePointCount(a, 2, 6 - 2))
+    assertEquals(5, Character.codePointCount(a, 12, 17 - 12))
+    assertEquals(2, Character.codePointCount(a, 8, 10 - 8))
+    assertEquals(2, Character.codePointCount(a, 7, 10 - 7))
+    assertEquals(0, Character.codePointCount(a, 7, 7 - 7))
+    assertEquals(1, Character.codePointCount(a, a.length - 1, a.length - (a.length - 1)))
+    assertEquals(0, Character.codePointCount(a, a.length - 1, a.length - 1 - (a.length - 1)))
+    assertEquals(0, Character.codePointCount(a, a.length, a.length - a.length))
+
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(a, -3, 4 - (-3)))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(a, 6, 2 - 6))
+    assertThrows(classOf[IndexOutOfBoundsException], Character.codePointCount(a, 10, 30 - 10))
   }
 
   @Test def compare(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/StringTest.scala
@@ -235,6 +235,8 @@ class StringTest {
         hasCompliantStringIndexOutOfBounds)
 
     assertThrows(classOf[StringIndexOutOfBoundsException],
+        "abc\ud834\udf06def".codePointBefore(-5))
+    assertThrows(classOf[StringIndexOutOfBoundsException],
         "abc\ud834\udf06def".codePointBefore(0))
     assertThrows(classOf[StringIndexOutOfBoundsException],
         "abc\ud834\udf06def".codePointBefore(9))
@@ -258,9 +260,11 @@ class StringTest {
     assertEquals(0, s.codePointCount(s.length - 1, s.length - 1))
     assertEquals(0, s.codePointCount(s.length, s.length))
 
+    assertThrows(classOf[IndexOutOfBoundsException], s.codePointCount(-3, 0))
     assertThrows(classOf[IndexOutOfBoundsException], s.codePointCount(-3, 4))
     assertThrows(classOf[IndexOutOfBoundsException], s.codePointCount(6, 2))
     assertThrows(classOf[IndexOutOfBoundsException], s.codePointCount(10, 30))
+    assertThrows(classOf[IndexOutOfBoundsException], s.codePointCount(10, 0))
   }
 
   @Test def offsetByCodePoints(): Unit = {
@@ -300,9 +304,9 @@ class StringTest {
     assertEquals(s.length - 1, s.offsetByCodePoints(s.length - 1, -0))
     assertEquals(s.length, s.offsetByCodePoints(s.length, -0))
 
-    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(-3, 4))
-    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(6, 18))
-    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(30, 2))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(-3, -4))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(6, -18))
+    assertThrows(classOf[IndexOutOfBoundsException], s.offsetByCodePoints(30, -2))
   }
 
   @Test def substringBegin(): Unit = {


### PR DESCRIPTION
Implement all overloads of `java.lang.Character.`:

* `codePointAt`
* `codePointBefore`
* `codePointCount`
* `offsetByCodePoints`

In the process, unify with the implementations of methods of the same name in `jl.String`.

This completes the set of methods of `jl.Character` that do not need the Unicode database.

Fixes #5010, among other things.