### PR TITLE
Refactoring: Generic notion of CheckingPhase for the IR checkers.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -29,6 +29,7 @@ import org.scalajs.ir.Trees.{MemberNamespace, JSNativeLoadSpec}
 import org.scalajs.ir.Types.ClassRef
 
 import org.scalajs.linker._
+import org.scalajs.linker.checker.CheckingPhase
 import org.scalajs.linker.frontend.IRLoader
 import org.scalajs.linker.interface._
 import org.scalajs.linker.interface.unstable.ModuleInitializerImpl
@@ -43,15 +44,10 @@ import Analysis._
 import Infos.{NamespacedMethodName, ReachabilityInfo, ReachabilityInfoInClass}
 
 final class Analyzer(config: CommonPhaseConfig, initial: Boolean,
-    checkIR: Boolean, failOnError: Boolean, irLoader: IRLoader) {
+    checkIRFor: Option[CheckingPhase], failOnError: Boolean, irLoader: IRLoader) {
 
-  private val infoLoader: InfoLoader = {
-    new InfoLoader(irLoader,
-        if (!checkIR) InfoLoader.NoIRCheck
-        else if (initial) InfoLoader.InitialIRCheck
-        else InfoLoader.InternalIRCheck
-    )
-  }
+  private val infoLoader: InfoLoader =
+    new InfoLoader(irLoader, checkIRFor)
 
   def computeReachability(moduleInitializers: Seq[ModuleInitializer],
       symbolRequirements: SymbolRequirement, logger: Logger)(implicit ec: ExecutionContext): Future[Analysis] = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/CheckingPhase.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/CheckingPhase.scala
@@ -1,0 +1,28 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.checker
+
+/** A phase *after which* we are checking IR.
+ *
+ *  When checking IR (with `ClassDefChecker` or `IRChecker`), different nodes
+ *  and transients are allowed between different phases. The `CheckingPhase`
+ *  records the *previous* phase to run before the check. We are therefore
+ *  checking that the IR is a valid *output* of the target phase.
+ */
+sealed abstract class CheckingPhase
+
+object CheckingPhase {
+  case object Compiler extends CheckingPhase
+  case object BaseLinker extends CheckingPhase
+  case object Optimizer extends CheckingPhase
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/FeatureSet.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/FeatureSet.scala
@@ -1,0 +1,76 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.checker
+
+import org.scalajs.linker.checker.CheckingPhase._
+
+/** A set of conditional IR features that the checkers can accept.
+ *
+ *  At any given phase, the `ClassDefChecker` and the `IRChecker` must agree on
+ *  the set of IR features that are valid. A `FeatureSet` factors out the
+ *  knowledge of what feature is acceptable when.
+ */
+private[checker] final class FeatureSet private (private val flags: Int) extends AnyVal {
+  /** Does this feature set support (all of) the given feature set. */
+  def supports(features: FeatureSet): Boolean =
+    (features.flags & flags) == features.flags
+
+  /** The union of this feature set and `that` feature set. */
+  def |(that: FeatureSet): FeatureSet =
+    new FeatureSet(this.flags | that.flags)
+}
+
+private[checker] object FeatureSet {
+  /** Empty feature set. */
+  val Empty = new FeatureSet(0)
+
+  // Individual features
+
+  /** Optional constructors in module classes and JS classes. */
+  val OptionalConstructors = new FeatureSet(1 << 0)
+
+  /** Explicit reflective proxy definitions. */
+  val ReflectiveProxies = new FeatureSet(1 << 1)
+
+  /** Transients that are the result of optimizations. */
+  val OptimizedTransients = new FeatureSet(1 << 2)
+
+  /** Records and record types. */
+  val Records = new FeatureSet(1 << 3)
+
+  /** Relaxed constructor discipline.
+   *
+   *  - Optional super/delegate constructor call.
+   *  - Delegate constructor calls can target any super class.
+   *  - `this.x = ...` assignments before the delegate call can assign super class fields.
+   *  - `StoreModule` can be anywhere, or not be there at all.
+   */
+  val RelaxedCtorBodies = new FeatureSet(1 << 4)
+
+  // Common sets
+
+  /** Features introduced by the base linker. */
+  private val Linked =
+    OptionalConstructors | ReflectiveProxies
+
+  /** IR that is only the result of optimizations. */
+  private val Optimized =
+    OptimizedTransients | Records | RelaxedCtorBodies
+
+  /** The set of features allowed as output of the given phase. */
+  def allowedAfter(phase: CheckingPhase): FeatureSet = phase match {
+    case Compiler   => Empty
+    case BaseLinker => Linked
+    case Optimizer  => Linked | Optimized
+  }
+}

--- a/linker/shared/src/test/scala/org/scalajs/linker/BaseLinkerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/BaseLinkerTest.scala
@@ -24,7 +24,7 @@ import org.scalajs.junit.async._
 
 import org.scalajs.logging._
 
-import org.scalajs.linker.checker.ClassDefChecker
+import org.scalajs.linker.checker._
 import org.scalajs.linker.interface.StandardConfig
 import org.scalajs.linker.standard._
 
@@ -86,7 +86,8 @@ class BaseLinkerTest {
 
     for (moduleSet <- linkToModuleSet(classDefs, MainTestModuleInitializers, config = config)) yield {
       val clazz = findClass(moduleSet, BoxedIntegerClass).get
-      val errorCount = ClassDefChecker.check(clazz, postOptimizer = false,
+      val previousPhase = CheckingPhase.BaseLinker
+      val errorCount = ClassDefChecker.check(clazz, previousPhase,
           new ScalaConsoleLogger(Level.Error))
       assertEquals(0, errorCount)
     }

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -257,7 +257,7 @@ class ClassDefCheckerTest {
           )
         ),
         "reflective profixes are only allowed in the public namespace",
-        allowReflectiveProxies = true
+        previousPhase = CheckingPhase.BaseLinker
     )
   }
 
@@ -817,13 +817,13 @@ class ClassDefCheckerTest {
     assertError(
         mainTestClassDef(Assign(RecordSelect(int(5), "i")(IntType), int(6))),
         "Assignment to RecordSelect of illegal tree: org.scalajs.ir.Trees$IntLiteral",
-        allowTransients = true)
+        previousPhase = CheckingPhase.Optimizer)
   }
 }
 
 private object ClassDefCheckerTest {
   private def assertError(clazz: ClassDef, expectMsg: String,
-      allowReflectiveProxies: Boolean = false, allowTransients: Boolean = false) = {
+      previousPhase: CheckingPhase = CheckingPhase.Compiler): Unit = {
     var seen = false
     val reporter = new ErrorReporter {
       def reportError(msg: String)(implicit ctx: ErrorReporter.ErrorContext) = {
@@ -833,7 +833,7 @@ private object ClassDefCheckerTest {
       }
     }
 
-    new ClassDefChecker(clazz, allowReflectiveProxies, allowTransients, reporter).checkClassDef()
+    new ClassDefChecker(clazz, previousPhase, reporter).checkClassDef()
     assertTrue("no errors reported", seen)
   }
 }

--- a/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/testutils/LinkingUtils.scala
@@ -20,6 +20,7 @@ import org.scalajs.logging._
 
 import org.scalajs.linker._
 import org.scalajs.linker.analyzer._
+import org.scalajs.linker.checker.CheckingPhase
 import org.scalajs.linker.frontend.FileIRLoader
 import org.scalajs.linker.interface._
 import org.scalajs.linker.standard._
@@ -101,8 +102,9 @@ object LinkingUtils {
     val injectedIRFiles = StandardLinkerBackend(config).injectedIRFiles
 
     val irLoader = new FileIRLoader
+    val checkIRFor = Some(CheckingPhase.Compiler)
     val analyzer = new Analyzer(CommonPhaseConfig.fromStandardConfig(config),
-        initial = true, checkIR = true, failOnError = false, irLoader)
+        initial = true, checkIRFor, failOnError = false, irLoader)
     val logger = new ScalaConsoleLogger(Level.Error)
 
     for {


### PR DESCRIPTION
Extracted from #5101.

I have not yet included the following comments:

* https://github.com/scala-js/scala-js/pull/5101#discussion_r1921502439
* https://github.com/scala-js/scala-js/pull/5101#discussion_r1921503428

However, I did add a second commit that removes the distinction between `Emitter(afterOptimizer = true/false)`. There's only `Emitter` now, and it always accepts optimized IR, even if it is actually run without the optimizer.