### PR TITLE
Wasm: Switch to `try_table` to compile `TryCatch`.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/FunctionBuilder.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/FunctionBuilder.scala
@@ -377,7 +377,7 @@ final class FunctionBuilder(
         while (nestingLevel >= 0 && iter.hasNext) {
           val deadCodeInstr = iter.next()
           deadCodeInstr match {
-            case End | Else | _: Catch if nestingLevel == 0 =>
+            case End | Else if nestingLevel == 0 =>
               /* We have reached the end of the original block of dead code.
                * Actually emit this END or ELSE and then drop `nestingLevel`
                * below 0 to end the dead code processing loop.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Instructions.scala
@@ -120,17 +120,6 @@ object Instructions {
 
   case object Else extends SimpleInstr("else", 0x05)
 
-  /** `try` in the legacy exception system.
-   *
-   *  @see
-   *    [[https://webassembly.github.io/exception-handling/legacy/exceptions/core/syntax.html]]
-   */
-  final case class Try(i: BlockType, label: Option[LabelID] = None)
-      extends BlockTypeLabeledInstr("try", 0x06, i)
-
-  /** `catch` in the legacy exception system. */
-  final case class Catch(i: TagID) extends TagInstr("catch", 0x07, i)
-
   final case class Throw(i: TagID) extends TagInstr("throw", 0x08, i) with StackPolymorphicInstr
   case object ThrowRef extends SimpleInstr("throw_ref", 0x0A) with StackPolymorphicInstr
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/TextWriter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/TextWriter.scala
@@ -411,8 +411,8 @@ private class TextWriter(module: Module) {
 
       case _ =>
         instr match {
-          case End | Else | _: Catch => b.deindent()
-          case _                     => // do nothing
+          case End | Else => b.deindent()
+          case _          => // do nothing
         }
         b.newLine()
         b.appendElement(instr.mnemonic)
@@ -429,8 +429,8 @@ private class TextWriter(module: Module) {
         writeInstrImmediates(instr)
 
         instr match {
-          case _: StructuredLabeledInstr | Else | _: Catch => b.indent()
-          case _                                           => // do nothing
+          case _: StructuredLabeledInstr | Else => b.indent()
+          case _                                => // do nothing
         }
     }
   }


### PR DESCRIPTION
And remove the internal support for the legacy `try/catch` instruction pair.

Now that Node.js 23 is released, we can always use `try_table`. The main browsers already have full support for `try_table`.

---

Our CI servers were upgraded to Node.js 23 to support this.

/cc @tanishiking 