### PR TITLE
PoC: Default Export Annotation for Scala.js ES Module Output

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -681,6 +681,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
 
       val topLevelExportDefs = genTopLevelExports(sym)
 
+      checkOrphanDefaultExports()
+
       // Static initializer
       val optStaticInitializer = {
         // Initialization of reflection data, if required
@@ -861,6 +863,8 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
       }
 
       val topLevelExports = genTopLevelExports(sym)
+
+      checkOrphanDefaultExports()
 
       val (generatedCtor, jsClassCaptures) = withNewLocalNameScope {
         val isNested = isNestedJSClass(sym)

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -64,17 +64,18 @@ trait JSDefinitions {
 
     lazy val JavaScriptExceptionClass = getClassIfDefined("scala.scalajs.js.JavaScriptException")
 
-    lazy val JSNameAnnotation          = getRequiredClass("scala.scalajs.js.annotation.JSName")
-    lazy val JSBracketAccessAnnotation = getRequiredClass("scala.scalajs.js.annotation.JSBracketAccess")
-    lazy val JSBracketCallAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSBracketCall")
-    lazy val JSExportAnnotation        = getRequiredClass("scala.scalajs.js.annotation.JSExport")
-    lazy val JSExportAllAnnotation     = getRequiredClass("scala.scalajs.js.annotation.JSExportAll")
-    lazy val JSExportStaticAnnotation  = getRequiredClass("scala.scalajs.js.annotation.JSExportStatic")
+    lazy val JSNameAnnotation           = getRequiredClass("scala.scalajs.js.annotation.JSName")
+    lazy val JSBracketAccessAnnotation  = getRequiredClass("scala.scalajs.js.annotation.JSBracketAccess")
+    lazy val JSBracketCallAnnotation    = getRequiredClass("scala.scalajs.js.annotation.JSBracketCall")
+    lazy val JSExportAnnotation         = getRequiredClass("scala.scalajs.js.annotation.JSExport")
+    lazy val JSExportAllAnnotation      = getRequiredClass("scala.scalajs.js.annotation.JSExportAll")
+    lazy val JSExportStaticAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSExportStatic")
     lazy val JSExportTopLevelAnnotation = getRequiredClass("scala.scalajs.js.annotation.JSExportTopLevel")
-    lazy val JSImportAnnotation        = getRequiredClass("scala.scalajs.js.annotation.JSImport")
-    lazy val JSGlobalAnnotation        = getRequiredClass("scala.scalajs.js.annotation.JSGlobal")
-    lazy val JSGlobalScopeAnnotation   = getRequiredClass("scala.scalajs.js.annotation.JSGlobalScope")
-    lazy val JSOperatorAnnotation      = getRequiredClass("scala.scalajs.js.annotation.JSOperator")
+    lazy val JSExportDefaultAnnotation  = getRequiredClass("scala.scalajs.js.annotation.JSExportDefault")
+    lazy val JSImportAnnotation         = getRequiredClass("scala.scalajs.js.annotation.JSImport")
+    lazy val JSGlobalAnnotation         = getRequiredClass("scala.scalajs.js.annotation.JSGlobal")
+    lazy val JSGlobalScopeAnnotation    = getRequiredClass("scala.scalajs.js.annotation.JSGlobalScope")
+    lazy val JSOperatorAnnotation       = getRequiredClass("scala.scalajs.js.annotation.JSOperator")
 
     lazy val JSImportNamespaceObject = getRequiredModule("scala.scalajs.js.annotation.JSImport.Namespace")
 

--- a/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/PrepJSExports.scala
@@ -366,7 +366,7 @@ trait PrepJSExports[G <: Global with Singleton] { this: PrepJSInterop[G] =>
         else
           group.size > 1
       }
-      .foreach(_ => reporter.warning(sym.pos, s"Found duplicate @JSExport"))
+      .foreach(_ => reporter.warning(sym.pos, "Found duplicate @JSExport"))
 
     val defaultExports = allExportInfos.filter(_.destination.isInstanceOf[ExportDestination.DefaultExport.type])
     if (defaultExports.size > 1) {

--- a/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
+++ b/compiler/src/test/scala/org/scalajs/nscplugin/test/JSExportTest.scala
@@ -1964,4 +1964,76 @@ class JSExportTest extends DirectTest with TestHelpers {
     }
     """.succeeds()
   }
+
+  @Test
+  def succeedsWhenTopLevelExportWithDefaultExportOnClass(): Unit = {
+    """
+    @JSExportTopLevel("A")
+    @JSExportDefault
+    class A
+    """.succeeds()
+  }
+
+  @Test
+  def succeedsWhenTopLevelExportWithDefaultExportOnObject(): Unit = {
+    """
+    @JSExportTopLevel("A")
+    @JSExportDefault
+    object A
+    """.succeeds()
+  }
+
+  @Test
+  def succeedsWhenTopLevelExportWithDefaultExportOnObjectMember(): Unit = {
+    """
+    object A {
+      @JSExportTopLevel("foo")
+      @JSExportDefault
+      def foo(x: Int): Int = x + 1
+    }
+    """.succeeds()
+  }
+
+  @Test
+  def failsWhenUsingOnlyDefaultExportAnnotation(): Unit = {
+    """
+    @JSExportDefault
+    class A
+    """ hasErrors
+    """newSource1.scala:3: error: @DefaultExport can be used in combination with @JSTopLevelExport only
+      |    @JSExportDefault
+      |     ^""".stripMargin
+  }
+
+  @Test
+  def failsWhenThereAreMoreThanOneDefaultExports(): Unit = {
+    """
+    @JSExportTopLevel("A")
+    @JSExportDefault
+    class A
+
+    @JSExportTopLevel("B")
+    @JSExportDefault
+    class B
+    """ hasErrors
+    """newSource1.scala:8: error: cannot export symbol: constructor B, symbol constructor A already exported at pos source-newSource1.scala,line-4,offset=78
+      |    @JSExportDefault
+      |     ^""".stripMargin
+  }
+
+  @Test
+  def failedWhenDefaultExportIsCombinedWithRegularExportOnly(): Unit = {
+    """
+    @JSExportTopLevel("A")
+    object A {
+      @JSExport
+      @JSExportDefault
+      def foo(x: Int): Int = x + 1
+    }
+    """ hasErrors
+    """
+    newSource1.scala:6: error: @DefaultExport can be used in combination with @JSTopLevelExport only
+    |      @JSExportDefault
+    |       ^""".stripMargin
+  }
 }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Hashers.scala
@@ -111,8 +111,8 @@ object Hashers {
   }
 
   def hashTopLevelExportDef(tle: TopLevelExportDef): TopLevelExportDef = tle match {
-    case TopLevelMethodExportDef(moduleID, methodDef) =>
-      TopLevelMethodExportDef(moduleID, hashJSMethodDef(methodDef))(tle.pos)
+    case TopLevelMethodExportDef(moduleID, methodDef, isDefault) =>
+      TopLevelMethodExportDef(moduleID, hashJSMethodDef(methodDef), isDefault)(tle.pos)
 
     case _:TopLevelFieldExportDef | _:TopLevelModuleExportDef |
         _:TopLevelJSClassExportDef =>

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -1093,25 +1093,28 @@ object Printers {
     }
 
     def print(topLevelExportDef: TopLevelExportDef): Unit = {
-      print("export top[moduleID=\"")
+      print("export ")
+      if (topLevelExportDef.isDefault)
+        print("default ")
+      print("top[moduleID=\"")
       printEscapeJS(topLevelExportDef.moduleID, out)
       print("\"] ")
 
       topLevelExportDef match {
-        case TopLevelJSClassExportDef(_, exportName) =>
+        case TopLevelJSClassExportDef(_, exportName, _) =>
           print("class \"")
           printEscapeJS(exportName, out)
           print("\"")
 
-        case TopLevelModuleExportDef(_, exportName) =>
+        case TopLevelModuleExportDef(_, exportName, _) =>
           print("module \"")
           printEscapeJS(exportName, out)
           print("\"")
 
-        case TopLevelMethodExportDef(_, methodDef) =>
+        case TopLevelMethodExportDef(_, methodDef, _) =>
           print(methodDef)
 
-        case TopLevelFieldExportDef(_, exportName, field) =>
+        case TopLevelFieldExportDef(_, exportName, field, _) =>
           print("static field ")
           print(field)
           print(" as \"")

--- a/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Serializers.scala
@@ -783,21 +783,21 @@ object Serializers {
       import buffer._
       writePosition(topLevelExportDef.pos)
       topLevelExportDef match {
-        case TopLevelJSClassExportDef(moduleID, exportName) =>
+        case TopLevelJSClassExportDef(moduleID, exportName, isDefault) =>
           writeByte(TagTopLevelJSClassExportDef)
-          writeString(moduleID); writeString(exportName)
+          writeString(moduleID); writeString(exportName) ; writeBoolean(isDefault)
 
-        case TopLevelModuleExportDef(moduleID, exportName) =>
+        case TopLevelModuleExportDef(moduleID, exportName, isDefault) =>
           writeByte(TagTopLevelModuleExportDef)
-          writeString(moduleID); writeString(exportName)
+          writeString(moduleID); writeString(exportName) ; writeBoolean(isDefault)
 
-        case TopLevelMethodExportDef(moduleID, methodDef) =>
+        case TopLevelMethodExportDef(moduleID, methodDef, isDefault) =>
           writeByte(TagTopLevelMethodExportDef)
-          writeString(moduleID); writeMemberDef(methodDef)
+          writeString(moduleID); writeMemberDef(methodDef) ; writeBoolean(isDefault)
 
-        case TopLevelFieldExportDef(moduleID, exportName, field) =>
+        case TopLevelFieldExportDef(moduleID, exportName, field, isDefault) =>
           writeByte(TagTopLevelFieldExportDef)
-          writeString(moduleID); writeString(exportName); writeFieldIdentForEnclosingClass(field)
+          writeString(moduleID); writeString(exportName); writeFieldIdentForEnclosingClass(field) ; writeBoolean(isDefault)
       }
     }
 
@@ -2429,12 +2429,12 @@ object Serializers {
         else readString()
 
       (tag: @switch) match {
-        case TagTopLevelJSClassExportDef => TopLevelJSClassExportDef(readModuleID(), readString())
-        case TagTopLevelModuleExportDef  => TopLevelModuleExportDef(readModuleID(), readString())
-        case TagTopLevelMethodExportDef  => TopLevelMethodExportDef(readModuleID(), readJSMethodDef())
+        case TagTopLevelJSClassExportDef => TopLevelJSClassExportDef(readModuleID(), readString(), readBoolean())
+        case TagTopLevelModuleExportDef  => TopLevelModuleExportDef(readModuleID(), readString(), readBoolean())
+        case TagTopLevelMethodExportDef  => TopLevelMethodExportDef(readModuleID(), readJSMethodDef(), readBoolean())
 
         case TagTopLevelFieldExportDef =>
-          TopLevelFieldExportDef(readModuleID(), readString(), readFieldIdentForEnclosingClass())
+          TopLevelFieldExportDef(readModuleID(), readString(), readFieldIdentForEnclosingClass(), readBoolean())
       }
     }
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -160,6 +160,10 @@ private[ir] object Tags {
   final val TagTopLevelModuleExportDef = TagTopLevelJSClassExportDef + 1
   final val TagTopLevelMethodExportDef = TagTopLevelModuleExportDef + 1
   final val TagTopLevelFieldExportDef = TagTopLevelMethodExportDef + 1
+  final val TagTopLevelJSClassExportDefaultDef = TagTopLevelFieldExportDef + 1
+  final val TagTopLevelModuleExportDefaultDef = TagTopLevelJSClassExportDefaultDef + 1
+  final val TagTopLevelMethodExportDefaultDef = TagTopLevelModuleExportDefaultDef + 1
+  final val TagTopLevelFieldExportDefaultDef = TagTopLevelMethodExportDefaultDef + 1
 
   // Tags for Types
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Tags.scala
@@ -160,10 +160,6 @@ private[ir] object Tags {
   final val TagTopLevelModuleExportDef = TagTopLevelJSClassExportDef + 1
   final val TagTopLevelMethodExportDef = TagTopLevelModuleExportDef + 1
   final val TagTopLevelFieldExportDef = TagTopLevelMethodExportDef + 1
-  final val TagTopLevelJSClassExportDefaultDef = TagTopLevelFieldExportDef + 1
-  final val TagTopLevelModuleExportDefaultDef = TagTopLevelJSClassExportDefaultDef + 1
-  final val TagTopLevelMethodExportDefaultDef = TagTopLevelModuleExportDefaultDef + 1
-  final val TagTopLevelFieldExportDefaultDef = TagTopLevelMethodExportDefaultDef + 1
 
   // Tags for Types
 

--- a/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Transformers.scala
@@ -289,8 +289,8 @@ object Transformers {
             _:TopLevelFieldExportDef =>
           exportDef
 
-        case TopLevelMethodExportDef(moduleID, methodDef) =>
-          TopLevelMethodExportDef(moduleID, transformJSMethodDef(methodDef))
+        case TopLevelMethodExportDef(moduleID, methodDef, isDefault) =>
+          TopLevelMethodExportDef(moduleID, transformJSMethodDef(methodDef), isDefault)
       }
     }
   }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Traversers.scala
@@ -254,7 +254,7 @@ object Traversers {
         case _:TopLevelJSClassExportDef | _:TopLevelModuleExportDef |
             _:TopLevelFieldExportDef =>
 
-        case TopLevelMethodExportDef(_, methodDef) =>
+        case TopLevelMethodExportDef(_, methodDef, _) =>
           traverseJSMethodPropDef(methodDef)
       }
     }

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -1491,16 +1491,17 @@ object Trees {
     import TopLevelExportDef._
 
     def moduleID: String
+    def isDefault: Boolean
 
     final def topLevelExportName: String = this match {
-      case TopLevelModuleExportDef(_, name)  => name
-      case TopLevelJSClassExportDef(_, name) => name
+      case TopLevelModuleExportDef(_, name, _)  => name
+      case TopLevelJSClassExportDef(_, name, _) => name
 
-      case TopLevelMethodExportDef(_, JSMethodDef(_, propName, _, _, _)) =>
+      case TopLevelMethodExportDef(_, JSMethodDef(_, propName, _, _, _), _) =>
         val StringLiteral(name) = propName: @unchecked  // unchecked is needed for Scala 3.2+
         name
 
-      case TopLevelFieldExportDef(_, name, _) => name
+      case TopLevelFieldExportDef(_, name, _, _) => name
     }
 
     require(isValidTopLevelExportName(topLevelExportName),
@@ -1512,7 +1513,7 @@ object Trees {
       isJSIdentifierName(exportName)
   }
 
-  sealed case class TopLevelJSClassExportDef(moduleID: String, exportName: String)(
+  sealed case class TopLevelJSClassExportDef(moduleID: String, exportName: String, isDefault: Boolean)(
       implicit val pos: Position) extends TopLevelExportDef
 
   /** Export for a top-level object.
@@ -1520,15 +1521,15 @@ object Trees {
    *  This exports the singleton instance of the containing module class.
    *  The instance is initialized during ES module instantiation.
    */
-  sealed case class TopLevelModuleExportDef(moduleID: String, exportName: String)(
+  sealed case class TopLevelModuleExportDef(moduleID: String, exportName: String, isDefault: Boolean)(
       implicit val pos: Position) extends TopLevelExportDef
 
   sealed case class TopLevelMethodExportDef(moduleID: String,
-      methodDef: JSMethodDef)(
+      methodDef: JSMethodDef, isDefault: Boolean)(
       implicit val pos: Position) extends TopLevelExportDef
 
   sealed case class TopLevelFieldExportDef(moduleID: String,
-      exportName: String, field: FieldIdent)(
+      exportName: String, field: FieldIdent, isDefault: Boolean)(
       implicit val pos: Position) extends TopLevelExportDef
 
   // Miscellaneous

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -1316,7 +1316,7 @@ class PrintersTest {
             List(JSMethodDef(MemberFlags.empty, StringLiteral("o"), Nil, None, i(5))(NoOptHints, UNV)),
             List(JSNativeMemberDef(MemberFlags.empty.withNamespace(Static), MethodName("p", Nil, O),
                 JSNativeLoadSpec.Global("foo", Nil))),
-            List(TopLevelModuleExportDef("main", "Foo")))(
+            List(TopLevelModuleExportDef("main", "Foo", false)))(
             NoOptHints))
   }
 
@@ -1562,13 +1562,25 @@ class PrintersTest {
   @Test def printJSClassExportDef(): Unit = {
     assertPrintEquals(
         """export top[moduleID="my-mod"] class "Foo"""",
-        TopLevelJSClassExportDef("my-mod", "Foo"))
+        TopLevelJSClassExportDef("my-mod", "Foo", false))
+  }
+
+  @Test def printJSClassDefaultExportDef(): Unit = {
+    assertPrintEquals(
+        """export default top[moduleID="my-mod"] class "Foo"""",
+        TopLevelJSClassExportDef("my-mod", "Foo", true))
   }
 
   @Test def printTopLevelModuleExportDef(): Unit = {
     assertPrintEquals(
         """export top[moduleID="bar"] module "Foo"""",
-        TopLevelModuleExportDef("bar", "Foo"))
+        TopLevelModuleExportDef("bar", "Foo", false))
+  }
+
+  @Test def printTopLevelModuleDefaultExportDef(): Unit = {
+    assertPrintEquals(
+        """export default top[moduleID="bar"] module "Foo"""",
+        TopLevelModuleExportDef("bar", "Foo", true))
   }
 
   @Test def printTopLevelMethodExportDef(): Unit = {
@@ -1580,7 +1592,19 @@ class PrintersTest {
         TopLevelMethodExportDef("main", JSMethodDef(
             MemberFlags.empty.withNamespace(Static), StringLiteral("foo"),
             List(ParamDef("x", NON, AnyType, mutable = false)), None,
-            i(5))(NoOptHints, UNV)))
+            i(5))(NoOptHints, UNV), false))
+  }
+
+  @Test def printTopLevelMethodDefaultExportDef(): Unit = {
+    assertPrintEquals(
+        """
+          |export default top[moduleID="main"] static def "foo"(x: any): any = {
+          |  5
+          |}""",
+        TopLevelMethodExportDef("main", JSMethodDef(
+            MemberFlags.empty.withNamespace(Static), StringLiteral("foo"),
+            List(ParamDef("x", NON, AnyType, mutable = false)), None,
+            i(5))(NoOptHints, UNV), true))
   }
 
   @Test def printTopLevelFieldExportDef(): Unit = {
@@ -1588,6 +1612,14 @@ class PrintersTest {
         """
           |export top[moduleID="main"] static field Test::x$1 as "x"
         """,
-        TopLevelFieldExportDef("main", "x", FieldName("Test", "x$1")))
+        TopLevelFieldExportDef("main", "x", FieldName("Test", "x$1"), false))
+  }
+
+  @Test def printTopLevelFieldDefaultExportDef(): Unit = {
+    assertPrintEquals(
+        """
+          |export default top[moduleID="main"] static field Test::x$1 as "x"
+        """,
+        TopLevelFieldExportDef("main", "x", FieldName("Test", "x$1"), true))
   }
 }

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExportDefault.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExportDefault.scala
@@ -1,0 +1,24 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package scala.scalajs.js.annotation
+
+import scala.annotation.meta._
+
+/** Specifies that the given member should be exported to the top level of the module.
+ *
+ *  @see [[http://www.scala-js.org/doc/export-to-javascript.html Export Scala.js APIs to JavaScript]]
+ */
+@field @getter @setter
+class JSExportDefault extends scala.annotation.StaticAnnotation {
+  def this(name: String) = this()
+}

--- a/library/src/main/scala/scala/scalajs/js/annotation/JSExportDefault.scala
+++ b/library/src/main/scala/scala/scalajs/js/annotation/JSExportDefault.scala
@@ -19,6 +19,4 @@ import scala.annotation.meta._
  *  @see [[http://www.scala-js.org/doc/export-to-javascript.html Export Scala.js APIs to JavaScript]]
  */
 @field @getter @setter
-class JSExportDefault extends scala.annotation.StaticAnnotation {
-  def this(name: String) = this()
-}
+class JSExportDefault extends scala.annotation.StaticAnnotation

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analysis.scala
@@ -164,6 +164,7 @@ object Analysis {
   trait TopLevelExportInfo {
     def moduleID: ModuleID
     def exportName: String
+    def isDefault: Boolean
     def owningClass: ClassName
     def staticDependencies: scala.collection.Set[ClassName]
     def externalDependencies: scala.collection.Set[String]

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Analyzer.scala
@@ -1389,6 +1389,7 @@ private class AnalyzerRun(config: CommonPhaseConfig, initial: Boolean,
       extends Analysis.TopLevelExportInfo with ModuleUnit {
     val moduleID: ModuleID = data.moduleID
     val exportName: String = data.exportName
+    val isDefault: Boolean = data.isDefault
 
     if (isNoModule && !ir.Trees.JSGlobalRef.isValidJSGlobalRefName(exportName)) {
       _errors ::= InvalidTopLevelExportInScript(this)

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -95,7 +95,8 @@ object Infos {
   final class TopLevelExportInfo private[Infos] (
       val reachability: ReachabilityInfo,
       val moduleID: ModuleID,
-      val exportName: String
+      val exportName: String,
+      val isDefault: Boolean
   )
 
   sealed class ReachabilityInfo private[Infos] (
@@ -578,7 +579,8 @@ object Infos {
           .generateTopLevelExportInfo(enclosingClass, topLevelExportDef)
       new TopLevelExportInfo(info,
           ModuleID(topLevelExportDef.moduleID),
-          topLevelExportDef.topLevelExportName)
+          topLevelExportDef.topLevelExportName,
+        topLevelExportDef.isDefault)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -888,13 +888,13 @@ final class Emitter(config: Emitter.Config, prePrinter: Emitter.PrePrinter) {
       tles1.corresponds(tles2) { (tle1, tle2) =>
         tle1.tree.pos == tle2.tree.pos && tle1.owningClass == tle2.owningClass && {
           (tle1.tree, tle2.tree) match {
-            case (TopLevelJSClassExportDef(_, exportName1), TopLevelJSClassExportDef(_, exportName2)) =>
+            case (TopLevelJSClassExportDef(_, exportName1, _), TopLevelJSClassExportDef(_, exportName2, _)) =>
               exportName1 == exportName2
-            case (TopLevelModuleExportDef(_, exportName1), TopLevelModuleExportDef(_, exportName2)) =>
+            case (TopLevelModuleExportDef(_, exportName1, _), TopLevelModuleExportDef(_, exportName2, _)) =>
               exportName1 == exportName2
-            case (TopLevelMethodExportDef(_, methodDef1), TopLevelMethodExportDef(_, methodDef2)) =>
+            case (TopLevelMethodExportDef(_, methodDef1, _), TopLevelMethodExportDef(_, methodDef2, _)) =>
               methodDef1.version.sameVersion(methodDef2.version)
-            case (TopLevelFieldExportDef(_, exportName1, field1), TopLevelFieldExportDef(_, exportName2, field2)) =>
+            case (TopLevelFieldExportDef(_, exportName1, field1, _), TopLevelFieldExportDef(_, exportName2, field2, _)) =>
               exportName1 == exportName2 && field1.name == field2.name && field1.pos == field2.pos
             case _ =>
               false

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/KnowledgeGuardian.scala
@@ -162,7 +162,7 @@ private[emitter] final class KnowledgeGuardian(config: Emitter.Config) {
         export <- module.topLevelExports
       } {
         export.tree match {
-          case TopLevelFieldExportDef(_, exportName, FieldIdent(fieldName)) =>
+          case TopLevelFieldExportDef(_, exportName, FieldIdent(fieldName), _) =>
             val className = export.owningClass
             val mirrors = result.getOrElse(className, Map.empty)
             val newExportNames = exportName :: mirrors.getOrElse(fieldName, Nil)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarGen.scala
@@ -124,18 +124,22 @@ private[emitter] final class VarGen(jsGen: JSGen, nameGen: NameGen,
   }
 
   def globalVarExport[T: Scope](field: VarField, scope: T, exportName: ExportName,
-      origName: OriginalName = NoOriginalName)(
+      origName: OriginalName = NoOriginalName, isDefault: Boolean)(
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
       pos: Position): Tree = {
     assert(config.coreSpec.moduleKind == ModuleKind.ESModule)
 
     val ident = globalVarIdent(field, scope, origName)
-    foldSameModule[T, Tree](scope) {
-      Export((ident -> exportName) :: Nil)
-    } { moduleID =>
-      val importName = ExportName(ident.name)
-      val moduleName = config.internalModulePattern(moduleID)
-      ExportImport((importName -> exportName) :: Nil, StringLiteral(moduleName))
+    if(isDefault) {
+      ExportDefault(exportName)
+    } else {
+      foldSameModule[T, Tree](scope) {
+        Export((ident -> exportName) :: Nil)
+      } { moduleID =>
+        val importName = ExportName(ident.name)
+        val moduleName = config.internalModulePattern(moduleID)
+        ExportImport((importName -> exportName) :: Nil, StringLiteral(moduleName))
+      }
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Printers.scala
@@ -728,6 +728,11 @@ object Printers {
           }
           print(" };")
 
+          case ExportDefault(binding) =>
+            print("export default ")
+            print(binding)
+            print(";")
+
         case ExportImport(bindings, from) =>
           print("export { ")
           var first = true

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/javascript/Trees.scala
@@ -582,6 +582,18 @@ object Trees {
       implicit val pos: Position)
       extends Tree
 
+  /** `export default` statement.
+   *
+   *  This corresponds to the following syntax:
+   *  {{{
+   *  export default <binding>
+   *  }}}
+   *  The `binding` is a name that is going to be exported
+   */
+  sealed case class ExportDefault(binding: ExportName)(
+      implicit val pos: Position)
+      extends Tree
+
   /** "forwarding" `export` statement.
    *
    *  This corresponds to the following syntax:

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/Preprocessor.scala
@@ -74,7 +74,7 @@ object Preprocessor {
     var result = Map.empty[ClassName, Map[FieldName, List[String]]]
     for (tle <- tles) {
       tle.tree match {
-        case TopLevelFieldExportDef(_, exportName, FieldIdent(fieldName)) =>
+        case TopLevelFieldExportDef(_, exportName, FieldIdent(fieldName), _) =>
           val className = tle.owningClass
           val mirrors = result.getOrElse(className, Map.empty)
           val newExportNames = exportName :: mirrors.getOrElse(fieldName, Nil)
@@ -259,7 +259,7 @@ object Preprocessor {
 
     def collectAbstractMethodCalls(tle: LinkedTopLevelExport): Unit = {
       tle.tree match {
-        case TopLevelMethodExportDef(_, jsMethodDef) =>
+        case TopLevelMethodExportDef(_, jsMethodDef, _) =>
           traverseJSMethodPropDef(jsMethodDef)
         case _ =>
           ()

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -450,7 +450,7 @@ private final class ClassDefChecker(classDef: ClassDef,
         if (!classDef.kind.hasModuleAccessor)
           reportError("Top-level module export def can only appear in a module class")
 
-      case TopLevelMethodExportDef(_, methodDef) =>
+      case TopLevelMethodExportDef(_, methodDef, _) =>
         checkTopLevelMethodExportDef(methodDef)
 
       case topLevelExportDef: TopLevelFieldExportDef =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -71,7 +71,7 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
 
     for (topLevelExport <- unit.topLevelExports) {
       topLevelExport.tree match {
-        case TopLevelMethodExportDef(_, methodDef) =>
+        case TopLevelMethodExportDef(_, methodDef, _) =>
           implicit val ctx = ErrorContext(methodDef)
           typecheckAny(methodDef.body, Env.empty)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -166,7 +166,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
     val newTopLevelExports = tles.map { tle =>
       tle.tree match {
         case method: TopLevelMethodExportDef =>
-          topLevelExports.optimizedMethod(method.moduleID, method.topLevelExportName)
+          topLevelExports.optimizedMethod(method.moduleID, method.topLevelExportName, method.isDefault)
 
         case tree =>
           tree
@@ -1244,10 +1244,10 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
       methods = newMethods
     }
 
-    def optimizedMethod(moduleID: String, name: String): TopLevelMethodExportDef = {
+    def optimizedMethod(moduleID: String, name: String, isDefault: Boolean): TopLevelMethodExportDef = {
       val (impl, pos) = methods((moduleID, name))
       val newMethod = impl.optimizedDef.asInstanceOf[JSMethodDef]
-      TopLevelMethodExportDef(moduleID, newMethod)(pos)
+      TopLevelMethodExportDef(moduleID, newMethod, isDefault)(pos)
     }
   }
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/AnalyzerTest.scala
@@ -473,7 +473,7 @@ class AnalyzerTest {
                 TopLevelMethodExportDef("main", JSMethodDef(
                     EMF.withNamespace(MemberNamespace.PublicStatic),
                     str("default"), Nil, None, Undefined())(
-                    EOH, UNV))
+                    EOH, UNV), false)
             )
         )
     )
@@ -494,7 +494,7 @@ class AnalyzerTest {
       classDef(name,
           kind = ClassKind.ModuleClass, superClass = Some(ObjectClass),
           methods = List(trivialCtor(name, forModuleClass = true)),
-          topLevelExportDefs = List(TopLevelModuleExportDef(name, "foo")))
+          topLevelExportDefs = List(TopLevelModuleExportDef(name, "foo", false)))
     }
 
     val classDefs = Seq(singleDef("A"), singleDef("B"))
@@ -517,7 +517,7 @@ class AnalyzerTest {
       classDef(name,
           kind = ClassKind.ModuleClass, superClass = Some(ObjectClass),
           methods = List(trivialCtor(name, forModuleClass = true)),
-          topLevelExportDefs = List(TopLevelModuleExportDef("main", "foo")))
+          topLevelExportDefs = List(TopLevelModuleExportDef("main", "foo", false)))
     }
 
     val classDefs = Seq(singleDef("A"), singleDef("B"))
@@ -539,8 +539,8 @@ class AnalyzerTest {
         kind = ClassKind.ModuleClass, superClass = Some(ObjectClass),
         methods = List(trivialCtor("A", forModuleClass = true)),
         topLevelExportDefs = List(
-            TopLevelModuleExportDef("main", "foo"),
-            TopLevelModuleExportDef("main", "foo"))))
+            TopLevelModuleExportDef("main", "foo", false),
+            TopLevelModuleExportDef("main", "foo", false))))
 
     val analysis = computeAnalysis(classDefs)
     assertContainsError("ConflictingTopLevelExport(_, foo, <degenerate>)", analysis) {
@@ -556,7 +556,7 @@ class AnalyzerTest {
             trivialCtor("A", forModuleClass = true),
             mainMethodDef(Skip())
         ),
-        topLevelExportDefs = List(TopLevelModuleExportDef("A", "foo"))))
+        topLevelExportDefs = List(TopLevelModuleExportDef("A", "foo", false))))
 
     val moduleInitializer =
       ModuleInitializer.mainMethodWithArgs("A", "main").withModuleID("B")

--- a/linker/shared/src/test/scala/org/scalajs/linker/IncrementalTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/IncrementalTest.scala
@@ -445,7 +445,7 @@ class IncrementalTest {
           topLevelExportDefs = List(
               TopLevelMethodExportDef("main", JSMethodDef(EMF.withNamespace(MemberNamespace.PublicStatic),
                   str("foo"), Nil, None,
-                  Apply(EAF, LoadModule(BModule), targetMethodName, Nil)(IntType))(EOH, UNV))
+                  Apply(EAF, LoadModule(BModule), targetMethodName, Nil)(IntType))(EOH, UNV), false)
           )
       ),
       v(pre) -> classDef(

--- a/linker/shared/src/test/scala/org/scalajs/linker/SmallModulesForSplittingTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/SmallModulesForSplittingTest.scala
@@ -129,9 +129,9 @@ class SmallModulesForSplittingTest {
       ),
       topLevelExportDefs = List(
         TopLevelMethodExportDef("moda",
-            JSMethodDef(SMF, str("expa"), Nil, None, call("lib.A", "baz"))(EOH, UNV)),
+            JSMethodDef(SMF, str("expa"), Nil, None, call("lib.A", "baz"))(EOH, UNV), false),
         TopLevelMethodExportDef("modb",
-            JSMethodDef(SMF, str("expb"), Nil, None, call("lib.A", "baz"))(EOH, UNV))
+            JSMethodDef(SMF, str("expb"), Nil, None, call("lib.A", "baz"))(EOH, UNV), false)
       )
     )
 
@@ -183,9 +183,9 @@ class SmallModulesForSplittingTest {
       ),
       topLevelExportDefs = List(
         TopLevelMethodExportDef("moda",
-            JSMethodDef(SMF, str("expa"), Nil, None, call("app.A", "baz"))(EOH, UNV)),
+            JSMethodDef(SMF, str("expa"), Nil, None, call("app.A", "baz"))(EOH, UNV), false),
         TopLevelMethodExportDef("modb",
-            JSMethodDef(SMF, str("expb"), Nil, None, call("app.A", "baz"))(EOH, UNV))
+            JSMethodDef(SMF, str("expb"), Nil, None, call("app.A", "baz"))(EOH, UNV), false)
       )
     )
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/checker/ClassDefCheckerTest.scala
@@ -162,7 +162,7 @@ class ClassDefCheckerTest {
         ),
         methods = List(trivialCtor("A", forModuleClass = true)),
         topLevelExportDefs = List(
-          TopLevelFieldExportDef("main", "foo", FieldName("B", "foo"))
+          TopLevelFieldExportDef("main", "foo", FieldName("B", "foo"), false)
         )
       ),
       "Cannot export non-existent static field 'B::foo'"


### PR DESCRIPTION
# Description
This is a proof of concept for an annotation that marks a top-level export as the default export.

## Motivation
Some third-party tools I work with require modules to use export default. Currently, to comply with this requirement, I need to introduce an intermediate script that re-exports the top-level symbol as a default export. This workaround feels unnecessary and could be avoided with native support.

This appears to be a missing feature in the current Scala.js implementation. I'm not aware of any specific reasons why it hasn't been added, so I’ve taken a first step toward exploring it.

I’ve implemented a basic PoC and tested it only for the ES6 module system.

## Open Questions
1. How should this annotation behave in CommonJS and WebAssembly targets? Should it emit a warning or be silently ignored?
2. Would it make more sense to introduce this functionality as a separate, dedicated annotation instead of extending the existing one?

