### PR TITLE
Wasm: Implement fmod on the Scala side.

### DIFF
--- a/linker-private-library/src/main/scala/org/scalajs/linker/runtime/WasmRuntime.scala
+++ b/linker-private-library/src/main/scala/org/scalajs/linker/runtime/WasmRuntime.scala
@@ -1,0 +1,455 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.runtime
+
+object WasmRuntime {
+  /** `fmod` for `Double`s, the implementation of `Double_%`.
+   *
+   *  Floating point remainders are specified by
+   *  https://262.ecma-international.org/#sec-numeric-types-number-remainder
+   *  which says that it is equivalent to the C library function `fmod`.
+   *
+   *  This method is a translation to Scala of the Rust generic implementation,
+   *  which can be found at
+   *  https://github.com/rust-lang/libm/blob/c9672e5a1a75bfa82981b6240b7bc3ed3524b8b3/src/math/generic/fmod.rs
+   *  under the MIT license
+   *
+   *  (The naive function `x - trunc(x / y) * y` that we can find on the
+   *  Web does not work.)
+   */
+  @inline // inline into the static forwarder, which will be the entry point
+  def fmodd(x: Double, y: Double): Double = {
+    // Configuration that depends on the floating-point type and its corresponding integer type
+
+    type FType = Double
+    type IType = Long
+
+    val mbits = 52
+    val ebits = 11
+    val fZero = 0.0
+    val iZero = 0L
+    val iOne = 1L
+
+    /* TODO Use doubleToRawLongBits when we add support for it. Either is
+     * correct in this context, but the raw variant would be more efficient.
+     */
+    @inline def toBits(v: FType): IType = java.lang.Double.doubleToLongBits(v)
+    @inline def fromBits(v: IType): FType = java.lang.Double.longBitsToDouble(v)
+    @inline def leadingZeros(v: IType): Int = java.lang.Long.numberOfLeadingZeros(v)
+    @inline def extendFromInt(v: Int): IType = v.toLong
+    @inline def wrapToInt(v: IType): Int = v.toInt
+
+    /* Usually we use an @inline def to specialize code like this. Here,
+     * copy-pasting is (unfortunately) better. There are lot of primitive
+     * numeric operations (arithmetics, shifts, comparisons) that are correctly
+     * resolved because they have the same name, which works with the
+     * copy-paste. They don't have a common abstraction, though, so the @inline
+     * def would not work.
+     */
+
+    // --- BEGIN COPY-PASTE wrt. fmodf ----------------------------------------
+
+    // scalastyle:off return
+
+    // --- BEGIN MIT license
+
+    // derived constants
+    val mmask: IType = (iOne << mbits) - iOne
+    val emask: Int = (1 << ebits) - 1
+    val SignBit: IType = iOne << (mbits + ebits)
+
+    /* let mut ix = x.to_bits();
+     * let mut iy = y.to_bits();
+     */
+    var ix: IType = toBits(x)
+    var iy: IType = toBits(y)
+
+    /* let sx = ix & F::SIGN_MASK;
+     * The Rust implementation does this after initializing ex and ey. We must
+     * do it now, *before* masking off the sign bits.
+     */
+    val sx: IType = ix & SignBit
+
+    /* The Rust implementation exploits the unsinged semantics of `ix` and
+     * `iy`. In Scala, this is a bit awkward to do. Instead, we mask off the
+     * sign bit of both now, so we have less work to do later.
+     */
+    ix &= ~SignBit
+    iy &= ~SignBit
+
+    /* let mut ex = x.ex().signed();
+     * let mut ey = y.ex().signed();
+     * -> wrapToInt(ix >>> mbits) & emask
+     *    but `& emask` is redundant since the sign bit is already 0 for us
+     */
+    var ex: Int = wrapToInt(ix >>> mbits)
+    var ey: Int = wrapToInt(iy >>> mbits)
+
+    /* if iy << 1 == zero || y.is_nan() || ex == F::EXP_SAT as i32 {
+     *     return (x * y) / (x * y);
+     * }
+     *
+     * `iy << 1 == zero` is the same as `iy == zero` for us, since we masked
+     * off the sign bit.
+     */
+    if (iy == iZero || y != y || ex == emask)
+      return (x * y) / (x * y)
+
+    /* if ix << 1 <= iy << 1 {
+     *     if ix << 1 == iy << 1 {
+     *         return F::ZERO * x;
+     *     }
+     *     return x;
+     * }
+     * Since we masked off the sign bit already, all the `<< 1` above are not
+     * necessary. That also means that our signed comparison does the right
+     * thing.
+     */
+    if (ix <= iy) { // semantically, this tests whether abs(x) <= abs(y) at this point
+      if (ix == iy)
+        return fZero * x
+      return x
+    }
+
+    /* if ex == 0 {
+     *     let i = ix << (F::EXP_BITS + 1);
+     *     ex -= i.leading_zeros() as i32;
+     *     ix <<= -ex + 1;
+     * } else {
+     *     ix &= F::Int::MAX >> (F::EXP_BITS + 1); // this is mmask
+     *     ix |= one << F::SIG_BITS;
+     * }
+     * and same for y
+     *
+     * Note that the two `F::EXP_BITS + 1` do *not* have the `+ 1` in the
+     * original Rust implementation. The `+ 1`s I added account for the sign
+     * bit, in addition to the exponent bits.
+     *
+     * I believe the first one is just wrong, and fails to correctly handle
+     * subnormal values. Removing that one causes the tests for subnormals to
+     * fail.
+     *
+     * The second one makes no actual difference, since the bit that is
+     * affected is anyway or'ed back to 1 on the last line. However to me it
+     * makes more sense to have it, as it then really corresponds to `mmask`,
+     * and we use it to mask mantissa bits.
+     */
+    if (ex == 0) {
+      // subnormal
+      ex -= leadingZeros(ix << (ebits + 1))
+      ix <<= -ex + 1
+    } else {
+      // normal form
+      ix = (ix & mmask) | (iOne << mbits)
+    }
+    if (ey == 0) {
+      // subnormal
+      ey -= leadingZeros(iy << (ebits + 1))
+      iy <<= -ey + 1
+    } else {
+      // normal form
+      iy = (iy & mmask) | (iOne << mbits)
+    }
+
+    // x mod y
+
+    /* while ex > ey {
+     *     let i = ix.wrapping_sub(iy);
+     *     if i >> (F::BITS - 1) == zero { // i.e., i >= 0 with signed semantics
+     *         if i == zero {
+     *             return F::ZERO * x;
+     *         }
+     *         ix = i;
+     *     }
+     *
+     *     ix <<= 1;
+     *     ex -= 1;
+     * }
+     *
+     * let i = ix.wrapping_sub(iy);
+     * if i >> (F::BITS - 1) == zero {
+     *     if i == zero {
+     *         return F::ZERO * x;
+     *     }
+     *     ix = i;
+     * }
+     *
+     * but we factor out the duplicate block inside the loop, taking
+     * advantage of a funny-looking "while loop with condition in the middle".
+     */
+    while ({
+      val i = ix - iy
+      if (i >= iZero) {
+        if (i == iZero)
+          return fZero * x
+        ix = i
+      }
+
+      ex > ey // the actual condition of the while loop
+    }) {
+      ix <<= 1
+      ex -= 1
+    }
+
+    // re-normalize the result in ix
+
+    /* let shift = ix.leading_zeros().saturating_sub(F::EXP_BITS);
+     * ix <<= shift;
+     * ex -= shift as i32;
+     */
+    val shift = leadingZeros(ix) - ebits
+    ix <<= shift
+    ex -= shift
+
+    // scale result
+
+    /* if ex > 0 {
+     *     ix -= one << F::SIG_BITS;
+     *     ix |= F::Int::cast_from(ex) << F::SIG_BITS;
+     * } else {
+     *     ix >>= -ex + 1;
+     * }
+     */
+    if (ex > 0) {
+      // normal form
+      ix = (ix - (iOne << mbits)) | (extendFromInt(ex) << mbits)
+    } else {
+      // subnormal
+      ix >>>= -ex + 1
+    }
+
+    // integrate the sign bit and return
+
+    /* ix |= sx;
+     * F::from_bits(ix)
+     */
+    fromBits(ix | sx)
+
+    // --- END MIT license
+
+    // scalastyle:on return
+
+    // --- END COPY-PASTE wrt. fmodf ------------------------------------------
+  }
+
+  /** `fmod` for `Float`s, the implementation of `Float_%`.
+   *
+   *  See `fmodd` for details.
+   */
+  @inline // inline into the static forwarder, which will be the entry point
+  def fmodf(x: Float, y: Float): Float = {
+    // Configuration that depends on the floating-point type and its corresponding integer type
+
+    type FType = Float
+    type IType = Int
+
+    val mbits = 23
+    val ebits = 8
+    val fZero = 0.0f
+    val iZero = 0
+    val iOne = 1
+
+    /* TODO Use floatToRawIntBits when we add support for it. Either is
+     * correct in this context, but the raw variant would be more efficient.
+     */
+    @inline def toBits(v: FType): IType = java.lang.Float.floatToIntBits(v)
+    @inline def fromBits(v: IType): FType = java.lang.Float.intBitsToFloat(v)
+    @inline def leadingZeros(v: IType): Int = java.lang.Integer.numberOfLeadingZeros(v)
+    @inline def extendFromInt(v: Int): IType = v
+    @inline def wrapToInt(v: IType): Int = v
+
+    // --- BEGIN COPY-PASTE wrt. fmodd ----------------------------------------
+
+    // scalastyle:off return
+
+    // --- BEGIN MIT license
+
+    // derived constants
+    val mmask: IType = (iOne << mbits) - iOne
+    val emask: Int = (1 << ebits) - 1
+    val SignBit: IType = iOne << (mbits + ebits)
+
+    /* let mut ix = x.to_bits();
+     * let mut iy = y.to_bits();
+     */
+    var ix: IType = toBits(x)
+    var iy: IType = toBits(y)
+
+    /* let sx = ix & F::SIGN_MASK;
+     * The Rust implementation does this after initializing ex and ey. We must
+     * do it now, *before* masking off the sign bits.
+     */
+    val sx: IType = ix & SignBit
+
+    /* The Rust implementation exploits the unsinged semantics of `ix` and
+     * `iy`. In Scala, this is a bit awkward to do. Instead, we mask off the
+     * sign bit of both now, so we have less work to do later.
+     */
+    ix &= ~SignBit
+    iy &= ~SignBit
+
+    /* let mut ex = x.ex().signed();
+     * let mut ey = y.ex().signed();
+     * -> wrapToInt(ix >>> mbits) & emask
+     *    but `& emask` is redundant since the sign bit is already 0 for us
+     */
+    var ex: Int = wrapToInt(ix >>> mbits)
+    var ey: Int = wrapToInt(iy >>> mbits)
+
+    /* if iy << 1 == zero || y.is_nan() || ex == F::EXP_SAT as i32 {
+     *     return (x * y) / (x * y);
+     * }
+     *
+     * `iy << 1 == zero` is the same as `iy == zero` for us, since we masked
+     * off the sign bit.
+     */
+    if (iy == iZero || y != y || ex == emask)
+      return (x * y) / (x * y)
+
+    /* if ix << 1 <= iy << 1 {
+     *     if ix << 1 == iy << 1 {
+     *         return F::ZERO * x;
+     *     }
+     *     return x;
+     * }
+     * Since we masked off the sign bit already, all the `<< 1` above are not
+     * necessary. That also means that our signed comparison does the right
+     * thing.
+     */
+    if (ix <= iy) { // semantically, this tests whether abs(x) <= abs(y) at this point
+      if (ix == iy)
+        return fZero * x
+      return x
+    }
+
+    /* if ex == 0 {
+     *     let i = ix << (F::EXP_BITS + 1);
+     *     ex -= i.leading_zeros() as i32;
+     *     ix <<= -ex + 1;
+     * } else {
+     *     ix &= F::Int::MAX >> (F::EXP_BITS + 1); // this is mmask
+     *     ix |= one << F::SIG_BITS;
+     * }
+     * and same for y
+     *
+     * Note that the two `F::EXP_BITS + 1` do *not* have the `+ 1` in the
+     * original Rust implementation. The `+ 1`s I added account for the sign
+     * bit, in addition to the exponent bits.
+     *
+     * I believe the first one is just wrong, and fails to correctly handle
+     * subnormal values. Removing that one causes the tests for subnormals to
+     * fail.
+     *
+     * The second one makes no actual difference, since the bit that is
+     * affected is anyway or'ed back to 1 on the last line. However to me it
+     * makes more sense to have it, as it then really corresponds to `mmask`,
+     * and we use it to mask mantissa bits.
+     */
+    if (ex == 0) {
+      // subnormal
+      ex -= leadingZeros(ix << (ebits + 1))
+      ix <<= -ex + 1
+    } else {
+      // normal form
+      ix = (ix & mmask) | (iOne << mbits)
+    }
+    if (ey == 0) {
+      // subnormal
+      ey -= leadingZeros(iy << (ebits + 1))
+      iy <<= -ey + 1
+    } else {
+      // normal form
+      iy = (iy & mmask) | (iOne << mbits)
+    }
+
+    // x mod y
+
+    /* while ex > ey {
+     *     let i = ix.wrapping_sub(iy);
+     *     if i >> (F::BITS - 1) == zero { // i.e., i >= 0 with signed semantics
+     *         if i == zero {
+     *             return F::ZERO * x;
+     *         }
+     *         ix = i;
+     *     }
+     *
+     *     ix <<= 1;
+     *     ex -= 1;
+     * }
+     *
+     * let i = ix.wrapping_sub(iy);
+     * if i >> (F::BITS - 1) == zero {
+     *     if i == zero {
+     *         return F::ZERO * x;
+     *     }
+     *     ix = i;
+     * }
+     *
+     * but we factor out the duplicate block inside the loop, taking
+     * advantage of a funny-looking "while loop with condition in the middle".
+     */
+    while ({
+      val i = ix - iy
+      if (i >= iZero) {
+        if (i == iZero)
+          return fZero * x
+        ix = i
+      }
+
+      ex > ey // the actual condition of the while loop
+    }) {
+      ix <<= 1
+      ex -= 1
+    }
+
+    // re-normalize the result in ix
+
+    /* let shift = ix.leading_zeros().saturating_sub(F::EXP_BITS);
+     * ix <<= shift;
+     * ex -= shift as i32;
+     */
+    val shift = leadingZeros(ix) - ebits
+    ix <<= shift
+    ex -= shift
+
+    // scale result
+
+    /* if ex > 0 {
+     *     ix -= one << F::SIG_BITS;
+     *     ix |= F::Int::cast_from(ex) << F::SIG_BITS;
+     * } else {
+     *     ix >>= -ex + 1;
+     * }
+     */
+    if (ex > 0) {
+      // normal form
+      ix = (ix - (iOne << mbits)) | (extendFromInt(ex) << mbits)
+    } else {
+      // subnormal
+      ix >>>= -ex + 1
+    }
+
+    // integrate the sign bit and return
+
+    /* ix |= sx;
+     * F::from_bits(ix)
+     */
+    fromBits(ix | sx)
+
+    // --- END MIT license
+
+    // scalastyle:on return
+
+    // --- END COPY-PASTE wrt. fmodd ------------------------------------------
+  }
+}

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/emitter/PrivateLibHolder.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/emitter/PrivateLibHolder.scala
@@ -27,6 +27,8 @@ object PrivateLibHolder {
       "org/scalajs/linker/runtime/RuntimeLong.sjsir",
       "org/scalajs/linker/runtime/RuntimeLong$.sjsir",
       "org/scalajs/linker/runtime/UndefinedBehaviorError.sjsir",
+      "org/scalajs/linker/runtime/WasmRuntime.sjsir",
+      "org/scalajs/linker/runtime/WasmRuntime$.sjsir",
       "scala/scalajs/js/JavaScriptException.sjsir"
   )
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -377,8 +377,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     addHelperImport(genFunctionID.uIFallback, List(anyref), List(Int32))
     addHelperImport(genFunctionID.typeTest(IntRef), List(anyref), List(Int32))
 
-    addHelperImport(genFunctionID.fmod, List(Float64, Float64), List(Float64))
-
     addHelperImport(genFunctionID.jsValueToString, List(RefType.any), List(RefType.extern))
     addHelperImport(genFunctionID.jsValueToStringForConcat, List(anyref), List(RefType.extern))
     addHelperImport(genFunctionID.booleanToString, List(Int32), List(RefType.extern))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -446,7 +446,11 @@ object Emitter {
 
       // See genIdentityHashCode in HelperFunctions
       callMethodStatically(BoxedDoubleClass, hashCodeMethodName),
-      callMethodStatically(BoxedStringClass, hashCodeMethodName)
+      callMethodStatically(BoxedStringClass, hashCodeMethodName),
+
+      // Implementation of Float_% and Double_%
+      callStaticMethod(WasmRuntimeClass, fmodfMethodName),
+      callStaticMethod(WasmRuntimeClass, fmoddMethodName)
     )
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1721,31 +1721,6 @@ private class FunctionEmitter private (
       case Long_>> =>
         genLongShiftOp(wa.I64ShrS)
 
-      /* Floating point remainders are specified by
-       * https://262.ecma-international.org/#sec-numeric-types-number-remainder
-       * which says that it is equivalent to the C library function `fmod`.
-       * For `Float`s, we promote and demote to `Double`s.
-       * `fmod` seems quite hard to correctly implement, so we delegate to a
-       * JavaScript Helper.
-       * (The naive function `x - trunc(x / y) * y` that we can find on the
-       * Web does not work.)
-       */
-      case Float_% =>
-        genTree(lhs, FloatType)
-        fb += wa.F64PromoteF32
-        genTree(rhs, FloatType)
-        fb += wa.F64PromoteF32
-        markPosition(tree)
-        fb += wa.Call(genFunctionID.fmod)
-        fb += wa.F32DemoteF64
-        FloatType
-      case Double_% =>
-        genTree(lhs, DoubleType)
-        genTree(rhs, DoubleType)
-        markPosition(tree)
-        fb += wa.Call(genFunctionID.fmod)
-        DoubleType
-
       case String_charAt =>
         genTree(lhs, StringType)
         genTree(rhs, IntType)
@@ -1884,6 +1859,9 @@ private class FunctionEmitter private (
   private def getElementaryBinaryOpInstr(op: BinaryOp.Code): wa.Instr = {
     import BinaryOp._
 
+    def fmodFunctionID(methodName: MethodName): wanme.FunctionID =
+      genFunctionID.forMethod(MemberNamespace.PublicStatic, SpecialNames.WasmRuntimeClass, methodName)
+
     (op: @switch) match {
       case Boolean_== => wa.I32Eq
       case Boolean_!= => wa.I32Ne
@@ -1924,11 +1902,13 @@ private class FunctionEmitter private (
       case Float_- => wa.F32Sub
       case Float_* => wa.F32Mul
       case Float_/ => wa.F32Div
+      case Float_% => wa.Call(fmodFunctionID(SpecialNames.fmodfMethodName))
 
       case Double_+ => wa.F64Add
       case Double_- => wa.F64Sub
       case Double_* => wa.F64Mul
       case Double_/ => wa.F64Div
+      case Double_% => wa.Call(fmodFunctionID(SpecialNames.fmoddMethodName))
 
       case Double_== => wa.F64Eq
       case Double_!= => wa.F64Ne

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1648,9 +1648,18 @@ private class FunctionEmitter private (
 
     def genLongShiftOp(shiftInstr: wa.Instr): Type = {
       genTree(lhs, LongType)
-      genTree(rhs, IntType)
-      markPosition(tree)
-      fb += wa.I64ExtendI32S
+      rhs match {
+        case IntLiteral(r) =>
+          // common case: fold the extension to 64 bits into the literal
+          markPosition(rhs)
+          fb += wa.I64Const(r.toLong)
+          markPosition(tree)
+        case _ =>
+          // otherwise, extend at run-time
+          genTree(rhs, IntType)
+          markPosition(tree)
+          fb += wa.I64ExtendI32S
+      }
       fb += shiftInstr
       LongType
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -100,9 +100,6 @@ const scalaJSHelpers = {
   tF: (x) => typeof x === 'number' && (Math.fround(x) === x || x !== x),
   tD: (x) => typeof x === 'number',
 
-  // fmod, to implement Float_% and Double_% (it is apparently quite hard to implement fmod otherwise)
-  fmod: (x, y) => x % y,
-
   // Strings
   emptyString: "",
   jsValueToString: (x) => (x === void 0) ? "undefined" : x.toString(),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SpecialNames.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SpecialNames.scala
@@ -37,6 +37,9 @@ object SpecialNames {
   val UndefinedBehaviorErrorClass =
     ClassName("org.scalajs.linker.runtime.UndefinedBehaviorError")
 
+  val WasmRuntimeClass =
+    ClassName("org.scalajs.linker.runtime.WasmRuntime")
+
   // Field names
 
   val valueFieldSimpleName = SimpleFieldName("value")
@@ -51,6 +54,9 @@ object SpecialNames {
   val ThrowableArgConsructorName = MethodName.constructor(List(ClassRef(ThrowableClass)))
 
   val hashCodeMethodName = MethodName("hashCode", Nil, IntRef)
+
+  val fmodfMethodName = MethodName("fmodf", List(FloatRef, FloatRef), FloatRef)
+  val fmoddMethodName = MethodName("fmodd", List(DoubleRef, DoubleRef), DoubleRef)
 
   /** A unique simple method name to map all method *signatures* into `MethodName`s. */
   val normalizedSimpleMethodName = SimpleMethodName("m")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -130,8 +130,6 @@ object VarGen {
     case object bIFallback extends JSHelperFunctionID
     case object uIFallback extends JSHelperFunctionID
 
-    case object fmod extends JSHelperFunctionID
-
     case object jsValueToString extends JSHelperFunctionID // for actual toString() call
     case object jsValueToStringForConcat extends JSHelperFunctionID
     case object booleanToString extends JSHelperFunctionID

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/DoubleTest.scala
@@ -221,6 +221,8 @@ class DoubleTest {
     test(Double.NaN, Double.NaN, 2.1)
     test(Double.NaN, Double.NaN, 5.5)
     test(Double.NaN, Double.NaN, -151.189)
+    test(Double.NaN, Double.NaN, 3.123e-320)
+    test(Double.NaN, Double.NaN, 2.253547e-318)
 
     // If d is NaN, return NaN
     test(Double.NaN, Double.NaN, Double.NaN)
@@ -231,6 +233,8 @@ class DoubleTest {
     test(Double.NaN, 2.1, Double.NaN)
     test(Double.NaN, 5.5, Double.NaN)
     test(Double.NaN, -151.189, Double.NaN)
+    test(Double.NaN, 3.123e-320, Double.NaN)
+    test(Double.NaN, 2.253547e-318, Double.NaN)
 
     // If n is PositiveInfinity, return NaN
     test(Double.NaN, Double.PositiveInfinity, Double.PositiveInfinity)
@@ -240,6 +244,8 @@ class DoubleTest {
     test(Double.NaN, Double.PositiveInfinity, 2.1)
     test(Double.NaN, Double.PositiveInfinity, 5.5)
     test(Double.NaN, Double.PositiveInfinity, -151.189)
+    test(Double.NaN, Double.PositiveInfinity, 3.123e-320)
+    test(Double.NaN, Double.PositiveInfinity, 2.253547e-318)
 
     // If n is NegativeInfinity, return NaN
     test(Double.NaN, Double.NegativeInfinity, Double.PositiveInfinity)
@@ -249,6 +255,8 @@ class DoubleTest {
     test(Double.NaN, Double.NegativeInfinity, 2.1)
     test(Double.NaN, Double.NegativeInfinity, 5.5)
     test(Double.NaN, Double.NegativeInfinity, -151.189)
+    test(Double.NaN, Double.NegativeInfinity, 3.123e-320)
+    test(Double.NaN, Double.NegativeInfinity, 2.253547e-318)
 
     // If d is PositiveInfinity, return n
     test(+0.0, +0.0, Double.PositiveInfinity)
@@ -256,6 +264,8 @@ class DoubleTest {
     test(2.1, 2.1, Double.PositiveInfinity)
     test(5.5, 5.5, Double.PositiveInfinity)
     test(-151.189, -151.189, Double.PositiveInfinity)
+    test(3.123e-320, 3.123e-320, Double.PositiveInfinity)
+    test(2.253547e-318, 2.253547e-318, Double.PositiveInfinity)
 
     // If d is NegativeInfinity, return n
     test(+0.0, +0.0, Double.NegativeInfinity)
@@ -263,6 +273,8 @@ class DoubleTest {
     test(2.1, 2.1, Double.NegativeInfinity)
     test(5.5, 5.5, Double.NegativeInfinity)
     test(-151.189, -151.189, Double.NegativeInfinity)
+    test(3.123e-320, 3.123e-320, Double.NegativeInfinity)
+    test(2.253547e-318, 2.253547e-318, Double.NegativeInfinity)
 
     // If d is +0.0, return NaN
     test(Double.NaN, +0.0, +0.0)
@@ -270,6 +282,8 @@ class DoubleTest {
     test(Double.NaN, 2.1, +0.0)
     test(Double.NaN, 5.5, +0.0)
     test(Double.NaN, -151.189, +0.0)
+    test(Double.NaN, 3.123e-320, +0.0)
+    test(Double.NaN, 2.253547e-318, +0.0)
 
     // If d is -0.0, return NaN
     test(Double.NaN, +0.0, -0.0)
@@ -277,28 +291,51 @@ class DoubleTest {
     test(Double.NaN, 2.1, -0.0)
     test(Double.NaN, 5.5, -0.0)
     test(Double.NaN, -151.189, -0.0)
+    test(Double.NaN, 3.123e-320, -0.0)
+    test(Double.NaN, 2.253547e-318, -0.0)
 
     // If n is +0.0, return n
     test(+0.0, +0.0, 2.1)
     test(+0.0, +0.0, 5.5)
     test(+0.0, +0.0, -151.189)
+    test(+0.0, +0.0, 3.123e-320)
+    test(+0.0, +0.0, 2.253547e-318)
 
     // If n is -0.0, return n
     test(-0.0, -0.0, 2.1)
     test(-0.0, -0.0, 5.5)
     test(-0.0, -0.0, -151.189)
+    test(-0.0, -0.0, 3.123e-320)
+    test(-0.0, -0.0, 2.253547e-318)
 
     // Non-special values
-    // { val l = List(2.1, 5.5, -151.189); for (n <- l; d <- l) println(s"    test(${n % d}, $n, $d)") }
+    // { val l = List(2.1, 5.5, -151.189, 3.123e-320, 2.253547e-318);
+    //   for (n <- l; d <- l) println(s"    test(${n % d}, $n, $d)".toLowerCase()) }
     test(0.0, 2.1, 2.1)
     test(2.1, 2.1, 5.5)
     test(2.1, 2.1, -151.189)
+    test(2.0696e-320, 2.1, 3.123e-320)
+    test(1.772535e-318, 2.1, 2.253547e-318)
     test(1.2999999999999998, 5.5, 2.1)
     test(0.0, 5.5, 5.5)
     test(5.5, 5.5, -151.189)
+    test(3.607e-321, 5.5, 3.123e-320)
+    test(6.8103e-319, 5.5, 2.253547e-318)
     test(-2.0889999999999866, -151.189, 2.1)
     test(-2.688999999999993, -151.189, 5.5)
     test(-0.0, -151.189, -151.189)
+    test(-1.94e-320, -151.189, 3.123e-320)
+    test(-4.1349e-319, -151.189, 2.253547e-318)
+    test(3.123e-320, 3.123e-320, 2.1)
+    test(3.123e-320, 3.123e-320, 5.5)
+    test(3.123e-320, 3.123e-320, -151.189)
+    test(0.0, 3.123e-320, 3.123e-320)
+    test(3.123e-320, 3.123e-320, 2.253547e-318)
+    test(2.253547e-318, 2.253547e-318, 2.1)
+    test(2.253547e-318, 2.253547e-318, 5.5)
+    test(2.253547e-318, 2.253547e-318, -151.189)
+    test(4.995e-321, 2.253547e-318, 3.123e-320)
+    test(0.0, 2.253547e-318, 2.253547e-318)
   }
 
   @Test

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/FloatTest.scala
@@ -73,6 +73,8 @@ class FloatTest {
     test(Float.NaN, Float.NaN, 2.1f)
     test(Float.NaN, Float.NaN, 5.5f)
     test(Float.NaN, Float.NaN, -151.189f)
+    test(Float.NaN, Float.NaN, 8.858e-42f)
+    test(Float.NaN, Float.NaN, 6.39164e-40f)
 
     // If d is NaN, return NaN
     test(Float.NaN, Float.NaN, Float.NaN)
@@ -83,6 +85,8 @@ class FloatTest {
     test(Float.NaN, 2.1f, Float.NaN)
     test(Float.NaN, 5.5f, Float.NaN)
     test(Float.NaN, -151.189f, Float.NaN)
+    test(Float.NaN, 8.858e-42f, Float.NaN)
+    test(Float.NaN, 6.39164e-40f, Float.NaN)
 
     // If n is PositiveInfinity, return NaN
     test(Float.NaN, Float.PositiveInfinity, Float.PositiveInfinity)
@@ -92,6 +96,8 @@ class FloatTest {
     test(Float.NaN, Float.PositiveInfinity, 2.1f)
     test(Float.NaN, Float.PositiveInfinity, 5.5f)
     test(Float.NaN, Float.PositiveInfinity, -151.189f)
+    test(Float.NaN, Float.PositiveInfinity, 8.858e-42f)
+    test(Float.NaN, Float.PositiveInfinity, 6.39164e-40f)
 
     // If n is NegativeInfinity, return NaN
     test(Float.NaN, Float.NegativeInfinity, Float.PositiveInfinity)
@@ -101,6 +107,8 @@ class FloatTest {
     test(Float.NaN, Float.NegativeInfinity, 2.1f)
     test(Float.NaN, Float.NegativeInfinity, 5.5f)
     test(Float.NaN, Float.NegativeInfinity, -151.189f)
+    test(Float.NaN, Float.NegativeInfinity, 8.858e-42f)
+    test(Float.NaN, Float.NegativeInfinity, 6.39164e-40f)
 
     // If d is PositiveInfinity, return n
     test(+0.0f, +0.0f, Float.PositiveInfinity)
@@ -108,6 +116,8 @@ class FloatTest {
     test(2.1f, 2.1f, Float.PositiveInfinity)
     test(5.5f, 5.5f, Float.PositiveInfinity)
     test(-151.189f, -151.189f, Float.PositiveInfinity)
+    test(8.858e-42f, 8.858e-42f, Float.PositiveInfinity)
+    test(6.39164e-40f, 6.39164e-40f, Float.PositiveInfinity)
 
     // If d is NegativeInfinity, return n
     test(+0.0f, +0.0f, Float.NegativeInfinity)
@@ -115,6 +125,8 @@ class FloatTest {
     test(2.1f, 2.1f, Float.NegativeInfinity)
     test(5.5f, 5.5f, Float.NegativeInfinity)
     test(-151.189f, -151.189f, Float.NegativeInfinity)
+    test(8.858e-42f, 8.858e-42f, Float.NegativeInfinity)
+    test(6.39164e-40f, 6.39164e-40f, Float.NegativeInfinity)
 
     // If d is +0.0, return NaN
     test(Float.NaN, +0.0f, +0.0f)
@@ -122,6 +134,8 @@ class FloatTest {
     test(Float.NaN, 2.1f, +0.0f)
     test(Float.NaN, 5.5f, +0.0f)
     test(Float.NaN, -151.189f, +0.0f)
+    test(Float.NaN, 8.858e-42f, +0.0f)
+    test(Float.NaN, 6.39164e-40f, +0.0f)
 
     // If d is -0.0, return NaN
     test(Float.NaN, +0.0f, -0.0f)
@@ -129,28 +143,51 @@ class FloatTest {
     test(Float.NaN, 2.1f, -0.0f)
     test(Float.NaN, 5.5f, -0.0f)
     test(Float.NaN, -151.189f, -0.0f)
+    test(Float.NaN, 8.858e-42f, -0.0f)
+    test(Float.NaN, 6.39164e-40f, -0.0f)
 
     // If n is +0.0, return n
     test(+0.0f, +0.0f, 2.1f)
     test(+0.0f, +0.0f, 5.5f)
     test(+0.0f, +0.0f, -151.189f)
+    test(+0.0f, +0.0f, 8.858e-42f)
+    test(+0.0f, +0.0f, 6.39164e-40f)
 
     // If n is -0.0, return n
     test(-0.0f, -0.0f, 2.1f)
     test(-0.0f, -0.0f, 5.5f)
     test(-0.0f, -0.0f, -151.189f)
+    test(-0.0f, -0.0f, 8.858e-42f)
+    test(-0.0f, -0.0f, 6.39164e-40f)
 
     // Non-special values
-    // { val l = List(2.1f, 5.5f, -151.189f); for (n <- l; d <- l) println(s"      test(${n % d}f, ${n}f, ${d}f)") }
+    // { val l = List(2.1f, 5.5f, -151.189f, 8.858e-42f, 6.39164e-40f);
+    //   for (n <- l; d <- l) println(s"    test(${n % d}f, ${n}f, ${d}f)".toLowerCase()) }
     test(0.0f, 2.1f, 2.1f)
     test(2.1f, 2.1f, 5.5f)
     test(2.1f, 2.1f, -151.189f)
+    test(8.085e-42f, 2.1f, 8.858e-42f)
+    test(6.1636e-40f, 2.1f, 6.39164e-40f)
     test(1.3000002f, 5.5f, 2.1f)
     test(0.0f, 5.5f, 5.5f)
     test(5.5f, 5.5f, -151.189f)
+    test(5.11e-43f, 5.5f, 8.858e-42f)
+    test(4.77036e-40f, 5.5f, 6.39164e-40f)
     test(-2.0890021f, -151.189f, 2.1f)
     test(-2.6889954f, -151.189f, 5.5f)
     test(-0.0f, -151.189f, -151.189f)
+    test(-1.139e-42f, -151.189f, 8.858e-42f)
+    test(-5.64734e-40f, -151.189f, 6.39164e-40f)
+    test(8.858e-42f, 8.858e-42f, 2.1f)
+    test(8.858e-42f, 8.858e-42f, 5.5f)
+    test(8.858e-42f, 8.858e-42f, -151.189f)
+    test(0.0f, 8.858e-42f, 8.858e-42f)
+    test(8.858e-42f, 8.858e-42f, 6.39164e-40f)
+    test(6.39164e-40f, 6.39164e-40f, 2.1f)
+    test(6.39164e-40f, 6.39164e-40f, 5.5f)
+    test(6.39164e-40f, 6.39164e-40f, -151.189f)
+    test(1.417e-42f, 6.39164e-40f, 8.858e-42f)
+    test(0.0f, 6.39164e-40f, 6.39164e-40f)
   }
 
   @Test


### PR DESCRIPTION
This avoids the JS call overhead for that "primitive" operation.

As can be seen in the implementation, `fmod` is far from a primitive, though. It requires an involved algorithm in software.

We took an MIT implemention of `fmod` written in Rust, generic in the bit-width, and translated it to Scala. The "generic" aspect is turned into a big copy-pasted blob between the `Float` and `Double` versions, with some "configuration" at the top.

We put that implementation in the linker private library, in a new object `WasmRuntime`. The Wasm backend compiles `Float_%` and `Double_%` as calls to those runtime functions.

---

(Probably better) alternative to #5147. At least we read Scala code and not Wasm code. It's not a *lot* less code in total, but there are 175 lines that are a brutal copy-paste, so those duplicate 175 lines don't need to be reviewed.