### PR TITLE
replace to new wildcard syntax

### DIFF
--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LinkerImpl.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/LinkerImpl.scala
@@ -125,7 +125,7 @@ object LinkerImpl {
       "jdk.internal.reflect."
     )
 
-    override def loadClass(name: String, resolve: Boolean): Class[_] = {
+    override def loadClass(name: String, resolve: Boolean): Class[?] = {
       if (parentPrefixes.exists(name.startsWith _))
         super.loadClass(name, resolve)
       else
@@ -144,7 +144,7 @@ object LinkerImpl {
   final class Reflect private[LinkerImpl] (val loader: ClassLoader)
       extends LinkerImpl {
 
-    private def loadMethod(clazz: String, method: String, result: Class[_], params: Class[_]*): Method = {
+    private def loadMethod(clazz: String, method: String, result: Class[?], params: Class[?]*): Method = {
       val m = Class.forName("org.scalajs.linker." + clazz, true, loader).getMethod(method, params: _*)
       require(Modifier.isStatic(m.getModifiers()))
       require(result.isAssignableFrom(m.getReturnType()))
@@ -164,7 +164,7 @@ object LinkerImpl {
       loadMethod("StandardImpl", "irFileCache", classOf[IRFileCache], classOf[IRFileCacheConfig])
 
     private val irContainersMethod = {
-      loadMethod("PathIRContainer", "fromClasspath", classOf[Future[_]],
+      loadMethod("PathIRContainer", "fromClasspath", classOf[Future[?]],
           classOf[Seq[Path]], classOf[ExecutionContext])
     }
 

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSJUnitPlugin.scala
@@ -25,7 +25,7 @@ object ScalaJSJUnitPlugin extends AutoPlugin {
    */
   val ScalaJSTestPlugin = config("scala-js-test-plugin").hide
 
-  override def projectSettings: Seq[Setting[_]] = Seq(
+  override def projectSettings: Seq[Setting[?]] = Seq(
     /* The `scala-js-test-plugin` configuration adds a plugin only to the `test`
      * configuration. It is a refinement of the `plugin` configuration which adds
      * it to both `compile` and `test`.

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPlugin.scala
@@ -287,7 +287,7 @@ object ScalaJSPlugin extends AutoPlugin {
 
   import autoImport._
 
-  override def globalSettings: Seq[Setting[_]] = {
+  override def globalSettings: Seq[Setting[?]] = {
     Seq(
         scalaJSStage := Stage.FastOpt,
 
@@ -391,7 +391,7 @@ object ScalaJSPlugin extends AutoPlugin {
     )
   }
 
-  override def projectSettings: Seq[Setting[_]] =
+  override def projectSettings: Seq[Setting[?]] =
     ScalaJSPluginInternal.scalaJSProjectSettings
 
   /** Basic set of settings enabling Scala.js for a configuration.
@@ -404,7 +404,7 @@ object ScalaJSPlugin extends AutoPlugin {
    *  (resp. `Test`), you should use [[compileConfigSettings]] (resp.
    *  [[testConfigSettings]]) instead.
    */
-  def baseConfigSettings: Seq[Setting[_]] =
+  def baseConfigSettings: Seq[Setting[?]] =
     ScalaJSPluginInternal.scalaJSConfigSettings
 
   /** Complete set of settings enabling Scala.js for a `Compile`-like
@@ -414,7 +414,7 @@ object ScalaJSPlugin extends AutoPlugin {
    *  settings. Directly using this method is only necessary if you want to
    *  configure a custom `Compile`-like configuration.
    */
-  def compileConfigSettings: Seq[Setting[_]] =
+  def compileConfigSettings: Seq[Setting[?]] =
     ScalaJSPluginInternal.scalaJSCompileSettings
 
   /** Complete set of settings enabling Scala.js for a `Test`-like
@@ -424,6 +424,6 @@ object ScalaJSPlugin extends AutoPlugin {
    *  Directly using this method is only necessary if you want to configure a
    *  custom `Test`-like configuration, e.g., `IntegrationTest`.
    */
-  def testConfigSettings: Seq[Setting[_]] =
+  def testConfigSettings: Seq[Setting[?]] =
     ScalaJSPluginInternal.scalaJSTestSettings
 }

--- a/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
+++ b/sbt-plugin/src/main/scala/org/scalajs/sbtplugin/ScalaJSPluginInternal.scala
@@ -97,7 +97,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
     }
   }
 
-  private def enhanceNotInstalledException[A](skey: ScopedKey[_], log: Logger)(body: => A): A = {
+  private def enhanceNotInstalledException[A](skey: ScopedKey[?], log: Logger)(body: => A): A = {
     try {
       body
     } catch {
@@ -111,7 +111,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
     }
   }
 
-  private def linkerOutputDirectory(v: Attributed[Report], scope: Scope, key: TaskKey[_]): File = {
+  private def linkerOutputDirectory(v: Attributed[Report], scope: Scope, key: TaskKey[?]): File = {
     v.get(scalaJSLinkerOutputDirectory.key).getOrElse {
       val keyStr = Scope.display(scope, key.key.label)
       throw new MessageOnlyException(
@@ -147,7 +147,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
   /** Settings for the production key (e.g. fastLinkJS) of a given stage */
   private def scalaJSStageSettings(stage: Stage,
       key: TaskKey[Attributed[Report]], outputKey: TaskKey[File],
-      legacyKey: TaskKey[Attributed[File]]): Seq[Setting[_]] = Seq(
+      legacyKey: TaskKey[Attributed[File]]): Seq[Setting[?]] = Seq(
 
       scalaJSLinkerBox in key := new CacheBox,
 
@@ -338,7 +338,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
       }
   )
 
-  val scalaJSConfigSettings: Seq[Setting[_]] = Seq(
+  val scalaJSConfigSettings: Seq[Setting[?]] = Seq(
       incOptions ~= scalaJSPatchIncOptions
   ) ++ (
       scalaJSStageSettings(Stage.FastOpt, fastLinkJS, fastLinkJSOutput, fastOptJS) ++
@@ -632,11 +632,11 @@ private[sbtplugin] object ScalaJSPluginInternal {
       }
   )
 
-  val scalaJSCompileSettings: Seq[Setting[_]] = (
+  val scalaJSCompileSettings: Seq[Setting[?]] = (
       scalaJSConfigSettings
   )
 
-  val scalaJSTestSettings: Seq[Setting[_]] = (
+  val scalaJSTestSettings: Seq[Setting[?]] = (
       scalaJSConfigSettings
   ) ++ Seq(
       /* Always default to false for scalaJSUseMainModuleInitializer in testing
@@ -830,7 +830,7 @@ private[sbtplugin] object ScalaJSPluginInternal {
       }
   )
 
-  val scalaJSProjectSettings: Seq[Setting[_]] = (
+  val scalaJSProjectSettings: Seq[Setting[?]] = (
       scalaJSProjectBaseSettings ++
       inConfig(Compile)(scalaJSCompileSettings) ++
       inConfig(Test)(scalaJSTestSettings)


### PR DESCRIPTION
- sbt 2.x depends on Scala 3.7 https://www.scala-sbt.org/2.x/docs/en/changes/sbt-2.0-change-summary.html
- Scala 3.7 report warn old wildcard syntax
- latest Scala 2.12.x allow new wildcard syntax by default


```
Welcome to Scala 2.12.20 (OpenJDK 64-Bit Server VM, Java 21.0.8).
Type in expressions for evaluation. Or try :help.

scala> def a: Class[?] = null
a: Class[_]
```

```
Welcome to Scala 3.7.3 (21.0.8, Java OpenJDK 64-Bit Server VM).
Type in expressions for evaluation. Or try :help.
                                                                                                                                             
scala> def a1: Class[_] = null
1 warning found
-- Warning: --------------------------------------------------------------------
1 |def a1: Class[_] = null
  |              ^
  |        `_` is deprecated for wildcard arguments of types: use `?` instead
def a1: Class[?]
                                                                                                                                             
scala> def a2: Class[?] = null
def a2: Class[?]
```