### PR TITLE
Fix #5048: Wasm: Emit no files when no modules are defined.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -451,7 +451,10 @@ def Tasks = [
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
         'set scalaJSStage in Global := FullOptStage' \
-        testingExample$v/testHtml
+        testingExample$v/testHtml &&
+    sbtretry ++$scala \
+        'set Global/enableWasmEverywhere := true' \
+        irJS$v/fastLinkJS
   ''',
 
   /* For the bootstrap tests to be able to call


### PR DESCRIPTION
fix https://github.com/scala-js/scala-js/issues/5048

After the 1.17.0 release, I received several questions about the error message: `The WebAssembly backend does not support multiple modules. Found: `. This is caused by users not exporting anything and not setting `scalaJSUseMainModuleInitializer := true`. However, for those unfamiliar with Scala.js, the current error message seems somewhat misleading.

---

The current error message in `WebAssemblyLinkerBackend` is not clear for users not very familiar with Scala.js when no modules are defined. It says: `"The WebAssembly backend does not support multiple modules. Found: "`.

https://github.com/scala-js/scala-js/blob/7c95972e30c9897440e4404515d05bf663639daa/linker/shared/src/main/scala/org/scalajs/linker/backend/WebAssemblyLinkerBackend.scala#L69-L72

This behavior is not aligned with JS backend, and it can be confusing for users.
This commit changes the behavior of Wasm backend when no modules are defined: delete previous artifacts and emit no files.

