### PR TITLE
Fix #5165: Use defaultable types for the locals of TryFinallys.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1040,6 +1040,13 @@ private class FunctionEmitter private (
          * not need to store the receiver in a local at all.
          * For the case with the args, it does not hurt either way. We could
          * move it out, but that would make for a less consistent codegen.
+         *
+         * Loading the arguments and storing them in locals inside the block
+         * only works if their type is defaultable. Currently, for instance
+         * methods, parameter types are always defaultable, so this is fine.
+         * We may need to revisit this strategy if that invariant changes.
+         * If we do, it may be better to use different code paths for the
+         * no-args case and the with-args case. See #5165 for more context.
          */
         val argsLocals = fb.block(watpe.RefType.any) { labelNotOurObject =>
           // Load receiver and arguments and store them in temporary variables
@@ -3623,6 +3630,11 @@ private class FunctionEmitter private (
    * we cannot use the stack for the `try_table` itself: each label has a
    * dedicated local for its result if it comes from such a crossing `return`.
    *
+   * Those locals must have defaultable types, because they are read outside of
+   * the block where they are first ininitialized. If their natural type is not
+   * defaultable, we make it defaultable, and cast away nullability when we
+   * read them back. See #5165.
+   *
    * Two more complications:
    *
    * - If the `finally` block itself contains another `try..finally`, they may
@@ -3850,7 +3862,7 @@ private class FunctionEmitter private (
         _crossInfo.getOrElse {
           val destinationTag = allocateDestinationTag()
           val resultTypes = transformResultType(expectedType)
-          val resultLocals = resultTypes.map(addSyntheticLocal(_))
+          val resultLocals = resultTypes.map(tpe => addSyntheticLocal(tpe.toDefaultableType))
           val crossLabel = fb.genLabel()
           val info = CrossInfo(destinationTag, resultLocals, crossLabel)
           _crossInfo = Some(info)
@@ -3941,8 +3953,11 @@ private class FunctionEmitter private (
         // Add the `br`, `end` and `local.get` at the current position, as usual
         fb += wa.Br(entry.regularWasmLabel)
         fb += wa.End
-        for (local <- resultLocals)
+        for ((local, origType) <- resultLocals.zip(ty)) {
           fb += wa.LocalGet(local)
+          if (!origType.isDefaultable)
+            fb += wa.RefAsNonNull
+        }
       }
 
       fb += wa.End
@@ -3959,7 +3974,7 @@ private class FunctionEmitter private (
       val entry = new TryFinallyEntry(currentUnwindingStackDepth)
 
       val resultType = transformResultType(expectedType)
-      val resultLocals = resultType.map(addSyntheticLocal(_))
+      val resultLocals = resultType.map(tpe => addSyntheticLocal(tpe.toDefaultableType))
 
       markPosition(tree)
 
@@ -4074,8 +4089,11 @@ private class FunctionEmitter private (
       } // end block $done
 
       // reload the result onto the stack
-      for (resultLocal <- resultLocals)
+      for ((resultLocal, origType) <- resultLocals.zip(resultType)) {
         fb += wa.LocalGet(resultLocal)
+        if (!origType.isDefaultable)
+          fb += wa.RefAsNonNull
+      }
 
       if (expectedType == NothingType)
         fb += wa.Unreachable

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Types.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/webassembly/Types.scala
@@ -33,7 +33,24 @@ object Types {
    *  typing" point of view. It is also the kind of type we manipulate the most
    *  across the backend, so it also makes sense for it to be the "default".
    */
-  sealed abstract class Type extends StorageType
+  sealed abstract class Type extends StorageType {
+    /** Returns true if and only if this type is defaultable. */
+    final def isDefaultable: Boolean = this match {
+      case RefType(nullable, _) => nullable
+      case _                    => true
+    }
+
+    /** Returns a defaultable supertype of this type.
+     *
+     *  If this type is already defaultable, return `this`. Otherwise, this
+     *  type must be a non-nullable reference type, and this method returns the
+     *  nullable variant.
+     */
+    final def toDefaultableType: Type = this match {
+      case RefType(false, heapType) => RefType.nullable(heapType)
+      case _                        => this
+    }
+  }
 
   /** Convenience superclass for `Type`s that are encoded with a simple opcode. */
   sealed abstract class SimpleType(val textName: String, val binaryCode: Byte) extends Type

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/TryFinallyTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/TryFinallyTest.scala
@@ -229,4 +229,44 @@ class TryFinallyTest {
       "in finally 2"
     )
   }
+
+  @Test
+  def nonDefaultableTryResultType_Issue5165(): Unit = {
+    test { println =>
+      // after the optimizer, some has type Some! (a non-nullable reference type)
+      val some = try {
+        println("in try")
+        Some(1)
+      } finally {
+        println("in finally")
+      }
+      assertEquals(1, some.value)
+    } (
+      "in try",
+      "in finally"
+    )
+  }
+
+  @Test
+  def nonDefaultableLabeledResultType_Issue5165(): Unit = {
+    test { println =>
+      /* After the optimizer, the result type of the Labeled block that gets
+       * inlined is a Some! (a non-nullable reference type).
+       */
+      @inline def nonDefaultableLabeledResultTypeInner(): Some[Int] = {
+        try {
+          println("in try")
+          return Some(1)
+        } finally {
+          println("in finally")
+        }
+      }
+
+      val some = nonDefaultableLabeledResultTypeInner()
+      assertEquals(1, some.value)
+    } (
+      "in try",
+      "in finally"
+    )
+  }
 }

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/TryFinallyTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/TryFinallyTest.scala
@@ -1,0 +1,232 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.compiler
+
+import scala.collection.mutable
+
+import org.junit.Test
+import org.junit.Assert._
+
+// Much of the point of this test class is to test `return`s inside `try..finally`s
+// scalastyle:off return
+
+class TryFinallyTest {
+
+  /* Some of these tests are ported from the partest run/finally.scala.
+   * We have copies of them in our own test suite to more quickly identify
+   * any issues with our compilation scheme for try..finally. On JS it is
+   * straightforward, but it is a huge beast in Wasm.
+   */
+
+  type SideEffect = Any => Unit
+
+  @noinline
+  def test(body: SideEffect => Unit)(expectedSideEffects: String*): Unit = {
+    val sideEffects = mutable.ListBuffer.empty[String]
+
+    try {
+      body(x => sideEffects += ("" + x))
+    } catch {
+      case e: Throwable =>
+        sideEffects += ("CAUGHT: " + e)
+    }
+
+    if (!sideEffects.sameElements(expectedSideEffects)) {
+      // Custom message for easier debugging
+      fail(
+          "Expected side effects:" +
+          expectedSideEffects.mkString("\n* ", "\n* ", "\n") +
+          "but got:" +
+          sideEffects.mkString("\n* ", "\n* ", "\n"))
+    }
+  }
+
+  // test that finally is not covered by any exception handlers.
+  @Test
+  def throwCatchFinally(): Unit = {
+    test { println =>
+      def bar(): Unit = {
+        try {
+          println("hi")
+        } catch {
+          case e: Throwable => println("SHOULD NOT GET HERE")
+        } finally {
+          println("In Finally")
+          throw new RuntimeException("ouch")
+        }
+      }
+
+      try {
+        bar()
+      } catch {
+        case e: Throwable => println(e)
+      }
+    } (
+      "hi",
+      "In Finally",
+      "java.lang.RuntimeException: ouch"
+    )
+  }
+
+  // test that finally is not covered by any exception handlers.
+  // return in catch (finally is executed)
+  @Test
+  def retCatch(): Unit = {
+    test { println =>
+      def retCatchInner(): Unit = {
+        try {
+          throw new Exception
+        } catch {
+          case e: Throwable =>
+            println(e)
+            return
+        } finally {
+          println("in finally")
+        }
+      }
+
+      retCatchInner()
+    } (
+      "java.lang.Exception",
+      "in finally"
+    )
+  }
+
+  // throw in catch (finally is executed, exception propagated)
+  @Test
+  def throwCatch(): Unit = {
+    test { println =>
+      try {
+        throw new Exception
+      } catch {
+        case e: Throwable =>
+          println(e)
+          throw e
+      } finally {
+        println("in finally")
+      }
+    } (
+      "java.lang.Exception",
+      "in finally",
+      "CAUGHT: java.lang.Exception"
+    )
+  }
+
+  // return inside body (finally is executed)
+  @Test
+  def retBody(): Unit = {
+    test { println =>
+      def retBodyInner(): Unit = {
+        try {
+          return
+        } catch {
+          case e: Throwable =>
+            println(e)
+            throw e
+        } finally println("in finally")
+      }
+
+      retBodyInner()
+    } (
+      "in finally"
+    )
+  }
+
+  // throw inside body (finally and catch are executed)
+  @Test
+  def throwBody(): Unit = {
+    test { println =>
+      try {
+        throw new Exception
+      } catch {
+        case e: Throwable =>
+          println(e)
+      } finally {
+        println("in finally")
+      }
+    } (
+      "java.lang.Exception",
+      "in finally"
+    )
+  }
+
+  // return inside finally (each finally is executed once)
+  @Test
+  def retFinally(): Unit = {
+    test { println =>
+      def retFinallyInner(): Unit = {
+        try {
+          try {
+            println("body")
+          } finally {
+            println("in finally 1")
+            return
+          }
+        } finally {
+          println("in finally 2")
+        }
+      }
+
+      retFinallyInner()
+    } (
+      "body",
+      "in finally 1",
+      "in finally 2"
+    )
+  }
+
+  // throw inside finally (finally is executed once, exception is propagated)
+  @Test
+  def throwFinally(): Unit = {
+    test { println =>
+      try {
+        try {
+          println("body")
+        } finally {
+          println("in finally")
+          throw new Exception
+        }
+      } catch {
+        case e: Throwable => println(e)
+      }
+    } (
+      "body",
+      "in finally",
+      "java.lang.Exception"
+    )
+  }
+
+  // nested finally blocks with return value
+  @Test
+  def nestedFinallyBlocks(): Unit = {
+    test { println =>
+      def nestedFinallyBlocksInner(): Int = {
+        try {
+          try {
+            return 10
+          } finally {
+            try { () } catch { case _: Throwable => () }
+            println("in finally 1")
+          }
+        } finally {
+          println("in finally 2")
+        }
+      }
+
+      assertEquals(10, nestedFinallyBlocksInner())
+    } (
+      "in finally 1",
+      "in finally 2"
+    )
+  }
+}


### PR DESCRIPTION
As well as for the locals of `Labeled` blocks whose `Return`s cross a `try..finally` boundary.

If their original type was not defaultable, we cast away nullability when reading them back.