### PR TITLE
Optimize the shapes of `js.Dynamic.literal()` in Scala 2.13.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3086,7 +3086,7 @@ private[optimizer] abstract class OptimizerCore(
         tprops match {
           case PreTransMaybeBlock(bindingsAndStats,
               PreTransLocalDef(LocalDef(
-                  RefinedType(ClassType(JSWrappedArrayClass, _), _),
+                  RefinedType(ClassType(JSWrappedArrayClass | WrappedVarArgsClass, _), _),
                   false,
                   InlineClassInstanceReplacement(_, wrappedArrayFields, _)))) =>
             assert(wrappedArrayFields.size == 1)
@@ -5597,6 +5597,7 @@ private[optimizer] object OptimizerCore {
   private val ClassTagModuleClass = ClassName("scala.reflect.ClassTag$")
   private val JavaScriptExceptionClass = ClassName("scala.scalajs.js.JavaScriptException")
   private val JSWrappedArrayClass = ClassName("scala.scalajs.js.WrappedArray")
+  private val WrappedVarArgsClass = ClassName("scala.scalajs.runtime.WrappedVarArgs")
   private val NilClass = ClassName("scala.collection.immutable.Nil$")
   private val Tuple2Class = ClassName("scala.Tuple2")
 
@@ -6495,6 +6496,7 @@ private[optimizer] object OptimizerCore {
     private val ClassClassRef = ClassRef(ClassClass)
     private val StringClassRef = ClassRef(BoxedStringClass)
     private val SeqClassRef = ClassRef(ClassName("scala.collection.Seq"))
+    private val ImmutableSeqClassRef = ClassRef(ClassName("scala.collection.immutable.Seq"))
     private val JSObjectClassRef = ClassRef(ClassName("scala.scalajs.js.Object"))
     private val JSArrayClassRef = ClassRef(ClassName("scala.scalajs.js.Array"))
 
@@ -6520,7 +6522,8 @@ private[optimizer] object OptimizerCore {
             m("getName", Nil, StringClassRef) -> ClassGetName
         ),
         ClassName("scala.scalajs.js.special.package$") -> List(
-            m("objectLiteral", List(SeqClassRef), JSObjectClassRef) -> ObjectLiteral
+            m("objectLiteral", List(SeqClassRef), JSObjectClassRef) -> ObjectLiteral, // 2.12
+            m("objectLiteral", List(ImmutableSeqClassRef), JSObjectClassRef) -> ObjectLiteral // 2.13
         )
     )
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2066,17 +2066,17 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 449000 to 450000,
-                  fullLink = 95000 to 96000,
-                  fastLinkGz = 58000 to 59000,
+                  fastLink = 439000 to 440000,
+                  fullLink = 92000 to 93000,
+                  fastLinkGz = 57000 to 58000,
                   fullLinkGz = 25000 to 26000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 304000 to 305000,
-                  fullLink = 261000 to 262000,
-                  fastLinkGz = 48000 to 49000,
-                  fullLinkGz = 43000 to 44000,
+                  fastLink = 298000 to 299000,
+                  fullLink = 256000 to 257000,
+                  fastLinkGz = 47000 to 48000,
+                  fullLinkGz = 42000 to 43000,
               ))
             }
 


### PR DESCRIPTION
Somehow it had always escaped us that we did not correctly perform that optimization in Scala 2.13.

---

This solves #5017 on Scala 2.13, but not on 3.