### PR TITLE
Fix #5044: Handle the IllegalArgumentExceptions in jlr.Array.newInstance.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -612,6 +612,10 @@ object Names {
   val ClassCastExceptionClass: ClassName =
     ClassName("java.lang.ClassCastException")
 
+  /** The exception thrown by a `Class_newArray` if the first argument is `classOf[Unit]`. */
+  val IllegalArgumentExceptionClass: ClassName =
+    ClassName("java.lang.IllegalArgumentException")
+
   /** The set of classes and interfaces that are ancestors of array classes. */
   private[ir] val AncestorsOfPseudoArrayClass: Set[ClassName] = {
     /* This would logically be defined in Types, but that introduces a cyclic

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -395,7 +395,8 @@ object Trees {
    *  - `Class_cast` throws a CCE if its second argument is non-null and
    *    not an instance of the class represented by its first argument.
    *  - `Class_newArray` throws a `NegativeArraySizeException` if its second
-   *    argument is negative.
+   *    argument is negative and an `IllegalArgumentException` if its first
+   *    argument is `classOf[Unit]`.
    *
    *  Otherwise, binary operations preserve pureness.
    */

--- a/javalib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Array.scala
@@ -38,9 +38,12 @@ object Array {
       result
     }
 
+    val len = dimensions.length
+    if (len == 0)
+      throw new IllegalArgumentException()
     var outermostComponentType = componentType
     var i = 1
-    while (i != dimensions.length) {
+    while (i != len) {
       outermostComponentType = newInstance(outermostComponentType, 0).getClass()
       i += 1
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -381,6 +381,9 @@ object Infos {
     def addUsedExponentOperator(): this.type =
       setFlag(ReachabilityInfo.FlagUsedExponentOperator)
 
+    def addUsedIntLongDivModByMaybeZero(): this.type =
+      addInstantiatedClass(ArithmeticExceptionClass, StringArgConstructorName)
+
     def addUsedClassSuperClass(): this.type =
       setFlag(ReachabilityInfo.FlagUsedClassSuperClass)
 
@@ -667,21 +670,16 @@ object Infos {
             case BinaryOp(op, _, rhs) =>
               import BinaryOp._
 
-              def addArithmeticException(): Unit = {
-                builder.addInstantiatedClass(ArithmeticExceptionClass,
-                    StringArgConstructorName)
-              }
-
               op match {
                 case Int_/ | Int_% =>
                   rhs match {
                     case IntLiteral(r) if r != 0 =>
-                    case _                       => addArithmeticException()
+                    case _                       => builder.addUsedIntLongDivModByMaybeZero()
                   }
                 case Long_/ | Long_% =>
                   rhs match {
                     case LongLiteral(r) if r != 0L =>
-                    case _                         => addArithmeticException()
+                    case _                         => builder.addUsedIntLongDivModByMaybeZero()
                   }
                 case _ =>
                   // do nothing

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -384,6 +384,9 @@ object Infos {
     def addUsedIntLongDivModByMaybeZero(): this.type =
       addInstantiatedClass(ArithmeticExceptionClass, StringArgConstructorName)
 
+    def addUsedClassNewArray(): this.type =
+      addInstantiatedClass(IllegalArgumentExceptionClass, NoArgConstructorName)
+
     def addUsedClassSuperClass(): this.type =
       setFlag(ReachabilityInfo.FlagUsedClassSuperClass)
 
@@ -681,6 +684,8 @@ object Infos {
                     case LongLiteral(r) if r != 0L =>
                     case _                         => builder.addUsedIntLongDivModByMaybeZero()
                   }
+                case Class_newArray =>
+                  builder.addUsedClassNewArray()
                 case _ =>
                   // do nothing
               }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1274,7 +1274,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case BinaryOp(BinaryOp.Class_cast, lhs, rhs) =>
           allowBehavior(semantics.asInstanceOfs) && test(lhs) && test(rhs)
         case BinaryOp(BinaryOp.Class_newArray, lhs, rhs) =>
-          allowBehavior(semantics.negativeArraySizes) && allowUnpure && test(lhs) && test(rhs)
+          allowSideEffects && test(lhs) && test(rhs)
 
         // Expressions preserving pureness (modulo NPE)
         case Block(trees)            => trees forall test

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -30,6 +30,11 @@ private[emitter] trait GlobalKnowledge {
    */
   def isArithmeticExceptionClassInstantiatedWithStringArg: Boolean
 
+  /** Tests whether the `java.lang.IllegalArgumentException` class is
+   *  instantiated with no argument.
+   */
+  def isIllegalArgumentExceptionClassInstantiatedWithNoArg: Boolean
+
   /** Tests whether the parent class data is accessed in the linking unit. */
   def isParentDataAccessed: Boolean
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/GlobalKnowledge.scala
@@ -19,11 +19,16 @@ import org.scalajs.ir.Types.Type
 import org.scalajs.linker.standard.ModuleSet.ModuleID
 
 private[emitter] trait GlobalKnowledge {
-  /** Tests whether the `java.lang.Class` class is instantiated. */
+  /** Tests whether the `java.lang.Class` class is instantiated.
+   *
+   *  If yes, it is necessarily without argument.
+   */
   def isClassClassInstantiated: Boolean
 
-  /** Tests whether the `java.lang.ArithmeticException` class is instantiated. */
-  def isArithmeticExceptionClassInstantiated: Boolean
+  /** Tests whether the `java.lang.ArithmeticException` class is instantiated
+   *  with a string argument.
+   */
+  def isArithmeticExceptionClassInstantiatedWithStringArg: Boolean
 
   /** Tests whether the parent class data is accessed in the linking unit. */
   def isParentDataAccessed: Boolean

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -434,6 +434,7 @@ object Emitter {
       // TODO Ideally we should not require these, but rather adapt to their absence
       instantiateClass(ClassClass, NoArgConstructorName),
       instantiateClass(JSExceptionClass, AnyArgConstructorName),
+      instantiateClass(IllegalArgumentExceptionClass, NoArgConstructorName),
 
       // See genIdentityHashCode in HelperFunctions
       callMethodStatically(BoxedDoubleClass, hashCodeMethodName),

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -78,7 +78,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
       },
       cond(targetIsWebAssembly) {
         // Required by the intrinsic CharacterCodePointToString
-        instantiateClass(OptimizerCore.IllegalArgumentExceptionClass, NoArgConstructorName)
+        instantiateClass(IllegalArgumentExceptionClass, NoArgConstructorName)
       }
     )
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1584,7 +1584,7 @@ private[optimizer] abstract class OptimizerCore(
           finishWithSideEffects
         case Class_cast if semantics.asInstanceOfs != CheckedBehavior.Unchecked =>
           finishWithSideEffects
-        case Class_newArray if semantics.negativeArraySizes != CheckedBehavior.Unchecked =>
+        case Class_newArray =>
           finishWithSideEffects
         case _ =>
           finishNoSideEffects
@@ -5641,7 +5641,6 @@ private[optimizer] object OptimizerCore {
   private val ClassTagModuleClass = ClassName("scala.reflect.ClassTag$")
   private val JavaScriptExceptionClass = ClassName("scala.scalajs.js.JavaScriptException")
   private val JSWrappedArrayClass = ClassName("scala.scalajs.js.WrappedArray")
-  private[optimizer] val IllegalArgumentExceptionClass = ClassName("java.lang.IllegalArgumentException")
   private val NilClass = ClassName("scala.collection.immutable.Nil$")
   private val Tuple2Class = ClassName("scala.Tuple2")
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2056,7 +2056,7 @@ object Build {
             } else {
               Some(ExpectedSizes(
                   fastLink = 423000 to 424000,
-                  fullLink = 280000 to 281000,
+                  fullLink = 281000 to 282000,
                   fastLinkGz = 60000 to 61000,
                   fullLinkGz = 43000 to 44000,
               ))
@@ -2065,7 +2065,7 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 449000 to 450000,
+                  fastLink = 450000 to 451000,
                   fullLink = 95000 to 96000,
                   fastLinkGz = 58000 to 59000,
                   fullLinkGz = 25000 to 26000,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/reflect/ReflectArrayTest.scala
@@ -93,4 +93,30 @@ class ReflectArrayTest {
     assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[String], 5, -5))
     assertThrows(classOf[NegativeArraySizeException], jlr.Array.newInstance(classOf[Array[AnyRef]], 5, -5))
   }
+
+  @Test def newInstanceIllegalArgument(): Unit = {
+    import java.lang.{reflect => jlr}
+
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[Unit], 0))
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[Unit], 5))
+
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[Unit]))
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[Unit], 1, 1))
+
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[Unit]))
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[Int]))
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[AnyRef]))
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[Array[Int]]))
+    assertThrows(classOf[IllegalArgumentException], jlr.Array.newInstance(classOf[Array[String]]))
+  }
+
+  @Test def newInstanceNegativeArraySizeOrIllegalArgument(): Unit = {
+    import java.lang.{reflect => jlr}
+
+    assumeTrue("Assuming compliant negative array sizes", hasCompliantNegativeArraySizes)
+
+    assertThrows(classOf[RuntimeException], jlr.Array.newInstance(classOf[Unit], -3))
+    assertThrows(classOf[RuntimeException], jlr.Array.newInstance(classOf[Unit], -3, 1))
+    assertThrows(classOf[RuntimeException], jlr.Array.newInstance(classOf[Unit], 3, -1))
+  }
 }


### PR DESCRIPTION
The case of an empty array of dimensions for the multi-dimensions overload is handled in user-space. The case of `classOf[Unit]` is handled in the backends, since not doing so leaves the door open for user-space IR to break the fundamental invariant that there is no array of `void`.

In the JS backend, we follow the strategy of int/long div/mod to emit the target method only if `IllegalArgumentException.<init>()` is reachable. In the Wasm backend, since we do not have that infrastructure, for now we add an unconditional dependency on that constructor, like we do for `jl.Class.<init>()`.