### PR TITLE
Wasm: Put JS import(...) calls in custom JS helpers.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/CoreWasmLib.scala
@@ -385,7 +385,6 @@ final class CoreWasmLib(coreSpec: CoreSpec, globalInfo: LinkedGlobalInfo) {
     addHelperImport(genFunctionID.jsSelect, List(anyref, anyref), List(anyref))
     addHelperImport(genFunctionID.jsSelectSet, List(anyref, anyref, anyref), Nil)
     addHelperImport(genFunctionID.jsNewNoArg, List(anyref), List(anyref))
-    addHelperImport(genFunctionID.jsImportCall, List(anyref), List(anyref))
     addHelperImport(genFunctionID.jsImportMeta, Nil, List(anyref))
     addHelperImport(genFunctionID.jsAwait, List(anyref), List(anyref))
     addHelperImport(genFunctionID.jsDelete, List(anyref, anyref), Nil)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -2800,10 +2800,18 @@ private class FunctionEmitter private (
   private def genJSImportCall(tree: JSImportCall): Type = {
     val JSImportCall(arg) = tree
 
-    genTree(arg, AnyType)
-    markPosition(tree)
-    fb += wa.Call(genFunctionID.jsImportCall)
-    AnyType
+    implicit val pos = tree.pos
+
+    /* Generate one custom helper for every import(...) call.
+     * This is particularly useful when
+     * - the argument is a constant string, and
+     * - the output of Scala.js is given to a bundler that really wants to see
+     *    constant strings in import(...) calls.
+     */
+    genThroughCustomJSHelper(List(arg)) { allJSArgs =>
+      val List(jsArg) = allJSArgs
+      js.Return(js.ImportCall(jsArg))
+    }
   }
 
   private def genJSImportMeta(tree: JSImportMeta): Type = {

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/LoaderContent.scala
@@ -151,7 +151,6 @@ const scalaJSHelpers = {
   jsSelect: (o, p) => o[p],
   jsSelectSet: (o, p, v) => o[p] = v,
   jsNewNoArg: (constr) => new constr(),
-  jsImportCall: (s) => import(s),
   jsImportMeta: () => import.meta,
   jsAwait: (WebAssembly.Suspending ? new WebAssembly.Suspending((x) => x) : ((x) => {
     /* This should not happen. We cannot get here without going through a

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/VarGen.scala
@@ -148,7 +148,6 @@ object VarGen {
     case object jsSelect extends JSHelperFunctionID
     case object jsSelectSet extends JSHelperFunctionID
     case object jsNewNoArg extends JSHelperFunctionID
-    case object jsImportCall extends JSHelperFunctionID
     case object jsImportMeta extends JSHelperFunctionID
     case object jsAwait extends JSHelperFunctionID
     case object jsDelete extends JSHelperFunctionID

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2278,7 +2278,7 @@ object Build {
         includeIf(testDir / "require-multi-modules",
             hasModules && !linkerConfig.closureCompiler && !isWebAssembly) :::
         includeIf(testDir / "require-dynamic-import",
-            moduleKind == ModuleKind.ESModule && !isWebAssembly) ::: // this is an approximation that works for now
+            moduleKind == ModuleKind.ESModule) :::
         includeIf(testDir / "require-esmodule",
             moduleKind == ModuleKind.ESModule) :::
         includeIf(testDir / "require-commonjs",


### PR DESCRIPTION
This is particularly useful when a) the argument is a constant string and b) the output of Scala.js is given to a bundler that really wants to see constant strings in `import(...)` calls.