### PR TITLE
Introduce IR UnaryOps for `numberOfLeadingZeros` (`clz`).

### DIFF
--- a/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
+++ b/compiler/src/main/scala/org/scalajs/nscplugin/GenJSCode.scala
@@ -7426,11 +7426,13 @@ private object GenJSCode {
     val byClass: Map[ClassName, Map[MethodName, JavalibOpBody]] = Map(
       jswkn.BoxedIntegerClass.withSuffix("$") -> Map(
         m("divideUnsigned", List(I, I), I)    -> ArgBinaryOp(binop.Int_unsigned_/),
-        m("remainderUnsigned", List(I, I), I) -> ArgBinaryOp(binop.Int_unsigned_%)
+        m("remainderUnsigned", List(I, I), I) -> ArgBinaryOp(binop.Int_unsigned_%),
+        m("numberOfLeadingZeros", List(I), I) -> ArgUnaryOp(unop.Int_clz)
       ),
       jswkn.BoxedLongClass.withSuffix("$") -> Map(
         m("divideUnsigned", List(J, J), J)    -> ArgBinaryOp(binop.Long_unsigned_/),
-        m("remainderUnsigned", List(J, J), J) -> ArgBinaryOp(binop.Long_unsigned_%)
+        m("remainderUnsigned", List(J, J), J) -> ArgBinaryOp(binop.Long_unsigned_%),
+        m("numberOfLeadingZeros", List(J), I) -> ArgUnaryOp(unop.Long_clz)
       ),
       jswkn.BoxedFloatClass.withSuffix("$") -> Map(
         m("floatToIntBits", List(F), I) -> ArgUnaryOp(unop.Float_toBits),

--- a/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Trees.scala
@@ -517,6 +517,10 @@ object Trees {
     // final val Double_toRawBits = 36 // Reserved
     final val Double_fromBits = 37
 
+    // Other nodes introduced in 1.20
+    final val Int_clz = 38
+    final val Long_clz = 39
+
     def isClassOp(op: Code): Boolean =
       op >= Class_name && op <= Class_superClass
 
@@ -538,7 +542,8 @@ object Trees {
       case IntToShort =>
         ShortType
       case CharToInt | ByteToInt | ShortToInt | LongToInt | DoubleToInt |
-          String_length | Array_length | IdentityHashCode | Float_toBits =>
+          String_length | Array_length | IdentityHashCode | Float_toBits |
+          Int_clz | Long_clz =>
         IntType
       case IntToLong | DoubleToLong | Double_toBits =>
         LongType

--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -274,30 +274,8 @@ object Integer {
   @inline def signum(i: scala.Int): scala.Int =
     if (i == 0) 0 else if (i < 0) -1 else 1
 
-  // Intrinsic, fallback on actual code for non-literal in JS
-  @inline def numberOfLeadingZeros(i: scala.Int): scala.Int = {
-    if (LinkingInfo.esVersion >= ESVersion.ES2015) js.Math.clz32(i)
-    else clz32Dynamic(i)
-  }
-
-  private def clz32Dynamic(i: scala.Int) = {
-    if (js.typeOf(js.Dynamic.global.Math.clz32) == "function") {
-      js.Math.clz32(i)
-    } else {
-      // See Hacker's Delight, Section 5-3
-      var x = i
-      if (x == 0) {
-        32
-      } else {
-        var r = 1
-        if ((x & 0xffff0000) == 0) { x <<= 16; r += 16 }
-        if ((x & 0xff000000) == 0) { x <<= 8; r += 8 }
-        if ((x & 0xf0000000) == 0) { x <<= 4; r += 4 }
-        if ((x & 0xc0000000) == 0) { x <<= 2; r += 2 }
-        r + (x >> 31)
-      }
-    }
-  }
+  @inline def numberOfLeadingZeros(i: scala.Int): scala.Int =
+    throw new Error("stub") // body replaced by the compiler back-end
 
   // Wasm intrinsic
   @inline def numberOfTrailingZeros(i: scala.Int): scala.Int =

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -419,13 +419,9 @@ object Long {
     else 1
   }
 
-  // Wasm intrinsic
   @inline
-  def numberOfLeadingZeros(l: scala.Long): Int = {
-    val hi = (l >>> 32).toInt
-    if (hi != 0) Integer.numberOfLeadingZeros(hi)
-    else         Integer.numberOfLeadingZeros(l.toInt) + 32
-  }
+  def numberOfLeadingZeros(l: scala.Long): Int =
+    throw new Error("stub") // body replaced by the compiler back-end
 
   // Wasm intrinsic
   @inline

--- a/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
+++ b/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
@@ -662,6 +662,13 @@ object RuntimeLong {
   }
 
   @inline
+  def clz(a: RuntimeLong): Int = {
+    val hi = a.hi
+    if (hi != 0) Integer.numberOfLeadingZeros(hi)
+    else 32 + Integer.numberOfLeadingZeros(a.lo)
+  }
+
+  @inline
   def fromInt(value: Int): RuntimeLong =
     new RuntimeLong(value, value >> 31)
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -2531,6 +2531,15 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
               genCallHelper(VarField.doubleToBits, newLhs)
             case Double_fromBits =>
               genCallHelper(VarField.doubleFromBits, newLhs)
+
+            // clz
+            case Int_clz =>
+              genCallPolyfillableBuiltin(PolyfillableBuiltin.Clz32Builtin, newLhs)
+            case Long_clz =>
+              if (useBigIntForLongs)
+                genCallHelper(VarField.longClz, newLhs)
+              else
+                genLongApplyStatic(LongImpl.clz, newLhs)
           }
 
         case BinaryOp(op, lhs, rhs) =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
@@ -89,6 +89,7 @@ private[linker] object LongImpl {
   final val toFloat = MethodName("toFloat", OneRTLongRef, FloatRef)
   final val toDouble = MethodName("toDouble", OneRTLongRef, DoubleRef)
   final val bitsToDouble = MethodName("bitsToDouble", List(RTLongRef, ObjectRef), DoubleRef)
+  final val clz = MethodName("clz", OneRTLongRef, IntRef)
 
   final val fromInt = MethodName("fromInt", List(IntRef), RTLongRef)
   final val fromDouble = MethodName("fromDouble", List(DoubleRef), RTLongRef)
@@ -100,7 +101,8 @@ private[linker] object LongImpl {
     divide, remainder, divideUnsigned, remainderUnsigned,
     or, and, xor, shl, shr, sar,
     equals_, notEquals, lt, le, gt, ge,
-    toInt, toFloat, toDouble, bitsToDouble, fromInt, fromDouble, fromDoubleBits
+    toInt, toFloat, toDouble, bitsToDouble, clz,
+    fromInt, fromDouble, fromDoubleBits
   )
 
   // Methods used for intrinsics

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/PolyfillableBuiltin.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/PolyfillableBuiltin.scala
@@ -21,6 +21,7 @@ private[emitter] object PolyfillableBuiltin {
   lazy val All: List[PolyfillableBuiltin] = List(
     ObjectIsBuiltin,
     ImulBuiltin,
+    Clz32Builtin,
     FroundBuiltin,
     PrivateSymbolBuiltin,
     GetOwnPropertyDescriptorsBuiltin
@@ -36,6 +37,7 @@ private[emitter] object PolyfillableBuiltin {
 
   case object ObjectIsBuiltin extends NamespacedBuiltin("Object", "is", VarField.is, ESVersion.ES2015)
   case object ImulBuiltin extends NamespacedBuiltin("Math", "imul", VarField.imul, ESVersion.ES2015)
+  case object Clz32Builtin extends NamespacedBuiltin("Math", "clz32", VarField.clz32, ESVersion.ES2015)
   case object FroundBuiltin extends NamespacedBuiltin("Math", "fround", VarField.fround, ESVersion.ES2015)
   case object PrivateSymbolBuiltin
       extends GlobalVarBuiltin("Symbol", VarField.privateJSFieldSymbol, ESVersion.ES2015)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
@@ -263,6 +263,8 @@ private[emitter] object VarField {
 
   final val checkLongDivisor = mk("$checkLongDivisor")
 
+  final val longClz = mk("$longClz")
+
   final val longToFloat = mk("$longToFloat")
 
   final val doubleToLong = mk("$doubleToLong")
@@ -277,6 +279,7 @@ private[emitter] object VarField {
   // Polyfills
 
   final val imul = mk("$imul")
+  final val clz32 = mk("$clz32")
   final val fround = mk("$fround")
   final val privateJSFieldSymbol = mk("$privateJSFieldSymbol")
   final val getOwnPropertyDescriptors = mk("$getOwnPropertyDescriptors")

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -1685,6 +1685,12 @@ private class FunctionEmitter private (
         fb += wa.LocalGet(bitsLocal)
       case Double_fromBits =>
         fb += wa.F64ReinterpretI64
+
+      case Int_clz =>
+        fb += wa.I32Clz
+      case Long_clz =>
+        fb += wa.I64Clz
+        fb += wa.I32WrapI64
     }
 
     tree.tpe

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmTransients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmTransients.scala
@@ -47,11 +47,9 @@ object WasmTransients {
       Transient(WasmUnaryOp(op, transformer.transform(lhs)))
 
     def wasmInstr: wa.SimpleInstr = (op: @switch) match {
-      case I32Clz    => wa.I32Clz
       case I32Ctz    => wa.I32Ctz
       case I32Popcnt => wa.I32Popcnt
 
-      case I64Clz    => wa.I64Clz
       case I64Ctz    => wa.I64Ctz
       case I64Popcnt => wa.I64Popcnt
 
@@ -75,27 +73,25 @@ object WasmTransients {
     /** Codes are raw Ints to be able to write switch matches on them. */
     type Code = Int
 
-    final val I32Clz = 1
-    final val I32Ctz = 2
-    final val I32Popcnt = 3
+    final val I32Ctz = 1
+    final val I32Popcnt = 2
 
-    final val I64Clz = 4
-    final val I64Ctz = 5
-    final val I64Popcnt = 6
+    final val I64Ctz = 3
+    final val I64Popcnt = 4
 
-    final val F32Abs = 7
+    final val F32Abs = 5
 
-    final val F64Abs = 8
-    final val F64Ceil = 9
-    final val F64Floor = 10
-    final val F64Nearest = 11
-    final val F64Sqrt = 12
+    final val F64Abs = 6
+    final val F64Ceil = 7
+    final val F64Floor = 8
+    final val F64Nearest = 9
+    final val F64Sqrt = 10
 
     def resultTypeOf(op: Code): Type = (op: @switch) match {
-      case I32Clz | I32Ctz | I32Popcnt =>
+      case I32Ctz | I32Popcnt =>
         IntType
 
-      case I64Clz | I64Ctz | I64Popcnt =>
+      case I64Ctz | I64Popcnt =>
         LongType
 
       case F32Abs =>

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -538,9 +538,11 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
             ByteType
           case ShortToInt =>
             ShortType
-          case IntToLong | IntToDouble | IntToChar | IntToByte | IntToShort | Float_fromBits =>
+          case IntToLong | IntToDouble | IntToChar | IntToByte | IntToShort |
+              Float_fromBits | Int_clz =>
             IntType
-          case LongToInt | LongToDouble | LongToFloat | Double_fromBits =>
+          case LongToInt | LongToDouble | LongToFloat | Double_fromBits |
+              Long_clz =>
             LongType
           case FloatToDouble | Float_toBits =>
             FloatType

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -2841,17 +2841,6 @@ private[optimizer] abstract class OptimizerCore(
 
       // java.lang.Integer
 
-      case IntegerNLZ =>
-        val tvalue = targs.head
-        tvalue match {
-          case PreTransLit(IntLiteral(value)) =>
-            contTree(IntLiteral(Integer.numberOfLeadingZeros(value)))
-          case _ =>
-            if (isWasm)
-              contTree(wasmUnaryOp(WasmUnaryOp.I32Clz, tvalue))
-            else
-              default
-        }
       case IntegerNTZ =>
         val tvalue = targs.head
         tvalue match {
@@ -2888,14 +2877,6 @@ private[optimizer] abstract class OptimizerCore(
 
       // java.lang.Long
 
-      case LongNLZ =>
-        val tvalue = targs.head
-        tvalue match {
-          case PreTransLit(LongLiteral(value)) =>
-            contTree(IntLiteral(java.lang.Long.numberOfLeadingZeros(value)))
-          case _ =>
-            contTree(longToInt(wasmUnaryOp(WasmUnaryOp.I64Clz, tvalue)))
-        }
       case LongNTZ =>
         val tvalue = targs.head
         tvalue match {
@@ -3581,6 +3562,9 @@ private[optimizer] abstract class OptimizerCore(
             expandBinaryOp(LongImpl.bitsToDouble,
                 arg, PreTransTree(Transient(GetFPBitsDataView)))
 
+          case Long_clz =>
+            expandUnaryOp(LongImpl.clz, arg, IntType)
+
           case _ =>
             cont(pretrans)
         }
@@ -3920,6 +3904,23 @@ private[optimizer] abstract class OptimizerCore(
         arg match {
           case PreTransLit(LongLiteral(v)) =>
             PreTransLit(DoubleLiteral(java.lang.Double.longBitsToDouble(v)))
+          case _ =>
+            default
+        }
+
+      // clz
+
+      case Int_clz =>
+        arg match {
+          case PreTransLit(IntLiteral(v)) =>
+            PreTransLit(IntLiteral(Integer.numberOfLeadingZeros(v)))
+          case _ =>
+            default
+        }
+      case Long_clz =>
+        arg match {
+          case PreTransLit(LongLiteral(v)) =>
+            PreTransLit(IntLiteral(java.lang.Long.numberOfLeadingZeros(v)))
           case _ =>
             default
         }
@@ -6534,14 +6535,12 @@ private[optimizer] object OptimizerCore {
     final val ArrayUpdate = ArrayApply       + 1
     final val ArrayLength = ArrayUpdate      + 1
 
-    final val IntegerNLZ = ArrayLength + 1
-    final val IntegerNTZ = IntegerNLZ + 1
+    final val IntegerNTZ = ArrayLength + 1
     final val IntegerBitCount = IntegerNTZ + 1
     final val IntegerRotateLeft = IntegerBitCount + 1
     final val IntegerRotateRight = IntegerRotateLeft + 1
 
-    final val LongNLZ = IntegerRotateRight + 1
-    final val LongNTZ = LongNLZ + 1
+    final val LongNTZ = IntegerRotateRight + 1
     final val LongBitCount = LongNTZ + 1
     final val LongRotateLeft = LongBitCount + 1
     final val LongRotateRight = LongRotateLeft + 1
@@ -6620,9 +6619,6 @@ private[optimizer] object OptimizerCore {
             m("array_update", List(O, I, O), V) -> ArrayUpdate,
             m("array_length", List(O), I) -> ArrayLength
         ),
-        ClassName("java.lang.Integer$") -> List(
-            m("numberOfLeadingZeros", List(I), I) -> IntegerNLZ
-        ),
         ClassName("java.lang.Class") -> List(
             m("getName", Nil, StringClassRef) -> ClassGetName
         ),
@@ -6666,14 +6662,12 @@ private[optimizer] object OptimizerCore {
 
     private val wasmIntrinsics: List[(ClassName, List[(MethodName, Int)])] = List(
         ClassName("java.lang.Integer$") -> List(
-            // note: numberOfLeadingZeros in already in the commonIntrinsics
             m("numberOfTrailingZeros", List(I), I) -> IntegerNTZ,
             m("bitCount", List(I), I) -> IntegerBitCount,
             m("rotateLeft", List(I, I), I) -> IntegerRotateLeft,
             m("rotateRight", List(I, I), I) -> IntegerRotateRight
         ),
         ClassName("java.lang.Long$") -> List(
-            m("numberOfLeadingZeros", List(J), I) -> LongNLZ,
             m("numberOfTrailingZeros", List(J), I) -> LongNTZ,
             m("bitCount", List(J), I) -> LongBitCount,
             m("rotateLeft", List(J, I), J) -> LongRotateLeft,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2060,7 +2060,7 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 425000 to 426000,
+                  fastLink = 424000 to 425000,
                   fullLink = 282000 to 283000,
                   fastLinkGz = 60000 to 61000,
                   fullLinkGz = 43000 to 44000,


### PR DESCRIPTION
This particular operation is used by a number of our core numerical algorithms. It makes sense for it to receive a dedicated opcode.

The dedicated opcode lets the optimizer reason about its purity.

---

Another benefit is that we avoid the `$uI()` call around `Math.clz32` in fastLinkJS. For a core function like this, it's not entirely useless.