### PR TITLE
Pretty-print subtractions of a literal with shorter, cleaner code.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2069,7 +2069,7 @@ object Build {
               ))
             } else {
               Some(ExpectedSizes(
-                  fastLink = 426000 to 427000,
+                  fastLink = 425000 to 426000,
                   fullLink = 284000 to 285000,
                   fastLinkGz = 61000 to 62000,
                   fullLinkGz = 43000 to 44000,


### PR DESCRIPTION
The optimizer normalizes `a - b` into `(-b) + a` when `b` is a literal. That's good internally to recognize shapes to fold, but it causes more characters than necessary to be printed in JS.

We add special-cases in the JS emitter to recover `a - b` for code size purposes.

---

Mostly motivated by #5277, which will generate even more of those subtractions.