### PR TITLE
Remove coreSpec from ModuleSet / LinkingUnit and verifyModuleSet

### DIFF
--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -99,8 +99,6 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
    */
   def emit(moduleSet: ModuleSet, output: OutputDirectory, logger: Logger)(
       implicit ec: ExecutionContext): Future[Report] = {
-    verifyModuleSet(moduleSet)
-
     require(moduleSet.modules.size <= 1,
         "Cannot use multiple modules with the Closure Compiler")
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/BasicLinkerBackend.scala
@@ -76,8 +76,6 @@ final class BasicLinkerBackend(config: LinkerBackendImpl.Config)
    */
   def emit(moduleSet: ModuleSet, output: OutputDirectory, logger: Logger)(
       implicit ec: ExecutionContext): Future[Report] = {
-    verifyModuleSet(moduleSet)
-
     // Reset stats.
 
     totalModules = moduleSet.modules.size

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/BaseLinker.scala
@@ -95,7 +95,7 @@ final class BaseLinker(config: CommonPhaseConfig, checkIR: Boolean) {
         analysis.isClassSuperClassUsed
       )
 
-      new LinkingUnit(config.coreSpec, linkedClassDefs.toList,
+      new LinkingUnit(linkedClassDefs.toList,
           linkedTopLevelExports.flatten.toList,
           moduleInitializers.toList,
           globalInfo)

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LinkingUnit.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LinkingUnit.scala
@@ -17,7 +17,6 @@ import org.scalajs.linker.interface.ModuleInitializer
 import org.scalajs.linker.standard._
 
 final class LinkingUnit private[frontend] (
-    val coreSpec: CoreSpec,
     val classDefs: List[LinkedClass],
     val topLevelExports: List[LinkedTopLevelExport],
     val moduleInitializers: List[ModuleInitializer],

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -73,7 +73,7 @@ final class Refiner(config: CommonPhaseConfig, checkIR: Boolean) {
           analysis.isClassSuperClassUsed
         )
 
-        new LinkingUnit(config.coreSpec, linkedClassDefs.toList,
+        new LinkingUnit(linkedClassDefs.toList,
             linkedTopLevelExports.flatten.toList, moduleInitializers, globalInfo)
       }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/modulesplitter/ModuleSplitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/modulesplitter/ModuleSplitter.scala
@@ -45,7 +45,7 @@ final class ModuleSplitter private (analyzer: ModuleAnalyzer) {
        * We have to do it here, otherwise we break the assumption, that all
        * non-abstract classes are reached through a static path.
        */
-      new ModuleSet(unit.coreSpec, Nil, Nil, unit.globalInfo)
+      new ModuleSet(Nil, Nil, unit.globalInfo)
     } else {
       val analysis = logger.time("Module Splitter: Analyze Modules") {
         analyzer.analyze(dependencyInfo)
@@ -124,7 +124,7 @@ final class ModuleSplitter private (analyzer: ModuleAnalyzer) {
 
     val modules = builders.values.map(_.result()).toList
 
-    new ModuleSet(unit.coreSpec, modules, abstractClasses.result(), unit.globalInfo)
+    new ModuleSet(modules, abstractClasses.result(), unit.globalInfo)
   }
 
   private def publicModuleDependencies(

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/LinkerBackend.scala
@@ -54,19 +54,4 @@ abstract class LinkerBackend {
   def emit(moduleSet: ModuleSet, output: OutputDirectory, logger: Logger)(
       implicit ec: ExecutionContext): Future[Report]
 
-  /** Verify that a `ModuleSet` can be processed by this `LinkerBackend`.
-   *
-   *  Currently, this only tests that the module set core specification
-   *  matches [[coreSpec]].
-   *
-   *  In the future, this test could be extended to test [[symbolRequirements]]
-   *  too.
-   *
-   *  @throws java.lang.IllegalArgumentException if there is a mismatch
-   */
-  protected def verifyModuleSet(moduleSet: ModuleSet): Unit = {
-    require(moduleSet.coreSpec == coreSpec,
-        "ModuleSet and LinkerBackend must agree on their core specification")
-  }
-
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/ModuleSet.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/ModuleSet.scala
@@ -34,7 +34,6 @@ import org.scalajs.linker.interface.ModuleInitializer
  *  are no public modules.
  */
 final class ModuleSet private[linker] (
-    val coreSpec: CoreSpec,
     val modules: List[ModuleSet.Module],
 
     /** Abstract classes may not have any definitions, but are still required

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -51,6 +51,10 @@ object BinaryIncompatibilities {
   )
 
   val Linker = Seq(
+    // !!! Breaking, OK in minor release
+    exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.ModuleSet.coreSpec"),
+    exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.ModuleSet.this"),
+    exclude[DirectMissingMethodProblem]("org.scalajs.linker.standard.LinkerBackend.verifyModuleSet"),
   )
 
   val LinkerInterface = Seq(


### PR DESCRIPTION
The core spec is configuration, not a part of the linking unit.

One could argue that `verifyModuleSet` adds a little bit of safety, but IMO, it does not warrant the cost / boilerplate of copying coreSpec around everywhere.

It felt like we might want to do this, when I looked at #5101.