### PR TITLE
Remove useless imports of `scala.scalajs.js` in the javalib.

### DIFF
--- a/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
+++ b/javalib/src/main/scala/java/io/ByteArrayOutputStream.scala
@@ -12,8 +12,6 @@
 
 package java.io
 
-import scala.scalajs.js
-
 import scala.annotation.tailrec
 
 class ByteArrayOutputStream(initBufSize: Int) extends OutputStream {

--- a/javalib/src/main/scala/java/io/DataInputStream.scala
+++ b/javalib/src/main/scala/java/io/DataInputStream.scala
@@ -12,8 +12,6 @@
 
 package java.io
 
-import scala.scalajs.js.typedarray._
-
 class DataInputStream(in: InputStream) extends FilterInputStream(in)
                                           with DataInput {
 

--- a/javalib/src/main/scala/java/lang/Boolean.scala
+++ b/javalib/src/main/scala/java/lang/Boolean.scala
@@ -14,8 +14,6 @@ package java.lang
 
 import java.lang.constant.Constable
 
-import scala.scalajs.js
-
 /* This is a hijacked class. Its instances are primitive booleans.
  * Constructors are not emitted.
  */

--- a/javalib/src/main/scala/java/lang/Byte.scala
+++ b/javalib/src/main/scala/java/lang/Byte.scala
@@ -14,8 +14,6 @@ package java.lang
 
 import java.lang.constant.Constable
 
-import scala.scalajs.js
-
 /* This is a hijacked class. Its instances are primitive numbers.
  * Constructors are not emitted.
  */

--- a/javalib/src/main/scala/java/lang/ClassLoader.scala
+++ b/javalib/src/main/scala/java/lang/ClassLoader.scala
@@ -12,8 +12,6 @@
 
 package java.lang
 
-import scala.scalajs.js
-
 class ClassLoader protected (parent: ClassLoader) {
   def this() = this(null)
 }

--- a/javalib/src/main/scala/java/lang/Long.scala
+++ b/javalib/src/main/scala/java/lang/Long.scala
@@ -274,8 +274,6 @@ object Long {
     parseUnsignedLong(s, 10)
 
   def parseUnsignedLongInternal(s: String, radix: Int, start: Int): scala.Long = {
-    import js.JSStringOps._
-
     val length = s.length
 
     if (start >= length || radix < Character.MIN_RADIX ||

--- a/javalib/src/main/scala/java/lang/Number.scala
+++ b/javalib/src/main/scala/java/lang/Number.scala
@@ -12,8 +12,6 @@
 
 package java.lang
 
-import scala.scalajs.js
-
 abstract class Number extends Object with java.io.Serializable {
   def byteValue(): scala.Byte = intValue().toByte
   def shortValue(): scala.Short = intValue().toShort

--- a/javalib/src/main/scala/java/lang/Runtime.scala
+++ b/javalib/src/main/scala/java/lang/Runtime.scala
@@ -12,8 +12,6 @@
 
 package java.lang
 
-import scala.scalajs.js
-
 class Runtime private {
   //def exit(status: Int): Unit
   //def addShutdownHook(hook: Thread): Unit

--- a/javalib/src/main/scala/java/lang/StackTraceElement.scala
+++ b/javalib/src/main/scala/java/lang/StackTraceElement.scala
@@ -12,9 +12,6 @@
 
 package java.lang
 
-import scala.scalajs.js
-import js.annotation.JSExport
-
 /* The primary constructor, taking a `columnNumber`, is not part of the JDK
  * API. It is used internally in `java.lang.StackTrace`, and could be accessed
  * by third-party libraries with a bit of IR manipulation.

--- a/javalib/src/main/scala/java/lang/Throwables.scala
+++ b/javalib/src/main/scala/java/lang/Throwables.scala
@@ -14,7 +14,6 @@ package java.lang
 
 import java.util.function._
 
-import scala.scalajs.js
 import scala.scalajs.js.annotation.JSExport
 
 class Throwable protected (s: String, private var e: Throwable,

--- a/javalib/src/main/scala/java/lang/reflect/Array.scala
+++ b/javalib/src/main/scala/java/lang/reflect/Array.scala
@@ -12,10 +12,6 @@
 
 package java.lang.reflect
 
-import scala.scalajs.js
-
-import java.lang.Class
-
 object Array {
   @inline
   def newInstance(componentType: Class[_], length: Int): AnyRef =

--- a/javalib/src/main/scala/java/net/URLDecoder.scala
+++ b/javalib/src/main/scala/java/net/URLDecoder.scala
@@ -12,8 +12,6 @@
 
 package java.net
 
-import scala.scalajs.js
-
 import java.io.UnsupportedEncodingException
 import java.nio.{CharBuffer, ByteBuffer}
 import java.nio.charset.{Charset, CharsetDecoder}

--- a/javalib/src/main/scala/java/util/ArrayList.scala
+++ b/javalib/src/main/scala/java/util/ArrayList.scala
@@ -16,7 +16,7 @@ import java.lang.Cloneable
 import java.lang.Utils._
 import java.util.ScalaOps._
 
-import scala.scalajs._
+import scala.scalajs.js
 import scala.scalajs.LinkingInfo.isWebAssembly
 
 class ArrayList[E] private (innerInit: AnyRef, private var _size: Int)

--- a/javalib/src/main/scala/java/util/Properties.scala
+++ b/javalib/src/main/scala/java/util/Properties.scala
@@ -21,8 +21,6 @@ import java.io._
 import java.nio.charset.StandardCharsets
 import java.util.function._
 
-import scala.scalajs.js
-
 import ScalaOps._
 
 class Properties(protected val defaults: Properties)

--- a/javalib/src/main/scala/java/util/UUID.scala
+++ b/javalib/src/main/scala/java/util/UUID.scala
@@ -12,8 +12,6 @@
 
 package java.util
 
-import scala.scalajs.js
-
 final class UUID private (
     private val i1: Int, private val i2: Int,
     private val i3: Int, private val i4: Int)

--- a/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
+++ b/javalib/src/main/scala/java/util/concurrent/CopyOnWriteArrayList.scala
@@ -24,8 +24,7 @@ import scala.annotation.tailrec
 
 import ScalaOps._
 
-import scala.scalajs._
-import scala.scalajs.LinkingInfo._
+import scala.scalajs.LinkingInfo
 
 class CopyOnWriteArrayList[E <: AnyRef] private (initialCapacity: Int)
     extends List[E] with RandomAccess with Cloneable with Serializable {

--- a/javalib/src/main/scala/java/util/regex/PatternSyntaxException.scala
+++ b/javalib/src/main/scala/java/util/regex/PatternSyntaxException.scala
@@ -12,9 +12,6 @@
 
 package java.util.regex
 
-import scala.scalajs.js
-import scala.scalajs.LinkingInfo
-
 class PatternSyntaxException(desc: String, regex: String, index: Int)
     extends IllegalArgumentException {
 


### PR DESCRIPTION
This is mostly to have a clearer view of where the javalib still relies on JS things.