### PR TITLE
Fix #5107: Add missing `CheckNotNull`s in deserialization hacks.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -1638,10 +1638,10 @@ object Serializers {
       }
 
       def arrayLength(t: Tree)(implicit pos: Position): Tree =
-        UnaryOp(UnaryOp.Array_length, t)
+        UnaryOp(UnaryOp.Array_length, UnaryOp(UnaryOp.CheckNotNull, t))
 
       def getClass(t: Tree)(implicit pos: Position): Tree =
-        UnaryOp(UnaryOp.GetClass, t)
+        UnaryOp(UnaryOp.GetClass, UnaryOp(UnaryOp.CheckNotNull, t))
 
       val jlClassRef = ClassRef(ClassClass)
       val intArrayTypeRef = ArrayTypeRef(IntRef, 1)

--- a/linker/shared/src/test/scala/org/scalajs/linker/BackwardsCompatTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/BackwardsCompatTest.scala
@@ -75,6 +75,40 @@ class BackwardsCompatTest {
     test(classDefs, MainTestModuleInitializers)
   }
 
+  @Test
+  def testThrowHackWithVariable_Issue5107(): AsyncResult = await {
+    val Base64Class = ClassName("java.util.Base64")
+    val DecoderClass = ClassName("java.util.Base64$Decoder")
+    val ByteBufferClass = ClassName("java.nio.ByteBuffer")
+
+    val DecoderTypeRef = ClassRef(DecoderClass)
+    val ByteBufferTypeRef = ClassRef(ByteBufferClass)
+    val AB = ArrayTypeRef(ByteRef, 1)
+
+    val DecoderType = ClassType(DecoderClass, nullable = true)
+    val ByteBufferType = ClassType(ByteBufferClass, nullable = true)
+
+    /* java.util.Base64.getDecoder().decode(java.nio.ByteBuffer.wrap(Array(65, 81, 73, 61)))
+     * That is the only method I found in our javalib that contains a `throw e`,
+     * as opposed to a `throw new ...`.
+     */
+    val classDefs = Seq(
+      mainTestClassDef(systemOutPrintln {
+        Apply(
+          EAF,
+          ApplyStatic(EAF, Base64Class, m("getDecoder", Nil, DecoderTypeRef), Nil)(DecoderType),
+          m("decode", List(ByteBufferTypeRef), ByteBufferTypeRef),
+          List(
+            ApplyStatic(EAF, ByteBufferClass, m("wrap", List(AB), ByteBufferTypeRef),
+                List(ArrayValue(AB, List[Byte](65, 81, 73, 61).map(ByteLiteral(_)))))(ByteBufferType)
+          )
+        )(ByteBufferType)
+      })
+    )
+
+    test(classDefs, MainTestModuleInitializers)
+  }
+
   private def test(classDefs: Seq[ClassDef],
       moduleInitializers: Seq[ModuleInitializer]): Future[_] = {
     val classDefFiles = classDefs.map(MemClassDefIRFile(_))


### PR DESCRIPTION
Back in Scala.js 1.11, we did not have `CheckNotNull` as a separate node. The deserialization hack was therefore pretty complicated, but all it wanted to do was check for null values.

Unfortunately we broke that deserialization hack in Scala.js 1.18.0 because `UnwrapFromThrowable` now demands a non-nullable argument. So we have to insert an explicit `CheckNotNull`.

It turns out we can dramatically simplify the whole hack with nothing but `CheckNotNull`.

---

@gzm0 This seems like a pretty big issue. I don't like it but maybe we should immediately release 1.18.1 with this fix, and skip 1.18.0 altogether. 😖 