### PR TITLE
Make the guards for deserialization hacks clearer.

### DIFF
--- a/ir/shared/src/test/scala/org/scalajs/ir/SerializersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/SerializersTest.scala
@@ -1,0 +1,61 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.ir
+
+import org.junit.Test
+import org.junit.Assert._
+
+class SerializersTest {
+  @Test def testHacksUseBelow(): Unit = {
+    import Serializers.Hacks
+
+    val hacks1_0 = new Hacks("1.0")
+    assertFalse(hacks1_0.useBelow(0))
+    assertTrue(hacks1_0.useBelow(1))
+    assertTrue(hacks1_0.useBelow(5))
+    assertTrue(hacks1_0.useBelow(15))
+    assertTrue(hacks1_0.useBelow(1000))
+
+    val hacks1_7 = new Hacks("1.7")
+    assertFalse(hacks1_7.useBelow(0))
+    assertFalse(hacks1_7.useBelow(1))
+    assertFalse(hacks1_7.useBelow(5))
+    assertFalse(hacks1_7.useBelow(7))
+    assertTrue(hacks1_7.useBelow(8))
+    assertTrue(hacks1_7.useBelow(15))
+    assertTrue(hacks1_7.useBelow(1000))
+
+    val hacks1_50 = new Hacks("1.50")
+    assertFalse(hacks1_50.useBelow(0))
+    assertFalse(hacks1_50.useBelow(1))
+    assertFalse(hacks1_50.useBelow(5))
+    assertFalse(hacks1_50.useBelow(15))
+    assertTrue(hacks1_50.useBelow(1000))
+
+    // Non-stable versions never get any hacks
+    val hacks1_9_snapshot = new Hacks("1.9-SNAPSHOT")
+    assertFalse(hacks1_9_snapshot.useBelow(0))
+    assertFalse(hacks1_9_snapshot.useBelow(1))
+    assertFalse(hacks1_9_snapshot.useBelow(5))
+    assertFalse(hacks1_9_snapshot.useBelow(15))
+    assertFalse(hacks1_9_snapshot.useBelow(1000))
+
+    // Incompatible versions never get any hacks
+    val hacks2_5 = new Hacks("2.5")
+    assertFalse(hacks2_5.useBelow(0))
+    assertFalse(hacks2_5.useBelow(1))
+    assertFalse(hacks2_5.useBelow(5))
+    assertFalse(hacks2_5.useBelow(15))
+    assertFalse(hacks2_5.useBelow(1000))
+  }
+}

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -5,6 +5,9 @@ import com.typesafe.tools.mima.core.ProblemFilters._
 
 object BinaryIncompatibilities {
   val IR = Seq(
+    // private, not an issue
+    ProblemFilters.exclude[MissingClassProblem]("org.scalajs.ir.Serializers$Deserializer$BodyHack5Transformer$"),
+    ProblemFilters.exclude[DirectMissingMethodProblem]("org.scalajs.ir.Serializers#Hacks.use*"),
   )
 
   val Linker = Seq(


### PR DESCRIPTION
Previously, deserialization hacks were guarded by the last IR version to which they applied. This was confusing when IR versions skipped one or more minor number, for example from 1.8 to 1.11. The version that introduces the hack was 1.11, but the guards were `hacks.use8`.

Comments and error messages were typically disagreeing with that convention. For example, in that situation, they would refer to "prior to 1.11" or "1.11 introduced". That was another mismatch between the programmatic guards and the text in the comments.

Overall this was very confusing.

Now, we refer to the *first* IR version to which a hack must *not* be applied. This corresponds to the comments, and in general to the IR version that introduced the hack.

---

In addition, we take the opportunity to use a unique `useBelow(V)` instead of individual `useV` methods. The fixed list of `useV` methods with their corresponding string versions had become too long.