### PR TITLE
Introduce a binary API with Scala functions in `Reflect`.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -1417,8 +1417,13 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
         implicit pos: Position): Option[js.Tree] = {
       val fqcnArg = js.StringLiteral(sym.fullName + "$")
       val runtimeClassArg = js.ClassOf(toTypeRef(sym.info))
-      val loadModuleFunArg =
-        js.Closure(js.ClosureFlags.arrow, Nil, Nil, None, jstpe.AnyType, genLoadModule(sym), Nil)
+
+      val loadModuleFunArg = js.NewLambda(
+          js.NewLambda.Descriptor(encodeClassName(AbstractFunctionClass(0)), Nil,
+              MethodName("apply", Nil, jswkn.ObjectRef),
+              Nil, jstpe.AnyType),
+          js.Closure(js.ClosureFlags.typed, Nil, Nil, None, jstpe.AnyType, genLoadModule(sym), Nil)
+      )(encodeClassType(FunctionClass(0)))
 
       val stat = genApplyMethod(
           genLoadModule(ReflectModule),
@@ -1437,12 +1442,40 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       if (ctors.isEmpty) {
         None
       } else {
+        val objectArrayRef = jstpe.ArrayTypeRef(jswkn.ObjectRef, 1)
+        val objectArrayType = jstpe.ArrayType(objectArrayRef, nullable = true)
+        val tuple2Class = encodeClassName(TupleClass(2))
+        val tuple2ArrayRef = jstpe.ArrayTypeRef(jstpe.ClassRef(tuple2Class), 1)
+        val classClassRef = jstpe.ClassRef(jswkn.ClassClass)
+        val classArrayRef = jstpe.ArrayTypeRef(classClassRef, 1)
+
+        val tuple2Ctor = MethodName.constructor(List(jswkn.ObjectRef, jswkn.ObjectRef))
+
+        val newInstanceFunDescriptor = {
+          js.NewLambda.Descriptor(encodeClassName(AbstractFunctionClass(1)), Nil,
+              MethodName("apply", List(jswkn.ObjectRef), jswkn.ObjectRef),
+              List(jstpe.AnyType), jstpe.AnyType)
+        }
+
         val constructorsInfos = for {
           ctor <- ctors
         } yield {
-          withNewLocalNameScope {
-            val (parameterTypes, formalParams, actualParams) = (for {
-              param <- ctor.tpe.params
+          val paramTypesArray = js.ArrayValue(classArrayRef,
+              ctor.tpe.params.map(p => js.ClassOf(toTypeRef(p.tpe))))
+
+          val newInstanceClosure = {
+            // param args: Object
+            val argsParamDef = js.ParamDef(js.LocalIdent(LocalName("args")),
+                NoOriginalName, jstpe.AnyType, mutable = false)
+
+            // val argsArray: Object[] = args.asInstanceOf[Object[]]
+            val argsArrayVarDef = js.VarDef(js.LocalIdent(LocalName("argsArray")),
+                NoOriginalName, objectArrayType, mutable = false,
+                js.AsInstanceOf(argsParamDef.ref, objectArrayType))
+
+            // argsArray[i].asInstanceOf[Ti] for every parameter of the constructor
+            val actualParams = for {
+              (param, index) <- ctor.tpe.params.zipWithIndex
             } yield {
               /* Note that we do *not* use `param.tpe` entering posterasure
                * (neither to compute `paramType` nor to give to `fromAny`).
@@ -1460,24 +1493,30 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
                * parameter types is `List(classOf[Int])`, and when invoked
                * reflectively, it must be given an `Int` (or `Integer`).
                */
-              val paramType = js.ClassOf(toTypeRef(param.tpe))
-              val paramDef = genParamDef(param, jstpe.AnyType)
-              val actualParam = fromAny(paramDef.ref, param.tpe)
-              (paramType, paramDef, actualParam)
-            }).unzip3
+              fromAny(
+                  js.ArraySelect(argsArrayVarDef.ref, js.IntLiteral(index))(jstpe.AnyType),
+                  param.tpe)
+            }
 
-            val paramTypesArray = js.JSArrayConstr(parameterTypes)
-
-            val newInstanceFun = js.Closure(js.ClosureFlags.arrow, Nil,
-              formalParams, None, jstpe.AnyType, genNew(sym, ctor, actualParams), Nil)
-
-            js.JSArrayConstr(List(paramTypesArray, newInstanceFun))
+            /* typed-lambda<>(args: Object): any = {
+             *   val argsArray: Object[] = args.asInstanceOf[Object[]]
+             *   new MyClass(...argsArray[i].asInstanceOf[Ti])
+             * }
+             */
+            js.Closure(js.ClosureFlags.typed, Nil, argsParamDef :: Nil, None, jstpe.AnyType, {
+              js.Block(argsArrayVarDef, genNew(sym, ctor, actualParams))
+            }, Nil)
           }
+
+          val newInstanceFun = js.NewLambda(newInstanceFunDescriptor, newInstanceClosure)(
+              encodeClassType(FunctionClass(1)))
+
+          js.New(tuple2Class, js.MethodIdent(tuple2Ctor), List(paramTypesArray, newInstanceFun))
         }
 
         val fqcnArg = js.StringLiteral(sym.fullName)
         val runtimeClassArg = js.ClassOf(toTypeRef(sym.info))
-        val ctorsInfosArg = js.JSArrayConstr(constructorsInfos)
+        val ctorsInfosArg = js.ArrayValue(tuple2ArrayRef, constructorsInfos)
 
         val stat = genApplyMethod(
             genLoadModule(ReflectModule),

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -151,8 +151,8 @@ trait JSDefinitions {
     def ScalaRunTime_isArray: Symbol = getMemberMethod(ScalaRunTimeModule, newTermName("isArray")).suchThat(_.tpe.params.size == 2)
 
     lazy val ReflectModule = getRequiredModule("scala.scalajs.reflect.Reflect")
-      lazy val Reflect_registerLoadableModuleClass = getMemberMethod(ReflectModule, newTermName("registerLoadableModuleClass"))
-      lazy val Reflect_registerInstantiatableClass = getMemberMethod(ReflectModule, newTermName("registerInstantiatableClass"))
+      lazy val Reflect_registerLoadableModuleClass = getMemberMethod(ReflectModule, newTermName("registerLoadableModuleClassV2"))
+      lazy val Reflect_registerInstantiatableClass = getMemberMethod(ReflectModule, newTermName("registerInstantiatableClassV2"))
 
     lazy val EnableReflectiveInstantiationAnnotation = getRequiredClass("scala.scalajs.reflect.annotation.EnableReflectiveInstantiation")
 

--- a/project/BinaryIncompatibilities.scala
+++ b/project/BinaryIncompatibilities.scala
@@ -23,6 +23,9 @@ object BinaryIncompatibilities {
   )
 
   val Library = Seq(
+    // private[reflect], not an issue
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.scalajs.reflect.InvokableConstructor.this"),
+    ProblemFilters.exclude[IncompatibleMethTypeProblem]("scala.scalajs.reflect.LoadableModuleClass.this"),
   )
 
   val TestInterface = Seq(


### PR DESCRIPTION
And make its internals independent of JS interop.
This way, it will be usable in Wasm without JS host.

We use new names for the methods, instead of overloads, because older compilers look for those methods by name only. If an older compiler gets a newer library on the classpath, and the methods with those names became overloaded, the compiler would crash.

In the commit, we do not change the compiler yet, to test that the deprecated methods are correct.

In the second commit, we change the compiler to use the new APIs.

---

This does not bring any immediate benefit. It's more for a long-term vision. But it also shouldn't hurt, besides the cost of maintaining a deprecated pair of methods. If we had had `NewLambda` all along, I think we would have designed this API using the Scala types to begin with. The `Reflect` object never pretended to be Scala-agnostic, since its public API is full of Scala types anyway.