### PR TITLE
Fix bounds checks for array of longs for large negative values.

### DIFF
--- a/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
+++ b/linker/shared/src/main/scala/org/scalajs/linker/backend/emitter/CoreJSLib.scala
@@ -691,11 +691,14 @@ private[emitter] object CoreJSLib {
       } :::
 
       condDefs(arrayIndexOutOfBounds != CheckedBehavior.Unchecked && !useBigIntForLongs)(
-        // u is the underlying array; i is the *already scaled* index (better for call sites)
+        // u is the underlying array; i is the unscaled index; return the scaled index
         defineFunction2(VarField.aJCheckGet) { (u, i) =>
-          If((i >>> 0) >= (u.length >>> 0), {
-            genCallHelper(VarField.throwArrayIndexOutOfBoundsException, (i >>> 1) | 0)
-          })
+          Block(
+            If((i >>> 0) >= (u.length >>> 1), {
+              genCallHelper(VarField.throwArrayIndexOutOfBoundsException, i)
+            }),
+            Return(i << 1)
+          )
         }
       )
     )

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/compiler/ArrayTest.scala
@@ -49,6 +49,24 @@ class ArrayTest {
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(Int.MinValue))
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(Int.MaxValue))
 
+    // For Long, we test inline and noinline because there is some logic to constant-fold the scaled index
+    val j = new Array[Long](5)
+
+    @noinline def testJNoinline(i: Int): Unit =
+      assertThrows(classOf[ArrayIndexOutOfBoundsException], j(i))
+
+    @inline def testJ(i: Int): Unit = {
+      testJNoinline(i)
+      assertThrows(classOf[ArrayIndexOutOfBoundsException], j(i))
+    }
+
+    testJ(-1)
+    testJ(5)
+    testJ(0x80000003) // (i << 1) == +6
+    testJ(0xc0000003) // (i << 1) < 0
+    testJ(Int.MinValue)
+    testJ(Int.MaxValue)
+
     val b = new Array[AnyRef](5)
     assertThrows(classOf[ArrayIndexOutOfBoundsException], b(-1))
     assertThrows(classOf[ArrayIndexOutOfBoundsException], b(5))
@@ -72,6 +90,14 @@ class ArrayTest {
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(5) = 1)
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(Int.MinValue) = 1)
     assertThrows(classOf[ArrayIndexOutOfBoundsException], a(Int.MaxValue) = 1)
+
+    val j = new Array[Long](5)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], j(-1) = 1)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], j(5) = 1)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], j(0x80000003) = 1) // (i << 1) == +6
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], j(0xc0000003) = 1) // (i << 1) < 0
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], j(Int.MinValue) = 1)
+    assertThrows(classOf[ArrayIndexOutOfBoundsException], j(Int.MaxValue) = 1)
 
     val b = new Array[AnyRef](5)
     val obj = new AnyRef


### PR DESCRIPTION
When reading from an `Array[Long]`, we were scaling the index before checking its bounds. This does not work for large negative values, because scaling can wrap around to small positive values, which are in bounds.

We now perform the scaling inside `aJCheckGet`, after performing the bounds checks.