### PR TITLE
Add missing cases in `Printers` for `{Int,Long}_clz`.

### DIFF
--- a/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
+++ b/ir/shared/src/main/scala/org/scalajs/ir/Printers.scala
@@ -450,6 +450,9 @@ object Printers {
             case Float_fromBits  => p("<floatFromBits>(", ")")
             case Double_toBits   => p("<doubleToBits>(", ")")
             case Double_fromBits => p("<doubleFromBits>(", ")")
+
+            case Int_clz  => p("<clz>(", ")")
+            case Long_clz => p("<clz>(", ")")
           }
 
         case BinaryOp(BinaryOp.Int_-, IntLiteral(0), rhs) =>

--- a/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
+++ b/ir/shared/src/test/scala/org/scalajs/ir/PrintersTest.scala
@@ -519,6 +519,9 @@ class PrintersTest {
     assertPrintEquals("<floatFromBits>(x)", UnaryOp(Float_fromBits, ref("x", IntType)))
     assertPrintEquals("<doubleToBits>(x)", UnaryOp(Double_toBits, ref("x", DoubleType)))
     assertPrintEquals("<doubleFromBits>(x)", UnaryOp(Double_fromBits, ref("x", LongType)))
+
+    assertPrintEquals("<clz>(x)", UnaryOp(Int_clz, ref("x", IntType)))
+    assertPrintEquals("<clz>(x)", UnaryOp(Long_clz, ref("x", LongType)))
   }
 
   @Test def printPseudoUnaryOp(): Unit = {


### PR DESCRIPTION
This was forgotten in f414dae55c11e1aa41209076e4cccb467d6d7576.