### PR TITLE
Fix #5231: Partial revert of "Fail if we cannot inline RuntimeLong".

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/OptimizerCore.scala
@@ -3617,14 +3617,11 @@ private[optimizer] abstract class OptimizerCore(
       implicit val scope = scope1
       val tRef = VarRef(tName)(rtLongClassType)
 
-      val lo = Apply(ApplyFlags.empty, tRef, MethodIdent(LongImpl.lo), Nil)(IntType)
-      val hi = Apply(ApplyFlags.empty, tRef, MethodIdent(LongImpl.hi), Nil)(IntType)
-
-      pretransformExprs(lo, hi) { (tlo, thi) =>
-        inlineClassConstructor(AllocationSite.Anonymous, LongImpl.RuntimeLongClass,
-            inlinedRTLongStructure, MethodIdent(LongImpl.initFromParts), List(tlo, thi),
-            () => throw new AssertionError(s"rolled-back RuntimeLong inlining at $pos"))(cont1)
-      }
+      val newTree = New(LongImpl.RuntimeLongClass,
+          MethodIdent(LongImpl.initFromParts),
+          List(Apply(ApplyFlags.empty, tRef, MethodIdent(LongImpl.lo), Nil)(IntType),
+              Apply(ApplyFlags.empty, tRef, MethodIdent(LongImpl.hi), Nil)(IntType)))
+      pretransformExpr(newTree)(cont1)
     } (cont)
   }
 

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -666,6 +666,28 @@ class OptimizerTest {
 
     assertTrue(called)
   }
+
+  @Test def expandedRTAssertionOriginal_Issue5231(): Unit = {
+    def expandedRTLongBug: (Array[Int], Long) => Long = { (array, z) =>
+      array.foldRight(z)(_ - _)
+    }
+
+    assertEquals(-3L, expandedRTLongBug(Array(1, 2, 3), 5L))
+  }
+
+  @Test def expandedRTAssertionMinimal_Issue5231(): Unit = {
+    @noinline def hideLong(x: Long): Long = x
+    @noinline def hide(x: Any): Any = x
+
+    val z0: Long = hideLong(5L)
+    var i = 0
+    var z: Any = z0
+    while (i < 2) {
+      z = hide(i.toLong)
+      i += 1
+    }
+    assertEquals(1L, z)
+  }
 }
 
 object OptimizerTest {


### PR DESCRIPTION
This commit partially reverts 3a253e332524a007bfff18e62339a56c0d618e40.

It turns out that an expanded `RuntimeLong` *can* be canceled, in some corner case scenarios. There might be a proper fix to the underlying issue, but in the meantime, let the cancellation happen.

---

Will need a force-amend after #5230 is merged so that the "Towards 1.20.1" commit doesn't appear to belong to this PR.