### PR TITLE
Add JDK 17 and 21 to the CI; remove 16.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -64,7 +64,7 @@ rm -rf $TEST_LOCAL_IVY_HOME
 mkdir $TEST_LOCAL_IVY_HOME
 ln -s "$LOC_IVY_HOME/cache" "$TEST_LOCAL_IVY_HOME/cache"
 
-export SBT_OPTS="-J-Xmx5G -J-XX:MaxPermSize=512M -Dsbt.boot.directory=$LOC_SBT_BOOT -Dsbt.ivy.home=$TEST_LOCAL_IVY_HOME -Divy.home=$TEST_LOCAL_IVY_HOME -Dsbt.global.base=$LOC_SBT_BASE"
+export SBT_OPTS="-J-Xmx5G -Dsbt.boot.directory=$LOC_SBT_BOOT -Dsbt.ivy.home=$TEST_LOCAL_IVY_HOME -Divy.home=$TEST_LOCAL_IVY_HOME -Dsbt.global.base=$LOC_SBT_BASE"
 export COURSIER_CACHE="$LOC_CS_CACHE"
 
 export NODE_PATH="$HOME/node_modules/"
@@ -539,7 +539,7 @@ def Tasks = [
 ]
 
 def mainJavaVersion = "1.8"
-def otherJavaVersions = ["11", "16"]
+def otherJavaVersions = ["11", "17", "21"]
 def allJavaVersions = otherJavaVersions.clone()
 allJavaVersions << mainJavaVersion
 
@@ -577,7 +577,7 @@ def otherScalaVersions = [
   "2.13.12"
 ]
 
-def scala3Version = "3.2.1"
+def scala3Version = "3.3.4"
 
 def allESVersions = [
   "ES5_1",
@@ -614,7 +614,10 @@ allESVersions.each { esVersion ->
 }
 allJavaVersions.each { javaVersion ->
   // the `scala` version is irrelevant here
-  quickMatrix.add([task: "sbt-plugin-and-scalastyle", scala: mainScalaVersion, java: javaVersion])
+  // We exclude JDK 21 because our sbt scripted tests use old sbt versions (on purpose), which do not support JDK 21
+  if (javaVersion != '21') {
+    quickMatrix.add([task: "sbt-plugin-and-scalastyle", scala: mainScalaVersion, java: javaVersion])
+  }
 }
 quickMatrix.add([task: "scala3-compat", scala: scala3Version, java: mainJavaVersion])
 

--- a/sbt-plugin/src/sbt-test/scala3/basic/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/basic/build.sbt
@@ -1,6 +1,6 @@
 enablePlugins(ScalaJSPlugin)
 
-scalaVersion := "3.0.0"
+scalaVersion := "3.3.4"
 
 // Test CrossVersion.for3Use2_13 for %%% dependencies
 libraryDependencies +=

--- a/sbt-plugin/src/sbt-test/scala3/junit/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/junit/build.sbt
@@ -1,3 +1,3 @@
 enablePlugins(ScalaJSPlugin, ScalaJSJUnitPlugin)
 
-scalaVersion := "3.0.0"
+scalaVersion := "3.3.4"

--- a/sbt-plugin/src/sbt-test/scala3/tasty-reader/build.sbt
+++ b/sbt-plugin/src/sbt-test/scala3/tasty-reader/build.sbt
@@ -3,7 +3,7 @@ lazy val root = project.in(file("."))
 lazy val testlib = project.in(file("testlib"))
   .enablePlugins(ScalaJSPlugin)
   .settings(
-    scalaVersion := "3.1.3"
+    scalaVersion := "3.3.4"
   )
 
 lazy val app = project.in(file("app"))

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -36,6 +36,8 @@ object Platform {
 
   final val executingInJVMOnLowerThanJDK17 = false
 
+  def executingInJVMOnLowerThanJDK(version: Int): Boolean = false
+
   def executingInWebAssembly: Boolean = BuildInfo.isWebAssembly
 
   def executingInNodeJS: Boolean = {

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -34,6 +34,8 @@ object Platform {
 
   def executingInJVMOnLowerThanJDK17: Boolean = jdkVersion < 17
 
+  def executingInJVMOnLowerThanJDK(version: Int): Boolean = jdkVersion < version
+
   private lazy val jdkVersion = {
     val v = System.getProperty("java.version")
     if (v.startsWith("1.")) Integer.parseInt(v.drop(2).takeWhile(_.isDigit))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
@@ -508,7 +508,13 @@ class ThreadLocalRandomTest {
   @Test def nextDoubleDoubleDouble(): Unit = {
     implicit val tlr = ThreadLocalRandom.current()
 
-    checkDoubleBounds(Double.MinValue, Double.MaxValue)
+    if (!executingInJVMOnLowerThanJDK(19) || executingInJVMOnLowerThanJDK(17)) {
+      /* For some reason, JDK 17-18 throw an IllegalArgumentException for this one.
+       * Older and more recent versions of the JDK succeed.
+       */
+      checkDoubleBounds(Double.MinValue, Double.MaxValue)
+    }
+
     checkDoubleBounds(Double.MinValue, 0L)
     checkDoubleBounds(Double.MaxValue, 0L)
     checkDoubleBounds(0.14303466203185822, 0.7471945354839639)


### PR DESCRIPTION
Now we test the four active LTS versions: 1.8, 11, 17 and 21.

We upgrade our Scala 3 references to 3.3.4 which is the latest LTS. Scala 3.3.1+ is required for JDK 21.