### PR TITLE
Do not use `Double` arithmetics in `Integer.parseInt()`.

### DIFF
--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/IntegerTest.scala
@@ -572,8 +572,8 @@ class IntegerTest {
 
     test("abc")
     test("5a")
-    test("4294967296")
-    test("ffFFffFF", 20)
+    test("4294967296") // the last addition of `digit` (the '6') overflows
+    test("ffFFffFF", 20) // the last multiplication by `radix` overflows
     test("99", 8)
     test("-")
     test("")
@@ -725,7 +725,7 @@ class IntegerTest {
     test("abc")
     test("5a")
     test("99", 8)
-    test("4294967296")
+    test("4294967296") // the last addition of `digit` (the '6') overflows
     test("-30000")
     test("+")
     test("-")


### PR DESCRIPTION
Only use `Int` arithmetics. To detect overflow, we precompute a table of the maximum string length for each radix.

`Int` arithmetics is faster than `Double` arithmetics. The previous code used `Double`s to have a concise way of detecting the overflow, which is not bad on JS engines. Given a cached overflow detection mechanism, resorting to `Double`s is not necessary anymore.