### PR TITLE
Remove ancient codegen opt for expanded Scala anon function classes.

### DIFF
--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSSAMTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSSAMTest.scala
@@ -126,10 +126,10 @@ class JSSAMTest extends DirectTest with TestHelpers {
     }
     """ hasErrors
     """
-      |newSource1.scala:14: error: The SAM or apply method for a js.ThisFunction must have a leading non-varargs parameter
+      |newSource1.scala:14: error: The apply method for a js.ThisFunction must have a leading non-varargs parameter
       |      val badThisFunction1: BadThisFunction1 = () => 42
       |                                                  ^
-      |newSource1.scala:15: error: The SAM or apply method for a js.ThisFunction must have a leading non-varargs parameter
+      |newSource1.scala:15: error: The apply method for a js.ThisFunction must have a leading non-varargs parameter
       |      val badThisFunction2: BadThisFunction2 = args => args.size
       |                                                    ^
     """


### PR DESCRIPTION
Since the very early days of Scala.js, we have had a code size optimization for lambdas expanded as anonymous classes. We tried very hard to recover the captures from fields, and the body of the `apply` method, in order to reconstruct a `js.Closure`.

That made sense as long as we supported Scala 2.11 (and before that, 2.10). However, since Scala 2.12.x, scalac almost never expands lambdas of `scala.FunctionN`. Instead, they reach the backend as `Function` node.

The only situations where scalac still expands lambdas as anonymous classes is if it used in an argument to a super constructor (or delegate `this()` constructor).

The code paths for that code size optimization are therefore almost dead code, and do not pull their weight anymore. It was, AFAICT, the only place where we still *tried* to emit something a certain way, with a fallback.

This commit removes the optimization and all the related infrastructure.

---

Here is a report of the affected anonymous function classes in our repo:
https://gist.github.com/sjrd/eeb2145a9dd22e6d6e50460243059274
* `+`: classes for which the optimization *succeeded*.
* `!`: classes that did not pass the initial test `!sym.superClass.fullName.startsWith("scala.runtime.AbstractFunction")`.
* `-` (no occurrence): classes for which the optimization was tried but had to *rollback*.