### PR TITLE
Upgrade to sbt 1.11.7

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -1226,7 +1226,18 @@ object Build {
       name := "Scala.js linker private library",
       publishArtifact in Compile := false,
       delambdafySetting,
-      cleanIRSettings
+      cleanIRSettings,
+
+      /* Remove the Compile config artifact from the full test classpath,
+       * so that only the (patched) injected IR files are taken into account.
+       */
+      Test / fullClasspath := {
+        val prev = (Test / fullClasspath).value
+        prev.filterNot { f =>
+          val path = f.data.getPath()
+          path.contains("linker-private-library") && !path.contains("test-classes")
+        }
+      },
   ).withScalaJSCompiler2_12.withScalaJSJUnitPlugin2_12.dependsOnLibrary2_12.dependsOn(
       jUnitRuntime.v2_12 % "test", testBridge.v2_12 % "test",
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.3
+sbt.version=1.11.7


### PR DESCRIPTION
Can't cross build sbt 2

```
java.lang.RuntimeException: unknown sbt version 2
	at scala.sys.package$.error(package.scala:30)
	at sbt.Defaults$.sbtPluginExtra(Defaults.scala:2664)
	at sbt.Classpaths$.$anonfun$pluginProjectID$1(Defaults.scala:3624)
	at sbt.internal.util.EvaluateSettings$MixedNode.evaluate0(INode.scala:229)
	at sbt.internal.util.EvaluateSettings$INode.evaluate(INode.scala:171)
	at sbt.internal.util.EvaluateSettings.$anonfun$submitEvaluate$1(INode.scala:88)
	at sbt.internal.util.EvaluateSettings.sbt$internal$util$EvaluateSettings$$run0(INode.scala:100)
	at sbt.internal.util.EvaluateSettings$$anon$3.run(INode.scala:95)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
[error] unknown sbt version 2
[error] Use 'last' for the full log.
[warn] Project loading failed: (r)etry, (q)uit, (l)ast, or (i)gnore? (default: r)
```


- https://github.com/sbt/sbt/releases/tag/v1.11.4
- https://github.com/sbt/librarymanagement/commit/607ae8b9c75912c4c8bcad1ff5b741d4dee8fa8c
- https://github.com/sbt/sbt/commit/3e21938c207510d62062757fb1a29a9d7c5b7db4