### PR TITLE
WiP Redesign the encoding of Longs in JavaScript + GCC v20240317 (JDK 17+).

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '17' ]
 
     # Use the latest supported version. We will be less affected by ambient changes
     # due to the lack of pinning than by breakages because of changing version support.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -523,8 +523,8 @@ def Tasks = [
   '''
 ]
 
-def mainJavaVersion = "1.8"
-def otherJavaVersions = ["11", "17", "21"]
+def mainJavaVersion = "17"
+def otherJavaVersions = ["21"]
 def allJavaVersions = otherJavaVersions.clone()
 allJavaVersions << mainJavaVersion
 

--- a/linker/js/src/main/scala/org/scalajs/linker/backend/emitter/PrivateLibHolder.scala
+++ b/linker/js/src/main/scala/org/scalajs/linker/backend/emitter/PrivateLibHolder.scala
@@ -28,7 +28,8 @@ object PrivateLibHolder {
       val path = "org/scalajs/linker/runtime/" + name
       val content = Base64.getDecoder().decode(contentBase64)
       val tree = ir.Serializers.deserialize(ByteBuffer.wrap(content))
-      new MemClassDefIRFileImpl(path, stableVersion, tree)
+      val patchedTree = PrivateLibPatches.patchClassDef(tree)
+      new MemClassDefIRFileImpl(path, stableVersion, patchedTree)
     }
   }
 }

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureAstTransformer.scala
@@ -445,7 +445,7 @@ private class ClosureAstTransformer(featureSet: FeatureSet,
 
       case StringLiteral(name) =>
         val node = Node.newString(Token.STRING_KEY, name)
-        node.setQuotedString()
+        node.setQuotedStringKey()
         node
 
       case ComputedName(nameExpr) =>

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/closure/ClosureLinkerBackend.scala
@@ -154,7 +154,7 @@ final class ClosureLinkerBackend(config: LinkerBackendImpl.Config)
         new LoggerErrorReportGenerator(logger)))))
 
     val result =
-      compiler.compileModules(externs, Arrays.asList(chunk), options)
+      compiler.compileChunks(externs, Arrays.asList(chunk), options)
 
     if (!result.success) {
       throw new LinkingException(

--- a/linker/jvm/src/main/scala/org/scalajs/linker/backend/emitter/PrivateLibHolder.scala
+++ b/linker/jvm/src/main/scala/org/scalajs/linker/backend/emitter/PrivateLibHolder.scala
@@ -24,14 +24,14 @@ object PrivateLibHolder {
   private val stableVersion = ir.Version.fromInt(0) // never changes
 
   private val sjsirPaths = Seq(
-      "org/scalajs/linker/runtime/FloatingPointBitsPolyfills.sjsir",
-      "org/scalajs/linker/runtime/FloatingPointBitsPolyfills$.sjsir",
-      "org/scalajs/linker/runtime/RuntimeLong.sjsir",
-      "org/scalajs/linker/runtime/RuntimeLong$.sjsir",
-      "org/scalajs/linker/runtime/UndefinedBehaviorError.sjsir",
-      "org/scalajs/linker/runtime/WasmRuntime.sjsir",
-      "org/scalajs/linker/runtime/WasmRuntime$.sjsir",
-      "scala/scalajs/js/JavaScriptException.sjsir"
+      "org/scalajs/linker/runtime/FloatingPointBitsPolyfills.sjsirp",
+      "org/scalajs/linker/runtime/FloatingPointBitsPolyfills$.sjsirp",
+      "org/scalajs/linker/runtime/RuntimeLong.sjsirp",
+      "org/scalajs/linker/runtime/RuntimeLong$.sjsirp",
+      "org/scalajs/linker/runtime/UndefinedBehaviorError.sjsirp",
+      "org/scalajs/linker/runtime/WasmRuntime.sjsirp",
+      "org/scalajs/linker/runtime/WasmRuntime$.sjsirp",
+      "scala/scalajs/js/JavaScriptException.sjsirp"
   )
 
   val files: Seq[IRFile] = {
@@ -39,7 +39,8 @@ object PrivateLibHolder {
       val name = path.substring(path.lastIndexOf('/') + 1)
       val content = readResource(name)
       val tree = ir.Serializers.deserialize(ByteBuffer.wrap(content))
-      new MemClassDefIRFileImpl(path, stableVersion, tree)
+      val patchedTree = PrivateLibPatches.patchClassDef(tree)
+      new MemClassDefIRFileImpl(path, stableVersion, patchedTree)
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/ClassEmitter.scala
@@ -371,8 +371,17 @@ private[emitter] final class ClassEmitter(sjsGen: SJSGen) {
     } yield {
       val field = anyField.asInstanceOf[FieldDef]
       implicit val pos = field.pos
-      js.Assign(genSelectForDef(js.This(), field.name, field.originalName),
-          genZeroOf(field.ftpe))
+      field.ftpe match {
+        case LongType if !useBigIntForLongs =>
+          val (lo, hi) = genSelectLongForDef(js.This(), field.name, field.originalName)
+          js.Block(
+            js.Assign(lo, js.IntLiteral(0)),
+            js.Assign(hi, js.IntLiteral(0))
+          )
+        case _ =>
+          js.Assign(genSelectForDef(js.This(), field.name, field.originalName),
+              genZeroOf(field.ftpe))
+      }
     }
   }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -520,7 +520,13 @@ private[emitter] object CoreJSLib {
 
     private def defineResHi(): List[Tree] = {
       condDefs(!allowBigIntsForLongs)(
-        extractWithGlobals(globallyMutableVarDef(VarField.resHi, VarField.setResHi, CoreVar, int(0)))
+        extractWithGlobals(globallyMutableVarDef(VarField.resHi, VarField.setResHi, CoreVar, {
+          if (esVersion >= ESVersion.ES2015) {
+            New(globalRef("Int32Array"), List(int(1)))
+          } else {
+            ArrayConstr(List(int(0)))
+          }
+        }))
       )
     }
 
@@ -1504,12 +1510,12 @@ private[emitter] object CoreJSLib {
             } else {
               If(v === Null(), {
                 Block(
-                  globalVar(VarField.resHi, CoreVar) := 0,
+                  genResHi() := 0,
                   0
                 )
               }, {
                 Block(
-                  globalVar(VarField.resHi, CoreVar) := v DOT cpn.hi,
+                  genResHi() := v DOT cpn.hi,
                   v DOT cpn.lo
                 )
               })
@@ -1536,12 +1542,12 @@ private[emitter] object CoreJSLib {
             } else {
               If(v === Null(), {
                 Block(
-                  globalVar(VarField.resHi, CoreVar) := 0,
+                  genResHi() := 0,
                   Return(0)
                 )
               }, {
                 Block(
-                  globalVar(VarField.resHi, CoreVar) := v DOT cpn.hi,
+                  genResHi() := v DOT cpn.hi,
                   Return(v DOT cpn.lo)
                 )
               })
@@ -1596,7 +1602,7 @@ private[emitter] object CoreJSLib {
                   Block(
                       boundsCheck,
                       i := (i << 1),
-                      globalVar(VarField.resHi, CoreVar) := BracketSelect(This().u, (i + 1) | 0),
+                      genResHi() := BracketSelect(This().u, (i + 1) | 0),
                       Return(BracketSelect(This().u, i))
                   )
                 }),

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -133,8 +133,9 @@ private[emitter] object CoreJSLib {
     private def buildPreObjectDefinitions(): List[Tree] = {
       defineFileLevelThis() :::
       defineJSBuiltinsSnapshotsAndPolyfills() :::
-      declareCachedL0() :::
+      defineResHi() :::
       defineCharClass() :::
+      defineLongClass() :::
       defineRuntimeFunctions() :::
       defineObjectGetClassFunctions() :::
       defineDispatchFunctions() :::
@@ -155,7 +156,7 @@ private[emitter] object CoreJSLib {
     }
 
     private def buildInitializations(): List[Tree] = {
-      assignCachedL0()
+      Nil
     }
 
     private def defineFileLevelThis(): List[Tree] = {
@@ -517,18 +518,10 @@ private[emitter] object CoreJSLib {
       }
     }
 
-    private def declareCachedL0(): List[Tree] = {
+    private def defineResHi(): List[Tree] = {
       condDefs(!allowBigIntsForLongs)(
-        extractWithGlobals(globalVarDecl(VarField.L0, CoreVar))
+        extractWithGlobals(globallyMutableVarDef(VarField.resHi, VarField.setResHi, CoreVar, int(0)))
       )
-    }
-
-    private def assignCachedL0(): List[Tree] = {
-      condDefs(!allowBigIntsForLongs)(List(
-        globalVar(VarField.L0, CoreVar) := genScalaClassNew(
-            LongImpl.RuntimeLongClass, LongImpl.initFromParts, 0, 0),
-        genClassDataOf(LongRef) DOT cpn.zero := globalVar(VarField.L0, CoreVar)
-      ))
     }
 
     private def defineCharClass(): List[Tree] = {
@@ -552,6 +545,33 @@ private[emitter] object CoreJSLib {
         defineFunction(VarField.Char, ctor.args, ctor.body) :::
         setPrototypeVar(globalVar(VarField.Char, CoreVar)) :::
         assignES5ClassMembers(globalVar(VarField.Char, CoreVar), List(toStr))
+      }
+    }
+
+    private def defineLongClass(): List[Tree] = {
+      condDefs(!allowBigIntsForLongs) {
+        val ctor = {
+          val lo = varRef("lo")
+          val hi = varRef("hi")
+          MethodDef(static = false, Ident("constructor"), paramList(lo, hi), None, Block(
+            This() DOT cpn.lo := lo,
+            This() DOT cpn.hi := hi
+          ))
+        }
+
+        val toStr = {
+          MethodDef(static = false, Ident("toString"), Nil, None, {
+            Return(genLongApplyStatic(LongImpl.toString_, This() DOT cpn.lo, This() DOT cpn.hi))
+          })
+        }
+
+        if (useClassesForRegularClasses) {
+          extractWithGlobals(globalClassDef(VarField.Long, CoreVar, None, ctor :: toStr :: Nil))
+        } else {
+          defineFunction(VarField.Long, ctor.args, ctor.body) :::
+          setPrototypeVar(globalVar(VarField.Long, CoreVar)) :::
+          assignES5ClassMembers(globalVar(VarField.Long, CoreVar), List(toStr))
+        }
       }
     }
 
@@ -809,10 +829,15 @@ private[emitter] object CoreJSLib {
         }
 
         def genHijackedMethodApply(className: ClassName): Tree = {
-          val instanceAsPrimitive =
-            if (className == BoxedCharacterClass) genCallHelper(VarField.uC, instance)
-            else instance
-          Apply(globalVar(VarField.f, (className, methodName)), instanceAsPrimitive :: args)
+          val instanceAsPrimitive = className match {
+            case BoxedCharacterClass =>
+              List(instance DOT cpn.c)
+            case BoxedLongClass if !useBigIntForLongs =>
+              List(instance DOT cpn.lo, instance DOT cpn.hi)
+            case _ =>
+              List(instance)
+          }
+          Apply(globalVar(VarField.f, (className, methodName)), instanceAsPrimitive ::: args)
         }
 
         def genBodyNoSwitch(hijackedClasses: List[ClassName]): Tree = {
@@ -930,7 +955,10 @@ private[emitter] object CoreJSLib {
               })
             }, {
               genArrowFunction(paramList(x), {
-                Return(Apply(globalVar(VarField.s, (FloatingPointBitsPolyfillsClass, polyfillMethod)), List(x)))
+                val args =
+                  if (polyfillMethod.paramTypeRefs.head != LongRef || useBigIntForLongs) List(x)
+                  else List(x DOT cpn.lo, x DOT cpn.hi)
+                Return(Apply(globalVar(VarField.s, (FloatingPointBitsPolyfillsClass, polyfillMethod)), args))
               })
             })
           }))
@@ -1070,7 +1098,7 @@ private[emitter] object CoreJSLib {
             Return(Apply(genIdentBracketSelect(fpBitsDataView, "getFloat64"), List(0, bool(true))))
           )
         } else {
-          Return(genLongApplyStatic(LongImpl.bitsToDouble, x, fpBitsDataView))
+          Return(genLongApplyStatic(LongImpl.bitsToDouble, x DOT cpn.lo, x DOT cpn.hi, fpBitsDataView))
         }
       }
     }
@@ -1190,7 +1218,15 @@ private[emitter] object CoreJSLib {
 
       condDefs(esVersion < ESVersion.ES2015)(
         defineFunction5(VarField.systemArraycopy) { (src, srcPos, dest, destPos, length) =>
-          genCallHelper(VarField.arraycopyGeneric, src.u, srcPos, dest.u, destPos, length)
+          if (useBigIntForLongs) {
+            genCallHelper(VarField.arraycopyGeneric, src.u, srcPos, dest.u, destPos, length)
+          } else {
+            If((src DOT classData) === genClassDataOf(ArrayTypeRef(LongRef, 1)), {
+              genCallHelper(VarField.arraycopyGeneric, src.u, srcPos << 1, dest.u, destPos << 1, length << 1)
+            }, {
+              genCallHelper(VarField.arraycopyGeneric, src.u, srcPos, dest.u, destPos, length)
+            })
+          }
         }
       ) :::
       condDefs(esVersion >= ESVersion.ES2015 && nullPointers != CheckedBehavior.Unchecked)(
@@ -1433,7 +1469,15 @@ private[emitter] object CoreJSLib {
       defineFunction1(VarField.bC) { c =>
         Return(New(globalVar(VarField.Char, CoreVar), c :: Nil))
       } :::
-      extractWithGlobals(globalVarDef(VarField.bC0, CoreVar, genCallHelper(VarField.bC, 0)))
+      extractWithGlobals(globalVarDef(VarField.bC0, CoreVar, genCallHelper(VarField.bC, 0))) :::
+
+      // Boxes for Longs
+      condDefs(!useBigIntForLongs)(
+        defineFunction2(VarField.bL) { (lo, hi) =>
+          Return(New(globalVar(VarField.Long, CoreVar), lo :: hi :: Nil))
+        } :::
+        extractWithGlobals(globalVarDef(VarField.bL0, CoreVar, genCallHelper(VarField.bL, 0, 0)))
+      )
     ) ::: (
       if (asInstanceOfs != CheckedBehavior.Unchecked) {
         // Unboxes for everything
@@ -1453,7 +1497,24 @@ private[emitter] object CoreJSLib {
           defineUnbox(VarField.uB, BoxedByteClass, _ | 0) :::
           defineUnbox(VarField.uS, BoxedShortClass, _ | 0) :::
           defineUnbox(VarField.uI, BoxedIntegerClass, _ | 0) :::
-          defineUnbox(VarField.uJ, BoxedLongClass, v => If(v === Null(), genLongZero(), v)) :::
+
+          defineUnbox(VarField.uJ, BoxedLongClass, { v =>
+            if (useBigIntForLongs) {
+              If(v === Null(), genLongZero(), v)
+            } else {
+              If(v === Null(), {
+                Block(
+                  globalVar(VarField.resHi, CoreVar) := 0,
+                  0
+                )
+              }, {
+                Block(
+                  globalVar(VarField.resHi, CoreVar) := v DOT cpn.hi,
+                  v DOT cpn.lo
+                )
+              })
+            }
+          }) :::
 
           /* Since the type test ensures that v is either null or a float, we can
            * use + instead of fround.
@@ -1470,7 +1531,21 @@ private[emitter] object CoreJSLib {
             Return(If(v === Null(), 0, v DOT cpn.c))
           } :::
           defineFunction1(VarField.uJ) { v =>
-            Return(If(v === Null(), genLongZero(), v))
+            if (useBigIntForLongs) {
+              Return(If(v === Null(), genLongZero(), v))
+            } else {
+              If(v === Null(), {
+                Block(
+                  globalVar(VarField.resHi, CoreVar) := 0,
+                  Return(0)
+                )
+              }, {
+                Block(
+                  globalVar(VarField.resHi, CoreVar) := v DOT cpn.hi,
+                  Return(v DOT cpn.lo)
+                )
+              })
+            }
           }
         )
       }
@@ -1498,32 +1573,58 @@ private[emitter] object CoreJSLib {
           })
         }
 
+        def lengthOf(arrayVal: Tree): Tree =
+          if (componentTypeRef == LongRef && !useBigIntForLongs) (arrayVal.u.length >>> 1) | 0
+          else arrayVal.u.length
+
         val getAndSet = if (arrayIndexOutOfBounds != CheckedBehavior.Unchecked) {
           val i = varRef("i")
           val v = varRef("v")
+          val w = varRef("w")
 
           val boundsCheck = {
-            If((i < 0) || (i >= This().u.length),
+            If((i < 0) || (i >= lengthOf(This())),
                 genCallHelper(VarField.throwArrayIndexOutOfBoundsException, i))
           }
 
           val getName = genSyntheticPropertyForDef(SyntheticProperty.get)
           val setName = genSyntheticPropertyForDef(SyntheticProperty.set)
 
-          List(
-              MethodDef(static = false, getName, paramList(i), None, {
-                Block(
-                    boundsCheck,
-                    Return(BracketSelect(This().u, i))
-                )
-              }),
-              MethodDef(static = false, setName, paramList(i, v), None, {
-                Block(
-                    boundsCheck,
-                    BracketSelect(This().u, i) := v
-                )
-              })
-          )
+          if (componentTypeRef == LongRef && !useBigIntForLongs) {
+            List(
+                MethodDef(static = false, getName, paramList(i), None, {
+                  Block(
+                      boundsCheck,
+                      i := (i << 1),
+                      globalVar(VarField.resHi, CoreVar) := BracketSelect(This().u, (i + 1) | 0),
+                      Return(BracketSelect(This().u, i))
+                  )
+                }),
+                MethodDef(static = false, setName, paramList(i, v, w), None, {
+                  Block(
+                      boundsCheck,
+                      i := (i << 1),
+                      BracketSelect(This().u, i) := v,
+                      BracketSelect(This().u, (i + 1) | 0) := w
+                  )
+                })
+            )
+          } else {
+            List(
+                MethodDef(static = false, getName, paramList(i), None, {
+                  Block(
+                      boundsCheck,
+                      Return(BracketSelect(This().u, i))
+                  )
+                }),
+                MethodDef(static = false, setName, paramList(i, v), None, {
+                  Block(
+                      boundsCheck,
+                      BracketSelect(This().u, i) := v
+                  )
+                })
+            )
+          }
         } else if (isArrayOfObject && arrayStores != CheckedBehavior.Unchecked) {
           /* We need to define a straightforward "set" method, without any
            * check necessary, which will be overridden in subclasses.
@@ -1550,24 +1651,29 @@ private[emitter] object CoreJSLib {
 
           val copyToName = genSyntheticPropertyForDef(SyntheticProperty.copyTo)
 
+          def scale(sizeVal: Tree): Tree =
+            if (componentTypeRef == LongRef && !useBigIntForLongs) sizeVal << 1
+            else sizeVal
+
           val methodDef = MethodDef(static = false, copyToName,
               paramList(srcPos, dest, destPos, length), None, {
             if (isTypedArray) {
               Block(
                   if (semantics.arrayIndexOutOfBounds != CheckedBehavior.Unchecked) {
-                    genCallHelper(VarField.arraycopyCheckBounds, This().u.length,
-                        srcPos, dest.u.length, destPos, length)
+                    genCallHelper(VarField.arraycopyCheckBounds, lengthOf(This()),
+                        srcPos, lengthOf(dest), destPos, length)
                   } else {
                     Skip()
                   },
                   Apply(genIdentBracketSelect(dest.u, "set"),
-                      Apply(genIdentBracketSelect(This().u, "subarray"), srcPos :: ((srcPos + length) | 0) :: Nil) ::
-                      destPos ::
+                      Apply(genIdentBracketSelect(This().u, "subarray"),
+                          scale(srcPos) :: scale((srcPos + length) | 0) :: Nil) ::
+                      scale(destPos) ::
                       Nil)
               )
             } else {
-              genCallHelper(VarField.arraycopyGeneric, This().u, srcPos,
-                  dest.u, destPos, length)
+              genCallHelper(VarField.arraycopyGeneric, This().u, scale(srcPos),
+                  dest.u, scale(destPos), length)
             }
           })
           methodDef :: Nil
@@ -1616,18 +1722,27 @@ private[emitter] object CoreJSLib {
           If(arg < 0, genCallHelper(VarField.throwNegativeArraySizeException))
         }
 
+        val scaleArg =
+          if (componentTypeRef == LongRef && !useBigIntForLongs) Assign(arg, arg << 1)
+          else Skip()
+
         getArrayUnderlyingTypedArrayClassRef(componentTypeRef) match {
           case Some(typeArrayClassWithGlobalRefs) =>
             Block(
                 arraySizeCheck,
+                scaleArg,
                 This().u := New(extractWithGlobals(typeArrayClassWithGlobalRefs), arg :: Nil)
             )
           case None =>
+            val zeroElem =
+              if (componentTypeRef == LongRef && !useBigIntForLongs) int(0)
+              else genZeroOf(componentTypeRef)
             Block(
                 arraySizeCheck,
+                scaleArg,
                 This().u := New(ArrayRef, arg :: Nil),
                 For(let(i, 0), i < arg, i.++, {
-                  BracketSelect(This().u, i) := genZeroOf(componentTypeRef)
+                  BracketSelect(This().u, i) := zeroElem
                 })
             )
         }
@@ -1702,7 +1817,7 @@ private[emitter] object CoreJSLib {
               If(arrayClass !== Undefined(), { // it is undefined for void
                 privateFieldSet(cpn._arrayOf,
                     Apply(New(globalVar(VarField.TypeData, CoreVar), Nil) DOT cpn.initSpecializedArray,
-                        List(This(), arrayClass, typedArrayClass)))
+                        List(This(), arrayClass, typedArrayClass, arrayEncodedName === str("J"))))
               }),
               Return(This())
           )
@@ -1793,13 +1908,14 @@ private[emitter] object CoreJSLib {
         val componentData = varRef("componentData")
         val arrayClass = varRef("arrayClass")
         val typedArrayClass = varRef("typedArrayClass")
+        val isLongArray = varRef("isLongArray")
         val isAssignableFromFun = varRef("isAssignableFromFun")
         val self = varRef("self")
         val that = varRef("that")
         val obj = varRef("obj")
         val array = varRef("array")
         MethodDef(static = false, Ident(cpn.initSpecializedArray),
-            paramList(componentData, arrayClass, typedArrayClass, isAssignableFromFun), None, {
+            paramList(componentData, arrayClass, typedArrayClass, isLongArray, isAssignableFromFun), None, {
           Block(
               arrayClass.prototype DOT classData := This(),
               initArrayCommonBody(arrayClass, componentData, componentData, 1),
@@ -1808,15 +1924,41 @@ private[emitter] object CoreJSLib {
                 genArrowFunction(paramList(that), Return(self === that))
               }),
               privateFieldSet(cpn.wrapArray, {
-                If(typedArrayClass, {
-                  genArrowFunction(paramList(array), {
-                    Return(New(arrayClass, New(typedArrayClass, array :: Nil) :: Nil))
+                val whenNotRuntimeLongArray = {
+                  If(typedArrayClass, {
+                    genArrowFunction(paramList(array), {
+                      Return(New(arrayClass, New(typedArrayClass, array :: Nil) :: Nil))
+                    })
+                  }, {
+                    genArrowFunction(paramList(array), {
+                      Return(New(arrayClass, array :: Nil))
+                    })
                   })
-                }, {
-                  genArrowFunction(paramList(array), {
-                    Return(New(arrayClass, array :: Nil))
+                }
+                if (useBigIntForLongs) {
+                  whenNotRuntimeLongArray
+                } else {
+                  If(isLongArray, {
+                    genArrowFunction(paramList(array), {
+                      val len = varRef("len")
+                      val result = varRef("result")
+                      val u = varRef("u")
+                      val i = varRef("i")
+                      Block(
+                        const(len, array.length | 0),
+                        const(result, New(arrayClass, len :: Nil)),
+                        const(u, result.u),
+                        For(let(i, 0), i < len, i := (i + 1) | 0, Block(
+                          BracketSelect(u, i << 1) := BracketSelect(array, i) DOT cpn.lo,
+                          BracketSelect(u, ((i << 1) + 1) | 0) := BracketSelect(array, i) DOT cpn.hi
+                        )),
+                        Return(result)
+                      )
+                    })
+                  }, {
+                    whenNotRuntimeLongArray
                   })
-                })
+                }
               }),
               privateFieldSet(cpn.isInstance,
                   genArrowFunction(paramList(obj), Return(obj instanceof arrayClass))),
@@ -2187,6 +2329,7 @@ private[emitter] object CoreJSLib {
               typeDataVar,
               globalVar(VarField.ac, ObjectClass),
               Undefined(), // typedArray
+              bool(false), // isLongArray
               genArrowFunction(paramList(that), {
                 val thatDepth = varRef("thatDepth")
                 Block(
@@ -2214,7 +2357,7 @@ private[emitter] object CoreJSLib {
          */
         val zero = primRef match {
           case VoidRef                          => Undefined()
-          case LongRef if !allowBigIntsForLongs => Null() // set later when $L0 is initialized
+          case LongRef if !allowBigIntsForLongs => genBoxedZeroOf(LongType)
           case _                                => genZeroOf(primRef)
         }
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Emitter.scala
@@ -1434,12 +1434,7 @@ object Emitter {
         callMethod(BoxedStringClass, hashCodeMethodName),
 
         cond(!config.coreSpec.esFeatures.allowBigIntsForLongs) {
-          multiple(
-              instanceTests(LongImpl.RuntimeLongClass),
-              instantiateClass(LongImpl.RuntimeLongClass, LongImpl.AllConstructors.toList),
-              callMethods(LongImpl.RuntimeLongClass, LongImpl.BoxedLongMethods.toList),
-              callStaticMethods(LongImpl.RuntimeLongClass, LongImpl.OperatorMethods.toList)
-          )
+          callStaticMethods(LongImpl.RuntimeLongClass, LongImpl.OperatorMethods.toList)
         },
 
         cond(config.coreSpec.esFeatures.esVersion < ESVersion.ES2015) {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/LongImpl.scala
@@ -18,6 +18,7 @@ import org.scalajs.ir.WellKnownNames._
 
 private[linker] object LongImpl {
   final val RuntimeLongClass = ClassName("org.scalajs.linker.runtime.RuntimeLong")
+  final val RuntimeLongModClass = ClassName("org.scalajs.linker.runtime.RuntimeLong$")
 
   final val lo = MethodName("lo", Nil, IntRef)
   final val hi = MethodName("hi", Nil, IntRef)
@@ -26,35 +27,23 @@ private[linker] object LongImpl {
   private final val OneRTLongRef = RTLongRef :: Nil
   private final val TwoRTLongRefs = RTLongRef :: OneRTLongRef
 
+  private final val TwoIntRefs = IntRef :: IntRef :: Nil
+  private final val ThreeIntRefs = IntRef :: TwoIntRefs
+  private final val FourIntRefs = IntRef :: ThreeIntRefs
+
+  final val pack = MethodName("pack", TwoIntRefs, LongRef)
+
   def unaryOp(name: String): MethodName =
-    MethodName(name, OneRTLongRef, RTLongRef)
+    MethodName(name, TwoIntRefs, LongRef)
 
   def binaryOp(name: String): MethodName =
-    MethodName(name, TwoRTLongRefs, RTLongRef)
+    MethodName(name, FourIntRefs, LongRef)
 
   def shiftOp(name: String): MethodName =
-    MethodName(name, List(RTLongRef, IntRef), RTLongRef)
+    MethodName(name, ThreeIntRefs, LongRef)
 
   def compareOp(name: String): MethodName =
-    MethodName(name, TwoRTLongRefs, BooleanRef)
-
-  // Instance methods that we need to reach as part of the jl.Long boxing
-
-  private final val byteValue = MethodName("byteValue", Nil, ByteRef)
-  private final val shortValue = MethodName("shortValue", Nil, ShortRef)
-  private final val intValue = MethodName("intValue", Nil, IntRef)
-  private final val longValue = MethodName("longValue", Nil, LongRef)
-  private final val floatValue = MethodName("floatValue", Nil, FloatRef)
-  private final val doubleValue = MethodName("doubleValue", Nil, DoubleRef)
-
-  private final val equalsO = MethodName("equals", List(ClassRef(ObjectClass)), BooleanRef)
-  private final val hashCode_ = MethodName("hashCode", Nil, IntRef)
-  private final val compareTo = MethodName("compareTo", List(ClassRef(BoxedLongClass)), IntRef)
-  private final val compareToO = MethodName("compareTo", List(ClassRef(ObjectClass)), IntRef)
-
-  val BoxedLongMethods = Set(
-      byteValue, shortValue, intValue, longValue, floatValue, doubleValue,
-      equalsO, hashCode_, compareTo, compareToO)
+    MethodName(name, FourIntRefs, BooleanRef)
 
   // Operator methods
 
@@ -86,16 +75,18 @@ private[linker] object LongImpl {
   final val gtu = compareOp("gtu")
   final val geu = compareOp("geu")
 
-  final val toInt = MethodName("toInt", OneRTLongRef, IntRef)
-  final val toFloat = MethodName("toFloat", OneRTLongRef, FloatRef)
-  final val toDouble = MethodName("toDouble", OneRTLongRef, DoubleRef)
-  final val bitsToDouble = MethodName("bitsToDouble", List(RTLongRef, ObjectRef), DoubleRef)
-  final val clz = MethodName("clz", OneRTLongRef, IntRef)
+  final val toInt = MethodName("toInt", TwoIntRefs, IntRef)
+  final val toFloat = MethodName("toFloat", TwoIntRefs, FloatRef)
+  final val toDouble = MethodName("toDouble", TwoIntRefs, DoubleRef)
+  final val bitsToDouble = MethodName("bitsToDouble", List(IntRef, IntRef, ObjectRef), DoubleRef)
+  final val clz = MethodName("clz", TwoIntRefs, IntRef)
 
-  final val fromInt = MethodName("fromInt", List(IntRef), RTLongRef)
-  final val fromUnsignedInt = MethodName("fromUnsignedInt", List(IntRef), RTLongRef)
-  final val fromDouble = MethodName("fromDouble", List(DoubleRef), RTLongRef)
-  final val fromDoubleBits = MethodName("fromDoubleBits", List(DoubleRef, ObjectRef), RTLongRef)
+  final val fromInt = MethodName("fromInt", List(IntRef), LongRef)
+  final val fromUnsignedInt = MethodName("fromUnsignedInt", List(IntRef), LongRef)
+  final val fromDouble = MethodName("fromDouble", List(DoubleRef), LongRef)
+  final val fromDoubleBits = MethodName("fromDoubleBits", List(DoubleRef, ObjectRef), LongRef)
+
+  final val toString_ = MethodName("toString", TwoIntRefs, ClassRef(BoxedStringClass))
 
   val OperatorMethods = Set(
     add, sub, mul,
@@ -103,31 +94,22 @@ private[linker] object LongImpl {
     or, and, xor, shl, shr, sar,
     equals_, notEquals, lt, le, gt, ge, ltu, leu, gtu, geu,
     toInt, toFloat, toDouble, bitsToDouble, clz,
-    fromInt, fromUnsignedInt, fromDouble, fromDoubleBits
+    fromInt, fromUnsignedInt, fromDouble, fromDoubleBits,
+    toString_
   )
 
   // Methods used for intrinsics
 
-  final val toString_ = MethodName("toString", OneRTLongRef, ClassRef(BoxedStringClass))
+  final val compare = MethodName("compare", FourIntRefs, IntRef)
 
-  final val compare = MethodName("compare", TwoRTLongRefs, IntRef)
-
-  final val abs = MethodName("abs", OneRTLongRef, RTLongRef)
-  final val multiplyFull = MethodName("multiplyFull", List(IntRef, IntRef), RTLongRef)
+  final val abs = MethodName("abs", TwoIntRefs, LongRef)
+  final val multiplyFull = MethodName("multiplyFull", TwoIntRefs, LongRef)
 
   val AllIntrinsicMethods = Set(
-    toString_,
     compare,
     abs,
     multiplyFull
   )
-
-  // Constructors
-
-  final val initFromParts = MethodName.constructor(List(IntRef, IntRef))
-
-  val AllConstructors = Set(
-      initFromParts)
 
   // Extract the parts to give to the initFromParts constructor
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/PrivateLibPatches.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/PrivateLibPatches.scala
@@ -1,0 +1,72 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.linker.backend.emitter
+
+import org.scalajs.ir.Trees._
+import org.scalajs.ir.WellKnownNames._
+
+/** Load-time patches for the private lib IR.
+ *
+ *  This introduces Transients into selected methods of the private lib. They
+ *  cannot be serialized, so they cannot be adapted when producing the sjsir.
+ */
+object PrivateLibPatches {
+  def patchClassDef(classDef: ClassDef): ClassDef = {
+    if (classDef.className == LongImpl.RuntimeLongModClass)
+      patchRuntimeLongModClass(classDef)
+    else
+      classDef
+  }
+
+  /** Patches the `RuntimeLong` module class.
+   *
+   *  Replaces the body of `pack()` by a `Transients.PackLong`.
+   */
+  private def patchRuntimeLongModClass(classDef: ClassDef): ClassDef = {
+    import classDef._
+
+    val newMethods = methods.map { methodDef =>
+      if (methodDef.methodName == LongImpl.pack)
+        patchRTLongPack(methodDef)
+      else
+        methodDef
+    }
+
+    ClassDef(
+      name,
+      originalName,
+      kind,
+      jsClassCaptures,
+      superClass,
+      interfaces,
+      jsSuperClass,
+      jsNativeLoadSpec,
+      fields,
+      newMethods,
+      jsConstructor,
+      jsMethodProps,
+      jsNativeMembers,
+      topLevelExportDefs
+    )(optimizerHints)
+  }
+
+  private def patchRTLongPack(methodDef: MethodDef): MethodDef = {
+    import methodDef._
+    val newBody = {
+      implicit val pos = body.get.pos
+      Transient(Transients.PackLong(args(0).ref, args(1).ref))
+    }
+    MethodDef(flags, name, originalName, args, resultType, Some(newBody))(
+        optimizerHints, version)(pos)
+  }
+}

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/SJSGen.scala
@@ -186,6 +186,21 @@ private[emitter] final class SJSGen(
     else Nil
   }
 
+  def genResHi()(
+      implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
+      pos: Position): Tree = {
+    BracketSelect(globalVar(VarField.resHi, CoreVar), IntLiteral(0))
+  }
+
+  def isResHi(tree: Tree)(
+      implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
+      pos: Position): Boolean = {
+    tree match {
+      case BracketSelect(qual, IntLiteral(0)) => qual == globalVar(VarField.resHi, CoreVar)
+      case _                                  => false
+    }
+  }
+
   def genZeroOf(tpe: Type)(
       implicit moduleContext: ModuleContext, globalKnowledge: GlobalKnowledge,
       pos: Position): Tree = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
@@ -21,6 +21,47 @@ import org.scalajs.ir.Types._
 
 object Transients {
 
+  /** Packs a `long` value from its `lo` and `hi` words. */
+  final case class PackLong(lo: Tree, hi: Tree) extends Transient.Value {
+    val tpe = LongType
+
+    def traverse(traverser: Traverser): Unit = {
+      traverser.traverse(lo)
+      traverser.traverse(hi)
+    }
+
+    def transform(transformer: Transformer)(implicit pos: Position): Tree =
+      Transient(PackLong(transformer.transform(lo), transformer.transform(hi)))
+
+    def printIR(out: IRTreePrinter): Unit = {
+      out.print("<packLong>(")
+      out.print(lo)
+      out.print(", ")
+      out.print(hi)
+      out.print(")")
+    }
+  }
+
+  /** Extracts the `hi` word of a `long` value.
+   *
+   *  To extract the `lo` word, use a `UnaryOp.LongToInt`.
+   */
+  final case class ExtractLongHi(value: Tree) extends Transient.Value {
+    val tpe = IntType
+
+    def traverse(traverser: Traverser): Unit =
+      traverser.traverse(value)
+
+    def transform(transformer: Transformer)(implicit pos: Position): Tree =
+      Transient(ExtractLongHi(transformer.transform(value)))
+
+    def printIR(out: IRTreePrinter): Unit = {
+      out.print("<hi>(")
+      out.print(value)
+      out.print(")")
+    }
+  }
+
   /** Casts `expr` to the given `tpe`, without any check.
    *
    *  This operation is only valid if we know that `expr` is indeed a value of

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/TreeDSL.scala
@@ -57,6 +57,8 @@ private[emitter] object TreeDSL {
 
     def +(that: Tree)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.+, self, that)
+    def +(that: Int)(implicit pos: Position): Tree =
+      BinaryOp(ir.Trees.JSBinaryOp.+, self, IntLiteral(that))
     def -(that: Tree)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.-, self, that)
     def *(that: Tree)(implicit pos: Position): Tree =
@@ -77,6 +79,8 @@ private[emitter] object TreeDSL {
 
     def <<(that: Tree)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.<<, self, that)
+    def <<(that: Int)(implicit pos: Position): Tree =
+      BinaryOp(ir.Trees.JSBinaryOp.<<, self, IntLiteral(that))
     def >>(that: Tree)(implicit pos: Position): Tree =
       BinaryOp(ir.Trees.JSBinaryOp.>>, self, that)
     def >>>(that: Tree)(implicit pos: Position): Tree =

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/VarField.scala
@@ -58,6 +58,9 @@ private[emitter] object VarField {
   /** Static fields. */
   final val t = mk("$t")
 
+  /** Static fields, hi word of a long. */
+  final val thi = mk("$thi")
+
   /** Scala module accessor. */
   final val m = mk("$m")
 
@@ -123,11 +126,17 @@ private[emitter] object VarField {
   /** Local field for class captures. */
   final val cc = mk("$cc")
 
+  /** Local field for the hi word of a long class capture. */
+  final val cchi = mk("$cchi")
+
   /** Local field for super class. */
   final val superClass = mk("$superClass")
 
   /** Local field for this replacement. */
   final val thiz = mk("$thiz")
+
+  /** Local field for the hi word of a this replacement. */
+  final val thizhi = mk("$thizhi")
 
   /** Local field for dynamic imports. */
   final val module = mk("$module")
@@ -143,8 +152,11 @@ private[emitter] object VarField {
   /** The TypeData class. */
   final val TypeData = mk("$TypeData")
 
-  /** Long zero. */
-  final val L0 = mk("$L0")
+  /** Hi word of a long result. */
+  final val resHi = mk("$resHi")
+
+  /** Setter for resHi (for ES Modules). */
+  final val setResHi = mk("$setResHi")
 
   /** DataView for floating point bit manipulation. */
   final val fpBitsDataView = mk("$fpBitsDataView")
@@ -166,6 +178,17 @@ private[emitter] object VarField {
   final val charToString = mk("$cToS")
 
   final val charAt = mk("$charAt")
+
+  // Long
+
+  /** The Long class. */
+  final val Long = mk("$Long")
+
+  /** Box long. */
+  final val bL = mk("$bL")
+
+  /** Boxed Long zero. */
+  final val bL0 = mk("$bL0")
 
   // Object helpers
 

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/ClassDefChecker.scala
@@ -24,6 +24,7 @@ import org.scalajs.ir.WellKnownNames._
 
 import org.scalajs.logging._
 
+import org.scalajs.linker.backend.emitter.Transients
 import org.scalajs.linker.checker.ErrorReporter._
 import org.scalajs.linker.standard.LinkedClass
 
@@ -1049,6 +1050,14 @@ private final class ClassDefChecker(classDef: ClassDef,
 
       case CreateJSClass(className, captureValues) =>
         checkTrees(captureValues, env)
+
+      /* Since PackLong is introduced at load time into the IR of RuntimeLong,
+       * we have to unconditionally allow it. We trust users not to use it on
+       * their own.
+       */
+      case Transient(Transients.PackLong(lo, hi)) =>
+        checkTree(lo, env)
+        checkTree(hi, env)
 
       case Transient(transient) =>
         if (!featureSet.supports(FeatureSet.OptimizedTransients))

--- a/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/checker/IRChecker.scala
@@ -24,6 +24,7 @@ import org.scalajs.ir.WellKnownNames._
 
 import org.scalajs.logging._
 
+import org.scalajs.linker.backend.emitter.Transients
 import org.scalajs.linker.frontend.{LinkingUnit, LinkTimeEvaluator, LinkTimeProperties}
 import org.scalajs.linker.standard.LinkedClass
 import org.scalajs.linker.checker.ErrorReporter._
@@ -776,6 +777,14 @@ private final class IRChecker(linkTimeProperties: LinkTimeProperties,
           for ((ParamDef(_, _, ctpe, _), value) <- captureParams.zip(captureValues))
             typecheckExpect(value, env, ctpe)
         }
+
+      /* Since PackLong is introduced at load time into the IR of RuntimeLong,
+       * we have to unconditionally allow it. We trust users not to use it on
+       * their own.
+       */
+      case Transient(Transients.PackLong(lo, hi)) =>
+        typecheckExpect(lo, env, IntType)
+        typecheckExpect(hi, env, IntType)
 
       case Transient(transient) if featureSet.supports(FeatureSet.OptimizedTransients) =>
         // No precise rules, but at least check that its children type-check on their own

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/Refiner.scala
@@ -38,16 +38,6 @@ final class Refiner(config: CommonPhaseConfig, checkIR: Boolean) {
     new Analyzer(config, initial = false, checkIRFor, failOnError = true, irLoader)
   }
 
-  /* TODO: Remove this and replace with `checkIR` once the optimizer generates
-   * well-typed IR with runtime longs.
-   */
-  private val shouldRunIRChecker = {
-    val optimizerUsesRuntimeLong =
-      !config.coreSpec.esFeatures.allowBigIntsForLongs &&
-      !config.coreSpec.targetIsWebAssembly
-    checkIR && !optimizerUsesRuntimeLong
-  }
-
   def refine(classDefs: Seq[(ClassDef, Version)],
       moduleInitializers: List[ModuleInitializer],
       symbolRequirements: SymbolRequirement, logger: Logger)(
@@ -81,7 +71,7 @@ final class Refiner(config: CommonPhaseConfig, checkIR: Boolean) {
             linkedTopLevelExports.flatten.toList, moduleInitializers, globalInfo)
       }
 
-      if (shouldRunIRChecker) {
+      if (checkIR) {
         logger.time("Refiner: Check IR") {
           val errorCount = IRChecker.check(linkTimeProperties, result, logger,
               CheckingPhase.Optimizer)

--- a/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/EmitterTest.scala
@@ -178,7 +178,7 @@ class EmitterTest {
       val Seq(classCacheReused2, classCacheInvalidated2) =
         lines2.assertContainsMatch(EmitterClassTreeCacheStatsMessage).map(_.toInt)
 
-      // At the time of writing this test, classCacheInvalidated1 reports 47
+      // As of the latest update to this test, classCacheInvalidated1 reports 46
       assertTrue(
           s"Not enough invalidated class caches (got $classCacheInvalidated1); extraction must have gone wrong",
           classCacheInvalidated1 > 40)
@@ -196,10 +196,10 @@ class EmitterTest {
       val Seq(methodCacheReused2, methodCacheInvalidated2) =
         lines2.assertContainsMatch(EmitterMethodTreeCacheStatsMessage).map(_.toInt)
 
-      // At the time of writing this test, methodCacheInvalidated1 reports 107
+      // As of the latest update to this test, methodCacheInvalidated1 reports 100
       assertTrue(
           s"Not enough invalidated method caches (got $methodCacheInvalidated1); extraction must have gone wrong",
-          methodCacheInvalidated1 > 100)
+          methodCacheInvalidated1 > 95)
 
       assertEquals("First run must not reuse any method cache", 0, methodCacheReused1)
 
@@ -214,10 +214,10 @@ class EmitterTest {
       val Seq(prePrints2) =
         lines2.assertContainsMatch(EmitterPrePrintsStatsMessage).map(_.toInt)
 
-      // At the time of writing this test, prePrints1 reports 188
+      // As of the latest update to this test, prePrints1 reports 176
       assertTrue(
           s"Not enough pre prints (got $prePrints1); extraction must have gone wrong",
-          prePrints1 > 180)
+          prePrints1 > 170)
 
       assertEquals("Second run may not have pre prints", 0, prePrints2)
     }

--- a/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/LibrarySizeTest.scala
@@ -70,9 +70,9 @@ class LibrarySizeTest {
     )
 
     testLinkedSizes(
-      expectedFastLinkSize = 147395,
-      expectedFullLinkSizeWithoutClosure = 87201,
-      expectedFullLinkSizeWithClosure = 20680,
+      expectedFastLinkSize = 142541,
+      expectedFullLinkSizeWithoutClosure = 87181,
+      expectedFullLinkSizeWithClosure = 19936,
       classDefs,
       moduleInitializers = MainTestModuleInitializers
     )

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.20/run/t6827.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.12.20/run/t6827.check
@@ -1,0 +1,15 @@
+start at -5: java.lang.ArrayIndexOutOfBoundsException: -5
+start at -1: java.lang.ArrayIndexOutOfBoundsException: -1
+start at limit: ok
+start at limit-1: ok
+first 10: ok
+read all: ok
+test huge len: ok
+5 from 5: ok
+20 from 5: ok
+test len overflow: ok
+start beyond limit: ok
+read 0: ok
+read -1: ok
+invalid read 0: ok
+invalid read -1: ok

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.16/BlacklistedTests.txt
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.16/BlacklistedTests.txt
@@ -94,6 +94,7 @@ run/predef-cycle.scala
 run/synchronized.scala
 run/sd409.scala
 run/t12572.scala
+run/t12918.scala
 run/deadlock.scala
 
 # Uses java.security

--- a/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.16/run/t6827.check
+++ b/partest-suite/src/test/resources/scala/tools/partest/scalajs/2.13.16/run/t6827.check
@@ -1,0 +1,15 @@
+start at -5: java.lang.ArrayIndexOutOfBoundsException: -5
+start at -1: java.lang.ArrayIndexOutOfBoundsException: -1
+start at limit: ok
+start at limit-1: ok
+first 10: ok
+read all: ok
+test huge len: ok
+5 from 5: ok
+20 from 5: ok
+test len overflow: ok
+start beyond limit: ok
+read 0: ok
+read -1: ok
+invalid read 0: ok
+invalid read -1: ok

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2080,7 +2080,7 @@ object Build {
             } else {
               Some(ExpectedSizes(
                   fastLink = 424000 to 425000,
-                  fullLink = 282000 to 283000,
+                  fullLink = 283000 to 284000,
                   fastLinkGz = 61000 to 62000,
                   fullLinkGz = 44000 to 45000,
               ))
@@ -2097,7 +2097,7 @@ object Build {
             } else {
               Some(ExpectedSizes(
                   fastLink = 300000 to 301000,
-                  fullLink = 259000 to 260000,
+                  fullLink = 260000 to 261000,
                   fastLinkGz = 47000 to 48000,
                   fullLinkGz = 43000 to 44000,
               ))

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1330,7 +1330,7 @@ object Build {
       commonLinkerSettings,
 
       libraryDependencies ++= Seq(
-          "com.google.javascript" % "closure-compiler" % "v20220202",
+          "com.google.javascript" % "closure-compiler" % "v20240317",
           "com.google.jimfs" % "jimfs" % "1.1" % "test",
           "org.scala-js" %% "scalajs-env-nodejs" % "1.4.0" % "test",
           "org.scala-js" %% "scalajs-js-envs-test-kit" % "1.4.0" % "test"
@@ -2566,9 +2566,6 @@ object Build {
       testSuiteExCommonSettings(isJSTest = true),
       name := "Scala.js test suite ex",
       publishArtifact in Compile := false,
-
-      // FIXME Closure breaks the new Longs in this project
-      Test/fullLinkJS/scalaJSLinkerConfig ~= { _.withClosureCompiler(false) },
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
       javalibExtDummies, jUnitRuntime, testBridge % "test", testSuite
   )
@@ -2762,9 +2759,6 @@ object Build {
       NoIDEExport.noIDEExportSettings,
 
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s"),
-
-      // FIXME Closure breaks the new Longs in this project
-      Test/fullLinkJS/scalaJSLinkerConfig ~= { _.withClosureCompiler(false) },
   ).zippedSettings(partest)(partest =>
       unmanagedSources in Compile ++= {
         val scalaV = scalaVersion.value

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1232,7 +1232,18 @@ object Build {
       name := "Scala.js linker private library",
       publishArtifact in Compile := false,
       delambdafySetting,
-      cleanIRSettings
+      cleanIRSettings,
+
+      /* Remove the Compile config artifact from the full test classpath,
+       * so that only the (patched) injected IR files are taken into account.
+       */
+      Test / fullClasspath := {
+        val prev = (Test / fullClasspath).value
+        prev.filterNot { f =>
+          val path = f.data.getPath()
+          path.contains("linker-private-library") && !path.contains("test-classes")
+        }
+      },
   ).withScalaJSCompiler2_12.withScalaJSJUnitPlugin2_12.dependsOnLibrary2_12.dependsOn(
       jUnitRuntime.v2_12 % "test", testBridge.v2_12 % "test",
   )
@@ -1336,7 +1347,8 @@ object Build {
         val privateLibProducts = (products in (linkerPrivateLibrary, Compile)).value
 
         // Copy all *.sjsir files to resourceDir.
-        val mappings = (privateLibProducts ** "*.sjsir").pair(Path.flat(resourceDir))
+        val mappings = (privateLibProducts ** "*.sjsir")
+          .pair(file => Some(new File(resourceDir, file.getName + "p"))) // "p" for "private"
         Sync.sync(s.cacheStoreFactory.make("linker-library"))(mappings)
 
         mappings.unzip._2
@@ -2060,34 +2072,34 @@ object Build {
           case `default212Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 623000 to 624000,
+                  fastLink = 618000 to 619000,
                   fullLink = 94000 to 95000,
                   fastLinkGz = 75000 to 79000,
                   fullLinkGz = 24000 to 25000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 425000 to 426000,
+                  fastLink = 424000 to 425000,
                   fullLink = 282000 to 283000,
-                  fastLinkGz = 60000 to 61000,
-                  fullLinkGz = 43000 to 44000,
+                  fastLinkGz = 61000 to 62000,
+                  fullLinkGz = 44000 to 45000,
               ))
             }
 
           case `default213Version` =>
             if (!useMinifySizes) {
               Some(ExpectedSizes(
-                  fastLink = 442000 to 443000,
+                  fastLink = 436000 to 437000,
                   fullLink = 90000 to 91000,
                   fastLinkGz = 57000 to 58000,
                   fullLinkGz = 24000 to 25000,
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 301000 to 302000,
-                  fullLink = 258000 to 259000,
+                  fastLink = 300000 to 301000,
+                  fullLink = 259000 to 260000,
                   fastLinkGz = 47000 to 48000,
-                  fullLinkGz = 42000 to 43000,
+                  fullLinkGz = 43000 to 44000,
               ))
             }
 
@@ -2554,6 +2566,9 @@ object Build {
       testSuiteExCommonSettings(isJSTest = true),
       name := "Scala.js test suite ex",
       publishArtifact in Compile := false,
+
+      // FIXME Closure breaks the new Longs in this project
+      Test/fullLinkJS/scalaJSLinkerConfig ~= { _.withClosureCompiler(false) },
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
       javalibExtDummies, jUnitRuntime, testBridge % "test", testSuite
   )
@@ -2747,6 +2762,9 @@ object Build {
       NoIDEExport.noIDEExportSettings,
 
       testOptions += Tests.Argument(TestFrameworks.JUnit, "-a", "-s"),
+
+      // FIXME Closure breaks the new Longs in this project
+      Test/fullLinkJS/scalaJSLinkerConfig ~= { _.withClosureCompiler(false) },
   ).zippedSettings(partest)(partest =>
       unmanagedSources in Compile ++= {
         val scalaV = scalaVersion.value


### PR DESCRIPTION
Mostly to test that upgrading GCC actually fixes the issue and doesn't break anything else.

The requirement on JDK 17+ makes this a bit of a non-starter at this point. However, since Scala 3 is about to drop support under JDK 17, we might have a chance to do this in the coming ~year.