### PR TITLE
Wasm: Make itables immutable struct

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -120,7 +120,6 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     genArrayClassTypes()
 
     genBoxedZeroGlobals()
-    genArrayClassGlobals()
   }
 
   // --- Type definitions ---
@@ -161,10 +160,21 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
       genTypeID.typeDataArray,
       ArrayType(FieldType(RefType(genTypeID.typeData), isMutable = false))
     )
+
     genCoreType(
       genTypeID.itables,
-      ArrayType(FieldType(RefType.nullable(HeapType.Struct), isMutable = true))
+      StructType(
+        (0 until ctx.itablesLength).map { i =>
+          StructField(
+            genFieldID.itablesStruct.itableSlot(i),
+            OriginalName.NoOriginalName,
+            RefType.nullable(HeapType.Struct),
+            isMutable = false
+          )
+        }.toList
+      )
     )
+
     genCoreType(
       genTypeID.reflectiveProxies,
       ArrayType(FieldType(RefType(genTypeID.reflectiveProxy), isMutable = false))
@@ -590,23 +600,6 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
         )
       )
     }
-  }
-
-  private def genArrayClassGlobals()(implicit ctx: WasmContext): Unit = {
-    // Common itable global for all array classes
-    val itablesInit = List(
-      I32Const(ctx.itablesLength),
-      ArrayNewDefault(genTypeID.itables)
-    )
-    ctx.addGlobal(
-      Global(
-        genGlobalID.arrayClassITable,
-        OriginalName(genGlobalID.arrayClassITable.toString()),
-        isMutable = false,
-        RefType(genTypeID.itables),
-        init = Expr(itablesInit)
-      )
-    )
   }
 
   // --- Function definitions ---

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1151,8 +1151,10 @@ private class FunctionEmitter private (
     def genITableDispatch(): Unit = {
       fb += wa.LocalGet(receiverLocalForDispatch)
       fb += wa.StructGet(genTypeID.ObjectStruct, genFieldID.objStruct.itables)
-      fb += wa.I32Const(receiverClassInfo.itableIdx)
-      fb += wa.ArrayGet(genTypeID.itables)
+      fb += wa.StructGet(
+        genTypeID.itables,
+        genFieldID.itablesStruct.itableSlot(receiverClassInfo.itableIdx)
+      )
       fb += wa.RefCast(watpe.RefType(genTypeID.forITable(receiverClassInfo.name)))
       fb += wa.StructGet(
         genTypeID.forITable(receiverClassInfo.name),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -294,6 +294,10 @@ object VarGen {
       case object arrayUnderlying extends FieldID
     }
 
+    object itablesStruct {
+      final case class itableSlot(i: Int) extends FieldID
+    }
+
     object reflectiveProxy {
       case object methodID extends FieldID
       case object funcRef extends FieldID


### PR DESCRIPTION
Previously, we used mutable array-based interface tables (itables) without a specific reason. However, accessing mutable arrays can lead to missed optimization opportunities. For instance, loop-invariant code motion (LICM) won't be able to move certain parts of interface dispatching operations out of loops: When we invoke a method using interface table dispatching, it requires retrieving an itable from the class's itable array, which is considered non-pure.

In fact, reading from an array is marked as unsafe to move in wasm-opt's LICM implementation:

https://github.com/WebAssembly/binaryen/blob/34ad6a7598e662e9ff357987f2c81fde1e05c522/src/ir/effects.h#L207-L210 https://github.com/WebAssembly/binaryen/blob/34ad6a7598e662e9ff357987f2c81fde1e05c522/src/passes/LoopInvariantCodeMotion.cpp#L125-L128

(Note: We may not run wasm-opt's LICM in favor of the VM's LICM, as discussed in https://github.com/WebAssembly/binaryen/issues/6924)

This commit changes itables to be immutable structs, making itable retrieval a pure operation. Here's a comparison of benchmark results between commit 4c9494e424e0e8b60b6a198e461320897c6e8806 and this change:

|             | array itables | struct itables |
| ----------- | ------------- | -------------- |
| sha512      | 12128.73213   | 12107.94142    |
| queens      | 3.632068223   | 3.655815179    |
| list        | 84.61223471   | 65.69730564    |
| richards    | 92.12833022   | 91.19028905    |
| cd          | 46267.10318   | 46574.81215    |
| gcbench     | 116540.568    | 112594.324     |
| tracerFloat | 2569.675034   | 2551.227714    |
| tracer      | 1725.591249   | 1697.907466    |
| sudoku      | 14863.33909   | 12066.23882    |
| nbody       | 366388.3292   | 199625.971     |
| permute     | 1006.215249   | 983.9858283    |
| deltaBlue   | 2205.002528   | 2320.038418    |
| kmeans      | 1752457.829   | 1754425.973    |
| brainfuck   | 36983.97583   | 36093.7837     |
| json        | 1205.92764    | 1191.768986    |
| bounce      | 21.14001572   | 20.8851082     |

While most benchmark results remain same, some tests such as `list`, `sudoku`, and `nbody` show improved performance compared to the array-based itables (may be thanks to the VM's optimization capabilities).

**immutable array?**
In this change, we implement itables using immutable structs However, we can use immutable arrays as an alternative. We implemented and benchmarked itables using immutable arrays, and the results show nearly same performance as the immutable struct-based implementation.

https://github.com/WebAssembly/gc/issues/250
https://github.com/v8/v8/commit/6e36e3ec8576527de6a8bed2eec034679ef95a10

Let's proceed with the immutable struct-based implementation for now because

- While V8 seems to optimize immutable array-related operations, other VMs may not offer similar optimizations (?)
- Currently, wasm-opt doesn't take into account the mutability of arrays in its optimization process.