### PR TITLE
Add trait definitions for ju.Sequenced{Collection,Map,Set}.

### DIFF
--- a/javalib/src/main/scala/java/util/Deque.scala
+++ b/javalib/src/main/scala/java/util/Deque.scala
@@ -12,7 +12,7 @@
 
 package java.util
 
-trait Deque[E] extends Queue[E] {
+trait Deque[E] extends Queue[E] with SequencedCollection[E] {
   def addFirst(e: E): Unit
   def addLast(e: E): Unit
   def offerFirst(e: E): Boolean

--- a/javalib/src/main/scala/java/util/LinkedHashMap.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashMap.scala
@@ -17,7 +17,7 @@ import java.util.function.BiConsumer
 
 class LinkedHashMap[K, V](initialCapacity: Int, loadFactor: Float,
     accessOrder: Boolean)
-    extends HashMap[K, V](initialCapacity, loadFactor) {
+    extends HashMap[K, V](initialCapacity, loadFactor) with SequencedMap[K, V] {
   self =>
 
   import LinkedHashMap._

--- a/javalib/src/main/scala/java/util/LinkedHashSet.scala
+++ b/javalib/src/main/scala/java/util/LinkedHashSet.scala
@@ -15,7 +15,7 @@ package java.util
 import java.lang.Cloneable
 
 class LinkedHashSet[E] private[util] (inner: LinkedHashMap[E, Any])
-    extends HashSet[E](inner) with Set[E] with Cloneable with Serializable {
+    extends HashSet[E](inner) with SequencedSet[E] with Cloneable with Serializable {
 
   def this(initialCapacity: Int, loadFactor: Float) =
     this(new LinkedHashMap[E, Any](initialCapacity, loadFactor))

--- a/javalib/src/main/scala/java/util/List.scala
+++ b/javalib/src/main/scala/java/util/List.scala
@@ -14,7 +14,7 @@ package java.util
 
 import java.util.function.UnaryOperator
 
-trait List[E] extends Collection[E] {
+trait List[E] extends SequencedCollection[E] {
   def replaceAll(operator: UnaryOperator[E]): Unit = {
     val iter = listIterator()
     while (iter.hasNext())

--- a/javalib/src/main/scala/java/util/SequencedCollection.scala
+++ b/javalib/src/main/scala/java/util/SequencedCollection.scala
@@ -12,11 +12,4 @@
 
 package java.util
 
-trait SortedSet[E] extends SequencedSet[E] {
-  def comparator(): Comparator[_ >: E]
-  def subSet(fromElement: E, toElement: E): SortedSet[E]
-  def headSet(toElement: E): SortedSet[E]
-  def tailSet(fromElement: E): SortedSet[E]
-  def first(): E
-  def last(): E
-}
+trait SequencedCollection[E] extends Collection[E]

--- a/javalib/src/main/scala/java/util/SequencedMap.scala
+++ b/javalib/src/main/scala/java/util/SequencedMap.scala
@@ -12,11 +12,6 @@
 
 package java.util
 
-trait SortedSet[E] extends SequencedSet[E] {
-  def comparator(): Comparator[_ >: E]
-  def subSet(fromElement: E, toElement: E): SortedSet[E]
-  def headSet(toElement: E): SortedSet[E]
-  def tailSet(fromElement: E): SortedSet[E]
-  def first(): E
-  def last(): E
-}
+import java.util.Map.Entry
+
+trait SequencedMap[K, V] extends Map[K, V]

--- a/javalib/src/main/scala/java/util/SequencedSet.scala
+++ b/javalib/src/main/scala/java/util/SequencedSet.scala
@@ -12,11 +12,4 @@
 
 package java.util
 
-trait SortedSet[E] extends SequencedSet[E] {
-  def comparator(): Comparator[_ >: E]
-  def subSet(fromElement: E, toElement: E): SortedSet[E]
-  def headSet(toElement: E): SortedSet[E]
-  def tailSet(fromElement: E): SortedSet[E]
-  def first(): E
-  def last(): E
-}
+trait SequencedSet[E] extends SequencedCollection[E] with Set[E]

--- a/javalib/src/main/scala/java/util/SortedMap.scala
+++ b/javalib/src/main/scala/java/util/SortedMap.scala
@@ -12,7 +12,7 @@
 
 package java.util
 
-trait SortedMap[K, V] extends Map[K, V] {
+trait SortedMap[K, V] extends SequencedMap[K, V] {
   def firstKey(): K
   def comparator(): Comparator[_ >: K]
   def lastKey(): K

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2134,6 +2134,7 @@ object Build {
         collectionsEraDependentDirectory(scalaV, sharedTestDir) ::
         includeIf(sharedTestDir / "require-jdk11", javaV >= 11) :::
         includeIf(sharedTestDir / "require-jdk15", javaV >= 15) :::
+        includeIf(sharedTestDir / "require-jdk21", javaV >= 21) :::
         includeIf(testDir / "require-scala2", isJSTest)
       },
 

--- a/test-suite/shared/src/test/require-jdk21/org/scalajs/testsuite/javalib/util/SequencedCollectionTest.scala
+++ b/test-suite/shared/src/test/require-jdk21/org/scalajs/testsuite/javalib/util/SequencedCollectionTest.scala
@@ -1,0 +1,46 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+class SequencedCollectionTest {
+
+  @Test def knownSequencedCollections(): Unit = {
+    def test(expected: Boolean, testClass: Class[_]): Unit = {
+      assertEquals(expected, classOf[ju.SequencedCollection[_]].isAssignableFrom(testClass))
+    }
+
+    test(true, classOf[ju.List[String]])
+    test(true, classOf[ju.LinkedList[String]])
+    test(true, classOf[ju.ArrayList[String]])
+    test(true, classOf[ju.LinkedHashSet[String]])
+    test(true, classOf[ju.TreeSet[String]])
+    test(true, classOf[ju.NavigableSet[String]])
+    test(true, classOf[ju.Deque[String]])
+    test(true, classOf[ju.ArrayDeque[String]])
+    test(true, classOf[ju.SequencedSet[String]])
+
+    test(false, classOf[ju.SequencedMap[String, String]])
+    test(false, classOf[ju.HashSet[String]])
+    test(false, classOf[ju.HashMap[String, String]])
+    test(false, classOf[ju.LinkedHashMap[String, String]])
+    test(false, classOf[ju.TreeMap[String, String]])
+    test(false, classOf[ju.NavigableMap[String, String]])
+    test(false, classOf[ju.Queue[String]])
+  }
+
+}

--- a/test-suite/shared/src/test/require-jdk21/org/scalajs/testsuite/javalib/util/SequencedMapTest.scala
+++ b/test-suite/shared/src/test/require-jdk21/org/scalajs/testsuite/javalib/util/SequencedMapTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+class SequencedMapTest {
+
+  @Test def knownSequencedMaps(): Unit = {
+    def test(expected: Boolean, testClass: Class[_]): Unit = {
+      assertEquals(expected, classOf[ju.SequencedMap[_, _]].isAssignableFrom(testClass))
+    }
+
+    test(true, classOf[ju.SortedMap[String, String]])
+    test(true, classOf[ju.LinkedHashMap[String, String]])
+    test(true, classOf[ju.TreeMap[String, String]])
+    test(true, classOf[ju.NavigableMap[String, String]])
+
+    test(false, classOf[ju.HashMap[String, String]])
+    test(false, classOf[ju.LinkedHashSet[String]])
+    test(false, classOf[ju.LinkedHashSet[String]])
+    test(false, classOf[ju.TreeSet[String]])
+    test(false, classOf[ju.NavigableSet[String]])
+    test(false, classOf[ju.List[String]])
+    test(false, classOf[ju.LinkedList[String]])
+    test(false, classOf[ju.ArrayList[String]])
+    test(false, classOf[ju.Deque[String]])
+    test(false, classOf[ju.ArrayDeque[String]])
+    test(false, classOf[ju.HashSet[String]])
+    test(false, classOf[ju.SequencedCollection[String]])
+    test(false, classOf[ju.SequencedSet[String]])
+  }
+
+}

--- a/test-suite/shared/src/test/require-jdk21/org/scalajs/testsuite/javalib/util/SequencedSetTest.scala
+++ b/test-suite/shared/src/test/require-jdk21/org/scalajs/testsuite/javalib/util/SequencedSetTest.scala
@@ -1,0 +1,47 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util
+
+import org.junit.Test
+import org.junit.Assert._
+
+import java.{util => ju}
+
+class SequencedSetTest {
+
+  @Test def knownSequencedSets(): Unit = {
+    def test(expected: Boolean, testClass: Class[_]): Unit = {
+      assertEquals(expected, classOf[ju.SequencedSet[_]].isAssignableFrom(testClass))
+    }
+
+    test(true, classOf[ju.LinkedHashSet[String]])
+    test(true, classOf[ju.LinkedHashSet[String]])
+    test(true, classOf[ju.TreeSet[String]])
+    test(true, classOf[ju.NavigableSet[String]])
+    test(true, classOf[ju.SortedSet[String]])
+
+    test(false, classOf[ju.List[String]])
+    test(false, classOf[ju.LinkedList[String]])
+    test(false, classOf[ju.ArrayList[String]])
+    test(false, classOf[ju.Deque[String]])
+    test(false, classOf[ju.ArrayDeque[String]])
+    test(false, classOf[ju.HashSet[String]])
+    test(false, classOf[ju.HashMap[String, String]])
+    test(false, classOf[ju.LinkedHashMap[String, String]])
+    test(false, classOf[ju.TreeMap[String, String]])
+    test(false, classOf[ju.NavigableMap[String, String]])
+    test(false, classOf[ju.SequencedCollection[String]])
+    test(false, classOf[ju.SequencedMap[String, String]])
+  }
+
+}


### PR DESCRIPTION
We only add the trait definitions and the relevant inheritance relationships. This is enough to fix linking issues arising only from type inference when compiling on JDK 21+.

We do not any of the methods of those new traits in this commit. They all rely on new `reversed()` methods, which are supposed to provide reverse *views* of the collections. Implementing all those views correctly turns out to be a bottomless well, which is left for future work.

---

Based on #5073 but otherwise ready to review. Only the second commit belongs to this PR.