### PR TITLE
Add separate linker profiling project

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -485,13 +485,14 @@ def Tasks = [
   ''',
 
   // These are agnostic to the Scala version
-  "sbt-plugin-and-scalastyle": '''
+  "sbt-plugin-and-scalastyle-linker-profile": '''
     setJavaVersion $java
     npm install &&
     sbtnoretry \
         sbtPlugin/compile:doc \
         sbtPlugin/mimaReportBinaryIssues \
-        scalastyleCheck &&
+        scalastyleCheck \
+        linkerProfile/compile &&
     sbtnoretry sbtPlugin/scripted
   ''',
 
@@ -602,7 +603,7 @@ allJavaVersions.each { javaVersion ->
   // the `scala` version is irrelevant here
   // We exclude JDK 21 because our sbt scripted tests use old sbt versions (on purpose), which do not support JDK 21
   if (javaVersion != '21') {
-    quickMatrix.add([task: "sbt-plugin-and-scalastyle", scala: mainScalaVersion, java: javaVersion])
+    quickMatrix.add([task: "sbt-plugin-and-scalastyle-linker-profile", scala: mainScalaVersion, java: javaVersion])
   }
 }
 quickMatrix.add([task: "scala3-compat", scala: scala3Version, java: mainJavaVersion])

--- a/build.sbt
+++ b/build.sbt
@@ -38,5 +38,6 @@ val testSuiteLinker = Build.testSuiteLinker
 val partest = Build.partest
 val partestSuite = Build.partestSuite
 val scalaTestSuite = Build.scalaTestSuite
+val linkerProfile = Build.linkerProfile
 
 inThisBuild(Build.thisBuildSettings)

--- a/linker-profile/src/main/scala/ProfileRun.scala
+++ b/linker-profile/src/main/scala/ProfileRun.scala
@@ -1,0 +1,85 @@
+/*
+ * Scala.js (https://www.scala-js.org/)
+ *
+ * Copyright EPFL.
+ *
+ * Licensed under Apache License 2.0
+ * (https://www.apache.org/licenses/LICENSE-2.0).
+ *
+ * See the NOTICE file distributed with this work for
+ * additional information regarding copyright ownership.
+ */
+
+import scala.concurrent.Await
+import scala.concurrent.ExecutionContext.Implicits.global
+import scala.concurrent.duration.Duration
+
+import scala.io.StdIn
+
+import java.io.IOException
+import java.nio.file.{Path, Files, FileVisitResult, SimpleFileVisitor}
+import java.nio.file.attribute.BasicFileAttributes
+
+import org.scalajs.logging._
+
+import org.scalajs.linker._
+import org.scalajs.linker.interface._
+
+import org.scalajs.testing.adapter.TestAdapterInitializer
+
+import buildinfo.BuildInfo.testClasspath
+
+object ProfileRun {
+  def main(args: Array[String]): Unit = {
+    val overallCache = StandardImpl.irFileCache()
+    val cache = overallCache.newCache
+
+    val linker = StandardImpl.linker(StandardConfig())
+
+    // Use a real FS (not Jimfs) to get real I/O numbers.
+    val outputDir = Files.createTempDirectory("sjs-linker-profile-")
+
+    try {
+      waitForUser("Ready to link, please start profiling.")
+      link(cache, linker, outputDir)
+      System.gc()
+      waitForUser("Done linking. Please take a heap dump now and stop profiling.")
+    } finally {
+      Files.walkFileTree(outputDir, DeletingPathVisitor)
+    }
+  }
+
+  private def link(cache: IRFileCache.Cache, linker: Linker, outputDir: Path): Unit = {
+    val moduleInitializers = Seq(
+      ModuleInitializer.mainMethod(
+          TestAdapterInitializer.ModuleClassName,
+          TestAdapterInitializer.MainMethodName)
+    )
+
+    val result = PathIRContainer
+      .fromClasspath(testClasspath.map(_.toPath()))
+      .map(_._1)
+      .flatMap(cache.cached _)
+      .flatMap(linker.link(_, moduleInitializers, PathOutputDirectory(outputDir), new ScalaConsoleLogger))
+
+    Await.result(result, Duration.Inf)
+  }
+
+  private def waitForUser(prompt: String): Unit = {
+    print(f"$prompt Hit enter to continue...")
+
+    StdIn.readLine()
+  }
+
+  private object DeletingPathVisitor extends SimpleFileVisitor[Path] {
+    override def visitFile(file: Path, attr: BasicFileAttributes): FileVisitResult = {
+      Files.delete(file)
+      FileVisitResult.CONTINUE
+    }
+
+    override def postVisitDirectory(directory: Path, exc: IOException): FileVisitResult = {
+      Files.delete(directory)
+      FileVisitResult.CONTINUE
+    }
+  }
+}

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -998,7 +998,7 @@ object Build {
 
       {
         val allProjects: Seq[Project] = Seq(
-            plugin, linkerPrivateLibrary
+            plugin, linkerPrivateLibrary, linkerProfile
         ) ++ Seq(
             compiler, irProject, irProjectJS,
             linkerInterface, linkerInterfaceJS, linker, linkerJS,
@@ -2797,5 +2797,21 @@ object Build {
   ).withScalaJSCompiler.withScalaJSJUnitPlugin.dependsOnLibrary.dependsOn(
       jUnitRuntime, testBridge % "test"
   )
+
+  lazy val linkerProfile = Project(
+      id = "linkerProfile", base = file("linker-profile")
+  ).settings(
+      commonSettings,
+      fatalWarningsSettings,
+      name := "Scala.js linker profile helper",
+      run / fork := true, // run isolated, easy to attach with YourKit
+      run / connectInput := true, // so we can wait for user input
+      buildInfoOrStubs(Compile, Def.setting(baseDirectory.value / "src/main")),
+      buildInfoKeys := Seq(
+        BuildInfoKey.map((testSuite.v2_12 / Test / fullClasspath)) {
+          case (_, v) => "testClasspath" -> Attributed.data(v)
+        }
+      ),
+  ).dependsOn(linker.v2_12, testAdapter.v2_12)
 
 }


### PR DESCRIPTION
This allows us to easily run the linker on a bigger workload (the test suite) with a profiler attached.

Mostly driven by #4906, but likely generally useful.