### PR TITLE
Fix #5097: Implement most of `ju.random.RandomGenerator`.

### DIFF
--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -17,7 +17,11 @@ import scala.annotation.tailrec
 import scala.scalajs.js
 import scala.scalajs.LinkingInfo
 
-class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
+import java.util.random.RandomGenerator
+
+class Random(seed_in: Long)
+    extends AnyRef with RandomGenerator with java.io.Serializable {
+
   /* This class has two different implementations of seeding and computing
    * bits, depending on whether we are on Wasm or JS. On Wasm, we use the
    * implementation specified in the JavaDoc verbatim. On JS, however, that is
@@ -108,16 +112,16 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
     result32 >>> (32 - bits)
   }
 
-  def nextDouble(): Double = {
+  override def nextDouble(): Double = {
     // ((next(26).toLong << 27) + next(27)) / (1L << 53).toDouble
     ((next(26).toDouble * (1L << 27).toDouble) + next(27).toDouble) / (1L << 53).toDouble
   }
 
-  def nextBoolean(): Boolean = next(1) != 0
+  override def nextBoolean(): Boolean = next(1) != 0
 
-  def nextInt(): Int = next(32)
+  override def nextInt(): Int = next(32)
 
-  def nextInt(n: Int): Int = {
+  override def nextInt(n: Int): Int = {
     if (n <= 0) {
       throw new IllegalArgumentException("n must be positive")
     } else if ((n & -n) == n) { // i.e., n is a power of 2
@@ -148,12 +152,12 @@ class Random(seed_in: Long) extends AnyRef with java.io.Serializable {
 
   def nextLong(): Long = (next(32).toLong << 32) + next(32)
 
-  def nextFloat(): Float = {
+  override def nextFloat(): Float = {
     // next(24).toFloat / (1 << 24).toFloat
     (next(24).toDouble / (1 << 24).toDouble).toFloat
   }
 
-  def nextBytes(bytes: Array[Byte]): Unit = {
+  override def nextBytes(bytes: Array[Byte]): Unit = {
     var i = 0
     while (i < bytes.length) {
       var rnd = nextInt()

--- a/javalib/src/main/scala/java/util/SplittableRandom.scala
+++ b/javalib/src/main/scala/java/util/SplittableRandom.scala
@@ -12,6 +12,8 @@
 
 package java.util
 
+import java.util.random.RandomGenerator
+
 /*
  * This is a clean room implementation derived from the original paper
  * and Java implementation mentioned there:
@@ -23,7 +25,6 @@ package java.util
  */
 private object SplittableRandom {
 
-  private final val DoubleULP = 1.0 / (1L << 53)
   private final val GoldenGamma = 0x9e3779b97f4a7c15L
 
   private var defaultGen: Long = new Random().nextLong()
@@ -80,7 +81,8 @@ private object SplittableRandom {
 
 }
 
-final class SplittableRandom private (private var seed: Long, gamma: Long) {
+final class SplittableRandom private (private var seed: Long, gamma: Long)
+    extends RandomGenerator {
   import SplittableRandom._
 
   def this(seed: Long) = {
@@ -106,27 +108,13 @@ final class SplittableRandom private (private var seed: Long, gamma: Long) {
     seed
   }
 
-  def nextInt(): Int = mix32(nextSeed())
-
-  //def nextInt(bound: Int): Int
-
-  //def nextInt(origin: Int, bound: Int): Int
+  /* According to the JavaDoc, this method is not overridden anymore.
+   * However, if we remove our override, we break tests in
+   * `SplittableRandomTest`. I don't know how the JDK produces the values it
+   * produces without that override. So we keep it on our side.
+   */
+  override def nextInt(): Int = mix32(nextSeed())
 
   def nextLong(): Long = mix64(nextSeed())
-
-  //def nextLong(bound: Long): Long
-
-  //def nextLong(origin: Long, bound: Long): Long
-
-  def nextDouble(): Double =
-    (nextLong() >>> 11).toDouble * DoubleULP
-
-  //def nextDouble(bound: Double): Double
-
-  //def nextDouble(origin: Double, bound: Double): Double
-
-  // this should be properly tested
-  // looks to work but just by chance maybe
-  def nextBoolean(): Boolean = nextInt() < 0
 
 }

--- a/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
+++ b/javalib/src/main/scala/java/util/concurrent/ThreadLocalRandom.scala
@@ -9,7 +9,6 @@
 package java.util.concurrent
 
 import java.util.Random
-import scala.annotation.tailrec
 
 class ThreadLocalRandom extends Random {
 
@@ -21,98 +20,6 @@ class ThreadLocalRandom extends Random {
       throw new UnsupportedOperationException()
 
     super.setSeed(seed)
-  }
-
-  def nextInt(least: Int, bound: Int): Int = {
-    if (least >= bound)
-      throw new IllegalArgumentException()
-
-    val difference = bound - least
-    if (difference > 0) {
-      nextInt(difference) + least
-    } else {
-      /* The interval size here is greater than Int.MaxValue,
-       * so the loop will exit with a probability of at least 1/2.
-       */
-      @tailrec
-      def loop(): Int = {
-        val n = nextInt()
-        if (n >= least && n < bound) n
-        else loop()
-      }
-
-      loop()
-    }
-  }
-
-  def nextLong(_n: Long): Long = {
-    if (_n <= 0)
-      throw new IllegalArgumentException("n must be positive")
-
-    /*
-     * Divide n by two until small enough for nextInt. On each
-     * iteration (at most 31 of them but usually much less),
-     * randomly choose both whether to include high bit in result
-     * (offset) and whether to continue with the lower vs upper
-     * half (which makes a difference only if odd).
-     */
-
-    var offset = 0L
-    var n = _n
-
-    while (n >= Integer.MAX_VALUE) {
-      val bits = next(2)
-      val halfn = n >>> 1
-      val nextn =
-        if ((bits & 2) == 0) halfn
-        else n - halfn
-      if ((bits & 1) == 0)
-        offset += n - nextn
-      n = nextn
-    }
-    offset + nextInt(n.toInt)
-  }
-
-  def nextLong(least: Long, bound: Long): Long = {
-    if (least >= bound)
-      throw new IllegalArgumentException()
-
-    val difference = bound - least
-    if (difference > 0) {
-      nextLong(difference) + least
-    } else {
-      /* The interval size here is greater than Long.MaxValue,
-       * so the loop will exit with a probability of at least 1/2.
-       */
-      @tailrec
-      def loop(): Long = {
-        val n = nextLong()
-        if (n >= least && n < bound) n
-        else loop()
-      }
-
-      loop()
-    }
-  }
-
-  def nextDouble(n: Double): Double = {
-    if (n <= 0)
-      throw new IllegalArgumentException("n must be positive")
-
-    nextDouble() * n
-  }
-
-  def nextDouble(least: Double, bound: Double): Double = {
-    if (least >= bound)
-      throw new IllegalArgumentException()
-
-    /* Based on documentation for Random.doubles to avoid issue #2144 and other
-     * possible rounding up issues:
-     * https://docs.oracle.com/javase/8/docs/api/java/util/Random.html#doubles-double-double-
-     */
-    val next = nextDouble() * (bound - least) + least
-    if (next < bound) next
-    else Math.nextAfter(bound, Double.NegativeInfinity)
   }
 }
 

--- a/javalib/src/main/scala/java/util/random/RandomGenerator.scala
+++ b/javalib/src/main/scala/java/util/random/RandomGenerator.scala
@@ -1,0 +1,335 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package java.util.random
+
+import scala.annotation.tailrec
+
+import java.util.ScalaOps._
+
+trait RandomGenerator {
+  // Comments starting with `// >` are cited from the JavaDoc.
+
+  // Not implemented: all the methods using Streams
+
+  // Not implemented, because
+  // > The default implementation checks for the @Deprecated annotation.
+  // def isDeprecated(): Boolean = ???
+
+  def nextBoolean(): Boolean =
+    nextInt() < 0 // is the sign bit 1?
+
+  def nextBytes(bytes: Array[Byte]): Unit = {
+    val len = bytes.length // implicit NPE
+    var i = 0
+
+    for (_ <- 0 until (len >> 3)) {
+      var rnd = nextLong()
+      for (_ <- 0 until 8) {
+        bytes(i) = rnd.toByte
+        rnd >>>= 8
+        i += 1
+      }
+    }
+
+    if (i != len) {
+      var rnd = nextLong()
+      while (i != len) {
+        bytes(i) = rnd.toByte
+        rnd >>>= 8
+        i += 1
+      }
+    }
+  }
+
+  def nextFloat(): Float = {
+    // > Uses the 24 high-order bits from a call to nextInt()
+    val bits = nextInt() >>> (32 - 24)
+    bits.toFloat * (1.0f / (1 << 24)) // lossless multiplication
+  }
+
+  def nextFloat(bound: Float): Float = {
+    // false for NaN
+    if (bound > 0 && bound != Float.PositiveInfinity)
+      ensureBelowBound(nextFloatBoundedInternal(bound), bound)
+    else
+      throw new IllegalArgumentException(s"Illegal bound: $bound")
+  }
+
+  def nextFloat(origin: Float, bound: Float): Float = {
+    // `origin < bound` is false if either input is NaN
+    if (origin != Float.NegativeInfinity && origin < bound && bound != Float.PositiveInfinity) {
+      val difference = bound - origin
+      val result = if (difference != Float.PositiveInfinity) {
+        // Easy case
+        origin + nextFloatBoundedInternal(difference)
+      } else {
+        // Overflow: scale everything down by 0.5 then scale it back up by 2.0
+        val halfOrigin = origin * 0.5f
+        val halfBound = bound * 0.5f
+        (halfOrigin + nextFloatBoundedInternal(halfBound - halfOrigin)) * 2.0f
+      }
+
+      ensureBelowBound(result, bound)
+    } else {
+      throw new IllegalArgumentException(s"Illegal bounds: [$origin, $bound)")
+    }
+  }
+
+  @inline
+  private def nextFloatBoundedInternal(bound: Float): Float =
+    nextFloat() * bound
+
+  @inline
+  private def ensureBelowBound(value: Float, bound: Float): Float = {
+    /* Based on documentation for Random.doubles to avoid issue #2144 and other
+     * possible rounding up issues:
+     * https://docs.oracle.com/javase/8/docs/api/java/util/Random.html#doubles-double-double-
+     */
+    if (value < bound) value
+    else Math.nextDown(value)
+  }
+
+  def nextDouble(): Double = {
+    // > Uses the 53 high-order bits from a call to nextLong()
+    val bits = nextLong() >>> (64 - 53)
+    bits.toDouble * (1.0 / (1L << 53)) // lossless multiplication
+  }
+
+  def nextDouble(bound: Double): Double = {
+    // false for NaN
+    if (bound > 0 && bound != Double.PositiveInfinity)
+      ensureBelowBound(nextDoubleBoundedInternal(bound), bound)
+    else
+      throw new IllegalArgumentException(s"Illegal bound: $bound")
+  }
+
+  def nextDouble(origin: Double, bound: Double): Double = {
+    // `origin < bound` is false if either input is NaN
+    if (origin != Double.NegativeInfinity && origin < bound && bound != Double.PositiveInfinity) {
+      val difference = bound - origin
+      val result = if (difference != Double.PositiveInfinity) {
+        // Easy case
+        origin + nextDoubleBoundedInternal(difference)
+      } else {
+        // Overflow: scale everything down by 0.5 then scale it back up by 2.0
+        val halfOrigin = origin * 0.5
+        val halfBound = bound * 0.5
+        (halfOrigin + nextDoubleBoundedInternal(halfBound - halfOrigin)) * 2.0
+      }
+
+      ensureBelowBound(result, bound)
+    } else {
+      throw new IllegalArgumentException(s"Illegal bounds: [$origin, $bound)")
+    }
+  }
+
+  @inline
+  private def nextDoubleBoundedInternal(bound: Double): Double =
+    nextDouble() * bound
+
+  @inline
+  private def ensureBelowBound(value: Double, bound: Double): Double = {
+    /* Based on documentation for Random.doubles to avoid issue #2144 and other
+     * possible rounding up issues:
+     * https://docs.oracle.com/javase/8/docs/api/java/util/Random.html#doubles-double-double-
+     */
+    if (value < bound) value
+    else Math.nextDown(value)
+  }
+
+  def nextInt(): Int = {
+    // > Uses the 32 high-order bits from a call to nextLong()
+    (nextLong() >>> 32).toInt
+  }
+
+  /* The algorithms used in nextInt() with bounds were initially part of
+   * ThreadLocalRandom. That implementation had been written by Doug Lea with
+   * assistance from members of JCP JSR-166 Expert Group and released to the
+   * public domain, as explained at
+   * http://creativecommons.org/publicdomain/zero/1.0/
+   */
+
+  def nextInt(bound: Int): Int = {
+    if (bound <= 0)
+      throw new IllegalArgumentException(s"Illegal bound: $bound")
+
+    nextIntBoundedInternal(bound)
+  }
+
+  def nextInt(origin: Int, bound: Int): Int = {
+    if (bound <= origin)
+      throw new IllegalArgumentException(s"Illegal bounds: [$origin, $bound)")
+
+    val difference = bound - origin
+    if (difference > 0 || difference == Int.MinValue) {
+      /* Either the difference did not overflow, or it is the only power of 2
+       * that overflows. In both cases, use the straightforward algorithm.
+       * It works for `MinValue` because the code path for powers of 2
+       * basically interprets the bound as unsigned.
+       */
+      origin + nextIntBoundedInternal(difference)
+    } else {
+      /* The interval size here is greater than Int.MaxValue,
+       * so the loop will exit with a probability of at least 1/2.
+       */
+      @tailrec
+      def loop(): Int = {
+        val rnd = nextInt()
+        if (rnd >= origin && rnd < bound)
+          rnd
+        else
+          loop()
+      }
+
+      loop()
+    }
+  }
+
+  private def nextIntBoundedInternal(bound: Int): Int = {
+    // bound > 0 || bound == Int.MinValue
+
+    if ((bound & -bound) == bound) { // i.e., bound is a power of 2
+      // > If bound is a power of two then limiting is a simple masking operation.
+      nextInt() & (bound - 1)
+    } else {
+      /* > Otherwise, the result is re-calculated by invoking nextInt() until
+       * > the result is greater than or equal zero and less than bound.
+       */
+
+      /* Taken literally, that spec would lead to huge rejection rates for
+       * small bounds.
+       * Instead, we start from a random 31-bit (non-negative) int `rnd`, and
+       * we compute `rnd % bound`.
+       * In order to get a uniform distribution, we must reject and retry if
+       * we get an `rnd` that is >= the largest int multiple of `bound`.
+       */
+
+      @tailrec
+      def loop(): Int = {
+        val rnd = nextInt() >>> 1
+        val value = rnd % bound // candidate result
+
+        // largest multiple of bound that is <= rnd
+        val multiple = rnd - value
+
+        // if multiple + bound overflows
+        if (multiple + bound < 0) {
+          /* then `multiple` is the largest multiple of bound, and
+           * `rnd >= multiple`, so we must retry.
+           */
+          loop()
+        } else {
+          value
+        }
+      }
+
+      loop()
+    }
+  }
+
+  // The only abstract method of RandomGenerator
+  def nextLong(): Long
+
+  /* The algorithms for nextLong() with bounds are copy-pasted from the ones
+   * for nextInt(), mutatis mutandis.
+   */
+
+  def nextLong(bound: Long): Long = {
+    if (bound <= 0)
+      throw new IllegalArgumentException(s"Illegal bound: $bound")
+
+    nextLongBoundedInternal(bound)
+  }
+
+  def nextLong(origin: Long, bound: Long): Long = {
+    if (bound <= origin)
+      throw new IllegalArgumentException(s"Illegal bounds: [$origin, $bound)")
+
+    val difference = bound - origin
+    if (difference > 0 || difference == Long.MinValue) {
+      /* Either the difference did not overflow, or it is the only power of 2
+       * that overflows. In both cases, use the straightforward algorithm.
+       * It works for `MinValue` because the code path for powers of 2
+       * basically interprets the bound as unsigned.
+       */
+      origin + nextLongBoundedInternal(difference)
+    } else {
+      /* The interval size here is greater than Long.MaxValue,
+       * so the loop will exit with a probability of at least 1/2.
+       */
+      @tailrec
+      def loop(): Long = {
+        val rnd = nextLong()
+        if (rnd >= origin && rnd < bound)
+          rnd
+        else
+          loop()
+      }
+
+      loop()
+    }
+  }
+
+  private def nextLongBoundedInternal(bound: Long): Long = {
+    // bound > 0 || bound == Long.MinValue
+
+    if ((bound & -bound) == bound) { // i.e., bound is a power of 2
+      // > If bound is a power of two then limiting is a simple masking operation.
+      nextLong() & (bound - 1L)
+    } else {
+      /* > Otherwise, the result is re-calculated by invoking nextLong() until
+       * > the result is greater than or equal zero and less than bound.
+       */
+
+      /* Taken literally, that spec would lead to huge rejection rates for
+       * small bounds.
+       * Instead, we start from a random 63-bit (non-negative) int `rnd`, and
+       * we compute `rnd % bound`.
+       * In order to get a uniform distribution, we must reject and retry if
+       * we get an `rnd` that is >= the largest int multiple of `bound`.
+       */
+
+      @tailrec
+      def loop(): Long = {
+        val rnd = nextLong() >>> 1
+        val value = rnd % bound // candidate result
+
+        // largest multiple of bound that is <= rnd
+        val multiple = rnd - value
+
+        // if multiple + bound overflows
+        if (multiple + bound < 0L) {
+          /* then `multiple` is the largest multiple of bound, and
+           * `rnd >= multiple`, so we must retry.
+           */
+          loop()
+        } else {
+          value
+        }
+      }
+
+      loop()
+    }
+  }
+
+  // Not implemented
+  // def nextGaussian(): Double = ???
+  // def nextGaussian(mean: Double, stddev: Double): Double = ???
+  // def nextExponential(): Double = ???
+}
+
+object RandomGenerator { // scalastyle:ignore
+  // Not implemented
+  // def of(name: String): RandomGenerator = ???
+  // def getDefault(): RandomGenerator = ???
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2135,6 +2135,7 @@ object Build {
         collectionsEraDependentDirectory(scalaV, sharedTestDir) ::
         includeIf(sharedTestDir / "require-jdk11", javaV >= 11) :::
         includeIf(sharedTestDir / "require-jdk15", javaV >= 15) :::
+        includeIf(sharedTestDir / "require-jdk17", javaV >= 17) :::
         includeIf(sharedTestDir / "require-jdk21", javaV >= 21) :::
         includeIf(testDir / "require-scala2", isJSTest)
       },

--- a/test-suite/shared/src/test/require-jdk17/org/scalajs/testsuite/javalib/util/random/RandomGeneratorTest.scala
+++ b/test-suite/shared/src/test/require-jdk17/org/scalajs/testsuite/javalib/util/random/RandomGeneratorTest.scala
@@ -1,0 +1,433 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.util.random
+
+import org.junit.Assert._
+import org.junit.Test
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.Platform._
+
+import java.util.random.RandomGenerator
+
+class RandomGeneratorTest {
+  /** Returns a RandomGenerator whose calls to `nextLong()` will return
+   *  the elements of `nextLongs`.
+   *
+   *  It does not loop. Requesting more elements will throw an AssertionError.
+   */
+  private def make(nextLongs: Long*): RandomGenerator = {
+    val iter = nextLongs.iterator
+    new RandomGenerator {
+      def nextLong(): Long = {
+        if (!iter.hasNext)
+          throw new AssertionError("Generator has run out")
+        iter.next()
+      }
+    }
+  }
+
+  /* 20 random Long values that we use as `nextLong` values in our tests
+   * 0xcdff356ba8f073c7L
+   * 0x4dd3ce2b9e4f98d3L
+   * 0xb85927b9d6e3249bL
+   * 0x0bf3df8c2f645e7dL
+   * 0x857f63be5f2f9ca0L
+   * 0xa12351957679f21fL
+   * 0xe01389542264f955L
+   * 0x1348eac1e0b1d30dL
+   * 0x496620384f075af6L
+   * 0xc7a71275b30dde50L
+   * 0xff5c1abdc835a88dL
+   * 0x7cd709fed6fc0e33L
+   * 0x457edabdccfc99b3L
+   * 0x867f0bae045cc0b5L
+   * 0xd9110b1c6a647a80L
+   * 0x27f8c35e876aa500L
+   * 0x700455bf2802ddacL
+   * 0x06b54104f821ddfeL
+   * 0xbf3b87070bbc6313L
+   * 0x74fa600cd5741c70L
+   */
+
+  @Test def testNextBoolean(): Unit = {
+    assertEquals(true, make(0xcdff356ba8f073c7L).nextBoolean())
+    assertEquals(false, make(0x4dd3ce2b9e4f98d3L).nextBoolean())
+    assertEquals(true, make(0xb85927b9d6e3249bL).nextBoolean())
+    assertEquals(false, make(0x0bf3df8c2f645e7dL).nextBoolean())
+    assertEquals(true, make(0x857f63be5f2f9ca0L).nextBoolean())
+    assertEquals(true, make(0xa12351957679f21fL).nextBoolean())
+    assertEquals(true, make(0xe01389542264f955L).nextBoolean())
+    assertEquals(false, make(0x1348eac1e0b1d30dL).nextBoolean())
+    assertEquals(false, make(0x496620384f075af6L).nextBoolean())
+    assertEquals(true, make(0xc7a71275b30dde50L).nextBoolean())
+    assertEquals(true, make(0xff5c1abdc835a88dL).nextBoolean())
+    assertEquals(false, make(0x7cd709fed6fc0e33L).nextBoolean())
+    assertEquals(false, make(0x457edabdccfc99b3L).nextBoolean())
+    assertEquals(true, make(0x867f0bae045cc0b5L).nextBoolean())
+    assertEquals(true, make(0xd9110b1c6a647a80L).nextBoolean())
+    assertEquals(false, make(0x27f8c35e876aa500L).nextBoolean())
+    assertEquals(false, make(0x700455bf2802ddacL).nextBoolean())
+    assertEquals(false, make(0x06b54104f821ddfeL).nextBoolean())
+    assertEquals(true, make(0xbf3b87070bbc6313L).nextBoolean())
+    assertEquals(false, make(0x74fa600cd5741c70L).nextBoolean())
+  }
+
+  @Test def testNextBytes(): Unit = {
+    val a16 = new Array[Byte](16)
+    make(0xcdff356ba8f073c7L, 0x4dd3ce2b9e4f98d3L).nextBytes(a16)
+    assertArrayEquals(
+        Array[Byte](-57, 115, -16, -88, 107, 53, -1, -51, -45, -104, 79, -98, 43, -50, -45, 77),
+        a16)
+
+    val a27 = new Array[Byte](27)
+    make(0xb85927b9d6e3249bL, 0x0bf3df8c2f645e7dL, 0x857f63be5f2f9ca0L, 0xa12351957679f21fL).nextBytes(a27)
+    assertArrayEquals(
+        Array[Byte](-101, 36, -29, -42, -71, 39, 89, -72, 125, 94, 100, 47, -116,
+            -33, -13, 11, -96, -100, 47, 95, -66, 99, 127, -123, 31, -14, 121),
+        a27)
+  }
+
+  @noinline
+  private def assertExactEquals(expected: Float, actual: Float): Unit =
+    assertTrue(s"expected $expected but got $actual", expected.equals(actual))
+
+  @Test def testNextFloat(): Unit = {
+    assertExactEquals(0.8046754f, make(0xcdff356ba8f073c7L).nextFloat())
+    assertExactEquals(0.30401313f, make(0x4dd3ce2b9e4f98d3L).nextFloat())
+    assertExactEquals(0.72011036f, make(0xb85927b9d6e3249bL).nextFloat())
+    assertExactEquals(0.046689928f, make(0x0bf3df8c2f645e7dL).nextFloat())
+    assertExactEquals(0.521475f, make(0x857f63be5f2f9ca0L).nextFloat())
+    assertExactEquals(0.62944514f, make(0xa12351957679f21fL).nextFloat())
+    assertExactEquals(0.8752981f, make(0xe01389542264f955L).nextFloat())
+    assertExactEquals(0.07533133f, make(0x1348eac1e0b1d30dL).nextFloat())
+    assertExactEquals(0.28671455f, make(0x496620384f075af6L).nextFloat())
+    assertExactEquals(0.77989304f, make(0xc7a71275b30dde50L).nextFloat())
+    assertExactEquals(0.9974991f, make(0xff5c1abdc835a88dL).nextFloat())
+    assertExactEquals(0.48765618f, make(0x7cd709fed6fc0e33L).nextFloat())
+    assertExactEquals(0.27146685f, make(0x457edabdccfc99b3L).nextFloat())
+    assertExactEquals(0.525376f, make(0x867f0bae045cc0b5L).nextFloat())
+    assertExactEquals(0.8479163f, make(0xd9110b1c6a647a80L).nextFloat())
+    assertExactEquals(0.15613955f, make(0x27f8c35e876aa500L).nextFloat())
+    assertExactEquals(0.4375661f, make(0x700455bf2802ddacL).nextFloat())
+    assertExactEquals(0.026203215f, make(0x06b54104f821ddfeL).nextFloat())
+    assertExactEquals(0.74700207f, make(0xbf3b87070bbc6313L).nextFloat())
+    assertExactEquals(0.45694542f, make(0x74fa600cd5741c70L).nextFloat())
+  }
+
+  @Test def testNextFloatWithBound(): Unit = {
+    assertExactEquals(0.8046754f, make(0xcdff356ba8f073c7L).nextFloat(1.0f))
+    assertExactEquals(0.15200657f, make(0x4dd3ce2b9e4f98d3L).nextFloat(0.5f))
+    assertExactEquals(88902.516f, make(0xb85927b9d6e3249bL).nextFloat(123456.789f))
+    assertExactEquals(7.0590034f, make(0x0bf3df8c2f645e7dL).nextFloat(151.189f))
+    assertExactEquals(0.0f, make(0x857f63be5f2f9ca0L).nextFloat(Float.MinPositiveValue))
+    assertExactEquals(2.1418906e38f, make(0xa12351957679f21fL).nextFloat(Float.MaxValue))
+
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(-10.0f))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(0.0f))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(-0.0f))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(Float.MinValue))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(Float.PositiveInfinity))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(Float.NegativeInfinity))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(Float.NaN))
+  }
+
+  @Test def testNextFloatWithOriginAndBound(): Unit = {
+    assertExactEquals(0.9023377f, make(0xcdff356ba8f073c7L).nextFloat(0.5f, 1.0f))
+    assertExactEquals(-10.63579f, make(0x4dd3ce2b9e4f98d3L).nextFloat(-15.5f, 0.5f))
+    assertExactEquals(745774.4f, make(0xb85927b9d6e3249bL).nextFloat(123456.789f, 987654.321f))
+    assertExactEquals(-561941.4f, make(0x0bf3df8c2f645e7dL).nextFloat(-589456.0f, -151.189f))
+    assertExactEquals(123.456f, make(0x857f63be5f2f9ca0L).nextFloat(123.456f, 123.45601f)) // 1 ulp of difference
+
+    if (!executingInJVMOnLowerThanJDK(19)) {
+      // Before JDK 19, these threw IllegalArgumentException's.
+
+      import Float.{MinValue, MaxValue}
+
+      assertExactEquals(-5.4696933e37f, make(0xa12351957679f21fL).nextFloat(MinValue, MaxValue/3.0f))
+      assertExactEquals(8.809577e37f, make(0xa12351957679f21fL).nextFloat(MinValue, MaxValue))
+      assertExactEquals(1.7215796e38f, make(0xa12351957679f21fL).nextFloat(MinValue/3.0f, MaxValue))
+
+      assertExactEquals(5.684898e37f, make(0xe01389542264f955L).nextFloat(MinValue, MaxValue/3.0f))
+      assertExactEquals(2.5541462e38f, make(0xe01389542264f955L).nextFloat(MinValue, MaxValue))
+      assertExactEquals(2.8370388e38f, make(0xe01389542264f955L).nextFloat(MinValue/3.0f, MaxValue))
+
+      assertExactEquals(-3.0610379e38f, make(0x1348eac1e0b1d30dL).nextFloat(MinValue, MaxValue/3.0f))
+      assertExactEquals(-2.890145e38f, make(0x1348eac1e0b1d30dL).nextFloat(MinValue, MaxValue))
+      assertExactEquals(-7.9248886e37f, make(0x1348eac1e0b1d30dL).nextFloat(MinValue/3.0f, MaxValue))
+    }
+
+    // Make sure we do not underflow MinPositiveValue to 0.0
+    assertExactEquals(Float.MinPositiveValue,
+        make(0L).nextFloat(Float.MinPositiveValue, 1024 * Float.MinPositiveValue))
+
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(-10.0f, -10.0f))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(-0.0f, 0.0f))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(5.0f, 4.0f))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(Float.MinValue, Float.MinValue))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(Float.NegativeInfinity, -1.0f))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(1.0f, Float.NegativeInfinity))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(Float.NaN, 0.0f))
+    assertThrows(classOf[IllegalArgumentException], make().nextFloat(0.0f, Float.NaN))
+  }
+
+  @noinline
+  private def assertExactEquals(expected: Double, actual: Double): Unit =
+    assertTrue(s"expected $expected but got $actual", expected.equals(actual))
+
+  @Test def testNextDouble(): Unit = {
+    assertExactEquals(0.8046754253236388, make(0xcdff356ba8f073c7L).nextDouble())
+    assertExactEquals(0.30401314320471184, make(0x4dd3ce2b9e4f98d3L).nextDouble())
+    assertExactEquals(0.7201104000768166, make(0xb85927b9d6e3249bL).nextDouble())
+    assertExactEquals(0.04668996021736527, make(0x0bf3df8c2f645e7dL).nextDouble())
+    assertExactEquals(0.5214750613951636, make(0x857f63be5f2f9ca0L).nextDouble())
+    assertExactEquals(0.6294451703929338, make(0xa12351957679f21fL).nextDouble())
+    assertExactEquals(0.8752981024175773, make(0xe01389542264f955L).nextDouble())
+    assertExactEquals(0.0753313754400502, make(0x1348eac1e0b1d30dL).nextDouble())
+    assertExactEquals(0.28671456694340003, make(0x496620384f075af6L).nextDouble())
+    assertExactEquals(0.7798930680610775, make(0xc7a71275b30dde50L).nextDouble())
+    assertExactEquals(0.9974991525015954, make(0xff5c1abdc835a88dL).nextDouble())
+    assertExactEquals(0.4876562354247512, make(0x7cd709fed6fc0e33L).nextDouble())
+    assertExactEquals(0.271466895425862, make(0x457edabdccfc99b3L).nextDouble())
+    assertExactEquals(0.5253760623785295, make(0x867f0bae045cc0b5L).nextDouble())
+    assertExactEquals(0.8479163116811764, make(0xd9110b1c6a647a80L).nextDouble())
+    assertExactEquals(0.1561395746024723, make(0x27f8c35e876aa500L).nextDouble())
+    assertExactEquals(0.43756614605809874, make(0x700455bf2802ddacL).nextDouble())
+    assertExactEquals(0.026203216279220398, make(0x06b54104f821ddfeL).nextDouble())
+    assertExactEquals(0.7470020668222204, make(0xbf3b87070bbc6313L).nextDouble())
+    assertExactEquals(0.456945422299626, make(0x74fa600cd5741c70L).nextDouble())
+  }
+
+  @Test def testNextDoubleWithBound(): Unit = {
+    assertExactEquals(0.8046754253236388, make(0xcdff356ba8f073c7L).nextDouble(1.0))
+    assertExactEquals(0.15200657160235592, make(0x4dd3ce2b9e4f98d3L).nextDouble(0.5))
+    assertExactEquals(88902.51771898914, make(0xb85927b9d6e3249bL).nextDouble(123456.789))
+    assertExactEquals(7.059008395303237, make(0x0bf3df8c2f645e7dL).nextDouble(151.189))
+    assertExactEquals(0.0, make(0x857f63be5f2f9ca0L).nextDouble(Double.MinPositiveValue))
+    assertExactEquals(1.1315492615876175E308, make(0xa12351957679f21fL).nextDouble(Double.MaxValue))
+
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(-10.0))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(0.0))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(-0.0))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(Double.MinValue))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(Double.PositiveInfinity))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(Double.NegativeInfinity))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(Double.NaN))
+  }
+
+  @Test def testNextDoubleWithOriginAndBound(): Unit = {
+    assertExactEquals(0.9023377126618194, make(0xcdff356ba8f073c7L).nextDouble(0.5, 1.0))
+    assertExactEquals(-10.63578970872461, make(0x4dd3ce2b9e4f98d3L).nextDouble(-15.5, 0.5))
+    assertExactEquals(745774.4195139175, make(0xb85927b9d6e3249bL).nextDouble(123456.789, 987654.321))
+    assertExactEquals(-561941.381818508, make(0x0bf3df8c2f645e7dL).nextDouble(-589456.0, -151.189))
+    assertExactEquals(123.456, make(0x857f63be5f2f9ca0L).nextDouble(123.456, 123.45600000000002)) // 1 ulp of diff
+
+    if (!executingInJVMOnLowerThanJDK(19)) {
+      // Before JDK 19, these threw IllegalArgumentException's.
+
+      import Double.{MinValue, MaxValue}
+
+      assertExactEquals(-2.8896078607882544e307, make(0xa12351957679f21fL).nextDouble(MinValue, MaxValue/3.0))
+      assertExactEquals(4.654053883129194e307, make(0xa12351957679f21fL).nextDouble(MinValue, MaxValue))
+      assertExactEquals(9.095013038293849e307, make(0xa12351957679f21fL).nextDouble(MinValue/3.0, MaxValue))
+
+      assertExactEquals(3.003300513698057e307, make(0xe01389542264f955L).nextDouble(MinValue, MaxValue/3.0))
+      assertExactEquals(1.349341644485866e308, make(0xe01389542264f955L).nextDouble(MinValue, MaxValue))
+      assertExactEquals(1.4987921412780162e308, make(0xe01389542264f955L).nextDouble(MinValue/3.0, MaxValue))
+
+      assertExactEquals(-1.6171295395712306e308, make(0x1348eac1e0b1d30dL).nextDouble(MinValue, MaxValue/3.0))
+      assertExactEquals(-1.5268477419256879e308, make(0x1348eac1e0b1d30dL).nextDouble(MinValue, MaxValue))
+      assertExactEquals(-4.1866744966302007e307, make(0x1348eac1e0b1d30dL).nextDouble(MinValue/3.0, MaxValue))
+    }
+
+    // Make sure we do not underflow MinPositiveValue to 0.0
+    assertExactEquals(Double.MinPositiveValue,
+        make(0L).nextDouble(Double.MinPositiveValue, 1024 * Double.MinPositiveValue))
+
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(-10.0, -10.0))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(-0.0, 0.0))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(5.0, 4.0))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(Double.MinValue, Double.MinValue))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(Double.NegativeInfinity, -1.0))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(1.0, Double.NegativeInfinity))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(Double.NaN, 0.0))
+    assertThrows(classOf[IllegalArgumentException], make().nextDouble(0.0, Double.NaN))
+  }
+
+  @Test def testNextInt(): Unit = {
+    assertEquals(-838912661, make(0xcdff356ba8f073c7L).nextInt())
+    assertEquals(1305726507, make(0x4dd3ce2b9e4f98d3L).nextInt())
+    assertEquals(-1202116679, make(0xb85927b9d6e3249bL).nextInt())
+    assertEquals(200531852, make(0x0bf3df8c2f645e7dL).nextInt())
+    assertEquals(-2055248962, make(0x857f63be5f2f9ca0L).nextInt())
+    assertEquals(-1591520875, make(0xa12351957679f21fL).nextInt())
+    assertEquals(-535590572, make(0xe01389542264f955L).nextInt())
+    assertEquals(323545793, make(0x1348eac1e0b1d30dL).nextInt())
+    assertEquals(1231429688, make(0x496620384f075af6L).nextInt())
+    assertEquals(-945352075, make(0xc7a71275b30dde50L).nextInt())
+    assertEquals(-10741059, make(0xff5c1abdc835a88dL).nextInt())
+    assertEquals(2094467582, make(0x7cd709fed6fc0e33L).nextInt())
+    assertEquals(1165941437, make(0x457edabdccfc99b3L).nextInt())
+    assertEquals(-2038494290, make(0x867f0bae045cc0b5L).nextInt())
+    assertEquals(-653194468, make(0xd9110b1c6a647a80L).nextInt())
+    assertEquals(670614366, make(0x27f8c35e876aa500L).nextInt())
+    assertEquals(1879332287, make(0x700455bf2802ddacL).nextInt())
+    assertEquals(112541956, make(0x06b54104f821ddfeL).nextInt())
+    assertEquals(-1086617849, make(0xbf3b87070bbc6313L).nextInt())
+    assertEquals(1962565644, make(0x74fa600cd5741c70L).nextInt())
+  }
+
+  @Test def testNextIntWithBound(): Unit = {
+    assertEquals(353, make(0xcdff356ba8f073c7L).nextInt(1234))
+    assertEquals(652863253, make(0x4dd3ce2b9e4f98d3L).nextInt(987654321))
+    assertEquals(1546425308, make(0xb85927b9d6e3249bL).nextInt(2000000000))
+    assertEquals(6, make(0x0bf3df8c2f645e7dL).nextInt(10))
+    assertEquals(0, make(0x857f63be5f2f9ca0L).nextInt(1))
+    assertEquals(1351723210, make(0xa12351957679f21fL).nextInt(Int.MaxValue))
+
+    // Rejects one sample
+    assertEquals(1047233791, make(0xff5c1abdc835a88dL, 0x7cd709fed6fc0e33L).nextInt(2000000000))
+
+    // Powers of 2 have a dedicated path
+    assertEquals(5, make(0x457edabdccfc99b3L).nextInt(8))
+    assertEquals(942, make(0x867f0bae045cc0b5L).nextInt(1024))
+    assertEquals(420547356, make(0xd9110b1c6a647a80L).nextInt(1 << 30))
+
+    assertThrows(classOf[IllegalArgumentException], make().nextInt(0))
+    assertThrows(classOf[IllegalArgumentException], make().nextInt(-10))
+    assertThrows(classOf[IllegalArgumentException], make().nextInt(Int.MinValue))
+  }
+
+  @Test def testNextIntWithOriginAndBound(): Unit = {
+    assertEquals(3353, make(0xcdff356ba8f073c7L).nextInt(3000, 4234))
+    assertEquals(529406464, make(0x4dd3ce2b9e4f98d3L).nextInt(-123456789, 987654321))
+    assertEquals(-453574692, make(0xb85927b9d6e3249bL).nextInt(-2000000000, -123456789))
+    assertEquals(-4, make(0x0bf3df8c2f645e7dL).nextInt(-10, 0))
+
+    assertEquals(56, make(0x857f63be5f2f9ca0L).nextInt(56, 57)) // no choice
+
+    // Close to min or max
+    assertEquals(-2147483647, make(0xa12351957679f21fL).nextInt(Int.MinValue, Int.MinValue + 3))
+    assertEquals(2147483645, make(0xe01389542264f955L).nextInt(Int.MaxValue - 3, Int.MaxValue))
+    assertEquals(161772897, make(0x1348eac1e0b1d30dL).nextInt(1, Int.MaxValue))
+
+    // Rejects one sample
+    assertEquals(47233791, make(0xff5c1abdc835a88dL, 0x7cd709fed6fc0e33L).nextInt(-1000000000, 1000000000))
+
+    // bound - origin overflows
+    assertEquals(1165941437, make(0x457edabdccfc99b3L).nextInt(-1000000000, 2000000000))
+
+    // bound - origin overflows and rejects one sample
+    assertEquals(112541956, make(0x77fa600cd5741c70L, 0x06b54104f821ddfeL).nextInt(-1000000000, 2000000000))
+
+    // Powers of 2 have a dedicated path
+    assertEquals(45, make(0x457edabdccfc99b3L).nextInt(40, 40 + 8))
+    assertEquals(-999999058, make(0x867f0bae045cc0b5L).nextInt(-1000000000, -1000000000 + 1024))
+    assertEquals(420090567, make(0xd9110b1c6a647a80L).nextInt(-456789, -456789 + (1 << 30)))
+
+    // The power of 2 that also overflows
+    assertEquals(670157577, make(0x27f8c35e876aa500L).nextInt(-456789, -456789 + (1 << 31)))
+
+    assertThrows(classOf[IllegalArgumentException], make().nextInt(56, 56))
+    assertThrows(classOf[IllegalArgumentException], make().nextInt(-10, -30))
+    assertThrows(classOf[IllegalArgumentException], make().nextInt(Int.MaxValue, Int.MinValue))
+  }
+
+  @Test def testNextLong(): Unit = {
+    assertEquals(-3603102440361004089L, make(0xcdff356ba8f073c7L).nextLong())
+    assertEquals(5608052647741331667L, make(0x4dd3ce2b9e4f98d3L).nextLong())
+    assertEquals(-5163051818675919717L, make(0xb85927b9d6e3249bL).nextLong())
+    assertEquals(861277746941419133L, make(0x0bf3df8c2f645e7dL).nextLong())
+    assertEquals(-8827227075330990944L, make(0x857f63be5f2f9ca0L).nextLong())
+    assertEquals(-6835530107038600673L, make(0xa12351957679f21fL).nextLong())
+    assertEquals(-2300343990208890539L, make(0xe01389542264f955L).nextLong())
+    assertEquals(1389618603463136013L, make(0x1348eac1e0b1d30dL).nextLong())
+    assertEquals(5288950238609365750L, make(0x496620384f075af6L).nextLong())
+    assertEquals(-4060256242326708656L, make(0xc7a71275b30dde50L).nextLong())
+    assertEquals(-46132493770446707L, make(0xff5c1abdc835a88dL).nextLong())
+    assertEquals(8995669770829041203L, make(0x7cd709fed6fc0e33L).nextLong())
+    assertEquals(5007680344405350835L, make(0x457edabdccfc99b3L).nextLong())
+    assertEquals(-8755266308559552331L, make(0x867f0bae045cc0b5L).nextLong())
+    assertEquals(-2805448876203148672L, make(0xd9110b1c6a647a80L).nextLong())
+    assertEquals(2880266772469687552L, make(0x27f8c35e876aa500L).nextLong())
+    assertEquals(8071670711653162412L, make(0x700455bf2802ddacL).nextLong())
+    assertEquals(483364024610840062L, make(0x06b54104f821ddfeL).nextLong())
+    assertEquals(-4666988124507970797L, make(0xbf3b87070bbc6313L).nextLong())
+    assertEquals(8429155260814335088L, make(0x74fa600cd5741c70L).nextLong())
+  }
+
+  @Test def testNextLongWithBound(): Unit = {
+    assertEquals(1179L, make(0xcdff356ba8f073c7L).nextLong(1234L))
+    assertEquals(6567945330301L, make(0x4dd3ce2b9e4f98d3L).nextLong(9876543219876L))
+    assertEquals(2641846127516815949L, make(0xb85927b9d6e3249bL).nextLong(4000000000000000000L))
+    assertEquals(6, make(0x0bf3df8c2f645e7dL).nextLong(10L))
+    assertEquals(0, make(0x857f63be5f2f9ca0L).nextLong(1L))
+    assertEquals(5805606983335475471L, make(0xa12351957679f21fL).nextLong(Long.MaxValue))
+
+    // Rejects one sample
+    assertEquals(497834885414520601L, make(0xff5c1abdc835a88dL, 0x7cd709fed6fc0e33L).nextLong(4000000000000000000L))
+
+    // Powers of 2 have a dedicated path
+    assertEquals(3L, make(0x457edabdccfc99b3L).nextLong(8L))
+    assertEquals(181L, make(0x867f0bae045cc0b5L).nextLong(1024L))
+    assertEquals(711228032L, make(0xd9110b1c6a647a80L).nextLong(1L << 30))
+    assertEquals(214810766255360L, make(0x27f8c35e876aa500L).nextLong(1L << 50))
+    assertEquals(3459984693225774508L, make(0x700455bf2802ddacL).nextLong(1L << 62))
+
+    assertThrows(classOf[IllegalArgumentException], make().nextLong(0L))
+    assertThrows(classOf[IllegalArgumentException], make().nextLong(-10L))
+    assertThrows(classOf[IllegalArgumentException], make().nextLong(Long.MinValue))
+  }
+
+  @Test def testNextLongWithOriginAndBound(): Unit = {
+    assertEquals(4179L, make(0xcdff356ba8f073c7L).nextLong(3000L, 4234L))
+    assertEquals(2867080832779L, make(0x4dd3ce2b9e4f98d3L).nextLong(-1234567891234L, 9876543219876L))
+    assertEquals(-1358152637915292817L, make(0xb85927b9d6e3249bL).nextLong(-4000000000000000000L, -1234567891234L))
+    assertEquals(-4L, make(0x0bf3df8c2f645e7dL).nextLong(-10L, 0L))
+
+    assertEquals(56L, make(0x857f63be5f2f9ca0L).nextLong(56L, 57L)) // no choice
+
+    // Close to min or max
+    assertEquals(-9223372036854775806L, make(0xa12351957679f21fL).nextLong(Long.MinValue, Long.MinValue + 3L))
+    assertEquals(9223372036854775806L, make(0xe01389542264f955L).nextLong(Long.MaxValue - 3L, Long.MaxValue))
+    assertEquals(694809301731568007L, make(0x1348eac1e0b1d30dL).nextLong(1, Long.MaxValue))
+
+    // Rejects one sample
+    assertEquals(-1502165114585479399L,
+        make(0xff5c1abdc835a88dL, 0x7cd709fed6fc0e33L).nextLong(-2000000000000000000L, 2000000000000000000L))
+
+    // bound - origin overflows
+    assertEquals(861277746941419133L, make(0x0bf3df8c2f645e7dL).nextLong(-6000000000000000000L, 4000000000000000000L))
+
+    // bound - origin overflows and rejects one sample
+    assertEquals(483364024610840062L,
+        make(0x457edabdccfc99b3L, 0x06b54104f821ddfeL).nextLong(-6000000000000000000L, 4000000000000000000L))
+
+    // Powers of 2 have a dedicated path
+    assertEquals(43L, make(0x457edabdccfc99b3L).nextLong(40L, 40L + 8L))
+    assertEquals(-999999819L, make(0x867f0bae045cc0b5L).nextLong(-1000000000L, -1000000000 + 1024L))
+    assertEquals(710771243L, make(0xd9110b1c6a647a80L).nextLong(-456789L, -456789L + (1L << 30)))
+    assertEquals(2000214810766255360L,
+        make(0x27f8c35e876aa500L).nextLong(2000000000000000000L, 2000000000000000000L + (1L << 50)))
+    assertEquals(3459983458657883274L,
+        make(0x700455bf2802ddacL).nextLong(-1234567891234L, -1234567891234L + (1L << 62)))
+
+    // The power of 2 that also overflows
+    assertEquals(4556382677778913777L,
+        make(0xbf3b87070bbc6313L).nextLong(-1234567891234L, -1234567891234L + (1L << 63)))
+
+    assertThrows(classOf[IllegalArgumentException], make().nextLong(56L, 56L))
+    assertThrows(classOf[IllegalArgumentException], make().nextLong(-10L, -30L))
+    assertThrows(classOf[IllegalArgumentException], make().nextLong(Long.MaxValue, Long.MinValue))
+  }
+}


### PR DESCRIPTION
~~Most of it is bit-for-bit compatible with what the JDK produces. The only exception are `nextFloat(origin, bound)` and `nextDouble(origin, bound)` in the cases where `bound - origin` overflows. Those produce results within 4 ULPs of the JDK.~~

We did not implement the sub-interfaces of `RandomGenerator`.

We also did not implement the methods `nextGaussian` and `nextExponential`.