### PR TITLE
Fix #5159: Register static module dependency on used lambda classes.

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -264,6 +264,11 @@ def Tasks = [
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
         $testSuite$v/test &&
     sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallestModules))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
+        'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withOptimizer(false))' \
+        $testSuite$v/test &&
+    sbtretry ++$scala 'set Global/enableMinifyEverywhere := $testMinify' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleSplitStyle(ModuleSplitStyle.SmallModulesFor(List("org.scalajs.testsuite"))))' \
         'set scalaJSLinkerConfig in $testSuite.v$v ~= (_.withModuleKind(ModuleKind.ESModule))' \
         $testSuite$v/test &&

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1488,6 +1488,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
         lookupOrSynthesizeClass(className, SyntheticClassKind.Lambda(descriptor)) { lambdaClassInfo =>
           lambdaClassInfo.instantiated()
           lambdaClassInfo.callMethodStatically(MemberNamespace.Constructor, ctorName)
+          moduleUnit.addStaticDependency(lambdaClassInfo.className)
         }
       }
     }


### PR DESCRIPTION
When we use a lambda class, we implicitly instantiate it. That constitutes a static dependency, which we previously failed to register.