### PR TITLE
Fix #5085: Zero.stripTrailingZeros() returns BigDecimal.ZERO.

### DIFF
--- a/javalib/src/main/scala/java/math/BigDecimal.scala
+++ b/javalib/src/main/scala/java/math/BigDecimal.scala
@@ -1226,9 +1226,8 @@ class BigDecimal() extends Number with Comparable[BigDecimal] {
 
   def stripTrailingZeros(): BigDecimal = {
     if (isZero) {
-      // Preserve RI compatibility, so BigDecimal.equals (which checks
-      // value *and* scale) continues to work.
-      this
+      // As specified by the JavaDoc, we must return BigDecimal.ZERO, which has a scale of 0
+      BigDecimal.ZERO
     } else {
       val lastPow = BigTenPows.length - 1
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalScaleOperationsTest.scala
@@ -287,4 +287,8 @@ class  BigDecimalScaleOperationsTest {
     val prec = aNumber.precision()
     assertEquals(prec, 68)
   }
+
+  @Test def testStripTrailingZeros(): Unit = {
+    assertEquals(0, java.math.BigDecimal.valueOf(0, 9).stripTrailingZeros().scale())
+  }
 }


### PR DESCRIPTION
As directly specified by its JavaDoc.