### PR TITLE
Remove the stat/expr distinction from `Transformers.Transformer`.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -19,204 +19,197 @@ import Version.Unversioned
 object Transformers {
 
   abstract class Transformer {
-    final def transformStats(trees: List[Tree]): List[Tree] =
-      trees.map(transformStat(_))
-
-    final def transformStat(tree: Tree): Tree =
-      transform(tree, isStat = true)
-
-    final def transformExpr(tree: Tree): Tree =
-      transform(tree, isStat = false)
-
-    def transformExprOrJSSpread(tree: TreeOrJSSpread): TreeOrJSSpread = {
+    final def transformTreeOrJSSpread(tree: TreeOrJSSpread): TreeOrJSSpread = {
       implicit val pos = tree.pos
 
       tree match {
-        case JSSpread(items) => JSSpread(transformExpr(items))
-        case tree: Tree      => transformExpr(tree)
+        case JSSpread(items) => JSSpread(transform(items))
+        case tree: Tree      => transform(tree)
       }
     }
 
-    def transform(tree: Tree, isStat: Boolean): Tree = {
+    final def transformTrees(trees: List[Tree]): List[Tree] =
+      trees.map(transform(_))
+
+    final def transformTreeOpt(treeOpt: Option[Tree]): Option[Tree] =
+      treeOpt.map(transform(_))
+
+    def transform(tree: Tree): Tree = {
       implicit val pos = tree.pos
 
       tree match {
         // Definitions
 
         case VarDef(ident, originalName, vtpe, mutable, rhs) =>
-          VarDef(ident, originalName, vtpe, mutable, transformExpr(rhs))
+          VarDef(ident, originalName, vtpe, mutable, transform(rhs))
 
         // Control flow constructs
 
         case Block(stats) =>
-          Block(stats.init.map(transformStat) :+ transform(stats.last, isStat))
+          Block(transformTrees(stats))
 
         case Labeled(label, tpe, body) =>
-          Labeled(label, tpe, transform(body, isStat))
+          Labeled(label, tpe, transform(body))
 
         case Assign(lhs, rhs) =>
-          Assign(transformExpr(lhs).asInstanceOf[AssignLhs], transformExpr(rhs))
+          Assign(transform(lhs).asInstanceOf[AssignLhs], transform(rhs))
 
         case Return(expr, label) =>
-          Return(transformExpr(expr), label) // pessimistic; maybe `expr` is actually a statement
+          Return(transform(expr), label)
 
         case If(cond, thenp, elsep) =>
-          If(transformExpr(cond), transform(thenp, isStat),
-              transform(elsep, isStat))(tree.tpe)
+          If(transform(cond), transform(thenp), transform(elsep))(tree.tpe)
 
         case While(cond, body) =>
-          While(transformExpr(cond), transformStat(body))
+          While(transform(cond), transform(body))
 
         case ForIn(obj, keyVar, keyVarOriginalName, body) =>
-          ForIn(transformExpr(obj), keyVar, keyVarOriginalName,
-              transformStat(body))
+          ForIn(transform(obj), keyVar, keyVarOriginalName, transform(body))
 
         case TryCatch(block, errVar, errVarOriginalName, handler) =>
-          TryCatch(transform(block, isStat), errVar, errVarOriginalName,
-              transform(handler, isStat))(tree.tpe)
+          TryCatch(transform(block), errVar, errVarOriginalName,
+              transform(handler))(tree.tpe)
 
         case TryFinally(block, finalizer) =>
-          TryFinally(transform(block, isStat), transformStat(finalizer))
+          TryFinally(transform(block), transform(finalizer))
 
         case Throw(expr) =>
-          Throw(transformExpr(expr))
+          Throw(transform(expr))
 
         case Match(selector, cases, default) =>
-          Match(transformExpr(selector),
-              cases map (c => (c._1, transform(c._2, isStat))),
-              transform(default, isStat))(tree.tpe)
+          Match(transform(selector), cases.map(c => (c._1, transform(c._2))),
+              transform(default))(tree.tpe)
 
         // Scala expressions
 
         case New(className, ctor, args) =>
-          New(className, ctor, args map transformExpr)
+          New(className, ctor, transformTrees(args))
 
         case Select(qualifier, field) =>
-          Select(transformExpr(qualifier), field)(tree.tpe)
+          Select(transform(qualifier), field)(tree.tpe)
 
         case Apply(flags, receiver, method, args) =>
-          Apply(flags, transformExpr(receiver), method,
-              args map transformExpr)(tree.tpe)
+          Apply(flags, transform(receiver), method,
+              transformTrees(args))(tree.tpe)
 
         case ApplyStatically(flags, receiver, className, method, args) =>
-          ApplyStatically(flags, transformExpr(receiver), className, method,
-              args map transformExpr)(tree.tpe)
+          ApplyStatically(flags, transform(receiver), className, method,
+              transformTrees(args))(tree.tpe)
 
         case ApplyStatic(flags, className, method, args) =>
-          ApplyStatic(flags, className, method, args map transformExpr)(tree.tpe)
+          ApplyStatic(flags, className, method, transformTrees(args))(tree.tpe)
 
         case ApplyDynamicImport(flags, className, method, args) =>
-          ApplyDynamicImport(flags, className, method, args.map(transformExpr))
+          ApplyDynamicImport(flags, className, method, transformTrees(args))
 
         case UnaryOp(op, lhs) =>
-          UnaryOp(op, transformExpr(lhs))
+          UnaryOp(op, transform(lhs))
 
         case BinaryOp(op, lhs, rhs) =>
-          BinaryOp(op, transformExpr(lhs), transformExpr(rhs))
+          BinaryOp(op, transform(lhs), transform(rhs))
 
         case NewArray(tpe, length) =>
-          NewArray(tpe, transformExpr(length))
+          NewArray(tpe, transform(length))
 
         case ArrayValue(tpe, elems) =>
-          ArrayValue(tpe, elems map transformExpr)
+          ArrayValue(tpe, transformTrees(elems))
 
         case ArrayLength(array) =>
-          ArrayLength(transformExpr(array))
+          ArrayLength(transform(array))
 
         case ArraySelect(array, index) =>
-          ArraySelect(transformExpr(array), transformExpr(index))(tree.tpe)
+          ArraySelect(transform(array), transform(index))(tree.tpe)
 
         case RecordValue(tpe, elems) =>
-          RecordValue(tpe, elems map transformExpr)
+          RecordValue(tpe, transformTrees(elems))
 
         case RecordSelect(record, field) =>
-          RecordSelect(transformExpr(record), field)(tree.tpe)
+          RecordSelect(transform(record), field)(tree.tpe)
 
         case IsInstanceOf(expr, testType) =>
-          IsInstanceOf(transformExpr(expr), testType)
+          IsInstanceOf(transform(expr), testType)
 
         case AsInstanceOf(expr, tpe) =>
-          AsInstanceOf(transformExpr(expr), tpe)
+          AsInstanceOf(transform(expr), tpe)
 
         case GetClass(expr) =>
-          GetClass(transformExpr(expr))
+          GetClass(transform(expr))
 
         case Clone(expr) =>
-          Clone(transformExpr(expr))
+          Clone(transform(expr))
 
         case IdentityHashCode(expr) =>
-          IdentityHashCode(transformExpr(expr))
+          IdentityHashCode(transform(expr))
 
         case WrapAsThrowable(expr) =>
-          WrapAsThrowable(transformExpr(expr))
+          WrapAsThrowable(transform(expr))
 
         case UnwrapFromThrowable(expr) =>
-          UnwrapFromThrowable(transformExpr(expr))
+          UnwrapFromThrowable(transform(expr))
 
         // JavaScript expressions
 
         case JSNew(ctor, args) =>
-          JSNew(transformExpr(ctor), args.map(transformExprOrJSSpread))
+          JSNew(transform(ctor), args.map(transformTreeOrJSSpread))
 
         case JSPrivateSelect(qualifier, field) =>
-          JSPrivateSelect(transformExpr(qualifier), field)
+          JSPrivateSelect(transform(qualifier), field)
 
         case JSSelect(qualifier, item) =>
-          JSSelect(transformExpr(qualifier), transformExpr(item))
+          JSSelect(transform(qualifier), transform(item))
 
         case JSFunctionApply(fun, args) =>
-          JSFunctionApply(transformExpr(fun), args.map(transformExprOrJSSpread))
+          JSFunctionApply(transform(fun), args.map(transformTreeOrJSSpread))
 
         case JSMethodApply(receiver, method, args) =>
-          JSMethodApply(transformExpr(receiver), transformExpr(method),
-              args.map(transformExprOrJSSpread))
+          JSMethodApply(transform(receiver), transform(method),
+              args.map(transformTreeOrJSSpread))
 
         case JSSuperSelect(superClass, qualifier, item) =>
-          JSSuperSelect(superClass, transformExpr(qualifier),
-              transformExpr(item))
+          JSSuperSelect(superClass, transform(qualifier), transform(item))
 
         case JSSuperMethodCall(superClass, receiver, method, args) =>
-          JSSuperMethodCall(superClass, transformExpr(receiver),
-              transformExpr(method), args.map(transformExprOrJSSpread))
+          JSSuperMethodCall(superClass, transform(receiver),
+              transform(method), args.map(transformTreeOrJSSpread))
 
         case JSSuperConstructorCall(args) =>
-          JSSuperConstructorCall(args.map(transformExprOrJSSpread))
+          JSSuperConstructorCall(args.map(transformTreeOrJSSpread))
 
         case JSImportCall(arg) =>
-          JSImportCall(transformExpr(arg))
+          JSImportCall(transform(arg))
 
         case JSDelete(qualifier, item) =>
-          JSDelete(transformExpr(qualifier), transformExpr(item))
+          JSDelete(transform(qualifier), transform(item))
 
         case JSUnaryOp(op, lhs) =>
-          JSUnaryOp(op, transformExpr(lhs))
+          JSUnaryOp(op, transform(lhs))
 
         case JSBinaryOp(op, lhs, rhs) =>
-          JSBinaryOp(op, transformExpr(lhs), transformExpr(rhs))
+          JSBinaryOp(op, transform(lhs), transform(rhs))
 
         case JSArrayConstr(items) =>
-          JSArrayConstr(items.map(transformExprOrJSSpread))
+          JSArrayConstr(items.map(transformTreeOrJSSpread))
 
         case JSObjectConstr(fields) =>
           JSObjectConstr(fields.map { field =>
-            (transformExpr(field._1), transformExpr(field._2))
+            (transform(field._1), transform(field._2))
           })
 
         case JSTypeOfGlobalRef(globalRef) =>
-          JSTypeOfGlobalRef(transformExpr(globalRef).asInstanceOf[JSGlobalRef])
+          JSTypeOfGlobalRef(transform(globalRef).asInstanceOf[JSGlobalRef])
 
         // Atomic expressions
 
         case Closure(arrow, captureParams, params, restParam, body, captureValues) =>
-          Closure(arrow, captureParams, params, restParam, transformExpr(body),
-              captureValues.map(transformExpr))
+          Closure(arrow, captureParams, params, restParam, transform(body),
+              transformTrees(captureValues))
 
         case CreateJSClass(className, captureValues) =>
-          CreateJSClass(className, captureValues.map(transformExpr))
+          CreateJSClass(className, transformTrees(captureValues))
 
         // Transients
         case Transient(value) =>
-          value.transform(this, isStat)
+          value.transform(this)
 
         // Trees that need not be transformed
 
@@ -233,7 +226,7 @@ object Transformers {
     def transformClassDef(tree: ClassDef): ClassDef = {
       import tree._
       ClassDef(name, originalName, kind, jsClassCaptures, superClass,
-          interfaces, jsSuperClass.map(transformExpr), jsNativeLoadSpec,
+          interfaces, transformTreeOpt(jsSuperClass), jsNativeLoadSpec,
           fields.map(transformAnyFieldDef(_)),
           methods.map(transformMethodDef), jsConstructor.map(transformJSConstructorDef),
           jsMethodProps.map(transformJSMethodPropDef), jsNativeMembers,
@@ -246,7 +239,7 @@ object Transformers {
 
     def transformMethodDef(methodDef: MethodDef): MethodDef = {
       val MethodDef(flags, name, originalName, args, resultType, body) = methodDef
-      val newBody = body.map(transform(_, isStat = resultType == VoidType))
+      val newBody = transformTreeOpt(body)
       MethodDef(flags, name, originalName, args, resultType, newBody)(
           methodDef.optimizerHints, Unversioned)(methodDef.pos)
     }
@@ -265,29 +258,26 @@ object Transformers {
         case JSPropertyDef(flags, name, getterBody, setterArgAndBody) =>
           JSPropertyDef(
               flags,
-              transformExpr(name),
-              getterBody.map(transformStat),
-              setterArgAndBody map { case (arg, body) =>
-                (arg, transformStat(body))
+              transform(name),
+              transformTreeOpt(getterBody),
+              setterArgAndBody.map { case (arg, body) =>
+                (arg, transform(body))
               })(Unversioned)(jsMethodPropDef.pos)
       }
     }
 
     def transformJSMethodDef(jsMethodDef: JSMethodDef): JSMethodDef = {
       val JSMethodDef(flags, name, args, restParam, body) = jsMethodDef
-      JSMethodDef(flags, transformExpr(name), args, restParam, transformExpr(body))(
+      JSMethodDef(flags, transform(name), args, restParam, transform(body))(
           jsMethodDef.optimizerHints, Unversioned)(jsMethodDef.pos)
     }
 
     def transformJSConstructorBody(body: JSConstructorBody): JSConstructorBody = {
       implicit val pos = body.pos
 
-      val newBeforeSuper = body.beforeSuper.map(transformStat(_))
-      val newSuperCall = transformStat(body.superCall).asInstanceOf[JSSuperConstructorCall]
-      val newAfterSuper = body.afterSuper match {
-        case stats :+ expr => stats.map(transformStat(_)) :+ transformExpr(expr)
-        case empty         => empty // cannot use Nil here because the compiler does not know that it is exhaustive
-      }
+      val newBeforeSuper = transformTrees(body.beforeSuper)
+      val newSuperCall = transform(body.superCall).asInstanceOf[JSSuperConstructorCall]
+      val newAfterSuper = transformTrees(body.afterSuper)
 
       JSConstructorBody(newBeforeSuper, newSuperCall, newAfterSuper)
     }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -1158,7 +1158,7 @@ object Trees {
        *
        *  Implementations should transform contained trees and potentially adjust the result.
        */
-      def transform(transformer: Transformers.Transformer, isStat: Boolean)(
+      def transform(transformer: Transformers.Transformer)(
           implicit pos: Position): Tree
 
       /** Prints the IR representation of this transient node.

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -948,7 +948,7 @@ class PrintersTest {
 
       def traverse(traverser: Traversers.Traverser): Unit = ???
 
-      def transform(transformer: Transformers.Transformer, isStat: Boolean)(
+      def transform(transformer: Transformers.Transformer)(
           implicit pos: Position): Tree = ???
 
       def printIR(out: Printers.IRTreePrinter): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -3355,10 +3355,8 @@ private object FunctionEmitter {
 
     def traverse(traverser: Traverser): Unit = ()
 
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
+    def transform(transformer: Transformer)(implicit pos: Position): Tree =
       Transient(this)
-    }
 
     def printIR(out: org.scalajs.ir.Printers.IRTreePrinter): Unit =
       out.print(ident.name)
@@ -3373,10 +3371,9 @@ private object FunctionEmitter {
       traverser.traverse(argArray)
     }
 
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
-      Transient(JSNewVararg(transformer.transformExpr(ctor),
-          transformer.transformExpr(argArray)))
+    def transform(transformer: Transformer)(implicit pos: Position): Tree = {
+      Transient(JSNewVararg(transformer.transform(ctor),
+          transformer.transform(argArray)))
     }
 
     def printIR(out: IRTreePrinter): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
@@ -40,9 +40,9 @@ object Transients {
     def traverse(traverser: Traverser): Unit =
       traverser.traverse(expr)
 
-    def transform(transformer: Transformer, isStat: Boolean)(
+    def transform(transformer: Transformer)(
         implicit pos: Position): Tree = {
-      Transient(Cast(transformer.transformExpr(expr), tpe))
+      Transient(Cast(transformer.transform(expr), tpe))
     }
 
     def printIR(out: IRTreePrinter): Unit = {
@@ -72,12 +72,9 @@ object Transients {
       traverser.traverse(length)
     }
 
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
-      import transformer.transformExpr
-
-      Transient(SystemArrayCopy(transformExpr(src), transformExpr(srcPos),
-          transformExpr(dest), transformExpr(destPos), transformExpr(length)))
+    def transform(t: Transformer)(implicit pos: Position): Tree = {
+      Transient(SystemArrayCopy(t.transform(src), t.transform(srcPos),
+          t.transform(dest), t.transform(destPos), t.transform(length)))
     }
 
     def printIR(out: IRTreePrinter): Unit = {
@@ -101,9 +98,9 @@ object Transients {
     def traverse(traverser: Traverser): Unit =
       traverser.traverse(runtimeClass)
 
-    def transform(transformer: Transformer, isStat: Boolean)(
+    def transform(transformer: Transformer)(
         implicit pos: Position): Tree = {
-      Transient(ZeroOf(transformer.transformExpr(runtimeClass)))
+      Transient(ZeroOf(transformer.transform(runtimeClass)))
     }
 
     def printIR(out: IRTreePrinter): Unit = {
@@ -126,10 +123,10 @@ object Transients {
       traverser.traverse(nativeArray)
     }
 
-    def transform(transformer: Transformer, isStat: Boolean)(
+    def transform(transformer: Transformer)(
         implicit pos: Position): Tree = {
-      Transient(NativeArrayWrapper(transformer.transformExpr(elemClass),
-          transformer.transformExpr(nativeArray))(tpe))
+      Transient(NativeArrayWrapper(transformer.transform(elemClass),
+          transformer.transform(nativeArray))(tpe))
     }
 
     def printIR(out: IRTreePrinter): Unit = {
@@ -150,9 +147,9 @@ object Transients {
     def traverse(traverser: Traverser): Unit =
       traverser.traverse(obj)
 
-    def transform(transformer: Transformer, isStat: Boolean)(
+    def transform(transformer: Transformer)(
         implicit pos: Position): Tree = {
-      Transient(ObjectClassName(transformer.transformExpr(obj)))
+      Transient(ObjectClassName(transformer.transform(obj)))
     }
 
     def printIR(out: IRTreePrinter): Unit = {
@@ -172,9 +169,9 @@ object Transients {
     def traverse(traverser: Traverser): Unit =
       traverser.traverse(expr)
 
-    def transform(transformer: Transformer, isStat: Boolean)(
+    def transform(transformer: Transformer)(
         implicit pos: Position): Tree = {
-      Transient(ArrayToTypedArray(transformer.transformExpr(expr), primRef))
+      Transient(ArrayToTypedArray(transformer.transform(expr), primRef))
     }
 
     def printIR(out: IRTreePrinter): Unit = {
@@ -198,9 +195,9 @@ object Transients {
     def traverse(traverser: Traverser): Unit =
       traverser.traverse(expr)
 
-    def transform(transformer: Transformer, isStat: Boolean)(
+    def transform(transformer: Transformer)(
         implicit pos: Position): Tree = {
-      Transient(TypedArrayToArray(transformer.transformExpr(expr), primRef))
+      Transient(TypedArrayToArray(transformer.transform(expr), primRef))
     }
 
     def printIR(out: IRTreePrinter): Unit = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmTransients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmTransients.scala
@@ -43,10 +43,8 @@ object WasmTransients {
     def traverse(traverser: Traverser): Unit =
       traverser.traverse(lhs)
 
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
-      Transient(WasmUnaryOp(op, transformer.transformExpr(lhs)))
-    }
+    def transform(transformer: Transformer)(implicit pos: Position): Tree =
+      Transient(WasmUnaryOp(op, transformer.transform(lhs)))
 
     def wasmInstr: wa.SimpleInstr = (op: @switch) match {
       case I32Clz    => wa.I32Clz
@@ -141,10 +139,9 @@ object WasmTransients {
       traverser.traverse(rhs)
     }
 
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
-      Transient(WasmBinaryOp(op, transformer.transformExpr(lhs),
-          transformer.transformExpr(rhs)))
+    def transform(transformer: Transformer)(implicit pos: Position): Tree = {
+      Transient(WasmBinaryOp(op, transformer.transform(lhs),
+          transformer.transform(rhs)))
     }
 
     def wasmInstr: wa.SimpleInstr = (op: @switch) match {
@@ -234,10 +231,8 @@ object WasmTransients {
       traverser.traverse(codePoint)
     }
 
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
-      Transient(WasmStringFromCodePoint(transformer.transformExpr(codePoint)))
-    }
+    def transform(transformer: Transformer)(implicit pos: Position): Tree =
+      Transient(WasmStringFromCodePoint(transformer.transform(codePoint)))
 
     def printIR(out: IRTreePrinter): Unit = {
       out.print("$stringFromCodePoint")
@@ -269,10 +264,9 @@ object WasmTransients {
       traverser.traverse(index)
     }
 
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
-      Transient(WasmCodePointAt(transformer.transformExpr(string),
-          transformer.transformExpr(index)))
+    def transform(transformer: Transformer)(implicit pos: Position): Tree = {
+      Transient(WasmCodePointAt(transformer.transform(string),
+          transformer.transform(index)))
     }
 
     def printIR(out: IRTreePrinter): Unit = {
@@ -308,10 +302,9 @@ object WasmTransients {
       optEnd.foreach(traverser.traverse(_))
     }
 
-    def transform(transformer: Transformer, isStat: Boolean)(
-        implicit pos: Position): Tree = {
-      Transient(WasmSubstring(transformer.transformExpr(string),
-          transformer.transformExpr(start), optEnd.map(transformer.transformExpr(_))))
+    def transform(transformer: Transformer)(implicit pos: Position): Tree = {
+      Transient(WasmSubstring(transformer.transform(string),
+          transformer.transform(start), transformer.transformTreeOpt(optEnd)))
     }
 
     def printIR(out: IRTreePrinter): Unit = {

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -10,6 +10,15 @@ object BinaryIncompatibilities {
     ProblemFilters.exclude[MissingClassProblem]("org.scalajs.ir.Trees$JSLinkingInfo$"),
     ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.scalajs.ir.Trees#*.tpe"),
     ProblemFilters.exclude[MissingClassProblem]("org.scalajs.ir.Types$NoType$"),
+
+    // !!! Breaking, OK in minor release
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Transformers#Transformer.transform"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Transformers#Transformer.transformExpr"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Transformers#Transformer.transformExprOrJSSpread"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Transformers#Transformer.transformStat"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Transformers#Transformer.transformStats"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Trees#Transient#Value.transform"),
+    ProblemFilters.exclude[ReversedMissingMethodProblem]("org.scalajs.ir.Trees#Transient#Value.transform"),
   )
 
   val Linker = Seq(

--- a/project/JavalibIRCleaner.scala
+++ b/project/JavalibIRCleaner.scala
@@ -302,12 +302,12 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
       }
     }
 
-    override def transform(tree: Tree, isStat: Boolean): Tree = {
+    override def transform(tree: Tree): Tree = {
       implicit val pos = tree.pos
 
-      val tree1 = preTransform(tree, isStat)
-      val tree2 = if (tree1 eq tree) super.transform(tree, isStat) else transform(tree1, isStat)
-      val result = postTransform(tree2, isStat)
+      val tree1 = preTransform(tree)
+      val tree2 = if (tree1 eq tree) super.transform(tree) else transform(tree1)
+      val result = postTransform(tree2)
 
       if (transformType(result.tpe) != result.tpe)
         reportError(s"the result type of a ${result.getClass().getSimpleName()} was not transformed")
@@ -315,7 +315,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
       result
     }
 
-    private def preTransform(tree: Tree, isStat: Boolean): Tree = {
+    private def preTransform(tree: Tree): Tree = {
       implicit val pos = tree.pos
 
       tree match {
@@ -421,7 +421,7 @@ final class JavalibIRCleaner(baseDirectoryURI: URI) {
       }
     }
 
-    private def postTransform(tree: Tree, isStat: Boolean): Tree = {
+    private def postTransform(tree: Tree): Tree = {
       implicit val pos = tree.pos
 
       tree match {


### PR DESCRIPTION
Recent changes have all but removed the distinction between statements and expressions in the IR. Notably:

* bb4f6da3628913639a82ad371c22731d9b2347f5 Allow Return arg to be a void if the target Labeled is a void.
* cdcff9973579ed77e87343f3edd9429661b4a786 Rename NoType to VoidType and print it as "void".

Therefore, it made no sense anymore that `Transformer.transform` had an `isStat` argument. In fact, the first of the two commits mentionned above semi-broke the semantics of that argument anyway. Moreover, `isStat` was never *used* in our codebase (only forwarded everywhere for no reason).

The only exception was a deserialization hack for IR <= 1.5. This one was already hacking around the fact the IR produced back then was not well-typed. See #4442 for context.

We now remove that parameter everywhere. It makes the deserialization hack a bit more verbose, but everything else becomes simpler.