### PR TITLE
Rewrite old IR with AnonFunctionN references to use NewLambda.

### DIFF
--- a/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/AnonFunctions.scala
@@ -17,142 +17,93 @@ import scala.runtime._
 
 // scalastyle:off line.size.limit
 
-@deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction0[+R](f: js.Function0[R]) extends AbstractFunction0[R] {
-  override def apply(): R = f()
-}
+/* Before 1.19, these classes were concrete. They had a 1-argument constructor
+ * taking a js.FunctionN, and their `apply()` method called that function.
+ *
+ * In 1.19, we introduced `NewLambda` nodes, which superseded these specialized
+ * classes with a compilation mode that is more efficient on Wasm.
+ * However, libraries compiled with earlier versions still contain references
+ * to `AnonFunctionN`.
+ *
+ * The IR deserializer patches allocations of the form
+ *   New(AnonFunctionN, ctor, closure :: Nil)
+ * into
+ *   NewLambda(AnonFunctionN, ..., (...xs) => closure(...xs))
+ *
+ * When the `closure` is directly a JS `Closure` with the right number of
+ * arguments (which is supposed to be always, as far as our codegens were
+ * concerned), it rewrites that as
+ *   NewLambda(AnonFunctionN, ..., (...closureParams) => closureBody)
+ * which provides the best performance for old code.
+ */
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction1[-T1, +R](f: js.Function1[T1, R]) extends AbstractFunction1[T1, R] {
-  override def apply(arg1: T1): R = f(arg1)
-}
+sealed abstract class AnonFunction0[+R] extends AbstractFunction0[R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction2[-T1, -T2, +R](f: js.Function2[T1, T2, R]) extends AbstractFunction2[T1, T2, R] {
-  override def apply(arg1: T1, arg2: T2): R = f(arg1, arg2)
-}
+sealed abstract class AnonFunction1[-T1, +R] extends AbstractFunction1[T1, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction3[-T1, -T2, -T3, +R](f: js.Function3[T1, T2, T3, R]) extends AbstractFunction3[T1, T2, T3, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3): R = f(arg1, arg2, arg3)
-}
+sealed abstract class AnonFunction2[-T1, -T2, +R] extends AbstractFunction2[T1, T2, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction4[-T1, -T2, -T3, -T4, +R](f: js.Function4[T1, T2, T3, T4, R]) extends AbstractFunction4[T1, T2, T3, T4, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4): R = f(arg1, arg2, arg3, arg4)
-}
+sealed abstract class AnonFunction3[-T1, -T2, -T3, +R] extends AbstractFunction3[T1, T2, T3, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction5[-T1, -T2, -T3, -T4, -T5, +R](f: js.Function5[T1, T2, T3, T4, T5, R]) extends AbstractFunction5[T1, T2, T3, T4, T5, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5): R = f(arg1, arg2, arg3, arg4, arg5)
-}
+sealed abstract class AnonFunction4[-T1, -T2, -T3, -T4, +R] extends AbstractFunction4[T1, T2, T3, T4, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction6[-T1, -T2, -T3, -T4, -T5, -T6, +R](f: js.Function6[T1, T2, T3, T4, T5, T6, R]) extends AbstractFunction6[T1, T2, T3, T4, T5, T6, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6): R = f(arg1, arg2, arg3, arg4, arg5, arg6)
-}
+sealed abstract class AnonFunction5[-T1, -T2, -T3, -T4, -T5, +R] extends AbstractFunction5[T1, T2, T3, T4, T5, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R](f: js.Function7[T1, T2, T3, T4, T5, T6, T7, R]) extends AbstractFunction7[T1, T2, T3, T4, T5, T6, T7, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7)
-}
+sealed abstract class AnonFunction6[-T1, -T2, -T3, -T4, -T5, -T6, +R] extends AbstractFunction6[T1, T2, T3, T4, T5, T6, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R](f: js.Function8[T1, T2, T3, T4, T5, T6, T7, T8, R]) extends AbstractFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8)
-}
+sealed abstract class AnonFunction7[-T1, -T2, -T3, -T4, -T5, -T6, -T7, +R] extends AbstractFunction7[T1, T2, T3, T4, T5, T6, T7, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R](f: js.Function9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]) extends AbstractFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9)
-}
+sealed abstract class AnonFunction8[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, +R] extends AbstractFunction8[T1, T2, T3, T4, T5, T6, T7, T8, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R](f: js.Function10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]) extends AbstractFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10)
-}
+sealed abstract class AnonFunction9[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, +R] extends AbstractFunction9[T1, T2, T3, T4, T5, T6, T7, T8, T9, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R](f: js.Function11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]) extends AbstractFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11)
-}
+sealed abstract class AnonFunction10[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, +R] extends AbstractFunction10[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R](f: js.Function12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]) extends AbstractFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12)
-}
+sealed abstract class AnonFunction11[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, +R] extends AbstractFunction11[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R](f: js.Function13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]) extends AbstractFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13)
-}
+sealed abstract class AnonFunction12[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, +R] extends AbstractFunction12[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R](f: js.Function14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]) extends AbstractFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14)
-}
+sealed abstract class AnonFunction13[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, +R] extends AbstractFunction13[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R](f: js.Function15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]) extends AbstractFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15)
-}
+sealed abstract class AnonFunction14[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, +R] extends AbstractFunction14[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R](f: js.Function16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]) extends AbstractFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16)
-}
+sealed abstract class AnonFunction15[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, +R] extends AbstractFunction15[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R](f: js.Function17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]) extends AbstractFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17)
-}
+sealed abstract class AnonFunction16[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, +R] extends AbstractFunction16[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R](f: js.Function18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]) extends AbstractFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18)
-}
+sealed abstract class AnonFunction17[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, +R] extends AbstractFunction17[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R](f: js.Function19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]) extends AbstractFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19)
-}
+sealed abstract class AnonFunction18[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, +R] extends AbstractFunction18[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R](f: js.Function20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]) extends AbstractFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20)
-}
+sealed abstract class AnonFunction19[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, +R] extends AbstractFunction19[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R](f: js.Function21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]) extends AbstractFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20, arg21: T21): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21)
-}
+sealed abstract class AnonFunction20[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, +R] extends AbstractFunction20[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, R]
 
 @deprecated("used by the codegen before 1.19", since = "1.19.0")
-@inline
-final class AnonFunction22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, -T22, +R](f: js.Function22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]) extends AbstractFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R] {
-  override def apply(arg1: T1, arg2: T2, arg3: T3, arg4: T4, arg5: T5, arg6: T6, arg7: T7, arg8: T8, arg9: T9, arg10: T10, arg11: T11, arg12: T12, arg13: T13, arg14: T14, arg15: T15, arg16: T16, arg17: T17, arg18: T18, arg19: T19, arg20: T20, arg21: T21, arg22: T22): R = f(arg1, arg2, arg3, arg4, arg5, arg6, arg7, arg8, arg9, arg10, arg11, arg12, arg13, arg14, arg15, arg16, arg17, arg18, arg19, arg20, arg21, arg22)
-}
+sealed abstract class AnonFunction21[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, +R] extends AbstractFunction21[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, R]
+
+@deprecated("used by the codegen before 1.19", since = "1.19.0")
+sealed abstract class AnonFunction22[-T1, -T2, -T3, -T4, -T5, -T6, -T7, -T8, -T9, -T10, -T11, -T12, -T13, -T14, -T15, -T16, -T17, -T18, -T19, -T20, -T21, -T22, +R] extends AbstractFunction22[T1, T2, T3, T4, T5, T6, T7, T8, T9, T10, T11, T12, T13, T14, T15, T16, T17, T18, T19, T20, T21, T22, R]
 
 // scalastyle:on line.size.limit

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -64,6 +64,10 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+    // Changes covered by a deserialization hack (and the code cannot be used on the JVM, such as in macros)
+    ProblemFilters.exclude[AbstractClassProblem]("scala.scalajs.runtime.AnonFunction*"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.scalajs.runtime.AnonFunction*.this"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("scala.scalajs.runtime.AnonFunction*.apply"),
   )
 
   val TestInterface = Seq(

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/build.sbt
@@ -1,0 +1,61 @@
+val scala2Version = "2.12.20"
+
+ThisBuild / version := scalaJSVersion
+ThisBuild / scalaVersion := scala2Version
+
+ThisBuild / scalaJSLinkerConfig ~= { _.withCheckIR(true) }
+
+val ScalaJSVersionBeforeTypedClosures = "1.18.2"
+
+/** In libraryDependencies, replace the dependency whose `name` starts with
+ *  `artifactNamePrefix` by the given `newModuleID`.
+ */
+def replaceDependency(artifactNamePrefix: String, newModuleID: ModuleID): Setting[_] = {
+  libraryDependencies := {
+    libraryDependencies.value.map { dep =>
+      if (dep.name.startsWith(artifactNamePrefix))
+        newModuleID
+      else
+        dep
+    }
+  }
+}
+
+def scalaJSCompilerPlugin(v: String): ModuleID =
+  compilerPlugin("org.scala-js" % "scalajs-compiler" % v cross CrossVersion.full)
+
+lazy val scala2OldCompilerOldLib = project.in(file("scala2-old-compiler-old-lib"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    replaceDependency("scalajs-compiler",
+        scalaJSCompilerPlugin(ScalaJSVersionBeforeTypedClosures)),
+    replaceDependency("scalajs-library",
+        "org.scala-js" %% "scalajs-library" % ScalaJSVersionBeforeTypedClosures),
+    replaceDependency("scalajs-scalalib",
+        "org.scala-js" %% "scalajs-scalalib" % s"$scala2Version+$ScalaJSVersionBeforeTypedClosures"),
+    scalaJSUseMainModuleInitializer := true
+  )
+
+lazy val scala2OldCompilerNewLib = project.in(file("scala2-old-compiler-new-lib"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    replaceDependency("scalajs-compiler",
+        scalaJSCompilerPlugin(ScalaJSVersionBeforeTypedClosures)),
+    scalaJSUseMainModuleInitializer := true
+  )
+
+lazy val scala3OldCompilerOldLib = project.in(file("scala3-old-compiler-old-lib"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    scalaVersion := "3.6.3",
+    replaceDependency("scalajs-library",
+        "org.scala-js" % "scalajs-library_2.13" % ScalaJSVersionBeforeTypedClosures),
+    scalaJSUseMainModuleInitializer := true
+  )
+
+lazy val scala3OldCompilerNewLib = project.in(file("scala3-old-compiler-new-lib"))
+  .enablePlugins(ScalaJSPlugin)
+  .settings(
+    scalaVersion := "3.6.3",
+    scalaJSUseMainModuleInitializer := true
+  )

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/project/build.properties
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=1.9.0

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/project/build.sbt
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/project/build.sbt
@@ -1,0 +1,5 @@
+val scalaJSVersion = sys.props("plugin.version")
+
+addSbtPlugin("org.scala-js" % "sbt-scalajs" % scalaJSVersion)
+
+libraryDependencies += "org.scala-js" %% "scalajs-linker" % scalaJSVersion

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/scala2-old-compiler-new-lib/Main.scala
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/scala2-old-compiler-new-lib/Main.scala
@@ -1,0 +1,9 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val xs = List(2, 3, 5, 7, 11)
+    xs.foreach(println(_))
+    xs.map(i => i * 2).foreach(println(_))
+  }
+}

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/scala2-old-compiler-old-lib/Main.scala
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/scala2-old-compiler-old-lib/Main.scala
@@ -1,0 +1,9 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def main(args: Array[String]): Unit = {
+    val xs = List(2, 3, 5, 7, 11)
+    xs.foreach(println(_))
+    xs.map(i => i * 2).foreach(println(_))
+  }
+}

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/scala3-old-compiler-new-lib/Main.scala
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/scala3-old-compiler-new-lib/Main.scala
@@ -1,0 +1,18 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def foo(f: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int): Int = {
+    f(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val xs = List(2, 3, 5, 7, 11)
+    xs.foreach(println(_))
+    xs.map(i => i * 2).foreach(println(_))
+
+    println(foo { (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25) =>
+      x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25
+    })
+  }
+}

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/scala3-old-compiler-old-lib/Main.scala
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/scala3-old-compiler-old-lib/Main.scala
@@ -1,0 +1,18 @@
+package org.scalajs.sbtplugin.test
+
+object Main {
+  def foo(f: (Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int,
+      Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int, Int) => Int): Int = {
+    f(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25)
+  }
+
+  def main(args: Array[String]): Unit = {
+    val xs = List(2, 3, 5, 7, 11)
+    xs.foreach(println(_))
+    xs.map(i => i * 2).foreach(println(_))
+
+    println(foo { (x1, x2, x3, x4, x5, x6, x7, x8, x9, x10, x11, x12, x13, x14, x15, x16, x17, x18, x19, x20, x21, x22, x23, x24, x25) =>
+      x1 + x2 + x3 + x4 + x5 + x6 + x7 + x8 + x9 + x10 + x11 + x12 + x13 + x14 + x15 + x16 + x17 + x18 + x19 + x20 + x21 + x22 + x23 + x24 + x25
+    })
+  }
+}

--- a/sbt-plugin/src/sbt-test/linker/anonfunction-compat/test
+++ b/sbt-plugin/src/sbt-test/linker/anonfunction-compat/test
@@ -1,0 +1,25 @@
+> show scala2OldCompilerOldLib/libraryDependencies
+> show scala2OldCompilerOldLib/Compile/fullClasspath
+> scala2OldCompilerOldLib/scalajsp scala.scalajs.runtime.AnonFunction2
+> scala2OldCompilerOldLib/scalajsp org.scalajs.sbtplugin.test.Main$
+> scala2OldCompilerOldLib/run
+
+> show scala2OldCompilerNewLib/libraryDependencies
+> show scala2OldCompilerNewLib/Compile/fullClasspath
+> scala2OldCompilerNewLib/scalajsp scala.scalajs.runtime.AnonFunction2
+> scala2OldCompilerNewLib/scalajsp org.scalajs.sbtplugin.test.Main$
+> scala2OldCompilerNewLib/run
+
+> show scala3OldCompilerOldLib/libraryDependencies
+> show scala3OldCompilerOldLib/Compile/fullClasspath
+> scala3OldCompilerOldLib/scalajsp scala.scalajs.runtime.AnonFunction2
+> scala3OldCompilerOldLib/scalajsp scala.scalajs.runtime.AnonFunctionXXL
+> scala3OldCompilerOldLib/scalajsp org.scalajs.sbtplugin.test.Main$
+> scala3OldCompilerOldLib/run
+
+> show scala3OldCompilerNewLib/libraryDependencies
+> show scala3OldCompilerNewLib/Compile/fullClasspath
+> scala3OldCompilerNewLib/scalajsp scala.scalajs.runtime.AnonFunction2
+> scala3OldCompilerNewLib/scalajsp scala.scalajs.runtime.AnonFunctionXXL
+> scala3OldCompilerNewLib/scalajsp org.scalajs.sbtplugin.test.Main$
+> scala3OldCompilerNewLib/run


### PR DESCRIPTION
~~Based on #5111.~~

We change the definition of `AnonFunctionN`s from `final class`es with concrete `apply` methods to `sealed abstract` classes. We rewrite `New` nodes to them to use `NewLambda` instead.

See comments in the IR deserializer for more details on the performed rewrites.

The rewritten `NewLambda` must target classes with the same identity (and not directly `AbstractFunctionN`) because the class names can be used in *types* somewhere else in the IR. The result of the `NewLambda` nodes must stay compatible with those types.

This change ensures that even old libraries benefit from all the new optimizations for lambdas on Wasm, and that they can participate in a call chain between `js.async` and an orphan `js.await`.