### PR TITLE
Wasm: Remove the `--turboshaft-wasm` option for Node.js 24.

### DIFF
--- a/DEVELOPING.md
+++ b/DEVELOPING.md
@@ -9,7 +9,7 @@ in the [Javalib documentation](./JAVALIB.md)*** .
 
 Scala.js is entirely built with [sbt](https://www.scala-sbt.org/), and also
 requires [Node.js](https://nodejs.org/en/) to be installed. For complete
-support, Node.js >= 13.2.0 is required.
+support, Node.js >= 24.0.0 is required.
 
 The first time, or in the rare events where `package.json` changes
 ([history](https://github.com/scala-js/scala-js/commits/main/package.json)),

--- a/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
+++ b/partest/src/main/scala/scala/tools/nsc/MainGenericRunner.scala
@@ -139,11 +139,6 @@ class MainGenericRunner {
         NodeJSEnv.Config().withArgs(List(
           "--experimental-wasm-exnref",
           "--experimental-wasm-imported-strings", // for JS string builtins
-          /* Force using the Turboshaft infrastructure for the optimizing compiler.
-           * It appears to be more stable for the Wasm that we throw at it.
-           * See also the use of this flag in Build.scala.
-           */
-          "--turboshaft-wasm"
         ))
       }
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -242,12 +242,6 @@ object MyScalaJSPlugin extends AutoPlugin {
             "--experimental-wasm-exnref",
             "--experimental-wasm-imported-strings", // for JS string builtins
             "--experimental-wasm-jspi", // for JSPI, used by async/await
-            /* Force using the Turboshaft infrastructure for the optimizing compiler.
-             * It appears to be more stable for the Wasm that we throw at it.
-             * If you remove it, try running `scalaTestSuite2_13/test` with Wasm.
-             * See also the use of this flag in MainGenericRunner.scala.
-             */
-            "--turboshaft-wasm",
           ))
         } else {
           baseConfig


### PR DESCRIPTION
Between Node.js 23 and 24, `--turboshaft-wasm` became the default *änd* was removed as a command-line argument. With the upgrade of our CI infrastructure to Node.js 24, we must therefore remove that flag.