### PR TITLE
Wasm: Implement `Class_superClass`.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/WebAssemblyLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/WebAssemblyLinkerBackend.scala
@@ -69,7 +69,7 @@ final class WebAssemblyLinkerBackend(config: LinkerBackendImpl.Config)
     }
     val moduleID = onlyModule.id.id
 
-    val emitterResult = emitter.emit(onlyModule, logger)
+    val emitterResult = emitter.emit(onlyModule, moduleSet.globalInfo, logger)
     val wasmModule = emitterResult.wasmModule
 
     val outputImpl = OutputDirectoryImpl.fromOutputDirectory(output)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/EmbeddedConstants.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/EmbeddedConstants.scala
@@ -63,6 +63,7 @@ object EmbeddedConstants {
   final val KindClass = 21
   final val KindInterface = 22
   final val KindJSType = 23
+  final val KindJSTypeWithSuperClass = 24
 
   final val KindLastPrimitive = KindDouble
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1461,9 +1461,7 @@ private class FunctionEmitter private (
       case Class_componentType =>
         fb += wa.Call(genFunctionID.getComponentType)
       case Class_superClass =>
-        // FIXME Implement this
-        fb += wa.Drop
-        fb += wa.RefNull(watpe.HeapType.None)
+        fb += wa.Call(genFunctionID.getSuperClass)
     }
 
     tree.tpe

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -256,6 +256,7 @@ object VarGen {
     case object isAssignableFrom extends FunctionID
     case object cast extends FunctionID
     case object getComponentType extends FunctionID
+    case object getSuperClass extends FunctionID
     case object newArray extends FunctionID
     case object anyGetClass extends FunctionID
     case object anyGetClassName extends FunctionID
@@ -343,11 +344,15 @@ object VarGen {
 
       /** Array of the strict ancestor classes of this class.
        *
-       *  This is `null` for primitive and array types. For all other types, including JS types, it
+       *  This is `null` for primitives. For all other types, including JS types, it
        *  contains an array of the typeData of their ancestors that:
        *
        *  - are not themselves (hence the *strict* ancestors),
        *  - have typeData to begin with.
+       *
+       *  If this class has a `superClass`, the first element is guaranteed to
+       *  be the `superClass`. The implementation of `Class_superClass` relies
+       *  on that guarantee.
        */
       case object strictAncestors extends FieldID
 

--- a/test-suite-ex/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassJSTestEx.scala
+++ b/test-suite-ex/js/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassJSTestEx.scala
@@ -1,0 +1,64 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang
+
+import org.junit.Test
+import org.junit.Assert._
+import org.junit.Assume._
+
+import scala.scalajs.js
+
+import org.scalajs.testsuite.utils.Platform._
+
+class ClassJSTestEx {
+  import ClassJSTestEx._
+
+  /** Tests for `java.lang.Class.getSuperclass()` on JS classes and traits. */
+  @Test def getSuperclass(): Unit = {
+    def test(parent: Class[_], child: Class[_]): Unit =
+      assertSame(parent, child.getSuperclass())
+
+    test(null, classOf[js.Any])
+
+    test(classOf[Object], classOf[js.Object])
+
+    test(classOf[SomeParentClass], classOf[SomeChildClass])
+    test(classOf[AnyRef], classOf[String])
+    test(classOf[Number], classOf[Integer])
+
+    test(null, classOf[SomeParentTrait])
+    test(null, classOf[SomeChildTrait])
+
+    test(classOf[Object], classOf[Array[js.Object]])
+    test(classOf[Object], classOf[Array[SomeChildClass]])
+    test(classOf[Object], classOf[Array[SomeChildTrait]])
+    test(classOf[Object], classOf[Array[Array[SomeChildClass]]])
+  }
+
+  @Test def getSuperclassWhenParentClassDataIsNotDirectlyAccessed_Issue1489(): Unit = {
+    assertEquals(
+        "org.scalajs.testsuite.javalib.lang.ClassJSTestEx$ParentClassWhoseDataIsNotAccessedDirectly",
+        classOf[ChildClassWhoseDataIsAccessedDirectly].getSuperclass().getName())
+  }
+}
+
+object ClassJSTestEx {
+  class SomeParentClass extends js.Object
+  class SomeChildClass extends SomeParentClass
+
+  class ParentClassWhoseDataIsNotAccessedDirectly extends js.Object
+  class ChildClassWhoseDataIsAccessedDirectly extends ParentClassWhoseDataIsNotAccessedDirectly
+
+  trait SomeParentTrait extends js.Object
+  trait SomeChildTrait extends SomeParentTrait
+}

--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTestEx.scala
@@ -29,12 +29,13 @@ class ClassTestEx {
    *  pollute the whole test suite with those.
    */
   @Test def getSuperclass(): Unit = {
-    assumeFalse("Not implemented yet on WebAssembly", executingInWebAssembly)
-
     def test(parent: Class[_], child: Class[_]): Unit =
       assertSame(parent, child.getSuperclass())
 
     test(null, classOf[AnyRef])
+
+    test(null, classOf[Unit])
+    test(null, classOf[Int])
 
     test(classOf[SomeParentClass], classOf[SomeChildClass])
     test(classOf[AnyRef], classOf[String])
@@ -52,8 +53,6 @@ class ClassTestEx {
   }
 
   @Test def getSuperclassWhenParentClassDataIsNotDirectlyAccessed_Issue1489(): Unit = {
-    assumeFalse("Not implemented yet on WebAssembly", executingInWebAssembly)
-
     assertEquals("org.scalajs.testsuite.javalib.lang.ClassTestEx$ParentClassWhoseDataIsNotAccessedDirectly",
         classOf[ChildClassWhoseDataIsAccessedDirectly].getSuperclass.getName)
   }


### PR DESCRIPTION
Since `strictAncestors` already contains an array of the `typeData` of the ancestors, we reuse it to mention the `superClass`. We make sure it appears first when `Class_superClass` is used.

We determine whether a given `jl.Class` has a `superClass` at all based on its `kind`. For JS types, we introduce an additional kind `KindJSTypeWithSuperClass`. We only used that kind when `Class_superClass` is used at all, as its presence requires more computations in two places.

Review by @gzm0 and @tanishiking.

AFAIK, this was the last functional (semantic) thing that was not yet correct for the Wasm backend.