### PR TITLE
Opt: Avoid the `Long` division in `RuntimeLong.toString`.

### DIFF
--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 147744,
-      expectedFullLinkSizeWithoutClosure = 87106,
-      expectedFullLinkSizeWithClosure = 21197,
+      expectedFastLinkSize = 148312,
+      expectedFullLinkSizeWithoutClosure = 87480,
+      expectedFullLinkSizeWithClosure = 20659,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2053,14 +2053,14 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 624000 to 625000,
+                  fastLink = 625000 to 626000,
                   fullLink = 94000 to 95000,
                   fastLinkGz = 75000 to 79000,
                   fullLinkGz = 24000 to 25000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 424000 to 425000,
+                  fastLink = 425000 to 426000,
                   fullLink = 282000 to 283000,
                   fastLinkGz = 60000 to 61000,
                   fullLinkGz = 43000 to 44000,
@@ -2077,7 +2077,7 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 300000 to 301000,
+                  fastLink = 301000 to 302000,
                   fullLink = 258000 to 259000,
                   fastLinkGz = 47000 to 48000,
                   fullLinkGz = 42000 to 43000,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
@@ -274,6 +274,33 @@ class LongTest {
     assertEquals("89000000005", JLong.toString(89000000005L))
     assertEquals("-9223372036854775808", JLong.toString(JLong.MIN_VALUE))
     assertEquals("9223372036854775807", JLong.toString(JLong.MAX_VALUE))
+
+    // Corner cases of the approximation inside RuntimeLong.toUnsignedString
+
+    // Approximated quotient is too high
+    assertEquals("2777572447999999934", JLong.toString(0x268beb6cdcf3bfbeL))
+    assertEquals("3611603422999999979", JLong.toString(0x321efe2d997ff5ebL))
+    assertEquals("7742984029999999701", JLong.toString(0x6b749af381ac2ad5L))
+    assertEquals("2161767614999999954", JLong.toString(0x1e0024313b04b5d2L))
+    assertEquals("5388513109999999953", JLong.toString(0x4ac7d81fbd15dbd1L))
+    assertEquals("3713052774999999769", JLong.toString(0x338769d386274519L))
+    assertEquals("-5647508785999999800", JLong.toString(0xb1a004ae50928cc8L))
+    assertEquals("-1406561754999999938", JLong.toString(0xec7ae3893e93323eL))
+    assertEquals("-8621287367999999564", JLong.toString(0x885b08d0fbcc31b4L))
+    assertEquals("-8876380314999999920", JLong.toString(0x84d0c321f127b250L))
+    assertEquals("-5002322935999999598", JLong.toString(0xba942dcb0bee5192L))
+    assertEquals("-4971399139999999950", JLong.toString(0xbb020ad25f9e1832L))
+    assertEquals("-8515854999999999733", JLong.toString(0x89d19aff1644110bL))
+    assertEquals("-4806014223999999712", JLong.toString(0xbd4d9b86d1016120L))
+    assertEquals("-9133328502999999878", JLong.toString(0x813fe61df1bc1a7aL))
+    assertEquals("-7816299703999999849", JLong.toString(0x9386ecd4ed16d097L))
+    assertEquals("-7259227631999999909", JLong.toString(0x9b420aee02f0a05bL))
+    assertEquals("-2526704305999999860", JLong.toString(0xdcef57d21c6b8c8cL))
+    assertEquals("-1100666257999999982", JLong.toString(0xf0b9a5deb3a6cc12L))
+
+    // Approximated quotient is too low
+    assertEquals("7346875325000000000", JLong.toString(0x65f5582ec3b52200L))
+    assertEquals("-7993685585000000000", JLong.toString(0x9110b95013ea1600L))
   }
 
   @Test def toStringRadix(): Unit = {


### PR DESCRIPTION
Through clever analysis of approximation errors, it turns out we can rely on a `Double` division by 10^9 rather than a `Long` division.

Since there was already a `Double` division (and remainder) at the end of the `Long` division algorithm, the new implementation should be strictly better. We do have a new call to `js.Math.floor`, but that should be efficient, as `floor` is typically a hardware instruction.

We also remove the hackish way of reusing `unsignedDivModHelper` to compute `toString()`.