### PR TITLE
Rename NoType to VoidType and print it as "void".

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSExports.scala
@@ -870,7 +870,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
       }
 
       // #4684 If the getter returns void, we must "box" it by returning undefined
-      if (callGetter.tpe == jstpe.NoType)
+      if (callGetter.tpe == jstpe.VoidType)
         js.Block(callGetter, js.Undefined())
       else
         callGetter
@@ -975,7 +975,7 @@ trait GenJSExports[G <: Global with Singleton] extends SubComponent {
         (toIRType(tpe): @unchecked) match {
           case jstpe.AnyType | jstpe.AnyNotNullType => NoTypeTest
 
-          case jstpe.NoType      => PrimitiveTypeTest(jstpe.UndefType, 0)
+          case jstpe.VoidType    => PrimitiveTypeTest(jstpe.UndefType, 0)
           case jstpe.BooleanType => PrimitiveTypeTest(jstpe.BooleanType, 1)
           case jstpe.CharType    => PrimitiveTypeTest(jstpe.CharType, 2)
           case jstpe.ByteType    => PrimitiveTypeTest(jstpe.ByteType, 3)

--- a/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/TypeConversions.scala
@@ -25,7 +25,7 @@ trait TypeConversions[G <: Global with Singleton] extends SubComponent {
 
   private lazy val primitiveIRTypeMap: Map[Symbol, Types.Type] = {
     Map(
-        UnitClass    -> Types.NoType,
+        UnitClass    -> Types.VoidType,
         BooleanClass -> Types.BooleanType,
         CharClass    -> Types.CharType,
         ByteClass    -> Types.ByteType,

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -581,7 +581,7 @@ object Hashers {
     def mixTypeRef(typeRef: TypeRef): Unit = typeRef match {
       case PrimRef(tpe) =>
         tpe match {
-          case NoType      => mixTag(TagVoidRef)
+          case VoidType    => mixTag(TagVoidRef)
           case BooleanType => mixTag(TagBooleanRef)
           case CharType    => mixTag(TagCharRef)
           case ByteType    => mixTag(TagByteRef)
@@ -621,7 +621,7 @@ object Hashers {
       case DoubleType     => mixTag(TagDoubleType)
       case StringType     => mixTag(TagStringType)
       case NullType       => mixTag(TagNullType)
-      case NoType         => mixTag(TagNoType)
+      case VoidType       => mixTag(TagVoidType)
 
       case ClassType(className, nullable) =>
         mixTag(if (nullable) TagClassType else TagNonNullClassType)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Names.scala
@@ -393,7 +393,7 @@ object Names {
       def appendTypeRef(typeRef: TypeRef): Unit = typeRef match {
         case PrimRef(tpe) =>
           tpe match {
-            case NoType      => builder.append('V')
+            case VoidType    => builder.append('V')
             case BooleanType => builder.append('Z')
             case CharType    => builder.append('C')
             case ByteType    => builder.append('B')

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -781,7 +781,7 @@ object Printers {
         // Literals
 
         case Undefined() =>
-          print("(void 0)")
+          print("undefined")
 
         case Null() =>
           print("null")
@@ -1093,7 +1093,7 @@ object Printers {
       case AnyType        => print("any")
       case AnyNotNullType => print("any!")
       case NothingType    => print("nothing")
-      case UndefType      => print("void")
+      case UndefType      => print("undef")
       case BooleanType    => print("boolean")
       case CharType       => print("char")
       case ByteType       => print("byte")

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -106,7 +106,7 @@ object Printers {
 
       print(")")
 
-      if (resultType != NoType) {
+      if (resultType != VoidType) {
         print(": ")
         print(resultType)
         print(" = ")
@@ -173,7 +173,7 @@ object Printers {
 
         case Labeled(label, tpe, body) =>
           print(label)
-          if (tpe != NoType) {
+          if (tpe != VoidType) {
             print('[')
             print(tpe)
             print(']')
@@ -1037,7 +1037,7 @@ object Printers {
             print(flags.namespace.prefixString)
             print("set ")
             printJSMemberName(name)
-            printSig(arg :: Nil, None, NoType)
+            printSig(arg :: Nil, None, VoidType)
             printBlock(body)
           }
 
@@ -1104,7 +1104,7 @@ object Printers {
       case DoubleType     => print("double")
       case StringType     => print("string")
       case NullType       => print("null")
-      case NoType         => print("<notype>")
+      case VoidType       => print("void")
 
       case ClassType(className, nullable) =>
         print(className)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -171,11 +171,14 @@ private[ir] object Tags {
   final val TagClassType = TagNullType + 1
   final val TagArrayType = TagClassType + 1
   final val TagRecordType = TagArrayType + 1
-  final val TagNoType = TagRecordType + 1
+  final val TagVoidType = TagRecordType + 1
+
+  @deprecated("Use TagVoidType instead", since = "1.18.0")
+  final val TagNoType = TagVoidType
 
   // New in 1.17
 
-  final val TagAnyNotNullType = TagNoType + 1
+  final val TagAnyNotNullType = TagVoidType + 1
   final val TagNonNullClassType = TagAnyNotNullType + 1
   final val TagNonNullArrayType = TagNonNullClassType + 1
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -246,7 +246,7 @@ object Transformers {
 
     def transformMethodDef(methodDef: MethodDef): MethodDef = {
       val MethodDef(flags, name, originalName, args, resultType, body) = methodDef
-      val newBody = body.map(transform(_, isStat = resultType == NoType))
+      val newBody = body.map(transform(_, isStat = resultType == VoidType))
       MethodDef(flags, name, originalName, args, resultType, newBody)(
           methodDef.optimizerHints, Unversioned)(methodDef.pos)
     }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -102,7 +102,7 @@ object Trees {
   sealed case class VarDef(name: LocalIdent, originalName: OriginalName,
       vtpe: Type, mutable: Boolean, rhs: Tree)(
       implicit val pos: Position) extends Tree {
-    val tpe = NoType // cannot be in expression position
+    val tpe = VoidType
 
     def ref(implicit pos: Position): VarRef = VarRef(name)(vtpe)
   }
@@ -116,7 +116,7 @@ object Trees {
   // Control flow constructs
 
   sealed case class Skip()(implicit val pos: Position) extends Tree {
-    val tpe = NoType // cannot be in expression position
+    val tpe = VoidType
   }
 
   sealed class Block private (val stats: List[Tree])(
@@ -157,7 +157,7 @@ object Trees {
 
   sealed case class Assign(lhs: AssignLhs, rhs: Tree)(
       implicit val pos: Position) extends Tree {
-    val tpe = NoType // cannot be in expression position
+    val tpe = VoidType
   }
 
   sealed case class Return(expr: Tree, label: LabelIdent)(
@@ -170,17 +170,16 @@ object Trees {
 
   sealed case class While(cond: Tree, body: Tree)(
       implicit val pos: Position) extends Tree {
-    // cannot be in expression position, unless it is infinite
     val tpe = cond match {
       case BooleanLiteral(true) => NothingType
-      case _                    => NoType
+      case _                    => VoidType
     }
   }
 
   sealed case class ForIn(obj: Tree, keyVar: LocalIdent,
       keyVarOriginalName: OriginalName, body: Tree)(
       implicit val pos: Position) extends Tree {
-    val tpe = NoType
+    val tpe = VoidType
   }
 
   sealed case class TryCatch(block: Tree, errVar: LocalIdent,
@@ -224,7 +223,7 @@ object Trees {
       default: Tree)(val tpe: Type)(implicit val pos: Position) extends Tree
 
   sealed case class Debugger()(implicit val pos: Position) extends Tree {
-    val tpe = NoType // cannot be in expression position
+    val tpe = VoidType
   }
 
   // Scala expressions
@@ -246,7 +245,7 @@ object Trees {
   }
 
   sealed case class StoreModule()(implicit val pos: Position) extends Tree {
-    val tpe = NoType // cannot be in expression position
+    val tpe = VoidType
   }
 
   sealed case class Select(qualifier: Tree, field: FieldIdent)(val tpe: Type)(
@@ -734,7 +733,7 @@ object Trees {
    */
   sealed case class JSSuperConstructorCall(args: List[TreeOrJSSpread])(
       implicit val pos: Position) extends Tree {
-    val tpe = NoType
+    val tpe = VoidType
   }
 
   /** JavaScript dynamic import of the form `import(arg)`.
@@ -827,7 +826,7 @@ object Trees {
       implicit val pos: Position)
       extends Tree {
 
-    val tpe = NoType // cannot be in expression position
+    val tpe = VoidType
   }
 
   /** Unary operation (always preserves pureness).

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -52,7 +52,7 @@ class PrintersTest {
     assertPrintEquals("any", AnyType)
     assertPrintEquals("any!", AnyNotNullType)
     assertPrintEquals("nothing", NothingType)
-    assertPrintEquals("void", UndefType)
+    assertPrintEquals("undef", UndefType)
     assertPrintEquals("boolean", BooleanType)
     assertPrintEquals("char", CharType)
     assertPrintEquals("byte", ByteType)
@@ -808,7 +808,7 @@ class PrintersTest {
   }
 
   @Test def printUndefined(): Unit = {
-    assertPrintEquals("(void 0)", Undefined())
+    assertPrintEquals("undefined", Undefined())
   }
 
   @Test def printNull(): Unit = {
@@ -1298,7 +1298,7 @@ class PrintersTest {
           |constructor def constructor(x: any): any = {
           |  5;
           |  super(6);
-          |  (void 0)
+          |  undefined
           |}
         """,
         JSConstructorDef(MemberFlags.empty.withNamespace(Constructor),

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -63,7 +63,7 @@ class PrintersTest {
     assertPrintEquals("double", DoubleType)
     assertPrintEquals("string", StringType)
     assertPrintEquals("null", NullType)
-    assertPrintEquals("<notype>", NoType)
+    assertPrintEquals("void", VoidType)
 
     assertPrintEquals("java.lang.Object", ClassType(ObjectClass, nullable = true))
     assertPrintEquals("java.lang.String!",
@@ -127,7 +127,7 @@ class PrintersTest {
           |  6
           |}
         """,
-        Labeled("lab", NoType, i(6)))
+        Labeled("lab", VoidType, i(6)))
 
     assertPrintEquals(
         """
@@ -144,7 +144,7 @@ class PrintersTest {
           |  6
           |}
         """,
-        Labeled("lab", NoType, Block(i(5), i(6))))
+        Labeled("lab", VoidType, Block(i(5), i(6))))
   }
 
   @Test def printAssign(): Unit = {
@@ -173,7 +173,7 @@ class PrintersTest {
           |  5
           |}
         """,
-        If(b(true), i(5), Skip())(NoType))
+        If(b(true), i(5), Skip())(VoidType))
 
     assertPrintEquals(
         """
@@ -322,7 +322,7 @@ class PrintersTest {
 
   @Test def printApply(): Unit = {
     assertPrintEquals("x.m;V()",
-        Apply(EAF, ref("x", "test.Test"), MethodName("m", Nil, V), Nil)(NoType))
+        Apply(EAF, ref("x", "test.Test"), MethodName("m", Nil, V), Nil)(VoidType))
     assertPrintEquals("x.m;I;I(5)",
         Apply(EAF, ref("x", "test.Test"), MethodName("m", List(I), I),
             List(i(5)))(IntType))
@@ -334,7 +334,7 @@ class PrintersTest {
   @Test def printApplyStatically(): Unit = {
     assertPrintEquals("x.test.Test::m;V()",
         ApplyStatically(EAF, ref("x", "test.Test"), "test.Test",
-            MethodName("m", Nil, V), Nil)(NoType))
+            MethodName("m", Nil, V), Nil)(VoidType))
     assertPrintEquals("x.test.Test::m;I;I(5)",
         ApplyStatically(EAF, ref("x", "test.Test"), "test.Test",
             MethodName("m", List(I), I), List(i(5)))(IntType))
@@ -344,12 +344,12 @@ class PrintersTest {
 
     assertPrintEquals("x.test.Test::private::m;V()",
         ApplyStatically(EAF.withPrivate(true), ref("x", "test.Test"),
-            "test.Test", MethodName("m", Nil, V), Nil)(NoType))
+            "test.Test", MethodName("m", Nil, V), Nil)(VoidType))
   }
 
   @Test def printApplyStatic(): Unit = {
     assertPrintEquals("test.Test::m;V()",
-        ApplyStatic(EAF, "test.Test", MethodName("m", Nil, V), Nil)(NoType))
+        ApplyStatic(EAF, "test.Test", MethodName("m", Nil, V), Nil)(VoidType))
     assertPrintEquals("test.Test::m;I;I(5)",
         ApplyStatic(EAF, "test.Test", MethodName("m", List(I), I),
             List(i(5)))(IntType))
@@ -359,7 +359,7 @@ class PrintersTest {
 
     assertPrintEquals("test.Test::private::m;V()",
         ApplyStatic(EAF.withPrivate(true), "test.Test", MethodName("m", Nil, V),
-            Nil)(NoType))
+            Nil)(VoidType))
   }
 
   @Test def printApplyDynamicImportStatic(): Unit = {
@@ -1251,7 +1251,7 @@ class PrintersTest {
         """,
         MethodDef(MemberFlags.empty, mIVMethodName, NON,
             List(ParamDef("x", NON, IntType, mutable = false)),
-            NoType, Some(i(5)))(NoOptHints, UNV))
+            VoidType, Some(i(5)))(NoOptHints, UNV))
 
     assertPrintEquals(
         """

--- a/linker/jvm/src/test/scala/org/scalajs/linker/RunTest.scala
+++ b/linker/jvm/src/test/scala/org/scalajs/linker/RunTest.scala
@@ -89,7 +89,7 @@ class RunTest {
     If(UnaryOp(UnaryOp.Boolean_!, test),
         Throw(JSNew(JSGlobalRef("Error"), List(str("Assertion failed")))),
         Skip())(
-        NoType)
+        VoidType)
   }
 
   private def testLinkAndRun(classDefs: Seq[ClassDef],

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -254,7 +254,7 @@ object Infos {
         case NullType | NothingType =>
           // Nothing to do
 
-        case NoType | RecordType(_) =>
+        case VoidType | RecordType(_) =>
           throw new IllegalArgumentException(
               s"Illegal receiver type: $receiverTpe")
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -320,10 +320,10 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
         val initMethodBody = initMethodDef.body.getOrElse {
           throw new AssertionError("Cannot generate an abstract constructor")
         }
-        assert(initMethodDef.resultType == NoType,
+        assert(initMethodDef.resultType == VoidType,
             s"Found a constructor with type ${initMethodDef.resultType} at $pos")
         desugarToFunction(className, initMethodDef.args, initMethodBody,
-            resultType = NoType)
+            resultType = VoidType)
       }
 
       for (generatedInitMethodFun <- generatedInitMethodFunWithGlobals) yield {
@@ -597,7 +597,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     // optional setter definition
     val optSetterWithGlobals = property.setterArgAndBody map {
       case (arg, body) =>
-        desugarToFunction(className, arg :: Nil, body, resultType = NoType)
+        desugarToFunction(className, arg :: Nil, body, resultType = VoidType)
     }
 
     for {
@@ -629,7 +629,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
       }
 
       val setterWithGlobals = property.setterArgAndBody.map { case (arg, body) =>
-        for (fun <- desugarToFunction(className, arg :: Nil, body, resultType = NoType))
+        for (fun <- desugarToFunction(className, arg :: Nil, body, resultType = VoidType))
           yield js.SetterDef(static, propName, fun.args.head, fun.body)
       }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -2109,7 +2109,7 @@ private[emitter] object CoreJSLib {
          * `scala.collection.mutable.ArrayBuilder.genericArrayBuilderResult`.
          * This code is Scala-specific, and "unboxes" `null` as the zero of
          * primitive types. For `void`, it is even more special, as it produces
-         * a boxed Unit value, which is `undefined` (although `VoidRef`/`NoType`
+         * a boxed Unit value, which is `undefined` (although `VoidRef`/`VoidType`
          * doesn't have a zero value per se).
          */
         val zero = primRef match {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -284,7 +284,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
       globalRefTracking: GlobalRefTracking, pos: Position): WithGlobals[js.Function] = {
     new JSDesugar(globalRefTracking).desugarToFunction(
-        params, restParam, body, isStat = resultType == NoType,
+        params, restParam, body, isStat = resultType == VoidType,
         Env.empty(resultType).withEnclosingClassName(Some(enclosingClassName)))
   }
 
@@ -296,7 +296,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
       globalRefTracking: GlobalRefTracking, pos: Position): WithGlobals[js.Function] = {
     new JSDesugar(globalRefTracking).desugarToFunctionWithExplicitThis(
-        params, body, isStat = resultType == NoType,
+        params, body, isStat = resultType == VoidType,
         Env.empty(resultType).withEnclosingClassName(Some(enclosingClassName)))
   }
 
@@ -307,7 +307,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
       globalRefTracking: GlobalRefTracking, pos: Position): WithGlobals[js.Function] = {
     new JSDesugar(globalRefTracking).desugarToFunction(
-        params, restParam, body, isStat = resultType == NoType,
+        params, restParam, body, isStat = resultType == VoidType,
         Env.empty(resultType))
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
@@ -144,7 +144,7 @@ private[backend] final class NameGen {
         typeRef match {
           case PrimRef(tpe) =>
             tpe match {
-              case NoType      => builder.append('V')
+              case VoidType    => builder.append('V')
               case BooleanType => builder.append('Z')
               case CharType    => builder.append('C')
               case ByteType    => builder.append('B')

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -213,7 +213,7 @@ private[emitter] final class SJSGen(
       case UndefType   => Undefined()
       case NullType    => Null()
 
-      case NoType | NothingType =>
+      case VoidType | NothingType =>
         throw new IllegalArgumentException(s"cannot generate a zero for $tpe")
     }
   }
@@ -443,7 +443,7 @@ private[emitter] final class SJSGen(
 
       case AnyNotNullType => expr !== Null()
 
-      case NoType | NullType | NothingType | AnyType |
+      case VoidType | NullType | NothingType | AnyType |
           ClassType(_, true) | ArrayType(_, true) | _:RecordType =>
         throw new AssertionError(s"Unexpected type $tpe in genIsInstanceOf")
     }
@@ -527,7 +527,7 @@ private[emitter] final class SJSGen(
           if (semantics.strictFloats) genCallPolyfillableBuiltin(FroundBuiltin, expr)
           else wg(UnaryOp(irt.JSUnaryOp.+, expr))
 
-        case NoType | NullType | NothingType | AnyNotNullType |
+        case VoidType | NullType | NothingType | AnyNotNullType |
             ClassType(_, false) | ArrayType(_, false) | _:RecordType =>
           throw new AssertionError(s"Unexpected type $tpe in genAsInstanceOf")
       }
@@ -553,7 +553,7 @@ private[emitter] final class SJSGen(
         case StringType  => genCallHelper(VarField.uT, expr)
         case AnyType     => expr
 
-        case NoType | NullType | NothingType | AnyNotNullType |
+        case VoidType | NullType | NothingType | AnyNotNullType |
             ClassType(_, false) | ArrayType(_, false) | _:RecordType =>
           throw new AssertionError(s"Unexpected type $tpe in genAsInstanceOf")
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
@@ -62,7 +62,7 @@ object Transients {
   final case class SystemArrayCopy(src: Tree, srcPos: Tree, dest: Tree,
       destPos: Tree, length: Tree)
       extends Transient.Value {
-    val tpe: Type = NoType
+    val tpe: Type = VoidType
 
     def traverse(traverser: Traverser): Unit = {
       traverser.traverse(src)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -379,7 +379,7 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
       def subField(x: PrimRef): String = {
         // The mapping in this function is an implementation detail of the emitter
         x.tpe match {
-          case NoType      => "V"
+          case VoidType    => "V"
           case BooleanType => "Z"
           case CharType    => "C"
           case ByteType    => "B"

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/ClassEmitter.scala
@@ -1201,7 +1201,7 @@ class ClassEmitter(coreSpec: CoreSpec) {
                 setterParamDef :: Nil,
                 restParam = None,
                 setterBody,
-                resultType = NoType
+                resultType = VoidType
               )
               val setterRef = helperBuilder.addWasmInput("set", watpe.RefType.func) {
                 fb += ctx.refFuncWithDeclaration(closureFuncID)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/DerivedClasses.scala
@@ -103,7 +103,7 @@ object DerivedClasses {
       MethodIdent(MethodName.constructor(List(primType.primRef))),
       NON,
       List(ctorParamDef),
-      NoType,
+      VoidType,
       Some(Assign(selectField, ctorParamDef.ref))
     )(EOH, NOV)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -40,7 +40,7 @@ object SWasmGen {
       case AnyType | ClassType(_, true) | ArrayType(_, true) | NullType =>
         RefNull(Types.HeapType.None)
 
-      case NothingType | NoType | ClassType(_, false) | ArrayType(_, false) |
+      case NothingType | VoidType | ClassType(_, false) | ArrayType(_, false) |
           AnyNotNullType | _:RecordType =>
         throw new AssertionError(s"Unexpected type for field: ${tpe.show()}")
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/TypeTransformer.scala
@@ -68,7 +68,7 @@ object TypeTransformer {
    */
   def transformResultType(tpe: Type)(implicit ctx: WasmContext): List[watpe.Type] = {
     tpe match {
-      case NoType             => Nil
+      case VoidType           => Nil
       case NothingType        => Nil
       case RecordType(fields) => fields.flatMap(f => transformResultType(f.tpe))
       case _                  => List(transformSingleType(tpe))
@@ -134,7 +134,7 @@ object TypeTransformer {
       case StringType  => watpe.RefType.extern
       case NullType    => watpe.RefType.nullref
 
-      case NoType | NothingType =>
+      case VoidType | NothingType =>
         throw new IllegalArgumentException(
             s"${tpe.show()} does not have a corresponding Wasm type")
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -139,8 +139,8 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
     body.superCall.args.foreach(typecheckExprOrSpread(_, bodyEnv))
     body.afterSuper.foreach(typecheck(_, bodyEnv))
 
-    val resultType = body.afterSuper.lastOption.fold[Type](NoType)(_.tpe)
-    if (resultType == NoType)
+    val resultType = body.afterSuper.lastOption.fold[Type](VoidType)(_.tpe)
+    if (resultType == VoidType)
       reportError(i"${AnyType} expected but $resultType found for JS constructor body")
   }
 
@@ -257,7 +257,7 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
 
       case Return(expr, label) =>
         val returnType = env.returnTypes(label.name)
-        if (returnType == NoType)
+        if (returnType == VoidType)
           typecheckExpr(expr, env)
         else
           typecheckExpect(expr, env, returnType)
@@ -312,7 +312,7 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter) {
         val clazz = lookupClass(className)
         if (clazz.kind != ClassKind.Class)
           reportError(i"new $className which is not a class")
-        checkApplyGeneric(className, ctor.name, args, NoType, isStatic = false)
+        checkApplyGeneric(className, ctor.name, args, VoidType, isStatic = false)
 
       case LoadModule(className) =>
         val clazz = lookupClass(className)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -419,7 +419,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
     val className: ClassName = linkedClass.className
 
     def untrackedThisType: Type =
-      if (namespace.isStatic) NoType
+      if (namespace.isStatic) VoidType
       else myInterface.untrackedInstanceThisType
 
     val methods = mutable.Map.empty[MethodName, MethodImpl]
@@ -1162,7 +1162,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
     def untrackedJSClassCaptures: List[ParamDef] = _jsClassCaptures
 
     def untrackedThisType(namespace: MemberNamespace): Type =
-      if (namespace.isStatic) NoType
+      if (namespace.isStatic) VoidType
       else myInterface.untrackedInstanceThisType
 
     def updateWith(linkedClass: LinkedClass): Unit = {
@@ -1220,7 +1220,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
     private[this] var methods = Map.empty[(String, String), (JSMethodImpl, Position)]
 
     val untrackedJSClassCaptures: List[ParamDef] = Nil
-    def untrackedThisType(namespace: MemberNamespace): Type = NoType
+    def untrackedThisType(namespace: MemberNamespace): Type = VoidType
 
     override def toString(): String = "<top-level>"
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -315,9 +315,9 @@ class AnalyzerTest {
         classDef("A", superClass = Some(ObjectClass),
             methods = List(
                 trivialCtor("A"),
-                MethodDef(EMF, barMethodName, NON, Nil, NoType, Some(Block(
-                  Apply(EAF, thisFor("A"), fooMethodName, Nil)(NoType),
-                  Apply(EAF, New("B", NoArgConstructorName, Nil), fooMethodName, Nil)(NoType)
+                MethodDef(EMF, barMethodName, NON, Nil, VoidType, Some(Block(
+                  Apply(EAF, thisFor("A"), fooMethodName, Nil)(VoidType),
+                  Apply(EAF, New("B", NoArgConstructorName, Nil), fooMethodName, Nil)(VoidType)
                 )))(EOH, UNV)
             )),
         classDef("B", superClass = Some("A"),
@@ -413,7 +413,7 @@ class AnalyzerTest {
     val testName = m("test", Nil, O)
     val method = MethodDef(
         EMF.withNamespace(MemberNamespace.PublicStatic),
-        mainName, NON, Nil, NoType,
+        mainName, NON, Nil, VoidType,
         Some(SelectJSNativeMember("A", testName)))(EOH, UNV)
 
     val classDefs = Seq(
@@ -433,7 +433,7 @@ class AnalyzerTest {
   @Test
   def conflictingDefaultMethods(): AsyncResult = await {
     val defaultMethodDef = MethodDef(EMF, m("foo", Nil, V), NON, Nil,
-        NoType, Some(Skip()))(EOH, UNV)
+        VoidType, Some(Skip()))(EOH, UNV)
     val classDefs = Seq(
         classDef("I1", kind = ClassKind.Interface,
             methods = List(defaultMethodDef)),
@@ -603,7 +603,7 @@ class AnalyzerTest {
 
     val mainMethod = MethodDef(
         EMF.withNamespace(MemberNamespace.PublicStatic),
-        mainName, NON, Nil, NoType,
+        mainName, NON, Nil, VoidType,
         Some(SelectJSNativeMember("A", testName)))(EOH, UNV)
     val nativeMember = JSNativeMemberDef(
         EMF.withNamespace(MemberNamespace.PublicStatic), testName,

--- a/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IRCheckerTest.scala
@@ -48,7 +48,7 @@ class IRCheckerTest {
     val nullBarMethodName = m("nullBar", Nil, ClassRef(BarClass))
 
     def callMethOn(receiver: Tree): Tree =
-      Apply(EAF, receiver, methMethodName, List(Null()))(NoType)
+      Apply(EAF, receiver, methMethodName, List(Null()))(VoidType)
 
     val classDefs = Seq(
         // LFoo will be dropped by base linking
@@ -63,7 +63,7 @@ class IRCheckerTest {
                  * instances of `Bar`. It will therefore not make `Foo` reachable.
                  */
                 MethodDef(EMF, methMethodName, NON,
-                    List(paramDef("foo", ClassType("Foo", nullable = true))), NoType,
+                    List(paramDef("foo", ClassType("Foo", nullable = true))), VoidType,
                     Some(Skip()))(
                     EOH, UNV)
             )
@@ -114,7 +114,7 @@ class IRCheckerTest {
           interfaces = Nil,
           methods = List(
             MethodDef(EMF, fooMethodName, NON,
-                List(paramDef("x", ClassType(B, nullable = true))), NoType, Some(Skip()))(
+                List(paramDef("x", ClassType(B, nullable = true))), VoidType, Some(Skip()))(
                 EOH, UNV)
           )
         ),
@@ -143,19 +143,19 @@ class IRCheckerTest {
                 paramDef("c", ClassType(C, nullable = true)),
                 paramDef("d", ClassType(D, nullable = true))
               ),
-              NoType,
+              VoidType,
               Some(Block(
                 Apply(EAF, VarRef("x")(receiverType), fooMethodName,
-                    List(VarRef("c")(ClassType(C, nullable = true))))(NoType),
+                    List(VarRef("c")(ClassType(C, nullable = true))))(VoidType),
                 Apply(EAF, VarRef("x")(receiverType), fooMethodName,
-                    List(VarRef("d")(ClassType(D, nullable = true))))(NoType)
+                    List(VarRef("d")(ClassType(D, nullable = true))))(VoidType)
               ))
             )(EOH, UNV)
           )
         ),
 
         mainTestClassDef(
-          ApplyStatic(EAF, D, testMethodName, List(newD, newD, newD))(NoType)
+          ApplyStatic(EAF, D, testMethodName, List(newD, newD, newD))(VoidType)
         )
       )
 
@@ -220,7 +220,7 @@ class IRCheckerTest {
 
     for (log <- testLinkIRErrors(classDefs, MainTestModuleInitializers)) yield {
       log.assertContainsError(
-          "any expected but <notype> found for JS constructor body")
+          "any expected but void found for JS constructor body")
     }
   }
 
@@ -249,7 +249,7 @@ class IRCheckerTest {
 
     for (log <- testLinkIRErrors(classDefs, MainTestModuleInitializers)) yield {
       log.assertContainsError(
-          "any expected but <notype> found for JS constructor body")
+          "any expected but void found for JS constructor body")
     }
   }
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/IncrementalTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IncrementalTest.scala
@@ -205,10 +205,10 @@ class IncrementalTest {
     val meth2 = m("meth2", Nil, VoidRef)
 
     def methDef(name: MethodName, body: Tree): MethodDef =
-      MethodDef(EMF, name, NON, Nil, NoType, Some(body))(EOH.withNoinline(true), UNV)
+      MethodDef(EMF, name, NON, Nil, VoidType, Some(body))(EOH.withNoinline(true), UNV)
 
     def callMeth(targetMeth: MethodName): Tree =
-      Apply(EAF, LoadModule(FooClass), targetMeth, Nil)(NoType)
+      Apply(EAF, LoadModule(FooClass), targetMeth, Nil)(VoidType)
 
     def classDefs(step: Int) = {
       val stepDependentMembers = step match {
@@ -263,12 +263,12 @@ class IncrementalTest {
 
     def methDef(name: MethodName, body: Tree): MethodDef = {
       MethodDef(EMF.withNamespace(MemberNamespace.PublicStatic), name, NON, Nil,
-          NoType, Some(body))(
+          VoidType, Some(body))(
           EOH.withNoinline(true), UNV)
     }
 
     def callMeth(targetMeth: MethodName): Tree =
-      ApplyStatic(EAF, FooClass, targetMeth, Nil)(NoType)
+      ApplyStatic(EAF, FooClass, targetMeth, Nil)(VoidType)
 
     def classDefs(step: Int) = {
       val stepDependentMembers = step match {
@@ -317,7 +317,7 @@ class IncrementalTest {
         ApplyStatically(EAF.withConstructor(true),
             thisFor(FooModule),
             ObjectClass, MethodIdent(NoArgConstructorName),
-            Nil)(NoType)
+            Nil)(VoidType)
       }
 
       val body =
@@ -325,7 +325,7 @@ class IncrementalTest {
         else Block(superCtor, consoleLog(str("bar")))
 
       MethodDef(MemberFlags.empty.withNamespace(MemberNamespace.Constructor),
-          MethodIdent(NoArgConstructorName), NON, Nil, NoType,
+          MethodIdent(NoArgConstructorName), NON, Nil, VoidType,
           Some(body))(EOH, UNV)
     }
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibraryReachabilityTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibraryReachabilityTest.scala
@@ -43,7 +43,7 @@ class LibraryReachabilityTest {
     val classDefs = Seq(
         classDef("A", superClass = Some(ObjectClass), methods = List(
             trivialCtor("A"),
-            MethodDef(EMF, m("test", Nil, V), NON, Nil, NoType, Some(Block(
+            MethodDef(EMF, m("test", Nil, V), NON, Nil, VoidType, Some(Block(
                 Apply(EAF, systemMod, m("getProperty", List(T), T), List(emptyStr))(StringType),
                 Apply(EAF, systemMod, m("getProperty", List(T, T), T), List(emptyStr, emptyStr))(StringType),
                 Apply(EAF, systemMod, m("setProperty", List(T, T), T), List(emptyStr, emptyStr))(StringType),
@@ -72,7 +72,7 @@ class LibraryReachabilityTest {
     val classDefs = Seq(
       classDef("A", superClass = Some(ObjectClass), methods = List(
         trivialCtor("A"),
-        MethodDef(EMF, m("test", Nil, V), NON, Nil, NoType, Some(Block(
+        MethodDef(EMF, m("test", Nil, V), NON, Nil, VoidType, Some(Block(
           ApplyStatic(EAF, BoxedStringClass, formatMethod, List(str("hello %d"), int(42)))(StringType)
         )))(EOH, UNV)
       ))

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -274,16 +274,16 @@ class OptimizerTest {
 
     val classDefs = Seq(
         mainTestClassDef(Block(
-            Labeled(matchResult1, NoType, Block(
+            Labeled(matchResult1, VoidType, Block(
                 VarDef(x1, NON, AnyType, mutable = false, Null()),
-                Labeled(matchAlts1, NoType, Block(
-                    Labeled(matchAlts2, NoType, Block(
+                Labeled(matchAlts1, VoidType, Block(
+                    Labeled(matchAlts2, VoidType, Block(
                         If(IsInstanceOf(VarRef(x1)(AnyType), ClassType(BoxedIntegerClass, nullable = false)), {
                           Return(Undefined(), matchAlts2)
-                        }, Skip())(NoType),
+                        }, Skip())(VoidType),
                         If(IsInstanceOf(VarRef(x1)(AnyType), ClassType(BoxedStringClass, nullable = false)), {
                           Return(Undefined(), matchAlts2)
-                        }, Skip())(NoType),
+                        }, Skip())(VoidType),
                         Return(Undefined(), matchAlts1)
                     )),
                     Return(Undefined(), matchResult1)
@@ -505,7 +505,7 @@ class OptimizerTest {
             //   this.y = 5
             //   this.jl.Object::<init>()
             // }
-            MethodDef(EMF.withNamespace(Constructor), NoArgConstructorName, NON, Nil, NoType, Some(Block(
+            MethodDef(EMF.withNamespace(Constructor), NoArgConstructorName, NON, Nil, VoidType, Some(Block(
               Assign(Select(thisFor("Foo"), FieldName("Foo", "x"))(witnessType), Null()),
               Assign(Select(thisFor("Foo"), FieldName("Foo", "y"))(IntType), int(5)),
               trivialSuperCtorCall("Foo")

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -173,7 +173,7 @@ class ClassDefCheckerTest {
       ArrayType(ArrayTypeRef(I, 1), nullable = false),
       RecordType(List(RecordType.Field("I", NON, IntType, mutable = true))),
       NothingType,
-      NoType
+      VoidType
     )
 
     for (fieldType <- badFieldTypes) {
@@ -210,7 +210,7 @@ class ClassDefCheckerTest {
 
     val callPrimaryCtorBody: Tree = {
       ApplyStatically(EAF.withConstructor(true), thisFor(FooClass),
-          FooClass, NoArgConstructorName, Nil)(NoType)
+          FooClass, NoArgConstructorName, Nil)(VoidType)
     }
 
     assertError(
@@ -219,11 +219,11 @@ class ClassDefCheckerTest {
               trivialCtor(FooClass),
               MethodDef(EMF.withNamespace(MemberNamespace.Constructor),
                   stringCtorName, NON, List(paramDef("x", BoxedStringType)),
-                  NoType, Some(callPrimaryCtorBody))(
+                  VoidType, Some(callPrimaryCtorBody))(
                   EOH, UNV),
               MethodDef(EMF.withNamespace(MemberNamespace.Constructor),
                   stringCtorName, NON, List(paramDef("y", BoxedStringType)),
-                  NoType, Some(callPrimaryCtorBody))(
+                  VoidType, Some(callPrimaryCtorBody))(
                   EOH, UNV)
           )),
         "duplicate constructor method '<init>(java.lang.String)void'")
@@ -293,7 +293,7 @@ class ClassDefCheckerTest {
   def noDuplicateVarDefTryCatch(): Unit = {
     val body = Block(
       VarDef("x", NoOriginalName, IntType, mutable = false, int(1)),
-      TryCatch(Skip(), "x", NoOriginalName, Skip())(NoType)
+      TryCatch(Skip(), "x", NoOriginalName, Skip())(VoidType)
     )
 
     assertError(
@@ -310,7 +310,7 @@ class ClassDefCheckerTest {
         classDef(
           "Foo", superClass = Some(ObjectClass),
           methods = List(
-            MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, NoType,
+            MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, VoidType,
                 Some(int(5)))(EOH, UNV)
           )
         ),
@@ -325,9 +325,9 @@ class ClassDefCheckerTest {
         classDef(
           "Foo", superClass = Some(ObjectClass),
           methods = List(
-            MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, NoType, Some {
+            MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, VoidType, Some {
               ApplyStatically(EAF.withConstructor(true), thisFor("Foo"),
-                  "Bar", NoArgConstructorName, Nil)(NoType)
+                  "Bar", NoArgConstructorName, Nil)(VoidType)
             })(EOH, UNV)
           )
         ),
@@ -341,7 +341,7 @@ class ClassDefCheckerTest {
 
     def ctorCall(receiver: Tree): ApplyStatically = {
       ApplyStatically(EAF.withConstructor(true), receiver,
-          ObjectClass, NoArgConstructorName, Nil)(NoType)
+          ObjectClass, NoArgConstructorName, Nil)(VoidType)
     }
 
     val thiz = thisFor("Foo")
@@ -350,7 +350,7 @@ class ClassDefCheckerTest {
         classDef(
           "Foo", superClass = Some(ObjectClass),
           methods = List(
-            MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, NoType, Some(Block(
+            MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, VoidType, Some(Block(
               ctorCall(thiz),
               ctorCall(Null())
             )))(EOH, UNV)
@@ -362,9 +362,9 @@ class ClassDefCheckerTest {
         classDef(
           "Foo", superClass = Some(ObjectClass),
           methods = List(
-            MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, NoType, Some(Block(
+            MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, VoidType, Some(Block(
               ctorCall(thiz),
-              If(BooleanLiteral(true), ctorCall(thiz), Skip())(NoType)
+              If(BooleanLiteral(true), ctorCall(thiz), Skip())(VoidType)
             )))(EOH, UNV)
           )
         ),
@@ -375,7 +375,7 @@ class ClassDefCheckerTest {
           "Foo", superClass = Some(ObjectClass),
           methods = List(
             trivialCtor("Foo"),
-            MethodDef(EMF, m("foo", Nil, V), NON, Nil, NoType, Some(Block(
+            MethodDef(EMF, m("foo", Nil, V), NON, Nil, VoidType, Some(Block(
               ctorCall(thiz)
             )))(EOH, UNV)
           )
@@ -394,7 +394,7 @@ class ClassDefCheckerTest {
           classDef(
             "Foo", superClass = Some(ObjectClass),
             methods = List(
-              MethodDef(methodFlags, m("bar", Nil, V), NON, Nil, NoType, Some({
+              MethodDef(methodFlags, m("bar", Nil, V), NON, Nil, VoidType, Some({
                 consoleLog(expr)
               }))(EOH, UNV)
             )
@@ -403,7 +403,7 @@ class ClassDefCheckerTest {
     }
 
     testThisTypeError(static = true,
-        This()(NoType),
+        This()(VoidType),
         "Cannot find `this` in scope")
 
     testThisTypeError(static = true,
@@ -411,8 +411,8 @@ class ClassDefCheckerTest {
         "Cannot find `this` in scope")
 
     testThisTypeError(static = false,
-        This()(NoType),
-        "`this` of type Foo! typed as <notype>")
+        This()(VoidType),
+        "`this` of type Foo! typed as void")
 
     testThisTypeError(static = false,
         This()(AnyType),
@@ -431,7 +431,7 @@ class ClassDefCheckerTest {
         "`this` of type Foo! typed as Foo")
 
     testThisTypeError(static = false,
-        Closure(arrow = true, Nil, Nil, None, This()(NoType), Nil),
+        Closure(arrow = true, Nil, Nil, None, This()(VoidType), Nil),
         "Cannot find `this` in scope")
 
     testThisTypeError(static = false,
@@ -439,8 +439,8 @@ class ClassDefCheckerTest {
         "Cannot find `this` in scope")
 
     testThisTypeError(static = false,
-        Closure(arrow = false, Nil, Nil, None, This()(NoType), Nil),
-        "`this` of type any typed as <notype>")
+        Closure(arrow = false, Nil, Nil, None, This()(VoidType), Nil),
+        "`this` of type any typed as void")
 
     testThisTypeError(static = false,
         Closure(arrow = false, Nil, Nil, None, This()(ClassType("Foo", nullable = false)), Nil),
@@ -460,7 +460,7 @@ class ClassDefCheckerTest {
             "Foo", superClass = Some(ObjectClass),
             methods = List(
               MethodDef(ctorFlags, MethodName.constructor(List(I)), NON,
-                  List(xParamDef), NoType, Some(Block(ctorStats: _*)))(EOH, UNV)
+                  List(xParamDef), VoidType, Some(Block(ctorStats: _*)))(EOH, UNV)
             )
           ),
           "Restricted use of `this` before the super constructor call")
@@ -497,7 +497,7 @@ class ClassDefCheckerTest {
     testRestrictedThisError(
       ApplyStatically(EAF.withConstructor(true), thiz, ObjectClass,
           MethodIdent(MethodName.constructor(List(O))),
-          List(thiz))(NoType)
+          List(thiz))(VoidType)
     )
   }
 
@@ -513,7 +513,7 @@ class ClassDefCheckerTest {
         kind = ClassKind.Class,
         superClass = Some(ObjectClass),
         methods = List(
-          MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, NoType, Some {
+          MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, VoidType, Some {
             Block(
               superCtorCall,
               StoreModule()
@@ -530,7 +530,7 @@ class ClassDefCheckerTest {
         kind = ClassKind.ModuleClass,
         superClass = Some(ObjectClass),
         methods = List(
-          MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, NoType, Some {
+          MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, VoidType, Some {
             Block(
               StoreModule(),
               superCtorCall
@@ -547,10 +547,10 @@ class ClassDefCheckerTest {
         kind = ClassKind.ModuleClass,
         superClass = Some(ObjectClass),
         methods = List(
-          MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, NoType, Some {
+          MethodDef(ctorFlags, NoArgConstructorName, NON, Nil, VoidType, Some {
             Block(
               superCtorCall,
-              If(BooleanLiteral(true), StoreModule(), Skip())(NoType)
+              If(BooleanLiteral(true), StoreModule(), Skip())(VoidType)
             )
           })(EOH, UNV)
         )
@@ -565,7 +565,7 @@ class ClassDefCheckerTest {
         superClass = Some(ObjectClass),
         methods = List(
           trivialCtor("Foo"),
-          MethodDef(EMF, MethodName("foo", Nil, VoidRef), NON, Nil, NoType, Some {
+          MethodDef(EMF, MethodName("foo", Nil, VoidRef), NON, Nil, VoidType, Some {
             Block(
               StoreModule()
             )
@@ -597,7 +597,7 @@ class ClassDefCheckerTest {
         jsConstructor = Some(
           JSConstructorDef(JSCtorFlags, Nil, None,
               JSConstructorBody(Nil, JSSuperConstructorCall(Nil),
-                  If(BooleanLiteral(true), StoreModule(), Skip())(NoType) :: Undefined() :: Nil))(
+                  If(BooleanLiteral(true), StoreModule(), Skip())(VoidType) :: Undefined() :: Nil))(
               EOH, UNV)
         )
       ),
@@ -624,7 +624,7 @@ class ClassDefCheckerTest {
       testAsInstanceOfError(tpe)
     }
 
-    testIsAsInstanceOfError(NoType)
+    testIsAsInstanceOfError(VoidType)
     testIsAsInstanceOfError(NullType)
     testIsAsInstanceOfError(NothingType)
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/TestIRBuilder.scala
@@ -88,7 +88,7 @@ object TestIRBuilder {
 
   def trivialCtor(enclosingClassName: ClassName, parentClassName: ClassName = ObjectClass): MethodDef = {
     val flags = MemberFlags.empty.withNamespace(MemberNamespace.Constructor)
-    MethodDef(flags, MethodIdent(NoArgConstructorName), NON, Nil, NoType,
+    MethodDef(flags, MethodIdent(NoArgConstructorName), NON, Nil, VoidType,
         Some(trivialSuperCtorCall(enclosingClassName, parentClassName)))(
         EOH, UNV)
   }
@@ -98,7 +98,7 @@ object TestIRBuilder {
     ApplyStatically(EAF.withConstructor(true),
         thisFor(enclosingClassName),
         parentClassName, MethodIdent(NoArgConstructorName),
-        Nil)(NoType)
+        Nil)(VoidType)
   }
 
   def trivialJSCtor: JSConstructorDef = {
@@ -112,7 +112,7 @@ object TestIRBuilder {
   def mainMethodDef(body: Tree): MethodDef = {
     val argsParamDef = paramDef("args", ArrayType(AT, nullable = true))
     MethodDef(MemberFlags.empty.withNamespace(MemberNamespace.PublicStatic),
-        MainMethodName, NON, List(argsParamDef), NoType, Some(body))(
+        MainMethodName, NON, List(argsParamDef), VoidType, Some(body))(
         EOH, UNV)
   }
 
@@ -126,7 +126,7 @@ object TestIRBuilder {
 
     val out = ApplyStatic(EAF, "java.lang.System", outMethodName, Nil)(
         ClassType(PrintStreamClass, nullable = true))
-    Apply(EAF, out, printlnMethodName, List(expr))(NoType)
+    Apply(EAF, out, printlnMethodName, List(expr))(VoidType)
   }
 
   def paramDef(name: LocalName, ptpe: Type): ParamDef =

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -7,7 +7,9 @@ object BinaryIncompatibilities {
   val IR = Seq(
     // !!! Breaking, OK in minor release
     ProblemFilters.exclude[MissingClassProblem]("org.scalajs.ir.Trees$JSLinkingInfo"),
-    ProblemFilters.exclude[MissingClassProblem]("org.scalajs.ir.Trees$JSLinkingInfo$")
+    ProblemFilters.exclude[MissingClassProblem]("org.scalajs.ir.Trees$JSLinkingInfo$"),
+    ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.scalajs.ir.Trees#*.tpe"),
+    ProblemFilters.exclude[MissingClassProblem]("org.scalajs.ir.Types$NoType$"),
   )
 
   val Linker = Seq(

--- a/project/JavaLangObject.scala
+++ b/project/JavaLangObject.scala
@@ -51,7 +51,7 @@ object JavaLangObject {
           MethodIdent(NoArgConstructorName),
           NoOriginalName,
           Nil,
-          NoType,
+          VoidType,
           Some(Skip()))(OptimizerHints.empty, Unversioned),
 
         /* def getClass(): java.lang.Class[_] = <getclass>(this) */
@@ -148,7 +148,7 @@ object JavaLangObject {
           MethodIdent(MethodName("notify", Nil, VoidRef)),
           NoOriginalName,
           Nil,
-          NoType,
+          VoidType,
           Some(Skip()))(OptimizerHints.empty, Unversioned),
 
         /* def notifyAll(): Unit = () */
@@ -157,7 +157,7 @@ object JavaLangObject {
           MethodIdent(MethodName("notifyAll", Nil, VoidRef)),
           NoOriginalName,
           Nil,
-          NoType,
+          VoidType,
           Some(Skip()))(OptimizerHints.empty, Unversioned),
 
         /* def finalize(): Unit = () */
@@ -166,7 +166,7 @@ object JavaLangObject {
           MethodIdent(MethodName("finalize", Nil, VoidRef)),
           NoOriginalName,
           Nil,
-          NoType,
+          VoidType,
           Some(Skip()))(OptimizerHints.empty, Unversioned),
       ),
       jsConstructor = None,


### PR DESCRIPTION
We have been using `void` in the "theoretical" type system since Scala.js 1.0.0, but for historical, `NoType` kept its old name.

We now officially rename it to `VoidType`, and print it as `void` instead of `<notype>`, giving it a true `Type` status.

---

I've been wanting to do this for a while now. I finally took it up. :sweat_smile: 