### PR TITLE
Codegen: Inline the target of `Function` nodes in their `js.Closure`s.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSNewTargetTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSNewTargetTest.scala
@@ -122,16 +122,6 @@ class JSNewTargetTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:4: error: Illegal use of js.`new`.target.
-      |It can only be used in the constructor of a JS class, as a statement or in the rhs of a val or var.
-      |It cannot be used inside a lambda or by-name parameter, nor in any other location.
-      |      val x = () => js.`new`.target
-      |                             ^
-      |newSource1.scala:5: error: Illegal use of js.`new`.target.
-      |It can only be used in the constructor of a JS class, as a statement or in the rhs of a val or var.
-      |It cannot be used inside a lambda or by-name parameter, nor in any other location.
-      |      val y = Option(null).getOrElse(js.`new`.target)
-      |                                              ^
       |newSource1.scala:6: error: Illegal use of js.`new`.target.
       |It can only be used in the constructor of a JS class, as a statement or in the rhs of a val or var.
       |It cannot be used inside a lambda or by-name parameter, nor in any other location.
@@ -142,6 +132,16 @@ class JSNewTargetTest extends DirectTest with TestHelpers {
       |It cannot be used inside a lambda or by-name parameter, nor in any other location.
       |      val w: js.ThisFunction0[Any, Any] = (x: Any) => js.`new`.target
       |                                                               ^
+      |newSource1.scala:4: error: Illegal use of js.`new`.target.
+      |It can only be used in the constructor of a JS class, as a statement or in the rhs of a val or var.
+      |It cannot be used inside a lambda or by-name parameter, nor in any other location.
+      |      val x = () => js.`new`.target
+      |                             ^
+      |newSource1.scala:5: error: Illegal use of js.`new`.target.
+      |It can only be used in the constructor of a JS class, as a statement or in the rhs of a val or var.
+      |It cannot be used inside a lambda or by-name parameter, nor in any other location.
+      |      val y = Option(null).getOrElse(js.`new`.target)
+      |                                              ^
     """
 
   }


### PR DESCRIPTION
The body of `Function` nodes always has a simple shape that calls a helper method. We previously generated that call in the body of the `js.Closure`, and marked the target method `@inline` so that the optimizer would always inline it.

Instead, we now directly "inline" it from the codegen, by generating the `js.MethodDef` right inside the `js.Closure` scope.

As is, this does not change the generated code. However, it may speed up (cold) linker runs, since it will have less work to do. Notably, it performs two fewer knowledge queries to find and inline the target method. It also reduces the total amount of methods to manipulate in the incremental analysis.

More importantly, this will be necessary later if we want to add support for `async/await` or `function*/yield`. Indeed, for those, we will need `await`/`yield` expressions to be lexically scoped in the body of their enclosing closure. That won't work if they are in the body of a separate helper method.