### PR TITLE
Embed syntheticKind and nonExistent in Infos.ClassInfo

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/InfoLoader.scala
@@ -126,10 +126,11 @@ private[analyzer] object InfoLoader {
       val jsNativeMembers = classDef.jsNativeMembers
         .map(m => m.name.name -> m.jsNativeLoadSpec).toMap
 
-      new Infos.ClassInfo(classDef.className, classDef.kind,
-          classDef.superClass.map(_.name), classDef.interfaces.map(_.name),
-          classDef.jsNativeLoadSpec, referencedFieldClasses, prevMethodInfos,
-          jsNativeMembers, exportedMembers, topLevelExports)
+      new Infos.ClassInfo(classDef.className, classDef.kind, syntheticKind = None,
+          nonExistent = false, classDef.superClass.map(_.name),
+          classDef.interfaces.map(_.name), classDef.jsNativeLoadSpec,
+          referencedFieldClasses, prevMethodInfos, jsNativeMembers, exportedMembers,
+          topLevelExports)
     }
 
     /** Returns true if the cache has been used and should be kept. */

--- a/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/analyzer/Infos.scala
@@ -22,7 +22,7 @@ import org.scalajs.ir.Types._
 import org.scalajs.ir.Version
 import org.scalajs.ir.WellKnownNames._
 
-import org.scalajs.linker.frontend.{LinkTimeEvaluator, LinkTimeProperties}
+import org.scalajs.linker.frontend.{LinkTimeEvaluator, LinkTimeProperties, SyntheticClassKind}
 import org.scalajs.linker.standard.ModuleSet.ModuleID
 
 object Infos {
@@ -47,6 +47,8 @@ object Infos {
   final class ClassInfo(
       val className: ClassName,
       val kind: ClassKind,
+      val syntheticKind: Option[SyntheticClassKind],
+      val nonExistent: Boolean,
       val superClass: Option[ClassName], // always None for interfaces
       val interfaces: List[ClassName], // direct parent interfaces only
       val jsNativeLoadSpec: Option[JSNativeLoadSpec],

--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/LambdaSynthesizer.scala
@@ -104,8 +104,8 @@ private[linker] object LambdaSynthesizer {
     methodInfos(MemberNamespace.Public.ordinal) =
       Map(descriptor.methodName -> implMethodInfo)
 
-    new ClassInfo(className, ClassKind.Class,
-        Some(descriptor.superClass), descriptor.interfaces,
+    new ClassInfo(className, ClassKind.Class, Some(SyntheticClassKind.Lambda(descriptor)),
+        nonExistent = false, Some(descriptor.superClass), descriptor.interfaces,
         jsNativeLoadSpec = None, referencedFieldClasses = Map.empty, methodInfos,
         jsNativeMembers = Map.empty, jsMethodProps = Nil, topLevelExports = Nil)
   }


### PR DESCRIPTION
Discovered while working on #5241.

While this is "conceptually wrong" it simplifies both creation and usage sites of ClassInfo. Notably, it avoids dragging the two aditional fields along with the risk of them getting out of sync with the infos.