### PR TITLE
Branchless algorithms for the integer abs functions.

### DIFF
--- a/javalib/src/main/scala/java/lang/Math.scala
+++ b/javalib/src/main/scala/java/lang/Math.scala
@@ -26,8 +26,17 @@ object Math {
   @inline private def assumingES6: scala.Boolean =
     LinkingInfo.esVersion >= ESVersion.ES2015
 
-  @inline def abs(a: scala.Int): scala.Int = if (a < 0) -a else a
-  @inline def abs(a: scala.Long): scala.Long = if (a < 0) -a else a
+  @inline def abs(a: scala.Int): scala.Int = {
+    // Hacker's Delight, Section 2-4
+    val sign = a >> 31
+    (a ^ sign) - sign
+  }
+
+  // RuntimeLong intrinsic
+  @inline def abs(a: scala.Long): scala.Long = {
+    val sign = a >> 63
+    (a ^ sign) - sign
+  }
 
   // Wasm intrinsics
   @inline def abs(a: scala.Float): scala.Float = js.Math.abs(a).toFloat

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
@@ -112,11 +112,13 @@ private[linker] object LongImpl {
 
   final val compare = MethodName("compare", TwoRTLongRefs, IntRef)
 
+  final val abs = MethodName("abs", OneRTLongRef, RTLongRef)
   final val multiplyFull = MethodName("multiplyFull", List(IntRef, IntRef), RTLongRef)
 
   val AllIntrinsicMethods = Set(
     toString_,
     compare,
+    abs,
     multiplyFull
   )
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -2964,6 +2964,13 @@ private[optimizer] abstract class OptimizerCore(
 
       // java.lang.Math
 
+      case MathAbsLong =>
+        pretransformApplyStatic(ApplyFlags.empty, LongImpl.RuntimeLongClass,
+            MethodIdent(LongImpl.abs), targs,
+            ClassType(LongImpl.RuntimeLongClass, nullable = true),
+            isStat, usePreTransform)(
+            cont)
+
       case MathAbsFloat =>
         contTree(wasmUnaryOp(WasmUnaryOp.F32Abs, targs.head))
       case MathAbsDouble =>
@@ -6733,7 +6740,8 @@ private[optimizer] object OptimizerCore {
     final val StringSubstringStart = StringCodePointAt + 1
     final val StringSubstringStartEnd = StringSubstringStart + 1
 
-    final val MathAbsFloat = StringSubstringStartEnd + 1
+    final val MathAbsLong = StringSubstringStartEnd + 1
+    final val MathAbsFloat = MathAbsLong + 1
     final val MathAbsDouble = MathAbsFloat + 1
     final val MathCeil = MathAbsDouble + 1
     final val MathFloor = MathCeil + 1
@@ -6836,6 +6844,7 @@ private[optimizer] object OptimizerCore {
             m("compare", List(J, J), I) -> LongCompare
         ),
         ClassName("java.lang.Math$") -> List(
+            m("abs", List(J), J) -> MathAbsLong,
             m("multiplyFull", List(I, I), J) -> MathMultiplyFull
         )
     )

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,8 +70,8 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 148960,
-      expectedFullLinkSizeWithoutClosure = 88111,
+      expectedFastLinkSize = 148481,
+      expectedFullLinkSizeWithoutClosure = 87816,
       expectedFullLinkSizeWithClosure = 20704,
       classDefs,
       moduleInitializers = MainTestModuleInitializers

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2061,7 +2061,7 @@ object Build {
             } else {
               Some(ExpectedSizes(
                   fastLink = 425000 to 426000,
-                  fullLink = 283000 to 284000,
+                  fullLink = 282000 to 283000,
                   fastLinkGz = 61000 to 62000,
                   fullLinkGz = 43000 to 44000,
               ))
@@ -2070,7 +2070,7 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 443000 to 444000,
+                  fastLink = 442000 to 443000,
                   fullLink = 90000 to 91000,
                   fastLinkGz = 57000 to 58000,
                   fullLinkGz = 24000 to 25000,

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/MathTest.scala
@@ -47,20 +47,46 @@ class MathTest {
   private def assertSameFloat(msg: String, expected: Float, actual: Float): Unit =
     assertTrue(s"$msg; expected: $expected but was: $actual", expected.equals(actual))
 
-  @Test def abs(): Unit = {
-    assertSameDouble(0, Math.abs(0))
-    assertSameDouble(0.0, Math.abs(-0.0))
-    assertEquals(42, Math.abs(42))
-    assertEquals(42, Math.abs(-42))
-    assertTrue(Math.abs(0.0).equals(0.0))
-    assertTrue(Math.abs(-0.0).equals(0.0))
-    assertEquals(42.0, Math.abs(42.0), 0.0)
-    assertEquals(42.0, Math.abs(-42.0), 0.0)
-    assertEquals(Double.PositiveInfinity, Math.abs(Double.PositiveInfinity), 0.0)
-    assertEquals(Double.PositiveInfinity, Math.abs(Double.NegativeInfinity), 0.0)
-    assertTrue(Math.abs(Double.NaN).isNaN)
+  @Test def absInt(): Unit = {
+    assertEquals(0, Math.abs(0))
+    assertEquals(156, Math.abs(156))
+    assertEquals(156, Math.abs(-156))
+    assertEquals(49841354, Math.abs(49841354))
+    assertEquals(98433, Math.abs(-98433))
+    assertEquals(Int.MaxValue, Math.abs(Int.MaxValue))
+    assertEquals(Int.MaxValue, Math.abs(Int.MinValue + 1))
+    assertEquals(Int.MinValue, Math.abs(Int.MinValue))
+  }
+
+  @Test def absLong(): Unit = {
+    assertEquals(0L, Math.abs(0L))
+    assertEquals(156L, Math.abs(156L))
+    assertEquals(156L, Math.abs(-156L))
+    assertEquals(498413546584635135L, Math.abs(498413546584635135L))
+    assertEquals(984335433487676L, Math.abs(-984335433487676L))
     assertEquals(Long.MaxValue, Math.abs(Long.MaxValue))
+    assertEquals(Long.MaxValue, Math.abs(Long.MinValue + 1L))
     assertEquals(Long.MinValue, Math.abs(Long.MinValue))
+  }
+
+  @Test def absFloat(): Unit = {
+    assertSameFloat(0.0f, Math.abs(0.0f))
+    assertSameFloat(0.0f, Math.abs(-0.0f))
+    assertSameFloat(42.156f, Math.abs(42.156f))
+    assertSameFloat(42.654f, Math.abs(-42.654f))
+    assertSameFloat(Float.PositiveInfinity, Math.abs(Float.PositiveInfinity))
+    assertSameFloat(Float.PositiveInfinity, Math.abs(Float.NegativeInfinity))
+    assertSameFloat(Float.NaN, Math.abs(Float.NaN))
+  }
+
+  @Test def absDouble(): Unit = {
+    assertSameDouble(0.0, Math.abs(0.0))
+    assertSameDouble(0.0, Math.abs(-0.0))
+    assertSameDouble(42.156, Math.abs(42.156))
+    assertSameDouble(42.654, Math.abs(-42.654))
+    assertSameDouble(Double.PositiveInfinity, Math.abs(Double.PositiveInfinity))
+    assertSameDouble(Double.PositiveInfinity, Math.abs(Double.NegativeInfinity))
+    assertSameDouble(Double.NaN, Math.abs(Double.NaN))
   }
 
   @Test def max(): Unit = {


### PR DESCRIPTION
In the library, we use Hacker's Delight, Section 2-4. That provides good code for the Int's on all platforms, as well as for Long's when we do not use `RuntimeLong`.

For `RuntimeLong`, we devise a variant of that algorithm. The big comment provides the proof.