### PR TITLE
Opt: Use unsigned arithmetics in Range, instead of Longs.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -4141,6 +4141,10 @@ private[optimizer] abstract class OptimizerCore(
                   PreTransLit(IntLiteral(y)), z)) =>
             foldBinaryOp(innerOp, PreTransLit(IntLiteral(x + y)), z)
 
+          // 1 + (-1 ^ x) == 1 + ~x == -x == 0 - x (this appears when optimizing a Range with step == -1)
+          case (PreTransLit(IntLiteral(1)), PreTransBinaryOp(Int_^, PreTransLit(IntLiteral(-1)), x)) =>
+            foldBinaryOp(Int_-, PreTransLit(IntLiteral(0)), x)
+
           case _ => default
         }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -4401,6 +4401,9 @@ private[optimizer] abstract class OptimizerCore(
               PreTransLit(IntLiteral(z))) =>
             foldBinaryOp(op, y, PreTransLit(IntLiteral(x ^ z)))
 
+          case (PreTransLocalDef(l), PreTransLocalDef(r)) if l eq r =>
+            booleanLit(op == Int_==)
+
           case (PreTransLit(_), _) => foldBinaryOp(op, rhs, lhs)
 
           case _ => default
@@ -4451,6 +4454,9 @@ private[optimizer] abstract class OptimizerCore(
 
               case _ => default
             }
+
+          case (PreTransLocalDef(l), PreTransLocalDef(r)) if l eq r =>
+            booleanLit(op == Int_<= || op == Int_>=)
 
           case (PreTransLit(IntLiteral(_)), _) =>
             foldBinaryOp(flippedOp, rhs, lhs)
@@ -4695,6 +4701,9 @@ private[optimizer] abstract class OptimizerCore(
               PreTransLit(LongLiteral(z))) =>
             foldBinaryOp(op, y, PreTransLit(LongLiteral(x ^ z)))
 
+          case (PreTransLocalDef(l), PreTransLocalDef(r)) if l eq r =>
+            booleanLit(positive)
+
           case (PreTransLit(LongLiteral(_)), _) => foldBinaryOp(op, rhs, lhs)
 
           case _ => default
@@ -4817,6 +4826,9 @@ private[optimizer] abstract class OptimizerCore(
                   ).toPreTransform)
               } (finishTransform(isStat = false))(emptyScope)
             }.toPreTransform
+
+          case (PreTransLocalDef(l), PreTransLocalDef(r)) if l eq r =>
+            booleanLit(op == Long_<= || op == Long_>=)
 
           case (PreTransLit(LongLiteral(_)), _) =>
             foldBinaryOp(flippedOp, rhs, lhs)

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2053,16 +2053,16 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 626000 to 627000,
-                  fullLink = 96000 to 97000,
+                  fastLink = 624000 to 625000,
+                  fullLink = 94000 to 95000,
                   fastLinkGz = 75000 to 79000,
-                  fullLinkGz = 25000 to 26000,
+                  fullLinkGz = 24000 to 25000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 425000 to 426000,
-                  fullLink = 283000 to 284000,
-                  fastLinkGz = 61000 to 62000,
+                  fastLink = 424000 to 425000,
+                  fullLink = 281000 to 282000,
+                  fastLinkGz = 60000 to 61000,
                   fullLinkGz = 43000 to 44000,
               ))
             }
@@ -2070,15 +2070,15 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 443000 to 444000,
-                  fullLink = 92000 to 93000,
+                  fastLink = 442000 to 443000,
+                  fullLink = 90000 to 91000,
                   fastLinkGz = 57000 to 58000,
-                  fullLinkGz = 25000 to 26000,
+                  fullLinkGz = 24000 to 25000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 301000 to 302000,
-                  fullLink = 258000 to 259000,
+                  fastLink = 299000 to 300000,
+                  fullLink = 257000 to 258000,
                   fastLinkGz = 47000 to 48000,
                   fullLinkGz = 42000 to 43000,
               ))

--- a/scalalib/overrides-2.12/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Range.scala
@@ -33,7 +33,7 @@ import scala.collection.parallel.immutable.ParRange
  *  `init`) are also permitted on overfull ranges.
  *
  *  @param start      the start of this range.
- *  @param end        the end of the range.  For exclusive ranges, e.g. 
+ *  @param end        the end of the range.  For exclusive ranges, e.g.
  *                    `Range(0,3)` or `(0 until 3)`, this is one
  *                    step past the last one in the range.  For inclusive
  *                    ranges, e.g. `Range.inclusive(0,3)` or `(0 to 3)`,
@@ -78,9 +78,10 @@ extends scala.collection.AbstractSeq[Int]
   // which means it will not fail fast for those cases where failing was
   // correct.
   override final val isEmpty = (
-       (start > end && step > 0)
-    || (start < end && step < 0)
-    || (start == end && !isInclusive)
+    if (isInclusive)
+      (if (step >= 0) start > end else start < end)
+    else
+      (if (step >= 0) start >= end else start <= end)
   )
 
   private val numRangeElements: Int = {
@@ -194,7 +195,7 @@ extends scala.collection.AbstractSeq[Int]
       copy(locationAfterN(n), end, step)
     }
   )
-  
+
   /** Creates a new range containing the elements starting at `from` up to but not including `until`.
    *
    *  $doesNotUseBuilders
@@ -211,7 +212,7 @@ extends scala.collection.AbstractSeq[Int]
       if (from >= until) newEmptyRange(fromValue)
       else new Range.Inclusive(fromValue, locationAfterN(until-1), step)
     }
-    
+
   /** Creates a new range containing all the elements of this range except the last one.
    *
    *  $doesNotUseBuilders

--- a/scalalib/overrides-2.12/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.12/scala/collection/immutable/Range.scala
@@ -67,16 +67,6 @@ extends scala.collection.AbstractSeq[Int]
 {
   override def par = new ParRange(this)
 
-  private def gap           = end.toLong - start.toLong
-  private def isExact       = gap % step == 0
-  private def hasStub       = isInclusive || !isExact
-  private def longLength    = gap / step + ( if (hasStub) 1 else 0 )
-
-  // Check cannot be evaluated eagerly because we have a pattern where
-  // ranges are constructed like: "x to y by z" The "x to y" piece
-  // should not trigger an exception. So the calculation is delayed,
-  // which means it will not fail fast for those cases where failing was
-  // correct.
   override final val isEmpty = (
     if (isInclusive)
       (if (step >= 0) start > end else start < end)
@@ -84,25 +74,85 @@ extends scala.collection.AbstractSeq[Int]
       (if (step >= 0) start >= end else start <= end)
   )
 
+  if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
+
+  /** Number of elements in this range, if it is non-empty.
+   *
+   *  If the range is empty, `numRangeElements` does not have a meaningful value.
+   *
+   *  Otherwise, `numRangeElements` is interpreted in the range [1, 2^32],
+   *  respecting modular arithmetics wrt. the unsigned interpretation.
+   *  In other words, it is 0 if the mathematical value should be 2^32, and the
+   *  standard unsigned int encoding of the mathematical value otherwise.
+   *
+   *  This interpretation allows to represent all values with the correct
+   *  modular arithmetics, which streamlines the usage sites.
+   */
   private val numRangeElements: Int = {
-    if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
-    else if (isEmpty) 0
-    else {
-      val len = longLength
-      if (len > scala.Int.MaxValue) -1
-      else len.toInt
-    }
+    val stepSign = step >> 31 // if (step >= 0) 0 else -1
+    val gap = ((end - start) ^ stepSign) - stepSign // if (step >= 0) (end - start) else -(end - start)
+    val absStep = (step ^ stepSign) - stepSign // if (step >= 0) step else -step
+
+    /* If `absStep` is a constant 1, `div` collapses to being an alias of
+     * `gap`. Then `absStep * div` also collapses to `gap` and therefore
+     * `absStep * div != gap` constant-folds to `false`.
+     *
+     * Since most ranges are exclusive, that makes `numRangeElements` an alias
+     * of `gap`. Moreover, for exclusive ranges with step 1 and start 0 (which
+     * are the common case), it makes it an alias of `end` and the entire
+     * computation goes away.
+     */
+    val div = Integer.divideUnsigned(gap, absStep)
+    if (isInclusive || (absStep * div != gap)) div + 1 else div
   }
 
-  // This field has a sensible value only for non-empty ranges
-  private val lastElement = step match {
-    case 1  => if (isInclusive) end else end-1
-    case -1 => if (isInclusive) end else end+1
-    case _  =>
-      val remainder = (gap % step).toInt
-      if (remainder != 0) end - remainder
-      else if (isInclusive) end
-      else end - step
+  /** Computes the element of this range after `n` steps from `start`.
+   *
+   *  `n` is interpreted as an unsigned integer.
+   *
+   *  If the mathematical result is not within this Range, the result won't
+   *  make sense, but won't error out.
+   */
+  @inline
+  private[this] def locationAfterN(n: Int): Int = {
+    /* If `step >= 0`, we interpret `step * n` as an unsigned multiplication,
+     * and the addition as a mixed `(signed, unsigned) -> signed` operation.
+     * With those interpretation, they do not overflow, assuming the
+     * mathematical result is within this Range.
+     *
+     * If `step < 0`, we should compute `start - (-step * n)`, with the
+     * multiplication also interpreted as unsigned, and the subtraction as
+     * mixed. Again, using those interpreatations, they do not overflow.
+     * But then modular arithmetics allow us to cancel out the two `-` signs,
+     * so we end up with the same formula.
+     */
+    start + (step * n)
+  }
+
+  /** Last element of this non-empty range.
+   *
+   *  For empty ranges, this value is nonsensical.
+   */
+  private[this] val lastElement: Int = {
+    /* Since we can assume the range is non-empty, `(numRangeElements - 1)`
+     * is a valid unsigned value in the full int range. The general formula is
+     * therefore `locationAfterN(numRangeElements - 1)`.
+     *
+     * We special-case 1 and -1 so that, in the happy path where `step` is a
+     * constant 1 or -1, and we only use `foreach`, we can entirely
+     * dead-code-eliminate `numRangeElements` and its computation.
+     *
+     * When `step` is not constant, it is probably 1 or -1 anyway, so the
+     * single branch should be predictably true.
+     *
+     * `step == 1 || step == -1`
+     *   equiv `(step + 1 == 2) || (step + 1 == 0)`
+     *   equiv `((step + 1) & ~2) == 0`
+     */
+    if (((step + 1) & ~2) == 0)
+      (if (isInclusive) end else end - step)
+    else
+      locationAfterN(numRangeElements - 1)
   }
 
   /** The last element of this range.  This method will return the correct value
@@ -135,18 +185,31 @@ extends scala.collection.AbstractSeq[Int]
   def isInclusive = false
 
   override def size = length
-  override def length = if (numRangeElements < 0) fail() else numRangeElements
 
+  override def length: Int =
+    if (isEmpty) 0
+    else if (numRangeElements > 0) numRangeElements
+    else fail()
+
+  // Check cannot be evaluated eagerly because we have a pattern where
+  // ranges are constructed like: "x to y by z" The "x to y" piece
+  // should not trigger an exception. So the calculation is delayed,
+  // which means it will not fail fast for those cases where failing was
+  // correct.
   private def fail() = Range.fail(start, end, step, isInclusive)
   private def validateMaxLength() {
-    if (numRangeElements < 0)
+    if (numRangeElements <= 0 && !isEmpty)
       fail()
   }
 
   final def apply(idx: Int): Int = {
-    validateMaxLength()
-    if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(idx.toString)
-    else start + (step * idx)
+    /* If length is not valid, numRangeElements <= 0, so the condition is always true.
+     * We push validateMaxLength() inside the then branch, out of the happy path.
+     */
+    if (idx < 0 || idx >= numRangeElements || isEmpty) {
+      validateMaxLength()
+      throw new IndexOutOfBoundsException(idx.toString)
+    } else locationAfterN(idx)
   }
 
   @inline final override def foreach[@specialized(Unit) U](f: Int => U) {
@@ -162,6 +225,14 @@ extends scala.collection.AbstractSeq[Int]
     }
   }
 
+  /** Is the non-negative value `n` greater or equal to the number of elements
+   *  in this non-empty range?
+   *
+   *  This method returns nonsensical results if `n < 0` or if `this.isEmpty`.
+   */
+  @inline private[this] def greaterEqualNumRangeElements(n: Int): Boolean =
+    (n ^ Int.MinValue) > ((numRangeElements - 1) ^ Int.MinValue) // unsigned comparison
+
   /** Creates a new range containing the first `n` elements of this range.
    *
    *  $doesNotUseBuilders
@@ -169,15 +240,11 @@ extends scala.collection.AbstractSeq[Int]
    *  @param n  the number of elements to take.
    *  @return   a new range consisting of `n` first elements.
    */
-  final override def take(n: Int): Range = (
+  final override def take(n: Int): Range = {
     if (n <= 0 || isEmpty) newEmptyRange(start)
-    else if (n >= numRangeElements && numRangeElements >= 0) this
-    else {
-      // May have more than Int.MaxValue elements in range (numRangeElements < 0)
-      // but the logic is the same either way: take the first n
-      new Range.Inclusive(start, locationAfterN(n - 1), step)
-    }
-  )
+    else if (greaterEqualNumRangeElements(n)) this
+    else new Range.Inclusive(start, locationAfterN(n - 1), step)
+  }
 
   /** Creates a new range containing all the elements of this range except the first `n` elements.
    *
@@ -186,15 +253,11 @@ extends scala.collection.AbstractSeq[Int]
    *  @param n  the number of elements to drop.
    *  @return   a new range consisting of all the elements of this range except `n` first elements.
    */
-  final override def drop(n: Int): Range = (
+  final override def drop(n: Int): Range = {
     if (n <= 0 || isEmpty) this
-    else if (n >= numRangeElements && numRangeElements >= 0) newEmptyRange(end)
-    else {
-      // May have more than Int.MaxValue elements (numRangeElements < 0)
-      // but the logic is the same either way: go forwards n steps, keep the rest
-      copy(locationAfterN(n), end, step)
-    }
-  )
+    else if (greaterEqualNumRangeElements(n)) newEmptyRange(end)
+    else copy(locationAfterN(n), end, step)
+  }
 
   /** Creates a new range containing the elements starting at `from` up to but not including `until`.
    *
@@ -204,14 +267,16 @@ extends scala.collection.AbstractSeq[Int]
    *  @param until  the element at which to end (not included in the range)
    *  @return   a new range consisting of a contiguous interval of values in the old range
    */
-  override def slice(from: Int, until: Int): Range =
-    if (from <= 0) take(until)
-    else if (until >= numRangeElements && numRangeElements >= 0) drop(from)
+  override def slice(from: Int, until: Int): Range = {
+    if (isEmpty) this
+    else if (from <= 0) take(until)
+    else if (greaterEqualNumRangeElements(until) && until >= 0) drop(from)
     else {
       val fromValue = locationAfterN(from)
       if (from >= until) newEmptyRange(fromValue)
       else new Range.Inclusive(fromValue, locationAfterN(until-1), step)
     }
+  }
 
   /** Creates a new range containing all the elements of this range except the last one.
    *
@@ -250,9 +315,6 @@ extends scala.collection.AbstractSeq[Int]
       else current.toLong + step
     }
   }
-  // Methods like apply throw exceptions on invalid n, but methods like take/drop
-  // are forgiving: therefore the checks are with the methods.
-  private def locationAfterN(n: Int) = start + (step * n)
 
   // When one drops everything.  Can't ever have unchecked operations
   // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
@@ -300,15 +362,9 @@ extends scala.collection.AbstractSeq[Int]
    *  $doesNotUseBuilders
    */
   final override def takeRight(n: Int): Range = {
-    if (n <= 0) newEmptyRange(start)
-    else if (numRangeElements >= 0) drop(numRangeElements - n)
-    else {
-    // Need to handle over-full range separately
-      val y = last
-      val x = y - step.toLong*(n-1)
-      if ((step > 0 && x < start) || (step < 0 && x > start)) this
-      else new Range.Inclusive(x.toInt, y, step)
-    }
+    if (n <= 0 || isEmpty) newEmptyRange(start)
+    else if (greaterEqualNumRangeElements(n)) this
+    else copy(locationAfterN(numRangeElements - n), end, step)
   }
 
   /** Creates a new range consisting of the initial `length - n` elements of the range.
@@ -316,14 +372,9 @@ extends scala.collection.AbstractSeq[Int]
    *  $doesNotUseBuilders
    */
   final override def dropRight(n: Int): Range = {
-    if (n <= 0) this
-    else if (numRangeElements >= 0) take(numRangeElements - n)
-    else {
-    // Need to handle over-full range separately
-      val y = last - step.toInt*n
-      if ((step > 0 && y < start) || (step < 0 && y > start)) newEmptyRange(start)
-      else new Range.Inclusive(start, y.toInt, step)
-    }
+    if (n <= 0 || isEmpty) this
+    else if (greaterEqualNumRangeElements(n)) newEmptyRange(end)
+    else new Range.Inclusive(start, locationAfterN(numRangeElements - 1 - n), step)
   }
 
   /** Returns the reverse of this range.
@@ -341,14 +392,14 @@ extends scala.collection.AbstractSeq[Int]
     else new Range.Inclusive(start, end, step)
 
   final def contains(x: Int) = {
-    if (x==end && !isInclusive) false
+    if (isEmpty) false
     else if (step > 0) {
-      if (x < start || x > end) false
-      else (step == 1) || (((x - start) % step) == 0)
+      if (x < start || x > lastElement) false
+      else (step == 1) || (Integer.remainderUnsigned(x - start, step) == 0)
     }
     else {
-      if (x < end || x > start) false
-      else (step == -1) || (((x - start) % step) == 0)
+      if (x > start || x < lastElement) false
+      else (step == -1) || (Integer.remainderUnsigned(start - x, -step) == 0)
     }
   }
 
@@ -399,8 +450,13 @@ extends scala.collection.AbstractSeq[Int]
 
   override def toString = {
     val preposition = if (isInclusive) "to" else "until"
+
     val stepped = if (step == 1) "" else s" by $step"
-    val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
+    def isInexact =
+      if (isInclusive) lastElement != end
+      else (lastElement + step) != end
+
+    val prefix = if (isEmpty) "empty " else if (isInexact) "inexact " else ""
     s"${prefix}Range $start $preposition $end$stepped"
   }
 }
@@ -433,16 +489,19 @@ object Range {
     )
     if (isEmpty) 0
     else {
-      // Counts with Longs so we can recognize too-large ranges.
-      val gap: Long    = end.toLong - start.toLong
-      val jumps: Long  = gap / step
-      // Whether the size of this range is one larger than the
-      // number of full-sized jumps.
-      val hasStub      = isInclusive || (gap % step != 0)
-      val result: Long = jumps + ( if (hasStub) 1 else 0 )
+      val stepSign = step >> 31 // if (step >= 0) 0 else -1
+      val gap = ((end - start) ^ stepSign) - stepSign // if (step >= 0) (end - start) else -(end - start)
+      val absStep = (step ^ stepSign) - stepSign // if (step >= 0) step else -step
 
-      if (result > scala.Int.MaxValue) -1
-      else result.toInt
+      val div = Integer.divideUnsigned(gap, absStep)
+      if (isInclusive) {
+        if (div == -1) // max unsigned int
+          -1 // corner case: there are 2^32 elements, which would overflow to 0
+        else
+          div + 1
+      } else {
+        if (absStep * div != gap) div + 1 else div
+      }
     }
   }
   def count(start: Int, end: Int, step: Int): Int =

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -81,11 +81,6 @@ sealed abstract class Range(
     r.asInstanceOf[S with EfficientSplit]
   }
 
-  private[this] def gap           = end.toLong - start.toLong
-  private[this] def isExact       = gap % step == 0
-  private[this] def hasStub       = isInclusive || !isExact
-  private[this] def longLength    = gap / step + ( if (hasStub) 1 else 0 )
-
   def isInclusive: Boolean
 
   final override val isEmpty: Boolean = (
@@ -95,27 +90,90 @@ sealed abstract class Range(
       (if (step >= 0) start >= end else start <= end)
   )
 
+  if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
+
+  /** Number of elements in this range, if it is non-empty.
+   *
+   *  If the range is empty, `numRangeElements` does not have a meaningful value.
+   *
+   *  Otherwise, `numRangeElements` is interpreted in the range [1, 2^32],
+   *  respecting modular arithmetics wrt. the unsigned interpretation.
+   *  In other words, it is 0 if the mathematical value should be 2^32, and the
+   *  standard unsigned int encoding of the mathematical value otherwise.
+   *
+   *  This interpretation allows to represent all values with the correct
+   *  modular arithmetics, which streamlines the usage sites.
+   */
   private[this] val numRangeElements: Int = {
-    if (step == 0) throw new IllegalArgumentException("step cannot be 0.")
-    else if (isEmpty) 0
-    else {
-      val len = longLength
-      if (len > scala.Int.MaxValue) -1
-      else len.toInt
-    }
+    val stepSign = step >> 31 // if (step >= 0) 0 else -1
+    val gap = ((end - start) ^ stepSign) - stepSign // if (step >= 0) (end - start) else -(end - start)
+    val absStep = (step ^ stepSign) - stepSign // if (step >= 0) step else -step
+
+    /* If `absStep` is a constant 1, `div` collapses to being an alias of
+     * `gap`. Then `absStep * div` also collapses to `gap` and therefore
+     * `absStep * div != gap` constant-folds to `false`.
+     *
+     * Since most ranges are exclusive, that makes `numRangeElements` an alias
+     * of `gap`. Moreover, for exclusive ranges with step 1 and start 0 (which
+     * are the common case), it makes it an alias of `end` and the entire
+     * computation goes away.
+     */
+    val div = Integer.divideUnsigned(gap, absStep)
+    if (isInclusive || (absStep * div != gap)) div + 1 else div
   }
 
-  final def length = if (numRangeElements < 0) fail() else numRangeElements
+  final def length: Int =
+    if (isEmpty) 0
+    else if (numRangeElements > 0) numRangeElements
+    else fail()
 
-  // This field has a sensible value only for non-empty ranges
-  private[this] val lastElement = step match {
-    case 1  => if (isInclusive) end else end-1
-    case -1 => if (isInclusive) end else end+1
-    case _  =>
-      val remainder = (gap % step).toInt
-      if (remainder != 0) end - remainder
-      else if (isInclusive) end
-      else end - step
+  /** Computes the element of this range after `n` steps from `start`.
+   *
+   *  `n` is interpreted as an unsigned integer.
+   *
+   *  If the mathematical result is not within this Range, the result won't
+   *  make sense, but won't error out.
+   */
+  @inline
+  private[this] def locationAfterN(n: Int): Int = {
+    /* If `step >= 0`, we interpret `step * n` as an unsigned multiplication,
+     * and the addition as a mixed `(signed, unsigned) -> signed` operation.
+     * With those interpretation, they do not overflow, assuming the
+     * mathematical result is within this Range.
+     *
+     * If `step < 0`, we should compute `start - (-step * n)`, with the
+     * multiplication also interpreted as unsigned, and the subtraction as
+     * mixed. Again, using those interpreatations, they do not overflow.
+     * But then modular arithmetics allow us to cancel out the two `-` signs,
+     * so we end up with the same formula.
+     */
+    start + (step * n)
+  }
+
+  /** Last element of this non-empty range.
+   *
+   *  For empty ranges, this value is nonsensical.
+   */
+  private[this] val lastElement: Int = {
+    /* Since we can assume the range is non-empty, `(numRangeElements - 1)`
+     * is a valid unsigned value in the full int range. The general formula is
+     * therefore `locationAfterN(numRangeElements - 1)`.
+     *
+     * We special-case 1 and -1 so that, in the happy path where `step` is a
+     * constant 1 or -1, and we only use `foreach`, we can entirely
+     * dead-code-eliminate `numRangeElements` and its computation.
+     *
+     * When `step` is not constant, it is probably 1 or -1 anyway, so the
+     * single branch should be predictably true.
+     *
+     * `step == 1 || step == -1`
+     *   equiv `(step + 1 == 2) || (step + 1 == 0)`
+     *   equiv `((step + 1) & ~2) == 0`
+     */
+    if (((step + 1) & ~2) == 0)
+      (if (isInclusive) end else end - step)
+    else
+      locationAfterN(numRangeElements - 1)
   }
 
   /** The last element of this range.  This method will return the correct value
@@ -169,16 +227,21 @@ sealed abstract class Range(
   // which means it will not fail fast for those cases where failing was
   // correct.
   private[this] def validateMaxLength(): Unit = {
-    if (numRangeElements < 0)
+    if (numRangeElements <= 0 && !isEmpty)
       fail()
   }
   private[this] def fail() = Range.fail(start, end, step, isInclusive)
 
   @throws[IndexOutOfBoundsException]
   final def apply(idx: Int): Int = {
-    validateMaxLength()
-    if (idx < 0 || idx >= numRangeElements) throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max ${numRangeElements-1})")
-    else start + (step * idx)
+    /* If length is not valid, numRangeElements <= 0, so the condition is always true.
+     * We push validateMaxLength() inside the then branch, out of the happy path.
+     */
+    if (idx < 0 || idx >= numRangeElements || isEmpty) {
+      validateMaxLength()
+      val max = if (isEmpty) -1 else numRangeElements - 1
+      throw new IndexOutOfBoundsException(s"$idx is out of bounds (min 0, max $max)")
+    } else locationAfterN(idx)
   }
 
   /*@`inline`*/ final override def foreach[@specialized(Unit) U](f: Int => U): Unit = {
@@ -226,48 +289,44 @@ sealed abstract class Range(
     case _ => super.sameElements(that)
   }
 
+  /** Is the non-negative value `n` greater or equal to the number of elements
+   *  in this non-empty range?
+   *
+   *  This method returns nonsensical results if `n < 0` or if `this.isEmpty`.
+   */
+  @inline private[this] def greaterEqualNumRangeElements(n: Int): Boolean =
+    (n ^ Int.MinValue) > ((numRangeElements - 1) ^ Int.MinValue) // unsigned comparison
+
   /** Creates a new range containing the first `n` elements of this range.
     *
     *  @param n  the number of elements to take.
     *  @return   a new range consisting of `n` first elements.
     */
-  final override def take(n: Int): Range =
+  final override def take(n: Int): Range = {
     if (n <= 0 || isEmpty) newEmptyRange(start)
-    else if (n >= numRangeElements && numRangeElements >= 0) this
-    else {
-      // May have more than Int.MaxValue elements in range (numRangeElements < 0)
-      // but the logic is the same either way: take the first n
-      new Range.Inclusive(start, locationAfterN(n - 1), step)
-    }
+    else if (greaterEqualNumRangeElements(n)) this
+    else new Range.Inclusive(start, locationAfterN(n - 1), step)
+  }
 
   /** Creates a new range containing all the elements of this range except the first `n` elements.
     *
     *  @param n  the number of elements to drop.
     *  @return   a new range consisting of all the elements of this range except `n` first elements.
     */
-  final override def drop(n: Int): Range =
+  final override def drop(n: Int): Range = {
     if (n <= 0 || isEmpty) this
-    else if (n >= numRangeElements && numRangeElements >= 0) newEmptyRange(end)
-    else {
-      // May have more than Int.MaxValue elements (numRangeElements < 0)
-      // but the logic is the same either way: go forwards n steps, keep the rest
-      copy(locationAfterN(n), end, step)
-    }
+    else if (greaterEqualNumRangeElements(n)) newEmptyRange(end)
+    else copy(locationAfterN(n), end, step)
+  }
 
   /** Creates a new range consisting of the last `n` elements of the range.
     *
     *  $doesNotUseBuilders
     */
   final override def takeRight(n: Int): Range = {
-    if (n <= 0) newEmptyRange(start)
-    else if (numRangeElements >= 0) drop(numRangeElements - n)
-    else {
-      // Need to handle over-full range separately
-      val y = last
-      val x = y - step.toLong*(n-1)
-      if ((step > 0 && x < start) || (step < 0 && x > start)) this
-      else Range.inclusive(x.toInt, y, step)
-    }
+    if (n <= 0 || isEmpty) newEmptyRange(start)
+    else if (greaterEqualNumRangeElements(n)) this
+    else copy(locationAfterN(numRangeElements - n), end, step)
   }
 
   /** Creates a new range consisting of the initial `length - n` elements of the range.
@@ -275,14 +334,9 @@ sealed abstract class Range(
     *  $doesNotUseBuilders
     */
   final override def dropRight(n: Int): Range = {
-    if (n <= 0) this
-    else if (numRangeElements >= 0) take(numRangeElements - n)
-    else {
-      // Need to handle over-full range separately
-      val y = last - step.toInt*n
-      if ((step > 0 && y < start) || (step < 0 && y > start)) newEmptyRange(start)
-      else Range.inclusive(start, y.toInt, step)
-    }
+    if (n <= 0 || isEmpty) this
+    else if (greaterEqualNumRangeElements(n)) newEmptyRange(end)
+    else new Range.Inclusive(start, locationAfterN(numRangeElements - 1 - n), step)
   }
 
   // Advance from the start while we meet the given test
@@ -335,21 +389,19 @@ sealed abstract class Range(
     *  @param until  the element at which to end (not included in the range)
     *  @return   a new range consisting of a contiguous interval of values in the old range
     */
-  final override def slice(from: Int, until: Int): Range =
-    if (from <= 0) take(until)
-    else if (until >= numRangeElements && numRangeElements >= 0) drop(from)
+  final override def slice(from: Int, until: Int): Range = {
+    if (isEmpty) this
+    else if (from <= 0) take(until)
+    else if (greaterEqualNumRangeElements(until) && until >= 0) drop(from)
     else {
       val fromValue = locationAfterN(from)
       if (from >= until) newEmptyRange(fromValue)
-      else Range.inclusive(fromValue, locationAfterN(until-1), step)
+      else new Range.Inclusive(fromValue, locationAfterN(until-1), step)
     }
+  }
 
   // Overridden only to refine the return type
   final override def splitAt(n: Int): (Range, Range) = (take(n), drop(n))
-
-  // Methods like apply throw exceptions on invalid n, but methods like take/drop
-  // are forgiving: therefore the checks are with the methods.
-  private[this] def locationAfterN(n: Int) = start + (step * n)
 
   // When one drops everything.  Can't ever have unchecked operations
   // like "end + 1" or "end - 1" because ranges involving Int.{ MinValue, MaxValue }
@@ -370,13 +422,13 @@ sealed abstract class Range(
     else new Range.Inclusive(start, end, step)
 
   final def contains(x: Int) = {
-    if (x == end && !isInclusive) false
+    if (isEmpty) false
     else if (step > 0) {
-      if (x < start || x > end) false
+      if (x < start || x > lastElement) false
       else (step == 1) || (Integer.remainderUnsigned(x - start, step) == 0)
     }
     else {
-      if (x < end || x > start) false
+      if (x > start || x < lastElement) false
       else (step == -1) || (Integer.remainderUnsigned(start - x, -step) == 0)
     }
   }
@@ -479,7 +531,12 @@ sealed abstract class Range(
   final override def toString: String = {
     val preposition = if (isInclusive) "to" else "until"
     val stepped = if (step == 1) "" else s" by $step"
-    val prefix = if (isEmpty) "empty " else if (!isExact) "inexact " else ""
+
+    def isInexact =
+      if (isInclusive) lastElement != end
+      else (lastElement + step) != end
+
+    val prefix = if (isEmpty) "empty " else if (isInexact) "inexact " else ""
     s"${prefix}Range $start $preposition $end$stepped"
   }
 
@@ -550,16 +607,19 @@ object Range {
 
     if (isEmpty) 0
     else {
-      // Counts with Longs so we can recognize too-large ranges.
-      val gap: Long    = end.toLong - start.toLong
-      val jumps: Long  = gap / step
-      // Whether the size of this range is one larger than the
-      // number of full-sized jumps.
-      val hasStub      = isInclusive || (gap % step != 0)
-      val result: Long = jumps + ( if (hasStub) 1 else 0 )
+      val stepSign = step >> 31 // if (step >= 0) 0 else -1
+      val gap = ((end - start) ^ stepSign) - stepSign // if (step >= 0) (end - start) else -(end - start)
+      val absStep = (step ^ stepSign) - stepSign // if (step >= 0) step else -step
 
-      if (result > scala.Int.MaxValue) -1
-      else result.toInt
+      val div = Integer.divideUnsigned(gap, absStep)
+      if (isInclusive) {
+        if (div == -1) // max unsigned int
+          -1 // corner case: there are 2^32 elements, which would overflow to 0
+        else
+          div + 1
+      } else {
+        if (absStep * div != gap) div + 1 else div
+      }
     }
   }
   def count(start: Int, end: Int, step: Int): Int =

--- a/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
+++ b/scalalib/overrides-2.13/scala/collection/immutable/Range.scala
@@ -89,10 +89,11 @@ sealed abstract class Range(
   def isInclusive: Boolean
 
   final override val isEmpty: Boolean = (
-    (start > end && step > 0)
-      || (start < end && step < 0)
-      || (start == end && !isInclusive)
-    )
+    if (isInclusive)
+      (if (step >= 0) start > end else start < end)
+    else
+      (if (step >= 0) start >= end else start <= end)
+  )
 
   private[this] val numRangeElements: Int = {
     if (step == 0) throw new IllegalArgumentException("step cannot be 0.")


### PR DESCRIPTION
Previously, `Range` used a number of intermediate operations on `Long`s to avoid overflow. The optimizer was already good enough to remove them in many cases, in particular when the step is `1` and/or the start is `0`, which are common cases.

Now that the optimizer can reason about unsigned division, we can do a lot better. We can entirely avoid `Long` computations, *and* streamline a lot of code, by using unsigned `Int` arithmetics. This produces much better code for the cases where the optimizer cannot entirely get rid of the computations.

---

Diffs of the test suite in 2.12 and 2.13 can be seen here (I trimmed away all the local variable name changes):
https://gist.github.com/sjrd/e270bc3acaf86526b86767a4d107b409

My favorite diff is the following, happening for a range `by 2`:
```diff
   $x_1.require__Z__V((((this$2.length % 2) | 0) === 0));
   var this$4 = $n(s1);
   var end = this$4.length;
-  var isEmpty = (end <= 0);
   var isEmpty$1 = (end <= 0);
-  if (isEmpty$1) {
-  } else {
-    var hi$2 = (end >> 31);
-    var this$10 = $m_RTLong$();
-    var lo = this$10.divideImpl__I__I__I__I__I(end, hi$2, 2, 0);
-    var hi$3 = this$10.RTLong$__f_org$scalajs$linker$runtime$RuntimeLong$$hiReturn;
-    var hi$4 = (end >> 31);
-    var this$12 = $m_RTLong$();
-    this$12.remainderImpl__I__I__I__I__I(end, hi$4, 2, 0);
-  }
-  var hi$8 = (end >> 31);
-  var this$16 = $m_RTLong$();
-  var lo$3 = this$16.remainderImpl__I__I__I__I__I(end, hi$8, 2, 0);
-  var scala$collection$immutable$Range$$lastElement$1 = ((lo$3 !== 0) ? ((end - lo$3) | 0) : (((-2) + end) | 0));
+  var div = ((end >>> 1) | 0);
+  var scala$collection$immutable$Range$$numRangeElements = (((div << 1) !== end) ? ((1 + div) | 0) : div);
+  var n = (((-1) + scala$collection$immutable$Range$$numRangeElements) | 0);
+  var scala$collection$immutable$Range$$lastElement$1 = (n << 1);
   if ((!isEmpty$1)) {
     var i = 0;
     while (true) {
```
Turned 3 Long division operations into a few int shifts. 👌