### PR TITLE
Explicitly allow attaching an agent in linkerProfile

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2806,6 +2806,7 @@ object Build {
       name := "Scala.js linker profile helper",
       run / fork := true, // run isolated, easy to attach with YourKit
       run / connectInput := true, // so we can wait for user input
+      javaOptions += "-XX:+EnableDynamicAgentLoading",
       buildInfoOrStubs(Compile, Def.setting(baseDirectory.value / "src/main")),
       buildInfoKeys := Seq(
         BuildInfoKey.map((testSuite.v2_12 / Test / fullClasspath)) {


### PR DESCRIPTION
Silence warnings (and future proof):

```
WARNING: A JVM TI agent has been loaded dynamically (/opt/YourKit/bin/linux-x86-64/libyjpagent.so)
WARNING: If a serviceability tool is in use, please run with -XX:+EnableDynamicAgentLoading to hide this warning
WARNING: Dynamic loading of agents will be disallowed by default in a future release
```