### PR TITLE
Remove all user-space asUint/toUint in the libraries.

### DIFF
--- a/javalib/src/main/scala/java/lang/Integer.scala
+++ b/javalib/src/main/scala/java/lang/Integer.scala
@@ -298,6 +298,9 @@ object Integer {
   @inline def toUnsignedLong(x: Int): scala.Long =
     throw new Error("stub") // body replaced by the compiler back-end
 
+  @inline private[lang] def toUnsignedDouble(x: Int): scala.Double =
+    toUnsignedLong(x).toDouble
+
   // Wasm intrinsic
   def bitCount(i: scala.Int): scala.Int = {
     /* See http://graphics.stanford.edu/~seander/bithacks.html#CountBitsSetParallel
@@ -405,11 +408,6 @@ object Integer {
 
   @inline private[this] def toStringBase(i: scala.Int, base: scala.Int): String = {
     import js.JSNumberOps.enableJSNumberOps
-    asUint(i).toString(base)
-  }
-
-  @inline private def asUint(n: scala.Int): scala.Double = {
-    import js.DynamicImplicits.number2dynamic
-    (n.toDouble >>> 0).asInstanceOf[scala.Double]
+    toUnsignedDouble(i).toString(base)
   }
 }

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -15,7 +15,6 @@ package java.lang
 import scala.annotation.{switch, tailrec}
 
 import java.lang.constant.{Constable, ConstantDesc}
-import java.lang.Utils.toUint
 import java.util.ScalaOps._
 
 import scala.scalajs.js
@@ -169,7 +168,7 @@ object Long {
     if (hi == 0) {
       // It's an unsigned int32
       import js.JSNumberOps.enableJSNumberOps
-      Utils.toUint(lo).toString(radix)
+      Integer.toUnsignedDouble(lo).toString(radix)
     } else {
       toUnsignedStringInternalLarge(lo, hi, radix)
     }
@@ -186,7 +185,8 @@ object Long {
     }
 
     val TwoPow32 = (1L << 32).toDouble
-    val approxNum = toUint(hi) * TwoPow32 + toUint(lo)
+    val approxNum =
+      Integer.toUnsignedDouble(hi) * TwoPow32 + Integer.toUnsignedDouble(lo)
 
     if ((hi & 0xffe00000) == 0) { // see RuntimeLong.isUnsignedSafeDouble
       // (lo, hi) is small enough to be a Double, so approxNum is exact

--- a/javalib/src/main/scala/java/lang/Utils.scala
+++ b/javalib/src/main/scala/java/lang/Utils.scala
@@ -187,9 +187,4 @@ private[java] object Utils {
     false
     // scalastyle:on return
   }
-
-  @inline def toUint(x: scala.Double): scala.Double = {
-    import js.DynamicImplicits.number2dynamic
-    (x >>> 0).asInstanceOf[scala.Double]
-  }
 }

--- a/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
+++ b/library/src/main/scala/scala/scalajs/js/JSNumberOps.scala
@@ -79,15 +79,19 @@ object JSNumberOps {
   implicit def enableJSNumberOps(x: Double): js.JSNumberOps =
     x.asInstanceOf[js.JSNumberOps]
 
+  @deprecated("Use Integer.toUnsignedLong(x).toDouble instead of toUint.", since = "1.20.0")
   implicit def enableJSNumberExtOps(x: Int): ExtOps =
     new ExtOps(x.asInstanceOf[js.Dynamic])
 
+  @deprecated("Use Integer.toUnsignedLong(x).toDouble instead of toUint.", since = "1.20.0")
   implicit def enableJSNumberExtOps(x: Double): ExtOps =
     new ExtOps(x.asInstanceOf[js.Dynamic])
 
+  @deprecated("Use Integer.toUnsignedLong(x).toDouble instead of toUint.", since = "1.20.0")
   final class ExtOps private[JSNumberOps] (private val self: js.Dynamic)
       extends AnyVal {
 
+    @deprecated("Use Integer.toUnsignedLong(x).toDouble instead.", since = "1.20.0")
     @inline def toUint: Double =
       (self >>> 0.asInstanceOf[js.Dynamic]).asInstanceOf[Double]
   }

--- a/linker-private-library/src/main/scala/org/scalajs/linker/runtime/FloatingPointBitsPolyfills.scala
+++ b/linker-private-library/src/main/scala/org/scalajs/linker/runtime/FloatingPointBitsPolyfills.scala
@@ -86,7 +86,7 @@ object FloatingPointBitsPolyfills {
     val fbits = 52
     val hifbits = fbits - 32
     val hi = (bits >>> 32).toInt
-    val lo = toUint(bits.toInt)
+    val lo = (bits & 0xffffffffL).toDouble
     val sign = (hi >> 31) | 1 // -1 or 1
     val e = (hi >> hifbits) & ((1 << ebits) - 1)
     val f = (hi & ((1 << hifbits) - 1)).toDouble * 0x100000000L.toDouble + lo
@@ -180,9 +180,6 @@ object FloatingPointBitsPolyfills {
         ((av / powsOf2(e)) - 1.0) * twoPowFbits // Normal
     }
   }
-
-  @inline private def toUint(x: Int): Double =
-    (x.asInstanceOf[js.Dynamic] >>> 0.asInstanceOf[js.Dynamic]).asInstanceOf[Double]
 
   @inline private def rawToInt(x: Double): Int =
     (x.asInstanceOf[js.Dynamic] | 0.asInstanceOf[js.Dynamic]).asInstanceOf[Int]

--- a/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
+++ b/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
@@ -695,10 +695,9 @@ object RuntimeLong {
     a.lo
 
   @inline
-  def toDouble(a: RuntimeLong): Double =
-    toDouble(a.lo, a.hi)
-
-  private def toDouble(lo: Int, hi: Int): Double = {
+  def toDouble(a: RuntimeLong): Double = {
+    val lo = a.lo
+    val hi = a.hi
     if (hi < 0) {
       // We do asUint() on the hi part specifically for MinValue
       val neg = inline_negate(lo, hi)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmTransients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/WasmTransients.scala
@@ -60,6 +60,8 @@ object WasmTransients {
       case F64Floor   => wa.F64Floor
       case F64Nearest => wa.F64Nearest
       case F64Sqrt    => wa.F64Sqrt
+
+      case F64ConvertI32U => wa.F64ConvertI32U
     }
 
     def printIR(out: IRTreePrinter): Unit = {
@@ -87,6 +89,8 @@ object WasmTransients {
     final val F64Nearest = 9
     final val F64Sqrt = 10
 
+    final val F64ConvertI32U = 11
+
     def resultTypeOf(op: Code): Type = (op: @switch) match {
       case I32Ctz | I32Popcnt =>
         IntType
@@ -97,7 +101,7 @@ object WasmTransients {
       case F32Abs =>
         FloatType
 
-      case F64Abs | F64Ceil | F64Floor | F64Nearest | F64Sqrt =>
+      case F64Abs | F64Ceil | F64Floor | F64Nearest | F64Sqrt | F64ConvertI32U =>
         DoubleType
     }
   }

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -646,7 +646,40 @@ private[optimizer] abstract class OptimizerCore(
         JSUnaryOp(op, transformExpr(lhs))
 
       case JSBinaryOp(op, lhs, rhs) =>
-        JSBinaryOp(op, transformExpr(lhs), transformExpr(rhs))
+        val newTree = JSBinaryOp(op, transformExpr(lhs), transformExpr(rhs))
+
+        // Introduce casts for some idioms that are guaranteed to return certain types
+
+        // Is `arg` guaranteed to evaluate to a JS `number` (and hence, not a `bigint`)?
+        def isJSNumber(arg: Tree): Boolean = arg.tpe match {
+          case IntType | DoubleType | ByteType | ShortType | FloatType => true
+          case _                                                       => false
+        }
+
+        newTree match {
+          /* Unless it throws, `x | y` returns either a signed 32-bit integer
+           * (an `Int`) or a bigint.
+           *
+           * The only case in which it returns a bigint is when both arguments
+           * are (convertible to) bigint's. Custom objects can be converted to
+           * bigint's if their `valueOf()` method returns a bigint.
+           *
+           * Primitive numbers cannot be implicitly converted to bigint's.
+           * `x | y` throws if one side is a number and the other is (converted
+           * to) a bigint. Therefore, if at least one of the arguments is known
+           * to be a primitive number, we know that `x | y` will return a
+           * signed 32-bit integer (or throw).
+           */
+          case JSBinaryOp(JSBinaryOp.|, x, y) if isJSNumber(x) || isJSNumber(y) =>
+            makeCast(newTree, IntType)
+
+          // >>> always returns a positive number in the unsigned 32-bit range (it rejects bigints)
+          case JSBinaryOp(JSBinaryOp.>>>, _, _) =>
+            makeCast(newTree, DoubleType)
+
+          case _ =>
+            newTree
+        }
 
       case JSArrayConstr(items) =>
         JSArrayConstr(transformExprsOrSpreads(items))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2060,9 +2060,9 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 425000 to 426000,
-                  fullLink = 282000 to 283000,
-                  fastLinkGz = 60000 to 61000,
+                  fastLink = 426000 to 427000,
+                  fullLink = 283000 to 284000,
+                  fastLinkGz = 61000 to 62000,
                   fullLinkGz = 43000 to 44000,
               ))
             }
@@ -2070,7 +2070,7 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 442000 to 443000,
+                  fastLink = 443000 to 444000,
                   fullLink = 90000 to 91000,
                   fastLinkGz = 57000 to 58000,
                   fullLinkGz = 24000 to 25000,

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2062,7 +2062,7 @@ object Build {
               Some(ExpectedSizes(
                   fastLink = 425000 to 426000,
                   fullLink = 282000 to 283000,
-                  fastLinkGz = 61000 to 62000,
+                  fastLinkGz = 60000 to 61000,
                   fullLinkGz = 43000 to 44000,
               ))
             }


### PR DESCRIPTION
Instead, we use `Integer.toUnsignedLong(x).toDouble`, which is semantically equivalent. The only remaining use of `x >>> 0` is in the JS-only runtime libraries, notably `RuntimeLong`.

We add some optimizations to generate the best possible code on all targets.

For JS with `RuntimeLong`, we need to mark `RuntimeLong.toDouble` as fully inline. That is fine, as its body is actually very short (shorter than most methods of `RuntimeLong`). Moreover, we need a tailored rewrite in the optimizer to get rid of a `Double` addition of `0.0 + y` when `y` is provably non-negative.

For JS with `bigint`s, we directly fold `(double) <toLongUnsigned>(x)` into `x >>> 0`. Otherwise, we unnecessarily go through a `bigint` with `Number(BigInt(x >>> 0))`.

For Wasm, we fold the same shape into a single operation `f64.convert_i32_u`, which we add in `WasmTransients`.

Overall, this has no real impact on the JS target. However, it removes two round-trips from Wasm to JS. Previously, we needed to call a helper function to do the `x >>> 0`, then call the `$uD` helper to retrieve the result. Now, the same operations stays entirely within Wasm.