### PR TITLE
Opt: More simplifyOnlyInterestedInMask.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2089,7 +2089,7 @@ object Build {
             } else {
               Some(ExpectedSizes(
                   fastLink = 304000 to 305000,
-                  fullLink = 264000 to 265000,
+                  fullLink = 263000 to 264000,
                   fastLinkGz = 48000 to 49000,
                   fullLinkGz = 43000 to 44000,
               ))


### PR DESCRIPTION
* In the right-hand-size of int shifts, we are only interested in the mask 31.
* When the mask is of the form `00...0011...11`, we can also push the mask down into combinations of `+`, `-` and `*`. These operations respect modular arithmetics, which is true for 2^k as much as for 2^32.

Together, these recognize that `x shift (31 - y)` can be reduced to `x shift (-1 - y)`. That creates a number of new occurrences of the `-1 - y` pattern, which is equivalent to `~y`. We therefore add a rewrite for that pattern as well.

---

(Abridged) diff on the test suite: https://gist.github.com/sjrd/ab60dbcd6b7307efcb266629db575c88