### PR TITLE
Drop support for non-strict floats.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -233,17 +233,6 @@ def Tasks = [
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         $testSuite$v/test &&
     sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        $testSuite$v/test &&
-    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        'set scalaJSStage in Global := FullOptStage' \
-        $testSuite$v/test &&
-    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
-        $testSuite$v/test &&
-    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withAllowBigIntsForLongs(true)))' \
         $testSuite$v/test &&
     sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
@@ -312,20 +301,6 @@ def Tasks = [
         'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
-        'set Seq(jsEnv in $testSuite.v$v := new NodeJSEnvForcePolyfills(ESVersion.$esVersion), MyScalaJSPlugin.wantSourceMaps in $testSuite.v$v := ("$esVersion" != "ES5_1"))' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         ++$scala $testSuite$v/test
   ''',
 
@@ -353,17 +328,6 @@ def Tasks = [
         ++$scala $testSuite$v/test &&
     sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
-        'set scalaJSStage in Global := FullOptStage' \
-        ++$scala $testSuite$v/test &&
-    sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
-        'set scalaJSLinkerConfig in $testSuite.v$v ~= { _.withSemantics(_.withStrictFloats(false)) }' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         ++$scala $testSuite$v/test &&
     sbtretry 'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion).withAllowBigIntsForLongs(true)))' \

--- a/javalib/src/main/scala/java/lang/Float.scala
+++ b/javalib/src/main/scala/java/lang/Float.scala
@@ -150,14 +150,7 @@ object Float {
     val zDouble = z.toDouble
 
     if (zDouble == z0) {
-      /* This branch is always taken when strictFloats are disabled, and there
-       * is no Math.fround support. In that case, Floats are basically
-       * equivalent to Doubles, and we make no specific guarantee about the
-       * result, so we can quickly return `z`.
-       * More importantly, the computations in the `else` branch assume that
-       * Float operations are exact, so we must return early.
-       *
-       * This branch is also always taken when z0 is 0.0 or Infinity, which the
+      /* This branch is always taken when z0 is 0.0 or Infinity, which the
        * `else` branch assumes does not happen.
        */
       z

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/Semantics.scala
@@ -12,6 +12,8 @@
 
 package org.scalajs.linker.interface
 
+import scala.annotation.compileTimeOnly
+
 import CheckedBehavior._
 import Fingerprint.FingerprintBuilder
 
@@ -23,11 +25,15 @@ final class Semantics private (
     val nullPointers: CheckedBehavior,
     val stringIndexOutOfBounds: CheckedBehavior,
     val moduleInit: CheckedBehavior,
-    val strictFloats: Boolean,
     val productionMode: Boolean,
     val runtimeClassNameMapper: Semantics.RuntimeClassNameMapper) {
 
   import Semantics._
+
+  @deprecated(
+      "non-strict floats are not supported anymore; strictFloats is always true",
+      since = "1.19.0")
+  val strictFloats: Boolean = true
 
   def withAsInstanceOfs(behavior: CheckedBehavior): Semantics =
     copy(asInstanceOfs = behavior)
@@ -50,13 +56,11 @@ final class Semantics private (
   def withModuleInit(moduleInit: CheckedBehavior): Semantics =
     copy(moduleInit = moduleInit)
 
-  @deprecated(
-      "Scala.js now uses strict floats by default. " +
-      "Non-strict float semantics are deprecated and will eventually be " +
-      "removed.",
-      "1.9.0")
+  @compileTimeOnly(
+      "Non-strict floats are not supported anymore. " +
+      "The default is `true` and cannot be turned to `false`.")
   def withStrictFloats(strictFloats: Boolean): Semantics =
-    copy(strictFloats = strictFloats)
+    this
 
   def withProductionMode(productionMode: Boolean): Semantics =
     copy(productionMode = productionMode)
@@ -86,7 +90,6 @@ final class Semantics private (
       this.nullPointers == that.nullPointers &&
       this.stringIndexOutOfBounds == that.stringIndexOutOfBounds &&
       this.moduleInit == that.moduleInit &&
-      this.strictFloats == that.strictFloats &&
       this.productionMode == that.productionMode &&
       this.runtimeClassNameMapper == that.runtimeClassNameMapper
     case _ =>
@@ -103,7 +106,6 @@ final class Semantics private (
     acc = mix(acc, nullPointers.##)
     acc = mix(acc, stringIndexOutOfBounds.##)
     acc = mix(acc, moduleInit.##)
-    acc = mix(acc, strictFloats.##)
     acc = mix(acc, productionMode.##)
     acc = mixLast(acc, runtimeClassNameMapper.##)
     finalizeHash(acc, 10)
@@ -118,7 +120,6 @@ final class Semantics private (
        |  nullPointers           = $nullPointers,
        |  stringIndexOutOfBounds = $stringIndexOutOfBounds,
        |  moduleInit             = $moduleInit,
-       |  strictFloats           = $strictFloats,
        |  productionMode         = $productionMode
        |)""".stripMargin
   }
@@ -131,7 +132,6 @@ final class Semantics private (
       nullPointers: CheckedBehavior = this.nullPointers,
       stringIndexOutOfBounds: CheckedBehavior = this.stringIndexOutOfBounds,
       moduleInit: CheckedBehavior = this.moduleInit,
-      strictFloats: Boolean = this.strictFloats,
       productionMode: Boolean = this.productionMode,
       runtimeClassNameMapper: RuntimeClassNameMapper =
         this.runtimeClassNameMapper): Semantics = {
@@ -143,7 +143,6 @@ final class Semantics private (
         nullPointers = nullPointers,
         stringIndexOutOfBounds = stringIndexOutOfBounds,
         moduleInit = moduleInit,
-        strictFloats = strictFloats,
         productionMode = productionMode,
         runtimeClassNameMapper = runtimeClassNameMapper)
   }
@@ -262,7 +261,6 @@ object Semantics {
         .addField("nullPointers", semantics.nullPointers)
         .addField("stringIndexOutOfBounds", semantics.stringIndexOutOfBounds)
         .addField("moduleInit", semantics.moduleInit)
-        .addField("strictFloats", semantics.strictFloats)
         .addField("productionMode", semantics.productionMode)
         .addField("runtimeClassNameMapper", semantics.runtimeClassNameMapper)
         .build()
@@ -277,7 +275,6 @@ object Semantics {
       nullPointers = Fatal,
       stringIndexOutOfBounds = Fatal,
       moduleInit = Unchecked,
-      strictFloats = true,
       productionMode = false,
       runtimeClassNameMapper = RuntimeClassNameMapper.keepAll())
 }

--- a/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
+++ b/linker-interface/shared/src/main/scala/org/scalajs/linker/interface/StandardConfig.scala
@@ -192,7 +192,6 @@ final class StandardConfig private (
    *
    *  - `moduleKind == ModuleKind.ESModule`
    *  - `esFeatures.useECMAScript2015Semantics == true` (true by default)
-   *  - `semantics.strictFloats == true` (true by default; non-strict floats are deprecated)
    *
    *  We may lift these restrictions in the future, although we do not expect
    *  to do so.

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/WebAssemblyLinkerBackend.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/WebAssemblyLinkerBackend.scala
@@ -40,10 +40,6 @@ final class WebAssemblyLinkerBackend(config: LinkerBackendImpl.Config)
     coreSpec.esFeatures.useECMAScript2015Semantics,
     s"The WebAssembly backend only supports the ECMAScript 2015 semantics."
   )
-  require(
-    coreSpec.semantics.strictFloats,
-    "The WebAssembly backend only supports strict float semantics."
-  )
 
   require(coreSpec.targetIsWebAssembly,
       s"A WebAssembly backend cannot be used with CoreSpec targeting JavaScript")

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -17,6 +17,8 @@ object BinaryIncompatibilities {
   )
 
   val LinkerInterface = Seq(
+    // private, not an issue
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.linker.interface.Semantics.this"),
   )
 
   val SbtPlugin = Seq(

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2326,7 +2326,6 @@ object Build {
           "compliantNullPointers" -> (sems.nullPointers == CheckedBehavior.Compliant),
           "compliantStringIndexOutOfBounds" -> (sems.stringIndexOutOfBounds == CheckedBehavior.Compliant),
           "compliantModuleInit" -> (sems.moduleInit == CheckedBehavior.Compliant),
-          "strictFloats" -> sems.strictFloats,
           "productionMode" -> sems.productionMode,
           "esVersion" -> linkerConfig.esFeatures.esVersion.edition,
           "useECMAScript2015Semantics" -> linkerConfig.esFeatures.useECMAScript2015Semantics,

--- a/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
+++ b/test-suite/js/src/main/scala-ide-stubs/org/scalajs/testsuite/utils/BuildInfo.scala
@@ -31,7 +31,6 @@ private[utils] object BuildInfo {
   final val compliantNullPointers = false
   final val compliantStringIndexOutOfBounds = false
   final val compliantModuleInit = false
-  final val strictFloats = false
   final val productionMode = false
   final val esVersion = 0
   final val useECMAScript2015Semantics = false

--- a/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/js/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -88,40 +88,6 @@ object Platform {
 
   def hasDirectBuffers: Boolean = typedArrays
 
-  /** Do we use strict-floats semantics?
-   *
-   *  If yes, `number` values that cannot be exactly represented as `Float`
-   *  values respond `false` to an `isInstanceOf[Float]` test. If not, they
-   *  respond `true`.
-   *
-   *  In addition, if we use strict-float semantics, all arithmetic operations
-   *  on `Float` are accurate wrt. 32-bit floating point semantics. In other
-   *  words, `hasStrictFloats` implies `hasAccurateFloats`.
-   */
-  def hasStrictFloats: Boolean = BuildInfo.strictFloats
-
-  /** Are `Float` arithmetics accurate?
-   *
-   *  If yes, the result of arithmetic operations on `Float`s, as well as
-   *  `number.toFloat` operations, will be accurate wrt. IEEE-754 32-bit
-   *  floating point operations. In other words, they behave exactly as
-   *  specified on the JVM.
-   *
-   *  This is true if either or both of the following are true:
-   *
-   *  - We use strict-float semantics (see `hasStrictFloats`), or
-   *  - The JavaScript runtime supports `Math.fround`.
-   *
-   *  If neither is true, then the result of `Float` arithmetics can behave as
-   *  if they were `Double` arithmetics instead.
-   *
-   *  When the runtime does not support `Math.fround` but we strict-float
-   *  semantics, Scala.js uses a semantically correct polyfill for it, which
-   *  guarantees accurate float arithmetics.
-   */
-  def hasAccurateFloats: Boolean =
-    hasStrictFloats || js.typeOf(js.Dynamic.global.Math.fround) != "undefined"
-
   def regexSupportsUnicodeCase: Boolean =
     assumedESVersion >= ESVersion.ES2015
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/FloatJSTest.scala
@@ -17,8 +17,6 @@ import org.junit.Assert._
 
 import org.scalajs.testsuite.utils.Requires
 
-object FloatJSTest extends Requires.StrictFloats
-
 class FloatJSTest {
 
   @noinline def froundNotInlined(x: Double): Float =

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/Requires.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/utils/Requires.scala
@@ -23,9 +23,4 @@ object Requires {
       assumeTrue("Assumed typed arrays are supported", typedArrays)
   }
 
-  trait StrictFloats {
-    @BeforeClass def needsTypedArrays(): Unit =
-      assumeTrue("Assumed strict floats", hasStrictFloats)
-  }
-
 }

--- a/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
+++ b/test-suite/jvm/src/main/scala/org/scalajs/testsuite/utils/Platform.scala
@@ -46,8 +46,6 @@ object Platform {
   def hasCompliantStringIndexOutOfBounds: Boolean = true
   def hasCompliantModule: Boolean = true
   def hasDirectBuffers: Boolean = true
-  def hasStrictFloats: Boolean = true
-  def hasAccurateFloats: Boolean = true
 
   def regexSupportsUnicodeCase: Boolean = true
   def regexSupportsUnicodeCharacterClasses: Boolean = true

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -16,8 +16,6 @@ import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
 
-import org.scalajs.testsuite.utils.Platform.hasAccurateFloats
-
 class DoubleTest {
   final def assertExactEquals(expected: Double, actual: Double): Unit =
     assertTrue(s"expected: $expected; actual: $actual", expected.equals(actual))
@@ -61,8 +59,6 @@ class DoubleTest {
   @Test
   def toFloat(): Unit = {
     // This is the closest we get to directly testing our `Math.fround` polyfill
-
-    assumeTrue("requires accurate floats", hasAccurateFloats)
 
     @noinline
     def test(expected: Float, value: Double): Unit =

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -15,8 +15,6 @@ package org.scalajs.testsuite.compiler
 import org.junit.Test
 import org.junit.Assert._
 
-import org.scalajs.testsuite.utils.Platform.hasStrictFloats
-
 class FloatTest {
   final def assertExactEquals(expected: Float, actual: Float): Unit =
     assertTrue(s"expected: $expected; actual: $actual", expected.equals(actual))
@@ -144,17 +142,15 @@ class FloatTest {
 
     // Non-special values
     // { val l = List(2.1f, 5.5f, -151.189f); for (n <- l; d <- l) println(s"      test(${n % d}f, ${n}f, ${d}f)") }
-    if (hasStrictFloats) {
-      test(0.0f, 2.1f, 2.1f)
-      test(2.1f, 2.1f, 5.5f)
-      test(2.1f, 2.1f, -151.189f)
-      test(1.3000002f, 5.5f, 2.1f)
-      test(0.0f, 5.5f, 5.5f)
-      test(5.5f, 5.5f, -151.189f)
-      test(-2.0890021f, -151.189f, 2.1f)
-      test(-2.6889954f, -151.189f, 5.5f)
-      test(-0.0f, -151.189f, -151.189f)
-    }
+    test(0.0f, 2.1f, 2.1f)
+    test(2.1f, 2.1f, 5.5f)
+    test(2.1f, 2.1f, -151.189f)
+    test(1.3000002f, 5.5f, 2.1f)
+    test(0.0f, 5.5f, 5.5f)
+    test(5.5f, 5.5f, -151.189f)
+    test(-2.0890021f, -151.189f, 2.1f)
+    test(-2.6889954f, -151.189f, 5.5f)
+    test(-0.0f, -151.189f, -151.189f)
   }
 
   @Test
@@ -244,10 +240,8 @@ class FloatTest {
     @inline
     def negate(x: Float): Float = -x
 
-    if (hasStrictFloats) {
-      assertExactEquals(0.8f, (hide(0.1f) + 0.3f) + 0.4f)
-      assertExactEquals(0.8000001f, 0.1f + (0.3f + hide(0.4f)))
-    }
+    assertExactEquals(0.8f, (hide(0.1f) + 0.3f) + 0.4f)
+    assertExactEquals(0.8000001f, 0.1f + (0.3f + hide(0.4f)))
 
     assertExactEquals(0.0f, 0.0f + hide(-0.0f))
     assertExactEquals(0.0f, 0.0f - hide(0.0f))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/LongTest.scala
@@ -609,8 +609,6 @@ class LongTest {
   }
 
   @Test def toFloat(): Unit = {
-    assumeTrue("Assumed accurate floats", hasAccurateFloats)
-
     @inline def test(expected: Float, x: Long, epsilon: Float = 0.0f): Unit = {
       assertEquals(expected, x.toFloat, epsilon)
       assertEquals(expected, hideFromOptimizer(x).toFloat, epsilon)

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypeTestsTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/RuntimeTypeTestsTest.scala
@@ -198,7 +198,7 @@ class RuntimeTypeTestsTest {
     testFloat(false, 'e')
     testDouble(false, 'f')
 
-    testFloat(!hasStrictFloats, 1.2)
+    testFloat(false, 1.2)
 
     // Special cases for negative 0, NaN and Infinity
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ClassTest.scala
@@ -108,7 +108,7 @@ class ClassTest {
     test("java.lang.Float", -0.0f)
     test("java.lang.Float", 1.5f)
     test("java.lang.Float", Float.NaN)
-    test(if (hasStrictFloats) "java.lang.Double" else "java.lang.Float", 1.4)
+    test("java.lang.Double", 1.4)
     test("java.lang.String", "hello")
     test("java.lang.Object", new Object)
     test("scala.Some", Some(5))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/FloatTest.scala
@@ -21,7 +21,7 @@ import java.lang.{Float => JFloat}
 import scala.util.Try
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
-import org.scalajs.testsuite.utils.Platform.{executingInJVM, hasAccurateFloats}
+import org.scalajs.testsuite.utils.Platform.executingInJVM
 
 class FloatTest {
 
@@ -109,16 +109,9 @@ class FloatTest {
 
   @Test def parseStringMethods(): Unit = {
     def test(expected: Float, s: String): Unit = {
-      if (hasAccurateFloats) {
-        assertEquals(s, expected: Any, JFloat.parseFloat(s))
-        assertEquals(s, expected: Any, JFloat.valueOf(s).floatValue())
-        assertEquals(s, expected: Any, new JFloat(s).floatValue())
-      } else {
-        val epsilon = Math.ulp(expected)
-        assertEquals(s, expected, JFloat.parseFloat(s), epsilon)
-        assertEquals(s, expected, JFloat.valueOf(s).floatValue(), epsilon)
-        assertEquals(s, expected, new JFloat(s).floatValue(), epsilon)
-      }
+      assertEquals(s, expected: Any, JFloat.parseFloat(s))
+      assertEquals(s, expected: Any, JFloat.valueOf(s).floatValue())
+      assertEquals(s, expected: Any, new JFloat(s).floatValue())
     }
 
     // Specials

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/ObjectTest.scala
@@ -43,7 +43,7 @@ class ObjectTest {
     test(classOf[java.lang.Float], -0.0f)
     test(classOf[java.lang.Float], 1.5f)
     test(classOf[java.lang.Float], Float.NaN)
-    test(if (hasStrictFloats) classOf[java.lang.Double] else classOf[java.lang.Float], 1.4)
+    test(classOf[java.lang.Double], 1.4)
     test(classOf[java.lang.String], "hello")
     test(classOf[java.lang.Object], new Object)
     test(classOf[Some[_]], Some(5))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigDecimalConvertTest.scala
@@ -73,8 +73,6 @@ class BigDecimalConvertTest {
   }
 
   @Test def testFloatValueNegInfinity(): Unit = {
-    assumeTrue("requires accurate floats", hasAccurateFloats)
-
     val a = "-123809648392384755735.63567887678287E+200"
     val aNumber = new BigDecimal(a)
     val result =  Float.NegativeInfinity
@@ -89,8 +87,6 @@ class BigDecimalConvertTest {
   }
 
   @Test def testFloatValuePosInfinity(): Unit = {
-    assumeTrue("requires accurate floats", hasAccurateFloats)
-
     val a = "123809648373567356745735.6356789787678287E+200"
     val aNumber = new BigDecimal(a)
     val result =  Float.PositiveInfinity
@@ -99,14 +95,8 @@ class BigDecimalConvertTest {
 
   /** Test cases for `Float.parseFloat`, with an indirection through `BigDecimal`. */
   @Test def testFloatValueLikeParseFloat_Issue4726(): Unit = {
-    def test(expected: Float, s: String): Unit = {
-      if (hasAccurateFloats) {
-        assertEquals(s, expected: Any, new BigDecimal(s).floatValue())
-      } else {
-        val epsilon = Math.ulp(expected)
-        assertEquals(s, expected, new BigDecimal(s).floatValue(), epsilon)
-      }
-    }
+    def test(expected: Float, s: String): Unit =
+      assertEquals(s, expected: Any, new BigDecimal(s).floatValue())
 
     // Zeros (BigDecimal has no negative 0, so they all parse to +0.0f)
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConvertTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerConvertTest.scala
@@ -255,8 +255,6 @@ class BigIntegerConvertTest {
   }
 
   @Test def testFloatValueNegativeInfinity2(): Unit = {
-    assumeTrue("requires accurate floats", hasAccurateFloats)
-
     val a = Array[Byte](0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
     val aSign = -1
     val aNumber = new BigInteger(aSign, a).floatValue()
@@ -264,8 +262,6 @@ class BigIntegerConvertTest {
   }
 
   @Test def testFloatValueNegMantissaIsZero(): Unit = {
-    assumeTrue("requires accurate floats", hasAccurateFloats)
-
     val a = Array[Byte](1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
     val aSign = -1
     val aNumber = new BigInteger(aSign, a).floatValue()
@@ -300,8 +296,6 @@ class BigIntegerConvertTest {
   }
 
   @Test def testFloatValuePastNegMaxValue(): Unit = {
-    assumeTrue("requires accurate floats", hasAccurateFloats)
-
     val a = Array[Byte](0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
     val aSign = -1
     val aNumber = new BigInteger(aSign, a).floatValue()
@@ -309,8 +303,6 @@ class BigIntegerConvertTest {
   }
 
   @Test def testFloatValuePastPosMaxValue(): Unit = {
-    assumeTrue("requires accurate floats", hasAccurateFloats)
-
     val a = Array[Byte](0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
     val aSign = 1
     val aNumber = new BigInteger(aSign, a).floatValue()
@@ -333,8 +325,6 @@ class BigIntegerConvertTest {
   }
 
   @Test def testFloatValuePositiveInfinity1(): Unit = {
-    assumeTrue("requires accurate floats", hasAccurateFloats)
-
     val a = Array[Byte](0, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1)
     val aSign = 1
     val aNumber: Float = new BigInteger(aSign, a).floatValue()
@@ -648,8 +638,6 @@ class BigIntegerConvertTest {
   }
 
   @Test def testFloatValueBug2482(): Unit = {
-    assumeTrue("Assumed strict floats", hasStrictFloats)
-
     val a = "2147483649"
     val result = 2.14748365E9f
     val aNumber = new BigInteger(a).floatValue()


### PR DESCRIPTION
Non-strict floats were deprecated 3 years ago in Scala.js 1.9.0. I don't recall seeing any comment about them ever since.

---

If accepted, only merge when the upcoming version is a minor version.