### PR TITLE
JUnit: populate sbt.testing.Event.duration

### DIFF
--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertEquals2Test.test started
 leTest org.scalajs.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEquals2Test.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertEquals2Test.test started
 leTest org.scalajs.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEquals2Test.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEquals2Test.test started
 leTest org.scalajs.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEquals2Test.test started
 leTest org.scalajs.junit.AssertEquals2Test.test failed: java.lang.AssertionError: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEquals2Test.test started
 leTest org.scalajs.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEquals2Test.test started
 leTest org.scalajs.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEquals2Test[0m.[31mtest[0m failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEquals2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEquals2TestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEquals2Test.test started
 leTest org.scalajs.junit.AssertEquals2Test.test failed: This is the message expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEquals2Test.test::java.lang.AssertionError: This is the message expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEquals2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_.txt
@@ -1,23 +1,23 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_a.txt
@@ -1,23 +1,23 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: java.lang.[31mAssertionError[0m: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: java.lang.[31mAssertionError[0m: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_n.txt
@@ -1,23 +1,23 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ldTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_na.txt
@@ -1,23 +1,23 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble failed: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 ldTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_nv.txt
@@ -1,23 +1,23 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_nva.txt
@@ -1,23 +1,23 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble failed: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_nvc.txt
@@ -1,23 +1,23 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_nvca.txt
@@ -1,23 +1,23 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_v.txt
@@ -1,23 +1,23 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_va.txt
@@ -1,23 +1,23 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: java.lang.[31mAssertionError[0m: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: java.lang.[31mAssertionError[0m: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_vc.txt
@@ -1,23 +1,23 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_vs.txt
@@ -1,23 +1,23 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDouble[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDouble[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m started
 leTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[31mfailsWithDoubleMessage[0m failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mfailsWithDoubleMessage[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithByte[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithEpsilon[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithInt[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m started
 ldTest org.scalajs.junit.[33mAssertEqualsDoubleTest[0m.[36mworksWithShort[0m finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 6 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsDoubleTestAssertions_vsn.txt
@@ -1,23 +1,23 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDouble finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage started
 leTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage failed: Use assertEquals(expected, actual, delta) to compare floating-point numbers, took <TIME>
-e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers
+e2org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage::java.lang.AssertionError: Use assertEquals(expected, actual, delta) to compare floating-point numbers::true
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.failsWithDoubleMessage finished, took <TIME>
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithByte::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithEpsilon::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithInt::::true
 liTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort started
 ldTest org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort finished, took <TIME>
-e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::
+e0org.scalajs.junit.AssertEqualsDoubleTest.worksWithShort::::true
 liTest run finished: 2 failed, 0 ignored, 6 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertEqualsTest.test started
 leTest org.scalajs.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEqualsTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertEqualsTest.test started
 leTest org.scalajs.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEqualsTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsTest.test started
 leTest org.scalajs.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsTest.test started
 leTest org.scalajs.junit.AssertEqualsTest.test failed: java.lang.AssertionError: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsTest.test started
 leTest org.scalajs.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsTest.test started
 leTest org.scalajs.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertEqualsTest[0m.[31mtest[0m failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.[33mAssertEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertEqualsTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertEqualsTest.test started
 leTest org.scalajs.junit.AssertEqualsTest.test failed: expected:<false> but was:<true>, took <TIME>
-e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>
+e2org.scalajs.junit.AssertEqualsTest.test::java.lang.AssertionError: expected:<false> but was:<true>::true
 ldTest org.scalajs.junit.AssertEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertFalse2Test.test started
 leTest org.scalajs.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.AssertFalse2Test.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertFalse2Test.test started
 leTest org.scalajs.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.AssertFalse2Test.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalse2Test.test started
 leTest org.scalajs.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalse2Test.test started
 leTest org.scalajs.junit.AssertFalse2Test.test failed: java.lang.AssertionError: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalse2Test.test started
 leTest org.scalajs.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalse2Test.test started
 leTest org.scalajs.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalse2Test[0m.[31mtest[0m failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.[33mAssertFalse2Test[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalse2TestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalse2Test.test started
 leTest org.scalajs.junit.AssertFalse2Test.test failed: This is the message, took <TIME>
-e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message
+e2org.scalajs.junit.AssertFalse2Test.test::java.lang.AssertionError: This is the message::true
 ldTest org.scalajs.junit.AssertFalse2Test.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertFalseTest.test started
 leTest org.scalajs.junit.AssertFalseTest.test failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertFalseTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertFalseTest.test started
 leTest org.scalajs.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertFalseTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalseTest.test started
 leTest org.scalajs.junit.AssertFalseTest.test failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertFalseTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalseTest.test started
 leTest org.scalajs.junit.AssertFalseTest.test failed: java.lang.AssertionError: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertFalseTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalseTest.test started
 leTest org.scalajs.junit.AssertFalseTest.test failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertFalseTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalseTest.test started
 leTest org.scalajs.junit.AssertFalseTest.test failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertFalseTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertFalseTest[0m.[31mtest[0m failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertFalseTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertFalseTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertFalseTest.test started
 leTest org.scalajs.junit.AssertFalseTest.test failed: null, took <TIME>
-e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError
+e2org.scalajs.junit.AssertFalseTest.test::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertFalseTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertStringEqualsTest.test started
 leTest org.scalajs.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.AssertStringEqualsTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertStringEqualsTest.test started
 leTest org.scalajs.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.AssertStringEqualsTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertStringEqualsTest.test started
 leTest org.scalajs.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertStringEqualsTest.test started
 leTest org.scalajs.junit.AssertStringEqualsTest.test failed: org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertStringEqualsTest.test started
 leTest org.scalajs.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertStringEqualsTest.test started
 leTest org.scalajs.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: org.junit.[31mComparisonFailure[0m: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[31mtest[0m failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.[33mAssertStringEqualsTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertStringEqualsTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssertStringEqualsTest.test started
 leTest org.scalajs.junit.AssertStringEqualsTest.test failed: expected:<foob[a]r> but was:<foob[bb]r>, took <TIME>
-e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>
+e2org.scalajs.junit.AssertStringEqualsTest.test::org.junit.ComparisonFailure: expected:<foob[a]r> but was:<foob[bb]r>::true
 ldTest org.scalajs.junit.AssertStringEqualsTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_.txt
@@ -1,10 +1,10 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest org.scalajs.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_a.txt
@@ -1,10 +1,10 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest org.scalajs.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_n.txt
@@ -1,10 +1,10 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertTrueTest.failTest started
 leTest org.scalajs.junit.AssertTrueTest.failTest failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertTrueTest.failTest finished, took <TIME>
 ldTest org.scalajs.junit.AssertTrueTest.successTest started
 ldTest org.scalajs.junit.AssertTrueTest.successTest finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 ldTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_na.txt
@@ -1,10 +1,10 @@
 ldTest run started
 ldTest org.scalajs.junit.AssertTrueTest.failTest started
 leTest org.scalajs.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertTrueTest.failTest finished, took <TIME>
 ldTest org.scalajs.junit.AssertTrueTest.successTest started
 ldTest org.scalajs.junit.AssertTrueTest.successTest finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 ldTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_nv.txt
@@ -1,10 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssertTrueTest.failTest started
 leTest org.scalajs.junit.AssertTrueTest.failTest failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest org.scalajs.junit.AssertTrueTest.successTest started
 ldTest org.scalajs.junit.AssertTrueTest.successTest finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_nva.txt
@@ -1,10 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssertTrueTest.failTest started
 leTest org.scalajs.junit.AssertTrueTest.failTest failed: java.lang.AssertionError: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest org.scalajs.junit.AssertTrueTest.successTest started
 ldTest org.scalajs.junit.AssertTrueTest.successTest finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_nvc.txt
@@ -1,10 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssertTrueTest.failTest started
 leTest org.scalajs.junit.AssertTrueTest.failTest failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest org.scalajs.junit.AssertTrueTest.successTest started
 ldTest org.scalajs.junit.AssertTrueTest.successTest finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_nvca.txt
@@ -1,10 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssertTrueTest.failTest started
 leTest org.scalajs.junit.AssertTrueTest.failTest failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest org.scalajs.junit.AssertTrueTest.successTest started
 ldTest org.scalajs.junit.AssertTrueTest.successTest finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_v.txt
@@ -1,10 +1,10 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest org.scalajs.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_va.txt
@@ -1,10 +1,10 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest org.scalajs.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: java.lang.[31mAssertionError[0m: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_vc.txt
@@ -1,10 +1,10 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest org.scalajs.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_vs.txt
@@ -1,10 +1,10 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m started
 leTest org.scalajs.junit.[33mAssertTrueTest[0m.[31mfailTest[0m failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36mfailTest[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m started
 ldTest org.scalajs.junit.[33mAssertTrueTest[0m.[36msuccessTest[0m finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssertTrueTestAssertions_vsn.txt
@@ -1,10 +1,10 @@
 liTest run started
 liTest org.scalajs.junit.AssertTrueTest.failTest started
 leTest org.scalajs.junit.AssertTrueTest.failTest failed: null, took <TIME>
-e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError
+e2org.scalajs.junit.AssertTrueTest.failTest::java.lang.AssertionError::true
 ldTest org.scalajs.junit.AssertTrueTest.failTest finished, took <TIME>
 liTest org.scalajs.junit.AssertTrueTest.successTest started
 ldTest org.scalajs.junit.AssertTrueTest.successTest finished, took <TIME>
-e0org.scalajs.junit.AssertTrueTest.successTest::
+e0org.scalajs.junit.AssertTrueTest.successTest::::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_.txt
@@ -2,7 +2,7 @@ ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_a.txt
@@ -2,7 +2,7 @@ ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_n.txt
@@ -2,7 +2,7 @@ ldTest run started
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_na.txt
@@ -2,7 +2,7 @@ ldTest run started
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nv.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nva.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nvc.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_nvca.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_v.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_va.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vc.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vs.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterAssume[0m.[36massumeFail[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterAssumeAssertions_vsn.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.AssumeAfterAssume.assumeFail started
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.AssumeAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.AssumeAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterAssume.assumeFail finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_.txt
@@ -1,8 +1,8 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_a.txt
@@ -1,8 +1,8 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_n.txt
@@ -1,8 +1,8 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_na.txt
@@ -1,8 +1,8 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nv.txt
@@ -1,8 +1,8 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nva.txt
@@ -1,8 +1,8 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nvc.txt
@@ -1,8 +1,8 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_nvca.txt
@@ -1,8 +1,8 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_v.txt
@@ -1,8 +1,8 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_va.txt
@@ -1,8 +1,8 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vc.txt
@@ -1,8 +1,8 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vs.txt
@@ -1,8 +1,8 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mAssumeAfterClassTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.[33mAssumeAfterClassTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterClassTestAssertions_vsn.txt
@@ -1,8 +1,8 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterClassTest.test started
 ldTest org.scalajs.junit.AssumeAfterClassTest.test finished, took <TIME>
-e0org.scalajs.junit.AssumeAfterClassTest.test::
+e0org.scalajs.junit.AssumeAfterClassTest.test::::true
 lwTest assumption in test org.scalajs.junit.AssumeAfterClassTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeAfterClassTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.AssumeAfterException.test failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.[33mAssumeAfterException[0m.[31mtest[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.[33mAssumeAfterException[0m.[36mtest[0m finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeAfterExceptionAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeAfterException.test started
 leTest org.scalajs.junit.AssumeAfterException.test failed: java.lang.IllegalArgumentException: test throws, took <TIME>
-e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws
+e2org.scalajs.junit.AssumeAfterException.test::java.lang.IllegalArgumentException: test throws::true
 leTest org.scalajs.junit.AssumeAfterException.test failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
 ldTest org.scalajs.junit.AssumeAfterException.test finished, took <TIME>

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeInAfter.test started
 lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeInAfter.test started
 lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeInAfter.test started
 lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeInAfter.test started
 lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeInAfter.test started
 lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeInAfter.test started
 lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeInAfter[0m.[31mtest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeInAfter[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeInAfterAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeInAfter.test started
 lwTest assumption in test org.scalajs.junit.AssumeInAfter.test failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeInAfter.test::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeInAfter.test finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeTest.assumeFail started
 lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.AssumeTest.assumeFail started
 lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeTest.assumeFail started
 lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeTest.assumeFail started
 lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeTest.assumeFail started
 lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeTest.assumeFail started
 lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m started
 lwTest assumption in test org.scalajs.junit.[33mAssumeTest[0m.[31massumeFail[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mAssumeTest[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AssumeTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.AssumeTest.assumeFail started
 lwTest assumption in test org.scalajs.junit.AssumeTest.assumeFail failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.AssumeTest.assumeFail::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.AssumeTest.assumeFail finished, took <TIME>
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_.txt
@@ -1,13 +1,13 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest org.scalajs.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_a.txt
@@ -1,13 +1,13 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest org.scalajs.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_n.txt
@@ -1,13 +1,13 @@
 ldTest run started
 ldTest org.scalajs.junit.AsyncTest.asyncFailure started
 leTest org.scalajs.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.AsyncTest.asyncFailure finished, took <TIME>
 ldTest org.scalajs.junit.AsyncTest.expectedException started
 ldTest org.scalajs.junit.AsyncTest.expectedException finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 ldTest org.scalajs.junit.AsyncTest.success started
 ldTest org.scalajs.junit.AsyncTest.success finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 ldTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_na.txt
@@ -1,13 +1,13 @@
 ldTest run started
 ldTest org.scalajs.junit.AsyncTest.asyncFailure started
 leTest org.scalajs.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.AsyncTest.asyncFailure finished, took <TIME>
 ldTest org.scalajs.junit.AsyncTest.expectedException started
 ldTest org.scalajs.junit.AsyncTest.expectedException finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 ldTest org.scalajs.junit.AsyncTest.success started
 ldTest org.scalajs.junit.AsyncTest.success finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 ldTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_nv.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.AsyncTest.asyncFailure started
 leTest org.scalajs.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest org.scalajs.junit.AsyncTest.expectedException started
 ldTest org.scalajs.junit.AsyncTest.expectedException finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.AsyncTest.success started
 ldTest org.scalajs.junit.AsyncTest.success finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_nva.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.AsyncTest.asyncFailure started
 leTest org.scalajs.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest org.scalajs.junit.AsyncTest.expectedException started
 ldTest org.scalajs.junit.AsyncTest.expectedException finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.AsyncTest.success started
 ldTest org.scalajs.junit.AsyncTest.success finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_nvc.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.AsyncTest.asyncFailure started
 leTest org.scalajs.junit.AsyncTest.asyncFailure failed: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest org.scalajs.junit.AsyncTest.expectedException started
 ldTest org.scalajs.junit.AsyncTest.expectedException finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.AsyncTest.success started
 ldTest org.scalajs.junit.AsyncTest.success finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_nvca.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.AsyncTest.asyncFailure started
 leTest org.scalajs.junit.AsyncTest.asyncFailure failed: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest org.scalajs.junit.AsyncTest.expectedException started
 ldTest org.scalajs.junit.AsyncTest.expectedException finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.AsyncTest.success started
 ldTest org.scalajs.junit.AsyncTest.success finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_v.txt
@@ -1,13 +1,13 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest org.scalajs.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_va.txt
@@ -1,13 +1,13 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest org.scalajs.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_vc.txt
@@ -1,13 +1,13 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest org.scalajs.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_vs.txt
@@ -1,13 +1,13 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m started
 leTest org.scalajs.junit.[33mAsyncTest[0m.[31masyncFailure[0m failed: java.lang.[31mIllegalArgumentException[0m: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36masyncFailure[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36mexpectedException[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m started
 ldTest org.scalajs.junit.[33mAsyncTest[0m.[36msuccess[0m finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/AsyncTestAssertions_vsn.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.AsyncTest.asyncFailure started
 leTest org.scalajs.junit.AsyncTest.asyncFailure failed: java.lang.IllegalArgumentException: null, took <TIME>
-e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException
+e2org.scalajs.junit.AsyncTest.asyncFailure::java.lang.IllegalArgumentException::true
 ldTest org.scalajs.junit.AsyncTest.asyncFailure finished, took <TIME>
 liTest org.scalajs.junit.AsyncTest.expectedException started
 ldTest org.scalajs.junit.AsyncTest.expectedException finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.expectedException::
+e0org.scalajs.junit.AsyncTest.expectedException::::true
 liTest org.scalajs.junit.AsyncTest.success started
 ldTest org.scalajs.junit.AsyncTest.success finished, took <TIME>
-e0org.scalajs.junit.AsyncTest.success::
+e0org.scalajs.junit.AsyncTest.success::::true
 liTest run finished: 1 failed, 0 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.BeforeAndAfterTest.test started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.BeforeAndAfterTest.test started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.BeforeAndAfterTest.test started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.BeforeAndAfterTest.test started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m started
 ldTest org.scalajs.junit.[33mBeforeAndAfterTest[0m.[36mtest[0m finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAndAfterTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.BeforeAndAfterTest.test started
 ldTest org.scalajs.junit.BeforeAndAfterTest.test finished, took <TIME>
-e0org.scalajs.junit.BeforeAndAfterTest.test::
+e0org.scalajs.junit.BeforeAndAfterTest.test::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run started
 lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run started
 lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/BeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.BeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.BeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_.txt
@@ -2,7 +2,7 @@ ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_a.txt
@@ -2,7 +2,7 @@ ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_n.txt
@@ -2,7 +2,7 @@ ldTest run started
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_na.txt
@@ -2,7 +2,7 @@ ldTest run started
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nv.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nva.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nvc.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_nvca.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_v.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_va.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vc.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vs.txt
@@ -2,7 +2,7 @@ li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m started
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: org.junit.[31mTestCouldNotBeSkippedException[0m: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[31massumeFail[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionAfterAssume[0m.[36massumeFail[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterAssumeAssertions_vsn.txt
@@ -2,7 +2,7 @@ liTest run started
 liTest org.scalajs.junit.ExceptionAfterAssume.assumeFail started
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures, took <TIME>
 leCaused by: org.junit.AssumptionViolatedException: This assume should not pass
-e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures
+e2org.scalajs.junit.ExceptionAfterAssume.assumeFail::org.junit.TestCouldNotBeSkippedException: Test could not be skipped due to other failures::true
 leTest org.scalajs.junit.ExceptionAfterAssume.assumeFail failed: java.lang.IllegalArgumentException: after() must be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionAfterAssume.assumeFail finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_.txt
@@ -1,11 +1,11 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_a.txt
@@ -1,11 +1,11 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_n.txt
@@ -1,11 +1,11 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ldTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_na.txt
@@ -1,11 +1,11 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 ldTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_nv.txt
@@ -1,11 +1,11 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterClass.test1 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.ExceptionAfterClass.test2 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_nva.txt
@@ -1,11 +1,11 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterClass.test1 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.ExceptionAfterClass.test2 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_nvc.txt
@@ -1,11 +1,11 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterClass.test1 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.ExceptionAfterClass.test2 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.ExceptionAfterClass failed: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_nvca.txt
@@ -1,11 +1,11 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterClass.test1 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.ExceptionAfterClass.test2 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.ExceptionAfterClass failed: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_v.txt
@@ -1,11 +1,11 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_va.txt
@@ -1,11 +1,11 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_vc.txt
@@ -1,11 +1,11 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.[33mExceptionAfterClass[0m failed: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_vs.txt
@@ -1,11 +1,11 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest1[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m started
 ldTest org.scalajs.junit.[33mExceptionAfterClass[0m.[36mtest2[0m finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.[33mExceptionAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionAfterClassAssertions_vsn.txt
@@ -1,11 +1,11 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionAfterClass.test1 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test1 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test1::
+e0org.scalajs.junit.ExceptionAfterClass.test1::::true
 liTest org.scalajs.junit.ExceptionAfterClass.test2 started
 ldTest org.scalajs.junit.ExceptionAfterClass.test2 finished, took <TIME>
-e0org.scalajs.junit.ExceptionAfterClass.test2::
+e0org.scalajs.junit.ExceptionAfterClass.test2::::true
 leTest org.scalajs.junit.ExceptionAfterClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionAfterClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: java.lang.AssertionError: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: after, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: after, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mAssertionError[0m: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: after, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.[33mExceptionBeforeAndAfterClass[0m failed: java.lang.[31mIllegalArgumentException[0m: after, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeAndAfterClassAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: before, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before
+e2org.scalajs.junit.ExceptionBeforeAndAfterClass::java.lang.AssertionError: before::true
 leTest org.scalajs.junit.ExceptionBeforeAndAfterClass failed: java.lang.IllegalArgumentException: after, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run started
 leTest org.scalajs.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ldTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run started
 leTest org.scalajs.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 ldTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeClass failed: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeClass failed: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeClass[0m failed: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionBeforeClass[0m failed: java.lang.[31mIllegalArgumentException[0m: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionBeforeClassAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionBeforeClass failed: java.lang.IllegalArgumentException: foo, took <TIME>
-e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo
+e2org.scalajs.junit.ExceptionBeforeClass::java.lang.IllegalArgumentException: foo::true
 liTest run finished: 1 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 leTest org.scalajs.junit.ExceptionEverywhere failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.ExceptionEverywhere failed: after class, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 leTest org.scalajs.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionEverywhere failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.ExceptionEverywhere failed: after class, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionEverywhere failed: java.lang.AssertionError: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.ExceptionEverywhere failed: java.lang.AssertionError: after class, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionEverywhere failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.ExceptionEverywhere failed: after class, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionEverywhere failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.ExceptionEverywhere failed: after class, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: java.lang.[31mAssertionError[0m: after class, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.[33mExceptionEverywhere[0m failed: after class, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionEverywhereAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 leTest org.scalajs.junit.ExceptionEverywhere failed: before class, took <TIME>
-e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class
+e2org.scalajs.junit.ExceptionEverywhere::java.lang.AssertionError: before class::true
 leTest org.scalajs.junit.ExceptionEverywhere failed: after class, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionInAfterTest.test started
 leTest org.scalajs.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.ExceptionInAfterTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionInAfterTest.test started
 leTest org.scalajs.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.ExceptionInAfterTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInAfterTest.test started
 leTest org.scalajs.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInAfterTest.test started
 leTest org.scalajs.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInAfterTest.test started
 leTest org.scalajs.junit.ExceptionInAfterTest.test failed: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInAfterTest.test started
 leTest org.scalajs.junit.ExceptionInAfterTest.test failed: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.[33mExceptionInAfterTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInAfterTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInAfterTest.test started
 leTest org.scalajs.junit.ExceptionInAfterTest.test failed: java.lang.UnsupportedOperationException: Exception in after(), took <TIME>
-e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()
+e2org.scalajs.junit.ExceptionInAfterTest.test::java.lang.UnsupportedOperationException: Exception in after()::true
 ldTest org.scalajs.junit.ExceptionInAfterTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test started
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test started
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test finished, took <TIME>
 ldTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInBeforeTest.test started
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInBeforeTest.test started
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInBeforeTest.test started
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInBeforeTest.test started
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[31mtest[0m failed: java.lang.[31mIllegalArgumentException[0m: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.[33mExceptionInBeforeTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m2 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInBeforeTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInBeforeTest.test started
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.UnsupportedOperationException: Exception in before(), took <TIME>
-e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()
+e2org.scalajs.junit.ExceptionInBeforeTest.test::java.lang.UnsupportedOperationException: Exception in before()::true
 leTest org.scalajs.junit.ExceptionInBeforeTest.test failed: java.lang.IllegalArgumentException: after() must actually be called, took <TIME>
 ldTest org.scalajs.junit.ExceptionInBeforeTest.test finished, took <TIME>
 liTest run finished: 2 failed, 0 ignored, 1 total, <TIME>

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test started
 leTest org.scalajs.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test started
 leTest org.scalajs.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInConstructorTest.test started
 leTest org.scalajs.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInConstructorTest.test started
 leTest org.scalajs.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInConstructorTest.test started
 leTest org.scalajs.junit.ExceptionInConstructorTest.test failed: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInConstructorTest.test started
 leTest org.scalajs.junit.ExceptionInConstructorTest.test failed: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[31mtest[0m failed: java.lang.[31mUnsupportedOperationException[0m: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.[33mExceptionInConstructorTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionInConstructorTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionInConstructorTest.test started
 leTest org.scalajs.junit.ExceptionInConstructorTest.test failed: java.lang.UnsupportedOperationException: Exception while constructing the test class, took <TIME>
-e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class
+e2org.scalajs.junit.ExceptionInConstructorTest.test::java.lang.UnsupportedOperationException: Exception while constructing the test class::true
 ldTest org.scalajs.junit.ExceptionInConstructorTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_a.txt
@@ -1,7 +1,7 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_n.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionTest.test started
 leTest org.scalajs.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.ExceptionTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_na.txt
@@ -1,7 +1,7 @@
 ldTest run started
 ldTest org.scalajs.junit.ExceptionTest.test started
 leTest org.scalajs.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.ExceptionTest.test finished, took <TIME>
 ldTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_nv.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionTest.test started
 leTest org.scalajs.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.ExceptionTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_nva.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionTest.test started
 leTest org.scalajs.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.ExceptionTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_nvc.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionTest.test started
 leTest org.scalajs.junit.ExceptionTest.test failed: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.ExceptionTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_nvca.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionTest.test started
 leTest org.scalajs.junit.ExceptionTest.test failed: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.ExceptionTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_v.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_va.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_vc.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionTest[0m.[31mtest[0m failed: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_vs.txt
@@ -1,7 +1,7 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m started
 leTest org.scalajs.junit.[33mExceptionTest[0m.[31mtest[0m failed: java.lang.[31mIndexOutOfBoundsException[0m: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.[33mExceptionTest[0m.[36mtest[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m1 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExceptionTestAssertions_vsn.txt
@@ -1,7 +1,7 @@
 liTest run started
 liTest org.scalajs.junit.ExceptionTest.test started
 leTest org.scalajs.junit.ExceptionTest.test failed: java.lang.IndexOutOfBoundsException: Exception message, took <TIME>
-e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message
+e2org.scalajs.junit.ExceptionTest.test::java.lang.IndexOutOfBoundsException: Exception message::true
 ldTest org.scalajs.junit.ExceptionTest.test finished, took <TIME>
 liTest run finished: 1 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_.txt
@@ -1,22 +1,22 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_a.txt
@@ -1,22 +1,22 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 ld[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_n.txt
@@ -1,22 +1,22 @@
 ldTest run started
 ldTest org.scalajs.junit.ExpectTest.expectAssert started
 ldTest org.scalajs.junit.ExpectTest.expectAssert finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 ldTest org.scalajs.junit.ExpectTest.expectNormal started
 ldTest org.scalajs.junit.ExpectTest.expectNormal finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert started
 leTest org.scalajs.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert finished, took <TIME>
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent started
 leTest org.scalajs.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow started
 leTest org.scalajs.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 ldTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_na.txt
@@ -1,22 +1,22 @@
 ldTest run started
 ldTest org.scalajs.junit.ExpectTest.expectAssert started
 ldTest org.scalajs.junit.ExpectTest.expectAssert finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 ldTest org.scalajs.junit.ExpectTest.expectNormal started
 ldTest org.scalajs.junit.ExpectTest.expectNormal finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert started
 leTest org.scalajs.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert finished, took <TIME>
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent started
 leTest org.scalajs.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow started
 leTest org.scalajs.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 ldTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_nv.txt
@@ -1,22 +1,22 @@
 liTest run started
 liTest org.scalajs.junit.ExpectTest.expectAssert started
 ldTest org.scalajs.junit.ExpectTest.expectAssert finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.ExpectTest.expectNormal started
 ldTest org.scalajs.junit.ExpectTest.expectNormal finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.ExpectTest.failExpectAssert started
 leTest org.scalajs.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectDifferent started
 leTest org.scalajs.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectNoThrow started
 leTest org.scalajs.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_nva.txt
@@ -1,22 +1,22 @@
 liTest run started
 liTest org.scalajs.junit.ExpectTest.expectAssert started
 ldTest org.scalajs.junit.ExpectTest.expectAssert finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.ExpectTest.expectNormal started
 ldTest org.scalajs.junit.ExpectTest.expectNormal finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.ExpectTest.failExpectAssert started
 leTest org.scalajs.junit.ExpectTest.failExpectAssert failed: java.lang.AssertionError: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectDifferent started
 leTest org.scalajs.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectNoThrow started
 leTest org.scalajs.junit.ExpectTest.failExpectNoThrow failed: java.lang.AssertionError: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_nvc.txt
@@ -1,22 +1,22 @@
 liTest run started
 liTest org.scalajs.junit.ExpectTest.expectAssert started
 ldTest org.scalajs.junit.ExpectTest.expectAssert finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.ExpectTest.expectNormal started
 ldTest org.scalajs.junit.ExpectTest.expectNormal finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.ExpectTest.failExpectAssert started
 leTest org.scalajs.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectDifferent started
 leTest org.scalajs.junit.ExpectTest.failExpectDifferent failed: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectNoThrow started
 leTest org.scalajs.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_nvca.txt
@@ -1,22 +1,22 @@
 liTest run started
 liTest org.scalajs.junit.ExpectTest.expectAssert started
 ldTest org.scalajs.junit.ExpectTest.expectAssert finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.ExpectTest.expectNormal started
 ldTest org.scalajs.junit.ExpectTest.expectNormal finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.ExpectTest.failExpectAssert started
 leTest org.scalajs.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectDifferent started
 leTest org.scalajs.junit.ExpectTest.failExpectDifferent failed: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectNoThrow started
 leTest org.scalajs.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_v.txt
@@ -1,22 +1,22 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_va.txt
@@ -1,22 +1,22 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: java.lang.[31mAssertionError[0m: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_vc.txt
@@ -1,22 +1,22 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_vs.txt
@@ -1,22 +1,22 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectAssert[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m started
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mexpectNormal[0m finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectAssert[0m failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectAssert[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectDifferent[0m failed: java.lang.[31mException[0m: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectDifferent[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m started
 leTest org.scalajs.junit.[33mExpectTest[0m.[31mfailExpectNoThrow[0m failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.[33mExpectTest[0m.[36mfailExpectNoThrow[0m finished, took <TIME>
 li[34mTest run finished: [0m[31m3 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/ExpectTestAssertions_vsn.txt
@@ -1,22 +1,22 @@
 liTest run started
 liTest org.scalajs.junit.ExpectTest.expectAssert started
 ldTest org.scalajs.junit.ExpectTest.expectAssert finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectAssert::
+e0org.scalajs.junit.ExpectTest.expectAssert::::true
 liTest org.scalajs.junit.ExpectTest.expectNormal started
 ldTest org.scalajs.junit.ExpectTest.expectNormal finished, took <TIME>
-e0org.scalajs.junit.ExpectTest.expectNormal::
+e0org.scalajs.junit.ExpectTest.expectNormal::::true
 liTest org.scalajs.junit.ExpectTest.failExpectAssert started
 leTest org.scalajs.junit.ExpectTest.failExpectAssert failed: Expected exception: java.lang.AssertionError, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError
+e2org.scalajs.junit.ExpectTest.failExpectAssert::java.lang.AssertionError: Expected exception: java.lang.AssertionError::true
 ldTest org.scalajs.junit.ExpectTest.failExpectAssert finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectDifferent started
 leTest org.scalajs.junit.ExpectTest.failExpectDifferent failed: java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>, took <TIME>
 leCaused by: java.lang.IllegalArgumentException
-e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>
+e2org.scalajs.junit.ExpectTest.failExpectDifferent::java.lang.Exception: Unexpected exception, expected<java.io.IOException> but was<java.lang.IllegalArgumentException>::true
 ldTest org.scalajs.junit.ExpectTest.failExpectDifferent finished, took <TIME>
 liTest org.scalajs.junit.ExpectTest.failExpectNoThrow started
 leTest org.scalajs.junit.ExpectTest.failExpectNoThrow failed: Expected exception: java.io.IOException, took <TIME>
-e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException
+e2org.scalajs.junit.ExpectTest.failExpectNoThrow::java.lang.AssertionError: Expected exception: java.io.IOException::true
 ldTest org.scalajs.junit.ExpectTest.failExpectNoThrow finished, took <TIME>
 liTest run finished: 3 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
 liTest org.scalajs.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
 liTest org.scalajs.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run started
 liTest org.scalajs.junit.IgnoreTest.onlyTest ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run started
 liTest org.scalajs.junit.IgnoreTest.onlyTest ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 ldTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run started
 liTest org.scalajs.junit.IgnoreTest.onlyTest ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run started
 liTest org.scalajs.junit.IgnoreTest.onlyTest ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run started
 liTest org.scalajs.junit.IgnoreTest.onlyTest ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run started
 liTest org.scalajs.junit.IgnoreTest.onlyTest ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mIgnoreTest[0m.[36monlyTest[0m ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/IgnoreTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run started
 liTest org.scalajs.junit.IgnoreTest.onlyTest ignored
-e3org.scalajs.junit.IgnoreTest.onlyTest::
+e3org.scalajs.junit.IgnoreTest.onlyTest::::true
 liTest run finished: 0 failed, 1 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_a.txt
@@ -1,6 +1,6 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_n.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_na.txt
@@ -1,6 +1,6 @@
 ldTest run started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 ldTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_nv.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_nva.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_nvc.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_nvca.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$ finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_v.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_va.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_vc.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m started
 ldTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$[0m finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd$u0020$u2206ƒ$u0020$uD83D$uDE00$u0020$times$u0020$hash$amp$::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_vs.txt
@@ -1,6 +1,6 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd ∆ƒ 😀 * #&$[0m started
 ldTest org.scalajs.junit.[33mMethodNameDecodeTest[0m.[36mabcd ∆ƒ 😀 * #&$[0m finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 1 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MethodNameDecodeTestAssertions_vsn.txt
@@ -1,6 +1,6 @@
 liTest run started
 liTest org.scalajs.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$ started
 ldTest org.scalajs.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$ finished, took <TIME>
-e0org.scalajs.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$::
+e0org.scalajs.junit.MethodNameDecodeTest.abcd ∆ƒ 😀 * #&$::::true
 liTest run finished: 0 failed, 0 ignored, 1 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_.txt
@@ -1,9 +1,9 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_a.txt
@@ -1,9 +1,9 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_n.txt
@@ -1,9 +1,9 @@
 ldTest run started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 ldTest org.scalajs.junit.Multi1Test.multiTest2 started
 ldTest org.scalajs.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 ldTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_na.txt
@@ -1,9 +1,9 @@
 ldTest run started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 ldTest org.scalajs.junit.Multi1Test.multiTest2 started
 ldTest org.scalajs.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 ldTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_nv.txt
@@ -1,9 +1,9 @@
 liTest run started
 liTest org.scalajs.junit.Multi1Test.multiTest1 started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.Multi1Test.multiTest2 started
 ldTest org.scalajs.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_nva.txt
@@ -1,9 +1,9 @@
 liTest run started
 liTest org.scalajs.junit.Multi1Test.multiTest1 started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.Multi1Test.multiTest2 started
 ldTest org.scalajs.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_nvc.txt
@@ -1,9 +1,9 @@
 liTest run started
 liTest org.scalajs.junit.Multi1Test.multiTest1 started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.Multi1Test.multiTest2 started
 ldTest org.scalajs.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_nvca.txt
@@ -1,9 +1,9 @@
 liTest run started
 liTest org.scalajs.junit.Multi1Test.multiTest1 started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.Multi1Test.multiTest2 started
 ldTest org.scalajs.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_v.txt
@@ -1,9 +1,9 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_va.txt
@@ -1,9 +1,9 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_vc.txt
@@ -1,9 +1,9 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_vs.txt
@@ -1,9 +1,9 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 2 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi1TestAssertions_vsn.txt
@@ -1,9 +1,9 @@
 liTest run started
 liTest org.scalajs.junit.Multi1Test.multiTest1 started
 ldTest org.scalajs.junit.Multi1Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest1::
+e0org.scalajs.junit.Multi1Test.multiTest1::::true
 liTest org.scalajs.junit.Multi1Test.multiTest2 started
 ldTest org.scalajs.junit.Multi1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi1Test.multiTest2::
+e0org.scalajs.junit.Multi1Test.multiTest2::::true
 liTest run finished: 0 failed, 0 ignored, 2 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_.txt
@@ -1,18 +1,18 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_a.txt
@@ -1,18 +1,18 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_n.txt
@@ -1,18 +1,18 @@
 ldTest run started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 ldTest org.scalajs.junit.Multi2Test.multiTest2 started
 ldTest org.scalajs.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 ldTest org.scalajs.junit.Multi2Test.multiTest3 started
 ldTest org.scalajs.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 ldTest org.scalajs.junit.Multi2Test.multiTest4 started
 ldTest org.scalajs.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 ldTest org.scalajs.junit.Multi2Test.multiTest5 started
 ldTest org.scalajs.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_na.txt
@@ -1,18 +1,18 @@
 ldTest run started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 ldTest org.scalajs.junit.Multi2Test.multiTest2 started
 ldTest org.scalajs.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 ldTest org.scalajs.junit.Multi2Test.multiTest3 started
 ldTest org.scalajs.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 ldTest org.scalajs.junit.Multi2Test.multiTest4 started
 ldTest org.scalajs.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 ldTest org.scalajs.junit.Multi2Test.multiTest5 started
 ldTest org.scalajs.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_nv.txt
@@ -1,18 +1,18 @@
 liTest run started
 liTest org.scalajs.junit.Multi2Test.multiTest1 started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.Multi2Test.multiTest2 started
 ldTest org.scalajs.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.Multi2Test.multiTest3 started
 ldTest org.scalajs.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.Multi2Test.multiTest4 started
 ldTest org.scalajs.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.Multi2Test.multiTest5 started
 ldTest org.scalajs.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_nva.txt
@@ -1,18 +1,18 @@
 liTest run started
 liTest org.scalajs.junit.Multi2Test.multiTest1 started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.Multi2Test.multiTest2 started
 ldTest org.scalajs.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.Multi2Test.multiTest3 started
 ldTest org.scalajs.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.Multi2Test.multiTest4 started
 ldTest org.scalajs.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.Multi2Test.multiTest5 started
 ldTest org.scalajs.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_nvc.txt
@@ -1,18 +1,18 @@
 liTest run started
 liTest org.scalajs.junit.Multi2Test.multiTest1 started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.Multi2Test.multiTest2 started
 ldTest org.scalajs.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.Multi2Test.multiTest3 started
 ldTest org.scalajs.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.Multi2Test.multiTest4 started
 ldTest org.scalajs.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.Multi2Test.multiTest5 started
 ldTest org.scalajs.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_nvca.txt
@@ -1,18 +1,18 @@
 liTest run started
 liTest org.scalajs.junit.Multi2Test.multiTest1 started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.Multi2Test.multiTest2 started
 ldTest org.scalajs.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.Multi2Test.multiTest3 started
 ldTest org.scalajs.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.Multi2Test.multiTest4 started
 ldTest org.scalajs.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.Multi2Test.multiTest5 started
 ldTest org.scalajs.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_v.txt
@@ -1,18 +1,18 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_va.txt
@@ -1,18 +1,18 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_vc.txt
@@ -1,18 +1,18 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_vs.txt
@@ -1,18 +1,18 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest1[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMulti2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/Multi2TestAssertions_vsn.txt
@@ -1,18 +1,18 @@
 liTest run started
 liTest org.scalajs.junit.Multi2Test.multiTest1 started
 ldTest org.scalajs.junit.Multi2Test.multiTest1 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest1::
+e0org.scalajs.junit.Multi2Test.multiTest1::::true
 liTest org.scalajs.junit.Multi2Test.multiTest2 started
 ldTest org.scalajs.junit.Multi2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest2::
+e0org.scalajs.junit.Multi2Test.multiTest2::::true
 liTest org.scalajs.junit.Multi2Test.multiTest3 started
 ldTest org.scalajs.junit.Multi2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest3::
+e0org.scalajs.junit.Multi2Test.multiTest3::::true
 liTest org.scalajs.junit.Multi2Test.multiTest4 started
 ldTest org.scalajs.junit.Multi2Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest4::
+e0org.scalajs.junit.Multi2Test.multiTest4::::true
 liTest org.scalajs.junit.Multi2Test.multiTest5 started
 ldTest org.scalajs.junit.Multi2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.Multi2Test.multiTest5::
+e0org.scalajs.junit.Multi2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_.txt
@@ -1,19 +1,19 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_a.txt
@@ -1,19 +1,19 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_n.txt
@@ -1,19 +1,19 @@
 ldTest run started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_na.txt
@@ -1,19 +1,19 @@
 ldTest run started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nv.txt
@@ -1,19 +1,19 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nva.txt
@@ -1,19 +1,19 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nvc.txt
@@ -1,19 +1,19 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_nvca.txt
@@ -1,19 +1,19 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_v.txt
@@ -1,19 +1,19 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_va.txt
@@ -1,19 +1,19 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vc.txt
@@ -1,19 +1,19 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vs.txt
@@ -1,19 +1,19 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail1TestAssertions_vsn.txt
@@ -1,19 +1,19 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail1Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail1Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail1Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_.txt
@@ -1,20 +1,20 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_a.txt
@@ -1,20 +1,20 @@
 ld[34mTest run started[0m
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_n.txt
@@ -1,20 +1,20 @@
 ldTest run started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_na.txt
@@ -1,20 +1,20 @@
 ldTest run started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 ldTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nv.txt
@@ -1,20 +1,20 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nva.txt
@@ -1,20 +1,20 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nvc.txt
@@ -1,20 +1,20 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_nvca.txt
@@ -1,20 +1,20 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_v.txt
@@ -1,20 +1,20 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_va.txt
@@ -1,20 +1,20 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vc.txt
@@ -1,20 +1,20 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vs.txt
@@ -1,20 +1,20 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest1[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest1[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m started
 lwTest assumption in test org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[31mmultiTest4[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest4[0m finished, took <TIME>
 liTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiAssumeFail2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 5 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiAssumeFail2TestAssertions_vsn.txt
@@ -1,20 +1,20 @@
 liTest run started
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest1 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest1::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest1 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 started
 lwTest assumption in test org.scalajs.junit.MultiAssumeFail2Test.multiTest4 failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiAssumeFail2Test.multiTest4::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest4 finished, took <TIME>
 liTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiAssumeFail2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::
+e0org.scalajs.junit.MultiAssumeFail2Test.multiTest5::::true
 liTest run finished: 0 failed, 0 ignored, 5 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_a.txt
@@ -1,5 +1,5 @@
 ld[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_n.txt
@@ -1,5 +1,5 @@
 ldTest run started
 lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_na.txt
@@ -1,5 +1,5 @@
 ldTest run started
 lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 ldTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nv.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nva.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nvc.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_nvca.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_v.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_va.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vc.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vs.txt
@@ -1,5 +1,5 @@
 li[34mTest run started[0m
 lwTest assumption in test org.scalajs.junit.[33mMultiBeforeAssumeFailTest[0m failed: org.junit.[31mAssumptionViolatedException[0m: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[34m0 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiBeforeAssumeFailTestAssertions_vsn.txt
@@ -1,5 +1,5 @@
 liTest run started
 lwTest assumption in test org.scalajs.junit.MultiBeforeAssumeFailTest failed: org.junit.AssumptionViolatedException: This assume should not pass, took <TIME>
-e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass
+e3org.scalajs.junit.MultiBeforeAssumeFailTest::org.junit.AssumptionViolatedException: This assume should not pass::true
 liTest run finished: 0 failed, 0 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_.txt
@@ -1,17 +1,17 @@
 ld[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_a.txt
@@ -1,17 +1,17 @@
 ld[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_n.txt
@@ -1,17 +1,17 @@
 ldTest run started
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 ldTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_na.txt
@@ -1,17 +1,17 @@
 ldTest run started
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 ldTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_nv.txt
@@ -1,17 +1,17 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_nva.txt
@@ -1,17 +1,17 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_nvc.txt
@@ -1,17 +1,17 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_nvca.txt
@@ -1,17 +1,17 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_v.txt
@@ -1,17 +1,17 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_va.txt
@@ -1,17 +1,17 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_vc.txt
@@ -1,17 +1,17 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_vs.txt
@@ -1,17 +1,17 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest4[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore1Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m1 ignored[0m[34m, 4 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore1TestAssertions_vsn.txt
@@ -1,17 +1,17 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore1Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore1Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest4 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest4 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest4::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore1Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore1Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore1Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore1Test.multiTest5::::true
 liTest run finished: 0 failed, 1 ignored, 4 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_.txt
@@ -1,16 +1,16 @@
 ld[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_a.txt
@@ -1,16 +1,16 @@
 ld[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_n.txt
@@ -1,16 +1,16 @@
 ldTest run started
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 ldTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_na.txt
@@ -1,16 +1,16 @@
 ldTest run started
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 ldTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_nv.txt
@@ -1,16 +1,16 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_nva.txt
@@ -1,16 +1,16 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_nvc.txt
@@ -1,16 +1,16 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_nvca.txt
@@ -1,16 +1,16 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_v.txt
@@ -1,16 +1,16 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_va.txt
@@ -1,16 +1,16 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_vc.txt
@@ -1,16 +1,16 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_vs.txt
@@ -1,16 +1,16 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest2[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest3[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m started
 ldTest org.scalajs.junit.[33mMultiIgnore2Test[0m.[36mmultiTest5[0m finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m2 ignored[0m[34m, 3 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnore2TestAssertions_vsn.txt
@@ -1,16 +1,16 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest1::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest2 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest2 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest2::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest3 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest3 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest3::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnore2Test.multiTest4::
+e3org.scalajs.junit.MultiIgnore2Test.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnore2Test.multiTest5 started
 ldTest org.scalajs.junit.MultiIgnore2Test.multiTest5 finished, took <TIME>
-e0org.scalajs.junit.MultiIgnore2Test.multiTest5::
+e0org.scalajs.junit.MultiIgnore2Test.multiTest5::::true
 liTest run finished: 0 failed, 2 ignored, 3 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_.txt
@@ -1,13 +1,13 @@
 ld[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_a.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_a.txt
@@ -1,13 +1,13 @@
 ld[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 ld[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_n.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_n.txt
@@ -1,13 +1,13 @@
 ldTest run started
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 ldTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_na.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_na.txt
@@ -1,13 +1,13 @@
 ldTest run started
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 ldTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_nv.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_nv.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_nva.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_nva.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_nvc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_nvc.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_nvca.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_nvca.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_v.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_v.txt
@@ -1,13 +1,13 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_va.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_va.txt
@@ -1,13 +1,13 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_vc.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_vc.txt
@@ -1,13 +1,13 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_vs.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_vs.txt
@@ -1,13 +1,13 @@
 li[34mTest run started[0m
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest1[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest2[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest3[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest4[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.[33mMultiIgnoreAllTest[0m.[36mmultiTest5[0m ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 li[34mTest run finished: [0m[34m0 failed[0m[34m, [0m[33m5 ignored[0m[34m, 0 total, <TIME>[0m
 d

--- a/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_vsn.txt
+++ b/junit-test/outputs/org/scalajs/junit/MultiIgnoreAllTestAssertions_vsn.txt
@@ -1,13 +1,13 @@
 liTest run started
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest1 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest1::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest2 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest2::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest3 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest3::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest4 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest4::::true
 liTest org.scalajs.junit.MultiIgnoreAllTest.multiTest5 ignored
-e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::
+e3org.scalajs.junit.MultiIgnoreAllTest.multiTest5::::true
 liTest run finished: 0 failed, 5 ignored, 0 total, <TIME>
 d


### PR DESCRIPTION
If duration associated with the test event is available, bubble it up through the SBT's test interface using the slot dedicated to just such information: `sbt.testing.Event.duration`.

In addition to it being a shame to throw away information about the duration that is literally in our hands, this avoids weird-looking negative duration values in test reports.