### PR TITLE
Wasm: Remove dead code jsLinkingInfo object.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -259,25 +259,6 @@ final class Emitter(config: Emitter.Config) {
 
     implicit val noPos = Position.NoPosition
 
-    // Linking info
-    val linkingInfo = {
-      // must be in sync with scala.scalajs.runtime.LinkingInfo
-      import config.coreSpec._
-      import js.{BooleanLiteral => bool, IntLiteral => int, StringLiteral => str}
-
-      def objectFreeze(tree: js.Tree): js.Tree =
-        js.Apply(js.DotSelect(js.VarRef(js.Ident("Object")), js.Ident("freeze")), tree :: Nil)
-
-      objectFreeze(js.ObjectConstr(List(
-        str("esVersion") -> int(esFeatures.esVersion.edition),
-        str("assumingES6") -> bool(esFeatures.useECMAScript2015Semantics), // different name for historical reasons
-        str("isWebAssembly") -> bool(true),
-        str("productionMode") -> bool(semantics.productionMode),
-        str("linkerVersion") -> str(ScalaJSVersions.current),
-        str("fileLevelThis") -> js.This()
-      )))
-    }
-
     // Sort for stability
     val importedModules = module.externalDependencies.toList.sorted
 
@@ -326,7 +307,6 @@ final class Emitter(config: Emitter.Config) {
       js.VarRef(loadFunIdent),
       List(
         js.StringLiteral(config.internalWasmFileURIPattern(module.id)),
-        linkingInfo,
         exportSettersDict,
         customJSHelpersDict
       )

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -180,10 +180,9 @@ const stringBuiltinPolyfills = {
   equals: (a, b) => a === b,
 };
 
-export async function load(wasmFileURL, linkingInfo, exportSetters, customJSHelpers) {
+export async function load(wasmFileURL, exportSetters, customJSHelpers) {
   const myScalaJSHelpers = {
     ...scalaJSHelpers,
-    jsLinkingInfo: linkingInfo,
     idHashCodeMap: new WeakMap()
   };
   const importsObj = {


### PR DESCRIPTION
This was forgotten in 7bf410dd922662dabfc85f1d76d40431c1fe0910.