### PR TITLE
IRChecker: Fix type-checking of Array operations

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -253,7 +253,37 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
               _:JSSuperSelect | _:JSGlobalRef =>
         }
         typecheckExpr(lhs, env)
-        typecheckExpect(rhs, env, lhs.tpe)
+
+        val expectedRhsTpe = lhs match {
+          case ArraySelect(array, _) =>
+            /* Array assignments are unsound due to covariance of arrays
+             * To maintain the subtyping relationship in the IR, we have to
+             * allow assignments of any type to
+             * - Array[Object] (that's expected)
+             * - and its subtypes (that's not expected)
+             */
+
+            array.tpe match {
+              case ArrayType(ArrayTypeRef(PrimRef(tpe), 1), _) =>
+                // for primitive arrays, only allow assignment of that primitive.
+                tpe
+
+              case _ =>
+                /* All other types are either
+                 * - Subtypes of Array[Object] (including null / nothing)
+                 *   Recall: `Array[Array[A]] <: Array[Object]` even for primitive `A`.
+                 * - Ill typed IR
+                 *   (in which case typechecking the lhs above will emit an error).
+                 *
+                 * Allow any rhs.
+                 */
+                AnyType
+            }
+
+          case _ => lhs.tpe
+        }
+
+        typecheckExpect(rhs, env, expectedRhsTpe)
 
       case Return(expr, label) =>
         val returnType = env.returnTypes(label.name)

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -499,13 +499,17 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
 
       case ArrayLength(array) =>
         typecheckExpr(array, env)
-        if (!array.tpe.isInstanceOf[ArrayType])
+        if (array.tpe != NullType &&
+            array.tpe != NothingType &&
+            !array.tpe.isInstanceOf[ArrayType])
           reportError(i"Array type expected but ${array.tpe} found")
 
       case ArraySelect(array, index) =>
         typecheckExpect(index, env, IntType)
         typecheckExpr(array, env)
         array.tpe match {
+          case NothingType => // ok
+          case NullType => // will NPE, but allowed.
           case arrayType: ArrayType =>
             if (tree.tpe != arrayElemType(arrayType))
               reportError(i"Array select of array type $arrayType typed as ${tree.tpe}")

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -253,6 +253,22 @@ class IRCheckerTest {
     }
   }
 
+  @Test
+  def arrayOpsNullOrNothing(): AsyncResult = await {
+    val classDefs = Seq(
+      mainTestClassDef(
+        Block(
+          ArraySelect(Null(), int(1))(NothingType),
+          ArrayLength(Null()),
+          ArraySelect(Throw(Null()), int(1))(NothingType),
+          ArrayLength(Throw(Null()))
+        )
+      )
+    )
+
+    testLinkNoIRError(classDefs, MainTestModuleInitializers)
+  }
+
 }
 
 object IRCheckerTest {


### PR DESCRIPTION
- `NullType` / `NothingType` is a valid array type.
- Array covariance may lead to unsound assignments, so we need to allow them.

Discovered while attempting to run the IRChecker post optimizer.

I have inspected the backends to make sure they can handle the new unsound assignments:

For both backends, non-primitive arrays are not typed (beyond Object
for WASM). So unchecked assignments are trivial:

https://github.com/scala-js/scala-js/blob/0bc8c065a1db144f6bfcfbe72f2ad2a246284b2c/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala#L638-L642

https://github.com/scala-js/scala-js/blob/0bc8c065a1db144f6bfcfbe72f2ad2a246284b2c/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala#L741-L749
https://github.com/scala-js/scala-js/blob/0bc8c065a1db144f6bfcfbe72f2ad2a246284b2c/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala#L387-L403