### PR TITLE
Merge the itables into the corresponding vtables.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -117,7 +117,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
 
     genImports()
 
-    genEmptyITable()
     genPrimitiveTypeDataGlobals()
 
     genHelperDefinitions()
@@ -176,20 +175,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     )
 
     genCoreType(
-      genTypeID.itables,
-      StructType(
-        (0 until ctx.itablesLength).map { i =>
-          StructField(
-            genFieldID.itablesStruct.itableSlot(i),
-            OriginalName.NoOriginalName,
-            RefType.nullable(HeapType.Struct),
-            isMutable = false
-          )
-        }.toList
-      )
-    )
-
-    genCoreType(
       genTypeID.reflectiveProxies,
       ArrayType(FieldType(RefType(genTypeID.reflectiveProxy), isMutable = false))
     )
@@ -234,12 +219,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
       RefType(vtableTypeID),
       isMutable = false
     )
-    val itablesField = StructField(
-      genFieldID.objStruct.itables,
-      OriginalName(genFieldID.objStruct.itables.toString()),
-      RefType(genTypeID.itables),
-      isMutable = false
-    )
 
     val typeRefsWithArrays: List[(TypeID, TypeID)] =
       List(
@@ -266,7 +245,7 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
 
       val superType = genTypeID.ObjectStruct
       val structType = StructType(
-        List(vtableField, itablesField, underlyingArrayField)
+        List(vtableField, underlyingArrayField)
       )
       val subType = SubType(structTypeID, origName, isFinal = true, Some(superType), structType)
       ctx.mainRecType.addSubType(subType)
@@ -431,18 +410,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
 
   // --- Global definitions ---
 
-  private def genEmptyITable()(implicit ctx: WasmContext): Unit = {
-    ctx.addGlobal(
-      Global(
-        genGlobalID.emptyITable,
-        OriginalName(genGlobalID.emptyITable.toString()),
-        isMutable = false,
-        RefType(genTypeID.itables),
-        Expr(List(StructNewDefault(genTypeID.itables)))
-      )
-    )
-  }
-
   private def genPrimitiveTypeDataGlobals()(implicit ctx: WasmContext): Unit = {
     import genFieldID.typeData._
 
@@ -498,7 +465,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
       val boxStruct = genTypeID.forClass(boxClassName)
       val instrs: List[Instr] = List(
         GlobalGet(genGlobalID.forVTable(boxClassName)),
-        GlobalGet(genGlobalID.forITable(boxClassName)),
         zeroValueInstr,
         StructNew(boxStruct)
       )
@@ -1566,7 +1532,11 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
         // reflectiveProxies, empty since all methods of array classes exist in jl.Object
         fb += ArrayNewFixed(genTypeID.reflectiveProxies, 0)
 
+        // itable slots
         val objectClassInfo = ctx.getClassInfo(ObjectClass)
+        fb ++= ClassEmitter.genItableSlots(objectClassInfo, List(SerializableClass, CloneableClass))
+
+        // vtable items
         fb ++= objectClassInfo.tableEntries.map { methodName =>
           ctx.refFuncWithDeclaration(objectClassInfo.resolvedMethodInfos(methodName).tableEntryID)
         }
@@ -2256,17 +2226,16 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     fb += StructGet(genTypeID.ClassStruct, genFieldID.classData)
     fb += LocalTee(componentTypeDataLocal)
 
-    // Load the vtable and itables of the ArrayClass instance we will create
+    // Load the vtable of the ArrayClass instance we will create
     fb += I32Const(1)
-    fb += Call(genFunctionID.arrayTypeData) // vtable
-    fb += GlobalGet(genGlobalID.arrayClassITable) // itables
+    fb += Call(genFunctionID.arrayTypeData)
 
     // Load the length
     fb += LocalGet(lengthParam)
 
     // switch (componentTypeData.kind)
     val switchClauseSig = FunctionType(
-      List(arrayTypeDataType, RefType(genTypeID.itables), Int32),
+      List(arrayTypeDataType, Int32),
       List(RefType(genTypeID.ObjectStruct))
     )
     fb.switch(switchClauseSig) { () =>
@@ -2807,7 +2776,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     // Build the result arrayStruct
     fb += LocalGet(fromLocal)
     fb += StructGet(arrayStructTypeID, genFieldID.objStruct.vtable) // vtable
-    fb += GlobalGet(genGlobalID.arrayClassITable) // itable
     fb += LocalGet(resultUnderlyingLocal)
     fb += StructNew(arrayStructTypeID)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Emitter.scala
@@ -90,7 +90,6 @@ final class Emitter(config: Emitter.Config) {
     coreLib.genPreClasses()
     sortedClasses.foreach(classEmitter.genClassDef(_))
     topLevelExports.foreach(classEmitter.genTopLevelExport(_))
-    classEmitter.genGlobalArrayClassItable()
     coreLib.genPostClasses()
 
     genStartFunction(sortedClasses, moduleInitializers, topLevelExports)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1190,10 +1190,10 @@ private class FunctionEmitter private (
     // Generates an itable-based dispatch.
     def genITableDispatch(): Unit = {
       fb += wa.LocalGet(receiverLocalForDispatch)
-      fb += wa.StructGet(genTypeID.ObjectStruct, genFieldID.objStruct.itables)
+      fb += wa.StructGet(genTypeID.ObjectStruct, genFieldID.objStruct.vtable)
       fb += wa.StructGet(
-        genTypeID.itables,
-        genFieldID.itablesStruct.itableSlot(receiverClassInfo.itableIdx)
+        genTypeID.ObjectVTable,
+        genFieldID.vtableStruct.itableSlot(receiverClassInfo.itableIdx)
       )
       fb += wa.RefCast(watpe.RefType(genTypeID.forITable(receiverClassInfo.name)))
       fb += wa.StructGet(
@@ -2722,7 +2722,6 @@ private class FunctionEmitter private (
 
     fb += wa.LocalSet(primLocal)
     fb += wa.GlobalGet(genGlobalID.forVTable(boxClassName))
-    fb += wa.GlobalGet(genGlobalID.forITable(boxClassName))
     fb += wa.LocalGet(primLocal)
     fb += wa.StructNew(genTypeID.forClass(boxClassName))
 
@@ -3001,7 +3000,7 @@ private class FunctionEmitter private (
 
     markPosition(tree)
 
-    genLoadVTableAndITableForArray(fb, arrayTypeRef)
+    genLoadArrayTypeData(fb, arrayTypeRef) // vtable
 
     // Create the underlying array
     genTree(length, IntType)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
@@ -140,12 +140,6 @@ object Preprocessor {
       }
     }
 
-    // Does this Scala class implement any interface?
-    val classImplementsAnyInterface = {
-      (kind.isClass || kind == ClassKind.HijackedClass) &&
-      (clazz.interfaces.nonEmpty || superClass.exists(_.classImplementsAnyInterface))
-    }
-
     /* Should we emit a vtable/typeData global for this class?
      *
      * There are essentially three reasons for which we need them:
@@ -215,7 +209,6 @@ object Preprocessor {
       kind,
       clazz.jsClassCaptures,
       allFieldDefs,
-      classImplementsAnyInterface,
       clazz.hasInstances,
       !clazz.hasDirectInstances,
       hasRuntimeTypeInfo,

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/SWasmGen.scala
@@ -62,18 +62,9 @@ object SWasmGen {
     fb += Call(genFunctionID.arrayTypeData)
   }
 
-  /** Gen code to load the vtable and the itable of the given array type. */
-  def genLoadVTableAndITableForArray(fb: FunctionBuilder, arrayTypeRef: ArrayTypeRef): Unit = {
-    // Load the typeData of the resulting array type. It is the vtable of the resulting object.
-    genLoadArrayTypeData(fb, arrayTypeRef)
-
-    // Load the itables for the array type
-    fb += GlobalGet(genGlobalID.arrayClassITable)
-  }
-
   def genArrayValue(fb: FunctionBuilder, arrayTypeRef: ArrayTypeRef, length: Int)(
       genElems: => Unit): Unit = {
-    genLoadVTableAndITableForArray(fb, arrayTypeRef)
+    genLoadArrayTypeData(fb, arrayTypeRef) // vtable
 
     // Create the underlying array
     genElems

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -37,7 +37,6 @@ object VarGen {
         forVTable(ClassRef(className))
     }
 
-    final case class forITable(className: ClassName) extends GlobalID
     final case class forStaticField(fieldName: FieldName) extends GlobalID
     final case class forJSPrivateField(fieldName: FieldName) extends GlobalID
 
@@ -45,8 +44,6 @@ object VarGen {
 
     case object bZeroChar extends GlobalID
     case object bZeroLong extends GlobalID
-    case object emptyITable extends GlobalID
-    case object arrayClassITable extends GlobalID
     case object lastIDHashCode extends GlobalID
 
     /** A `GlobalID` for a JS helper global.
@@ -231,12 +228,7 @@ object VarGen {
 
     object objStruct {
       case object vtable extends FieldID
-      case object itables extends FieldID
       case object arrayUnderlying extends FieldID
-    }
-
-    object itablesStruct {
-      final case class itableSlot(i: Int) extends FieldID
     }
 
     object reflectiveProxy {
@@ -343,6 +335,11 @@ object VarGen {
       case object reflectiveProxies extends FieldID
     }
 
+    /** Extension of `typeData` for vtables, starting with `jl.Object`. */
+    object vtableStruct {
+      final case class itableSlot(i: Int) extends FieldID
+    }
+
     /** The magic `data` field of type `(ref typeData)`, injected into `jl.Class`. */
     case object classData extends FieldID
 
@@ -405,7 +402,6 @@ object VarGen {
     }
 
     case object typeDataArray extends TypeID
-    case object itables extends TypeID
     case object reflectiveProxies extends TypeID
 
     // primitive array types, underlying the Array[T] classes

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmContext.scala
@@ -256,7 +256,6 @@ object WasmContext {
       val kind: ClassKind,
       val jsClassCaptures: Option[List[ParamDef]],
       val allFieldDefs: List[FieldDef],
-      val classImplementsAnyInterface: Boolean,
       val hasInstances: Boolean,
       val isAbstract: Boolean,
       val hasRuntimeTypeInfo: Boolean,
@@ -271,7 +270,7 @@ object WasmContext {
     override def toString(): String =
       s"ClassInfo(${name.nameString})"
 
-    /** Returns the index of this interface's itable in the classes' interface tables.
+    /** Returns the index of this interface's itable in the classes' vtables.
      *
      *  Only interfaces that have instances get an itable index.
      */


### PR DESCRIPTION
This is a trade-off on memory and code size.

The big advantage is that run-time instances of our classes use one fewer word each, since we do not have an `itables` field anymore. There could be some execution time improvements as a side effect, since we have one fewer word to initialize.

There are two disadvantages, but IMO they are comparatively minor:

* We cannot use the "one empty itables to rule them all" trick anymore. Classes that implement no interfaces need to list their N `null` values. This has both a code size impact and a constant run-time memory cost.
* We cannot share the itables of array classes either. This has no impact on code size (there is a single place in the code where we initialize those fields), but it does add run-time footprint to the vtables of each array type that gets created.

Interface method calls are not impacted, neither in the code we generate, nor in their run-time performance. Virtual method calls are only impacted insofar as the index of virtual method pointers is bumped up by the number of itable slots. This can add one more byte to some calls, due to the var-length encoding. If we get very unlucky, it could also push some vtable method pointers past a pre-fetch boundary, slowing down the calls at run-time. But I don't really think that's plausible.

Review by @gzm0 and @tanishiking.