### PR TITLE
Wasm: Implement ju.ArrayList without js.Array for Wasm backend

### DIFF
--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -14,75 +14,154 @@ package java.util
 
 import java.lang.Cloneable
 import java.lang.Utils._
+import java.util.ScalaOps._
 
 import scala.scalajs._
+import scala.scalajs.LinkingInfo.isWebAssembly
 
-class ArrayList[E] private (private[ArrayList] val inner: js.Array[E])
+class ArrayList[E] private (innerInit: AnyRef, private var _size: Int)
     extends AbstractList[E] with RandomAccess with Cloneable with Serializable {
   self =>
 
+  /* This class has two different implementations for handling the
+   * internal data storage, depending on whether we are on Wasm or JS.
+   * On JS, we utilize `js.Array`. On Wasm, for performance reasons,
+   * we avoid JS interop and use a scala.Array.
+   * The `_size` field (unused in JS) keeps track of the effective size
+   * of the underlying Array for the Wasm implementation.
+   */
+
+  private val innerJS: js.Array[E] =
+    if (isWebAssembly) null
+    else innerInit.asInstanceOf[js.Array[E]]
+
+  private var innerWasm: Array[AnyRef] =
+    if (!isWebAssembly) null
+    else innerInit.asInstanceOf[Array[AnyRef]]
+
   def this(initialCapacity: Int) = {
-    this(new js.Array[E])
-    if (initialCapacity < 0)
-      throw new IllegalArgumentException
+    this(
+      {
+        if (initialCapacity < 0)
+          throw new IllegalArgumentException
+        if (isWebAssembly) new Array[AnyRef](initialCapacity)
+        else new js.Array[E]
+      },
+      0
+    )
   }
 
-  def this() =
-    this(new js.Array[E])
+  def this() = this(16)
 
   def this(c: Collection[_ <: E]) = {
-    this()
+    this(c.size())
     addAll(c)
   }
 
   def trimToSize(): Unit = {
-    // We ignore this as js.Array doesn't support explicit pre-allocation
+    if (isWebAssembly)
+      resizeTo(size())
+    // We ignore this in JS as js.Array doesn't support explicit pre-allocation
   }
 
   def ensureCapacity(minCapacity: Int): Unit = {
-    // We ignore this as js.Array doesn't support explicit pre-allocation
+    if (isWebAssembly) {
+      if (innerWasm.length < minCapacity) {
+        if (minCapacity > (1 << 30))
+          resizeTo(minCapacity)
+        else
+          resizeTo(((1 << 31) >>> (Integer.numberOfLeadingZeros(minCapacity - 1)) - 1))
+      }
+    }
+    // We ignore this in JS as js.Array doesn't support explicit pre-allocation
   }
 
   def size(): Int =
-    inner.length
+    if (isWebAssembly) _size
+    else innerJS.length
 
-  override def clone(): AnyRef =
-    new ArrayList(inner.jsSlice(0))
+  override def clone(): AnyRef = {
+    if (isWebAssembly)
+      new ArrayList(innerWasm.clone(), size())
+    else
+      new ArrayList(innerJS.jsSlice(0), 0)
+  }
 
   def get(index: Int): E = {
     checkIndexInBounds(index)
-    inner(index)
+    if (isWebAssembly)
+      innerWasm(index).asInstanceOf[E]
+    else
+      innerJS(index)
   }
 
   override def set(index: Int, element: E): E = {
     val e = get(index)
-    inner(index) = element
+    if (isWebAssembly)
+      innerWasm(index) = element.asInstanceOf[AnyRef]
+    else
+      innerJS(index) = element
     e
   }
 
   override def add(e: E): Boolean = {
-    inner.push(e)
+    if (isWebAssembly) {
+      if (size() >= innerWasm.length)
+        expand()
+      innerWasm(size()) = e.asInstanceOf[AnyRef]
+      _size += 1
+    } else {
+      innerJS.push(e)
+    }
     true
   }
 
   override def add(index: Int, element: E): Unit = {
     checkIndexOnBounds(index)
-    inner.splice(index, 0, element)
+    if (isWebAssembly) {
+      if (size() >= innerWasm.length)
+        expand()
+      System.arraycopy(innerWasm, index, innerWasm, index + 1, size() - index)
+      innerWasm(index) = element.asInstanceOf[AnyRef]
+      _size += 1
+    } else {
+      innerJS.splice(index, 0, element)
+    }
   }
 
   override def remove(index: Int): E = {
     checkIndexInBounds(index)
-    arrayRemoveAndGet(inner, index)
+    if (isWebAssembly) {
+      val removed = innerWasm(index).asInstanceOf[E]
+      System.arraycopy(innerWasm, index + 1, innerWasm, index, size() - index - 1)
+      innerWasm(size - 1) = null // free reference for GC
+      _size -= 1
+      removed
+    } else {
+      arrayRemoveAndGet(innerJS, index)
+    }
   }
 
   override def clear(): Unit =
-    inner.length = 0
+    if (isWebAssembly) {
+      Arrays.fill(innerWasm, null) // free references for GC
+      _size = 0
+    } else {
+      innerJS.length = 0
+    }
 
   override def addAll(index: Int, c: Collection[_ <: E]): Boolean = {
     c match {
       case other: ArrayList[_] =>
         checkIndexOnBounds(index)
-        inner.splice(index, 0, other.inner.toSeq: _*)
+        if (isWebAssembly) {
+          ensureCapacity(size() + other.size())
+          System.arraycopy(innerWasm, index, innerWasm, index + other.size(), size() - index)
+          System.arraycopy(other.innerWasm, 0, innerWasm, index, other.size())
+          _size += c.size()
+        } else {
+          innerJS.splice(index, 0, other.innerJS.toSeq: _*)
+        }
         other.size() > 0
       case _ => super.addAll(index, c)
     }
@@ -91,6 +170,25 @@ class ArrayList[E] private (private[ArrayList] val inner: js.Array[E])
   override protected def removeRange(fromIndex: Int, toIndex: Int): Unit = {
     if (fromIndex < 0 || toIndex > size() || toIndex < fromIndex)
       throw new IndexOutOfBoundsException()
-    inner.splice(fromIndex, toIndex - fromIndex)
+    if (isWebAssembly) {
+      if (fromIndex != toIndex) {
+        System.arraycopy(innerWasm, toIndex, innerWasm, fromIndex, size() - toIndex)
+        val newSize = size() - toIndex + fromIndex
+        Arrays.fill(innerWasm, newSize, size(), null) // free references for GC
+        _size = newSize
+      }
+    } else {
+      innerJS.splice(fromIndex, toIndex - fromIndex)
+    }
+  }
+
+  // Wasm only
+  private def expand(): Unit = {
+    resizeTo(Math.max(innerWasm.length * 2, 16))
+  }
+
+  // Wasm only
+  private def resizeTo(newCapacity: Int): Unit = {
+    innerWasm = Arrays.copyOf(innerWasm, newCapacity)
   }
 }

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -81,13 +81,16 @@ class ArrayList[E] private (private[ArrayList] val inner: js.Array[E])
   override def addAll(index: Int, c: Collection[_ <: E]): Boolean = {
     c match {
       case other: ArrayList[_] =>
+        checkIndexOnBounds(index)
         inner.splice(index, 0, other.inner.toSeq: _*)
         other.size() > 0
       case _ => super.addAll(index, c)
     }
   }
 
-  override protected def removeRange(fromIndex: Int, toIndex: Int): Unit =
+  override protected def removeRange(fromIndex: Int, toIndex: Int): Unit = {
+    if (fromIndex < 0 || toIndex > size() || toIndex < fromIndex)
+      throw new IndexOutOfBoundsException()
     inner.splice(fromIndex, toIndex - fromIndex)
-
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
@@ -13,6 +13,9 @@
 package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test
+import org.junit.Assert._
+
+import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 
 import java.{util => ju}
 
@@ -29,6 +32,60 @@ class ArrayListTest extends AbstractListTest {
     al.ensureCapacity(34)
     al.trimToSize()
   }
+
+  @Test def removeRangeFromIdenticalIndices(): Unit = {
+    val al = new ArrayListRangeRemovable[Int](
+        TrivialImmutableCollection(-175, 24, 7, 44))
+    val expected = Array[Int](-175, 24, 7, 44)
+    al.removeRangeList(0, 0)
+    assertTrue(al.toArray().sameElements(expected))
+    al.removeRangeList(1, 1)
+    assertTrue(al.toArray().sameElements(expected))
+    al.removeRangeList(al.size, al.size) // no op
+    assertTrue(al.toArray().sameElements(expected))
+  }
+
+  @Test def removeRangeFromToInvalidIndices(): Unit = {
+    val al = new ArrayListRangeRemovable[Int](
+        TrivialImmutableCollection(175, -24, -7, -44))
+
+    assertThrows(
+      classOf[java.lang.IndexOutOfBoundsException],
+      al.removeRangeList(-1, 2)
+    ) // fromIndex < 0
+    assertThrows(
+      classOf[java.lang.IndexOutOfBoundsException],
+      al.removeRangeList(0, al.size + 1)
+    ) // toIndex > size
+    assertThrows(
+      classOf[java.lang.IndexOutOfBoundsException],
+      al.removeRangeList(2, -1)
+    ) // toIndex < fromIndex
+  }
+
+  @Test def removeRangeFromToFirstTwoElements(): Unit = {
+    val al = new ArrayListRangeRemovable[Int](
+        TrivialImmutableCollection(284, -27, 995, 500, 267, 904))
+    val expected = Array[Int](995, 500, 267, 904)
+    al.removeRangeList(0, 2)
+    assertTrue(al.toArray().sameElements(expected))
+  }
+
+  @Test def removeRangeFromToTwoElementsFromMiddle(): Unit = {
+    val al = new ArrayListRangeRemovable[Int](
+        TrivialImmutableCollection(7, 9, -1, 20))
+    val expected = Array[Int](7, 20)
+    al.removeRangeList(1, 3)
+    assertTrue(al.toArray().sameElements(expected))
+  }
+
+  @Test def removeRangeFromToLastTwoElementsAtTail(): Unit = {
+    val al = new ArrayListRangeRemovable[Int](
+        TrivialImmutableCollection(50, 72, 650, 12, 7, 28, 3))
+    val expected = Array[Int](50, 72, 650, 12, 7)
+    al.removeRangeList(al.size - 2, al.size)
+    assertTrue(al.toArray().sameElements(expected))
+  }
 }
 
 class ArrayListFactory extends AbstractListFactory {
@@ -37,4 +94,13 @@ class ArrayListFactory extends AbstractListFactory {
 
   override def empty[E: ClassTag]: ju.ArrayList[E] =
     new ju.ArrayList[E]
+
+  override def fromElements[E: ClassTag](coll: E*): ju.ArrayList[E] =
+    new ju.ArrayList[E](TrivialImmutableCollection(coll: _*))
+}
+
+class ArrayListRangeRemovable[E](c: ju.Collection[_ <: E]) extends ju.ArrayList[E](c) {
+  def removeRangeList(fromIndex: Int, toIndex: Int): Unit = {
+    removeRange(fromIndex, toIndex)
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ArrayListTest.scala
@@ -14,8 +14,10 @@ package org.scalajs.testsuite.javalib.util
 
 import org.junit.Test
 import org.junit.Assert._
+import org.junit.Assume._
 
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
+import org.scalajs.testsuite.utils.Platform
 
 import java.{util => ju}
 
@@ -23,7 +25,7 @@ import scala.reflect.ClassTag
 
 class ArrayListTest extends AbstractListTest {
 
-  override def factory: AbstractListFactory = new ArrayListFactory
+  override def factory: ArrayListFactory = new ArrayListFactory
 
   @Test def ensureCapacity(): Unit = {
     // note that these methods become no ops in js
@@ -31,6 +33,32 @@ class ArrayListTest extends AbstractListTest {
     al.ensureCapacity(0)
     al.ensureCapacity(34)
     al.trimToSize()
+  }
+
+  @Test def constructorInitialCapacity(): Unit = {
+    val al1 = new ju.ArrayList(0)
+    assertTrue(al1.size() == 0)
+    assertTrue(al1.isEmpty())
+
+    val al2 = new ju.ArrayList(2)
+    assertTrue(al2.size() == 0)
+    assertTrue(al2.isEmpty())
+
+    assertThrows(classOf[IllegalArgumentException], new ju.ArrayList(-1))
+  }
+
+  @Test def constructorNullThrowsNullPointerException(): Unit = {
+    assumeTrue("assumed compliant NPEs", Platform.hasCompliantNullPointers)
+    assertThrows(classOf[NullPointerException], new ju.ArrayList(null))
+  }
+
+  @Test def testClone(): Unit = {
+    val al1 = factory.fromElements[Int](1, 2)
+    val al2 = al1.clone().asInstanceOf[ju.ArrayList[Int]]
+    al1.add(100)
+    al2.add(200)
+    assertTrue(Array[Int](1, 2, 100).sameElements(al1.toArray()))
+    assertTrue(Array[Int](1, 2, 200).sameElements(al2.toArray()))
   }
 
   @Test def removeRangeFromIdenticalIndices(): Unit = {

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/CollectionTest.scala
@@ -117,6 +117,16 @@ trait CollectionTest extends IterableTest {
     assertFalse(coll.contains(TestObj(200)))
   }
 
+  @Test def isEmpty(): Unit = {
+    val coll = factory.empty[Int]
+    assertTrue(coll.size() == 0)
+    assertTrue(coll.isEmpty())
+
+    val nonEmpty = factory.fromElements[Int](1)
+    assertTrue(nonEmpty.size() == 1)
+    assertFalse(nonEmpty.isEmpty())
+  }
+
   @Test def removeString(): Unit = {
     val coll = factory.empty[String]
 

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/util/ListTest.scala
@@ -96,6 +96,19 @@ trait ListTest extends CollectionTest with CollectionsTestBase {
     assertThrows(classOf[IndexOutOfBoundsException], lst.get(lst.size))
   }
 
+  @Test def addAllIndexBounds(): Unit = {
+    val al = factory.fromElements[String]("one", "two", "three")
+
+    val coll = factory.fromElements[String]("foo")
+    assertThrows(classOf[IndexOutOfBoundsException], al.addAll(-1, coll))
+    assertThrows(classOf[IndexOutOfBoundsException], al.addAll(al.size + 1, coll))
+
+    assertThrows(classOf[IndexOutOfBoundsException],
+        al.addAll(-1, TrivialImmutableCollection("foo")))
+    assertThrows(classOf[IndexOutOfBoundsException],
+        al.addAll(al.size + 1, TrivialImmutableCollection("foo")))
+  }
+
   @Test def removeStringRemoveIndex(): Unit = {
     val lst = factory.empty[String]
 


### PR DESCRIPTION
The original implementation of ju.ArrayList uses js.Array as its internal data structure. When compiling to Wasm, operations on ju.ArrayList require JS interop calls to access the underlying js.Array, which causes a slow performance.
This commit introduces an implementation of ju.ArrayList for the Wasm backend. This version uses Scala's Array instead of js.Array for better performance.

The second commit fixes JS implementation of `removeRange` to throw an `IndexOutOfBoundsException` if fromIndex or toIndex is out of range.

Upstreamed from https://github.com/scala-wasm/scala-wasm/pull/39