### PR TITLE
Simplify the test API we use to identify specific JDKs.

### DIFF
--- a/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTestEx.scala
+++ b/test-suite-ex/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTestEx.scala
@@ -76,7 +76,7 @@ class FormatterTestEx {
      * locale uses U+202F NARROW NO-BREAK SPACE as grouping
      * separator, instead of U+00A0 NO-BREAK SPACE.
      */
-    if (!executingInJVMOnLowerThanJDK13) {
+    if (!executingInJVMOnLowerThanJDK(13)) {
       // U+202F NARROW NO-BREAK SPACE
       assertF(French, "1\u202F234\u202F567", "%,d", 1234567)
       assertF(French, "1\u202F234\u202F567,89", "%,.2f", 1234567.89)
@@ -119,7 +119,7 @@ class FormatterTestEx {
 
   @Test def testFormatTurkish(): Unit = {
     assumeFalse("Affected by https://bugs.openjdk.java.net/browse/JDK-8060094",
-        executingInJVMOnJDK8OrLower)
+        executingInJVMOnLowerThanJDK(9))
 
     // U+0130 LATIN CAPITAL LETTER I WITH DOT ABOVE
     assertF(Turkish, "TİTLE", "%S", "title")

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -24,19 +24,9 @@ object Platform {
    */
   final val executingInJVM = false
 
-  final val executingInJVMOnJDK8OrLower = false
-
-  final val executingInJVMOnLowerThanJDK10 = false
-
-  final val executingInJVMOnLowerThanJDK13 = false
-
-  final val executingInJVMOnLowerThanJDK15 = false
-
-  final val executingInJVMOnLowerThanJDK16 = false
-
-  final val executingInJVMOnLowerThanJDK17 = false
-
   def executingInJVMOnLowerThanJDK(version: Int): Boolean = false
+
+  def executingInJVMWithJDKIn(range: Range): Boolean = false
 
   def executingInWebAssembly: Boolean = BuildInfo.isWebAssembly
 

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -22,19 +22,9 @@ object Platform {
    */
   final val executingInJVM = true
 
-  def executingInJVMOnJDK8OrLower: Boolean = jdkVersion <= 8
-
-  def executingInJVMOnLowerThanJDK10: Boolean = jdkVersion < 10
-
-  def executingInJVMOnLowerThanJDK13: Boolean = jdkVersion < 13
-
-  def executingInJVMOnLowerThanJDK15: Boolean = jdkVersion < 15
-
-  def executingInJVMOnLowerThanJDK16: Boolean = jdkVersion < 16
-
-  def executingInJVMOnLowerThanJDK17: Boolean = jdkVersion < 17
-
   def executingInJVMOnLowerThanJDK(version: Int): Boolean = jdkVersion < version
+
+  def executingInJVMWithJDKIn(range: Range): Boolean = range.contains(jdkVersion)
 
   private lazy val jdkVersion = {
     val v = System.getProperty("java.version")

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URITest.scala
@@ -18,7 +18,7 @@ import org.junit.Assert._
 import org.junit.Test
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
-import org.scalajs.testsuite.utils.Platform.executingInJVMOnLowerThanJDK15
+import org.scalajs.testsuite.utils.Platform._
 
 class URITest {
 
@@ -170,7 +170,7 @@ class URITest {
     val rel3 = new URI("/foo/ccc")
 
     // https://bugs.openjdk.java.net/browse/JDK-5064980
-    if (!executingInJVMOnLowerThanJDK15)
+    if (!executingInJVMOnLowerThanJDK(15))
       assertTrue(x.compareTo(y) == 0)
 
     assertTrue(x.compareTo(z) < 0)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URLDecoderTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/net/URLDecoderTest.scala
@@ -99,7 +99,7 @@ class URLDecoderTest {
      * the implementation. So in all likelihood, it will not be coming back.
      * It is still throwing as of JDK 17.
      */
-    if (!executingInJVMOnLowerThanJDK10) {
+    if (!executingInJVMOnLowerThanJDK(10)) {
       unsupportedEncoding("abc", enc = "dummy")
       unsupportedEncoding("a+b+c", enc = "dummy")
     }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/FormatterTest.scala
@@ -1694,7 +1694,7 @@ class FormatterTest {
 
   @Test def indexNotInRangeThrows(): Unit = {
     assumeFalse("https://bugs.openjdk.java.net/browse/JDK-8253875",
-        executingInJVMOnLowerThanJDK16)
+        executingInJVMOnLowerThanJDK(16))
 
     /* The public JavaDoc says that these situations throw an
      * IllegalFormatException, without being more specific. However, the bug
@@ -1716,7 +1716,7 @@ class FormatterTest {
 
   @Test def widthOrPrecisionTooLargeThrows(): Unit = {
     assumeFalse("https://bugs.openjdk.java.net/browse/JDK-8253875",
-        executingInJVMOnLowerThanJDK16)
+        executingInJVMOnLowerThanJDK(16))
 
     expectFormatterThrows(classOf[IllegalFormatWidthException], "%d %9876543210d", 56, 78)
     expectFormatterThrows(classOf[IllegalFormatPrecisionException], "%d %.9876543210f", 56, 78.5)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/MapTest.scala
@@ -1391,7 +1391,7 @@ trait MapTest {
        * https://bugs.openjdk.org/browse/JDK-8259622
        */
       assumeFalse("affected by JDK-8259622",
-          executingInJVMOnLowerThanJDK17 && !executingInJVMOnLowerThanJDK15 &&
+          executingInJVMWithJDKIn(15 to 16) &&
           mp.isInstanceOf[ju.TreeMap[_, _]])
 
       mp.put("nullable", null)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/concurrent/ThreadLocalRandomTest.scala
@@ -508,7 +508,7 @@ class ThreadLocalRandomTest {
   @Test def nextDoubleDoubleDouble(): Unit = {
     implicit val tlr = ThreadLocalRandom.current()
 
-    if (!executingInJVMOnLowerThanJDK(19) || executingInJVMOnLowerThanJDK(17)) {
+    if (!executingInJVMWithJDKIn(17 to 18)) {
       /* For some reason, JDK 17-18 throw an IllegalArgumentException for this one.
        * Older and more recent versions of the JDK succeed.
        */

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexEngineTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/regex/RegexEngineTest.scala
@@ -1034,7 +1034,7 @@ class RegexEngineTest  {
     assertNotMatches(lower, "É")
 
     // https://bugs.openjdk.java.net/browse/JDK-8214245
-    if (!executingInJVMOnLowerThanJDK15) {
+    if (!executingInJVMOnLowerThanJDK(15)) {
       val lowerCI = compile("\\p{Lower}", CaseInsensitive)
       assertMatches(lowerCI, "a")
       assertMatches(lowerCI, "f")
@@ -1223,7 +1223,7 @@ class RegexEngineTest  {
     assertNotMatches(lower, "É")
 
     // https://bugs.openjdk.java.net/browse/JDK-8214245
-    if (!executingInJVMOnLowerThanJDK15) {
+    if (!executingInJVMOnLowerThanJDK(15)) {
       val lowerCI = compile("\\p{Lower}", CaseInsensitive | UnicodeCharacterClass)
       assertMatches(lowerCI, "a")
       assertMatches(lowerCI, "f")
@@ -1389,7 +1389,7 @@ class RegexEngineTest  {
     checkConsistency("javaIdentifierIgnorable", "[\u0000-\u0008\u000E-\u001B\u007F-\u009F\\p{Cf}]")
     checkConsistency("javaIdeographic", "\\p{IsIdeographic}")
     checkConsistency("javaISOControl", "[\u0000-\u001F\u007F-\u009F]")
-    if (!executingInJVMOnJDK8OrLower) {
+    if (!executingInJVMOnLowerThanJDK(9)) {
       checkConsistency("javaJavaIdentifierPart",
           "[\\p{L}\\p{Sc}\\p{Pc}\\p{Nd}\\p{Nl}\\p{Mn}\\p{Mc}\u0000-\u0008\u000E-\u001B\u007F-\u009F\\p{Cf}]")
       checkConsistency("javaJavaIdentifierStart", "[\\p{L}\\p{Sc}\\p{Pc}\\p{Nl}]")
@@ -1459,7 +1459,7 @@ class RegexEngineTest  {
     /* SignWriting is special because of its canonical name, which is not Sign_Writing.
      * It's from Unicode 8.0.0, so it requires JDK 9+.
      */
-    if (!executingInJVMOnJDK8OrLower) {
+    if (!executingInJVMOnLowerThanJDK(9)) {
       val signWriting = compile("\\p{script=signwrItIng}")
       assertMatches(signWriting, "\uD836\uDC36") // U+1D836 SIGNWRITING HAND-FIST MIDDLE THUMB CUPPED INDEX UP
       assertNotMatches(signWriting, "A")
@@ -1846,7 +1846,7 @@ class RegexEngineTest  {
     assertNotMatches(complexUnionsAndIntersections, "z")
 
     // https://bugs.openjdk.java.net/browse/JDK-8216391
-    if (!executingInJVMOnJDK8OrLower) {
+    if (!executingInJVMOnLowerThanJDK(9)) {
       val not_ad_or_mp = compile("[^a-d[m-p]]")
       assertNotMatches(not_ad_or_mp, "a")
       assertNotMatches(not_ad_or_mp, "c")
@@ -2572,7 +2572,7 @@ class RegexEngineTest  {
     }
 
     // JDK 9+ features
-    if (!executingInJVMOnJDK8OrLower) {
+    if (!executingInJVMOnLowerThanJDK(9)) {
       assertSyntaxErrorInJS("\\N{DIGIT TWO}", "\\N is not supported", 1)
       assertSyntaxErrorInJS("foo\\b{g}.", "\\b{g} is not supported", 4)
       assertSyntaxErrorInJS("foo\\X", "\\X is not supported", 4)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/niobuffer/BaseBufferTest.scala
@@ -313,7 +313,7 @@ abstract class BaseBufferTest {
 
   @Test def compact(): Unit = {
     assumeFalse("Affected by a bug in the JDK.",
-        executingInJVMOnJDK8OrLower &&
+        executingInJVMOnLowerThanJDK(9) &&
         factory.isInstanceOf[BufferFactory.ByteBufferViewFactory])
 
     if (!createsReadOnly) {


### PR DESCRIPTION
Follow-up to https://github.com/scala-js/scala-js/pull/5073#discussion_r1844932292