### PR TITLE
Fix #5064: Add `js.async { ... js.await(p) ... }`, and support JSPI on WebAssembly.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -365,59 +365,75 @@ def Tasks = [
     npm install &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         helloworld$v/run &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSStage in Global := FullOptStage' \
         'set scalaJSLinkerConfig in helloworld.v$v ~= (_.withPrettyPrint(true))' \
         helloworld$v/run &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in reversi.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         reversi$v/fastLinkJS \
         reversi$v/fullLinkJS &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
-        jUnitTestOutputsJVM$v/test jUnitTestOutputsJS$v/test testBridge$v/test \
-        'set scalaJSStage in Global := FullOptStage' jUnitTestOutputsJS$v/test testBridge$v/test &&
+        'set scalaJSLinkerConfig in jUnitTestOutputsJS.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        'set scalaJSLinkerConfig in testBridge.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
+        jUnitTestOutputsJS$v/test testBridge$v/test \
+        'set scalaJSStage in Global := FullOptStage' \
+        jUnitTestOutputsJS$v/test testBridge$v/test &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         $testSuite$v/test &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSStage in Global := FullOptStage' \
         $testSuite$v/test &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         $testSuite$v/test &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         'set scalaJSStage in Global := FullOptStage' \
         $testSuite$v/test &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         $testSuite$v/test &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         'set scalaJSStage in Global := FullOptStage' \
         $testSuite$v/test &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= makeCompliant' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
         $testSuite$v/test &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         testingExample$v/testHtml &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         'set scalaJSStage in Global := FullOptStage' \
         testingExample$v/testHtml &&
     sbtretry ++$scala \
         'set Global/enableWasmEverywhere := true' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withESFeatures(_.withESVersion(ESVersion.$esVersion)))' \
         irJS$v/fastLinkJS
   ''',
 
@@ -551,6 +567,8 @@ def allESVersions = [
   "ES2020",
   "ES2021" // We do not use anything specifically from ES2021, but always test the latest to avoid #4675
 ]
+def defaultESVersion = "ES2015"
+def latestESVersion = "ES2021"
 
 // The 'quick' matrix
 def quickMatrix = []
@@ -562,11 +580,12 @@ mainScalaVersions.each { scalaVersion ->
   quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testMinify: "false", testSuite: "testSuite"])
   quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testMinify: "true", testSuite: "testSuite"])
   quickMatrix.add([task: "test-suite-custom-esversion", scala: scalaVersion, java: mainJavaVersion, esVersion: "ES5_1", testSuite: "testSuite"])
-  quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, testMinify: "false", testSuite: "testSuite"])
-  quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, testMinify: "false", testSuite: "testSuiteEx"])
+  quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, esVersion: defaultESVersion, testMinify: "false", testSuite: "testSuite"])
+  quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, esVersion: latestESVersion, testMinify: "false", testSuite: "testSuite"])
+  quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, esVersion: defaultESVersion, testMinify: "false", testSuite: "testSuiteEx"])
   quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: mainJavaVersion, testMinify: "false", testSuite: "scalaTestSuite"])
   quickMatrix.add([task: "test-suite-custom-esversion", scala: scalaVersion, java: mainJavaVersion, esVersion: "ES5_1", testSuite: "scalaTestSuite"])
-  quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, testMinify: "false", testSuite: "scalaTestSuite"])
+  quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, esVersion: defaultESVersion, testMinify: "false", testSuite: "scalaTestSuite"])
   quickMatrix.add([task: "bootstrap", scala: scalaVersion, java: mainJavaVersion])
   quickMatrix.add([task: "partest-fastopt", scala: scalaVersion, java: mainJavaVersion, partestopts: ""])
   quickMatrix.add([task: "partest-fastopt", scala: scalaVersion, java: mainJavaVersion, partestopts: "--wasm"])
@@ -591,7 +610,7 @@ otherScalaVersions.each { scalaVersion ->
 mainScalaVersions.each { scalaVersion ->
   otherJavaVersions.each { javaVersion ->
     quickMatrix.add([task: "test-suite-default-esversion", scala: scalaVersion, java: javaVersion, testMinify: "false", testSuite: "testSuite"])
-    quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, testMinify: "false", testSuite: "testSuite"])
+    quickMatrix.add([task: "test-suite-webassembly", scala: scalaVersion, java: mainJavaVersion, esVersion: defaultESVersion, testMinify: "false", testSuite: "testSuite"])
   }
   fullMatrix.add([task: "partest-noopt", scala: scalaVersion, java: mainJavaVersion, partestopts: ""])
   fullMatrix.add([task: "partest-noopt", scala: scalaVersion, java: mainJavaVersion, partestopts: "--wasm"])

--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -167,6 +167,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
     private val fieldsMutatedInCurrentClass = new ScopedVar[mutable.Set[Name]]
     private val generatedSAMWrapperCount = new ScopedVar[VarBox[Int]]
     private val delambdafyTargetDefDefs = new ScopedVar[mutable.Map[Symbol, DefDef]]
+    private val methodsAllowingJSAwait = new ScopedVar[mutable.Set[Symbol]]
 
     def currentThisTypeNullable: jstpe.Type =
       encodeClassType(currentClassSym)
@@ -241,6 +242,7 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
           fieldsMutatedInCurrentClass := mutable.Set.empty,
           generatedSAMWrapperCount := new VarBox(0),
           delambdafyTargetDefDefs := mutable.Map.empty,
+          methodsAllowingJSAwait := mutable.Set.empty,
           currentMethodSym := null,
           thisLocalVarName := null,
           enclosingLabelDefInfos := null,
@@ -469,7 +471,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                 currentClassSym := sym,
                 fieldsMutatedInCurrentClass := mutable.Set.empty,
                 generatedSAMWrapperCount := new VarBox(0),
-                delambdafyTargetDefDefs := mutable.Map.empty
+                delambdafyTargetDefDefs := mutable.Map.empty,
+                methodsAllowingJSAwait := mutable.Set.empty
             ) {
               val tree = if (isJSType(sym)) {
                 if (!sym.isTraitOrInterface && isNonNativeJSClass(sym) &&
@@ -5332,6 +5335,35 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         case JS_IMPORT_META =>
           // js.import.meta
           js.JSImportMeta()
+
+        case JS_ASYNC =>
+          // js.async(arg)
+          assert(args.size == 1,
+              s"Expected exactly 1 argument for JS primitive $code but got " +
+              s"${args.size} at $pos")
+          val Block(stats, fun @ Function(_, Apply(target, _))) = args.head
+          methodsAllowingJSAwait += target.symbol
+          val genStats = stats.map(genStat(_))
+          val asyncExpr = genAnonFunction(fun) match {
+            case js.NewLambda(_, closure: js.Closure)
+                if closure.params.isEmpty && closure.resultType == jstpe.AnyType =>
+              val newFlags = closure.flags.withTyped(false).withAsync(true)
+              js.JSFunctionApply(closure.copy(flags = newFlags), Nil)
+            case other =>
+              abort(s"Unexpected tree generated for the Function0 argument to js.async at $pos: $other")
+          }
+          js.Block(genStats, asyncExpr)
+
+        case JS_AWAIT =>
+          // js.await(arg)
+          if (!methodsAllowingJSAwait.contains(currentMethodSym)) {
+            reporter.error(pos,
+                "Illegal use of js.await().\n" +
+                "It can only be used inside a js.async {...} block, without any lambda,\n" +
+                "by-name argument or nested method in-between.")
+          }
+          val arg = genArgs1
+          js.JSAwait(arg)
 
         case DYNAMIC_IMPORT =>
           assert(args.size == 1,

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -47,6 +47,8 @@ trait JSDefinitions {
       lazy val JSPackage_native        = getMemberMethod(ScalaJSJSPackageModule, newTermName("native"))
       lazy val JSPackage_undefined     = getMemberMethod(ScalaJSJSPackageModule, newTermName("undefined"))
       lazy val JSPackage_dynamicImport = getMemberMethod(ScalaJSJSPackageModule, newTermName("dynamicImport"))
+      lazy val JSPackage_async         = getMemberMethod(ScalaJSJSPackageModule, newTermName("async"))
+      lazy val JSPackage_await         = getMemberMethod(ScalaJSJSPackageModule, newTermName("await"))
 
     lazy val JSNativeAnnotation = getRequiredClass("scala.scalajs.js.native")
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -116,6 +116,11 @@ trait JSDefinitions {
       lazy val Special_unwrapFromThrowable = getMemberMethod(SpecialPackageModule, newTermName("unwrapFromThrowable"))
       lazy val Special_debugger = getMemberMethod(SpecialPackageModule, newTermName("debugger"))
 
+    lazy val WasmJSPIModule = getRequiredModule("scala.scalajs.js.wasm.JSPI")
+    lazy val WasmJSPIModuleClass = WasmJSPIModule.moduleClass
+      lazy val WasmJSPI_allowOrphanJSAwaitModule = getMemberModule(WasmJSPIModuleClass, newTermName("allowOrphanJSAwait"))
+      lazy val WasmJSPI_allowOrphanJSAwaitModuleClass = WasmJSPI_allowOrphanJSAwaitModule.moduleClass
+
     lazy val RuntimePackageModule = getPackageObject("scala.scalajs.runtime")
       lazy val Runtime_toScalaVarArgs             = getMemberMethod(RuntimePackageModule, newTermName("toScalaVarArgs"))
       lazy val Runtime_toJSVarArgs                = getMemberMethod(RuntimePackageModule, newTermName("toJSVarArgs"))

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
@@ -51,7 +51,10 @@ abstract class JSPrimitives {
   final val JS_IMPORT = JS_NEW_TARGET + 1  // js.import.apply(specifier)
   final val JS_IMPORT_META = JS_IMPORT + 1 // js.import.meta
 
-  final val CONSTRUCTOROF = JS_IMPORT_META + 1                         // runtime.constructorOf(clazz)
+  final val JS_ASYNC = JS_IMPORT_META + 1 // js.async
+  final val JS_AWAIT = JS_ASYNC + 1       // js.await
+
+  final val CONSTRUCTOROF = JS_AWAIT + 1                               // runtime.constructorOf(clazz)
   final val CREATE_INNER_JS_CLASS = CONSTRUCTOROF + 1                  // runtime.createInnerJSClass
   final val CREATE_LOCAL_JS_CLASS = CREATE_INNER_JS_CLASS + 1          // runtime.createLocalJSClass
   final val WITH_CONTEXTUAL_JS_CLASS_VALUE = CREATE_LOCAL_JS_CLASS + 1 // runtime.withContextualJSClassValue
@@ -96,6 +99,8 @@ abstract class JSPrimitives {
 
     addPrimitive(JSPackage_typeOf, TYPEOF)
     addPrimitive(JSPackage_native, JS_NATIVE)
+    addPrimitive(JSPackage_async, JS_ASYNC)
+    addPrimitive(JSPackage_await, JS_AWAIT)
 
     addPrimitive(BoxedUnit_UNIT, UNITVAL)
 

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSAsyncAwaitTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSAsyncAwaitTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.nscplugin.test
+
+import org.scalajs.nscplugin.test.util._
+import org.junit.Test
+
+// scalastyle:off line.size.limit
+
+class JSAsyncAwaitTest extends DirectTest with TestHelpers {
+
+  override def preamble: String =
+    """import scala.scalajs.js
+    """
+
+  @Test
+  def orphanAwait(): Unit = {
+    """
+    class A {
+      def foo(x: js.Promise[Int]): Int =
+        js.await(x)
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: Illegal use of js.await().
+      |It can only be used inside a js.async {...} block, without any lambda,
+      |by-name argument or nested method in-between.
+      |        js.await(x)
+      |                ^
+    """
+
+    """
+    class A {
+      def foo(x: js.Promise[Int]): js.Promise[Int] = js.async {
+        val f: () => Int = () => js.await(x)
+        f()
+      }
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: Illegal use of js.await().
+      |It can only be used inside a js.async {...} block, without any lambda,
+      |by-name argument or nested method in-between.
+      |        val f: () => Int = () => js.await(x)
+      |                                         ^
+    """
+
+    """
+    class A {
+      def foo(x: js.Promise[Int]): js.Promise[Int] = js.async {
+        def f(): Int = js.await(x)
+        f()
+      }
+    }
+    """ hasErrors
+    """
+      |newSource1.scala:5: error: Illegal use of js.await().
+      |It can only be used inside a js.async {...} block, without any lambda,
+      |by-name argument or nested method in-between.
+      |        def f(): Int = js.await(x)
+      |                               ^
+    """
+  }
+}

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSAsyncAwaitTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSAsyncAwaitTest.scala
@@ -35,6 +35,9 @@ class JSAsyncAwaitTest extends DirectTest with TestHelpers {
       |newSource1.scala:5: error: Illegal use of js.await().
       |It can only be used inside a js.async {...} block, without any lambda,
       |by-name argument or nested method in-between.
+      |If you compile for WebAssembly, you can allow arbitrary js.await()
+      |calls by adding the following import:
+      |import scala.scalajs.js.wasm.JSPI.allowOrphanJSAwait
       |        js.await(x)
       |                ^
     """
@@ -51,6 +54,9 @@ class JSAsyncAwaitTest extends DirectTest with TestHelpers {
       |newSource1.scala:5: error: Illegal use of js.await().
       |It can only be used inside a js.async {...} block, without any lambda,
       |by-name argument or nested method in-between.
+      |If you compile for WebAssembly, you can allow arbitrary js.await()
+      |calls by adding the following import:
+      |import scala.scalajs.js.wasm.JSPI.allowOrphanJSAwait
       |        val f: () => Int = () => js.await(x)
       |                                         ^
     """
@@ -67,6 +73,9 @@ class JSAsyncAwaitTest extends DirectTest with TestHelpers {
       |newSource1.scala:5: error: Illegal use of js.await().
       |It can only be used inside a js.async {...} block, without any lambda,
       |by-name argument or nested method in-between.
+      |If you compile for WebAssembly, you can allow arbitrary js.await()
+      |calls by adding the following import:
+      |import scala.scalajs.js.wasm.JSPI.allowOrphanJSAwait
       |        def f(): Int = js.await(x)
       |                               ^
     """

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -242,6 +242,10 @@ object Hashers {
           mixTree(default)
           mixType(tree.tpe)
 
+        case JSAwait(arg) =>
+          mixTag(TagJSAwait)
+          mixTree(arg)
+
         case Debugger() =>
           mixTag(TagDebugger)
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -291,6 +291,11 @@ object Printers {
           undent()
           undent(); println(); print('}')
 
+        case JSAwait(arg) =>
+          print("await(")
+          print(arg)
+          print(")")
+
         case Debugger() =>
           print("debugger")
 
@@ -896,12 +901,16 @@ object Printers {
             print(name)
 
         case Closure(flags, captureParams, params, restParam, resultType, body, captureValues) =>
+          print("(")
+          if (flags.async)
+            print("async ")
           if (flags.typed)
-            print("(typed-lambda<")
+            print("typed-lambda")
           else if (flags.arrow)
-            print("(arrow-lambda<")
+            print("arrow-lambda")
           else
-            print("(lambda<")
+            print("lambda")
+          print("<")
           var first = true
           for ((param, value) <- captureParams.zip(captureValues)) {
             if (first)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -326,6 +326,10 @@ object Serializers {
           writeTree(default)
           writeType(tree.tpe)
 
+        case JSAwait(arg) =>
+          writeTagAndPos(TagJSAwait)
+          writeTree(arg)
+
         case Debugger() =>
           writeTagAndPos(TagDebugger)
 
@@ -1216,6 +1220,10 @@ object Serializers {
           Match(readTree(), List.fill(readInt()) {
             (readTrees().map(_.asInstanceOf[MatchableLiteral]), readTree())
           }, readTree())(readType())
+
+        case TagJSAwait =>
+          JSAwait(readTree())
+
         case TagDebugger => Debugger()
 
         case TagNew          => New(readClassName(), readMethodIdent(), readTrees())

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -133,6 +133,7 @@ private[ir] object Tags {
   // New in 1.19
   final val TagApplyTypedClosure = TagLinkTimeProperty + 1
   final val TagNewLambda = TagApplyTypedClosure + 1
+  final val TagJSAwait = TagNewLambda + 1
 
   // Tags for member defs
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -77,6 +77,9 @@ object Transformers {
           Match(transform(selector), cases.map(c => (c._1, transform(c._2))),
               transform(default))(tree.tpe)
 
+        case JSAwait(arg) =>
+          JSAwait(transform(arg))
+
         // Scala expressions
 
         case New(className, ctor, args) =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -69,6 +69,9 @@ object Traversers {
         cases foreach (c => (c._1 map traverse, traverse(c._2)))
         traverse(default)
 
+      case JSAwait(arg) =>
+        traverse(arg)
+
       // Scala expressions
 
       case New(_, _, args) =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -220,12 +220,15 @@ object Trees {
 
   /** `await arg`.
    *
-   *  This is directly equivalent to a JavaScript `await` expression. This node
-   *  is only valid within a [[Closure]] node with the `async` flag.
+   *  This is directly equivalent to a JavaScript `await` expression.
+   *
+   *  If used directly within a [[Closure]] node with the `async` flag, this
+   *  node is always valid. However, when used anywhere else, it is an "orphan"
+   *  await. Orphan awaits only link when targeting WebAssembly.
    *
    *  This is not a `UnaryOp` because of the above strict scoping rule. For
-   *  example, it is not safe to pull this node out of or into an intervening
-   *  closure, contrary to `UnaryOp`s.
+   *  example, unless it is orphan to begin with, it is not safe to pull this
+   *  node out of or into an intervening closure, contrary to `UnaryOp`s.
    */
   sealed case class JSAwait(arg: Tree)(implicit val pos: Position) extends Tree {
     val tpe = AnyType

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -218,6 +218,19 @@ object Trees {
   sealed case class Match(selector: Tree, cases: List[(List[MatchableLiteral], Tree)],
       default: Tree)(val tpe: Type)(implicit val pos: Position) extends Tree
 
+  /** `await arg`.
+   *
+   *  This is directly equivalent to a JavaScript `await` expression. This node
+   *  is only valid within a [[Closure]] node with the `async` flag.
+   *
+   *  This is not a `UnaryOp` because of the above strict scoping rule. For
+   *  example, it is not safe to pull this node out of or into an intervening
+   *  closure, contrary to `UnaryOp`s.
+   */
+  sealed case class JSAwait(arg: Tree)(implicit val pos: Position) extends Tree {
+    val tpe = AnyType
+  }
+
   sealed case class Debugger()(implicit val pos: Position) extends Tree {
     val tpe = VoidType
   }
@@ -1215,6 +1228,10 @@ object Trees {
    *  with `new`). If `false`, it is a regular Function (`function`), which
    *  does have a `this` parameter of type `AnyType`. Typed closures are always
    *  Arrow functions, since they do not have a `this` parameter.
+   *
+   *  If `flags.async` is `true`, it is an `async` closure. Async closures
+   *  return a `Promise` of their body, and can contain [[JSAwait]] nodes.
+   *  `flags.typed` and `flags.async` cannot both be `true`.
    */
   sealed case class Closure(flags: ClosureFlags, captureParams: List[ParamDef],
       params: List[ParamDef], restParam: Option[ParamDef], resultType: Type,
@@ -1574,6 +1591,8 @@ object Trees {
 
     def typed: Boolean = (bits & TypedBit) != 0
 
+    def async: Boolean = (bits & AsyncBit) != 0
+
     def withArrow(arrow: Boolean): ClosureFlags =
       if (arrow) new ClosureFlags(bits | ArrowBit)
       else new ClosureFlags(bits & ~ArrowBit)
@@ -1581,6 +1600,10 @@ object Trees {
     def withTyped(typed: Boolean): ClosureFlags =
       if (typed) new ClosureFlags(bits | TypedBit)
       else new ClosureFlags(bits & ~TypedBit)
+
+    def withAsync(async: Boolean): ClosureFlags =
+      if (async) new ClosureFlags(bits | AsyncBit)
+      else new ClosureFlags(bits & ~AsyncBit)
   }
 
   object ClosureFlags {
@@ -1592,6 +1615,9 @@ object Trees {
 
     private final val TypedShift = 1
     private final val TypedBit = 1 << TypedShift
+
+    private final val AsyncShift = 2
+    private final val AsyncBit = 1 << AsyncShift
 
     /** `function` closure base flags. */
     final val function: ClosureFlags =

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -295,6 +295,10 @@ class PrintersTest {
             i(11))(IntType))
   }
 
+  @Test def printJSAwait(): Unit = {
+    assertPrintEquals("await(p)", JSAwait(ref("p", AnyType)))
+  }
+
   @Test def printDebugger(): Unit = {
     assertPrintEquals("debugger", Debugger())
   }
@@ -947,6 +951,26 @@ class PrintersTest {
           |})
         """,
         Closure(ClosureFlags.function, Nil, Nil,
+            Some(ParamDef("z", NON, AnyType, mutable = false)),
+            AnyType, ref("z", AnyType), Nil))
+
+    assertPrintEquals(
+        """
+          |(async lambda<>(...z: any): any = {
+          |  z
+          |})
+        """,
+        Closure(ClosureFlags.function.withAsync(true), Nil, Nil,
+            Some(ParamDef("z", NON, AnyType, mutable = false)),
+            AnyType, ref("z", AnyType), Nil))
+
+    assertPrintEquals(
+        """
+          |(async arrow-lambda<>(...z: any): any = {
+          |  z
+          |})
+        """,
+        Closure(ClosureFlags.arrow.withAsync(true), Nil, Nil,
             Some(ParamDef("z", NON, AnyType, mutable = false)),
             AnyType, ref("z", AnyType), Nil))
 

--- a/library/src/main/scala/scala/scalajs/js/AwaitPermit.scala
+++ b/library/src/main/scala/scala/scalajs/js/AwaitPermit.scala
@@ -1,0 +1,29 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js
+
+/** Kind of permit for calling `js.await()`.
+ *
+ *  A default permit is always available. It allows to call `js.await()` when
+ *  directly enclosed by a `js.async { ... }` block.
+ *
+ *  @see [[scala.scalajs.js.async]]
+ */
+abstract class AwaitPermit private[js] ()
+
+object AwaitPermit {
+  /** Default permit for `js.await()` calls directly enclosed within a
+   *  `js.async` block.
+   */
+  implicit object directlyWithinAsync extends AwaitPermit
+}

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -158,4 +158,51 @@ package object js {
    */
   def dynamicImport[A](body: => A): js.Promise[A] =
     throw new java.lang.Error("stub")
+
+  /** <span class="badge badge-ecma2017" style="float: right;">ECMAScript 2017</span>
+   *  Executes a block of code under a JavaScript `async` context.
+   *
+   *  The block of code can await [[Promise js.Promise]]s using [[await js.await]].
+   *  Doing so will continue after the call to `js.await` when the given
+   *  `Promise` is resolved. If the `Promise` is rejected, the exception gets
+   *  rethrown at the call site.
+   *
+   *  A block such as `js.async { body }` is equivalent to an
+   *  immediately-applied JavaScript `async` function:
+   *
+   *  {{{
+   *  (async () => body)()
+   *  }}}
+   *
+   *  Example usage:
+   *
+   *  {{{
+   *  val p: js.Promise[String] = downloadSomething()
+   *  val result: js.Promise[Int] = js.async {
+   *    val text: String = js.await(p)
+   *    text.toInt
+   *  }
+   *  }}}
+   *
+   *  This method returns a [[Promise js.Promise]] that will be resolved with
+   *  the result of the code block. If the block throws an exception, the
+   *  `Promise` will be rejected.
+   *
+   *  Calls to `js.await` can only appear within a `js.async` block. They must
+   *  not be nested in any local method, class, by-name argument or closure.
+   *  The latter includes `for` comprehensions. They may appear within
+   *  conditional branches, `while` loops and `try/catch/finally` blocks.
+   */
+  def async[A](body: => A): js.Promise[A] =
+    throw new java.lang.Error("stub")
+
+  /** <span class="badge badge-ecma2017" style="float: right;">ECMAScript 2017</span>
+   *  Awaits a [[Promise js.Promise]] within the context of an [[async js.async]] block.
+   *
+   *  This method corresponds to the JavaScript `await` keyword.
+   *
+   *  See the documentation of [[async js.async]].
+   */
+  def await[A](promise: js.Promise[A]): A =
+    throw new java.lang.Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/js/package.scala
+++ b/library/src/main/scala/scala/scalajs/js/package.scala
@@ -192,6 +192,22 @@ package object js {
    *  not be nested in any local method, class, by-name argument or closure.
    *  The latter includes `for` comprehensions. They may appear within
    *  conditional branches, `while` loops and `try/catch/finally` blocks.
+   *
+   *  <h2>Orphan `await`s in WebAssembly</h2>
+   *
+   *  When compiling for Scala.js-on-Wasm only, you can allow calls to
+   *  `js.await` anywhere, by adding the following import:
+   *
+   *  {{{
+   *  import scala.scalajs.js.wasm.JSPI.allowOrphanJSAwait
+   *  }}}
+   *
+   *  Calls to orphan `js.await`s are validated at run-time. There must exist
+   *  a dynamically enclosing `js.async { ... }` block on the call stack.
+   *  Moreover, there cannot be any JavaScript frame (JavaScript function
+   *  invocation) in the call stack between the `js.async { ... }` block and
+   *  the call to `js.await`. If those conditions are not met, a JavaScript
+   *  exception of type `WebAssembly.SuspendError` gets thrown.
    */
   def async[A](body: => A): js.Promise[A] =
     throw new java.lang.Error("stub")
@@ -203,6 +219,6 @@ package object js {
    *
    *  See the documentation of [[async js.async]].
    */
-  def await[A](promise: js.Promise[A]): A =
+  def await[A](promise: js.Promise[A])(implicit permit: AwaitPermit): A =
     throw new java.lang.Error("stub")
 }

--- a/library/src/main/scala/scala/scalajs/js/wasm/JSPI.scala
+++ b/library/src/main/scala/scala/scalajs/js/wasm/JSPI.scala
@@ -1,0 +1,28 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js.wasm
+
+import scala.scalajs.js
+
+/** Features related to the WebAssembly JavaScript Promise Integration (JSPI). */
+object JSPI {
+  /** Allow arbitrary calls to `js.await()`.
+   *
+   *  Import this object to allow arbitrary calls to `js.await()`, even when
+   *  they are not directly nested within a `js.async { ... }` block.
+   *  The resulting code will then only link when targeting WebAssembly.
+   *
+   *  @see [[scala.scalajs.js.async]]
+   */
+  implicit object allowOrphanJSAwait extends js.AwaitPermit
+}

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -348,6 +348,8 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
         new Node(Token.DELPROP, transformExpr(prop))
       case UnaryOp(op, lhs) =>
         mkUnaryOp(op, transformExpr(lhs))
+      case Await(arg) =>
+        new Node(Token.AWAIT, transformExpr(arg))
       case IncDec(prefix, inc, arg) =>
         val token = if (inc) Token.INC else Token.DEC
         val node = new Node(token, transformExpr(arg))
@@ -385,9 +387,10 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
       case Super() =>
         new Node(Token.SUPER)
 
-      case Function(arrow, args, restParam, body) =>
+      case Function(flags, args, restParam, body) =>
         val node = genFunction("", args, restParam, body)
-        node.setIsArrowFunction(arrow)
+        node.setIsArrowFunction(flags.arrow)
+        node.setIsAsyncFunction(flags.async)
         node
       case FunctionDef(name, args, restParam, body) =>
         genFunction(name.resolveName(), args, restParam, body)

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -215,6 +215,8 @@ object Analysis {
 
   final case class ExponentOperatorWithoutES2016Support(from: From) extends Error
 
+  final case class AsyncWithoutES2017Support(from: From) extends Error
+
   final case class InvalidLinkTimeProperty(
     linkTimePropertyName: String,
     linkTimePropertyType: Type,
@@ -277,6 +279,8 @@ object Analysis {
         "Uses import.meta with a module kind other than ESModule"
       case ExponentOperatorWithoutES2016Support(_) =>
         "Uses the ** operator with an ECMAScript version older than ES 2016"
+      case AsyncWithoutES2017Support(_) =>
+        "Uses an async block with an ECMAScript version older than ES 2017"
       case InvalidLinkTimeProperty(name, tpe, _) =>
         s"Uses invalid link-time property ${name} of type ${tpe}"
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -217,6 +217,8 @@ object Analysis {
 
   final case class AsyncWithoutES2017Support(from: From) extends Error
 
+  final case class OrphanAwaitWithoutWebAssembly(from: From) extends Error
+
   final case class InvalidLinkTimeProperty(
     linkTimePropertyName: String,
     linkTimePropertyType: Type,
@@ -281,6 +283,8 @@ object Analysis {
         "Uses the ** operator with an ECMAScript version older than ES 2016"
       case AsyncWithoutES2017Support(_) =>
         "Uses an async block with an ECMAScript version older than ES 2017"
+      case OrphanAwaitWithoutWebAssembly(_) =>
+        "Uses an orphan await (outside of an async block) without targeting WebAssembly"
       case InvalidLinkTimeProperty(name, tpe, _) =>
         s"Uses invalid link-time property ${name} of type ${tpe}"
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1526,6 +1526,11 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
         _errors ::= AsyncWithoutES2017Support(from)
       }
 
+      if ((globalFlags & ReachabilityInfo.FlagUsedOrphanAwait) != 0 &&
+          !config.coreSpec.targetIsWebAssembly) {
+        _errors ::= OrphanAwaitWithoutWebAssembly(from)
+      }
+
       if ((globalFlags & ReachabilityInfo.FlagUsedClassSuperClass) != 0) {
         _classSuperClassUsed.set(true)
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1521,6 +1521,11 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
         _errors ::= ExponentOperatorWithoutES2016Support(from)
       }
 
+      if ((globalFlags & ReachabilityInfo.FlagUsedAsync) != 0 &&
+          config.coreSpec.esFeatures.esVersion < ESVersion.ES2017) {
+        _errors ::= AsyncWithoutES2017Support(from)
+      }
+
       if ((globalFlags & ReachabilityInfo.FlagUsedClassSuperClass) != 0) {
         _classSuperClassUsed.set(true)
       }

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -119,8 +119,9 @@ object Infos {
     final val FlagAccessedNewTarget = 1 << 1
     final val FlagAccessedImportMeta = 1 << 2
     final val FlagUsedExponentOperator = 1 << 3
-    final val FlagUsedClassSuperClass = 1 << 4
-    final val FlagNeedsDesugaring = 1 << 5
+    final val FlagUsedAsync = 1 << 4
+    final val FlagUsedClassSuperClass = 1 << 5
+    final val FlagNeedsDesugaring = 1 << 6
   }
 
   /** Things from a given class that are reached by one method. */
@@ -397,6 +398,9 @@ object Infos {
 
     def addUsedExponentOperator(): this.type =
       setFlag(ReachabilityInfo.FlagUsedExponentOperator)
+
+    def addUsedAsync(): this.type =
+      setFlag(ReachabilityInfo.FlagUsedAsync)
 
     def addUsedIntLongDivModByMaybeZero(): this.type =
       addInstantiatedClass(ArithmeticExceptionClass, StringArgConstructorName)
@@ -769,6 +773,10 @@ object Infos {
 
             case JSBinaryOp(JSBinaryOp.**, _, _) =>
               builder.addUsedExponentOperator()
+
+            case Closure(flags, _, _, _, _, _, _) =>
+              if (flags.async)
+                builder.addUsedAsync()
 
             case LoadJSConstructor(className) =>
               builder.addInstantiatedClass(className)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -314,7 +314,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     initToInline.fold {
       assert(className != ClassClass, s"java.lang.Class did not have an inlineable init")
       WithGlobals(
-          js.Function(arrow = false, Nil, None, js.Block(superCtorCallAndFieldDefs)))
+          js.Function(ClosureFlags.function, Nil, None, js.Block(superCtorCallAndFieldDefs)))
     } { initMethodDef =>
       val generatedInitMethodFunWithGlobals = {
         implicit val pos = initMethodDef.pos
@@ -354,7 +354,8 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     val dummyCtor = fileLevelVar(VarField.hh, genName(className))
 
     List(
-        js.JSDocConstructor(genConst(dummyCtor.ident, js.Function(false, Nil, None, js.Skip()))),
+        js.JSDocConstructor(
+            genConst(dummyCtor.ident, js.Function(ClosureFlags.function, Nil, None, js.Skip()))),
         dummyCtor.prototype := superCtor.prototype,
         genAssignPrototype(ctorVar, js.New(dummyCtor, Nil), localDeclPrototypeVar)
     )
@@ -523,7 +524,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     methodFun0WithGlobals.flatMap { methodFun0 =>
       val methodFun = if (namespace == MemberNamespace.Constructor) {
         // init methods have to return `this` so that we can chain them to `new`
-        js.Function(arrow = false, methodFun0.args, methodFun0.restParam, {
+        js.Function(ClosureFlags.function, methodFun0.args, methodFun0.restParam, {
           implicit val pos = methodFun0.body.pos
           js.Block(
               methodFun0.body,
@@ -1107,7 +1108,7 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
               exportsVarRef,
               js.StringLiteral(exportName),
               List(
-                  "get" -> js.Function(arrow = false, Nil, None, {
+                  "get" -> js.Function(ClosureFlags.function, Nil, None, {
                     js.Return(globalVar(VarField.t, field.name))
                   }),
                   "configurable" -> js.BooleanLiteral(true)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -20,7 +20,7 @@ import org.scalajs.ir.ScalaJSVersions
 import org.scalajs.ir.Position
 import org.scalajs.ir.Names._
 import org.scalajs.ir.OriginalName.NoOriginalName
-import org.scalajs.ir.Trees.{JSUnaryOp, JSBinaryOp}
+import org.scalajs.ir.Trees.{ClosureFlags, JSUnaryOp, JSBinaryOp}
 import org.scalajs.ir.Types._
 import org.scalajs.ir.WellKnownNames._
 
@@ -2127,7 +2127,7 @@ private[emitter] object CoreJSLib {
         MethodDef(static, name, args, restParam, body) <- members
       } yield {
         val target = if (static) classRef else prototypeFor(classRef)
-        genPropSelect(target, name) := Function(arrow = false, args, restParam, body)
+        genPropSelect(target, name) := Function(ClosureFlags.function, args, restParam, body)
       }
     }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/JSGen.scala
@@ -13,6 +13,7 @@
 package org.scalajs.linker.backend.emitter
 
 import org.scalajs.ir.Position
+import org.scalajs.ir.Trees.ClosureFlags
 
 import org.scalajs.linker.backend.javascript.Trees._
 import org.scalajs.linker.interface.ESVersion
@@ -117,7 +118,9 @@ private[emitter] final class JSGen(val config: Emitter.Config) {
    */
   def genArrowFunction(args: List[ParamDef], restParam: Option[ParamDef], body: Tree)(
       implicit pos: Position): Function = {
-    Function(esFeatures.esVersion >= ESVersion.ES2015, args, restParam, body)
+    val closureFlags =
+      ClosureFlags.function.withArrow(esFeatures.esVersion >= ESVersion.ES2015)
+    Function(closureFlags, args, restParam, body)
   }
 
   def genDefineProperty(obj: Tree, prop: Tree, descriptor: List[(String, Tree)])(

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -17,6 +17,7 @@ import scala.annotation.tailrec
 import org.scalajs.ir._
 import org.scalajs.ir.Names._
 import org.scalajs.ir.OriginalName.NoOriginalName
+import org.scalajs.ir.Trees.ClosureFlags
 import org.scalajs.ir.Types._
 import org.scalajs.ir.WellKnownNames._
 
@@ -294,8 +295,8 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
             if (mutable) {
               val x = Ident("x")
               genDefineProperty(exportsVarRef, name, List(
-                  "get" -> Function(arrow = false, Nil, None, Return(VarRef(ident))),
-                  "set" -> Function(arrow = false, List(ParamDef(x)), None, {
+                  "get" -> Function(ClosureFlags.function, Nil, None, Return(VarRef(ident))),
+                  "set" -> Function(ClosureFlags.function, List(ParamDef(x)), None, {
                       Assign(VarRef(ident), VarRef(x))
                   }),
                   "configurable" -> BooleanLiteral(true)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -591,9 +591,11 @@ object Printers {
           print("this")
           printSeparatorIfStat()
 
-        case Function(arrow, args, restParam, body) =>
-          if (arrow) {
+        case Function(flags, args, restParam, body) =>
+          if (flags.arrow) {
             print('(')
+            if (flags.async)
+              print("async ")
             printSig(args, restParam)
             print("=> ")
             body match {
@@ -611,7 +613,10 @@ object Printers {
             }
             print(')')
           } else {
-            print("(function")
+            if (flags.async)
+              print("(async function")
+            else
+              print("(function")
             printSig(args, restParam)
             printBlock(body)
             print(')')

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -20,6 +20,7 @@ import org.scalajs.ir
 import org.scalajs.ir.{OriginalName, Position}
 import org.scalajs.ir.OriginalName.NoOriginalName
 import org.scalajs.ir.Position.NoPosition
+import org.scalajs.ir.Trees.ClosureFlags
 
 object Trees {
   /* The case classes for JS Trees are sealed instead of final for historical
@@ -431,7 +432,15 @@ object Trees {
 
   sealed case class This()(implicit val pos: Position) extends Tree
 
-  sealed case class Function(arrow: Boolean, args: List[ParamDef],
+  /** Anonymous function.
+   *
+   *  For convenience to producers, `flags.typed` may or may not be true, and
+   *  is always ignored.
+   *
+   *  The other flags: `arrow` and `async`, are meaningful. They have the same
+   *  meaning as in `ir.Trees.Closure`.
+   */
+  sealed case class Function(flags: ClosureFlags, args: List[ParamDef],
       restParam: Option[ParamDef], body: Tree)(
       implicit val pos: Position) extends Tree
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -414,6 +414,7 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     addHelperImport(genFunctionID.jsNewNoArg, List(anyref), List(anyref))
     addHelperImport(genFunctionID.jsImportCall, List(anyref), List(anyref))
     addHelperImport(genFunctionID.jsImportMeta, Nil, List(anyref))
+    addHelperImport(genFunctionID.jsAwait, List(anyref), List(anyref))
     addHelperImport(genFunctionID.jsDelete, List(anyref, anyref), Nil)
     addHelperImport(genFunctionID.jsForInStart, List(anyref), List(anyref))
     addHelperImport(genFunctionID.jsForInNext, List(anyref), List(anyref, Int32))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CustomJSHelperBuilder.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CustomJSHelperBuilder.scala
@@ -179,7 +179,7 @@ class CustomJSHelperBuilder()(implicit ctx: WasmContext, pos: Position) {
       resolver.setResolved(allocatedName)
     }
 
-    val helperFun = js.Function(arrow = true, jsParamDefs.toList, None, body)
+    val helperFun = js.Function(ClosureFlags.arrow, jsParamDefs.toList, None, body)
     val wasmFunType = watpe.FunctionType(wasmParamTypes.toList, transformResultType(resultType))
     ctx.addCustomJSHelper(helperFun, wasmFunType)
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -15,6 +15,7 @@ package org.scalajs.linker.backend.wasmemitter
 import scala.concurrent.{ExecutionContext, Future}
 
 import org.scalajs.ir.Names._
+import org.scalajs.ir.Trees.ClosureFlags
 import org.scalajs.ir.Types._
 import org.scalajs.ir.OriginalName
 import org.scalajs.ir.Position
@@ -220,7 +221,7 @@ final class Emitter(config: Emitter.Config) {
       js.Return {
         val (argsParamDefs, restParamDef) = builder.genJSParamDefs(params, restParam)
         // Exported defs must be `function`s although they do not use their `this`
-        js.Function(arrow = false, argsParamDefs, restParamDef, {
+        js.Function(ClosureFlags.function, argsParamDefs, restParamDef, {
           js.Return(js.Apply(
               fRef,
               argsParamDefs.map(_.ref) ::: restParamDef.map(_.ref).toList
@@ -280,7 +281,7 @@ final class Emitter(config: Emitter.Config) {
       val decl = js.Let(ident, mutable = true, None)
       val exportStat = js.Export(List(ident -> js.ExportName(exportName)))
       val xParam = js.ParamDef(js.Ident("x"))
-      val setterFun = js.Function(arrow = true, List(xParam), None, {
+      val setterFun = js.Function(ClosureFlags.arrow, List(xParam), None, {
         js.Assign(js.VarRef(ident), xParam.ref)
       })
       val setterItem = js.StringLiteral(exportName) -> setterFun

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -157,6 +157,14 @@ const scalaJSHelpers = {
   jsNewNoArg: (constr) => new constr(),
   jsImportCall: (s) => import(s),
   jsImportMeta: () => import.meta,
+  jsAwait: (WebAssembly.Suspending ? new WebAssembly.Suspending((x) => x) : ((x) => {
+    /* This should not happen. We cannot get here without going through a
+     * `WebAssembly.promising()` function. If that one succeeded,
+     * `WebAssembly.Suspending` should also exist.
+     * TODO Remove this fallback when JSPI support is widespread.
+     */
+    throw new Error("Unexpected js.await() without JSPI support.");
+  })),
   jsDelete: (o, p) => { delete o[p]; },
   jsForInStart: function*(o) { for (var k in o) yield k; },
   jsForInNext: (g) => { var r = g.next(); return [r.value, r.done]; },

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -155,6 +155,7 @@ object VarGen {
     case object jsNewNoArg extends JSHelperFunctionID
     case object jsImportCall extends JSHelperFunctionID
     case object jsImportMeta extends JSHelperFunctionID
+    case object jsAwait extends JSHelperFunctionID
     case object jsDelete extends JSHelperFunctionID
     case object jsForInStart extends JSHelperFunctionID
     case object jsForInNext extends JSHelperFunctionID

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -790,8 +790,6 @@ private final class ClassDefChecker(classDef: ClassDef,
         checkTree(default, env)
 
       case JSAwait(arg) =>
-        if (!env.inAsync)
-          reportError(i"Illegal `await` outside of `async` closure")
         checkTree(arg, env)
 
       case Debugger() =>
@@ -1087,7 +1085,6 @@ private final class ClassDefChecker(classDef: ClassDef,
         .fromParams(captureParams ++ params ++ restParam)
         .withHasNewTarget(!flags.arrow)
         .withMaybeThisType(!flags.arrow, AnyType)
-        .withInAsync(flags.async)
       checkTree(body, bodyEnv)
     }
   }
@@ -1184,9 +1181,7 @@ object ClassDefChecker {
       /** Return types by label. */
       val returnLabels: Set[LabelName],
       /** Whether usages of `this` are restricted in this scope. */
-      val isThisRestricted: Boolean,
-      /** Whether we are in an `async` closure, where `await` expressions are valid. */
-      val inAsync: Boolean
+      val isThisRestricted: Boolean
   ) {
     import Env._
 
@@ -1209,17 +1204,13 @@ object ClassDefChecker {
     def withIsThisRestricted(isThisRestricted: Boolean): Env =
       copy(isThisRestricted = isThisRestricted)
 
-    def withInAsync(inAsync: Boolean): Env =
-      copy(inAsync = inAsync)
-
     private def copy(
       hasNewTarget: Boolean = hasNewTarget,
       locals: Map[LocalName, LocalDef] = locals,
       returnLabels: Set[LabelName] = returnLabels,
-      isThisRestricted: Boolean = isThisRestricted,
-      inAsync: Boolean = inAsync
+      isThisRestricted: Boolean = isThisRestricted
     ): Env = {
-      new Env(hasNewTarget, locals, returnLabels, isThisRestricted, inAsync)
+      new Env(hasNewTarget, locals, returnLabels, isThisRestricted)
     }
   }
 
@@ -1229,8 +1220,7 @@ object ClassDefChecker {
         hasNewTarget = false,
         locals = Map.empty,
         returnLabels = Set.empty,
-        isThisRestricted = false,
-        inAsync = false
+        isThisRestricted = false
       )
     }
 
@@ -1243,8 +1233,7 @@ object ClassDefChecker {
         hasNewTarget = false,
         paramLocalDefs.toMap,
         Set.empty,
-        isThisRestricted = false,
-        inAsync = false
+        isThisRestricted = false
       )
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -348,6 +348,9 @@ private final class IRChecker(unit: LinkingUnit, reporter: ErrorReporter,
           typecheckExpect(body, env, tpe)
         typecheckExpect(default, env, tpe)
 
+      case JSAwait(arg) =>
+        typecheckAny(arg, env)
+
       case Debugger() =>
 
       // Scala expressions

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -686,6 +686,25 @@ class AnalyzerTest {
   }
 
   @Test
+  def asyncWithoutES2017(): AsyncResult = await {
+    val classDefs = Seq(
+      mainTestClassDef {
+        Closure(ClosureFlags.arrow.withAsync(true), Nil, Nil, None, AnyType, int(5), Nil)
+      }
+    )
+
+    val moduleInitializer = MainTestModuleInitializers
+
+    val analysis = computeAnalysis(classDefs,
+        moduleInitializers = MainTestModuleInitializers,
+        config = StandardConfig().withESFeatures(_.withESVersion(ESVersion.ES2016)))
+
+    assertContainsError("AsyncWithoutES2017Support", analysis) {
+      case AsyncWithoutES2017Support(_) => true
+    }
+  }
+
+  @Test
   def importMetaWithoutESModule(): AsyncResult = await {
     val classDefs = Seq(
       classDef("A",

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -705,6 +705,25 @@ class AnalyzerTest {
   }
 
   @Test
+  def orphanAwaitWithoutWebAssembly(): AsyncResult = await {
+    val classDefs = Seq(
+      mainTestClassDef {
+        JSAwait(int(5))
+      }
+    )
+
+    val moduleInitializer = MainTestModuleInitializers
+
+    val analysis = computeAnalysis(classDefs,
+        moduleInitializers = MainTestModuleInitializers,
+        config = StandardConfig().withESFeatures(_.withESVersion(ESVersion.ES2017)))
+
+    assertContainsError("OrphanAwaitWithoutWebAssembly", analysis) {
+      case OrphanAwaitWithoutWebAssembly(_) => true
+    }
+  }
+
+  @Test
   def importMetaWithoutESModule(): AsyncResult = await {
     val classDefs = Seq(
       classDef("A",

--- a/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/backend/javascript/PrintersTest.scala
@@ -20,6 +20,7 @@ import org.junit.Test
 import org.junit.Assert._
 
 import org.scalajs.ir
+import org.scalajs.ir.Trees.ClosureFlags
 
 import Trees._
 
@@ -100,7 +101,7 @@ class PrintersTest {
         |ctor = (function() {
         |});
       """,
-      JSDocConstructor(Assign(VarRef("ctor"), Function(false, Nil, None, Skip())))
+      JSDocConstructor(Assign(VarRef("ctor"), Function(ClosureFlags.function, Nil, None, Skip())))
     )
   }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2260,6 +2260,8 @@ object Build {
             esVersion >= ESVersion.ES2016) :::
         includeIf(testDir / "require-async-await",
             esVersion >= ESVersion.ES2017) :::
+        includeIf(testDir / "require-orphan-await",
+            esVersion >= ESVersion.ES2017 && isWebAssembly) :::
         includeIf(testDir / "require-modules",
             hasModules) :::
         includeIf(testDir / "require-no-modules",

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -250,6 +250,7 @@ object MyScalaJSPlugin extends AutoPlugin {
           baseConfig.withArgs(List(
             "--experimental-wasm-exnref",
             "--experimental-wasm-imported-strings", // for JS string builtins
+            "--experimental-wasm-jspi", // for JSPI, used by async/await
             /* Force using the Turboshaft infrastructure for the optimizing compiler.
              * It appears to be more stable for the Wasm that we throw at it.
              * If you remove it, try running `scalaTestSuite2_13/test` with Wasm.
@@ -2257,6 +2258,8 @@ object Build {
             esVersion >= ESVersion.ES2015) :::
         includeIf(testDir / "require-exponent-op",
             esVersion >= ESVersion.ES2016) :::
+        includeIf(testDir / "require-async-await",
+            esVersion >= ESVersion.ES2017) :::
         includeIf(testDir / "require-modules",
             hasModules) :::
         includeIf(testDir / "require-no-modules",

--- a/test-suite/js/src/test/require-async-await/org/scalajs/testsuite/jsinterop/JSAsyncAwaitTest.scala
+++ b/test-suite/js/src/test/require-async-await/org/scalajs/testsuite/jsinterop/JSAsyncAwaitTest.scala
@@ -1,0 +1,148 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters._
+import scala.scalajs.js.|
+
+import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.scalajs.junit.async._
+
+class JSAsyncAwaitTest {
+  @Test
+  def basic(): AsyncResult = await {
+    val buf = new ArrayBuffer[String]()
+
+    val px = js.Promise.resolve[Int](5)
+
+    buf += "before"
+    val p = js.async {
+      buf += "start async"
+      val x = js.await(px)
+      buf += s"got x: $x"
+      x + 13
+    }
+    buf += "after"
+
+    assertArrayEquals(
+        Array[AnyRef]("before", "start async", "after"),
+        buf.toArray[AnyRef])
+
+    p.toFuture.map { (result: Int) =>
+      assertEquals(18, result)
+
+      assertArrayEquals(
+          Array[AnyRef]("before", "start async", "after", "got x: 5"),
+          buf.toArray[AnyRef])
+    }
+  }
+
+  @Test
+  def loop(): AsyncResult = await {
+    val buf = new ArrayBuffer[String]()
+
+    val inputs = (1 to 5).toList
+    val inputPromises = inputs.map(i => js.Promise.resolve[Int](i))
+
+    buf += "before"
+    val p = js.async {
+      buf += "start async"
+      var rest = inputPromises
+      while (!rest.isEmpty) {
+        val x = js.await(rest.head)
+        buf += x.toString()
+        rest = rest.tail
+      }
+      buf += "done"
+    }
+    buf += "after"
+
+    assertArrayEquals(
+        Array[AnyRef]("before", "start async", "after"),
+        buf.toArray[AnyRef])
+
+    p.toFuture.map { _ =>
+      assertArrayEquals(
+          ("before" :: "start async" :: "after" :: inputs.map(_.toString()) ::: "done" :: Nil).toArray[AnyRef],
+          buf.toArray[AnyRef])
+    }
+  }
+
+  @Test
+  def tryCatch(): AsyncResult = await {
+    val successfulInput = js.Promise.resolve[Int](42)
+    val failedInput: js.Promise[Int] = js.Promise.reject(new IllegalArgumentException("nope"))
+
+    val p = js.async {
+      val result1 = try {
+        js.await(successfulInput)
+      } catch {
+        case e: IllegalArgumentException =>
+          throw new AssertionError(e)
+      }
+      val result2 = try {
+        js.await(failedInput)
+        throw new AssertionError("awaiting a failed Promise did not throw")
+      } catch {
+        case e: IllegalArgumentException =>
+          56
+      }
+      (result1, result2)
+    }
+
+    p.toFuture.map { case (result1, result2) =>
+      assertEquals(42, result1)
+      assertEquals(56, result2)
+    }
+  }
+
+  @Test
+  def tryFinally(): AsyncResult = await {
+    val successfulInput = js.Promise.resolve[Int](42)
+    val failedInput: js.Promise[Int] = js.Promise.reject(new IllegalArgumentException("nope"))
+
+    val buf = new ArrayBuffer[String]()
+
+    val p: js.Promise[Int] = js.async {
+      val result1 = try {
+        js.await(successfulInput)
+      } finally {
+        buf += "first"
+      }
+      assertEquals(42, result1)
+      val result2 = try {
+        js.await(failedInput)
+        throw new AssertionError("awaiting a failed Promise did not throw")
+      } finally {
+        buf += "second"
+      }
+      throw new AssertionError("did not rethrow after the finally")
+    }
+
+    p.toFuture.failed.map { e =>
+      assertTrue(e.toString(), e.isInstanceOf[IllegalArgumentException])
+      assertArrayEquals(
+          Array[AnyRef]("first", "second"),
+          buf.toArray[AnyRef])
+    }
+  }
+}

--- a/test-suite/js/src/test/require-orphan-await/org/scalajs/testsuite/jsinterop/JSOrphanAwaitTest.scala
+++ b/test-suite/js/src/test/require-orphan-await/org/scalajs/testsuite/jsinterop/JSOrphanAwaitTest.scala
@@ -1,0 +1,89 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.jsinterop
+
+import scala.scalajs.js
+import scala.scalajs.js.JSConverters._
+import scala.scalajs.js.|
+
+import scala.scalajs.js.wasm.JSPI.allowOrphanJSAwait
+
+import scala.concurrent.{Future, ExecutionContext}
+import scala.concurrent.ExecutionContext.Implicits.global
+
+import scala.collection.mutable.ArrayBuffer
+
+import org.junit.Assert._
+import org.junit.Assume._
+import org.junit.Test
+
+import org.scalajs.junit.async._
+
+class JSOrphanAwaitTest {
+  @Test
+  def basic(): AsyncResult = await {
+    @noinline
+    def foo(p: js.Promise[Int]): Int =
+      js.await(p) * 3
+
+    val p = js.Promise.resolve[Int](13).`then`(
+        (i => i + 1): js.Function1[Int, Int | js.Thenable[Int]])
+
+    val result = js.async {
+      foo(p) - 1
+    }
+
+    result.toFuture.map { (result: Int) =>
+      assertEquals(((13 + 1) * 3) - 1, result)
+    }
+  }
+
+  @Test
+  def throughClosure(): AsyncResult = await {
+    @noinline
+    def foo(p: js.Promise[Int])(op: js.Promise[Int] => Int): Int =
+      op(p)
+
+    val p = js.Promise.resolve[Int](13).`then`(
+        (i => i + 1): js.Function1[Int, Int | js.Thenable[Int]])
+
+    val result = js.async {
+      foo(p)(p2 => js.await(p2) * 3) - 1
+    }
+
+    result.toFuture.map { (result: Int) =>
+      assertEquals(((13 + 1) * 3) - 1, result)
+    }
+  }
+
+  /* TODO Enable this test when browsers and Node.js implement the latest spec,
+   * with SuspendError. At the time of writing, it passed in Chrome Canary.
+   */
+  @Test
+  @org.junit.Ignore
+  def suspendError(): AsyncResult = await {
+    val p = js.Promise.resolve[Int](13)
+
+    Future {
+      try {
+        js.await(p)
+        throw new AssertionError(
+            "js.await without an enclosing js.async should throw SuspendError")
+      } catch {
+        case js.JavaScriptException(e: js.Error) =>
+          assertEquals("SuspendError", e.name)
+          assertTrue(js.special.instanceof(e, js.Dynamic.global.WebAssembly.SuspendError))
+      }
+    }
+  }
+}


### PR DESCRIPTION
We introduce a new pair of primitive methods, `js.async` and `js.await`. They correspond to JavaScript `async` functions and `await` expressions.

`js.await(p)` awaits a `Promise`, but it must be directly scoped within a `js.async { ... }` block.

---

At the IR level, `js.await(p)` directly translates to a dedicated IR node `JSAwait(arg)`. `js.async` blocks don't have a direct representation. Instead, the IR models `async function`s and `async =>`functions, as `Closure`s with an additionnal `async` flag. This corresponds to the JavaScript model for `async/await`.

A `js.async { body }` block therefore corresponds to an immediately-applied `async Closure`, which in JavaScript would be written as `(async () => body)()`.

---

On the JavaScript platform, async `Closure`s and `JSAwait` are directly compiled as their JavaScript equivalent.

On WebAssembly, we leverage the JavaScript Promise Integration feature (JSPI). We turn async `Closure`s into `WebAssembly.promising` functions. `js.await(p)` is compiled as a call to a unique `jsAwait` helper, which is declared as an "identity" `new WebAssembly.Suspending((x) => x)`. The static scoping rule of `js.await` guarantees that the suspending call is always performed in a valid context (one that will not throw a `WebAssembly.SuspendError`).

---

We then optionally allow orphan `js.await(p)` on WebAssembly.

With the JavaScript Promise Integration (JSPI), there can be as many frames as we want between a `WebAssembly.promising` function and the corresponding `WebAssembly.Suspending` calls. The former is introduced by our `js.async` blocks, and the latter by calls to `js.await`.

Normally, `js.await` must be directly enclosed within a `js.async` block. This ensures that it can be compiled to a JavaScript `async` function and `await` expression.

~~We introduce a compiler option to allow "orphan awaits". This way, we can decouple the `js.await` calls from their `js.async` blocks. The generated IR will then only link when targeting WebAssembly.~~
We introduce a sort of "language import" to allow "orphan awaits". This way, we can decouple the `js.await` calls from their `js.async` blocks. The generated IR will then only link when targeting WebAssembly. Technically, `js.await` requires an implicit `js.AwaitPermit`. The default one only allows `js.await` directly inside `js.async`, and we can import a stronger one that allows orphan awaits.

There must still be a `js.async` block *dynamically* enclosing any `js.await` call (on the call stack), without intervening JS frame. If that dynamic property is not satisfied, a `WebAssembly.SuspendError` gets thrown. This last point is not yet implemented in Node.js at the time of this commit; instead such a situation traps. The corresponding test is therefore currently ignored.