### PR TITLE
Wasm: Implement fmod on the Wasm side.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -100,9 +100,6 @@ const scalaJSHelpers = {
   tF: (x) => typeof x === 'number' && (Math.fround(x) === x || x !== x),
   tD: (x) => typeof x === 'number',
 
-  // fmod, to implement Float_% and Double_% (it is apparently quite hard to implement fmod otherwise)
-  fmod: (x, y) => x % y,
-
   // Strings
   emptyString: "",
   jsValueToString: (x) => (x === void 0) ? "undefined" : x.toString(),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -130,7 +130,8 @@ object VarGen {
     case object bIFallback extends JSHelperFunctionID
     case object uIFallback extends JSHelperFunctionID
 
-    case object fmod extends JSHelperFunctionID
+    case object fmodf extends JSHelperFunctionID
+    case object fmodd extends JSHelperFunctionID
 
     case object jsValueToString extends JSHelperFunctionID // for actual toString() call
     case object jsValueToStringForConcat extends JSHelperFunctionID

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/GenericInstructions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/GenericInstructions.scala
@@ -13,6 +13,7 @@
 package org.scalajs.linker.backend.webassembly
 
 import Instructions._
+import Types._
 
 /** Instructions grouped by type, to generically write algorithms on various datatypes.
  *
@@ -23,50 +24,172 @@ object GenericInstructions {
   abstract class NumericInstrs {
     type Value
 
+    val tpe: Type
+    val bits: Int
+
     def Const(value: Value): Instr
+    def ConstFromInt(value: Int): Instr
+
+    val Zero: Instr
+    val One: Instr
   }
 
   /** Instructions on `i32` or `i64`. */
   abstract class IntInstrs extends NumericInstrs {
-    val Zero: Instr
+    def ConstFromLong(value: Long): Instr
 
     val Eqz: Instr
     val Eq: Instr
+    val LeU: Instr
+
+    val Clz: Instr
 
     val Sub: Instr
     val DivS: Instr
     val RemS: Instr
+
+    val And: Instr
+    val Or: Instr
+    val Shl: Instr
+    val ShrU: Instr
+
+    val ReinterpretF: Instr
   }
 
   /** Instructions on `i32`. */
   object I32 extends IntInstrs {
     type Value = Int
 
+    val tpe = Int32
+    val bits = 32
+
     def Const(value: Int): Instr = I32Const(value)
+    def ConstFromInt(value: Int): Instr = I32Const(value)
+    def ConstFromLong(value: Long): Instr = I32Const(value.toInt)
 
     val Zero = I32Const(0)
+    val One = I32Const(1)
 
     val Eqz = I32Eqz
     val Eq = I32Eq
+    val LeU = I32LeU
+
+    val Clz = I32Clz
 
     val Sub = I32Sub
     val DivS = I32DivS
     val RemS = I32RemS
+
+    val And = I32And
+    val Or = I32Or
+    val Shl = I32Shl
+    val ShrU = I32ShrU
+
+    val ReinterpretF = I32ReinterpretF32
   }
 
   /** Instructions on `i64`. */
   object I64 extends IntInstrs {
     type Value = Long
 
+    val tpe = Int64
+    val bits = 64
+
     def Const(value: Long): Instr = I64Const(value)
+    def ConstFromInt(value: Int): Instr = I64Const(value.toLong)
+    def ConstFromLong(value: Long): Instr = I64Const(value)
 
     val Zero = I64Const(0L)
+    val One = I64Const(1L)
 
     val Eqz = I64Eqz
     val Eq = I64Eq
+    val LeU = I64LeU
+
+    val Clz = I64Clz
 
     val Sub = I64Sub
     val DivS = I64DivS
     val RemS = I64RemS
+
+    val And = I64And
+    val Or = I64Or
+    val Shl = I64Shl
+    val ShrU = I64ShrU
+
+    val ReinterpretF = I64ReinterpretF64
+  }
+
+  /** Instructions on `f32` or `f64`. */
+  abstract class FloatInstrs extends NumericInstrs {
+    def intInstrs: IntInstrs
+
+    val mbits: Int
+    val mmask: Long
+    val ebits: Int
+    val emask: Int
+
+    val Ne: Instr
+
+    val Mul: Instr
+    val Div: Instr
+
+    val ReinterpretI: Instr
+  }
+
+  /** Instructions on `f32`. */
+  object F32 extends FloatInstrs {
+    type Value = Float
+
+    val tpe = Float32
+    val bits = 32
+
+    def Const(value: Float): Instr = F32Const(value)
+    def ConstFromInt(value: Int): Instr = F32Const(value.toFloat)
+
+    val Zero = F32Const(0.0f)
+    val One = F32Const(1.0f)
+
+    def intInstrs: IntInstrs = I32
+
+    val mbits = 23
+    val mmask = (1 << mbits) - 1
+    val ebits = 8
+    val emask = (1 << ebits) - 1
+
+    val Ne = F32Ne
+
+    val Mul = F32Mul
+    val Div = F32Div
+
+    val ReinterpretI = F32ReinterpretI32
+  }
+
+  /** Instructions on `f64`. */
+  object F64 extends FloatInstrs {
+    type Value = Double
+
+    val tpe = Float64
+    val bits = 64
+
+    def Const(value: Double): Instr = F64Const(value)
+    def ConstFromInt(value: Int): Instr = F64Const(value.toDouble)
+
+    val Zero = F64Const(0.0)
+    val One = F64Const(1.0)
+
+    def intInstrs: IntInstrs = I64
+
+    val mbits = 52
+    val mmask = (1L << mbits) - 1
+    val ebits = 11
+    val emask = (1 << ebits) - 1
+
+    val Ne = F64Ne
+
+    val Mul = F64Mul
+    val Div = F64Div
+
+    val ReinterpretI = F64ReinterpretI64
   }
 }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/GenericInstructions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/GenericInstructions.scala
@@ -1,0 +1,72 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.webassembly
+
+import Instructions._
+
+/** Instructions grouped by type, to generically write algorithms on various datatypes.
+ *
+ *  The instructions here are not exhaustive. We include exactly what we need.
+ */
+object GenericInstructions {
+  /** Instructions on `i32`, `i64`, `f32` or `f64`. */
+  abstract class NumericInstrs {
+    type Value
+
+    def Const(value: Value): Instr
+  }
+
+  /** Instructions on `i32` or `i64`. */
+  abstract class IntInstrs extends NumericInstrs {
+    val Zero: Instr
+
+    val Eqz: Instr
+    val Eq: Instr
+
+    val Sub: Instr
+    val DivS: Instr
+    val RemS: Instr
+  }
+
+  /** Instructions on `i32`. */
+  object I32 extends IntInstrs {
+    type Value = Int
+
+    def Const(value: Int): Instr = I32Const(value)
+
+    val Zero = I32Const(0)
+
+    val Eqz = I32Eqz
+    val Eq = I32Eq
+
+    val Sub = I32Sub
+    val DivS = I32DivS
+    val RemS = I32RemS
+  }
+
+  /** Instructions on `i64`. */
+  object I64 extends IntInstrs {
+    type Value = Long
+
+    def Const(value: Long): Instr = I64Const(value)
+
+    val Zero = I64Const(0L)
+
+    val Eqz = I64Eqz
+    val Eq = I64Eq
+
+    val Sub = I64Sub
+    val DivS = I64DivS
+    val RemS = I64RemS
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -221,6 +221,8 @@ class DoubleTest {
     test(Double.NaN, Double.NaN, 2.1)
     test(Double.NaN, Double.NaN, 5.5)
     test(Double.NaN, Double.NaN, -151.189)
+    test(Double.NaN, Double.NaN, 3.123e-320)
+    test(Double.NaN, Double.NaN, 2.253547e-318)
 
     // If d is NaN, return NaN
     test(Double.NaN, Double.NaN, Double.NaN)
@@ -231,6 +233,8 @@ class DoubleTest {
     test(Double.NaN, 2.1, Double.NaN)
     test(Double.NaN, 5.5, Double.NaN)
     test(Double.NaN, -151.189, Double.NaN)
+    test(Double.NaN, 3.123e-320, Double.NaN)
+    test(Double.NaN, 2.253547e-318, Double.NaN)
 
     // If n is PositiveInfinity, return NaN
     test(Double.NaN, Double.PositiveInfinity, Double.PositiveInfinity)
@@ -240,6 +244,8 @@ class DoubleTest {
     test(Double.NaN, Double.PositiveInfinity, 2.1)
     test(Double.NaN, Double.PositiveInfinity, 5.5)
     test(Double.NaN, Double.PositiveInfinity, -151.189)
+    test(Double.NaN, Double.PositiveInfinity, 3.123e-320)
+    test(Double.NaN, Double.PositiveInfinity, 2.253547e-318)
 
     // If n is NegativeInfinity, return NaN
     test(Double.NaN, Double.NegativeInfinity, Double.PositiveInfinity)
@@ -249,6 +255,8 @@ class DoubleTest {
     test(Double.NaN, Double.NegativeInfinity, 2.1)
     test(Double.NaN, Double.NegativeInfinity, 5.5)
     test(Double.NaN, Double.NegativeInfinity, -151.189)
+    test(Double.NaN, Double.NegativeInfinity, 3.123e-320)
+    test(Double.NaN, Double.NegativeInfinity, 2.253547e-318)
 
     // If d is PositiveInfinity, return n
     test(+0.0, +0.0, Double.PositiveInfinity)
@@ -256,6 +264,8 @@ class DoubleTest {
     test(2.1, 2.1, Double.PositiveInfinity)
     test(5.5, 5.5, Double.PositiveInfinity)
     test(-151.189, -151.189, Double.PositiveInfinity)
+    test(3.123e-320, 3.123e-320, Double.PositiveInfinity)
+    test(2.253547e-318, 2.253547e-318, Double.PositiveInfinity)
 
     // If d is NegativeInfinity, return n
     test(+0.0, +0.0, Double.NegativeInfinity)
@@ -263,6 +273,8 @@ class DoubleTest {
     test(2.1, 2.1, Double.NegativeInfinity)
     test(5.5, 5.5, Double.NegativeInfinity)
     test(-151.189, -151.189, Double.NegativeInfinity)
+    test(3.123e-320, 3.123e-320, Double.NegativeInfinity)
+    test(2.253547e-318, 2.253547e-318, Double.NegativeInfinity)
 
     // If d is +0.0, return NaN
     test(Double.NaN, +0.0, +0.0)
@@ -270,6 +282,8 @@ class DoubleTest {
     test(Double.NaN, 2.1, +0.0)
     test(Double.NaN, 5.5, +0.0)
     test(Double.NaN, -151.189, +0.0)
+    test(Double.NaN, 3.123e-320, +0.0)
+    test(Double.NaN, 2.253547e-318, +0.0)
 
     // If d is -0.0, return NaN
     test(Double.NaN, +0.0, -0.0)
@@ -277,28 +291,51 @@ class DoubleTest {
     test(Double.NaN, 2.1, -0.0)
     test(Double.NaN, 5.5, -0.0)
     test(Double.NaN, -151.189, -0.0)
+    test(Double.NaN, 3.123e-320, -0.0)
+    test(Double.NaN, 2.253547e-318, -0.0)
 
     // If n is +0.0, return n
     test(+0.0, +0.0, 2.1)
     test(+0.0, +0.0, 5.5)
     test(+0.0, +0.0, -151.189)
+    test(+0.0, +0.0, 3.123e-320)
+    test(+0.0, +0.0, 2.253547e-318)
 
     // If n is -0.0, return n
     test(-0.0, -0.0, 2.1)
     test(-0.0, -0.0, 5.5)
     test(-0.0, -0.0, -151.189)
+    test(-0.0, -0.0, 3.123e-320)
+    test(-0.0, -0.0, 2.253547e-318)
 
     // Non-special values
-    // { val l = List(2.1, 5.5, -151.189); for (n <- l; d <- l) println(s"    test(${n % d}, $n, $d)") }
+    // { val l = List(2.1, 5.5, -151.189, 3.123e-320, 2.253547e-318);
+    //   for (n <- l; d <- l) println(s"    test(${n % d}, $n, $d)".toLowerCase()) }
     test(0.0, 2.1, 2.1)
     test(2.1, 2.1, 5.5)
     test(2.1, 2.1, -151.189)
+    test(2.0696e-320, 2.1, 3.123e-320)
+    test(1.772535e-318, 2.1, 2.253547e-318)
     test(1.2999999999999998, 5.5, 2.1)
     test(0.0, 5.5, 5.5)
     test(5.5, 5.5, -151.189)
+    test(3.607e-321, 5.5, 3.123e-320)
+    test(6.8103e-319, 5.5, 2.253547e-318)
     test(-2.0889999999999866, -151.189, 2.1)
     test(-2.688999999999993, -151.189, 5.5)
     test(-0.0, -151.189, -151.189)
+    test(-1.94e-320, -151.189, 3.123e-320)
+    test(-4.1349e-319, -151.189, 2.253547e-318)
+    test(3.123e-320, 3.123e-320, 2.1)
+    test(3.123e-320, 3.123e-320, 5.5)
+    test(3.123e-320, 3.123e-320, -151.189)
+    test(0.0, 3.123e-320, 3.123e-320)
+    test(3.123e-320, 3.123e-320, 2.253547e-318)
+    test(2.253547e-318, 2.253547e-318, 2.1)
+    test(2.253547e-318, 2.253547e-318, 5.5)
+    test(2.253547e-318, 2.253547e-318, -151.189)
+    test(4.995e-321, 2.253547e-318, 3.123e-320)
+    test(0.0, 2.253547e-318, 2.253547e-318)
   }
 
   @Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -73,6 +73,8 @@ class FloatTest {
     test(Float.NaN, Float.NaN, 2.1f)
     test(Float.NaN, Float.NaN, 5.5f)
     test(Float.NaN, Float.NaN, -151.189f)
+    test(Float.NaN, Float.NaN, 8.858e-42f)
+    test(Float.NaN, Float.NaN, 6.39164e-40f)
 
     // If d is NaN, return NaN
     test(Float.NaN, Float.NaN, Float.NaN)
@@ -83,6 +85,8 @@ class FloatTest {
     test(Float.NaN, 2.1f, Float.NaN)
     test(Float.NaN, 5.5f, Float.NaN)
     test(Float.NaN, -151.189f, Float.NaN)
+    test(Float.NaN, 8.858e-42f, Float.NaN)
+    test(Float.NaN, 6.39164e-40f, Float.NaN)
 
     // If n is PositiveInfinity, return NaN
     test(Float.NaN, Float.PositiveInfinity, Float.PositiveInfinity)
@@ -92,6 +96,8 @@ class FloatTest {
     test(Float.NaN, Float.PositiveInfinity, 2.1f)
     test(Float.NaN, Float.PositiveInfinity, 5.5f)
     test(Float.NaN, Float.PositiveInfinity, -151.189f)
+    test(Float.NaN, Float.PositiveInfinity, 8.858e-42f)
+    test(Float.NaN, Float.PositiveInfinity, 6.39164e-40f)
 
     // If n is NegativeInfinity, return NaN
     test(Float.NaN, Float.NegativeInfinity, Float.PositiveInfinity)
@@ -101,6 +107,8 @@ class FloatTest {
     test(Float.NaN, Float.NegativeInfinity, 2.1f)
     test(Float.NaN, Float.NegativeInfinity, 5.5f)
     test(Float.NaN, Float.NegativeInfinity, -151.189f)
+    test(Float.NaN, Float.NegativeInfinity, 8.858e-42f)
+    test(Float.NaN, Float.NegativeInfinity, 6.39164e-40f)
 
     // If d is PositiveInfinity, return n
     test(+0.0f, +0.0f, Float.PositiveInfinity)
@@ -108,6 +116,8 @@ class FloatTest {
     test(2.1f, 2.1f, Float.PositiveInfinity)
     test(5.5f, 5.5f, Float.PositiveInfinity)
     test(-151.189f, -151.189f, Float.PositiveInfinity)
+    test(8.858e-42f, 8.858e-42f, Float.PositiveInfinity)
+    test(6.39164e-40f, 6.39164e-40f, Float.PositiveInfinity)
 
     // If d is NegativeInfinity, return n
     test(+0.0f, +0.0f, Float.NegativeInfinity)
@@ -115,6 +125,8 @@ class FloatTest {
     test(2.1f, 2.1f, Float.NegativeInfinity)
     test(5.5f, 5.5f, Float.NegativeInfinity)
     test(-151.189f, -151.189f, Float.NegativeInfinity)
+    test(8.858e-42f, 8.858e-42f, Float.NegativeInfinity)
+    test(6.39164e-40f, 6.39164e-40f, Float.NegativeInfinity)
 
     // If d is +0.0, return NaN
     test(Float.NaN, +0.0f, +0.0f)
@@ -122,6 +134,8 @@ class FloatTest {
     test(Float.NaN, 2.1f, +0.0f)
     test(Float.NaN, 5.5f, +0.0f)
     test(Float.NaN, -151.189f, +0.0f)
+    test(Float.NaN, 8.858e-42f, +0.0f)
+    test(Float.NaN, 6.39164e-40f, +0.0f)
 
     // If d is -0.0, return NaN
     test(Float.NaN, +0.0f, -0.0f)
@@ -129,28 +143,51 @@ class FloatTest {
     test(Float.NaN, 2.1f, -0.0f)
     test(Float.NaN, 5.5f, -0.0f)
     test(Float.NaN, -151.189f, -0.0f)
+    test(Float.NaN, 8.858e-42f, -0.0f)
+    test(Float.NaN, 6.39164e-40f, -0.0f)
 
     // If n is +0.0, return n
     test(+0.0f, +0.0f, 2.1f)
     test(+0.0f, +0.0f, 5.5f)
     test(+0.0f, +0.0f, -151.189f)
+    test(+0.0f, +0.0f, 8.858e-42f)
+    test(+0.0f, +0.0f, 6.39164e-40f)
 
     // If n is -0.0, return n
     test(-0.0f, -0.0f, 2.1f)
     test(-0.0f, -0.0f, 5.5f)
     test(-0.0f, -0.0f, -151.189f)
+    test(-0.0f, -0.0f, 8.858e-42f)
+    test(-0.0f, -0.0f, 6.39164e-40f)
 
     // Non-special values
-    // { val l = List(2.1f, 5.5f, -151.189f); for (n <- l; d <- l) println(s"      test(${n % d}f, ${n}f, ${d}f)") }
+    // { val l = List(2.1f, 5.5f, -151.189f, 8.858e-42f, 6.39164e-40f);
+    //   for (n <- l; d <- l) println(s"    test(${n % d}f, ${n}f, ${d}f)".toLowerCase()) }
     test(0.0f, 2.1f, 2.1f)
     test(2.1f, 2.1f, 5.5f)
     test(2.1f, 2.1f, -151.189f)
+    test(8.085e-42f, 2.1f, 8.858e-42f)
+    test(6.1636e-40f, 2.1f, 6.39164e-40f)
     test(1.3000002f, 5.5f, 2.1f)
     test(0.0f, 5.5f, 5.5f)
     test(5.5f, 5.5f, -151.189f)
+    test(5.11e-43f, 5.5f, 8.858e-42f)
+    test(4.77036e-40f, 5.5f, 6.39164e-40f)
     test(-2.0890021f, -151.189f, 2.1f)
     test(-2.6889954f, -151.189f, 5.5f)
     test(-0.0f, -151.189f, -151.189f)
+    test(-1.139e-42f, -151.189f, 8.858e-42f)
+    test(-5.64734e-40f, -151.189f, 6.39164e-40f)
+    test(8.858e-42f, 8.858e-42f, 2.1f)
+    test(8.858e-42f, 8.858e-42f, 5.5f)
+    test(8.858e-42f, 8.858e-42f, -151.189f)
+    test(0.0f, 8.858e-42f, 8.858e-42f)
+    test(8.858e-42f, 8.858e-42f, 6.39164e-40f)
+    test(6.39164e-40f, 6.39164e-40f, 2.1f)
+    test(6.39164e-40f, 6.39164e-40f, 5.5f)
+    test(6.39164e-40f, 6.39164e-40f, -151.189f)
+    test(1.417e-42f, 6.39164e-40f, 8.858e-42f)
+    test(0.0f, 6.39164e-40f, 6.39164e-40f)
   }
 
   @Test


### PR DESCRIPTION
This avoids the JS call overhead for that "primitive" operation.

As can be seen in the implementation, `fmod` is far from a primitive, though. We took an MIT implemention of `fmod`, generic in the bit-width, and translated it by hand to Wasm. We use the newly introduced `GenericInstructions` to also have a generic implementation. So we generate one function for `Float_%` and one for `Double_%`.

---

/cc @tanishiking This also removes the dependency on JS for that operation, which will be useful to compile to Wasm-without-JS-host.