### PR TITLE
Optimize the worst case of RuntimeLong division and remainder.

### DIFF
--- a/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
+++ b/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
@@ -77,9 +77,9 @@ final class RuntimeLong(val lo: Int, val hi: Int) {
   // A few operator-friendly methods used by the division algorithms
 
   @inline private def <<(b: Int): RuntimeLong = RuntimeLong.shl(this, b)
-  @inline private def >>>(b: Int): RuntimeLong = RuntimeLong.shr(this, b)
   @inline private def +(b: RuntimeLong): RuntimeLong = RuntimeLong.add(this, b)
   @inline private def -(b: RuntimeLong): RuntimeLong = RuntimeLong.sub(this, b)
+  @inline private def *(b: RuntimeLong): RuntimeLong = RuntimeLong.mul(this, b)
 }
 
 object RuntimeLong {
@@ -617,14 +617,19 @@ object RuntimeLong {
      *
      * We convert the unsigned value num = (lo, hi) to a Double value
      * approxNum. This is an approximation. It can lose as many as
-     * 64 - 53 = 11 low-order bits. Hence |approxNum - num| <= 2^12.
+     * 64 - 53 = 11 low-order bits. If we were *truncating* the bits without
+     * rounding, |approxNum - num| could be as large as 2^11 - 1.
+     * Round-to-nearest limits the actual difference to half that range, with
+     * the maximum difference 2^10 being reached for values whose highest-order
+     * bit is 1 and whose lowest-order 11 bits are exactly 100 0000 0000.
+     * Hence |approxNum - num| <= 2^(11-1) = 2^10.
      *
      * We then compute an approximated quotient
      *   approxQuot = floor(approxNum / 10^9)
      * instead of the theoretical value
      *   quot = floor(num / 10^9)
      *
-     * Since 10^9 > 2^29 > 2^12, we have |approxNum - num| < 10^9.
+     * Since 10^9 > 2^29 > 2^10, we have |approxNum - num| < 10^9.
      * Therefore, |approxQuot - quot| <= 1.
      *
      * We also have 0 <= approxQuot < 2^53, which means that approxQuot is an
@@ -915,7 +920,7 @@ object RuntimeLong {
   }
 
   def divideImpl(alo: Int, ahi: Int, blo: Int, bhi: Int): Int = {
-    if (isZero(blo, bhi))
+    if (bothZero(blo, bhi))
       throw new ArithmeticException("/ by zero")
 
     if (isInt32(alo, ahi)) {
@@ -955,7 +960,7 @@ object RuntimeLong {
   }
 
   def divideUnsignedImpl(alo: Int, ahi: Int, blo: Int, bhi: Int): Int = {
-    if (isZero(blo, bhi))
+    if (bothZero(blo, bhi))
       throw new ArithmeticException("/ by zero")
 
     if (isUInt32(ahi)) {
@@ -973,7 +978,7 @@ object RuntimeLong {
   }
 
   private def unsigned_/(alo: Int, ahi: Int, blo: Int, bhi: Int): Int = {
-    // This method is not called if isInt32(alo, ahi) nor if isZero(blo, bhi)
+    // This method is not called if isInt32(alo, ahi) nor if bothZero(blo, bhi)
     if (isUnsignedSafeDouble(ahi)) {
       if (isUnsignedSafeDouble(bhi)) {
         val aDouble = asSafeDouble(alo, ahi)
@@ -1008,7 +1013,7 @@ object RuntimeLong {
   }
 
   def remainderImpl(alo: Int, ahi: Int, blo: Int, bhi: Int): Int = {
-    if (isZero(blo, bhi))
+    if (bothZero(blo, bhi))
       throw new ArithmeticException("/ by zero")
 
     if (isInt32(alo, ahi)) {
@@ -1043,7 +1048,7 @@ object RuntimeLong {
   }
 
   def remainderUnsignedImpl(alo: Int, ahi: Int, blo: Int, bhi: Int): Int = {
-    if (isZero(blo, bhi))
+    if (bothZero(blo, bhi))
       throw new ArithmeticException("/ by zero")
 
     if (isUInt32(ahi)) {
@@ -1061,7 +1066,7 @@ object RuntimeLong {
   }
 
   private def unsigned_%(alo: Int, ahi: Int, blo: Int, bhi: Int): Int = {
-    // This method is not called if isInt32(alo, ahi) nor if isZero(blo, bhi)
+    // This method is not called if isInt32(alo, ahi) nor if bothZero(blo, bhi)
     if (isUnsignedSafeDouble(ahi)) {
       if (isUnsignedSafeDouble(bhi)) {
         val aDouble = asSafeDouble(alo, ahi)
@@ -1087,77 +1092,392 @@ object RuntimeLong {
     }
   }
 
+  /* The algorithm of the following method uses 3 different cases, depending on
+   * the magnitude of b.
+   *
+   * - 0 < b < 2²¹
+   * - 2²¹ <= b < 2⁶²
+   * - 2⁶² <= b < 2⁶⁴
+   *
+   * The last case should be rare, as it is virtually useless in practice.
+   * It delegates to a separate method `unsignedDivModHugeDivisor`.
+   * The proof for the first two cases follows.
+   *
+   * The overall shape of the algorithm is inspired by Hacker's Delight,
+   * Section 9-5, Figure 9-5 (doubleword division based on "long" division,
+   * i.e., 64-by-32 division with a 32-bit result). We do not have that "long"
+   * division, but we do have a `double` division, which we will use with
+   * similar intent, although the applicability and properties are very
+   * different.
+   *
+   * Preliminaries
+   * =============
+   *
+   * Below, we use the mathematical definition of operators, on reals.
+   * The functions div(a, b) and rem(a, b) denote the floor division and
+   * its remainder. Formally, they are defined as div(a, b) = ⌊a / b⌋ and
+   * rem(a, b) = a - b∙div(a, b). They are not limited to any bit width, nor to
+   * integers. When the operands are known to be non-negative integers and fit
+   * in a particular bit width, they correspond to the computer semantics of
+   * unsigned integer division and remainder.
+   *
+   * For all reals a and b with b > 0, we have 0 <= rem(a, b) < b.
+   *
+   * The method we are implementing here computes div(a, b) if askQuotient
+   * is true, and rem(a, b) otherwise.
+   *
+   * The function ◦(x) rounds the real value x to the nearest `double`
+   * value, breaking ties to even. Double division can be expressed in
+   * terms of ◦ as ◦(a / b).
+   *
+   * Rounding never goes "farther than necessary" in any direction. Formally,
+   * for all reals x, y such that x >= y and y is exactly representable as a
+   * `double` value, we have ◦(x) >= y. Similarly for x <= y. We refer to this
+   * as the no-round-across-boundary property.
+   *
+   * For all integers 0 <= a, b < 2⁵³, ⌊◦(a / b)⌋ = ⌊a / b⌋ = div(a, b). This
+   * property is a corollary of Theorem 1 in
+   *
+   *   Vincent Lefèvre. The Euclidean Division Implemented with a
+   *   Floating-Point Division and a Floor.
+   *   [Research Report] RR-5604, INRIA. 2005, pp.16. <inria-00070403>
+   *   https://hal.science/inria-00070403/
+   *
+   * The function wrap32(x) denotes the JavaScript operation (x | 0), with
+   * the result interpreted as unsigned. For x a non-negative `double` value,
+   * by spec, it computes wrap32(x) = rem(⌊x⌋, 2³²). It is not defined for
+   * non-`double` values. Clearly, if 0 <= x < 2³², then wrap32(x) = ⌊x⌋.
+   *
+   * Combining the above two properties, we have that for all integers
+   * 0 <= a, b < 2⁵³, if div(a, b) < 2³², then div(a, b) can be computed with a
+   * double division and the wrap operation. Since ⌊◦(a / b)⌋ = div(a, b) and
+   * div(a, b) < 2³², we have ◦(a / b) < 2³². Therefore, we have
+   *
+   *   wrap32(◦(a / b)) = ⌊◦(a / b)⌋ = ⌊a / b⌋ = div(a, b)
+   *
+   * The quantities alo, ahi, blo and bhi are interpreted as unsigned,
+   * and are therefore mathematical values in the range [0, 2³²).
+   * By definition, a = 2³²∙ahi + alo and b = 2³²∙bhi + blo.
+   *
+   * Case 0 < b < 2²¹
+   * ================
+   *
+   * In this case, b = blo and bhi = 0.
+   *
+   * We apply the "grade-school algorithm" in base 2³².
+   * We decompose a as
+   *
+   *   a = 2³²∙ahi + alo
+   *     = 2³²∙(b∙div(ahi, b) + rem(ahi, b)) + alo
+   *     = 2³²∙b∙div(ahi, b) + 2³²∙rem(ahi, b) + alo
+   *
+   * We first prove for the case askQuotient = true.
+   *
+   *   div(a, b)
+   *     = ⌊ a / b ⌋
+   *     = ⌊ (2³²∙b∙div(ahi, b) + 2³²∙rem(ahi, b) + alo) / b ⌋
+   *     = ⌊ (2³²∙b∙div(ahi, b)) / b + (2³²∙rem(ahi, b) + alo) / b ⌋
+   *     = ⌊ (2³²∙div(ahi, b)) + (2³²∙rem(ahi, b) + alo) / b ⌋
+   *       since the first term is whole, we can take it out of the floor function:
+   *     = 2³²∙div(ahi, b) + ⌊(2³²∙rem(ahi, b) + alo) / b⌋
+   *     = 2³²∙div(ahi, b) + div(2³²∙rem(ahi, b) + alo, b)
+   *     = 2³²∙div(ahi, b) + div(2³²∙k + alo, b)
+   *
+   * for k = rem(ahi, b).
+   *
+   * Since k = rem(ahi, b) < b and alo < 2³², we know that 2³²∙k + alo < 2³²∙b.
+   * That means div(2³²∙k + alo, b) < 2³². We can decompose the result in hi
+   * and lo words as
+   *
+   *   quotHi = div(ahi, b)
+   *   quotLo = div(2³²∙k + alo, b)
+   *
+   * Since ahi < 2³² and b < 2²¹ < 2³², quotHi can be computed with a 32-bit
+   * unsigned division. We can compute k from the definition of rem as
+   *
+   *   k = rem(ahi, b)
+   *     = ahi - b∙div(ahi, b)
+   *     = ahi - b∙quotHi
+   *
+   * Because the three operands and the result fit in 32-bit unsigned integers,
+   * the computation can be performed modulo 2³², using `int` operations.
+   *
+   * We still need to compute quotLo. By construction, k < b < 2²¹. Therefore,
+   * 2³²∙k + alo < 2³²∙(k + 1) <= 2³²∙b < 2⁵³. Since both operands of the div
+   * of quotLo are < 2⁵³, and since quotLo < 2³², we can compute it with a
+   * double division and the wrap operation as
+   *
+   *   quotLo = wrap32(◦((2³²∙k + alo) / b))
+   *
+   * For the case askQuotient = false, we take the previous result for
+   * div(a, b) and expand it into the definition of rem(a, b):
+   *
+   *   rem(a, b)
+   *     = a - b∙div(a, b)
+   *     = a - b∙(2³²∙div(ahi, b) + div(2³²∙k + alo, b))
+   *     = (2³²∙ahi + alo) - b∙2³²∙div(ahi, b) - b∙div(2³²∙k + alo, b)
+   *     = 2³²∙(ahi - b∙div(ahi, b)) + alo - b∙div(2³²∙k + alo, b)
+   *     = 2³²∙rem(ahi, b) + alo - b∙div(2³²∙k + alo, b)
+   *     = 2³²∙k + alo - b∙div(2³²∙k + alo, b)
+   *     = 2³²∙k + alo - b∙quotLo
+   *
+   * The result rem(a, b) < b < 2²¹. Moreover, k, alo, b = blo and quotLo all
+   * fit in unsigned 32-bit integers. That means the last expression can be
+   * computed modulo 2³², using `int` operations. The term 2³²∙k disappears,
+   * leaving
+   *
+   *   rem(a, b) = alo -[int] (blo *[int] quotLo)
+   *
+   * In that code path, it is more efficient to compute k from its definition
+   * k = rem(ahi, b), as an unsigned integer remainder operation, since we do
+   * not need quotHi for anything else.
+   *
+   * Case 2²¹ < b < 2⁶²
+   * ==================
+   *
+   * In this case, we compute an approximation of the quotient using double
+   * division, where we approximate the dividend and divisor as doubles. We
+   * then compute the approximated remainder associated to that approximated
+   * quotient (using `long` operations for the definition of remainder), and
+   * use it to correct the result.
+   *
+   * The computations that we perform are:
+   *
+   *   â = ◦(a)
+   *   b̂ = ◦(b)
+   *   q̂₀ = ◦(â / b̂)
+   *   q̂ = 2³²∙wrap32(◦(q̂₀ / 2³²)) + wrap32(q̂₀)
+   *
+   * We will prove that |q̂ - q| <= 1, where q = div(a, b) is the exact integer
+   * quotient.
+   *
+   * Since 0 <= a < 2⁶⁴ and 2²¹ <= b < 2⁶⁴, and since 0, 2²¹ and 2⁶⁴ are all
+   * exactly representable as doubles, the no-round-across-boundary property
+   * tells us that 0 <= â <= 2⁶⁴ and 2²¹ <= b̂ <= 2⁶⁴.
+   * Therefore, â / b̂ <= 2⁶⁴ / 2²¹ = 2⁴³. Since 2⁴³ is also exactly
+   * representable, we have q̂₀ = ◦(â / b̂) <= 2⁴³.
+   *
+   * If a = 0, then q̂₀ = 0 and q̂₀ / 2³² = 0, hence ◦(q̂₀ / 2³²) is exact.
+   * Otherwise, a >= 1, hence â >= 1, and q̂₀ >= 1 / 2⁶⁴, which means q̂₀ is a
+   * *normal* `double` value. q̂₀ / 2³² >= 1 / 2⁹⁶ is also a normal `double`
+   * value. Therefore, ◦(q̂₀ / 2³²) cannot underflow, and it is exact because it
+   * divides by a power of 2.
+   * Hence in all cases, we have ◦(q̂₀ / 2³²) = q̂₀ / 2³².
+   *
+   * We will use Theorem D3 of Hacker's Delight (section 9-1):
+   * > For x real, d an integer ≠ 0: ⌊⌊x⌋ / d⌋ = ⌊x / d⌋.
+   *
+   * We can now develop q̂ as
+   *
+   *   q̂ = 2³²∙wrap32(◦(q̂₀ / 2³²))                     + wrap32(q̂₀)
+   *     = 2³²∙rem(⌊◦(q̂₀ / 2³²)⌋, 2³²)                 + rem(⌊q̂₀⌋, 2³²)               def of wrap32
+   *     = 2³²∙rem(⌊  q̂₀ / 2³² ⌋, 2³²)                 + rem(⌊q̂₀⌋, 2³²)               because ◦(q̂₀ / 2³²) = q̂₀ / 2³²
+   *     = 2³²∙(⌊q̂₀ / 2³²⌋ - 2³²∙div(⌊q̂₀ / 2³²⌋, 2³²)) + (⌊q̂₀⌋ - 2³²∙div(⌊q̂₀⌋, 2³²))  def of rem
+   *     = 2³²∙(⌊q̂₀ / 2³²⌋ - 2³²∙⌊⌊q̂₀ / 2³²⌋ / 2³²⌋  ) + (⌊q̂₀⌋ - 2³²∙⌊⌊q̂₀⌋ / 2³²⌋  )  def of div
+   *     = 2³²∙(⌊q̂₀ / 2³²⌋ - 2³²∙⌊ q̂₀ / 2³²  / 2³²⌋  ) + (⌊q̂₀⌋ - 2³²∙⌊ q̂₀  / 2³²⌋  )  Theorem D3
+   *     = 2³²∙(⌊q̂₀ / 2³²⌋ - 2³²∙⌊ q̂₀ / 2⁶⁴       ⌋  ) + (⌊q̂₀⌋ - 2³²∙⌊ q̂₀  / 2³²⌋  )
+   *     = 2³²∙(⌊q̂₀ / 2³²⌋ - 2³²∙0                   ) + (⌊q̂₀⌋ - 2³²∙⌊ q̂₀  / 2³²⌋  )  because q̂₀ <= 2⁴³ < 2⁶⁴
+   *     = 2³²∙⌊q̂₀ / 2³²⌋ + ⌊q̂₀⌋ - 2³²∙⌊q̂₀ / 2³²⌋
+   *     = ⌊q̂₀⌋
+   *     = ⌊◦(â / b̂)⌋
+   *
+   * We write δa = â - a. From elementary properties of ◦() and the range of a,
+   * we have that â is an integer (and so is δa) and |δa| <= 2¹⁰. See the
+   * explanation of toUnsignedStringLarge for more details.
+   * We similarly relate b, b̂ and δb.
+   *
+   * We will need the following lemma:
+   *
+   *   (Lemma 1) For all reals x and y in [0, 2⁵²) such that |x - y| <= 1/2,
+   *   it holds that |⌊◦(x)⌋ - ⌊y⌋| <= 1.
+   *
+   *   Proof.
+   *   From |x - y| <= 1/2, we have x - 1/2 <= y <= x + 1/2.
+   *   Rewrite x = n + f with n an integer and 0 <= f < 1.
+   *   Then n + f - 1/2 <= y <= n + f + 1/2.
+   *
+   *   Observe that, in the range [0, 2⁵²], all multiples of 1/2 are exactly
+   *   representable as doubles. n, n + 1/2 and n + 1 all belong to that range
+   *   and are multiples of 1/2, so they are exactly representable.
+   *
+   *   If 0 <= f < 1/2, then n <= ◦(x) <= n + 1/2 (no-round-across-boundary)
+   *   and ⌊◦(x)⌋ = n.
+   *   n - 1/2 <= y < n + 1, so n - 1 <= ⌊y⌋ <= n.
+   *   Therefore |⌊◦(x)⌋ - ⌊y⌋| <= 1, as desired.
+   *
+   *   Otherwise, 1/2 <= f < 1, then n + 1/2 <= ◦(x) <= n + 1 (no-round-across-boundary)
+   *   and n <= ⌊◦(x)⌋ <= n + 1.
+   *   n <= y < n + 3/2, so n <= ⌊y⌋ <= n + 1.
+   *   Therefore |⌊◦(x)⌋ - ⌊y⌋| <= 1 as well, as desired.
+   *
+   * Now, we will show that
+   *
+   *   |(â / b̂) - (a / b)| <= 1/2      (1)
+   *
+   * To prove (1), we split into two subcases:
+   * either 2²¹ <= b < 2⁵³, or 2⁵³ <= b < 2⁶².
+   *
+   * If 2²¹ <= b < 2⁵³, we know that b̂ = b. Therefore,
+   *
+   *   |(â / b̂) - (a / b)|
+   *     = |((a + δa) / b) - (a / b)|
+   *     = |δa / b|
+   *     <= 2¹⁰/2²¹
+   *     < 1/2
+   *
+   * The subcase 2⁵³ <= b < 2⁶² is harder, as both â and b̂ can be inexact.
+   * We decompose
+   *
+   *   |(â / b̂) - (a / b)|
+   *     = |((a + δa) / (b + δb)) - (a / b)|
+   *     = |(b∙(a + δa) - (b + δb)∙a) / (b∙(b + δb))|
+   *     <= |(b∙(a + 2¹⁰) - (b - 2¹⁰)∙a) / (b∙(b - 2¹⁰))|
+   *       (taking extreme values of δa and δb to maximize the result)
+   *     = |(a∙b + b∙2¹⁰ - a∙b + a∙2¹⁰) / (b² - b∙2¹⁰)|
+   *     = |((a + b)∙2¹⁰) / (b² - b∙2¹⁰)|
+   *     <= |((2⁶⁴ + 2⁶²)∙2¹⁰) / ((2⁵³)² - 2⁵³∙2¹⁰)|
+   *       (taking extreme values of a and b to maximize the result)
+   *     ~= 2.91 * 10⁻¹⁰
+   *     < 1/2
+   *
+   * From (1), Lemma 1, and the fact that both (â / b̂) and (a / b)
+   * are <= 2⁴³ < 2⁵², we conclude that
+   *
+   *   |q̂ - q| = |⌊◦(â / b̂)⌋ - ⌊a/b⌋| <= 1
+   *
+   * as desired.
+   *
+   * ---
+   *
+   * Now that we have computed q̂ and established that |q̂ - q| <= 1, we can use
+   * the estimated remainder to fix the result.
+   *
+   * We compute
+   *
+   *   r̂ = a - b∙q̂
+   *
+   * and compare it to the exact remainder r = rem(a, b):
+   *
+   *   |r̂ - r|
+   *     = |(a - b∙q̂) - (a - b∙q)|
+   *     = |-b∙q̂ + b∙q|
+   *     = |b∙q̂ - b∙q|
+   *     = |b∙(q̂ - q)|
+   *     = b∙|q̂ - q|
+   *     <= b
+   *
+   * Combining with 0 <= r < b, we get -b <= r̂ < 2∙b. Since, b < 2⁶², we have
+   * -2⁶² < r̂ < 2⁶³, and therefore the computation of r̂ does not overflow when
+   * done with `long` operations, interpreting r̂ as a signed quantity.
+   *
+   * Finally, we can compare r̂ against 0 and against b to decide whether
+   * q̂ - q was -1, 0, or 1, and correct accordingly.
+   */
+
   /** Helper for `unsigned_/` and `unsigned_%`.
    *
    *  If `askQuotient` is true, computes the quotient, otherwise computes the
    *  remainder. Stores the hi word of the result in `hiReturn`, and returns
    *  the lo word.
    */
+  @inline // inlined twice; specializes for askQuotient
   private def unsignedDivModHelper(alo: Int, ahi: Int, blo: Int, bhi: Int,
       askQuotient: Boolean): Int = {
 
-    var shift =
-      inlineNumberOfLeadingZeros(blo, bhi) - inlineNumberOfLeadingZeros(alo, ahi)
-    val initialBShift = new RuntimeLong(blo, bhi) << shift
-    var bShiftLo = initialBShift.lo
-    var bShiftHi = initialBShift.hi
-    var remLo = alo
-    var remHi = ahi
-    var quotLo = 0
-    var quotHi = 0
+    // scalastyle:off return
 
-    /* Invariants:
-     *   bShift == b << shift == b * 2^shift
-     *   quot >= 0
-     *   0 <= rem < 2 * bShift
-     *   quot * b + rem == a
-     *
-     * The loop condition should be
-     *   while (shift >= 0 && !isUnsignedSafeDouble(remHi))
-     * but we manually inline isUnsignedSafeDouble because remHi is a var. If
-     * we let the optimizer inline it, it will first store remHi in a temporary
-     * val, which will explose the while condition as a while(true) + if +
-     * break, and we don't want that.
-     */
-    while (shift >= 0 && (remHi & SafeDoubleHiMask) != 0) {
-      if (inlineUnsigned_>=(remLo, remHi, bShiftLo, bShiftHi)) {
-        val newRem =
-          new RuntimeLong(remLo, remHi) - new RuntimeLong(bShiftLo, bShiftHi)
-        remLo = newRem.lo
-        remHi = newRem.hi
-        if (shift < 32)
-          quotLo |= (1 << shift)
-        else
-          quotHi |= (1 << shift) // == (1 << (shift - 32))
-      }
-      shift -= 1
-      val newBShift = new RuntimeLong(bShiftLo, bShiftHi) >>> 1
-      bShiftLo = newBShift.lo
-      bShiftHi = newBShift.hi
-    }
-
-    // Now rem < 2^53, we can finish with a double division
-    if (inlineUnsigned_>=(remLo, remHi, blo, bhi)) {
-      val remDouble = asSafeDouble(remLo, remHi)
-      val bDouble = asSafeDouble(blo, bhi)
+    val result = if (bothZero(bhi, blo & 0xffe00000)) {
+      // b < 2^21
 
       if (askQuotient) {
-        val rem_div_bDouble = fromUnsignedSafeDouble(remDouble / bDouble)
-        val newQuot = new RuntimeLong(quotLo, quotHi) + rem_div_bDouble
-        hiReturn = newQuot.hi
-        newQuot.lo
+        val quotHi = Integer.divideUnsigned(ahi, blo)
+        val k = ahi - blo * quotHi
+        val quotLo = rawToInt(asSafeDouble(alo, k) / blo.toDouble)
+        new RuntimeLong(quotLo, quotHi)
       } else {
-        val rem_mod_bDouble = remDouble % bDouble
-        hiReturn = unsignedSafeDoubleHi(rem_mod_bDouble)
-        unsignedSafeDoubleLo(rem_mod_bDouble)
+        val k = Integer.remainderUnsigned(ahi, blo)
+        val quotLo = rawToInt(asSafeDouble(alo, k) / blo.toDouble)
+        val remLo = alo - blo * quotLo
+        new RuntimeLong(remLo, 0)
+      }
+    } else if ((bhi & 0xc0000000) == 0) {
+      // 2^21 <= b < 2^62
+
+      val a = new RuntimeLong(alo, ahi)
+      val b = new RuntimeLong(blo, bhi)
+      val aHat = unsignedToDoubleApprox(alo, ahi)
+      val bHat = unsignedToDoubleApprox(blo, bhi)
+      val qHat = fromUnsignedSafeDouble(aHat / bHat)
+      val rHat = a - b * qHat
+
+      if (rHat.hi < 0) {
+        if (askQuotient) qHat - new RuntimeLong(1, 0)
+        else rHat + b
+      } else if (geu(rHat, b)) {
+        if (askQuotient) qHat + new RuntimeLong(1, 0)
+        else rHat - b
+      } else {
+        if (askQuotient) qHat
+        else rHat
       }
     } else {
-      if (askQuotient) {
-        hiReturn = quotHi
-        quotLo
+      // 2^62 <= b
+      return unsignedDivModHugeDivisor(alo, ahi, blo, bhi, askQuotient)
+    }
+
+    hiReturn = result.hi
+    result.lo
+
+    // scalastyle:on return
+  }
+
+  private def unsignedDivModHugeDivisor(alo: Int, ahi: Int, blo: Int, bhi: Int,
+      askQuotient: Boolean): Int = {
+
+    /* Called for b >= 2^62.
+     * Such huge divisors are practically useless, but they defeat the
+     * correction code of the algorithm above.
+     *
+     * Since b >= 2^62 and a < 2^64, we know that a < 4*b (mathematically).
+     *
+     * Hence, there are only 4 possible outcomes for the quotient, we perform
+     * a "binary search" (with 1 or 2 steps) among those.
+     */
+
+    val a = new RuntimeLong(alo, ahi)
+    val b = new RuntimeLong(blo, bhi)
+
+    // First (optional) step of the binary search
+    var quot1 = 0
+    val rem1 = if (bhi >= 0) {
+      // Bit 63 is 0: 2*b does not overflow, and we need a 4-way search
+      val b2 = b << 1
+      if (geu(a, b2)) {
+        quot1 = 2
+        a - b2
       } else {
-        hiReturn = remHi
-        remLo
+        a
+      }
+    } else {
+      a
+    }
+
+    // Second (mandatory) step; at this point, rem1 < 2*b (mathematically)
+    val rem1LTUb = ltu(rem1, b) // compute once for code size
+    if (askQuotient) {
+      hiReturn = 0
+      if (rem1LTUb)
+        quot1
+      else
+        quot1 + 1
+    } else {
+      if (rem1LTUb) {
+        hiReturn = rem1.hi
+        rem1.lo
+      } else {
+        val rem2 = rem1 - b
+        hiReturn = rem2.hi
+        rem2.lo
       }
     }
   }
@@ -1168,9 +1488,9 @@ object RuntimeLong {
     s.jsSubstring(start)
   }
 
-  /** Tests whether the long (lo, hi) is 0. */
-  @inline def isZero(lo: Int, hi: Int): Boolean =
-    (lo | hi) == 0
+  /** Tests whether `a == 0 && b == 0` with a single comparison. */
+  @inline def bothZero(a: Int, b: Int): Boolean =
+    (a | b) == 0
 
   /** Tests whether the long (lo, hi)'s mathematical value fits in a signed Int. */
   @inline def isInt32(lo: Int, hi: Int): Boolean =
@@ -1289,17 +1609,6 @@ object RuntimeLong {
   /** Returns the log2 of the given unsigned Int assuming it is an exact power of 2. */
   @inline def log2OfPowerOfTwo(i: Int): Int =
     31 - Integer.numberOfLeadingZeros(i)
-
-  /** Returns the number of leading zeros in the given long (lo, hi). */
-  @inline def inlineNumberOfLeadingZeros(lo: Int, hi: Int): Int =
-    if (hi != 0) Integer.numberOfLeadingZeros(hi)
-    else Integer.numberOfLeadingZeros(lo) + 32
-
-  /** Tests whether the unsigned long (alo, ahi) is >= (blo, bhi). */
-  @inline
-  def inlineUnsigned_>=(alo: Int, ahi: Int, blo: Int, bhi: Int): Boolean =
-    if (ahi == bhi) inlineUnsignedInt_>=(alo, blo)
-    else inlineUnsignedInt_>=(ahi, bhi)
 
   @inline
   def inlineUnsignedInt_<(a: Int, b: Int): Boolean =

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 147395,
-      expectedFullLinkSizeWithoutClosure = 87201,
-      expectedFullLinkSizeWithClosure = 20680,
+      expectedFastLinkSize = 150284,
+      expectedFullLinkSizeWithoutClosure = 89402,
+      expectedFullLinkSizeWithClosure = 20674,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2060,16 +2060,16 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 623000 to 624000,
+                  fastLink = 626000 to 627000,
                   fullLink = 94000 to 95000,
                   fastLinkGz = 75000 to 79000,
                   fullLinkGz = 24000 to 25000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 425000 to 426000,
-                  fullLink = 282000 to 283000,
-                  fastLinkGz = 60000 to 61000,
+                  fastLink = 427000 to 428000,
+                  fullLink = 284000 to 285000,
+                  fastLinkGz = 61000 to 62000,
                   fullLinkGz = 43000 to 44000,
               ))
             }
@@ -2077,15 +2077,15 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 442000 to 443000,
+                  fastLink = 444000 to 445000,
                   fullLink = 90000 to 91000,
                   fastLinkGz = 57000 to 58000,
                   fullLinkGz = 24000 to 25000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 301000 to 302000,
-                  fullLink = 258000 to 259000,
+                  fastLink = 303000 to 304000,
+                  fullLink = 260000 to 261000,
                   fastLinkGz = 47000 to 48000,
                   fullLinkGz = 42000 to 43000,
               ))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/LongTest.scala
@@ -839,6 +839,53 @@ class LongTest {
     assertThrows(classOf[ArithmeticException], JLong.remainderUnsigned(5L, 0L))
   }
 
+  @Test def divideRemainderUnsignedHugeDivisors(): Unit = {
+    @inline def test(x: Long, y: Long, expectedQuot: Long, expectedRem: Long): Unit = {
+      assertEquals(expectedQuot, JLong.divideUnsigned(x, y))
+      assertEquals(expectedQuot, JLong.divideUnsigned(hideFromOptimizer(x), y))
+      assertEquals(expectedQuot, JLong.divideUnsigned(x, hideFromOptimizer(y)))
+      assertEquals(expectedQuot, JLong.divideUnsigned(hideFromOptimizer(x), hideFromOptimizer(y)))
+
+      assertEquals(expectedRem, JLong.remainderUnsigned(x, y))
+      assertEquals(expectedRem, JLong.remainderUnsigned(hideFromOptimizer(x), y))
+      assertEquals(expectedRem, JLong.remainderUnsigned(x, hideFromOptimizer(y)))
+      assertEquals(expectedRem, JLong.remainderUnsigned(hideFromOptimizer(x), hideFromOptimizer(y)))
+    }
+
+    test(-63003L, -2L, 0L, -63003L) // this particular case fails if we don't have the "huge" path at all
+    test(-3L, -2L, 0L, -3L)
+    test(-2L, -2L, 1L, 0L)
+    test(-1L, -2L, 1L, 1L)
+
+    test(0x7ffffffffffffffeL, 0x7fffffffffffffffL, 0L, 0x7ffffffffffffffeL)
+    test(0x7fffffffffffffffL, 0x7fffffffffffffffL, 1L, 0L)
+    test(0x8000000000000000L, 0x7fffffffffffffffL, 1L, 1L)
+    test(0xfffffffffffffffdL, 0x7fffffffffffffffL, 1L, 0x7ffffffffffffffeL)
+    test(0xfffffffffffffffeL, 0x7fffffffffffffffL, 2L, 0L)
+    test(0xffffffffffffffffL, 0x7fffffffffffffffL, 2L, 1L)
+
+    test(0x7ffffffffffffff8L, 0x7ffffffffffffffeL, 0L, 0x7ffffffffffffff8L)
+    test(0x7ffffffffffffffeL, 0x7ffffffffffffffeL, 1L, 0L)
+    test(0x8000000000000008L, 0x7ffffffffffffffeL, 1L, 0xaL)
+    test(0xffffffffffff09e5L, 0x7ffffffffffffffeL, 1L, 0x7fffffffffff09e7L)
+    test(0xfffffffffffffffbL, 0x7ffffffffffffffeL, 1L, 0x7ffffffffffffffdL)
+    test(0xfffffffffffffffcL, 0x7ffffffffffffffeL, 2L, 0L)
+    test(0xfffffffffffffffdL, 0x7ffffffffffffffeL, 2L, 1L)
+    test(0xffffffffffffffffL, 0x7ffffffffffffffeL, 2L, 3L)
+
+    test(0x3ffffffffffffff0L, 0x4000000000000001L, 0L, 0x3ffffffffffffff0L)
+    test(0x4000000000000000L, 0x4000000000000001L, 0L, 0x4000000000000000L)
+    test(0x4000000000000001L, 0x4000000000000001L, 1L, 0L)
+    test(0x4000000000000002L, 0x4000000000000001L, 1L, 1L)
+    test(0x8000000000000001L, 0x4000000000000001L, 1L, 0x4000000000000000L)
+    test(0x8000000000000002L, 0x4000000000000001L, 2L, 0L)
+    test(0x8000000000000003L, 0x4000000000000001L, 2L, 1L)
+    test(0xc000000000000002L, 0x4000000000000001L, 2L, 0x4000000000000000L)
+    test(0xc000000000000003L, 0x4000000000000001L, 3L, 0L)
+    test(0xc000000000000004L, 0x4000000000000001L, 3L, 1L)
+    test(0xffffffffffffffffL, 0x4000000000000001L, 3L, 0x3ffffffffffffffcL)
+  }
+
   @Test def toUnsignedString(): Unit = {
     def test(x: Long, s: String, radix: Int = 10): Unit = {
       assertEquals(s, JLong.toUnsignedString(x, radix))


### PR DESCRIPTION
These changes make the worst-worst case (we reach `unsignedDivModHelper` and `b` is small, so we need all 11 iterations of the loop) as fast as the best-worst case (we also reach the method but `b` is large and we only need 1 iteration). The cases where `b <= 2^21` even become faster.