### PR TITLE
Removes spurious js.AsInstanceOf around the js.LinkTimeIf

### DIFF
--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkTimeIfTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/library/LinkTimeIfTest.scala
@@ -92,4 +92,51 @@ class LinkTimeIfTest {
     }
     assertEquals(pow(2.0, 8.0), 256.0, 0)
   }
+
+  // This test verifies that the compiler can safely compile surrounding
+  // implicit asInstanceOf casts to a supertype.
+  @Test def subtyping(): Unit = {
+    trait A { def value: Int }
+    class B(val value: Int) extends A
+    class C(val value: Int) extends A
+
+    val b = new B(1)
+    val c = new C(2)
+
+    val result1 = linkTimeIf[A](productionMode) { b } { c }
+    assertEquals(if (Platform.isInProductionMode) b.value else c.value, result1.value)
+
+    val result2 = linkTimeIf[A](productionMode) { c } { b }
+    assertEquals(if (Platform.isInProductionMode) c.value else b.value, result2.value)
+  }
+
+  @Test def implPattern(): Unit = {
+    import LinkTimeIfTest._
+    val impl = linkTimeIf[ArrayImpl](productionMode) {
+      JSArrayImpl
+    } {
+      ScalaArrayImpl
+    }
+    assertEquals(0, impl.length(impl.empty()))
+  }
+}
+
+object LinkTimeIfTest {
+  sealed private abstract class ArrayImpl {
+    type Repr
+    def empty(): Repr
+    def length(v: Repr): Int
+  }
+
+  private object JSArrayImpl extends ArrayImpl {
+    type Repr = js.Array[AnyRef]
+    def empty(): Repr = js.Array[AnyRef]()
+    def length(v: Repr): Int = v.length
+  }
+
+  private object ScalaArrayImpl extends ArrayImpl {
+    type Repr = Array[AnyRef]
+    def empty(): Repr = new Array[AnyRef](0)
+    def length(v: Repr): Int = v.length
+  }
 }


### PR DESCRIPTION
Cherry-picking a change from https://github.com/scala-js/scala-js/pull/5168#issuecomment-2976694539 :)

When B<:A and C<:A, `linkTimeIf[A](cond){ B }{ C }` would generate an `.asInstanceOf[A]` that casts the resulting value to a supertype.
However, this cast is redundant,
as the linker will prune one branch at linktime,
and the remaining expression is already known to be a compatible type.

This commit eliminates the surrounding `.asInstanceOf` around the `linkTimeIf[T]` when both `thenp` and `elsep` are surely subtypes of `T`.

context: https://github.com/scala-js/scala-js/pull/5168