### PR TITLE
Fix #5112: Recognize asInstanceOf around jump to default label.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -3903,7 +3903,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         assert(guard == EmptyTree, s"found a case guard at ${caze.pos}")
 
         def genBody(body: Tree): js.Tree = body match {
-          case app @ Apply(_, Nil) if app.symbol == defaultLabelSym =>
+          case MaybeAsInstanceOf(app @ Apply(_, Nil)) if app.symbol == defaultLabelSym =>
             genJumpToElseClause
           case Block(List(app @ Apply(_, Nil)), _) if app.symbol == defaultLabelSym =>
             genJumpToElseClause

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RegressionTest.scala
@@ -418,10 +418,13 @@ class RegressionTest {
   @Test def switchMatchWithGuardAndResultTypeOfBoxedUnit_Issue1955(): Unit = {
     val bug = new Bug1955
     bug.bug(2, true)
-    assertEquals(0, bug.result)
+    assertEquals(22, bug.result)
+    bug.bug(2, false)
+    assertEquals(-1, bug.result)
     bug.bug(1, true)
     assertEquals(579, bug.result)
-    assertThrows(classOf[MatchError], bug.bug(2, false))
+    bug.bug(6, true)
+    assertEquals(-1, bug.result)
   }
 
   @Test def switchMatchWithGuardInStatementPosButWithNonUnitBranches_Issue4105(): Unit = {
@@ -987,9 +990,12 @@ object RegressionTest {
     }
 
     def bug(x: Int, e: Boolean): Unit = {
-      x match {
-        case 1 => doSomething(123, 456, ())
-        case 2 if e =>
+      (x: @switch) match {
+        case 1      => doSomething(123, 456, ())
+        case 2 if e => result = 22
+        case 3      => result = 33
+        case 4      => result = 44
+        case _      => result = -1
       }
 
       if (false) ()


### PR DESCRIPTION
And then make the whole thing much more generic, so that we will be more robust against further tweaks to nsc's codegen.

---

Based on #5113, but otherwise ready to review. The last commit is best reviewed with the "Hide whitespace" option.