### PR TITLE
PoC: Support for `function*/yield`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -95,6 +95,12 @@ trait JSDefinitions {
     lazy val JSConstructorTagModule = getRequiredModule("scala.scalajs.js.ConstructorTag")
       lazy val JSConstructorTag_materialize = getMemberMethod(JSConstructorTagModule, newTermName("materialize"))
 
+    lazy val JSGeneratorModule = getRequiredModule("scala.scalajs.js.Generator")
+    lazy val JSGeneratorModuleClass = JSGeneratorModule.moduleClass
+      lazy val JSGenerator_apply = getMemberMethod(JSGeneratorModuleClass, nme.apply)
+      lazy val JSGenerator_yield = getMemberMethod(JSGeneratorModuleClass, newTermName("yield"))
+      lazy val JSGenerator_yield_* = getMemberMethod(JSGeneratorModuleClass, newTermName("yield_$times"))
+
     lazy val JSNewModule = getRequiredModule("scala.scalajs.js.new")
     lazy val JSNewModuleClass = JSNewModule.moduleClass
       lazy val JSNew_target = getMemberMethod(JSNewModuleClass, newTermName("target"))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
@@ -54,7 +54,11 @@ abstract class JSPrimitives {
   final val JS_ASYNC = JS_IMPORT_META + 1 // js.async
   final val JS_AWAIT = JS_ASYNC + 1       // js.await
 
-  final val CONSTRUCTOROF = JS_AWAIT + 1                               // runtime.constructorOf(clazz)
+  final val JS_GENERATOR = JS_AWAIT + 1  // js.Generator.apply
+  final val JS_YIELD = JS_GENERATOR + 1  // js.Generator.yield
+  final val JS_YIELD_STAR = JS_YIELD + 1 // js.Generator.yield_*
+
+  final val CONSTRUCTOROF = JS_YIELD_STAR + 1                          // runtime.constructorOf(clazz)
   final val CREATE_INNER_JS_CLASS = CONSTRUCTOROF + 1                  // runtime.createInnerJSClass
   final val CREATE_LOCAL_JS_CLASS = CREATE_INNER_JS_CLASS + 1          // runtime.createLocalJSClass
   final val WITH_CONTEXTUAL_JS_CLASS_VALUE = CREATE_LOCAL_JS_CLASS + 1 // runtime.withContextualJSClassValue
@@ -108,6 +112,10 @@ abstract class JSPrimitives {
 
     addPrimitive(JSImport_apply, JS_IMPORT)
     addPrimitive(JSImport_meta, JS_IMPORT_META)
+
+    addPrimitive(JSGenerator_apply, JS_GENERATOR)
+    addPrimitive(JSGenerator_yield, JS_YIELD)
+    addPrimitive(JSGenerator_yield_*, JS_YIELD_STAR)
 
     addPrimitive(Runtime_constructorOf, CONSTRUCTOROF)
     addPrimitive(Runtime_createInnerJSClass, CREATE_INNER_JS_CLASS)

--- a/examples/helloworld/src/main/scala/helloworld/HelloWorld.scala
+++ b/examples/helloworld/src/main/scala/helloworld/HelloWorld.scala
@@ -9,87 +9,27 @@ import scala.scalajs.js
 import js.annotation._
 
 object HelloWorld {
-  def main(args: Array[String]): Unit = {
-    import js.DynamicImplicits.truthValue
-
-    if (js.typeOf(js.Dynamic.global.document) != "undefined" &&
-        js.Dynamic.global.document &&
-        js.Dynamic.global.document.getElementById("playground")) {
-      sayHelloFromDOM()
-      sayHelloFromTypedDOM()
-      sayHelloFromJQuery()
-      sayHelloFromTypedJQuery()
-    } else {
-      println("Hello world!")
+  def myGenerator(n: Int): js.Generator[Int, String, Int] = js.Generator[Int, String, Int] { implicit ev =>
+    println("one")
+    js.Generator.`yield`(42)
+    println("two")
+    var i = 0
+    var j = 0
+    while (i != n) {
+      j += js.Generator.`yield`(j)
+      i += 1
     }
+    "result"
   }
 
-  def sayHelloFromDOM(): Unit = {
-    val document = js.Dynamic.global.document
-    val playground = document.getElementById("playground")
+  def main(args: Array[String]): Unit = {
+    println("hello")
 
-    val newP = document.createElement("p")
-    newP.innerHTML = "Hello world! <i>-- DOM</i>"
-    playground.appendChild(newP)
+    /*
+    // Works on JS but not on WebAssembly
+    val g = myGenerator(5)
+    for (k <- 0 until 8)
+      js.Dynamic.global.console.log(g.next(k))
+    */
   }
-
-  def sayHelloFromTypedDOM(): Unit = {
-    val document = window.document
-    val playground = document.getElementById("playground")
-
-    val newP = document.createElement("p")
-    newP.innerHTML = "Hello world! <i>-- typed DOM</i>"
-    playground.appendChild(newP)
-  }
-
-  def sayHelloFromJQuery(): Unit = {
-    // val $ is fine too, but not very recommended in Scala code
-    val jQuery = js.Dynamic.global.jQuery
-    val newP = jQuery("<p>").html("Hello world! <i>-- jQuery</i>")
-    newP.appendTo(jQuery("#playground"))
-  }
-
-  def sayHelloFromTypedJQuery(): Unit = {
-    val jQuery = helloworld.JQuery
-    val newP = jQuery("<p>").html("Hello world! <i>-- typed jQuery</i>")
-    newP.appendTo(jQuery("#playground"))
-  }
-}
-
-@js.native
-@JSGlobalScope
-object window extends js.Object {
-  val document: DOMDocument = js.native
-
-  def alert(msg: String): Unit = js.native
-}
-
-@js.native
-trait DOMDocument extends js.Object {
-  def getElementById(id: String): DOMElement = js.native
-  def createElement(tag: String): DOMElement = js.native
-}
-
-@js.native
-trait DOMElement extends js.Object {
-  var innerHTML: String = js.native
-
-  def appendChild(child: DOMElement): Unit = js.native
-}
-
-@js.native
-@JSGlobal("jQuery")
-object JQuery extends js.Object {
-  def apply(selector: String): JQuery = js.native
-}
-
-@js.native
-trait JQuery extends js.Object {
-  def text(value: String): JQuery = js.native
-  def text(): String = js.native
-
-  def html(value: String): JQuery = js.native
-  def html(): String = js.native
-
-  def appendTo(parent: JQuery): JQuery = js.native
 }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -246,6 +246,11 @@ object Hashers {
           mixTag(TagJSAwait)
           mixTree(arg)
 
+        case JSYield(arg, star) =>
+          mixTag(TagJSYield)
+          mixTree(arg)
+          mixBoolean(star)
+
         case Debugger() =>
           mixTag(TagDebugger)
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -296,6 +296,14 @@ object Printers {
           print(arg)
           print(")")
 
+        case JSYield(arg, star) =>
+          if (star)
+            print("yield*(")
+          else
+            print("yield(")
+          print(arg)
+          print(")")
+
         case Debugger() =>
           print("debugger")
 
@@ -910,6 +918,8 @@ object Printers {
             print("arrow-lambda")
           else
             print("lambda")
+          if (flags.generator)
+            print("*")
           print("<")
           var first = true
           for ((param, value) <- captureParams.zip(captureValues)) {

--- a/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/ScalaJSVersions.scala
@@ -17,8 +17,8 @@ import java.util.concurrent.ConcurrentHashMap
 import scala.util.matching.Regex
 
 object ScalaJSVersions extends VersionChecks(
-    current = "1.19.1-SNAPSHOT",
-    binaryEmitted = "1.19"
+    current = "1.20.0-SNAPSHOT",
+    binaryEmitted = "1.20-SNAPSHOT"
 )
 
 /** Helper class to allow for testing of logic. */

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -330,6 +330,11 @@ object Serializers {
           writeTagAndPos(TagJSAwait)
           writeTree(arg)
 
+        case JSYield(arg, star) =>
+          writeTagAndPos(TagJSYield)
+          writeTree(arg)
+          writeBoolean(star)
+
         case Debugger() =>
           writeTagAndPos(TagDebugger)
 
@@ -1223,6 +1228,8 @@ object Serializers {
 
         case TagJSAwait =>
           JSAwait(readTree())
+        case TagJSYield =>
+          JSYield(readTree(), readBoolean())
 
         case TagDebugger => Debugger()
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -134,6 +134,7 @@ private[ir] object Tags {
   final val TagApplyTypedClosure = TagLinkTimeProperty + 1
   final val TagNewLambda = TagApplyTypedClosure + 1
   final val TagJSAwait = TagNewLambda + 1
+  final val TagJSYield = TagJSAwait + 1
 
   // Tags for member defs
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -80,6 +80,9 @@ object Transformers {
         case JSAwait(arg) =>
           JSAwait(transform(arg))
 
+        case JSYield(arg, star) =>
+          JSYield(transform(arg), star)
+
         // Scala expressions
 
         case New(className, ctor, args) =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -72,6 +72,9 @@ object Traversers {
       case JSAwait(arg) =>
         traverse(arg)
 
+      case JSYield(arg, star) =>
+        traverse(arg)
+
       // Scala expressions
 
       case New(_, _, args) =>

--- a/library/src/main/scala/scala/scalajs/js/Generator.scala
+++ b/library/src/main/scala/scala/scalajs/js/Generator.scala
@@ -1,0 +1,55 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+import scala.scalajs.js
+import scala.scalajs.js.annotation._
+
+/** <span class="badge badge-ecma6" style="float: right;">ECMAScript 6</span>
+ *  JavaScript Generator.
+ */
+trait Generator[+Elem, +Result, -NextParam] extends js.Iterator[Elem] with js.Iterable[Elem] {
+  def next(): js.Generator.Entry[Elem, Result]
+  def next(param: NextParam): js.Generator.Entry[Elem, Result]
+  def `return`[R >: Result](value: R): js.Generator.Entry[Elem, R]
+  def `throw`(exception: scala.Any): js.Generator.Entry[Elem, Result]
+
+  @JSName(js.Symbol.iterator)
+  def jsIterator(): this.type
+}
+
+object Generator {
+  def apply[Elem, Result, NextParam](
+      body: YieldEvidence[Elem, NextParam] => Result): js.Generator[Elem, Result, NextParam] = {
+    throw new java.lang.Error("stub")
+  }
+
+  def `yield`[Elem, NextParam](value: Elem)(
+      implicit evidence: YieldEvidence[Elem, NextParam]): NextParam = {
+    throw new java.lang.Error("stub")
+  }
+
+  def yield_*[Elem, NextParam](values: js.Iterable[Elem])(
+      implicit evidence: YieldEvidence[Elem, NextParam]): NextParam = {
+    throw new java.lang.Error("stub")
+  }
+
+  /** Return value of `js.Generator.next`. */
+  trait Entry[+Elem, +Result] extends js.Iterator.Entry[Elem] {
+    /** The result value. Reading this value is only valid if done is true. */
+    @JSName("value")
+    def resultValue: Result
+  }
+
+  sealed trait YieldEvidence[Elem, NextParam] extends js.Any
+}

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -350,6 +350,10 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
         mkUnaryOp(op, transformExpr(lhs))
       case Await(arg) =>
         new Node(Token.AWAIT, transformExpr(arg))
+      case Yield(arg, star) =>
+        val node = new Node(Token.YIELD, transformExpr(arg))
+        node.setYieldAll(star)
+        node
       case IncDec(prefix, inc, arg) =>
         val token = if (inc) Token.INC else Token.DEC
         val node = new Node(token, transformExpr(arg))
@@ -391,6 +395,7 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
         val node = genFunction("", args, restParam, body)
         node.setIsArrowFunction(flags.arrow)
         node.setIsAsyncFunction(flags.async)
+        node.setIsGeneratorFunction(flags.generator)
         node
       case FunctionDef(name, args, restParam, body) =>
         genFunction(name.resolveName(), args, restParam, body)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1379,6 +1379,8 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         // JavaScript expressions that can always have side-effects
         case JSAwait(arg) =>
           allowSideEffects && test(arg)
+        case JSYield(arg, star) =>
+          allowSideEffects && test(arg)
         case SelectJSNativeMember(_, _) =>
           allowSideEffects
         case JSNew(fun, args) =>
@@ -1747,6 +1749,11 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
         case JSAwait(arg) =>
           unnest(arg) { (newArg, env) =>
             redo(JSAwait(newArg))(env)
+          }
+
+        case JSYield(arg, star) =>
+          unnest(arg) { (newArg, env) =>
+            redo(JSYield(newArg, star))(env)
           }
 
         // Scala expressions (if we reach here their arguments are not expressions)
@@ -2236,6 +2243,9 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
 
         case JSAwait(arg) =>
           js.Await(transformExprNoChar(arg))
+
+        case JSYield(arg, star) =>
+          js.Yield(transformExprNoChar(arg), star)
 
         // Scala expressions
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -17,6 +17,7 @@ import org.scalajs.ir.Trees.ClosureFlags
 
 import org.scalajs.linker.backend.javascript.Trees._
 import org.scalajs.linker.interface.ESVersion
+import org.scalajs.ir.Trees.ClosureFlags
 
 /** Collection of tree generators that are used across the board.
  *  This class is fully stateless.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -441,6 +441,15 @@ object Printers {
           print(')')
           printSeparatorIfStat()
 
+        case Yield(expr, star) =>
+          if (star)
+            print("(yield* ")
+          else
+            print("(yield ")
+          print(expr)
+          print(')')
+          printSeparatorIfStat()
+
         case IncDec(prefix, inc, arg) =>
           val op = if (inc) "++" else "--"
           print('(')
@@ -617,6 +626,8 @@ object Printers {
               print("(async function")
             else
               print("(function")
+            if (flags.generator)
+              print('*')
             printSig(args, restParam)
             printBlock(body)
             print(')')

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -375,6 +375,9 @@ object Trees {
 
   sealed case class Await(expr: Tree)(implicit val pos: Position) extends Tree
 
+  sealed case class Yield(expr: Tree, star: Boolean)(implicit val pos: Position)
+      extends Tree
+
   /** `++x`, `x++`, `--x` or `x--`. */
   sealed case class IncDec(prefix: Boolean, inc: Boolean, arg: Tree)(
       implicit val pos: Position)
@@ -437,8 +440,8 @@ object Trees {
    *  For convenience to producers, `flags.typed` may or may not be true, and
    *  is always ignored.
    *
-   *  The other flags: `arrow` and `async`, are meaningful. They have the same
-   *  meaning as in `ir.Trees.Closure`.
+   *  The other flags: `arrow`, `async` and `generator`, are meaningful.
+   *  They have the same meaning as in `ir.Trees.Closure`.
    */
   sealed case class Function(flags: ClosureFlags, args: List[ParamDef],
       restParam: Option[ParamDef], body: Tree)(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -43,6 +43,7 @@ import org.scalajs.logging.Logger
 import SpecialNames._
 import VarGen._
 import org.scalajs.linker.backend.javascript.ByteArrayWriter
+import org.scalajs.ir.Trees.ClosureFlags
 
 final class Emitter(config: Emitter.Config) {
   import Emitter._

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -593,6 +593,7 @@ private class FunctionEmitter private (
       case t: TryFinally          => unwinding.genTryFinally(t, expectedType)
       case t: Match               => genMatch(t, expectedType)
       case t: JSAwait             => genJSAwait(t)
+      case t: JSYield             => genJSYield(t)
       case t: Debugger            => VoidType // ignore
       case t: Skip                => VoidType
 
@@ -3167,6 +3168,9 @@ private class FunctionEmitter private (
 
     implicit val pos = tree.pos
 
+    if (flags.generator)
+      throw new IllegalArgumentException(s"Unsupported function* in WebAssembly: $tree")
+
     val dataStructTypeID = ctx.getClosureDataStructType(captureParams.map(_.ptpe))
 
     // Define the function where captures are reified as a `__captureData` argument.
@@ -3292,6 +3296,14 @@ private class FunctionEmitter private (
     genTree(arg, AnyType)
     markPosition(tree)
     fb += wa.Call(genFunctionID.jsAwait)
+
+    AnyType
+  }
+
+  private def genJSYield(tree: JSYield): Type = {
+    val JSYield(arg, star) = tree
+
+    throw new IllegalArgumentException(s"Unsupported yield in WebAssembly: $tree")
 
     AnyType
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -794,6 +794,11 @@ private final class ClassDefChecker(classDef: ClassDef,
       case JSAwait(arg) =>
         checkTree(arg, env)
 
+      case JSYield(arg, star) =>
+        if (!env.inGenerator)
+          reportError(i"Illegal `yield` outside of generator closure")
+        checkTree(arg, env)
+
       case Debugger() =>
 
       // Scala expressions
@@ -1057,6 +1062,8 @@ private final class ClassDefChecker(classDef: ClassDef,
       reportError(i"A typed closure must have the 'arrow' flag")
     if (flags.typed && flags.async)
       reportError(i"A typed closure cannot have the 'async' flag")
+    if (flags.arrow && flags.generator)
+      reportError(i"Incompatible closure flags `arrow` and `generator`")
 
     /* Check compliance of captureValues wrt. captureParams in the current
      * method state, i.e., outside `withPerMethodState`.
@@ -1087,6 +1094,7 @@ private final class ClassDefChecker(classDef: ClassDef,
         .fromParams(captureParams ++ params ++ restParam)
         .withHasNewTarget(!flags.arrow)
         .withMaybeThisType(!flags.arrow, AnyType)
+        .withInGenerator(flags.generator)
       checkTree(body, bodyEnv)
     }
   }
@@ -1183,7 +1191,11 @@ object ClassDefChecker {
       /** Return types by label. */
       val returnLabels: Set[LabelName],
       /** Whether usages of `this` are restricted in this scope. */
-      val isThisRestricted: Boolean
+      val isThisRestricted: Boolean,
+      /** Whether we are in an `async` closure, where `await` expressions are valid. */
+      val inAsync: Boolean,
+      /** Whether we are in a generator closure, where `yield` expressions are valid. */
+      val inGenerator: Boolean
   ) {
     import Env._
 
@@ -1206,13 +1218,22 @@ object ClassDefChecker {
     def withIsThisRestricted(isThisRestricted: Boolean): Env =
       copy(isThisRestricted = isThisRestricted)
 
+    def withInAsync(inAsync: Boolean): Env =
+      copy(inAsync = inAsync)
+
+    def withInGenerator(inGenerator: Boolean): Env =
+      copy(inGenerator = inGenerator)
+
     private def copy(
       hasNewTarget: Boolean = hasNewTarget,
       locals: Map[LocalName, LocalDef] = locals,
       returnLabels: Set[LabelName] = returnLabels,
-      isThisRestricted: Boolean = isThisRestricted
+      isThisRestricted: Boolean = isThisRestricted,
+      inAsync: Boolean = inAsync,
+      inGenerator: Boolean = inGenerator
     ): Env = {
-      new Env(hasNewTarget, locals, returnLabels, isThisRestricted)
+      new Env(hasNewTarget, locals, returnLabels, isThisRestricted,
+          inAsync, inGenerator)
     }
   }
 
@@ -1222,7 +1243,9 @@ object ClassDefChecker {
         hasNewTarget = false,
         locals = Map.empty,
         returnLabels = Set.empty,
-        isThisRestricted = false
+        isThisRestricted = false,
+        inAsync = false,
+        inGenerator = false
       )
     }
 
@@ -1235,7 +1258,9 @@ object ClassDefChecker {
         hasNewTarget = false,
         paramLocalDefs.toMap,
         Set.empty,
-        isThisRestricted = false
+        isThisRestricted = false,
+        inAsync = false,
+        inGenerator = false
       )
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -351,6 +351,9 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter,
       case JSAwait(arg) =>
         typecheckAny(arg, env)
 
+      case JSYield(arg, star) =>
+        typecheckAny(arg, env)
+
       case Debugger() =>
 
       // Scala expressions

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -485,6 +485,9 @@ private[optimizer] abstract class OptimizerCore(
       case JSAwait(arg) =>
         JSAwait(transformExpr(arg))
 
+      case JSYield(arg, star) =>
+        JSYield(transformExpr(arg), star)
+
       // Scala expressions
 
       case New(className, ctor, args) =>
@@ -1012,14 +1015,15 @@ private[optimizer] abstract class OptimizerCore(
                 resultType, body, tcaptureValues)(cont)
           }
 
-          if (!flags.arrow || flags.async || restParam.isDefined) {
+          if (!flags.arrow || flags.async || flags.generator || restParam.isDefined) {
             /* TentativeClosureReplacement assumes there are no rest
              * parameters, because that would not be inlineable anyway.
              * Likewise, it assumes that there is no binding for `this` nor for
              * `new.target`, which is only true for arrow functions.
-             * Async closures cannot be inlined, due to their semantics.
-             * So we only ever try to inline non-async arrow Closures without
-             * rest parameters.
+             * Async and generator closures cannot be inlined, due to their
+             * semantics.
+             * So we only ever try to inline non-async, non-generator arrow
+             * Closures without rest parameters.
              */
             default()
           } else {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -256,6 +256,7 @@ object MyScalaJSPlugin extends AutoPlugin {
              * If you remove it, try running `scalaTestSuite2_13/test` with Wasm.
              * See also the use of this flag in MainGenericRunner.scala.
              */
+            "--experimental-wasm-jspi", // for JSPI, used by async/await
             "--turboshaft-wasm",
           ))
         } else {
@@ -2019,7 +2020,8 @@ object Build {
       exampleSettings,
       name := "Hello World - Scala.js example",
       moduleName := "helloworld",
-      scalaJSUseMainModuleInitializer := true
+      scalaJSUseMainModuleInitializer := true,
+      scalaJSLinkerConfig ~= { _.withESFeatures(_.withESVersion(ESVersion.ES2017)) }
   ).withScalaJSCompiler.dependsOnLibrary
 
   lazy val reversi: MultiScalaProject = MultiScalaProject(


### PR DESCRIPTION
Would fix #5079.

* Only only works on JS; not on Wasm.
* `yield_*` should work (on JS) but is untested.
* `async function*` has theoretical support in the linker, but no support in the compiler backend for now.

---

Try `helloworld2_12/run`. On JS you can uncomment the code that uses the generator. Left commented out in the PR so that there's a chance the CI can get green.