### PR TITLE
Refactoring: Introduce LocalScope{Transfomer,Traverser}.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -277,4 +277,19 @@ object Transformers {
     }
   }
 
+  /** Transformer that only transforms in the local scope.
+   *
+   *  In practice, this means stopping at `Closure` boundaries: their
+   *  `captureValues` are transformed, but not their other members.
+   */
+  abstract class LocalScopeTransformer extends Transformer {
+    override def transform(tree: Tree): Tree = tree match {
+      case Closure(arrow, captureParams, params, restParam, body, captureValues) =>
+        Closure(arrow, captureParams, params, restParam, body,
+            transformTrees(captureValues))(tree.pos)
+      case _ =>
+        super.transform(tree)
+    }
+  }
+
 }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -245,4 +245,18 @@ object Traversers {
     }
   }
 
+  /** Traverser that only traverses the local scope.
+   *
+   *  In practice, this means stopping at `Closure` boundaries: their
+   *  `captureValues` are traversed, but not their other members.
+   */
+  abstract class LocalScopeTraverser extends Traverser {
+    override def traverse(tree: Tree): Unit = tree match {
+      case Closure(_, _, _, _, _, captureValues) =>
+        captureValues.foreach(traverse(_))
+      case _ =>
+        super.traverse(tree)
+    }
+  }
+
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -1713,7 +1713,7 @@ private[optimizer] abstract class OptimizerCore(
   private def tryInsertAtFirstEvalContext(valName: LocalName, valTree: Tree, body: Tree): Option[Tree] = {
     import EvalContextInsertion._
 
-    object valTreeInfo extends Traversers.Traverser {
+    object valTreeInfo extends Traversers.LocalScopeTraverser {
       val mutatedLocalVars = mutable.Set.empty[LocalName]
 
       traverse(valTree)


### PR DESCRIPTION
In several places, we transform or traverse (part of) a method body in a way that is dependent on the local scope. In those situations, we must stop at `Closure` boundaries.

We now introduce dedicated subclasses that handle this particular behavior. This factors out the correct handling of `Closure`s, and at the same time makes the intent clearer.

One use of `Traverser` in `OptimizerCore` did not handle `Closure`s in a special way, but it should also be about the local scope.

---

Extracted from #5003.