### PR TITLE
Remove an ancient workaround in RTLong for a PhantomJS issue.

### DIFF
--- a/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
+++ b/linker-private-library/src/main/scala/org/scalajs/linker/runtime/RuntimeLong.scala
@@ -1016,15 +1016,9 @@ object RuntimeLong {
 
     if (isInt32(alo, ahi)) {
       if (isInt32(blo, bhi)) {
-        if (blo != -1) {
-          val lo = alo % blo
-          hiReturn = lo >> 31
-          lo
-        } else {
-          // Work around https://github.com/ariya/phantomjs/issues/12198
-          hiReturn = 0
-          0
-        }
+        val lo = alo % blo
+        hiReturn = lo >> 31
+        lo
       } else {
         // Either a == Int.MinValue && b == (Int.MaxValue + 1), or (abs(b) > abs(a))
         if (alo == Int.MinValue && (blo == 0x80000000 && bhi == 0)) {

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2070,7 +2070,7 @@ object Build {
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 443000 to 444000,
+                  fastLink = 442000 to 443000,
                   fullLink = 90000 to 91000,
                   fastLinkGz = 57000 to 58000,
                   fullLinkGz = 24000 to 25000,


### PR DESCRIPTION
PhantomJS has been discontinued years ago. Supposedly the issue was fixed in v2.x but we never truly checked. Anyway, there is no point in keeping a defunct engine-specific workaround.