### PR TITLE
Use Long arithmetics in ju.Random, instead of Doubles.

### DIFF
--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -14,7 +14,6 @@ package java.util
 
 import scala.annotation.tailrec
 
-import scala.scalajs.js
 import scala.scalajs.LinkingInfo
 
 import java.util.random.RandomGenerator
@@ -205,6 +204,6 @@ object Random {
     (randomInt().toLong << 32) | (randomInt().toLong & 0xffffffffL)
 
   private def randomInt(): Int =
-    (Math.floor(js.Math.random() * 4294967296.0) - 2147483648.0).toInt
+    (Math.floor(Math.random() * 4294967296.0) - 2147483648.0).toInt
 
 }

--- a/javalib/src/main/scala/java/util/Random.scala
+++ b/javalib/src/main/scala/java/util/Random.scala
@@ -23,15 +23,19 @@ class Random(seed_in: Long)
     extends AnyRef with RandomGenerator with java.io.Serializable {
 
   /* This class has two different implementations of seeding and computing
-   * bits, depending on whether we are on Wasm or JS. On Wasm, we use the
-   * implementation specified in the JavaDoc verbatim. On JS, however, that is
-   * too slow, due to the use of `Long`s. Therefore, we decompose the
-   * computations using 2x24 bits. See `nextJS()` for details.
+   * bits, depending on whether we are on Wasm or JS.
+   *
+   * On Wasm, we use the implementation specified in the JavaDoc verbatim.
+   *
+   * On JS, the naive implementation is too slow, due to the use of `Long`s.
+   * We use semantically equivalent formulas that better fold away.
+   * We also separately store the 2x32 bits of the `Long`, in order not to
+   * allocate a `RuntimeLong` when storing in the field.
    */
 
   private var seed: Long = _ // the full seed on Wasm (dce'ed on JS)
-  private var seedHi: Int = _ // 24 msb of the seed in JS (dce'ed on Wasm)
-  private var seedLo: Int = _ // 24 lsb of the seed in JS (dce'ed on Wasm)
+  private var seedHi: Int = _ // 32 msb of the seed in JS (dce'ed on Wasm)
+  private var seedLo: Int = _ // 32 lsb of the seed in JS (dce'ed on Wasm)
 
   // see nextGaussian()
   private var nextNextGaussian: Double = _
@@ -46,8 +50,8 @@ class Random(seed_in: Long)
     if (LinkingInfo.isWebAssembly) {
       this.seed = seed
     } else {
-      seedHi = (seed >>> 24).toInt
-      seedLo = seed.toInt & ((1 << 24) - 1)
+      seedHi = (seed >>> 32).toInt
+      seedLo = seed.toInt
     }
     haveNextNextGaussian = false
   }
@@ -67,49 +71,35 @@ class Random(seed_in: Long)
 
   @inline
   private def nextJS(bits: Int): Int = {
-    /* This method is originally supposed to work with a Long seed from which
-     * 48 bits are used.
-     * Since Longs are too slow, we manually decompose the 48-bit seed in two
-     * parts of 24 bits each.
-     * The computation below is the translation in 24-by-24 bits of the
-     * specified computation, taking care never to produce intermediate values
-     * requiring more than 52 bits of precision.
+    /* Spec: seed = (seed * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1)
+     *
+     * Instead we compute the new seed << 16. This is done by shifting both
+     * constants by 16 (appending 0000 at the end of their hex value) and
+     * removing the & ...
+     *
+     * Then we compute new values of `seedHi`, `seedLo` and the result by
+     * adding 16 to all the shifts.
+     *
+     * By doing this, the `a0` part of the multiplicative constants is `0`.
+     * That allows the optimizer to constant-fold away 2 of the 6 int
+     * multiplications it would normally have to do.
      */
 
-    @inline
-    def rawToInt(x: Double): Int =
-      (x.asInstanceOf[js.Dynamic] | 0.asInstanceOf[js.Dynamic]).asInstanceOf[Int]
+    val oldSeed = (seedHi.toLong << 32) | Integer.toUnsignedLong(seedLo) // free
+    val newSeedShift16 = 0x5DEECE66D0000L * oldSeed + 0xB0000L
+    seedHi = (newSeedShift16 >>> (16 + 32)).toInt
+    seedLo = (newSeedShift16 >>> 16).toInt
 
-    @inline
-    def _24msbOf(x: Double): Int = rawToInt(x / (1 << 24).toDouble)
-
-    @inline
-    def _24lsbOf(x: Double): Int = rawToInt(x) & ((1 << 24) - 1)
-
-    // seed = (seed * 0x5DEECE66DL + 0xBL) & ((1L << 48) - 1)
-
-    val oldSeedHi = seedHi
-    val oldSeedLo = seedLo
-
-    val mul = 0x5DEECE66DL
-    val mulHi = (mul >>> 24).toInt
-    val mulLo = mul.toInt & ((1 << 24) - 1)
-
-    val loProd = oldSeedLo.toDouble * mulLo.toDouble + 0xB
-    val hiProd = oldSeedLo.toDouble * mulHi.toDouble + oldSeedHi.toDouble * mulLo.toDouble
-    val newSeedHi =
-      (_24msbOf(loProd) + _24lsbOf(hiProd)) & ((1 << 24) - 1)
-    val newSeedLo =
-      _24lsbOf(loProd)
-
-    seedHi = newSeedHi
-    seedLo = newSeedLo
-
-    // (seed >>> (48 - bits)).toInt
-    //   === ((seed >>> 16) >>> (32 - bits)).toInt because (bits <= 32)
-
-    val result32 = (newSeedHi << 8) | (newSeedLo >> 16)
-    result32 >>> (32 - bits)
+    /* Spec:       (newSeed >>> (48 - bits)).toInt
+     * with shift: (newSeedShift16 >>> (16 + 48 - bits)).toInt
+     *
+     * Since 1 <= bits <= 32 (by spec of next(bits)), the shift is
+     * 32 <= 64 - bits <= 63, which should result in a branchless shift inside
+     * RuntimeLong. The optimizer does not know that, though, so we help it by
+     * first shifting by 32 (which is free), extracting the `toInt` (also free),
+     * then shifting by `32 - bits`.
+     */
+    (newSeedShift16 >>> 32).toInt >>> (32 - bits)
   }
 
   override def nextDouble(): Double = {


### PR DESCRIPTION
We've come full circle. Back in 5e27def9a12051526d8d008d014118fc06e9af33, we had optimized `ju.Random` by using `Double`s instead of `Long`s. This commit optimizes it further by ... using `Long`s instead of `Double`s.

It is still more complicated than using the spec as is. We compute things in a slightly different way, that allows some internal constant-folding to happen. This way, there are as many underlying int multiplications as there were double multiplications before (namely 4).

Here is the breakdown of how many operations in which category we have before and after.

| Category                      | Count before | Count after |
|-------------------------------|--------------|-------------|
| double multiplications        | 4            | 0           |
| int multiplications           | 0            | 4           |
| double additions              | 2            | 0           |
| int additions                 | 2            | 6           |
| double-to-int wrap (`x \| 0`) | 3            | 0           |
| logical                       | 7            | 12          |
| total                         | 18           | 22          |

That's 4 more primitive operations, but we removed 9 operations involving `Double`s to replace them by `Int` operations only.

---

I did not do any benchmarks of this. I'm not currently on a machine that is suited to benchmarking. I can do some benchmarks in a week, if that is desirable.

---

Produced code **before**:
```js
$c_ju_Random.prototype.setSeed__J__V = (function(seed_in) {
  var lo = ((-554899859) ^ seed_in.RTLong__f_lo);
  var hi = (5 ^ seed_in.RTLong__f_hi);
  var hi$1 = (65535 & hi);
  var lo$1 = (((lo >>> 24) | 0) | (hi$1 << 8));
  this.ju_Random__f_java$util$Random$$seedHi = lo$1;
  this.ju_Random__f_java$util$Random$$seedLo = (16777215 & lo);
  this.ju_Random__f_haveNextNextGaussian = false;
});
$c_ju_Random.prototype.next__I__I = (function(bits) {
  var oldSeedHi = this.ju_Random__f_java$util$Random$$seedHi;
  var oldSeedLo = this.ju_Random__f_java$util$Random$$seedLo;
  var loProd = ((1.5525485E7 * oldSeedLo) + 11.0);
  var hiProd = ((1502.0 * oldSeedLo) + (1.5525485E7 * oldSeedHi));
  var x = (loProd / 1.6777216E7);
  var newSeedHi = (16777215 & (($uI((x | 0)) + (16777215 & $uI((hiProd | 0)))) | 0));
  var newSeedLo = (16777215 & $uI((loProd | 0)));
  this.ju_Random__f_java$util$Random$$seedHi = newSeedHi;
  this.ju_Random__f_java$util$Random$$seedLo = newSeedLo;
  var result32 = ((newSeedHi << 8) | (newSeedLo >> 16));
  return ((result32 >>> ((32 - bits) | 0)) | 0);
});
```

Produced code **after**:
```js
$c_ju_Random.prototype.setSeed__J__V = (function(seed_in) {
  var lo = ((-554899859) ^ seed_in.RTLong__f_lo);
  var hi = (5 ^ seed_in.RTLong__f_hi);
  var hi$1 = (65535 & hi);
  this.ju_Random__f_java$util$Random$$seedHi = hi$1;
  this.ju_Random__f_java$util$Random$$seedLo = lo;
  this.ju_Random__f_haveNextNextGaussian = false;
});
$c_ju_Random.prototype.next__I__I = (function(bits) {
  var value = this.ju_Random__f_java$util$Random$$seedHi;
  var x = this.ju_Random__f_java$util$Random$$seedLo;
  var b0 = (65535 & x);
  var b1 = ((x >>> 16) | 0);
  var a1b0 = Math.imul(58989, b0);
  var lo = (a1b0 << 16);
  var hi$1 = ((((((Math.imul((-429064192), value) + Math.imul(384748, x)) | 0) + Math.imul(58989, b1)) | 0) + ((a1b0 >>> 16) | 0)) | 0);
  var lo$1 = ((720896 + lo) | 0);
  var hi$2 = ((hi$1 + (((lo & (~lo$1)) >>> 31) | 0)) | 0);
  var lo$2 = ((hi$2 >>> 16) | 0);
  this.ju_Random__f_java$util$Random$$seedHi = lo$2;
  var lo$3 = (((lo$1 >>> 16) | 0) | (hi$2 << 16));
  this.ju_Random__f_java$util$Random$$seedLo = lo$3;
  return ((hi$2 >>> ((32 - bits) | 0)) | 0);
});
```

Diff of `setSeed` (`next` is a complete rewrite, so no useful diff there):
```diff
@@ -316573,23 +316573,25 @@
   var lo = ((-554899859) ^ seed_in.RTLong__f_lo);
   var hi = (5 ^ seed_in.RTLong__f_hi);
   var hi$1 = (65535 & hi);
-  var lo$1 = (((lo >>> 24) | 0) | (hi$1 << 8));
-  this.ju_Random__f_java$util$Random$$seedHi = lo$1;
-  this.ju_Random__f_java$util$Random$$seedLo = (16777215 & lo);
+  this.ju_Random__f_java$util$Random$$seedHi = hi$1;
+  this.ju_Random__f_java$util$Random$$seedLo = lo;
   this.ju_Random__f_haveNextNextGaussian = false;
 });
```