### PR TITLE
Use static methods as entry points for RuntimeLong operator methods.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -1020,7 +1020,7 @@ private[emitter] object CoreJSLib {
             Return(Apply(genIdentBracketSelect(fpBitsDataView, "getBigInt64"), List(0, bool(true))))
           )
         } else {
-          Return(genLongModuleApply(LongImpl.fromDoubleBits, x, fpBitsDataView))
+          Return(genLongApplyStatic(LongImpl.fromDoubleBits, x, fpBitsDataView))
         }
       } :::
       defineFloatingPointBitsFunctionOrPolyfill(VarField.doubleFromBits, doubleFromBits) { (x, fpBitsDataView) =>
@@ -1030,7 +1030,7 @@ private[emitter] object CoreJSLib {
             Return(Apply(genIdentBracketSelect(fpBitsDataView, "getFloat64"), List(0, bool(true))))
           )
         } else {
-          Return(genApply(x, LongImpl.bitsToDouble, fpBitsDataView))
+          Return(genLongApplyStatic(LongImpl.bitsToDouble, x, fpBitsDataView))
         }
       }
     }

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -1437,8 +1437,8 @@ object Emitter {
           multiple(
               instanceTests(LongImpl.RuntimeLongClass),
               instantiateClass(LongImpl.RuntimeLongClass, LongImpl.AllConstructors.toList),
-              callMethods(LongImpl.RuntimeLongClass, LongImpl.AllMethods.toList),
-              callOnModule(LongImpl.RuntimeLongModuleClass, LongImpl.AllModuleMethods.toList)
+              callMethods(LongImpl.RuntimeLongClass, LongImpl.BoxedLongMethods.toList),
+              callStaticMethods(LongImpl.RuntimeLongClass, LongImpl.OperatorMethods.toList)
           )
         },
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2395,7 +2395,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               if (useBigIntForLongs)
                 js.Apply(genGlobalVarRef("BigInt"), List(newLhs))
               else
-                genLongModuleApply(LongImpl.fromInt, newLhs)
+                genLongApplyStatic(LongImpl.fromInt, newLhs)
 
             // Narrowing conversions
             case IntToChar =>
@@ -2412,7 +2412,7 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               if (useBigIntForLongs)
                 js.Apply(genGlobalVarRef("Number"), List(wrapBigInt32(newLhs)))
               else
-                genApply(newLhs, LongImpl.toInt)
+                genLongApplyStatic(LongImpl.toInt, newLhs)
             case DoubleToInt =>
               genCallHelper(VarField.doubleToInt, newLhs)
             case DoubleToFloat =>
@@ -2423,19 +2423,19 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               if (useBigIntForLongs)
                 js.Apply(genGlobalVarRef("Number"), List(newLhs))
               else
-                genApply(newLhs, LongImpl.toDouble)
+                genLongApplyStatic(LongImpl.toDouble, newLhs)
             case DoubleToLong =>
               if (useBigIntForLongs)
                 genCallHelper(VarField.doubleToLong, newLhs)
               else
-                genLongModuleApply(LongImpl.fromDouble, newLhs)
+                genLongApplyStatic(LongImpl.fromDouble, newLhs)
 
             // Long -> Float (neither widening nor narrowing)
             case LongToFloat =>
               if (useBigIntForLongs)
                 genCallHelper(VarField.longToFloat, newLhs)
               else
-                genApply(newLhs, LongImpl.toFloat)
+                genLongApplyStatic(LongImpl.toFloat, newLhs)
 
             // String.length
             case String_length =>
@@ -2668,25 +2668,25 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               if (useBigIntForLongs)
                 wrapBigInt64(js.BinaryOp(JSBinaryOp.+, newLhs, newRhs))
               else
-                genApply(newLhs, LongImpl.+, newRhs)
+                genLongApplyStatic(LongImpl.add, newLhs, newRhs)
             case Long_- =>
               lhs match {
                 case LongLiteral(0L) =>
                   if (useBigIntForLongs)
                     wrapBigInt64(js.UnaryOp(JSUnaryOp.-, newRhs))
                   else
-                    genApply(newRhs, LongImpl.UNARY_-)
+                    genLongApplyStatic(LongImpl.neg, newRhs)
                 case _ =>
                   if (useBigIntForLongs)
                     wrapBigInt64(js.BinaryOp(JSBinaryOp.-, newLhs, newRhs))
                   else
-                    genApply(newLhs, LongImpl.-, newRhs)
+                    genLongApplyStatic(LongImpl.sub, newLhs, newRhs)
               }
             case Long_* =>
               if (useBigIntForLongs)
                 wrapBigInt64(js.BinaryOp(JSBinaryOp.*, newLhs, newRhs))
               else
-                genApply(newLhs, LongImpl.*, newRhs)
+                genLongApplyStatic(LongImpl.mul, newLhs, newRhs)
             case Long_/ | Long_% | Long_unsigned_/ | Long_unsigned_% =>
               if (useBigIntForLongs) {
                 val newRhs1 = rhs match {
@@ -2702,83 +2702,83 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               } else {
                 // The zero divisor check is performed by the implementation methods
                 val implMethodName = (op: @switch) match {
-                  case Long_/          => LongImpl./
-                  case Long_%          => LongImpl.%
+                  case Long_/          => LongImpl.divide
+                  case Long_%          => LongImpl.remainder
                   case Long_unsigned_/ => LongImpl.divideUnsigned
                   case Long_unsigned_% => LongImpl.remainderUnsigned
                 }
-                genApply(newLhs, implMethodName, newRhs)
+                genLongApplyStatic(implMethodName, newLhs, newRhs)
               }
 
             case Long_| =>
               if (useBigIntForLongs)
                 wrapBigInt64(js.BinaryOp(JSBinaryOp.|, newLhs, newRhs))
               else
-                genApply(newLhs, LongImpl.|, newRhs)
+                genLongApplyStatic(LongImpl.or, newLhs, newRhs)
             case Long_& =>
               if (useBigIntForLongs)
                 wrapBigInt64(js.BinaryOp(JSBinaryOp.&, newLhs, newRhs))
               else
-                genApply(newLhs, LongImpl.&, newRhs)
+                genLongApplyStatic(LongImpl.and, newLhs, newRhs)
             case Long_^ =>
               lhs match {
                 case LongLiteral(-1L) =>
                   if (useBigIntForLongs)
                     wrapBigInt64(js.UnaryOp(JSUnaryOp.~, newRhs))
                   else
-                    genApply(newRhs, LongImpl.UNARY_~)
+                    genLongApplyStatic(LongImpl.not, newRhs)
                 case _ =>
                   if (useBigIntForLongs)
                     wrapBigInt64(js.BinaryOp(JSBinaryOp.^, newLhs, newRhs))
                   else
-                    genApply(newLhs, LongImpl.^, newRhs)
+                    genLongApplyStatic(LongImpl.xor, newLhs, newRhs)
               }
             case Long_<< =>
               if (useBigIntForLongs)
                 wrapBigInt64(js.BinaryOp(JSBinaryOp.<<, newLhs, bigIntShiftRhs(newRhs)))
               else
-                genApply(newLhs, LongImpl.<<, newRhs)
+                genLongApplyStatic(LongImpl.shl, newLhs, newRhs)
             case Long_>>> =>
               if (useBigIntForLongs)
                 wrapBigInt64(js.BinaryOp(JSBinaryOp.>>, wrapBigIntU64(newLhs), bigIntShiftRhs(newRhs)))
               else
-                genApply(newLhs, LongImpl.>>>, newRhs)
+                genLongApplyStatic(LongImpl.shr, newLhs, newRhs)
             case Long_>> =>
               if (useBigIntForLongs)
                 wrapBigInt64(js.BinaryOp(JSBinaryOp.>>, newLhs, bigIntShiftRhs(newRhs)))
               else
-                genApply(newLhs, LongImpl.>>, newRhs)
+                genLongApplyStatic(LongImpl.sar, newLhs, newRhs)
 
             case Long_== =>
               if (useBigIntForLongs)
                 js.BinaryOp(JSBinaryOp.===, newLhs, newRhs)
               else
-                genApply(newLhs, LongImpl.===, newRhs)
+                genLongApplyStatic(LongImpl.equals_, newLhs, newRhs)
             case Long_!= =>
               if (useBigIntForLongs)
                 js.BinaryOp(JSBinaryOp.!==, newLhs, newRhs)
               else
-                genApply(newLhs, LongImpl.!==, newRhs)
+                genLongApplyStatic(LongImpl.notEquals, newLhs, newRhs)
             case Long_< =>
               if (useBigIntForLongs)
                 js.BinaryOp(JSBinaryOp.<, newLhs, newRhs)
               else
-                genApply(newLhs, LongImpl.<, newRhs)
+                genLongApplyStatic(LongImpl.lt, newLhs, newRhs)
             case Long_<= =>
               if (useBigIntForLongs)
                 js.BinaryOp(JSBinaryOp.<=, newLhs, newRhs)
               else
-                genApply(newLhs, LongImpl.<=, newRhs)
+                genLongApplyStatic(LongImpl.le, newLhs, newRhs)
             case Long_> =>
               if (useBigIntForLongs)
                 js.BinaryOp(JSBinaryOp.>, newLhs, newRhs)
               else
-                genApply(newLhs, LongImpl.>, newRhs)
+                genLongApplyStatic(LongImpl.gt, newLhs, newRhs)
             case Long_>= =>
               if (useBigIntForLongs)
                 js.BinaryOp(JSBinaryOp.>=, newLhs, newRhs)
               else
-                genApply(newLhs, LongImpl.>=, newRhs)
+                genLongApplyStatic(LongImpl.ge, newLhs, newRhs)
 
             case Float_+ => genFround(js.BinaryOp(JSBinaryOp.+, newLhs, newRhs))
             case Float_- => genFround(js.BinaryOp(JSBinaryOp.-, newLhs, newRhs))

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
@@ -18,87 +18,104 @@ import org.scalajs.ir.WellKnownNames._
 
 private[linker] object LongImpl {
   final val RuntimeLongClass = ClassName("org.scalajs.linker.runtime.RuntimeLong")
-  final val RuntimeLongModuleClass = ClassName("org.scalajs.linker.runtime.RuntimeLong$")
 
   final val lo = MethodName("lo", Nil, IntRef)
   final val hi = MethodName("hi", Nil, IntRef)
 
   private final val RTLongRef = ClassRef(RuntimeLongClass)
   private final val OneRTLongRef = RTLongRef :: Nil
+  private final val TwoRTLongRefs = RTLongRef :: OneRTLongRef
 
   def unaryOp(name: String): MethodName =
-    MethodName(name, Nil, RTLongRef)
-
-  def binaryOp(name: String): MethodName =
     MethodName(name, OneRTLongRef, RTLongRef)
 
+  def binaryOp(name: String): MethodName =
+    MethodName(name, TwoRTLongRefs, RTLongRef)
+
   def shiftOp(name: String): MethodName =
-    MethodName(name, List(IntRef), RTLongRef)
+    MethodName(name, List(RTLongRef, IntRef), RTLongRef)
 
   def compareOp(name: String): MethodName =
-    MethodName(name, OneRTLongRef, BooleanRef)
+    MethodName(name, TwoRTLongRefs, BooleanRef)
 
-  final val UNARY_- = unaryOp("unary_$minus")
-  final val UNARY_~ = unaryOp("unary_$tilde")
+  // Instance methods that we need to reach as part of the jl.Long boxing
 
-  final val + = binaryOp("$plus")
-  final val - = binaryOp("$minus")
-  final val * = binaryOp("$times")
-  final val / = binaryOp("$div")
-  final val % = binaryOp("$percent")
+  private final val byteValue = MethodName("byteValue", Nil, ByteRef)
+  private final val shortValue = MethodName("shortValue", Nil, ShortRef)
+  private final val intValue = MethodName("intValue", Nil, IntRef)
+  private final val longValue = MethodName("longValue", Nil, LongRef)
+  private final val floatValue = MethodName("floatValue", Nil, FloatRef)
+  private final val doubleValue = MethodName("doubleValue", Nil, DoubleRef)
+
+  private final val equalsO = MethodName("equals", List(ClassRef(ObjectClass)), BooleanRef)
+  private final val hashCode_ = MethodName("hashCode", Nil, IntRef)
+  private final val compareTo = MethodName("compareTo", List(ClassRef(BoxedLongClass)), IntRef)
+  private final val compareToO = MethodName("compareTo", List(ClassRef(ObjectClass)), IntRef)
+
+  val BoxedLongMethods = Set(
+      byteValue, shortValue, intValue, longValue, floatValue, doubleValue,
+      equalsO, hashCode_, compareTo, compareToO)
+
+  // Operator methods
+
+  final val neg = unaryOp("neg")
+  final val not = unaryOp("not")
+
+  final val add = binaryOp("add")
+  final val sub = binaryOp("sub")
+  final val mul = binaryOp("mul")
+  final val divide = binaryOp("divide")
+  final val remainder = binaryOp("remainder")
 
   final val divideUnsigned = binaryOp("divideUnsigned")
   final val remainderUnsigned = binaryOp("remainderUnsigned")
 
-  final val | = binaryOp("$bar")
-  final val & = binaryOp("$amp")
-  final val ^ = binaryOp("$up")
+  final val or = binaryOp("or")
+  final val and = binaryOp("and")
+  final val xor = binaryOp("xor")
 
-  final val <<  = shiftOp("$less$less")
-  final val >>> = shiftOp("$greater$greater$greater")
-  final val >>  = shiftOp("$greater$greater")
+  final val shl = shiftOp("shl")
+  final val shr = shiftOp("shr")
+  final val sar = shiftOp("sar")
 
-  final val === = compareOp("equals")
-  final val !== = compareOp("notEquals")
-  final val <   = compareOp("$less")
-  final val <=  = compareOp("$less$eq")
-  final val >   = compareOp("$greater")
-  final val >=  = compareOp("$greater$eq")
+  final val equals_ = compareOp("equals")
+  final val notEquals = compareOp("notEquals")
+  final val lt = compareOp("lt")
+  final val le = compareOp("le")
+  final val gt = compareOp("gt")
+  final val ge = compareOp("ge")
 
-  final val toInt = MethodName("toInt", Nil, IntRef)
-  final val toFloat = MethodName("toFloat", Nil, FloatRef)
-  final val toDouble = MethodName("toDouble", Nil, DoubleRef)
-  final val bitsToDouble = MethodName("bitsToDouble", List(ObjectRef), DoubleRef)
+  final val toInt = MethodName("toInt", OneRTLongRef, IntRef)
+  final val toFloat = MethodName("toFloat", OneRTLongRef, FloatRef)
+  final val toDouble = MethodName("toDouble", OneRTLongRef, DoubleRef)
+  final val bitsToDouble = MethodName("bitsToDouble", List(RTLongRef, ObjectRef), DoubleRef)
 
-  final val byteValue   = MethodName("byteValue", Nil, ByteRef)
-  final val shortValue  = MethodName("shortValue", Nil, ShortRef)
-  final val intValue    = MethodName("intValue", Nil, IntRef)
-  final val longValue   = MethodName("longValue", Nil, LongRef)
-  final val floatValue  = MethodName("floatValue", Nil, FloatRef)
-  final val doubleValue = MethodName("doubleValue", Nil, DoubleRef)
+  final val fromInt = MethodName("fromInt", List(IntRef), RTLongRef)
+  final val fromDouble = MethodName("fromDouble", List(DoubleRef), RTLongRef)
+  final val fromDoubleBits = MethodName("fromDoubleBits", List(DoubleRef, ObjectRef), RTLongRef)
 
-  final val toString_  = MethodName("toString", Nil, ClassRef(BoxedStringClass))
-  final val equals_    = MethodName("equals", List(ClassRef(ObjectClass)), BooleanRef)
-  final val hashCode_  = MethodName("hashCode", Nil, IntRef)
-  final val compareTo  = MethodName("compareTo", List(ClassRef(BoxedLongClass)), IntRef)
-  final val compareToO = MethodName("compareTo", List(ClassRef(ObjectClass)), IntRef)
-
-  private val OperatorMethods = Set(
-      UNARY_-, UNARY_~, this.+, this.-, *, /, %, divideUnsigned, remainderUnsigned,
-      |, &, ^, <<, >>>, >>, ===, !==, <, <=, >, >=, toInt, toFloat, toDouble, bitsToDouble)
-
-  private val BoxedLongMethods = Set(
-      byteValue, shortValue, intValue, longValue, floatValue, doubleValue,
-      equals_, hashCode_, compareTo, compareToO)
-
-  val AllMethods = OperatorMethods ++ BoxedLongMethods
+  val OperatorMethods = Set(
+    neg, not,
+    add, sub, mul,
+    divide, remainder, divideUnsigned, remainderUnsigned,
+    or, and, xor, shl, shr, sar,
+    equals_, notEquals, lt, le, gt, ge,
+    toInt, toFloat, toDouble, bitsToDouble, fromInt, fromDouble, fromDoubleBits
+  )
 
   // Methods used for intrinsics
 
-  final val compareToRTLong = MethodName("compareTo", List(RTLongRef), IntRef)
+  final val toString_ = MethodName("toString", OneRTLongRef, ClassRef(BoxedStringClass))
+
+  final val compare = MethodName("compare", TwoRTLongRefs, IntRef)
+
+  final val multiplyFull = MethodName("multiplyFull", List(IntRef, IntRef), RTLongRef)
 
   val AllIntrinsicMethods = Set(
-      compareToRTLong)
+    toString_,
+    compare,
+    multiplyFull
+  )
 
   // Constructors
 
@@ -106,22 +123,6 @@ private[linker] object LongImpl {
 
   val AllConstructors = Set(
       initFromParts)
-
-  // Methods on the companion
-
-  final val fromInt = MethodName("fromInt", List(IntRef), RTLongRef)
-  final val fromDouble = MethodName("fromDouble", List(DoubleRef), RTLongRef)
-  final val fromDoubleBits = MethodName("fromDoubleBits", List(DoubleRef, ObjectRef), RTLongRef)
-
-  val AllModuleMethods = Set(
-      fromInt, fromDouble, fromDoubleBits)
-
-  // Methods on the companion used for intrinsics
-
-  final val multiplyFull = MethodName("multiplyFull", List(IntRef, IntRef), RTLongRef)
-
-  val AllIntrinsicModuleMethods = Set(
-      multiplyFull)
 
   // Extract the parts to give to the initFromParts constructor
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/NameGen.scala
@@ -63,7 +63,7 @@ private[backend] final class NameGen {
     cache.put(ObjectClass, "O")
     cache.put(BoxedStringClass, "T")
     cache.put(LongImpl.RuntimeLongClass, "RTLong")
-    cache.put(LongImpl.RuntimeLongModuleClass, "RTLong$")
+    cache.put(LongImpl.RuntimeLongClass.withSuffix("$"), "RTLong$")
     cache
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -241,13 +241,10 @@ private[emitter] final class SJSGen(
     globalVar(VarField.bC0, CoreVar)
   }
 
-  def genLongModuleApply(methodName: MethodName, args: Tree*)(
+  def genLongApplyStatic(methodName: MethodName, args: Tree*)(
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
       pos: Position): Tree = {
-    import TreeDSL._
-    genApply(
-        genLoadModule(LongImpl.RuntimeLongModuleClass), methodName,
-        args.toList)
+    Apply(globalVar(VarField.s, (LongImpl.RuntimeLongClass, methodName)), args.toList)
   }
 
   def usesUnderlyingTypedArray(elemTypeRef: NonArrayTypeRef): Boolean = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IncOptimizer.scala
@@ -75,10 +75,7 @@ final class IncOptimizer private[optimizer] (config: CommonPhaseConfig, collOps:
     multiple(
       cond(!targetIsWebAssembly && !esFeatures.allowBigIntsForLongs) {
         // Required by the intrinsics manipulating Longs
-        multiple(
-          callMethods(LongImpl.RuntimeLongClass, LongImpl.AllIntrinsicMethods.toList),
-          callMethods(LongImpl.RuntimeLongModuleClass, LongImpl.AllIntrinsicModuleMethods.toList)
-        )
+        callStaticMethods(LongImpl.RuntimeLongClass, LongImpl.AllIntrinsicMethods.toList)
       },
       cond(targetIsWebAssembly) {
         // Required by the intrinsic CharacterCodePointToString

--- a/linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/standard/SymbolRequirement.scala
@@ -79,6 +79,11 @@ object SymbolRequirement {
       CallStaticMethod(origin, className, methodName)
     }
 
+    def callStaticMethods(className: ClassName,
+        methodNames: List[MethodName]): SymbolRequirement = {
+      multipleInternal(methodNames.map(callStaticMethod(className, _)))
+    }
+
     @deprecated("broken (not actually optional), do not use", "1.13.2")
     def optional(requirement: SymbolRequirement): SymbolRequirement = requirement
 

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,8 +70,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 147727,
-      expectedFullLinkSizeWithoutClosure = 86377,
+      expectedFastLinkSize = 147744,
+      expectedFullLinkSizeWithoutClosure = 87106,
       expectedFullLinkSizeWithClosure = 21197,
       classDefs,
       moduleInitializers = MainTestModuleInitializers

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2060,8 +2060,8 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 424000 to 425000,
-                  fullLink = 281000 to 282000,
+                  fastLink = 425000 to 426000,
+                  fullLink = 282000 to 283000,
                   fastLinkGz = 60000 to 61000,
                   fullLinkGz = 43000 to 44000,
               ))
@@ -2077,8 +2077,8 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 299000 to 300000,
-                  fullLink = 257000 to 258000,
+                  fastLink = 300000 to 301000,
+                  fullLink = 258000 to 259000,
                   fastLinkGz = 47000 to 48000,
                   fullLinkGz = 42000 to 43000,
               ))


### PR DESCRIPTION
Previously, we used instance methods on `RuntimeLong` to implement the operators whose lhs is a `RuntimeLong`. Other operators, such as `fromDouble`, were implemented as methods of the module.

Now, we use static methods for all the operators. Once inline, it does not make any difference. However, it leaves behind a few unused static methods, instead of some instance methods. The former can be removed by off-the-shelf JS minifies, unlike the latter.

Paradoxically, the `Minify` output, as we measure it, gets bigger. That's because static method names are not renamed by the name minifier.