### PR TITLE
Make the `itables` field of objects non-nullable.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -106,6 +106,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
 
     genImports()
 
+    genEmptyITable()
     genPrimitiveTypeDataGlobals()
 
     genHelperDefinitions()
@@ -223,7 +224,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     val itablesField = StructField(
       genFieldID.objStruct.itables,
       OriginalName(genFieldID.objStruct.itables.toString()),
-      RefType.nullable(genTypeID.itables),
+      RefType(genTypeID.itables),
       isMutable = false
     )
 
@@ -514,6 +515,18 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
   }
 
   // --- Global definitions ---
+
+  private def genEmptyITable()(implicit ctx: WasmContext): Unit = {
+    ctx.addGlobal(
+      Global(
+        genGlobalID.emptyITable,
+        OriginalName(genGlobalID.emptyITable.toString()),
+        isMutable = false,
+        RefType(genTypeID.itables),
+        Expr(List(StructNewDefault(genTypeID.itables)))
+      )
+    )
+  }
 
   private def genPrimitiveTypeDataGlobals()(implicit ctx: WasmContext): Unit = {
     import genFieldID.typeData._
@@ -2550,7 +2563,7 @@ final class CoreWasmLib(coreSpec: CoreSpec) {
     val i32ArrayType = RefType(genTypeID.i32Array)
     val objectVTableType = RefType(genTypeID.ObjectVTable)
     val arrayTypeDataType = objectVTableType
-    val itablesType = RefType.nullable(genTypeID.itables)
+    val itablesType = RefType(genTypeID.itables)
     val nonNullObjectType = RefType(genTypeID.ObjectStruct)
     val anyArrayType = RefType(genTypeID.anyArray)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -44,6 +44,7 @@ object VarGen {
     case object bZeroChar extends GlobalID
     case object bZeroLong extends GlobalID
     case object stringLiteralCache extends GlobalID
+    case object emptyITable extends GlobalID
     case object arrayClassITable extends GlobalID
     case object lastIDHashCode extends GlobalID
 


### PR DESCRIPTION
Previously, classes that do not implement any interface had a `null` value for their `itables` field. Now, they all use a shared instance of `(ref $itables)` that contains `null`s everywhere.

This removes a code path for interface type tests. More importantly, it removes one source of null checks along the code paths for interface method calls.

---

@tanishiking Does this improve interface calls a bit more, in your benchmarking setup?