### PR TITLE
Directly use ju.function.* instead of Scala functions in the javalib.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -2068,7 +2068,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         } else {
           val shouldMarkInline = {
             sym.hasAnnotation(InlineAnnotationClass) ||
-            sym.name.startsWith(nme.ANON_FUN_NAME) ||
+            sym.name.containsName(nme.ANON_FUN_NAME) ||
             adHocInlineMethods.contains(sym.fullName)
           }
 

--- a/javalib/src/main/scala/java/io/PrintStream.scala
+++ b/javalib/src/main/scala/java/io/PrintStream.scala
@@ -214,15 +214,15 @@ class PrintStream private (_out: OutputStream, autoFlush: Boolean,
     this
   }
 
-  @inline private[this] def trapIOExceptions(body: () => Unit): Unit = {
+  @inline private[this] def trapIOExceptions(body: Runnable): Unit = {
     try {
-      body()
+      body.run()
     } catch {
       case _: IOException => setError()
     }
   }
 
-  @inline private[this] def ensureOpenAndTrapIOExceptions(body: () => Unit): Unit = {
+  @inline private[this] def ensureOpenAndTrapIOExceptions(body: Runnable): Unit = {
     if (closed) setError()
     else trapIOExceptions(body)
   }

--- a/javalib/src/main/scala/java/io/PrintStream.scala
+++ b/javalib/src/main/scala/java/io/PrintStream.scala
@@ -79,9 +79,9 @@ class PrintStream private (_out: OutputStream, autoFlush: Boolean,
   private var errorFlag: Boolean = false
 
   override def flush(): Unit =
-    ensureOpenAndTrapIOExceptions(out.flush())
+    ensureOpenAndTrapIOExceptions(() => out.flush())
 
-  override def close(): Unit = trapIOExceptions {
+  override def close(): Unit = trapIOExceptions { () =>
     if (!closing) {
       closing = true
       encoder.close()
@@ -133,7 +133,7 @@ class PrintStream private (_out: OutputStream, autoFlush: Boolean,
    */
 
   override def write(b: Int): Unit = {
-    ensureOpenAndTrapIOExceptions {
+    ensureOpenAndTrapIOExceptions { () =>
       out.write(b)
       if (autoFlush && b == '\n')
         flush()
@@ -141,7 +141,7 @@ class PrintStream private (_out: OutputStream, autoFlush: Boolean,
   }
 
   override def write(buf: Array[Byte], off: Int, len: Int): Unit = {
-    ensureOpenAndTrapIOExceptions {
+    ensureOpenAndTrapIOExceptions { () =>
       out.write(buf, off, len)
       if (autoFlush)
         flush()
@@ -157,17 +157,17 @@ class PrintStream private (_out: OutputStream, autoFlush: Boolean,
   def print(s: String): Unit   = printString(if (s == null) "null" else s)
   def print(obj: AnyRef): Unit = printString(String.valueOf(obj))
 
-  private def printString(s: String): Unit = ensureOpenAndTrapIOExceptions {
+  private def printString(s: String): Unit = ensureOpenAndTrapIOExceptions { () =>
     encoder.write(s)
     encoder.flushBuffer()
   }
 
-  def print(s: Array[Char]): Unit = ensureOpenAndTrapIOExceptions {
+  def print(s: Array[Char]): Unit = ensureOpenAndTrapIOExceptions { () =>
     encoder.write(s)
     encoder.flushBuffer()
   }
 
-  def println(): Unit = ensureOpenAndTrapIOExceptions {
+  def println(): Unit = ensureOpenAndTrapIOExceptions { () =>
     encoder.write('\n') // In Scala.js the line separator is always LF
     encoder.flushBuffer()
     if (autoFlush)
@@ -214,15 +214,15 @@ class PrintStream private (_out: OutputStream, autoFlush: Boolean,
     this
   }
 
-  @inline private[this] def trapIOExceptions(body: => Unit): Unit = {
+  @inline private[this] def trapIOExceptions(body: () => Unit): Unit = {
     try {
-      body
+      body()
     } catch {
       case _: IOException => setError()
     }
   }
 
-  @inline private[this] def ensureOpenAndTrapIOExceptions(body: => Unit): Unit = {
+  @inline private[this] def ensureOpenAndTrapIOExceptions(body: () => Unit): Unit = {
     if (closed) setError()
     else trapIOExceptions(body)
   }

--- a/javalib/src/main/scala/java/io/PrintWriter.scala
+++ b/javalib/src/main/scala/java/io/PrintWriter.scala
@@ -147,15 +147,15 @@ class PrintWriter(protected[io] var out: Writer,
     this
   }
 
-  @inline private[this] def trapIOExceptions(body: () => Unit): Unit = {
+  @inline private[this] def trapIOExceptions(body: Runnable): Unit = {
     try {
-      body()
+      body.run()
     } catch {
       case _: IOException => setError()
     }
   }
 
-  @inline private[this] def ensureOpenAndTrapIOExceptions(body: () => Unit): Unit = {
+  @inline private[this] def ensureOpenAndTrapIOExceptions(body: Runnable): Unit = {
     if (closed) setError()
     else trapIOExceptions(body)
   }

--- a/javalib/src/main/scala/java/io/PrintWriter.scala
+++ b/javalib/src/main/scala/java/io/PrintWriter.scala
@@ -41,9 +41,9 @@ class PrintWriter(protected[io] var out: Writer,
   private var errorFlag: Boolean = false
 
   def flush(): Unit =
-    ensureOpenAndTrapIOExceptions(out.flush())
+    ensureOpenAndTrapIOExceptions(() => out.flush())
 
-  def close(): Unit = trapIOExceptions {
+  def close(): Unit = trapIOExceptions { () =>
     if (!closed) {
       flush()
       closed = true
@@ -76,19 +76,19 @@ class PrintWriter(protected[io] var out: Writer,
   protected[io] def clearError(): Unit = errorFlag = false
 
   override def write(c: Int): Unit =
-    ensureOpenAndTrapIOExceptions(out.write(c))
+    ensureOpenAndTrapIOExceptions(() => out.write(c))
 
   override def write(buf: Array[Char], off: Int, len: Int): Unit =
-    ensureOpenAndTrapIOExceptions(out.write(buf, off, len))
+    ensureOpenAndTrapIOExceptions(() => out.write(buf, off, len))
 
   override def write(buf: Array[Char]): Unit =
-    ensureOpenAndTrapIOExceptions(out.write(buf))
+    ensureOpenAndTrapIOExceptions(() => out.write(buf))
 
   override def write(s: String, off: Int, len: Int): Unit =
-    ensureOpenAndTrapIOExceptions(out.write(s, off, len))
+    ensureOpenAndTrapIOExceptions(() => out.write(s, off, len))
 
   override def write(s: String): Unit =
-    ensureOpenAndTrapIOExceptions(out.write(s))
+    ensureOpenAndTrapIOExceptions(() => out.write(s))
 
   def print(b: Boolean): Unit     = write(String.valueOf(b))
   def print(c: Char): Unit        = write(c)
@@ -147,15 +147,15 @@ class PrintWriter(protected[io] var out: Writer,
     this
   }
 
-  @inline private[this] def trapIOExceptions(body: => Unit): Unit = {
+  @inline private[this] def trapIOExceptions(body: () => Unit): Unit = {
     try {
-      body
+      body()
     } catch {
       case _: IOException => setError()
     }
   }
 
-  @inline private[this] def ensureOpenAndTrapIOExceptions(body: => Unit): Unit = {
+  @inline private[this] def ensureOpenAndTrapIOExceptions(body: () => Unit): Unit = {
     if (closed) setError()
     else trapIOExceptions(body)
   }

--- a/javalib/src/main/scala/java/lang/ClassValue.scala
+++ b/javalib/src/main/scala/java/lang/ClassValue.scala
@@ -50,7 +50,7 @@ abstract class ClassValue[T] protected () {
 
   def get(`type`: Class[_]): T = {
     if (useJSMap) {
-      mapGetOrElseUpdate(jsMap, `type`)(computeValue(`type`))
+      mapGetOrElseUpdate(jsMap, `type`)(() => computeValue(`type`))
     } else {
       /* We first perform `get`, and if the result is null, we use
        * `containsKey` to disambiguate a present null from an absent key.

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -122,14 +122,14 @@ object Float {
     } else if (undefOrIsDefined(groups(4))) {
       // Decimal notation
       val fullNumberStr = undefOrForceGet(groups(4))
-      val integralPartStr = undefOrGetOrElse(groups(5))("")
-      val fractionalPartStr = undefOrGetOrElse(groups(6))("") + undefOrGetOrElse(groups(7))("")
-      val exponentStr = undefOrGetOrElse(groups(8))("0")
+      val integralPartStr = undefOrGetOrElse(groups(5))(() => "")
+      val fractionalPartStr = undefOrGetOrElse(groups(6))(() => "") + undefOrGetOrElse(groups(7))(() => "")
+      val exponentStr = undefOrGetOrElse(groups(8))(() => "0")
       parseFloatDecimal(fullNumberStr, integralPartStr, fractionalPartStr, exponentStr)
     } else {
       // Hexadecimal notation
-      val integralPartStr = undefOrGetOrElse(groups(10))("")
-      val fractionalPartStr = undefOrGetOrElse(groups(11))("") + undefOrGetOrElse(groups(12))("")
+      val integralPartStr = undefOrGetOrElse(groups(10))(() => "")
+      val fractionalPartStr = undefOrGetOrElse(groups(11))(() => "") + undefOrGetOrElse(groups(12))(() => "")
       val binaryExpStr = undefOrForceGet(groups(13))
       parseFloatHexadecimal(integralPartStr, fractionalPartStr, binaryExpStr)
     }

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -13,6 +13,7 @@
 package java.lang
 
 import java.lang.constant.{Constable, ConstantDesc}
+import java.util.function._
 
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo
@@ -132,7 +133,7 @@ object Integer {
     decodeGeneric(nm, valueOf(_, _))
 
   @inline private[lang] def decodeGeneric[A](nm: String,
-      parse: (String, Int) => A): A = {
+      parse: BiFunction[String, Int, A]): A = {
 
     val len = nm.length()
     var i = 0

--- a/javalib/src/main/scala/java/lang/StackTrace.scala
+++ b/javalib/src/main/scala/java/lang/StackTrace.scala
@@ -126,7 +126,7 @@ private[lang] object StackTrace {
           trace.push(new StackTraceElement(classAndMethodName(0),
               classAndMethodName(1), undefOrForceGet(mtch(2)),
               parseInt(undefOrForceGet(mtch(3))),
-              undefOrFold(mtch(4))(-1)(parseInt(_))))
+              undefOrFold(mtch(4))(() => -1)(parseInt(_))))
         } else {
           // just in case
           // (explicitly use the constructor with column number so that STE has an inlineable init)
@@ -413,7 +413,7 @@ private[lang] object StackTrace {
     while (i < len) {
       val mtch = lineRE.exec(lines(i))
       if (mtch ne null) {
-        val fnName = undefOrGetOrElse(mtch(3))("{anonymous}")
+        val fnName = undefOrGetOrElse(mtch(3))(() => "{anonymous}")
         result.push(
             fnName + "()@" + undefOrForceGet(mtch(2)) + ":" +
             undefOrForceGet(mtch(1))
@@ -438,7 +438,7 @@ private[lang] object StackTrace {
     while (i < len) {
       val mtch = lineRE.exec(lines(i))
       if (mtch ne null) {
-        val fnName = undefOrFold(mtch(1))("global code")(_ + "()")
+        val fnName = undefOrFold(mtch(1))(() => "global code")(_ + "()")
         result.push(fnName + "@" + undefOrForceGet(mtch(2)) + ":" + undefOrForceGet(mtch(3)))
       }
       i += 1
@@ -458,7 +458,7 @@ private[lang] object StackTrace {
       val mtch = lineRE.exec(lines(i))
       if (mtch ne null) {
         val location = undefOrForceGet(mtch(4)) + ":" + undefOrForceGet(mtch(1)) + ":" + undefOrForceGet(mtch(2))
-        val fnName0 = undefOrGetOrElse(mtch(2))("global code")
+        val fnName0 = undefOrGetOrElse(mtch(2))(() => "global code")
         val fnName = fnName0
           .jsReplace("""<anonymous function: (\S+)>""".re, "$1")
           .jsReplace("""<anonymous function>""".re, "{anonymous}")

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -19,6 +19,7 @@ import scala.scalajs.js.Dynamic.global
 import scala.scalajs.LinkingInfo
 
 import java.{util => ju}
+import java.util.function._
 
 object System {
   /* System contains a bag of unrelated features. If we naively implement
@@ -70,7 +71,7 @@ object System {
     (new js.Date).getTime().toLong
 
   private object NanoTime {
-    val getHighPrecisionTime: () => scala.Double = {
+    val getHighPrecisionTime: js.Function0[scala.Double] = {
       import js.DynamicImplicits.truthValue
 
       if (js.typeOf(global.performance) != "undefined") {
@@ -102,27 +103,27 @@ object System {
     def mismatch(): Nothing =
       throw new ArrayStoreException("Incompatible array types")
 
-    def impl(srcLen: Int, destLen: Int, f: (Int, Int) => Any): Unit = {
+    def impl(srcLen: Int, destLen: Int, f: BiConsumer[Int, Int]): Unit = {
       /* Perform dummy swaps to trigger an ArrayIndexOutOfBoundsException or
        * UBE if the positions / lengths are bad.
        */
       if (srcPos < 0 || destPos < 0)
-        f(destPos, srcPos)
+        f.accept(destPos, srcPos)
       if (length < 0)
-        f(length, length)
+        f.accept(length, length)
       if (srcPos > srcLen - length || destPos > destLen - length)
-        f(destPos + length, srcPos + length)
+        f.accept(destPos + length, srcPos + length)
 
       if ((src ne dest) || destPos < srcPos || srcPos + length < destPos) {
         var i = 0
         while (i < length) {
-          f(i + destPos, i + srcPos)
+          f.accept(i + destPos, i + srcPos)
           i += 1
         }
       } else {
         var i = length - 1
         while (i >= 0) {
-          f(i + destPos, i + srcPos)
+          f.accept(i + destPos, i + srcPos)
           i -= 1
         }
       }

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -233,11 +233,11 @@ object System {
     }
 
     def getProperty(key: String): String =
-      if (dict ne null) dictGetOrElse(dict, key)(null)
+      if (dict ne null) dictGetOrElse(dict, key)(() => null)
       else properties.getProperty(key)
 
     def getProperty(key: String, default: String): String =
-      if (dict ne null) dictGetOrElse(dict, key)(default)
+      if (dict ne null) dictGetOrElse(dict, key)(() => default)
       else properties.getProperty(key, default)
 
     def clearProperty(key: String): String =

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -12,6 +12,8 @@
 
 package java.lang
 
+import java.util.function._
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExport
 
@@ -80,21 +82,21 @@ class Throwable protected (s: String, private var e: Throwable,
   def printStackTrace(s: java.io.PrintWriter): Unit =
     printStackTraceImpl(s.println(_))
 
-  private[this] def printStackTraceImpl(sprintln: String => Unit): Unit = {
+  private[this] def printStackTraceImpl(sprintln: Consumer[String]): Unit = {
     getStackTrace() // will init it if still null
 
     // Message
-    sprintln(toString)
+    sprintln.accept(toString)
 
     // Trace
     if (stackTrace.length != 0) {
       var i = 0
       while (i < stackTrace.length) {
-        sprintln(s"  at ${stackTrace(i)}")
+        sprintln.accept(s"  at ${stackTrace(i)}")
         i += 1
       }
     } else {
-      sprintln("  <no stack trace available>")
+      sprintln.accept("  <no stack trace available>")
     }
 
     // Causes
@@ -107,7 +109,7 @@ class Throwable protected (s: String, private var e: Throwable,
       val thisLength = thisTrace.length
       val parentLength = parentTrace.length
 
-      sprintln(s"Caused by: $wCause")
+      sprintln.accept(s"Caused by: $wCause")
 
       if (thisLength != 0) {
         /* Count how many frames are shared between this stack trace and the
@@ -129,14 +131,14 @@ class Throwable protected (s: String, private var e: Throwable,
         val lengthToPrint = thisLength - sameFrameCount
         var i = 0
         while (i < lengthToPrint) {
-          sprintln(s"  at ${thisTrace(i)}")
+          sprintln.accept(s"  at ${thisTrace(i)}")
           i += 1
         }
 
         if (sameFrameCount > 0)
-          sprintln(s"  ... $sameFrameCount more")
+          sprintln.accept(s"  ... $sameFrameCount more")
       } else {
-        sprintln("  <no stack trace available>")
+        sprintln.accept("  <no stack trace available>")
       }
     }
   }

--- a/javalib/src/main/scala/java/lang/Utils.scala
+++ b/javalib/src/main/scala/java/lang/Utils.scala
@@ -14,6 +14,8 @@ package java.lang
 
 import scala.language.implicitConversions
 
+import java.util.function._
+
 import scala.scalajs.js
 import scala.scalajs.js.annotation._
 
@@ -34,9 +36,9 @@ private[java] object Utils {
     x.asInstanceOf[A]
 
   @inline
-  def undefOrGetOrElse[A](x: js.UndefOr[A])(default: () => A): A =
+  def undefOrGetOrElse[A](x: js.UndefOr[A])(default: Supplier[A]): A =
     if (undefOrIsDefined(x)) undefOrForceGet(x)
-    else default()
+    else default.get()
 
   @inline
   def undefOrGetOrNull[A >: Null](x: js.UndefOr[A]): A =
@@ -44,15 +46,15 @@ private[java] object Utils {
     else null
 
   @inline
-  def undefOrForeach[A](x: js.UndefOr[A])(f: A => Any): Unit = {
+  def undefOrForeach[A](x: js.UndefOr[A])(f: Consumer[A]): Unit = {
     if (undefOrIsDefined(x))
-      f(undefOrForceGet(x))
+      f.accept(undefOrForceGet(x))
   }
 
   @inline
-  def undefOrFold[A, B](x: js.UndefOr[A])(default: () => B)(f: A => B): B =
+  def undefOrFold[A, B](x: js.UndefOr[A])(default: Supplier[B])(f: Function[A, B]): B =
     if (undefOrIsDefined(x)) f(undefOrForceGet(x))
-    else default()
+    else default.get()
 
   private object Cache {
     val safeHasOwnProperty =
@@ -84,11 +86,11 @@ private[java] object Utils {
 
   @inline
   def dictGetOrElse[A](dict: js.Dictionary[_ <: A], key: String)(
-      default: () => A): A = {
+      default: Supplier[A]): A = {
     if (dictContains(dict, key))
       dictRawApply(dict, key)
     else
-      default()
+      default.get()
   }
 
   def dictGetOrElseAndRemove[A](dict: js.Dictionary[_ <: A], key: String,
@@ -139,27 +141,27 @@ private[java] object Utils {
     map.asInstanceOf[MapRaw[K, V]].set(key, value)
 
   @inline
-  def mapGetOrElse[K, V](map: js.Map[K, V], key: K)(default: () => V): V = {
+  def mapGetOrElse[K, V](map: js.Map[K, V], key: K)(default: Supplier[V]): V = {
     val value = map.asInstanceOf[MapRaw[K, V]].getOrUndefined(key)
     if (!isUndefined(value) || mapHas(map, key)) value.asInstanceOf[V]
-    else default()
+    else default.get()
   }
 
   @inline
-  def mapGetOrElseUpdate[K, V](map: js.Map[K, V], key: K)(default: () => V): V = {
+  def mapGetOrElseUpdate[K, V](map: js.Map[K, V], key: K)(default: Supplier[V]): V = {
     mapGetOrElse(map, key) { () =>
-      val value = default()
+      val value = default.get()
       mapSet(map, key, value)
       value
     }
   }
 
   @inline
-  def forArrayElems[A](array: js.Array[A])(f: A => Any): Unit = {
+  def forArrayElems[A](array: js.Array[A])(f: Consumer[A]): Unit = {
     val len = array.length
     var i = 0
     while (i != len) {
-      f(array(i))
+      f.accept(array(i))
       i += 1
     }
   }
@@ -173,12 +175,12 @@ private[java] object Utils {
     array.splice(index, 1)(0)
 
   @inline
-  def arrayExists[A](array: js.Array[A])(f: A => scala.Boolean): scala.Boolean = {
+  def arrayExists[A](array: js.Array[A])(f: Predicate[A]): scala.Boolean = {
     // scalastyle:off return
     val len = array.length
     var i = 0
     while (i != len) {
-      if (f(array(i)))
+      if (f.test(array(i)))
         return true
       i += 1
     }

--- a/javalib/src/main/scala/java/lang/Utils.scala
+++ b/javalib/src/main/scala/java/lang/Utils.scala
@@ -34,9 +34,9 @@ private[java] object Utils {
     x.asInstanceOf[A]
 
   @inline
-  def undefOrGetOrElse[A](x: js.UndefOr[A])(default: => A): A =
+  def undefOrGetOrElse[A](x: js.UndefOr[A])(default: () => A): A =
     if (undefOrIsDefined(x)) undefOrForceGet(x)
-    else default
+    else default()
 
   @inline
   def undefOrGetOrNull[A >: Null](x: js.UndefOr[A]): A =
@@ -50,9 +50,9 @@ private[java] object Utils {
   }
 
   @inline
-  def undefOrFold[A, B](x: js.UndefOr[A])(default: => B)(f: A => B): B =
+  def undefOrFold[A, B](x: js.UndefOr[A])(default: () => B)(f: A => B): B =
     if (undefOrIsDefined(x)) f(undefOrForceGet(x))
-    else default
+    else default()
 
   private object Cache {
     val safeHasOwnProperty =
@@ -84,11 +84,11 @@ private[java] object Utils {
 
   @inline
   def dictGetOrElse[A](dict: js.Dictionary[_ <: A], key: String)(
-      default: => A): A = {
+      default: () => A): A = {
     if (dictContains(dict, key))
       dictRawApply(dict, key)
     else
-      default
+      default()
   }
 
   def dictGetOrElseAndRemove[A](dict: js.Dictionary[_ <: A], key: String,
@@ -139,16 +139,16 @@ private[java] object Utils {
     map.asInstanceOf[MapRaw[K, V]].set(key, value)
 
   @inline
-  def mapGetOrElse[K, V](map: js.Map[K, V], key: K)(default: => V): V = {
+  def mapGetOrElse[K, V](map: js.Map[K, V], key: K)(default: () => V): V = {
     val value = map.asInstanceOf[MapRaw[K, V]].getOrUndefined(key)
     if (!isUndefined(value) || mapHas(map, key)) value.asInstanceOf[V]
-    else default
+    else default()
   }
 
   @inline
-  def mapGetOrElseUpdate[K, V](map: js.Map[K, V], key: K)(default: => V): V = {
-    mapGetOrElse(map, key) {
-      val value = default
+  def mapGetOrElseUpdate[K, V](map: js.Map[K, V], key: K)(default: () => V): V = {
+    mapGetOrElse(map, key) { () =>
+      val value = default()
       mapSet(map, key, value)
       value
     }

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -26,6 +26,7 @@ import java.lang.constant.{Constable, ConstantDesc}
 import java.nio.ByteBuffer
 import java.nio.charset.Charset
 import java.util.Locale
+import java.util.function._
 import java.util.regex._
 
 /* This is the implementation of java.lang.String, which is a hijacked class.
@@ -643,7 +644,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
    *    the character at the given index is not special.
    */
   @inline
-  private def replaceCharsAtIndex(replacementAtIndex: Int => String): String = {
+  private def replaceCharsAtIndex(replacementAtIndex: IntFunction[String]): String = {
     var prep = ""
     val len = this.length()
     var i = 0
@@ -776,7 +777,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
 
   def indent(n: Int): String = {
 
-    def forEachLn(f: String => String): String = {
+    def forEachLn(f: Function[String, String]): String = {
       var out = ""
       var i = 0
       val xs = splitLines()

--- a/javalib/src/main/scala/java/math/BigInteger.scala
+++ b/javalib/src/main/scala/java/math/BigInteger.scala
@@ -45,6 +45,7 @@ import scala.annotation.tailrec
 
 import java.util.Random
 import java.util.ScalaOps._
+import java.util.function._
 
 object BigInteger {
 
@@ -736,9 +737,9 @@ class BigInteger extends Number with Comparable[BigInteger] {
 
     @inline
     @tailrec
-    def loopBytes(tempDigit: Int => Unit): Unit = {
+    def loopBytes(tempDigit: IntConsumer): Unit = {
       if (bytesLen > firstByteNumber) {
-        tempDigit(digitIndex)
+        tempDigit.accept(digitIndex)
         loopBytes(tempDigit)
       }
     }

--- a/javalib/src/main/scala/java/math/BigInteger.scala
+++ b/javalib/src/main/scala/java/math/BigInteger.scala
@@ -124,12 +124,6 @@ object BigInteger {
       reference
   }
 
-  @inline
-  private def checkCriticalArgument(expression: Boolean, errorMessage: => String): Unit = {
-    if (!expression)
-      throw new IllegalArgumentException(errorMessage)
-  }
-
   private[math] def checkRangeBasedOnIntArrayLength(byteLength: Int): Unit = {
     if (byteLength < 0 || byteLength >= ((Int.MaxValue + 1) >>> 5))
       throw new ArithmeticException("BigInteger would overflow supported range")
@@ -221,7 +215,10 @@ class BigInteger extends Number with Comparable[BigInteger] {
 
   def this(numBits: Int, rnd: Random) = {
     this()
-    checkCriticalArgument(numBits >= 0, "numBits must be non-negative")
+
+    if (numBits < 0)
+      throw new IllegalArgumentException("numBits must be non-negative")
+
     if (numBits == 0) {
       sign = 0
       numberLength = 1

--- a/javalib/src/main/scala/java/nio/GenBuffer.scala
+++ b/javalib/src/main/scala/java/nio/GenBuffer.scala
@@ -12,6 +12,7 @@
 
 package java.nio
 
+import java.util.function._
 import java.util.internal.GenericArrayOps._
 
 private[nio] object GenBuffer {
@@ -137,7 +138,7 @@ private[nio] final class GenBuffer[B <: Buffer] private (val self: B)
 
   @inline
   def generic_compareTo(that: BufferType)(
-      compare: (ElementType, ElementType) => Int): Int = {
+      compare: BiFunction[ElementType, ElementType, Int]): Int = {
     // scalastyle:off return
     if (self eq that) {
       0

--- a/javalib/src/main/scala/java/nio/charset/Charset.scala
+++ b/javalib/src/main/scala/java/nio/charset/Charset.scala
@@ -80,7 +80,7 @@ object Charset {
     UTF_8
 
   def forName(charsetName: String): Charset = {
-    dictGetOrElse(CharsetMap, charsetName.toLowerCase()) {
+    dictGetOrElse(CharsetMap, charsetName.toLowerCase()) { () =>
       throw new UnsupportedCharsetException(charsetName)
     }
   }

--- a/javalib/src/main/scala/java/nio/charset/CoderResult.scala
+++ b/javalib/src/main/scala/java/nio/charset/CoderResult.scala
@@ -78,7 +78,7 @@ object CoderResult {
   }
 
   private def malformedForLengthImpl(length: Int): CoderResult = {
-    undefOrFold(uniqueMalformed(length)) {
+    undefOrFold(uniqueMalformed(length)) { () =>
       val result = new CoderResult(Malformed, length)
       uniqueMalformed(length) = result
       result
@@ -96,7 +96,7 @@ object CoderResult {
   }
 
   private def unmappableForLengthImpl(length: Int): CoderResult = {
-    undefOrFold(uniqueUnmappable(length)) {
+    undefOrFold(uniqueUnmappable(length)) { () =>
       val result = new CoderResult(Unmappable, length)
       uniqueUnmappable(length) = result
       result

--- a/javalib/src/main/scala/java/util/AbstractCollection.scala
+++ b/javalib/src/main/scala/java/util/AbstractCollection.scala
@@ -18,6 +18,8 @@ import ScalaOps._
 
 import java.lang.{reflect => jlr}
 
+import java.util.function.Predicate
+
 abstract class AbstractCollection[E] protected () extends Collection[E] {
   def iterator(): Iterator[E]
   def size(): Int
@@ -78,11 +80,11 @@ abstract class AbstractCollection[E] protected () extends Collection[E] {
   def clear(): Unit =
     removeWhere(_ => true)
 
-  private def removeWhere(p: Any => Boolean): Boolean = {
+  private def removeWhere(p: Predicate[Any]): Boolean = {
     val iter = iterator()
     var changed = false
     while (iter.hasNext()) {
-      if (p(iter.next())) {
+      if (p.test(iter.next())) {
         iter.remove()
         changed = true
       }

--- a/javalib/src/main/scala/java/util/AbstractMap.scala
+++ b/javalib/src/main/scala/java/util/AbstractMap.scala
@@ -94,7 +94,7 @@ abstract class AbstractMap[K, V] protected () extends java.util.Map[K, V] {
     entrySet().scalaOps.exists(entry => Objects.equals(key, entry.getKey()))
 
   def get(key: Any): V = {
-    entrySet().scalaOps.findFold(entry => Objects.equals(key, entry.getKey())) {
+    entrySet().scalaOps.findFold(entry => Objects.equals(key, entry.getKey())) { () =>
       null.asInstanceOf[V]
     } { entry =>
       entry.getValue()

--- a/javalib/src/main/scala/java/util/Date.scala
+++ b/javalib/src/main/scala/java/util/Date.scala
@@ -14,6 +14,7 @@ package java.util
 
 import java.lang.Cloneable
 import java.time.Instant
+import java.util.function._
 
 import scalajs.js
 
@@ -69,9 +70,9 @@ class Date(private var millis: Long) extends Object
   }
 
   @inline
-  private def mutDate(mutator: js.Date => Unit): Unit = {
+  private def mutDate(mutator: Consumer[js.Date]): Unit = {
     val date = asDate()
-    mutator(date)
+    mutator.accept(date)
     millis = safeGetTime(date)
   }
 

--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -51,9 +51,9 @@ final class Formatter private (private[this] var dest: Appendable,
   def this(a: Appendable, l: Locale) = this(a, new Formatter.LocaleLocaleInfo(l))
 
   @inline
-  private def trapIOExceptions(body: => Unit): Unit = {
+  private def trapIOExceptions(body: () => Unit): Unit = {
     try {
-      body
+      body()
     } catch {
       case th: IOException =>
         lastIOException = th
@@ -83,7 +83,7 @@ final class Formatter private (private[this] var dest: Appendable,
 
   @noinline
   private def sendToDestSlowPath(ss: js.Array[String]): Unit = {
-    trapIOExceptions {
+    trapIOExceptions { () =>
       forArrayElems(ss)(dest.append(_))
     }
   }
@@ -92,7 +92,7 @@ final class Formatter private (private[this] var dest: Appendable,
     if (!closed && (dest ne null)) {
       dest match {
         case cl: Closeable =>
-          trapIOExceptions {
+          trapIOExceptions { () =>
             cl.close()
           }
         case _ =>
@@ -106,7 +106,7 @@ final class Formatter private (private[this] var dest: Appendable,
     if (dest ne null) {
       dest match {
         case fl: Flushable =>
-          trapIOExceptions {
+          trapIOExceptions { () =>
             fl.flush()
           }
         case _ =>
@@ -335,7 +335,7 @@ final class Formatter private (private[this] var dest: Appendable,
    *  Int range.
    */
   private def parsePositiveInt(capture: js.UndefOr[String]): Int = {
-    undefOrFold(capture) {
+    undefOrFold(capture) { () =>
       -1
     } { s =>
       val x = js.Dynamic.global.parseInt(s, 10).asInstanceOf[Double]
@@ -993,7 +993,7 @@ object Formatter {
   }
 
   @inline
-  private def assert(condition: Boolean, msg: => String): Unit = {
+  private def assert(condition: Boolean, msg: String): Unit = {
     if (!condition)
       throw new AssertionError(msg)
   }

--- a/javalib/src/main/scala/java/util/Formatter.scala
+++ b/javalib/src/main/scala/java/util/Formatter.scala
@@ -51,9 +51,9 @@ final class Formatter private (private[this] var dest: Appendable,
   def this(a: Appendable, l: Locale) = this(a, new Formatter.LocaleLocaleInfo(l))
 
   @inline
-  private def trapIOExceptions(body: () => Unit): Unit = {
+  private def trapIOExceptions(body: Runnable): Unit = {
     try {
-      body()
+      body.run()
     } catch {
       case th: IOException =>
         lastIOException = th

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -19,6 +19,7 @@ import java.{lang => jl}
 import java.{util => ju}
 import java.io._
 import java.nio.charset.StandardCharsets
+import java.util.function._
 
 import scala.scalajs.js
 
@@ -114,8 +115,8 @@ class Properties(protected val defaults: Properties)
   }
 
   @inline @tailrec
-  private final def foreachAncestor(f: Properties => Unit): Unit = {
-    f(this)
+  private final def foreachAncestor(f: Consumer[Properties]): Unit = {
+    f.accept(this)
     if (defaults ne null)
       defaults.foreachAncestor(f)
   }

--- a/javalib/src/main/scala/java/util/RedBlackTree.scala
+++ b/javalib/src/main/scala/java/util/RedBlackTree.scala
@@ -14,6 +14,8 @@ package java.util
 
 import scala.annotation.tailrec
 
+import java.util.function._
+
 import scala.scalajs.js
 
 /** The red-black tree implementation used by `TreeSet`s and `TreeMap`s.
@@ -609,7 +611,7 @@ private[util] object RedBlackTree {
 
   /** Returns `null.asInstanceOf[C]` if `node eq null`, otherwise `f(node)`. */
   @inline
-  private def nullableNodeFlatMap[A, B, C](node: Node[A, B])(f: Node[A, B] => C): C =
+  private def nullableNodeFlatMap[A, B, C](node: Node[A, B])(f: Function[Node[A, B], C]): C =
     if (node eq null) null.asInstanceOf[C]
     else f(node)
 

--- a/javalib/src/main/scala/java/util/ScalaOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaOps.scala
@@ -72,7 +72,7 @@ private[java] object ScalaOps {
     @inline def indexWhere(f: A => Boolean): Int =
       __self.iterator().scalaOps.indexWhere(f)
 
-    @inline def findFold[B](f: A => Boolean)(default: => B)(g: A => B): B =
+    @inline def findFold[B](f: A => Boolean)(default: () => B)(g: A => B): B =
       __self.iterator().scalaOps.findFold(f)(default)(g)
 
     @inline def foldLeft[B](z: B)(f: (B, A) => B): B =
@@ -127,14 +127,14 @@ private[java] object ScalaOps {
       // scalastyle:on return
     }
 
-    @inline def findFold[B](f: A => Boolean)(default: => B)(g: A => B): B = {
+    @inline def findFold[B](f: A => Boolean)(default: () => B)(g: A => B): B = {
       // scalastyle:off return
       while (__self.hasNext()) {
         val x = __self.next()
         if (f(x))
           return g(x)
       }
-      default
+      default()
       // scalastyle:on return
     }
 

--- a/javalib/src/main/scala/java/util/ScalaOps.scala
+++ b/javalib/src/main/scala/java/util/ScalaOps.scala
@@ -12,6 +12,8 @@
 
 package java.util
 
+import java.util.function._
+
 /** Make some Scala collection APIs available on Java collections. */
 private[java] object ScalaOps {
 
@@ -26,10 +28,10 @@ private[java] object ScalaOps {
   @inline
   final class SimpleRange(start: Int, end: Int) {
     @inline
-    def foreach[U](f: Int => U): Unit = {
+    def foreach[U](f: IntConsumer): Unit = {
       var i = start
       while (i < end) {
-        f(i)
+        f.accept(i)
         i += 1
       }
     }
@@ -38,10 +40,10 @@ private[java] object ScalaOps {
   @inline
   final class SimpleInclusiveRange(start: Int, end: Int) {
     @inline
-    def foreach[U](f: Int => U): Unit = {
+    def foreach[U](f: IntConsumer): Unit = {
       var i = start
       while (i <= end) {
-        f(i)
+        f.accept(i)
         i += 1
       }
     }
@@ -57,28 +59,28 @@ private[java] object ScalaOps {
       val __self: java.lang.Iterable[A])
       extends AnyVal {
 
-    @inline def foreach[U](f: A => U): Unit =
+    @inline def foreach(f: Consumer[A]): Unit =
       __self.iterator().scalaOps.foreach(f)
 
-    @inline def count(f: A => Boolean): Int =
+    @inline def count(f: Predicate[A]): Int =
       __self.iterator().scalaOps.count(f)
 
-    @inline def exists(f: A => Boolean): Boolean =
+    @inline def exists(f: Predicate[A]): Boolean =
       __self.iterator().scalaOps.exists(f)
 
-    @inline def forall(f: A => Boolean): Boolean =
+    @inline def forall(f: Predicate[A]): Boolean =
       __self.iterator().scalaOps.forall(f)
 
-    @inline def indexWhere(f: A => Boolean): Int =
+    @inline def indexWhere(f: Predicate[A]): Int =
       __self.iterator().scalaOps.indexWhere(f)
 
-    @inline def findFold[B](f: A => Boolean)(default: () => B)(g: A => B): B =
+    @inline def findFold[B](f: Predicate[A])(default: Supplier[B])(g: Function[A, B]): B =
       __self.iterator().scalaOps.findFold(f)(default)(g)
 
-    @inline def foldLeft[B](z: B)(f: (B, A) => B): B =
+    @inline def foldLeft[B](z: B)(f: BiFunction[B, A, B]): B =
       __self.iterator().scalaOps.foldLeft(z)(f)
 
-    @inline def reduceLeft[B >: A](f: (B, A) => B): B =
+    @inline def reduceLeft[B >: A](f: BiFunction[B, A, B]): B =
       __self.iterator().scalaOps.reduceLeft(f)
 
     @inline def mkString(start: String, sep: String, end: String): String =
@@ -94,32 +96,32 @@ private[java] object ScalaOps {
   class JavaIteratorOps[A] private[ScalaOps] (val __self: Iterator[A])
       extends AnyVal {
 
-    @inline def foreach[U](f: A => U): Unit = {
+    @inline def foreach(f: Consumer[A]): Unit = {
       while (__self.hasNext())
-        f(__self.next())
+        f.accept(__self.next())
     }
 
-    @inline def count(f: A => Boolean): Int =
-      foldLeft(0)((prev, x) => if (f(x)) prev + 1 else prev)
+    @inline def count(f: Predicate[A]): Int =
+      foldLeft(0)((prev, x) => if (f.test(x)) prev + 1 else prev)
 
-    @inline def exists(f: A => Boolean): Boolean = {
+    @inline def exists(f: Predicate[A]): Boolean = {
       // scalastyle:off return
       while (__self.hasNext()) {
-        if (f(__self.next()))
+        if (f.test(__self.next()))
           return true
       }
       false
       // scalastyle:on return
     }
 
-    @inline def forall(f: A => Boolean): Boolean =
-      !exists(x => !f(x))
+    @inline def forall(f: Predicate[A]): Boolean =
+      !exists(x => !f.test(x))
 
-    @inline def indexWhere(f: A => Boolean): Int = {
+    @inline def indexWhere(f: Predicate[A]): Int = {
       // scalastyle:off return
       var i = 0
       while (__self.hasNext()) {
-        if (f(__self.next()))
+        if (f.test(__self.next()))
           return i
         i += 1
       }
@@ -127,25 +129,25 @@ private[java] object ScalaOps {
       // scalastyle:on return
     }
 
-    @inline def findFold[B](f: A => Boolean)(default: () => B)(g: A => B): B = {
+    @inline def findFold[B](f: Predicate[A])(default: Supplier[B])(g: Function[A, B]): B = {
       // scalastyle:off return
       while (__self.hasNext()) {
         val x = __self.next()
-        if (f(x))
+        if (f.test(x))
           return g(x)
       }
-      default()
+      default.get()
       // scalastyle:on return
     }
 
-    @inline def foldLeft[B](z: B)(f: (B, A) => B): B = {
+    @inline def foldLeft[B](z: B)(f: BiFunction[B, A, B]): B = {
       var result: B = z
       while (__self.hasNext())
         result = f(result, __self.next())
       result
     }
 
-    @inline def reduceLeft[B >: A](f: (B, A) => B): B = {
+    @inline def reduceLeft[B >: A](f: BiFunction[B, A, B]): B = {
       if (!__self.hasNext())
         throw new NoSuchElementException("collection is empty")
       foldLeft[B](__self.next())(f)
@@ -174,9 +176,9 @@ private[java] object ScalaOps {
   class JavaEnumerationOps[A] private[ScalaOps] (val __self: Enumeration[A])
       extends AnyVal {
 
-    @inline def foreach[U](f: A => U): Unit = {
+    @inline def foreach(f: Consumer[A]): Unit = {
       while (__self.hasMoreElements())
-        f(__self.nextElement())
+        f.accept(__self.nextElement())
     }
   }
 

--- a/javalib/src/main/scala/java/util/Timer.scala
+++ b/javalib/src/main/scala/java/util/Timer.scala
@@ -47,7 +47,7 @@ class Timer() {
 
   private def scheduleOnce(task: TimerTask, delay: Long): Unit = {
     acquire(task)
-    task.timeout(delay) {
+    task.timeout(delay) { () =>
       task.scheduledOnceAndStarted = true
       task.doRun()
     }
@@ -76,12 +76,12 @@ class Timer() {
       task.doRun()
       val endTime = System.nanoTime()
       val duration = (endTime - startTime) / 1000000
-      task.timeout(period - duration) {
+      task.timeout(period - duration) { () =>
         loop()
       }
     }
 
-    task.timeout(delay) {
+    task.timeout(delay) { () =>
       loop()
     }
   }
@@ -112,13 +112,13 @@ class Timer() {
         loop(nextScheduledTime)
       } else {
         // Re-run after a timeout.
-        task.timeout(nextScheduledTime - nowTime) {
+        task.timeout(nextScheduledTime - nowTime) { () =>
           loop(nextScheduledTime)
         }
       }
     }
 
-    task.timeout(delay) {
+    task.timeout(delay) { () =>
       loop(System.nanoTime() / 1000000L + period)
     }
   }

--- a/javalib/src/main/scala/java/util/TimerTask.scala
+++ b/javalib/src/main/scala/java/util/TimerTask.scala
@@ -41,9 +41,9 @@ abstract class TimerTask {
 
   def scheduledExecutionTime(): Long = lastScheduled
 
-  private[util] def timeout(delay: Long)(body: => Unit): Unit = {
+  private[util] def timeout(delay: Long)(body: () => Unit): Unit = {
     if (!canceled) {
-      handle = setTimeout(() => body, delay.toDouble)
+      handle = setTimeout(() => body(), delay.toDouble)
     }
   }
 

--- a/javalib/src/main/scala/java/util/TimerTask.scala
+++ b/javalib/src/main/scala/java/util/TimerTask.scala
@@ -41,9 +41,9 @@ abstract class TimerTask {
 
   def scheduledExecutionTime(): Long = lastScheduled
 
-  private[util] def timeout(delay: Long)(body: () => Unit): Unit = {
+  private[util] def timeout(delay: Long)(body: js.Function0[Any]): Unit = {
     if (!canceled) {
-      handle = setTimeout(() => body(), delay.toDouble)
+      handle = setTimeout(body, delay.toDouble)
     }
   }
 

--- a/javalib/src/main/scala/java/util/regex/IndicesBuilder.scala
+++ b/javalib/src/main/scala/java/util/regex/IndicesBuilder.scala
@@ -182,7 +182,7 @@ private[regex] object IndicesBuilder {
     final def propagateFromEnd(matchResult: js.RegExp.ExecResult,
         indices: IndicesArray, end: Int): Unit = {
 
-      val start = undefOrFold(matchResult(newGroup))(-1)(matched => end - matched.length)
+      val start = undefOrFold(matchResult(newGroup))(() => -1)(matched => end - matched.length)
       propagate(matchResult, indices, start, end)
     }
 
@@ -194,7 +194,7 @@ private[regex] object IndicesBuilder {
     final def propagateFromStart(matchResult: js.RegExp.ExecResult,
         indices: IndicesArray, start: Int): Int = {
 
-      val end = undefOrFold(matchResult(newGroup))(-1)(matched => start + matched.length)
+      val end = undefOrFold(matchResult(newGroup))(() => -1)(matched => start + matched.length)
       propagate(matchResult, indices, start, end)
       end
     }

--- a/javalib/src/main/scala/java/util/regex/Matcher.scala
+++ b/javalib/src/main/scala/java/util/regex/Matcher.scala
@@ -190,7 +190,7 @@ final class Matcher private[regex] (
     pattern().getIndices(ensureLastMatch, lastMatchIsForMatches)
 
   private def startInternal(compiledGroup: Int): Int =
-    undefOrFold(indices(compiledGroup))(-1)(_._1 + regionStart())
+    undefOrFold(indices(compiledGroup))(() => -1)(_._1 + regionStart())
 
   def start(group: Int): Int =
     startInternal(pattern().numberedGroup(group))
@@ -199,7 +199,7 @@ final class Matcher private[regex] (
     startInternal(pattern().namedGroup(name))
 
   private def endInternal(compiledGroup: Int): Int =
-    undefOrFold(indices(compiledGroup))(-1)(_._2 + regionStart())
+    undefOrFold(indices(compiledGroup))(() => -1)(_._2 + regionStart())
 
   def end(group: Int): Int =
     endInternal(pattern().numberedGroup(group))
@@ -278,10 +278,10 @@ object Matcher {
      */
 
     def start(group: Int): Int =
-      undefOrFold(indices(pattern.numberedGroup(group)))(-1)(_._1 + regionStart)
+      undefOrFold(indices(pattern.numberedGroup(group)))(() => -1)(_._1 + regionStart)
 
     def end(group: Int): Int =
-      undefOrFold(indices(pattern.numberedGroup(group)))(-1)(_._2 + regionStart)
+      undefOrFold(indices(pattern.numberedGroup(group)))(() => -1)(_._2 + regionStart)
 
     def group(group: Int): String =
       undefOrGetOrNull(ensureLastMatch(pattern.numberedGroup(group)))

--- a/javalib/src/main/scala/java/util/regex/Pattern.scala
+++ b/javalib/src/main/scala/java/util/regex/Pattern.scala
@@ -133,7 +133,7 @@ final class Pattern private[regex] (
   }
 
   private[regex] def namedGroup(name: String): Int = {
-    groupNumberMap(dictGetOrElse(namedGroups, name) {
+    groupNumberMap(dictGetOrElse(namedGroups, name) { () =>
       throw new IllegalArgumentException(s"No group with name <$name>")
     })
   }

--- a/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
+++ b/javalib/src/main/scala/java/util/regex/PatternCompiler.scala
@@ -1385,7 +1385,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
           parseError("\\k is not followed by '<' for named capturing group")
         pIndex += 1
         val groupName = parseGroupName()
-        val groupNumber = dictGetOrElse(namedGroups, groupName) {
+        val groupNumber = dictGetOrElse(namedGroups, groupName) { () =>
           parseError(s"named capturing group <$groupName> does not exit")
         }
         val compiledGroupNumber = groupNumberMap(groupNumber)
@@ -1639,7 +1639,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
       // For anything else, we need built-in support for \p
       requireES2018Features("Unicode character family")
 
-      mapGetOrElse(predefinedPCharacterClasses, property) {
+      mapGetOrElse(predefinedPCharacterClasses, property) { () =>
         val scriptPrefixLen = if (property.startsWith("Is")) {
           2
         } else if (property.startsWith("sc=")) {
@@ -1674,7 +1674,7 @@ private final class PatternCompiler(private val pattern: String, private var fla
 
     val lowercase = scriptName.toLowerCase()
 
-    mapGetOrElseUpdate(canonicalizedScriptNameCache, lowercase) {
+    mapGetOrElseUpdate(canonicalizedScriptNameCache, lowercase) { () =>
       val canonical = lowercase.jsReplace(scriptCanonicalizeRegExp,
           ((s: String) => s.toUpperCase()): js.Function1[String, String])
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 147459,
-      expectedFullLinkSizeWithoutClosure = 85718,
-      expectedFullLinkSizeWithClosure = 21495,
+      expectedFastLinkSize = 147046,
+      expectedFullLinkSizeWithoutClosure = 85355,
+      expectedFullLinkSizeWithClosure = 21492,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )


### PR DESCRIPTION
This way, we can simplify the `JavalibIRCleaner`. It does not need to deal with the function rewrites anymore.

Code readability is only affected at the definition sites of the higher-order methods. The use sites leverage SAM conversion. Some use sites need a bit more help for the type inference, because Java function types are invariant in all their type parameters.

Since virtually all the higher-order functions are always inlined anyway, this commit does not make a difference to the generated code. The only exceptions were `ju.TimerTask.timeout` and `jl.System.NanoTime.getPrecisionTime`. For those, we explicitly declare that we want a `js.Function0`. This won't make performance worse on Wasm because the relevant code uses JS interop anyway.

The changes in this commit will also make the transition to `TypedClosure`s easier. Indeed, it would be tricky for the `JavalibIRCleaner` to deal with Scala functions without the possibility to use JS `Closure`s and without the full liberty of sending bare `TypedClosure`s across methods.

---

This is motivated by #5003. If we restrict `TypedClosure`s to only be usable in `NewLambda` and/or if they cannot be passed bare across method boundaries, we need a way out for the `scala.FunctionN` transformations performed by the `JavalibIRCleaner`.