### PR TITLE
Fix #5246: Handle record trees that end up in statement position.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/FunctionEmitter.scala
@@ -1666,8 +1666,14 @@ private[emitter] class FunctionEmitter(sjsGen: SJSGen) {
             case Lhs.Return(l) =>
               doReturnToLabel(l)
 
-            case Lhs.ReturnFromFunction | Lhs.Throw =>
-              throw new AssertionError("Cannot return or throw a record value.")
+            case Lhs.ReturnFromFunction =>
+              assert(env.expectedReturnType == VoidType,
+                  "Cannot return a record value from a non-void function")
+              val (newStats, _) = transformBlockStats(elems)
+              js.Block(newStats :+ js.Return(js.Undefined()))
+
+            case Lhs.Throw =>
+              throw new AssertionError("Cannot throw a record value.")
           }
 
         // Control flow constructs

--- a/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
+++ b/test-suite/js/src/test/scala/org/scalajs/testsuite/compiler/OptimizerTest.scala
@@ -688,6 +688,19 @@ class OptimizerTest {
     }
     assertEquals(1L, z)
   }
+
+  @noinline // just to be sure
+  @Test def inlineClassLabeledReturnDiscardStatementPos_Issue5246(): Unit = {
+    @inline def makeBug(x: Int): Bug5246 = {
+      // Use an explicit `return` to cause a Labeled block and its Return node
+      return new Bug5246(x) // scalastyle:ignore
+    }
+
+    // Assign to val to cause a pretransform
+    val bug = makeBug(5)
+    // but then discard it and leave it in statement position
+    val _ = bug
+  }
 }
 
 object OptimizerTest {
@@ -704,5 +717,8 @@ object OptimizerTest {
     val y = x
     val z = t.y
   }
+
+  @inline
+  final class Bug5246(val x: Int)
 
 }


### PR DESCRIPTION
Usually, a record tree must always be used in a context that expects the same record type. However, they can also end up in statement position. Unfortunately, that means they can be put in a `PreTransTree`. For safety reasons, `PreTransTree` aggressively throws when given a tree with a `RecordType`, and that blows up in this situation.

We could get rid of the safety net in `PreTransTree`, but that would be a shame. Instead, when discarding the side effects of a tree, we must make sure never to leave a tree with a `RecordType`. We do this with a last resort of embedding it in a `Labeled` block with type `void`. Since `Labeled` blocks cannot be removed, that is safe.

Once we're past the optimizer, the emitters were also missing some handling of records in statement position:

* The JS emitter lacked a code path for returning a record value from a `void` function.
* The Wasm emitter was assuming that dropping a record always needs exactly one `drop`.