### PR TITLE
Allow `Return` arg to be a `void` if the target `Labeled` is a `void`.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -189,8 +189,10 @@ object Printers {
         case Return(expr, label) =>
           print("return@")
           print(label)
-          print(" ")
-          print(expr)
+          if (!expr.isInstanceOf[Skip]) {
+            print(" ")
+            print(expr)
+          }
 
         case If(cond, BooleanLiteral(true), elsep) =>
           print(cond)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -58,7 +58,7 @@ object Transformers {
           Assign(transformExpr(lhs).asInstanceOf[AssignLhs], transformExpr(rhs))
 
         case Return(expr, label) =>
-          Return(transformExpr(expr), label)
+          Return(transformExpr(expr), label) // pessimistic; maybe `expr` is actually a statement
 
         case If(cond, thenp, elsep) =>
           If(transformExpr(cond), transform(thenp, isStat),

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -154,6 +154,7 @@ class PrintersTest {
 
   @Test def printReturn(): Unit = {
     assertPrintEquals("return@lab 5", Return(i(5), "lab"))
+    assertPrintEquals("return@lab", Return(Skip(), "lab"))
   }
 
   @Test def printIf(): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -304,11 +304,7 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter,
         typecheckExpect(rhs, env, expectedRhsTpe)
 
       case Return(expr, label) =>
-        val returnType = env.returnTypes(label.name)
-        if (returnType == VoidType)
-          typecheckExpr(expr, env)
-        else
-          typecheckExpect(expr, env, returnType)
+        typecheckExpect(expr, env, env.returnTypes(label.name))
 
       case If(cond, thenp, elsep) =>
         val tpe = tree.tpe

--- a/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/OptimizerTest.scala
@@ -272,28 +272,32 @@ class OptimizerTest {
     val matchAlts1 = LabelIdent("matchAlts1")
     val matchAlts2 = LabelIdent("matchAlts2")
 
-    val classDefs = Seq(
-        mainTestClassDef(Block(
-            Labeled(matchResult1, VoidType, Block(
-                VarDef(x1, NON, AnyType, mutable = false, Null()),
-                Labeled(matchAlts1, VoidType, Block(
-                    Labeled(matchAlts2, VoidType, Block(
-                        If(IsInstanceOf(VarRef(x1)(AnyType), ClassType(BoxedIntegerClass, nullable = false)), {
-                          Return(Undefined(), matchAlts2)
-                        }, Skip())(VoidType),
-                        If(IsInstanceOf(VarRef(x1)(AnyType), ClassType(BoxedStringClass, nullable = false)), {
-                          Return(Undefined(), matchAlts2)
-                        }, Skip())(VoidType),
-                        Return(Undefined(), matchAlts1)
-                    )),
-                    Return(Undefined(), matchResult1)
-                )),
-                Throw(New("java.lang.Exception", NoArgConstructorName, Nil))
-            ))
-        ))
-    )
+    val results = for (voidReturnArgument <- List(Undefined(), Skip())) yield {
+      val classDefs = Seq(
+          mainTestClassDef(Block(
+              Labeled(matchResult1, VoidType, Block(
+                  VarDef(x1, NON, AnyType, mutable = false, Null()),
+                  Labeled(matchAlts1, VoidType, Block(
+                      Labeled(matchAlts2, VoidType, Block(
+                          If(IsInstanceOf(VarRef(x1)(AnyType), ClassType(BoxedIntegerClass, nullable = false)), {
+                            Return(voidReturnArgument, matchAlts2)
+                          }, Skip())(VoidType),
+                          If(IsInstanceOf(VarRef(x1)(AnyType), ClassType(BoxedStringClass, nullable = false)), {
+                            Return(voidReturnArgument, matchAlts2)
+                          }, Skip())(VoidType),
+                          Return(voidReturnArgument, matchAlts1)
+                      )),
+                      Return(voidReturnArgument, matchResult1)
+                  )),
+                  Throw(New("java.lang.Exception", NoArgConstructorName, Nil))
+              ))
+          ))
+      )
 
-    testLink(classDefs, MainTestModuleInitializers)
+      testLink(classDefs, MainTestModuleInitializers)
+    }
+
+    Future.sequence(results)
   }
 
   @Test


### PR DESCRIPTION
Previously, even if the target label of a `Return` declared a `void` result type, the argument to the `Return` had to be an expression, with a non-`void` type. Because of that rule, we generated fake `Undefined()` arguments to the `Return`s.

In this commit, we remove that restriction. This simplifies the IR specification and removes some ad hoc code paths to generate the fake `Undefined()`. We do have to add some handling in the JS function emitter. The Wasm function emitter requires no change.

The changes in `doReturnToLabel()` are necessary to maintain the status quo in terms of the emitted JS. My understanding is that before, we would get a lot of `Block(stats, Return(Undefined))` which are now `Return(Block(stats))`. If the `stats` contain `If`s and other branches, the new `Return` can be pushed down a lot more. When it wasn't pushed down, we would have regular fall-through behavior without `js.Break`s. Now with the `Return`s pushed down, we get a lot of `js.Break`s that are not actually necessary. The new optimization in `doReturnToLabel()` removes them.