### PR TITLE
Optimizer: Fix types of ArraySelect trees

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -1479,6 +1479,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
       dynamicCallers.forEachValue(Long.MaxValue, _.remove(dependee))
       staticCallers.foreach(_.forEachValue(Long.MaxValue, _.remove(dependee)))
       jsNativeImportsAskers.remove(dependee)
+      fieldsReadAskers.remove(dependee)
     }
 
     private def computeJSNativeImports(linkedClass: LinkedClass): JSNativeImports = {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2055,7 +2055,7 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 423000 to 424000,
+                  fastLink = 422000 to 423000,
                   fullLink = 280000 to 281000,
                   fastLinkGz = 60000 to 61000,
                   fullLinkGz = 43000 to 44000,


### PR DESCRIPTION
Split out from #5066

Diff on Reversi:
https://gist.github.com/gzm0/86b12a39875d53afdfe82674b504eee0

Seems we can eliminate some unnecessary casts like this.