### PR TITLE
Handle System.identityHashCode as a method with a special body.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -5254,11 +5254,6 @@ abstract class GenJSCode[G <: Global with Singleton](val global: G)
             genStatOrExpr(args(1), isStat)
           }
 
-        case IDENTITY_HASH_CODE =>
-          // runtime.identityHashCode(arg)
-          val arg = genArgs1
-          js.UnaryOp(js.UnaryOp.IdentityHashCode, arg)
-
         case DEBUGGER =>
           // js.special.debugger()
           js.Debugger()
@@ -7445,6 +7440,9 @@ private object GenJSCode {
         m("isInstance", List(O), Z)        -> ThisBinaryOp(binop.Class_isInstance),
         m("isAssignableFrom", List(CC), Z) -> ThisBinaryOp(binop.Class_isAssignableFrom, checkNulls = true),
         m("cast", List(O), O)              -> ThisBinaryOp(binop.Class_cast)
+      ),
+      ClassName("java.lang.System$") -> Map(
+        m("identityHashCode", List(O), I) -> ArgUnaryOp(unop.IdentityHashCode)
       ),
       ClassName("java.lang.reflect.Array$") -> Map(
         m("newInstance", List(CC, I), O) -> ArgBinaryOp(binop.Class_newArray, checkNulls = true)

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSDefinitions.scala
@@ -131,7 +131,6 @@ trait JSDefinitions {
       lazy val Runtime_withContextualJSClassValue = getMemberMethod(RuntimePackageModule, newTermName("withContextualJSClassValue"))
       lazy val Runtime_privateFieldsSymbol        = getMemberMethod(RuntimePackageModule, newTermName("privateFieldsSymbol"))
       lazy val Runtime_linkingInfo                = getMemberMethod(RuntimePackageModule, newTermName("linkingInfo"))
-      lazy val Runtime_identityHashCode           = getMemberMethod(RuntimePackageModule, newTermName("identityHashCode"))
       lazy val Runtime_dynamicImport              = getMemberMethod(RuntimePackageModule, newTermName("dynamicImport"))
 
     lazy val LinkingInfoModule = getRequiredModule("scala.scalajs.LinkingInfo")

--- a/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/JSPrimitives.scala
@@ -58,8 +58,7 @@ abstract class JSPrimitives {
   final val CREATE_INNER_JS_CLASS = CONSTRUCTOROF + 1                  // runtime.createInnerJSClass
   final val CREATE_LOCAL_JS_CLASS = CREATE_INNER_JS_CLASS + 1          // runtime.createLocalJSClass
   final val WITH_CONTEXTUAL_JS_CLASS_VALUE = CREATE_LOCAL_JS_CLASS + 1 // runtime.withContextualJSClassValue
-  final val IDENTITY_HASH_CODE = WITH_CONTEXTUAL_JS_CLASS_VALUE + 1    // runtime.identityHashCode
-  final val DYNAMIC_IMPORT = IDENTITY_HASH_CODE + 1                    // runtime.dynamicImport
+  final val DYNAMIC_IMPORT = WITH_CONTEXTUAL_JS_CLASS_VALUE + 1        // runtime.dynamicImport
 
   final val STRICT_EQ = DYNAMIC_IMPORT + 1                // js.special.strictEquals
   final val IN = STRICT_EQ + 1                            // js.special.in
@@ -115,7 +114,6 @@ abstract class JSPrimitives {
     addPrimitive(Runtime_createLocalJSClass, CREATE_LOCAL_JS_CLASS)
     addPrimitive(Runtime_withContextualJSClassValue,
         WITH_CONTEXTUAL_JS_CLASS_VALUE)
-    addPrimitive(Runtime_identityHashCode, IDENTITY_HASH_CODE)
     addPrimitive(Runtime_dynamicImport, DYNAMIC_IMPORT)
 
     addPrimitive(Special_strictEquals, STRICT_EQ)

--- a/javalib/src/main/scala/java/lang/System.scala
+++ b/javalib/src/main/scala/java/lang/System.scala
@@ -184,7 +184,7 @@ object System {
 
   @inline
   def identityHashCode(x: Any): scala.Int =
-    scala.scalajs.runtime.identityHashCode(x.asInstanceOf[AnyRef])
+    throw new Error("stub") // body replaced by the compiler back-end
 
   // System properties --------------------------------------------------------
 

--- a/library/src/main/scala/scala/scalajs/runtime/package.scala
+++ b/library/src/main/scala/scala/scalajs/runtime/package.scala
@@ -111,7 +111,9 @@ package object runtime {
   }
 
   /** Identity hash code of an object. */
-  def identityHashCode(x: Object): Int = throw new Error("stub")
+  @deprecated("Unused; use System.identityHashCode(x) instead.", since = "1.20.0")
+  def identityHashCode(x: Object): Int =
+    System.identityHashCode(x)
 
   def dynamicImport[A](thunk: DynamicImportThunk): js.Promise[A] =
     throw new Error("stub")


### PR DESCRIPTION
Instead of having it call a primitive whose sole purpose was to be called from `System.identityHashCode()`.