### PR TITLE
Introduce `UnaryOp.CheckNotNull` in the IR.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -1573,7 +1573,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
              * null check remains before the super call, while the associated
              * assignment is moved after.
              */
-            preSuperStats += js.GetClass(genExpr(outer))(tree.pos)
+            preSuperStats += js.UnaryOp(js.UnaryOp.CheckNotNull, genExpr(outer))(tree.pos)
             postSuperStats += genStat(assign)
 
           case stat =>
@@ -2388,7 +2388,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
             tree match {
               case OuterPointerNullCheck(outer, elsep) =>
                 js.Block(
-                  js.GetClass(genExpr(outer)), // null check
+                  js.UnaryOp(js.UnaryOp.CheckNotNull, genExpr(outer)),
                   genStat(elsep)
                 )
               case _ =>
@@ -4759,7 +4759,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           newArg
         case _ =>
           js.Block(
-              js.GetClass(newReceiver), // null check
+              js.UnaryOp(js.UnaryOp.CheckNotNull, newReceiver),
               newArg)
       }
     }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -343,33 +343,38 @@ object Printers {
           print(method)
           printArgs(args)
 
-        case UnaryOp(UnaryOp.String_length, lhs) =>
-          print(lhs)
-          print(".length")
-
         case UnaryOp(op, lhs) =>
           import UnaryOp._
-          print('(')
-          print((op: @switch) match {
-            case Boolean_! =>
-              "!"
-            case IntToChar =>
-              "(char)"
-            case IntToByte =>
-              "(byte)"
-            case IntToShort =>
-              "(short)"
-            case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt =>
-              "(int)"
-            case IntToLong | DoubleToLong =>
-              "(long)"
-            case DoubleToFloat | LongToFloat =>
-              "(float)"
-            case IntToDouble | LongToDouble | FloatToDouble =>
-              "(double)"
-          })
-          print(lhs)
-          print(')')
+
+          if (op < String_length) {
+            print('(')
+            print((op: @switch) match {
+              case Boolean_! =>
+                "!"
+              case IntToChar =>
+                "(char)"
+              case IntToByte =>
+                "(byte)"
+              case IntToShort =>
+                "(short)"
+              case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt =>
+                "(int)"
+              case IntToLong | DoubleToLong =>
+                "(long)"
+              case DoubleToFloat | LongToFloat =>
+                "(float)"
+              case IntToDouble | LongToDouble | FloatToDouble =>
+                "(double)"
+            })
+            print(lhs)
+            print(')')
+          } else {
+            print(lhs)
+            print((op: @switch) match {
+              case String_length => ".length"
+              case CheckNotNull  => ".notNull"
+            })
+          }
 
         case BinaryOp(BinaryOp.Int_-, IntLiteral(0), rhs) =>
           print("(-")

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -283,11 +283,16 @@ object Trees {
     val tpe = AnyType
   }
 
-  /** Unary operation (always preserves pureness). */
+  /** Unary operation.
+   *
+   *  `CheckNotNull` throws NPEs subject to UB.
+   *
+   *  Otherwise, unary operations preserve pureness.
+   */
   sealed case class UnaryOp(op: UnaryOp.Code, lhs: Tree)(
       implicit val pos: Position) extends Tree {
 
-    val tpe = UnaryOp.resultTypeOf(op)
+    val tpe = UnaryOp.resultTypeOf(op, lhs.tpe)
   }
 
   object UnaryOp {
@@ -322,7 +327,10 @@ object Trees {
     // String.length, introduced in 1.11
     final val String_length = 17
 
-    def resultTypeOf(op: Code): Type = (op: @switch) match {
+    // New in 1.17
+    final val CheckNotNull = 18
+
+    def resultTypeOf(op: Code, argType: Type): Type = (op: @switch) match {
       case Boolean_! =>
         BooleanType
       case IntToChar =>
@@ -339,6 +347,8 @@ object Trees {
         FloatType
       case IntToDouble | LongToDouble | FloatToDouble =>
         DoubleType
+      case CheckNotNull =>
+        argType.toNonNullable
     }
   }
 

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -392,6 +392,8 @@ class PrintersTest {
     assertPrintEquals("((float)x)", UnaryOp(LongToFloat, ref("x", LongType)))
 
     assertPrintEquals("x.length", UnaryOp(String_length, ref("x", StringType)))
+
+    assertPrintEquals("x.notNull", UnaryOp(CheckNotNull, ref("x", AnyType)))
   }
 
   @Test def printPseudoUnaryOp(): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
@@ -21,30 +21,6 @@ import org.scalajs.ir.Types._
 
 object Transients {
 
-  /** Checks that `obj ne null`, then returns `obj`.
-   *
-   *  If `obj eq null`, throw a `NullPointerException`, or a corresponding
-   *  `UndefinedBehaviorError`.
-   *
-   *  This node must not be used when NPEs are Unchecked.
-   */
-  final case class CheckNotNull(obj: Tree) extends Transient.Value {
-    val tpe: Type = obj.tpe.toNonNullable
-
-    def traverse(traverser: Traverser): Unit =
-      traverser.traverse(obj)
-
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
-      Transient(CheckNotNull(transformer.transformExpr(obj)))
-    }
-
-    def printIR(out: IRTreePrinter): Unit = {
-      out.print("$n")
-      out.printArgs(List(obj))
-    }
-  }
-
   /** Casts `expr` to the given `tpe`, without any check.
    *
    *  This operation is only valid if we know that `expr` is indeed a value of

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1408,6 +1408,10 @@ private class FunctionEmitter private (
       // String.length
       case String_length =>
         fb += wa.Call(genFunctionID.stringLength)
+
+      // Null check
+      case CheckNotNull =>
+        genAsNonNullOrNPEFor(lhs)
     }
 
     tree.tpe
@@ -3251,11 +3255,6 @@ private class FunctionEmitter private (
 
   private def genTransient(tree: Transient): Type = {
     tree.value match {
-      case Transients.CheckNotNull(expr) =>
-        genTreeAuto(expr)
-        genAsNonNullOrNPEFor(expr)
-        tree.tpe
-
       case Transients.Cast(expr, tpe) =>
         genCast(expr, tpe, tree.pos)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -443,6 +443,8 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
             DoubleType
           case String_length =>
             StringType
+          case CheckNotNull =>
+            AnyType
         }
         typecheckExpect(lhs, env, expectedArgType)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -865,7 +865,10 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
         case Closure(_, _, _, _, _, captureValues) =>
           captureValues.forall(isTriviallySideEffectFree(_))
 
-        case GetClass(expr) =>
+        case UnaryOp(UnaryOp.CheckNotNull, expr) =>
+          config.coreSpec.semantics.nullPointers == CheckedBehavior.Unchecked &&
+          isTriviallySideEffectFree(expr)
+        case GetClass(expr) => // Before 1.17, we used GetClass as CheckNotNull
           config.coreSpec.semantics.nullPointers == CheckedBehavior.Unchecked &&
           isTriviallySideEffectFree(expr)
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -9,6 +9,8 @@ object BinaryIncompatibilities {
 
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.scalajs.ir.Trees#*.tpe"),
 
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#UnaryOp.resultTypeOf"),
+
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ClassType.this"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ClassType.apply"),
     ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Types#ClassType.copy"),

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2056,7 +2056,7 @@ object Build {
               Some(ExpectedSizes(
                   fastLink = 425000 to 426000,
                   fullLink = 282000 to 283000,
-                  fastLinkGz = 61000 to 62000,
+                  fastLinkGz = 60000 to 61000,
                   fullLinkGz = 43000 to 44000,
               ))
             }


### PR DESCRIPTION
Now that we have non-nullable reference types in the IR, it makes sense to offer that operation at the IR level. It replaces the `Transient` of the same name.

We use it in the compiler instead of `GetClass`, as it is more direct.