### PR TITLE
Opt: Recognize non-nullabe RT long as subtype of LongType

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -271,6 +271,8 @@ private[optimizer] abstract class OptimizerCore(
       (lhs, rhs) match {
         case (LongType, ClassType(LongImpl.RuntimeLongClass, _)) =>
           true
+        case (ClassType(LongImpl.RuntimeLongClass, false), LongType) =>
+          true
         case (ClassType(BoxedLongClass, lhsNullable),
             ClassType(LongImpl.RuntimeLongClass, rhsNullable)) =>
           rhsNullable || !lhsNullable


### PR DESCRIPTION
Discovered while working on #5077. This allows to remove unnecessary unboxes and unlocks more inlining.