### PR TITLE
Fix ambiguous implicit values in `linker2_xx/Compile/doc`

### DIFF
--- a/linker/shared/src/test/scala/org/scalajs/linker/frontend/optimizer/IntegerDivisionsTreeShapeTest.scala
+++ b/linker/shared/src/test/scala/org/scalajs/linker/frontend/optimizer/IntegerDivisionsTreeShapeTest.scala
@@ -22,6 +22,7 @@ import org.scalajs.linker.testutils.TestIRBuilder._
 import org.scalajs.linker.testutils.TreeDSL._
 
 import IntegerDivisions._
+import IntegerDivisions.UnsignedIntegral._
 
 /** Tests for the specific shapes of trees produced for selected divisors.
  *


### PR DESCRIPTION
Closes https://github.com/scala-js/scala-js/issues/5272

Previously, `linker2_12/publishLocal` (or `linker2_13`) fails because the `linker2_12/Compile/doc` failed due to implicit resolution errors in `IntegerDivisions.scala`.

```
[error] /Users/tanishiking/ghq/github.com/scala-wasm/scala-wasm/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IntegerDivisions.scala:115:15: ambiguous implicit values:
[error]  both object IntIsUnsignedIntegral in object IntegerDivisions of type org.scalajs.linker.frontend.optimizer.IntegerDivisions.IntIsUnsignedIntegral.type
[error]  and object LongIsUnsignedIntegral in object IntegerDivisions of type org.scalajs.linker.frontend.optimizer.IntegerDivisions.LongIsUnsignedIntegral.type
[error]  match expected type org.scalajs.linker.frontend.optimizer.IntegerDivisions.UnsignedIntegral[T]
[error]         genOne(isQuotient, negativeDivisor)
[error]               ^
```

I suspect this is caused because `class IntegerDivision` imports its companion object's members at

https://github.com/scala-js/scala-js/blob/7b5e974d3b4dad5b86d72dca3ea4af480d071028/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IntegerDivisions.scala#L33

This introduces two implicits `UnsignedIntegral` instances to the scope. While the `compile` works (because an instance are passed via implicit parameters and it), `doc` seems confused and fails to compile.

This commit wraps those implicit `UnsignedIntegral` instances inside the companion object to hide them from `import IntegerDivision._` in `doc`.

Actually, doc compiles ok by excluding implicit instances from imports:

```diff
--- a/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IntegerDivisions.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/frontend/optimizer/IntegerDivisions.scala
@@ -30,7 +30,7 @@ import org.scalajs.linker.backend.emitter.LongImpl
  *  This class uses strategies from Hacker's Delight, Chapter 10.
  */
 private[optimizer] final class IntegerDivisions(useRuntimeLong: Boolean) {
-  import IntegerDivisions._
+  import IntegerDivisions.{UnsignedIntegral, NumeratorArgName, computeSignedMagic, computeUnsignedMagic, tempVarDef, tName, hiName}
 
   /** Should we apply the optimized rewrite for division by a constant?
    *
```