### PR TITLE
Introduce IR BinaryOps for unsigned division and remainder.

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -7424,6 +7424,14 @@ private object GenJSCode {
     val T = jstpe.ClassRef(jswkn.BoxedStringClass)
 
     val byClass: Map[ClassName, Map[MethodName, JavalibOpBody]] = Map(
+      jswkn.BoxedIntegerClass.withSuffix("$") -> Map(
+        m("divideUnsigned", List(I, I), I)    -> ArgBinaryOp(binop.Int_unsigned_/),
+        m("remainderUnsigned", List(I, I), I) -> ArgBinaryOp(binop.Int_unsigned_%)
+      ),
+      jswkn.BoxedLongClass.withSuffix("$") -> Map(
+        m("divideUnsigned", List(J, J), J)    -> ArgBinaryOp(binop.Long_unsigned_/),
+        m("remainderUnsigned", List(J, J), J) -> ArgBinaryOp(binop.Long_unsigned_%)
+      ),
       jswkn.BoxedFloatClass.withSuffix("$") -> Map(
         m("floatToIntBits", List(F), I) -> ArgUnaryOp(unop.Float_toBits),
         m("intBitsToFloat", List(I), F) -> ArgUnaryOp(unop.Float_fromBits)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -576,6 +576,11 @@ object Printers {
             case Double_<= => "<=[double]"
             case Double_>  => ">[double]"
             case Double_>= => ">=[double]"
+
+            case Int_unsigned_/  => "unsigned_/[int]"
+            case Int_unsigned_%  => "unsigned_%[int]"
+            case Long_unsigned_/ => "unsigned_/[long]"
+            case Long_unsigned_% => "unsigned_%[long]"
           })
           print(' ')
           print(rhs)

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -679,6 +679,12 @@ object Trees {
     final val Class_cast = 61
     final val Class_newArray = 62
 
+    // New in 1.20
+    final val Int_unsigned_/ = 63
+    final val Int_unsigned_% = 64
+    final val Long_unsigned_/ = 65
+    final val Long_unsigned_% = 66
+
     def isClassOp(op: Code): Boolean =
       op >= Class_isInstance && op <= Class_newArray
 
@@ -693,10 +699,12 @@ object Trees {
       case String_+ =>
         StringType
       case Int_+ | Int_- | Int_* | Int_/ | Int_% |
-          Int_| | Int_& | Int_^ | Int_<< | Int_>>> | Int_>> =>
+          Int_| | Int_& | Int_^ | Int_<< | Int_>>> | Int_>> |
+          Int_unsigned_/ | Int_unsigned_% =>
         IntType
       case Long_+ | Long_- | Long_* | Long_/ | Long_% |
-          Long_| | Long_& | Long_^ | Long_<< | Long_>>> | Long_>> =>
+          Long_| | Long_& | Long_^ | Long_<< | Long_>>> | Long_>> |
+          Long_unsigned_/ | Long_unsigned_% =>
         LongType
       case Float_+ | Float_- | Float_* | Float_/ | Float_% =>
         FloatType

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -671,6 +671,15 @@ class PrintersTest {
         BinaryOp(Class_isAssignableFrom, classVarRef, ref("y", ClassType(ClassClass, nullable = false))))
     assertPrintEquals("cast(x, y)", BinaryOp(Class_cast, classVarRef, ref("y", AnyType)))
     assertPrintEquals("newArray(x, y)", BinaryOp(Class_newArray, classVarRef, ref("y", IntType)))
+
+    assertPrintEquals("(x unsigned_/[int] y)",
+        BinaryOp(Int_unsigned_/, ref("x", IntType), ref("y", IntType)))
+    assertPrintEquals("(x unsigned_%[int] y)",
+        BinaryOp(Int_unsigned_%, ref("x", IntType), ref("y", IntType)))
+    assertPrintEquals("(x unsigned_/[long] y)",
+        BinaryOp(Long_unsigned_/, ref("x", LongType), ref("y", LongType)))
+    assertPrintEquals("(x unsigned_%[long] y)",
+        BinaryOp(Long_unsigned_%, ref("x", LongType), ref("y", LongType)))
   }
 
   @Test def printNewArray(): Unit = {

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -221,15 +221,11 @@ object Integer {
     (((t2 + (t2 >> 4)) & 0xF0F0F0F) * 0x1010101) >> 24
   }
 
-  // Wasm intrinsic
   @inline def divideUnsigned(dividend: Int, divisor: Int): Int =
-    if (divisor == 0) 0 / 0
-    else asInt(asUint(dividend) / asUint(divisor))
+    throw new Error("stub") // body replaced by the compiler back-end
 
-  // Wasm intrinsic
   @inline def remainderUnsigned(dividend: Int, divisor: Int): Int =
-    if (divisor == 0) 0 % 0
-    else asInt(asUint(dividend) % asUint(divisor))
+    throw new Error("stub") // body replaced by the compiler back-end
 
   @inline def highestOneBit(i: Int): Int = {
     /* The natural way of implementing this is:

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -348,47 +348,11 @@ object Long {
   @inline def compareUnsigned(x: scala.Long, y: scala.Long): scala.Int =
     compare(x ^ SignBit, y ^ SignBit)
 
-  // Intrinsic, except for JS when using bigint's for longs
-  def divideUnsigned(dividend: scala.Long, divisor: scala.Long): scala.Long =
-    divModUnsigned(dividend, divisor, isDivide = true)
+  @inline def divideUnsigned(dividend: scala.Long, divisor: scala.Long): scala.Long =
+    throw new Error("stub") // body replaced by the compiler back-end
 
-  // Intrinsic, except for JS when using bigint's for longs
-  def remainderUnsigned(dividend: scala.Long, divisor: scala.Long): scala.Long =
-    divModUnsigned(dividend, divisor, isDivide = false)
-
-  private def divModUnsigned(a: scala.Long, b: scala.Long,
-      isDivide: scala.Boolean): scala.Long = {
-    /* This is a much simplified (and slow) version of
-     * RuntimeLong.unsignedDivModHelper.
-     */
-
-    if (b == 0L)
-      throw new ArithmeticException("/ by zero")
-
-    var shift = numberOfLeadingZeros(b) - numberOfLeadingZeros(a)
-    var bShift = b << shift
-
-    var rem = a
-    var quot = 0L
-
-    /* Invariants:
-     *   bShift == b << shift == b * 2^shift
-     *   quot >= 0
-     *   0 <= rem < 2 * bShift
-     *   quot * b + rem == a
-     */
-    while (shift >= 0 && rem != 0) {
-      if ((rem ^ SignBit) >= (bShift ^ SignBit)) {
-        rem -= bShift
-        quot |= (1L << shift)
-      }
-      shift -= 1
-      bShift >>>= 1
-    }
-
-    if (isDivide) quot
-    else rem
-  }
+  @inline def remainderUnsigned(dividend: scala.Long, divisor: scala.Long): scala.Long =
+    throw new Error("stub") // body replaced by the compiler back-end
 
   @inline
   def highestOneBit(i: scala.Long): scala.Long = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -789,12 +789,12 @@ object Infos {
               import BinaryOp._
 
               op match {
-                case Int_/ | Int_% =>
+                case Int_/ | Int_% | Int_unsigned_/ | Int_unsigned_% =>
                   rhs match {
                     case IntLiteral(r) if r != 0 =>
                     case _                       => builder.addUsedIntLongDivModByMaybeZero()
                   }
-                case Long_/ | Long_% =>
+                case Long_/ | Long_% | Long_unsigned_/ | Long_unsigned_% =>
                   rhs match {
                     case LongLiteral(r) if r != 0L =>
                     case _                         => builder.addUsedIntLongDivModByMaybeZero()

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -919,17 +919,11 @@ private[emitter] object CoreJSLib {
       }
 
       condDefs(shouldDefineIntLongDivModFunctions)(
-        defineFunction2(VarField.intDiv) { (x, y) =>
+        defineFunction1(VarField.checkIntDivisor) { y =>
           If(y === 0, throwDivByZero, {
-            Return((x / y) | 0)
+            Return(y)
           })
-        } :::
-        defineFunction2(VarField.intMod) { (x, y) =>
-          If(y === 0, throwDivByZero, {
-            Return((x % y) | 0)
-          })
-        } :::
-        Nil
+        }
       ) :::
       defineFunction1(VarField.doubleToInt) { x =>
         Return(If(x > 2147483647, 2147483647, If(x < -2147483648, -2147483648, x | 0)))
@@ -953,17 +947,11 @@ private[emitter] object CoreJSLib {
         }
       ) :::
       condDefs(allowBigIntsForLongs && shouldDefineIntLongDivModFunctions)(
-        defineFunction2(VarField.longDiv) { (x, y) =>
+        defineFunction1(VarField.checkLongDivisor) { y =>
           If(y === bigInt(0), throwDivByZero, {
-            Return(wrapBigInt64(x / y))
+            Return(y)
           })
-        } :::
-        defineFunction2(VarField.longMod) { (x, y) =>
-          If(y === bigInt(0), throwDivByZero, {
-            Return(wrapBigInt64(x % y))
-          })
-        } :::
-        Nil
+        }
       ) :::
       condDefs(allowBigIntsForLongs)(
         defineFunction1(VarField.doubleToLong)(x => Return {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
@@ -47,6 +47,9 @@ private[linker] object LongImpl {
   final val / = binaryOp("$div")
   final val % = binaryOp("$percent")
 
+  final val divideUnsigned = binaryOp("divideUnsigned")
+  final val remainderUnsigned = binaryOp("remainderUnsigned")
+
   final val | = binaryOp("$bar")
   final val & = binaryOp("$amp")
   final val ^ = binaryOp("$up")
@@ -81,8 +84,8 @@ private[linker] object LongImpl {
   final val compareToO = MethodName("compareTo", List(ClassRef(ObjectClass)), IntRef)
 
   private val OperatorMethods = Set(
-      UNARY_-, UNARY_~, this.+, this.-, *, /, %, |, &, ^, <<, >>>, >>,
-      ===, !==, <, <=, >, >=, toInt, toFloat, toDouble, bitsToDouble)
+      UNARY_-, UNARY_~, this.+, this.-, *, /, %, divideUnsigned, remainderUnsigned,
+      |, &, ^, <<, >>>, >>, ===, !==, <, <=, >, >=, toInt, toFloat, toDouble, bitsToDouble)
 
   private val BoxedLongMethods = Set(
       byteValue, shortValue, intValue, longValue, floatValue, doubleValue,
@@ -92,12 +95,10 @@ private[linker] object LongImpl {
 
   // Methods used for intrinsics
 
-  final val compareToRTLong   = MethodName("compareTo", List(RTLongRef), IntRef)
-  final val divideUnsigned    = binaryOp("divideUnsigned")
-  final val remainderUnsigned = binaryOp("remainderUnsigned")
+  final val compareToRTLong = MethodName("compareTo", List(RTLongRef), IntRef)
 
   val AllIntrinsicMethods = Set(
-      compareToRTLong, divideUnsigned, remainderUnsigned)
+      compareToRTLong)
 
   // Constructors
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
@@ -259,15 +259,11 @@ private[emitter] object VarField {
 
   // Arithmetic Call Helpers
 
-  final val intDiv = mk("$intDiv")
+  final val checkIntDivisor = mk("$checkIntDivisor")
 
-  final val intMod = mk("$intMod")
+  final val checkLongDivisor = mk("$checkLongDivisor")
 
   final val longToFloat = mk("$longToFloat")
-
-  final val longDiv = mk("$longDiv")
-
-  final val longMod = mk("$longMod")
 
   final val doubleToLong = mk("$doubleToLong")
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmTransients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmTransients.scala
@@ -137,13 +137,9 @@ object WasmTransients {
     def wasmInstr: wa.SimpleInstr = (op: @switch) match {
       case I32GtU => wa.I32GtU
 
-      case I32DivU => wa.I32DivU
-      case I32RemU => wa.I32RemU
       case I32Rotl => wa.I32Rotl
       case I32Rotr => wa.I32Rotr
 
-      case I64DivU => wa.I64DivU
-      case I64RemU => wa.I64RemU
       case I64Rotl => wa.I64Rotl
       case I64Rotr => wa.I64Rotr
 
@@ -167,13 +163,9 @@ object WasmTransients {
 
     final val I32GtU = 1
 
-    final val I32DivU = 2
-    final val I32RemU = 3
     final val I32Rotl = 4
     final val I32Rotr = 5
 
-    final val I64DivU = 6
-    final val I64RemU = 7
     final val I64Rotl = 8
     final val I64Rotr = 9
 
@@ -187,10 +179,10 @@ object WasmTransients {
       case I32GtU =>
         BooleanType
 
-      case I32DivU | I32RemU | I32Rotl | I32Rotr =>
+      case I32Rotl | I32Rotr =>
         IntType
 
-      case I64DivU | I64RemU | I64Rotl | I64Rotr =>
+      case I64Rotl | I64Rotr =>
         LongType
 
       case F32Min | F32Max =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -571,11 +571,13 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
             BooleanType
           case Int_+ | Int_- | Int_* | Int_/ | Int_% |
               Int_| | Int_& | Int_^ | Int_<< | Int_>>> | Int_>> |
-              Int_== | Int_!= | Int_< | Int_<= | Int_> | Int_>= =>
+              Int_== | Int_!= | Int_< | Int_<= | Int_> | Int_>= |
+              Int_unsigned_/ | Int_unsigned_% =>
             IntType
           case Long_+ | Long_- | Long_* | Long_/ | Long_% |
               Long_| | Long_& | Long_^ | Long_<< | Long_>>> | Long_>> |
-              Long_== | Long_!= | Long_< | Long_<= | Long_> | Long_>= =>
+              Long_== | Long_!= | Long_< | Long_<= | Long_> | Long_>= |
+              Long_unsigned_/ | Long_unsigned_% =>
             LongType
           case Float_+ | Float_- | Float_* | Float_/ | Float_% =>
             FloatType

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,8 +70,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 146044,
-      expectedFullLinkSizeWithoutClosure = 85435,
+      expectedFastLinkSize = 147727,
+      expectedFullLinkSizeWithoutClosure = 86377,
       expectedFullLinkSizeWithClosure = 21197,
       classDefs,
       moduleInitializers = MainTestModuleInitializers

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2053,7 +2053,7 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 624000 to 625000,
+                  fastLink = 626000 to 627000,
                   fullLink = 96000 to 97000,
                   fastLinkGz = 75000 to 79000,
                   fullLinkGz = 25000 to 26000,
@@ -2061,7 +2061,7 @@ object Build {
             } else {
               Some(ExpectedSizes(
                   fastLink = 425000 to 426000,
-                  fullLink = 282000 to 283000,
+                  fullLink = 283000 to 284000,
                   fastLinkGz = 61000 to 62000,
                   fullLinkGz = 43000 to 44000,
               ))
@@ -2070,14 +2070,14 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 441000 to 442000,
+                  fastLink = 443000 to 444000,
                   fullLink = 92000 to 93000,
                   fastLinkGz = 57000 to 58000,
                   fullLinkGz = 25000 to 26000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 300000 to 301000,
+                  fastLink = 301000 to 302000,
                   fullLink = 258000 to 259000,
                   fastLinkGz = 47000 to 48000,
                   fullLinkGz = 42000 to 43000,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
@@ -27,6 +27,8 @@ class LongTest {
   final val MinRadix = Character.MIN_RADIX
   final val MaxRadix = Character.MAX_RADIX
 
+  @noinline def hideFromOptimizer(x: Long): Long = x
+
   @Test def reverseBytes(): Unit = {
     assertEquals(0x14ff01d49c68abf5L, JLong.reverseBytes(0xf5ab689cd401ff14L))
     assertEquals(0x780176af73b18fc7L, JLong.reverseBytes(0xc78fb173af760178L))
@@ -659,8 +661,12 @@ class LongTest {
   }
 
   @Test def divideUnsigned(): Unit = {
-    def test(dividend: Long, divisor: Long, result: Long): Unit =
-      assertEquals(result, JLong.divideUnsigned(dividend, divisor))
+    @inline def test(x: Long, y: Long, result: Long): Unit = {
+      assertEquals(result, JLong.divideUnsigned(x, y))
+      assertEquals(result, JLong.divideUnsigned(hideFromOptimizer(x), y))
+      assertEquals(result, JLong.divideUnsigned(x, hideFromOptimizer(y)))
+      assertEquals(result, JLong.divideUnsigned(hideFromOptimizer(x), hideFromOptimizer(y)))
+    }
 
     test(-9223372034182170740L, 53886L, 171164533265177L)
     test(-9223372036854775807L, 1L, -9223372036854775807L)
@@ -721,8 +727,12 @@ class LongTest {
   }
 
   @Test def remainderUnsigned(): Unit = {
-    def test(dividend: Long, divisor: Long, result: Long): Unit =
-      assertEquals(result, JLong.remainderUnsigned(dividend, divisor))
+    @inline def test(x: Long, y: Long, result: Long): Unit = {
+      assertEquals(result, JLong.remainderUnsigned(x, y))
+      assertEquals(result, JLong.remainderUnsigned(hideFromOptimizer(x), y))
+      assertEquals(result, JLong.remainderUnsigned(x, hideFromOptimizer(y)))
+      assertEquals(result, JLong.remainderUnsigned(hideFromOptimizer(x), hideFromOptimizer(y)))
+    }
 
     test(97062081516L, 772L, 668L)
     test(-9223372036854775472L, 49L, 43L)


### PR DESCRIPTION
This allows to better mutualize their implementation with the signed divisions.

Moreover, our 3 implementation strategies (JS with `RuntimeLong`, JS with `bigint` and Wasm) have different efficient implementations of those operations. Using IR BinaryOps for them allows each backend to use the most appropriate implementation, while letting the optimizer generically manipulate their mathematical properties.