### PR TITLE
Wasm: Opt: Fuse casts into custom JS helpers.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/Transients.scala
@@ -23,6 +23,8 @@ object Transients {
 
   /** Casts `expr` to the given `tpe`, without any check.
    *
+   *  `expr.tpe` and `tpe` must be subtypes of `AnyType`.
+   *
    *  This operation is only valid if we know that `expr` is indeed a value of
    *  the given `tpe`.
    *

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/FunctionEmitter.scala
@@ -563,9 +563,42 @@ private class FunctionEmitter private (
   def genTreeToAny(tree: Tree): Unit =
     genTree(tree, if (tree.tpe.isNullable) AnyType else AnyNotNullType)
 
-  def genTree(tree: Tree, expectedType: Type): Unit = {
+  /** Main codegen: evaluate the given `tree` and leave its result on the stack.
+   *
+   *  The Wasm type of the value left on the stack corresponds to `expectedType`.
+   *  In other words, it is `transformResultType(expectedType)` or a Wasm
+   *  subtype thereof.
+   *
+   *  If `allowCast` is `false` (the default), then `tree.tpe <: expectedType`
+   *  must be true. `genTree` will then only generate a possible *upcasting*
+   *  adaptation (through `genAdapt`), but will not downcast. `genTree` does
+   *  not actually check this invariant; it assumes it holds. If it does not,
+   *  we may generate invalid Wasm code, which will only be caught during
+   *  validation of the Wasm module (at run-time).
+   *
+   *  If `allowCast` if `true`, then `tree.tpe` and `expectedType` need not be
+   *  related. `genTree` will cast the result to match `expectedType`. If
+   *  possible, it pushes the cast inside the expected result type of custom JS
+   *  helpers (look for `ensureCastableThroughJSWasmBoundary` for more details).
+   *  Otherwise, it generates a downcast with `genActualCast`. This produces
+   *  correct code for any pair of `(tree.tpe, expectedType)`; however, it does
+   *  not produce efficient code when `tree.tpe <: expectedType` is indeed true.
+   *  That does not happen in practice, because the optimizer does not produce
+   *  `Cast` nodes where the target type is a supertype of the tree's type.
+   */
+  def genTree(tree: Tree, expectedType: Type, allowCast: Boolean = false): Unit = {
+    /* Note that while `VoidType` is not a valid target type for a `Cast`
+     * transient, it *is* a valid value for the `castTo` parameter of
+     * `genJS*` methods. Therefore, we can always use the `expectedType` as
+     * argument for `castTo`.
+     */
+
+    def expectedTypeNoCast: Type =
+      if (allowCast) tree.tpe
+      else expectedType
+
     val generatedType: Type = tree match {
-      case t: Literal             => genLiteral(t, expectedType)
+      case t: Literal             => genLiteral(t, expectedTypeNoCast)
       case t: UnaryOp             => genUnaryOp(t)
       case t: BinaryOp            => genBinaryOp(t)
       case t: VarRef              => genVarRef(t)
@@ -578,41 +611,41 @@ private class FunctionEmitter private (
       case t: ApplyTypedClosure   => genApplyTypedClosure(t)
       case t: IsInstanceOf        => genIsInstanceOf(t)
       case t: AsInstanceOf        => genAsInstanceOf(t)
-      case t: Block               => genBlock(t, expectedType)
-      case t: Labeled             => unwinding.genLabeled(t, expectedType)
+      case t: Block               => genBlock(t, expectedTypeNoCast)
+      case t: Labeled             => unwinding.genLabeled(t, expectedTypeNoCast)
       case t: Return              => unwinding.genReturn(t)
       case t: Select              => genSelect(t)
       case t: SelectStatic        => genSelectStatic(t)
       case t: Assign              => genAssign(t)
       case t: VarDef              => genVarDef(t)
       case t: New                 => genNew(t)
-      case t: If                  => genIf(t, expectedType)
+      case t: If                  => genIf(t, expectedTypeNoCast)
       case t: While               => genWhile(t)
       case t: ForIn               => genForIn(t)
-      case t: TryCatch            => genTryCatch(t, expectedType)
-      case t: TryFinally          => unwinding.genTryFinally(t, expectedType)
-      case t: Match               => genMatch(t, expectedType)
+      case t: TryCatch            => genTryCatch(t, expectedTypeNoCast)
+      case t: TryFinally          => unwinding.genTryFinally(t, expectedTypeNoCast)
+      case t: Match               => genMatch(t, expectedTypeNoCast)
       case t: JSAwait             => genJSAwait(t)
       case t: Debugger            => VoidType // ignore
       case t: Skip                => VoidType
 
       // JavaScript expressions
       case t: JSNew                => genJSNew(t)
-      case t: JSSelect             => genJSSelect(t)
-      case t: JSFunctionApply      => genJSFunctionApply(t)
-      case t: JSMethodApply        => genJSMethodApply(t)
+      case t: JSSelect             => genJSSelect(t, castTo = expectedType)
+      case t: JSFunctionApply      => genJSFunctionApply(t, castTo = expectedType)
+      case t: JSMethodApply        => genJSMethodApply(t, castTo = expectedType)
       case t: JSImportCall         => genJSImportCall(t)
       case t: JSImportMeta         => genJSImportMeta(t)
       case t: LoadJSConstructor    => genLoadJSConstructor(t)
       case t: LoadJSModule         => genLoadJSModule(t)
-      case t: SelectJSNativeMember => genSelectJSNativeMember(t)
+      case t: SelectJSNativeMember => genSelectJSNativeMember(t, castTo = expectedType)
       case t: JSDelete             => genJSDelete(t)
-      case t: JSUnaryOp            => genJSUnaryOp(t)
-      case t: JSBinaryOp           => genJSBinaryOp(t)
+      case t: JSUnaryOp            => genJSUnaryOp(t, castTo = expectedType)
+      case t: JSBinaryOp           => genJSBinaryOp(t, castTo = expectedType)
       case t: JSArrayConstr        => genJSArrayConstr(t)
       case t: JSObjectConstr       => genJSObjectConstr(t)
-      case t: JSGlobalRef          => genJSGlobalRef(t)
-      case t: JSTypeOfGlobalRef    => genJSTypeOfGlobalRef(t)
+      case t: JSGlobalRef          => genJSGlobalRef(t, castTo = expectedType)
+      case t: JSTypeOfGlobalRef    => genJSTypeOfGlobalRef(t, castTo = expectedType)
       case t: Closure              => genClosure(t)
 
       // array
@@ -624,7 +657,7 @@ private class FunctionEmitter private (
       case t: CreateJSClass     => genCreateJSClass(t)
       case t: JSPrivateSelect   => genJSPrivateSelect(t)
       case t: JSSuperSelect     => genJSSuperSelect(t)
-      case t: JSSuperMethodCall => genJSSuperMethodCall(t)
+      case t: JSSuperMethodCall => genJSSuperMethodCall(t, castTo = expectedType)
       case t: JSNewTarget       => genJSNewTarget(t)
 
       // Records (only generated by the optimizer)
@@ -639,7 +672,12 @@ private class FunctionEmitter private (
         throw new AssertionError(s"Invalid tree: $tree")
     }
 
-    genAdapt(generatedType, expectedType)
+    if (generatedType != expectedType) {
+      if (allowCast)
+        genActualCast(generatedType, expectedType)
+      else
+        genAdapt(generatedType, expectedType)
+    }
   }
 
   private def genAdapt(generatedType: Type, expectedType: Type): Unit = {
@@ -2375,19 +2413,20 @@ private class FunctionEmitter private (
   }
 
   private def genCast(expr: Tree, targetTpe: Type, pos: Position): Type = {
-    val sourceTpe = expr.tpe
+    genTree(expr, expectedType = targetTpe, allowCast = true)
+    targetTpe
+  }
 
+  /** Gen a cast of the value of type `sourceTpe` on the stack to the type `targetTpe`. */
+  private def genActualCast(sourceTpe: Type, targetTpe: Type): Unit = {
     /* We cannot call `transformSingleType` for NothingType, so we have to
      * handle these cases separately.
      */
 
     if (sourceTpe == NothingType) {
-      genTree(expr, NothingType)
-      NothingType
+      ()
     } else if (targetTpe == NothingType) {
-      genTree(expr, VoidType)
       fb += wa.Unreachable
-      NothingType
     } else {
       /* At this point, neither sourceTpe nor targetTpe can be NothingType,
        * VoidType or RecordType, so we can use `transformSingleType`.
@@ -2404,7 +2443,7 @@ private class FunctionEmitter private (
            * rules, there is no pair `(sourceTpe, targetTpe)` for which the Wasm
            * types are equal but a valid cast would require a *conversion*.
            */
-          genTreeAuto(expr)
+          ()
 
         case (watpe.RefType(true, sourceHeapType), watpe.RefType(false, targetHeapType))
             if sourceHeapType == targetHeapType =>
@@ -2412,14 +2451,10 @@ private class FunctionEmitter private (
            * Cast is a common case for checkNotNull's inserted by the optimizer
            * when null pointers are unchecked.
            */
-          genTreeAuto(expr)
-          markPosition(pos)
           fb += wa.RefAsNonNull
 
         case _ =>
-          genTree(expr, AnyType)
-
-          markPosition(pos)
+          genAdapt(sourceTpe, AnyType)
 
           targetTpe match {
             case targetTpe: PrimType =>
@@ -2442,8 +2477,6 @@ private class FunctionEmitter private (
               }
           }
       }
-
-      targetTpe
     }
   }
 
@@ -2758,40 +2791,40 @@ private class FunctionEmitter private (
 
     implicit val pos = tree.pos
 
-    genThroughCustomJSHelper(ctor :: args) { allJSArgs =>
+    genThroughCustomJSHelper(ctor :: args, AnyType) { allJSArgs =>
       val jsCtor :: jsArgs = allJSArgs
       js.Return(js.New(jsCtor, jsArgs))
     }
   }
 
-  private def genJSSelect(tree: JSSelect): Type = {
+  private def genJSSelect(tree: JSSelect, castTo: Type): Type = {
     val JSSelect(qualifier, item) = tree
 
     implicit val pos = tree.pos
 
-    genThroughCustomJSHelper(List(qualifier, item)) { allJSArgs =>
+    genThroughCustomJSHelper(List(qualifier, item), castTo) { allJSArgs =>
       val List(jsQualifier, jsItem) = allJSArgs
       js.Return(js.BracketSelect.makeOptimized(jsQualifier, jsItem))
     }
   }
 
-  private def genJSFunctionApply(tree: JSFunctionApply): Type = {
+  private def genJSFunctionApply(tree: JSFunctionApply, castTo: Type): Type = {
     val JSFunctionApply(fun, args) = tree
 
     implicit val pos = tree.pos
 
-    genThroughCustomJSHelper(fun :: args) { allJSArgs =>
+    genThroughCustomJSHelper(fun :: args, castTo) { allJSArgs =>
       val jsFun :: jsArgs = allJSArgs
       js.Return(js.Apply.makeProtected(jsFun, jsArgs))
     }
   }
 
-  private def genJSMethodApply(tree: JSMethodApply): Type = {
+  private def genJSMethodApply(tree: JSMethodApply, castTo: Type): Type = {
     val JSMethodApply(receiver, method, args) = tree
 
     implicit val pos = tree.pos
 
-    genThroughCustomJSHelper(receiver :: method :: args) { allJSArgs =>
+    genThroughCustomJSHelper(receiver :: method :: args, castTo) { allJSArgs =>
       val jsReceiver :: jsMethod :: jsArgs = allJSArgs
       js.Return(js.Apply(js.BracketSelect.makeOptimized(jsReceiver, jsMethod), jsArgs))
     }
@@ -2808,7 +2841,7 @@ private class FunctionEmitter private (
      * - the output of Scala.js is given to a bundler that really wants to see
      *    constant strings in import(...) calls.
      */
-    genThroughCustomJSHelper(List(arg)) { allJSArgs =>
+    genThroughCustomJSHelper(List(arg), AnyType) { allJSArgs =>
       val List(jsArg) = allJSArgs
       js.Return(js.ImportCall(jsArg))
     }
@@ -2827,13 +2860,12 @@ private class FunctionEmitter private (
 
     ctx.getClassInfo(className).jsNativeLoadSpec match {
       case Some(loadSpec) =>
-        genLoadJSFromSpec(loadSpec)(tree.pos)
+        genLoadJSFromSpec(loadSpec, castTo = AnyType)(tree.pos)
       case None =>
         // This is a non-native JS class
         fb += wa.Call(genFunctionID.loadJSClass(className))
+        AnyType
     }
-
-    AnyType
   }
 
   private def genLoadJSModule(tree: LoadJSModule): Type = {
@@ -2843,16 +2875,15 @@ private class FunctionEmitter private (
 
     ctx.getClassInfo(className).jsNativeLoadSpec match {
       case Some(loadSpec) =>
-        genLoadJSFromSpec(loadSpec)(tree.pos)
+        genLoadJSFromSpec(loadSpec, castTo = AnyType)(tree.pos)
       case None =>
         // This is a non-native JS module
         fb += wa.Call(genFunctionID.loadModule(className))
+        AnyType
     }
-
-    AnyType
   }
 
-  private def genSelectJSNativeMember(tree: SelectJSNativeMember): Type = {
+  private def genSelectJSNativeMember(tree: SelectJSNativeMember, castTo: Type): Type = {
     val SelectJSNativeMember(className, MethodIdent(memberName)) = tree
 
     val info = ctx.getClassInfo(className)
@@ -2860,14 +2891,13 @@ private class FunctionEmitter private (
       throw new AssertionError(
           s"Found $tree for non-existing JS native member at ${tree.pos}")
     })
-    genLoadJSFromSpec(jsNativeLoadSpec)(tree.pos)
-    AnyType
+    genLoadJSFromSpec(jsNativeLoadSpec, castTo)(tree.pos)
   }
 
-  private def genLoadJSFromSpec(jsNativeLoadSpec: JSNativeLoadSpec)(
-      implicit pos: Position): Unit = {
+  private def genLoadJSFromSpec(jsNativeLoadSpec: JSNativeLoadSpec, castTo: Type)(
+      implicit pos: Position): Type = {
 
-    genThroughCustomJSHelperWithBuilder(AnyType) { builder =>
+    genThroughCustomJSHelperWithBuilder(castTo) { builder =>
       js.Return(builder.genJSNativeLoadSpec(jsNativeLoadSpec))
     }
   }
@@ -2882,12 +2912,12 @@ private class FunctionEmitter private (
     VoidType
   }
 
-  private def genJSUnaryOp(tree: JSUnaryOp): Type = {
+  private def genJSUnaryOp(tree: JSUnaryOp, castTo: Type): Type = {
     val JSUnaryOp(op, lhs) = tree
 
     implicit val pos = tree.pos
 
-    genThroughCustomJSHelper(List(lhs), tree.tpe) { allJSArgs =>
+    genThroughCustomJSHelper(List(lhs), castTo) { allJSArgs =>
       val List(jsLhs) = allJSArgs
 
       val protectedLhs = if (op == JSUnaryOp.typeof && lhs.isInstanceOf[JSGlobalRef]) {
@@ -2901,11 +2931,9 @@ private class FunctionEmitter private (
 
       js.Return(js.UnaryOp(op, protectedLhs))
     }
-
-    tree.tpe
   }
 
-  private def genJSBinaryOp(tree: JSBinaryOp): Type = {
+  private def genJSBinaryOp(tree: JSBinaryOp, castTo: Type): Type = {
     val JSBinaryOp(op, lhs, rhs) = tree
 
     op match {
@@ -2933,17 +2961,16 @@ private class FunctionEmitter private (
             fb += wa.LocalGet(lhsLocal)
           }
         }
+        AnyType
 
       case _ =>
         implicit val pos = tree.pos
 
-        genThroughCustomJSHelper(List(lhs, rhs), tree.tpe) { allJSArgs =>
+        genThroughCustomJSHelper(List(lhs, rhs), castTo) { allJSArgs =>
           val List(jsLhs, jsRhs) = allJSArgs
           js.Return(js.BinaryOp(op, jsLhs, jsRhs))
         }
     }
-
-    tree.tpe
   }
 
   private def genJSArrayConstr(tree: JSArrayConstr): Type = {
@@ -2988,7 +3015,7 @@ private class FunctionEmitter private (
     }
   }
 
-  private def genJSGlobalRef(tree: JSGlobalRef): Type = {
+  private def genJSGlobalRef(tree: JSGlobalRef, castTo: Type): Type = {
     val JSGlobalRef(name) = tree
 
     implicit val pos = tree.pos
@@ -2997,20 +3024,20 @@ private class FunctionEmitter private (
       // In ES modules global this is undefined, and Wasm backend only supports `ESModule`
       markPosition(pos)
       fb += wa.GlobalGet(genGlobalID.undef)
-      AnyType
+      UndefType
     } else {
-      genThroughCustomJSHelperWithBuilder(AnyType) { builder =>
+      genThroughCustomJSHelperWithBuilder(castTo) { builder =>
         js.Return(builder.genGlobalRef(name))
       }
     }
   }
 
-  private def genJSTypeOfGlobalRef(tree: JSTypeOfGlobalRef): Type = {
+  private def genJSTypeOfGlobalRef(tree: JSTypeOfGlobalRef, castTo: Type): Type = {
     val JSTypeOfGlobalRef(JSGlobalRef(name)) = tree
 
     implicit val pos = tree.pos
 
-    genThroughCustomJSHelperWithBuilder(AnyType) { builder =>
+    genThroughCustomJSHelperWithBuilder(castTo) { builder =>
       js.Return(js.UnaryOp(JSUnaryOp.typeof, builder.genGlobalRef(name)))
     }
   }
@@ -3423,12 +3450,12 @@ private class FunctionEmitter private (
     AnyType
   }
 
-  private def genJSSuperMethodCall(tree: JSSuperMethodCall): Type = {
+  private def genJSSuperMethodCall(tree: JSSuperMethodCall, castTo: Type): Type = {
     val JSSuperMethodCall(superClass, receiver, method, args) = tree
 
     implicit val pos = tree.pos
 
-    genThroughCustomJSHelper(superClass :: receiver :: method :: args) { allJSArgs =>
+    genThroughCustomJSHelper(superClass :: receiver :: method :: args, castTo) { allJSArgs =>
       val jsSuperClass :: jsReceiver :: jsMethod :: jsArgs = allJSArgs
 
       // return superClass.prototype[method].call(receiver, ...args);
@@ -3627,18 +3654,22 @@ private class FunctionEmitter private (
    *  @see [[CustomJSHelperBuilder]]
    */
   private def genThroughCustomJSHelper(args: List[TreeOrJSSpread],
-      resultType: Type = AnyType)(
+      resultType: Type)(
       makeJSHelperBody: List[js.Tree] => js.Tree)(
       implicit pos: Position): Type = {
 
+    val boundaryResultType = ensureCastableThroughJSWasmBoundary(resultType)
+
     val builder = new CustomJSHelperBuilderWithTreeSupport()
     val jsArgs = args.map(builder.addInput(_))
-    val helperID = builder.build(resultType) {
+    val helperID = builder.build(boundaryResultType) {
       makeJSHelperBody(jsArgs)
     }
 
     markPosition(pos)
     fb += wa.Call(helperID)
+    if (boundaryResultType != resultType)
+      genActualCast(boundaryResultType, resultType)
 
     resultType
   }
@@ -3648,15 +3679,25 @@ private class FunctionEmitter private (
       makeJSHelperBody: CustomJSHelperBuilder => js.Tree)(
       implicit pos: Position): Type = {
 
+    val boundaryResultType = ensureCastableThroughJSWasmBoundary(resultType)
+
     val builder = new CustomJSHelperBuilder()
-    val helperID = builder.build(resultType) {
+    val helperID = builder.build(boundaryResultType) {
       makeJSHelperBody(builder)
     }
 
     markPosition(pos)
     fb += wa.Call(helperID)
+    if (boundaryResultType != resultType)
+      genActualCast(boundaryResultType, resultType)
 
     resultType
+  }
+
+  /** If `resultType` is castable through the JS-Wasm boundary, itself; otherwise, `AnyType`. */
+  private def ensureCastableThroughJSWasmBoundary(resultType: Type): Type = resultType match {
+    case UndefType | StringType | CharType | LongType | NothingType => AnyType
+    case _                                                          => resultType
   }
 
   private final class CustomJSHelperBuilderWithTreeSupport()(implicit pos: Position)

--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/README.md
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/wasmemitter/README.md
@@ -702,8 +702,9 @@ __scalaJSCustomHelpers: {
 
 and give it the type `[f64] -> [anyref]` at the Wasm level.
 
-So far, we still have to perform the unboxing operation of the result on the Wasm side, as an additional step.
-In the future, we should try to fuse it as well, so that the type of the helper becomes `[f64] -> [f64]`.
+For checked `asInstanceOf`s, we still have to perform the unboxing operation of the result on the Wasm side, as an additional step.
+When `asInstanceOf`s are unchecked (as in `fullLinkJS`), we can go one step further: we also fuse the unboxing operation from `anyref` down to `f64` into the JS-to-Wasm boundary.
+We use the same helper in JS, but we give it the type `[f64] -> [f64]`, which is as good as it gets.
 
 ### Closures
 


### PR DESCRIPTION
When the `expr` of a cast (including unchecked `asInstanceOf`s) is a node implemented with a custom JS helper, we now fuse the unboxing/cast operation into the JS-to-Wasm boundary, when possible.

This removes one round-trip to JS. For example, a call to `js.Math.cos(x)` now results in a single Wasm-to-JS call, where the JS helper has type `[f64] -> [f64]` in Wasm.