### PR TITLE
Add `isEmpty` to CharSequence

### DIFF
--- a/javalib/src/main/scala/java/lang/CharSequence.scala
+++ b/javalib/src/main/scala/java/lang/CharSequence.scala
@@ -17,6 +17,7 @@ trait CharSequence {
   def charAt(index: scala.Int): scala.Char
   def subSequence(start: scala.Int, end: scala.Int): CharSequence
   def toString(): String
+  def isEmpty(): scala.Boolean = length() == 0
 }
 
 private[lang] object CharSequence {

--- a/javalib/src/main/scala/java/lang/_String.scala
+++ b/javalib/src/main/scala/java/lang/_String.scala
@@ -244,7 +244,7 @@ final class _String private () // scalastyle:ignore
   def intern(): String = thisString
 
   @inline
-  def isEmpty(): scala.Boolean = (this: AnyRef) eq ("": AnyRef)
+  override def isEmpty(): scala.Boolean = (this: AnyRef) eq ("": AnyRef)
 
   def lastIndexOf(ch: Int): Int =
     lastIndexOf(Character.toString(ch))

--- a/test-suite/shared/src/test/require-jdk17/org/scalajs/testsuite/javalib/lang/CharSequenceTestOnJDK17.scala
+++ b/test-suite/shared/src/test/require-jdk17/org/scalajs/testsuite/javalib/lang/CharSequenceTestOnJDK17.scala
@@ -1,0 +1,25 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+package org.scalajs.testsuite.javalib.lang
+
+import org.junit.Test
+import org.junit.Assert._
+
+class CharSequenceTestOnJDK17 {
+
+  @Test def isEmpty(): Unit = {
+    assertTrue(("": CharSequence).isEmpty())
+    assertTrue(new java.lang.StringBuilder().isEmpty())
+  }
+
+}


### PR DESCRIPTION
Just a very simple default impl. to avoid issues when using [`CharSequence.isEmpty`](https://docs.oracle.com/en/java/javase/21/docs/api/java.base/java/lang/CharSequence.html#isEmpty()) in cross builds.