### PR TITLE
Update the CLA check after the rename of Lightbend to Akka.

### DIFF
--- a/ci/check-cla.sh
+++ b/ci/check-cla.sh
@@ -4,13 +4,13 @@ set -eux
 AUTHOR="$1"
 echo "Pull request submitted by $AUTHOR";
 URL_AUTHOR=$(jq -rn --arg x "$AUTHOR" '$x|@uri')
-signed=$(curl -s "https://www.lightbend.com/contribute/cla/scala/check/$URL_AUTHOR" | jq -r ".signed");
+signed=$(curl -s "https://contribute.akka.io/contribute/cla/scala/check/$URL_AUTHOR" | jq -r ".signed");
 if [ "$signed" = "true" ] ; then
   echo "CLA check for $AUTHOR successful";
 else
   echo "CLA check for $AUTHOR failed";
   echo "Please sign the Scala CLA to contribute to Scala.js.";
-  echo "Go to https://www.lightbend.com/contribute/cla/scala and then";
+  echo "Go to https://contribute.akka.io/contribute/cla/scala and then";
   echo "comment on the pull request to ask for a new check.";
   exit 1;
 fi;


### PR DESCRIPTION
The URLs did contain a redirect, but `curl` does not follow redirects by default.

We should always have the canonical URLs anyway, so I update them instead of making `curl` follow redirects.

---

See #5003 for an example of a failure atm.