### PR TITLE
Under restrictedThis, do not allow assigning fields of super classes.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -643,8 +643,11 @@ private final class ClassDefChecker(classDef: ClassDef,
 
       case Assign(lhs, rhs) =>
         lhs match {
-          case Select(This(), _) if env.isThisRestricted =>
-            checkTree(lhs, env.withIsThisRestricted(false))
+          case Select(This(), field) if env.isThisRestricted =>
+            if (postOptimizer || field.name.className == classDef.className)
+              checkTree(lhs, env.withIsThisRestricted(false))
+            else
+              checkTree(lhs, env)
           case _ =>
             checkTree(lhs, env)
         }

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -480,6 +480,11 @@ class ClassDefCheckerTest {
     )
 
     testRestrictedThisError(
+      Assign(Select(thiz, FieldName("Bar", "y"))(IntType), int(5)),
+      superCtorCall
+    )
+
+    testRestrictedThisError(
       Assign(Select(Select(thiz, xFieldName)(IntType), xFieldName)(IntType), int(5)),
       superCtorCall
     )


### PR DESCRIPTION
We can only assign fields of `this` that are declared by the current class. This restriction matches a restriction on the JVM.