### PR TITLE
Introduce an sbt task to regenerate all the Unicode data.

### DIFF
--- a/.github/workflows/os-sensitive-ci.yml
+++ b/.github/workflows/os-sensitive-ci.yml
@@ -13,7 +13,7 @@ jobs:
   build:
     strategy:
       matrix:
-        java: [ '8' ]
+        java: [ '8', '21' ]
         # Use the latest supported version. We will be less affected by ambient changes
         # due to the lack of pinning than by breakages because of changing version support.
         os: [ windows-latest, ubuntu-latest ]
@@ -56,3 +56,11 @@ jobs:
     # general Jenkins environment, so we test it here.
     - name: Scaladoc
       run: sbt 'compiler2_12/doc;jUnitPlugin2_12/doc;library2_12/doc;testInterface2_12/doc;jUnitRuntime2_12/doc;testBridge2_12/doc;ir2_12/doc;linkerInterface2_12/doc;linker2_12/doc;testAdapter2_12/doc'
+
+    # Verify that Unicode data is in sync with project/UnicodeDataGen.scala
+    # OS-sensitive because the patches logic must respect LF newlines even on Windows.
+    - name: Unicode data
+      if: ${{ matrix.java == '21' }}
+      run: |
+        sbt javalibInternal/regenerateUnicodeData
+        git diff --exit-code

--- a/javalib/src/main/scala/java/lang/Character.scala
+++ b/javalib/src/main/scala/java/lang/Character.scala
@@ -12,6 +12,11 @@
 
 package java.lang
 
+/* This file contains automatically generated snippets.
+ * To regenerate them, run the sbt task `javalibInternal/regenerateUnicodeData`,
+ * whose implementation is in `project/UnicodeDataGen.scala`.
+ */
+
 import scala.annotation.{tailrec, switch}
 
 import scala.scalajs.js
@@ -748,21 +753,9 @@ object Character {
 
   def toTitleCase(ch: scala.Char): scala.Char = toTitleCase(ch.toInt).toChar
 
-/*
-def format(codePoint: Int): String = "0x%04x".format(codePoint)
-
-for (cp <- 0 to Character.MAX_CODE_POINT) {
-  val titleCaseCP: Int = Character.toTitleCase(cp)
-  val upperCaseCP: Int = Character.toUpperCase(cp)
-
-  if (titleCaseCP != upperCaseCP) {
-    println(s"      case ${format(cp)} => ${format(titleCaseCP)}")
-  }
-}
-*/
   def toTitleCase(codePoint: scala.Int): scala.Int = {
     (codePoint: @switch) match {
-      // Begin Generated, last updated with Temurin-21+35 (build 21+35-LTS)
+      // BEGIN GENERATED: [titlecase-mappings]
       case 0x01c4 => 0x01c5
       case 0x01c5 => 0x01c5
       case 0x01c6 => 0x01c5
@@ -821,7 +814,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
       case 0x10fd => 0x10fd
       case 0x10fe => 0x10fe
       case 0x10ff => 0x10ff
-      // End generated
+      // END GENERATED: [titlecase-mappings]
 
       case _ => toUpperCase(codePoint)
     }
@@ -849,8 +842,11 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
       private val start: Int, private val end: Int) extends Subset(name)
 
   object UnicodeBlock {
-    // Initial size from script below
-    private[this] val allBlocks: ArrayList[UnicodeBlock] = new ArrayList[UnicodeBlock](220)
+    // BEGIN GENERATED: [unicode-block-constants]
+    private final val BlockCount = 327
+    // END GENERATED: [unicode-block-constants]
+
+    private[this] val allBlocks: ArrayList[UnicodeBlock] = new ArrayList[UnicodeBlock](BlockCount)
     private[this] val blocksByNormalizedName = new HashMap[String, UnicodeBlock]()
 
     private[this] def addNameAliases(properName: String, block: UnicodeBlock): Unit = {
@@ -894,70 +890,9 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     val SURROGATES_AREA = new UnicodeBlock("SURROGATES_AREA", 0x0, 0x0)
     blocksByNormalizedName.put("surrogates_area", SURROGATES_AREA)
 
-/*
-    // JVMName -> (historicalName, properName)
-    val historicalMap = Map(
-      "GREEK" -> ("Greek", "Greek and Coptic"),
-      "CYRILLIC_SUPPLEMENTARY" -> ("Cyrillic Supplementary", "Cyrillic Supplement"),
-      "COMBINING_MARKS_FOR_SYMBOLS" -> ("Combining Marks For Symbols", "Combining Diacritical Marks for Symbols")
-    )
-
-    // Get the "proper name" for JVM block name
-    val blockNameMap: Map[String, String] = {
-      val blocksSourceURL = new java.net.URL("http://unicode.org/Public/UCD/latest/ucd/Blocks.txt")
-      val source = scala.io.Source.fromURL(blocksSourceURL, "UTF-8")
-      source
-        .getLines()
-        .filterNot {
-          _.startsWith("#")
-        }
-        .flatMap { line =>
-          line.split(';') match {
-            case Array(_, name) =>
-              val trimmed = name.trim
-              val jvmName = trimmed.replaceAll(raw"[\s\-]", "_").toUpperCase
-              Some(jvmName -> trimmed)
-            case _ => None
-          }
-        }.toMap
-    }
-
-    val blocksAndCharacters = (0 to Character.MAX_CODE_POINT)
-      .map(cp => Character.UnicodeBlock.of(cp) -> cp).filterNot(_._1 == null)
-
-    val orderedBlocks = blocksAndCharacters.map(_._1).distinct
-
-    val blockLowAndHighCodePointsMap = {
-      blocksAndCharacters.groupBy(_._1).mapValues { v =>
-        val codePoints = v.map(_._2)
-        (codePoints.min, codePoints.max)
-      }
-    }
-
-    println("private[this] val allBlocks: ArrayList[UnicodeBlock] = " +
-        s"new ArrayList[UnicodeBlock](${orderedBlocks.size})\n\n\n\n")
-
-    orderedBlocks.foreach { b =>
-      val minCodePoint = "0x%04x".format(blockLowAndHighCodePointsMap(b)._1)
-      val maxCodePoint = "0x%04x".format(blockLowAndHighCodePointsMap(b)._2)
-
-      historicalMap.get(b.toString) match {
-        case Some((historicalName, properName)) =>
-          println(s"""    val $b = addUnicodeBlock("$properName", "$historicalName", $minCodePoint, $maxCodePoint)""")
-        case None =>
-          val properBlockName = blockNameMap.getOrElse(b.toString, throw new IllegalArgumentException("$b"))
-          val jvmBlockName = properBlockName.toUpperCase.replaceAll("[\\s\\-_]", "_")
-          assert(jvmBlockName == b.toString)
-          println(s"""    val $jvmBlockName = addUnicodeBlock("$properBlockName", $minCodePoint, $maxCodePoint)""")
-      }
-    }
-*/
-
-    //////////////////////////////////////////////////////////////////////////
-    // Begin Generated, last updated with Temurin-21+35 (build 21+35-LTS)
-    //////////////////////////////////////////////////////////////////////////
     // scalastyle:off line.size.limit
 
+    // BEGIN GENERATED: [unicode-blocks]
     val BASIC_LATIN = addUnicodeBlock("Basic Latin", 0x0000, 0x007f)
     val LATIN_1_SUPPLEMENT = addUnicodeBlock("Latin-1 Supplement", 0x0080, 0x00ff)
     val LATIN_EXTENDED_A = addUnicodeBlock("Latin Extended-A", 0x0100, 0x017f)
@@ -1285,11 +1220,9 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     val VARIATION_SELECTORS_SUPPLEMENT = addUnicodeBlock("Variation Selectors Supplement", 0xe0100, 0xe01ef)
     val SUPPLEMENTARY_PRIVATE_USE_AREA_A = addUnicodeBlock("Supplementary Private Use Area-A", 0xf0000, 0xfffff)
     val SUPPLEMENTARY_PRIVATE_USE_AREA_B = addUnicodeBlock("Supplementary Private Use Area-B", 0x100000, 0x10ffff)
+    // END GENERATED: [unicode-blocks]
 
     // scalastyle:on line.size.limit
-    ////////////////
-    // End Generated
-    ////////////////
 
     def forName(blockName: String): UnicodeBlock = {
       val key: String = blockName.toLowerCase()
@@ -1323,79 +1256,34 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     }
   }
 
-  // Based on Unicode 15.0
-  // Generated with Temurin-21+35 (build 21+35-LTS)
-
   // Types of characters from 0 to 255
-  private[this] lazy val charTypesFirst256: Array[Int] = Array(15, 15, 15, 15,
-    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
-    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 12, 24, 24, 24, 26, 24, 24, 24,
-    21, 22, 24, 25, 24, 20, 24, 24, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 24, 24, 25,
-    25, 25, 24, 24, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 21, 24, 22, 27, 23, 27, 2, 2, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 21, 25, 22, 25, 15, 15,
-    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
-    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 12, 24, 26, 26, 26,
-    26, 28, 24, 27, 28, 5, 29, 25, 16, 28, 27, 28, 25, 11, 11, 27, 2, 24, 24,
-    27, 11, 5, 30, 11, 11, 11, 24, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
-    1, 1, 1, 1, 1, 1, 1, 1, 1, 25, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2,
-    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 25, 2, 2, 2, 2, 2, 2,
-    2, 2)
+  private[this] lazy val charTypesFirst256: Array[Int] = Array(
+    // BEGIN GENERATED: [char-types-first-256]
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 12, 24, 24, 24, 26, 24,
+    24, 24, 21, 22, 24, 25, 24, 20, 24, 24, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 24,
+    24, 25, 25, 25, 24, 24, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 1, 1, 21, 24, 22, 27, 23, 27, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 21, 25, 22, 25, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15,
+    15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 15, 12, 24, 26, 26, 26, 26,
+    28, 24, 27, 28, 5, 29, 25, 16, 28, 27, 28, 25, 11, 11, 27, 2, 24, 24, 27,
+    11, 5, 30, 11, 11, 11, 24, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
+    1, 1, 1, 1, 1, 1, 1, 25, 1, 1, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2,
+    2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 2, 25, 2, 2, 2, 2, 2, 2, 2, 2
+    // END GENERATED: [char-types-first-256]
+  )
 
   /* Character type data by ranges of types
    * charTypeIndices: contains the index where the range ends
    * charType: contains the type of the character in the range ends
    * note that charTypeIndices.length + 1 = charType.length and that the
    * range 0 to 255 is not included because it is contained in charTypesFirst256
-   *
-   * They where generated with the following script, which can be pasted into
-   * a Scala REPL.
-
-def formatLargeArrayStr(array: Array[String], indent: String): String = {
-  val indentMinus1 = indent.substring(1)
-  val builder = new java.lang.StringBuilder
-  builder.append(indentMinus1)
-  var curLineLength = indentMinus1.length
-  for (i <- 0 until array.length) {
-    val toAdd = " " + array(i) + (if (i == array.length - 1) "" else ",")
-    if (curLineLength + toAdd.length >= 80) {
-      builder.append("\n")
-      builder.append(indentMinus1)
-      curLineLength = indentMinus1.length
-    }
-    builder.append(toAdd)
-    curLineLength += toAdd.length
-  }
-  builder.toString()
-}
-
-def formatLargeArray(array: Array[Int], indent: String): String =
-  formatLargeArrayStr(array.map(_.toString()), indent)
-
-val indicesAndTypes = (256 to Character.MAX_CODE_POINT)
-  .map(i => (i, Character.getType(i)))
-  .foldLeft[List[(Int, Int)]](Nil) {
-    case (x :: xs, elem) if x._2 == elem._2 => x :: xs
-    case (prevs, elem) => elem :: prevs
-  }.reverse
-val charTypeIndices = indicesAndTypes.map(_._1).tail
-val charTypeIndicesDeltas = charTypeIndices
-  .zip(0 :: charTypeIndices.init)
-  .map(tup => tup._1 - tup._2)
-val charTypes = indicesAndTypes.map(_._2)
-println("charTypeIndices, deltas:")
-println("    Array(")
-println(formatLargeArray(charTypeIndicesDeltas.toArray, "        "))
-println("    )")
-println("charTypes:")
-println("  Array(")
-println(formatLargeArray(charTypes.toArray, "      "))
-println("  )")
-
    */
 
   private[this] lazy val charTypeIndices: Array[Int] = {
     val deltas = Array(
+        // BEGIN GENERATED: [char-types-indices]
         257, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
         1, 1, 1, 1, 1, 1, 1, 1, 2, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1,
@@ -1575,11 +1463,13 @@ println("  )")
         147, 1, 55, 37, 10, 1030, 42720, 32, 4154, 6, 222, 2, 5762, 14, 7473,
         3103, 542, 1506, 4939, 5, 4192, 711761, 1, 30, 96, 128, 240, 65040,
         65534, 2, 65534
+        // END GENERATED: [char-types-indices]
     )
     uncompressDeltas(deltas)
   }
 
   private[this] lazy val charTypes: Array[Int] = Array(
+      // BEGIN GENERATED: [char-types]
       1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
       1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
       1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2, 1, 2,
@@ -1754,32 +1644,16 @@ println("  )")
       28, 0, 28, 0, 28, 0, 28, 0, 28, 0, 28, 0, 28, 0, 28, 0, 28, 0, 28, 0, 28,
       0, 28, 0, 28, 0, 28, 0, 9, 0, 5, 0, 5, 0, 5, 0, 5, 0, 5, 0, 5, 0, 5, 0,
       5, 0, 16, 0, 16, 0, 6, 0, 18, 0, 18, 0
+      // END GENERATED: [char-types]
   )
 
   /* Indices representing the start of ranges of codePoint that have the same
    * `isMirrored` result. It is true for the first range
    * (i.e. isMirrored(40)==true, isMirrored(41)==true, isMirrored(42)==false)
-   * They where generated with the following script, which can be pasted into
-   * a Scala REPL.
-
-val indicesAndRes = (0 to Character.MAX_CODE_POINT)
-  .map(i => (i, Character.isMirrored(i)))
-  .foldLeft[List[(Int, Boolean)]](Nil) {
-    case (x :: xs, elem) if x._2 == elem._2 => x :: xs
-    case (prevs, elem) => elem :: prevs
-  }.reverse
-val isMirroredIndices = indicesAndRes.map(_._1).tail
-val isMirroredIndicesDeltas = isMirroredIndices
-  .zip(0 :: isMirroredIndices.init)
-  .map(tup => tup._1 - tup._2)
-println("isMirroredIndices, deltas:")
-println("    Array(")
-println(formatLargeArray(isMirroredIndicesDeltas.toArray, "        "))
-println("    )")
-
    */
   private[this] lazy val isMirroredIndices: Array[Int] = {
     val deltas = Array(
+        // BEGIN GENERATED: [mirrored-indices]
         40, 2, 18, 1, 1, 1, 28, 1, 1, 1, 29, 1, 1, 1, 45, 1, 15, 1, 3710, 4,
         1885, 2, 2460, 2, 10, 2, 54, 2, 14, 2, 177, 1, 192, 4, 3, 6, 3, 1, 3,
         2, 3, 4, 1, 4, 1, 1, 1, 1, 4, 9, 5, 1, 1, 18, 5, 4, 9, 2, 1, 1, 1, 8,
@@ -1791,6 +1665,7 @@ println("    )")
         1, 3, 5, 1, 1, 256, 1, 515, 4, 3, 2, 1, 2, 14, 2, 2, 10, 43, 8, 427,
         10, 2, 8, 52797, 6, 5, 2, 162, 2, 18, 1, 1, 1, 28, 1, 1, 1, 29, 1, 1,
         1, 1, 2, 1, 2, 55159, 1, 57, 1, 57, 1, 57, 1, 57, 1
+        // END GENERATED: [mirrored-indices]
     )
     uncompressDeltas(deltas)
   }
@@ -1814,56 +1689,17 @@ println("    )")
    *
    * A range can be empty, i.e., it can happen that `array(i) == array(i + 1)`
    * (but then it is different from `array(i - 1)` and `array(i + 2)`).
-   *
-   * They where generated with the following script, which can be pasted into
-   * a Scala REPL.
-
-val url = new java.net.URL("http://unicode.org/Public/UCD/latest/ucd/UnicodeData.txt")
-val cpToValue = scala.io.Source.fromURL(url, "UTF-8")
-  .getLines()
-  .filter(!_.startsWith("#"))
-  .map(_.split(';'))
-  .map { arr =>
-    val cp = Integer.parseInt(arr(0), 16)
-    val value = arr(3).toInt match {
-      case 0   => 0
-      case 230 => 1
-      case _   => 2
-    }
-    cp -> value
-  }
-  .toMap
-  .withDefault(_ => 0)
-
-var lastValue = 0
-val indicesBuilder = List.newBuilder[Int]
-for (cp <- 0 to Character.MAX_CODE_POINT) {
-  val value = cpToValue(cp)
-  while (lastValue != value) {
-    indicesBuilder += cp
-    lastValue = (lastValue + 1) % 3
-  }
-}
-val indices = indicesBuilder.result()
-
-val indicesDeltas = indices
-  .zip(0 :: indices.init)
-  .map(tup => tup._1 - tup._2)
-println("combiningClassNoneOrAboveOrOtherIndices, deltas:")
-println("    Array(")
-println(formatLargeArray(indicesDeltas.toArray, "        "))
-println("    )")
-
    */
   private[this] lazy val combiningClassNoneOrAboveOrOtherIndices: Array[Int] = {
     val deltas = Array(
+        // BEGIN GENERATED: [combining-classes]
         768, 21, 40, 0, 8, 1, 0, 1, 3, 0, 3, 2, 1, 3, 4, 0, 1, 3, 0, 1, 7, 0,
         13, 0, 275, 5, 0, 265, 0, 1, 0, 4, 1, 0, 3, 2, 0, 6, 6, 0, 2, 1, 0, 2,
         2, 0, 1, 14, 1, 0, 1, 1, 0, 2, 1, 1, 1, 1, 0, 1, 72, 8, 3, 48, 0, 8, 0,
         2, 2, 0, 5, 1, 0, 2, 1, 16, 0, 1, 101, 7, 0, 2, 4, 1, 0, 1, 0, 2, 2, 0,
         1, 0, 1, 0, 2, 1, 35, 0, 1, 30, 1, 1, 0, 2, 1, 0, 2, 3, 0, 1, 2, 0, 1,
         1, 0, 3, 1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 0, 2, 0, 160, 7, 1, 0, 1, 0, 9,
-        0, 1, 24, 4, 0, 1, 9, 0, 1, 3, 0, 1, 5, 0, 43, 0, 3, 59, 2, 3, 0, 4, 0,
+        0, 1, 24, 4, 0, 1, 9, 0, 1, 3, 0, 1, 5, 0, 43, 0, 3, 60, 1, 3, 0, 4, 0,
         42, 5, 5, 0, 14, 0, 1, 0, 1, 0, 2, 1, 0, 2, 1, 0, 3, 6, 0, 3, 1, 0, 2,
         2, 0, 5, 0, 60, 0, 1, 16, 0, 1, 3, 1, 1, 0, 2, 0, 103, 0, 1, 16, 0, 1,
         48, 1, 0, 61, 0, 1, 16, 0, 1, 110, 0, 1, 16, 0, 1, 110, 0, 1, 16, 0, 1,
@@ -1882,17 +1718,18 @@ println("    )")
         1, 151, 0, 1, 27, 18, 0, 57, 0, 3, 37, 0, 1, 95, 0, 1, 12, 0, 1, 239,
         1, 0, 1, 2, 1, 2, 2, 0, 5, 2, 0, 1, 1, 0, 52, 0, 1, 246, 0, 1, 20272,
         0, 1, 769, 7, 7, 0, 2, 0, 973, 0, 1, 226, 0, 1, 149, 5, 0, 1682, 0, 1,
-        1, 1, 0, 40, 1, 2, 4, 0, 1, 165, 1, 1, 573, 4, 0, 65, 5, 0, 317, 2, 0,
-        80, 0, 3, 70, 0, 2, 0, 3, 1, 0, 1, 4, 49, 1, 1, 0, 1, 1, 192, 0, 1, 41,
-        0, 1, 14, 0, 1, 57, 0, 2, 69, 3, 0, 48, 0, 2, 62, 0, 1, 76, 0, 1, 9, 0,
-        1, 106, 0, 2, 178, 0, 2, 80, 0, 2, 16, 0, 1, 24, 7, 0, 3, 5, 0, 89, 0,
-        3, 113, 0, 1, 3, 0, 1, 23, 1, 0, 99, 0, 2, 251, 0, 2, 126, 0, 1, 118,
-        0, 2, 115, 0, 1, 269, 0, 2, 258, 0, 2, 4, 0, 1, 156, 0, 1, 83, 0, 1,
-        18, 0, 1, 81, 0, 1, 421, 0, 1, 258, 0, 1, 1, 0, 2, 81, 0, 1, 425, 0, 2,
-        16876, 0, 1, 2496, 0, 5, 59, 7, 0, 1209, 0, 2, 19628, 0, 1, 5318, 0, 5,
-        3, 0, 6, 8, 0, 8, 2, 5, 2, 30, 4, 0, 148, 3, 0, 3515, 7, 0, 1, 17, 0,
-        2, 7, 0, 1, 2, 0, 1, 5, 0, 100, 1, 0, 160, 7, 0, 375, 1, 0, 61, 4, 0,
-        508, 0, 3, 0, 1, 0, 254, 1, 1, 736, 0, 7, 109, 6, 1
+        1, 1, 0, 40, 1, 2, 4, 0, 1, 165, 1, 1, 573, 4, 0, 387, 2, 0, 80, 0, 3,
+        70, 0, 2, 0, 3, 1, 0, 1, 4, 49, 1, 1, 0, 1, 1, 192, 0, 1, 41, 0, 1, 14,
+        0, 1, 57, 0, 2, 69, 3, 0, 48, 0, 2, 62, 0, 1, 76, 0, 1, 9, 0, 1, 106,
+        0, 2, 178, 0, 2, 80, 0, 2, 16, 0, 1, 24, 7, 0, 3, 5, 0, 205, 0, 1, 3,
+        0, 1, 23, 1, 0, 99, 0, 2, 251, 0, 2, 126, 0, 1, 118, 0, 2, 115, 0, 1,
+        269, 0, 2, 258, 0, 2, 4, 0, 1, 156, 0, 1, 83, 0, 1, 18, 0, 1, 81, 0, 1,
+        421, 0, 1, 258, 0, 1, 1, 0, 2, 81, 0, 1, 425, 0, 2, 19373, 0, 5, 59, 7,
+        0, 1209, 0, 2, 19628, 0, 1, 5318, 0, 5, 3, 0, 6, 8, 0, 8, 2, 5, 2, 30,
+        4, 0, 148, 3, 0, 3515, 7, 0, 1, 17, 0, 2, 7, 0, 1, 2, 0, 1, 5, 0, 100,
+        1, 0, 160, 7, 0, 375, 1, 0, 61, 4, 0, 508, 0, 3, 0, 1, 0, 992, 0, 7,
+        109, 6, 1
+        // END GENERATED: [combining-classes]
     )
     uncompressDeltas(deltas)
   }
@@ -1954,29 +1791,21 @@ println("    )")
    *  Each of them is directly followed by 9 other code points mapping to the
    *  digits 1 to 9, in order. Conversely, there are no other non-ASCII code
    *  point mapping to digits from 0 to 9.
-
-val zeroCodePointReprs = for {
-  cp <- 0x80 to Character.MAX_CODE_POINT
-  if Character.digit(cp, 10) == 0
-} yield {
-  String.format("0x%x", cp)
-}
-println("nonASCIIZeroDigitCodePoints:")
-println("    Array(")
-println(formatLargeArrayStr(zeroCodePointReprs.toArray, "        "))
-println("    )")
-
+   *
+   *  These assumptions are checked when generating the table.
    */
   private[this] lazy val nonASCIIZeroDigitCodePoints: Array[Int] = {
     Array(
-        0x660, 0x6f0, 0x7c0, 0x966, 0x9e6, 0xa66, 0xae6, 0xb66, 0xbe6, 0xc66,
-        0xce6, 0xd66, 0xde6, 0xe50, 0xed0, 0xf20, 0x1040, 0x1090, 0x17e0,
-        0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0, 0x1c40, 0x1c50,
-        0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xa9f0, 0xaa50, 0xabf0, 0xff10,
+        // BEGIN GENERATED: [non-ascii-zero-digits]
+        0x0660, 0x06f0, 0x07c0, 0x0966, 0x09e6, 0x0a66, 0x0ae6, 0x0b66, 0x0be6,
+        0x0c66, 0x0ce6, 0x0d66, 0x0de6, 0x0e50, 0x0ed0, 0x0f20, 0x1040, 0x1090,
+        0x17e0, 0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0, 0x1c40,
+        0x1c50, 0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xa9f0, 0xaa50, 0xabf0, 0xff10,
         0x104a0, 0x10d30, 0x11066, 0x110f0, 0x11136, 0x111d0, 0x112f0, 0x11450,
         0x114d0, 0x11650, 0x116c0, 0x11730, 0x118e0, 0x11950, 0x11c50, 0x11d50,
         0x11da0, 0x11f50, 0x16a60, 0x16ac0, 0x16b50, 0x1d7ce, 0x1d7d8, 0x1d7e2,
         0x1d7ec, 0x1d7f6, 0x1e140, 0x1e2f0, 0x1e4f0, 0x1e950, 0x1fbf0
+        // END GENERATED: [non-ascii-zero-digits]
     )
   }
 }

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -60,6 +60,9 @@ object ExposedValues extends AutoPlugin {
     val enableWasmEverywhere: SettingKey[Boolean] =
       settingKey("enable the WebAssembly backend everywhere, including additional required linker config")
 
+    val regenerateUnicodeData: TaskKey[Unit] =
+      taskKey("regenerate all the Unicode data in the source files")
+
     // set scalaJSLinkerConfig in someProject ~= makeCompliant
     val makeCompliant: StandardConfig => StandardConfig = { prev =>
       prev.withSemantics { semantics =>
@@ -109,7 +112,12 @@ object ExposedValues extends AutoPlugin {
   }
 }
 
-import ExposedValues.autoImport.{enableMinifyEverywhere, enableGCCEverywhere, enableWasmEverywhere}
+import ExposedValues.autoImport.{
+  enableMinifyEverywhere,
+  enableGCCEverywhere,
+  enableWasmEverywhere,
+  regenerateUnicodeData,
+}
 
 final case class ExpectedSizes(fastLink: Range, fullLink: Range,
     fastLinkGz: Range, fullLinkGz: Range)
@@ -1531,6 +1539,11 @@ object Build {
       delambdafySetting,
 
       recompileAllOrNothingSettings,
+
+      regenerateUnicodeData := {
+        val detectedJDKVersion = javaVersion.value
+        UnicodeDataGen.generateAll(detectedJDKVersion)
+      },
 
       /* Do not import `Predef._` so that we have a better control of when
        * we rely on the Scala library.

--- a/project/SourceFilePatches.scala
+++ b/project/SourceFilePatches.scala
@@ -1,0 +1,103 @@
+package build
+
+import java.nio.charset.StandardCharsets.UTF_8
+
+import sbt.{IO, MessageOnlyException}
+
+/** Applies formatted and indented patches in-place to source files. */
+object SourceFilePatches {
+  sealed abstract class Patch
+
+  object Patch {
+    final case class Lines(lines: Seq[String]) extends Patch
+    final case class ArrayElements(elements: Seq[String]) extends Patch
+
+    object ArrayElements {
+      def ints(elements: Seq[Int]): ArrayElements =
+        ArrayElements(elements.map(_.toString()))
+    }
+  }
+
+  private final val MaxLineLength = 80
+
+  private val BeginGeneratedLineRE =
+    raw""" *// BEGIN GENERATED: \[(.*)\]""".r
+
+  def patchFile(fileName: String)(patches: (String, Patch)*): Unit = {
+    val patchMap = patches.toMap
+    val file = new java.io.File(fileName)
+    val lines = IO.readLines(file, UTF_8)
+
+    // Ensure that we provide exactly the patches that are expected in the file
+    val expectedPatchNames = lines.collect {
+      case BeginGeneratedLineRE(patchName) => patchName
+    }.sorted
+    val actualPatchNames = patches.map(_._1).toList.sorted
+    if (actualPatchNames != expectedPatchNames) {
+      throw new MessageOnlyException(
+          s"Some patches were missing or unexpected in $fileName\n" +
+          s"Expected: ${expectedPatchNames.mkString(", ")}\n" +
+          s"Actual:   ${actualPatchNames.mkString(", ")}")
+    }
+
+    val newLines = patches.foldLeft(lines) { case (lines, (patchName, patch)) =>
+      val beginLookup = s"// BEGIN GENERATED: [$patchName]"
+      val endLookup = s"// END GENERATED: [$patchName]"
+      val start = lines.indexWhere(_.endsWith(beginLookup))
+      val end = lines.indexWhere(_.endsWith(endLookup))
+
+      if (start < 0 || end < 0 || end < start)
+        throw new MessageOnlyException(s"Cannot locate patch [$patchName] in $fileName")
+
+      val (beginningAndOld, rest) = lines.splitAt(end)
+      val beginning = beginningAndOld.take(start + 1)
+
+      val indent = rest.head.takeWhile(_ == ' ')
+      if (indent != beginning.last.takeWhile(_ == ' '))
+        throw new MessageOnlyException(s"Inconsistent indent for patch [$patchName] in $fileName")
+
+      val formattedPatch = formatPatch(patch, indent)
+
+      beginning ::: formattedPatch ::: rest
+    }
+
+    // Do not use IO.writeLines; it uses CRLF on Windows
+    IO.write(file, newLines.mkString("", "\n", "\n").getBytes(UTF_8))
+  }
+
+  private def formatPatch(patch: Patch, indent: String): List[String] = {
+    patch match {
+      case Patch.Lines(lines)            => formatLines(lines, indent)
+      case Patch.ArrayElements(elements) => formatArrayElements(elements, indent)
+    }
+  }
+
+  private def formatLines(lines: Seq[String], indent: String): List[String] =
+    lines.toList.map(indent + _)
+
+  private def formatArrayElements(elements: Seq[Any], indent: String): List[String] = {
+    val lastIndex = elements.size - 1
+    val lines = List.newBuilder[String]
+    val lineBuilder = new java.lang.StringBuilder()
+
+    for ((element, i) <- elements.iterator.zipWithIndex) {
+      val toAdd = "" + element + (if (i == lastIndex) "" else ",")
+      if (lineBuilder.length() + 1 + toAdd.length() >= MaxLineLength) {
+        lines += lineBuilder.toString()
+        lineBuilder.setLength(0)
+      }
+
+      if (lineBuilder.length() == 0)
+        lineBuilder.append(indent)
+      else
+        lineBuilder.append(' ')
+
+      lineBuilder.append(toAdd)
+    }
+
+    if (lineBuilder.length() != 0)
+      lines += lineBuilder.toString()
+
+    lines.result()
+  }
+}

--- a/project/UnicodeDataGen.scala
+++ b/project/UnicodeDataGen.scala
@@ -1,0 +1,341 @@
+package build
+
+import java.lang.Character._
+
+import scala.collection.mutable
+
+import sbt.MessageOnlyException
+
+import SourceFilePatches._
+
+/** Generator for all the Unicode data tables and tests that we derived from
+ *  the JDK.
+ *
+ *  Run it with the sbt task `javalibInternal/regerateUnicodeData`. That task
+ *  updates source files in-place!
+ */
+object UnicodeDataGen {
+  /** When updating this to a newer version, you should then regenerate the
+   *  Unicode data so they stay in sync. The CI ensures that you do so. You
+   *  will have to update the relevant `java.version` used in the
+   *  `os-sensitive-ci.yml` CI workflow.
+   *
+   *  Trying to generate the Unicode data while the build is running on a
+   *  different JDK version will result in an error.
+   */
+  final val ReferenceJDKVersion = 21
+
+  def generateAll(detectedJDKVersion: Int): Unit = {
+    if (detectedJDKVersion != ReferenceJDKVersion) {
+      throw new MessageOnlyException(
+        s"The reference JDK version to generate Unicode data is " +
+        s"$ReferenceJDKVersion, but the build is running under " +
+        s"$detectedJDKVersion. " +
+        s"Make sure to run the build itself under JDK $ReferenceJDKVersion " +
+        s"to generate Unicode data."
+      )
+    }
+
+    generateCharacter()
+    generateCharacterTest()
+  }
+
+  private final val FirstNonASCII = 0x0080
+
+  /** First invalid code point.
+   *
+   *  When computing values by range, we go all the way up to the first
+   *  invalid code point. Most of the methods of jl.Character have a
+   *  well-defined result for invalid code points, i.e., negative or greater
+   *  than MAX_CODE_POINT. We include `MAX_CODE_POINT + 1` on purpose in our
+   *  ranges, so that there will always be a valid value for the invalid
+   *  code points.
+   */
+  private final val FirstInvalidCP = MAX_CODE_POINT + 1
+
+  // Helpers
+
+  private def constantDef(name: String, value: Int): String =
+    s"private final val $name = $value"
+
+  private def cpToStr(cp: Int): String =
+    String.valueOf(Character.toChars(cp)) // Character.toString(cp) does not compile on JDK 8
+
+  private def formatCP(cp: Int): String =
+    f"0x$cp%04x"
+
+  // --- jl.Character ---
+
+  private def generateCharacter(): Unit = {
+    val titleCaseMappings = computeTitleCaseMappings()
+
+    val unicodeBlocks = computeUnicodeBlocks()
+    val unicodeBlockConstants = List(constantDef("BlockCount", unicodeBlocks.size))
+
+    val charTypesFirst256 = (0 until 256).map(getType(_))
+    val (charTypeIndicesDeltas, charTypes) = computeCharTypes()
+
+    val nonASCIIZeroDigitCodePoints = computeZeroDigitCodePoints(FirstNonASCII)
+    val mirroredIndices = computeMirroredIndices()
+    val combiningClasses = computeCombiningClasses()
+
+    patchFile("javalib/src/main/scala/java/lang/Character.scala")(
+      "titlecase-mappings" -> Patch.Lines(titleCaseMappings),
+      "unicode-block-constants" -> Patch.Lines(unicodeBlockConstants),
+      "unicode-blocks" -> Patch.Lines(unicodeBlocks),
+      "char-types-first-256" -> Patch.ArrayElements.ints(charTypesFirst256),
+      "char-types-indices" -> Patch.ArrayElements.ints(charTypeIndicesDeltas),
+      "char-types" -> Patch.ArrayElements.ints(charTypes),
+      "non-ascii-zero-digits" -> Patch.ArrayElements(nonASCIIZeroDigitCodePoints.map(formatCP(_))),
+      "mirrored-indices" -> Patch.ArrayElements.ints(mirroredIndices),
+      "combining-classes" -> Patch.ArrayElements.ints(combiningClasses),
+    )
+  }
+
+  private def computeTitleCaseMappings(): Array[String] = {
+    val b = Array.newBuilder[String]
+
+    for (cp <- 0 to MAX_CODE_POINT) {
+      val titleCaseCP = toTitleCase(cp)
+      val upperCaseCP = toUpperCase(cp)
+
+      if (titleCaseCP != upperCaseCP)
+        b += f"case 0x$cp%04x => 0x$titleCaseCP%04x"
+    }
+
+    b.result()
+  }
+
+  private def computeUnicodeBlocks(): Array[String] = {
+    // JVMName -> (historicalName, properName)
+    val historicalMap = Map(
+      "GREEK" -> ("Greek", "Greek and Coptic"),
+      "CYRILLIC_SUPPLEMENTARY" -> ("Cyrillic Supplementary", "Cyrillic Supplement"),
+      "COMBINING_MARKS_FOR_SYMBOLS" -> ("Combining Marks For Symbols", "Combining Diacritical Marks for Symbols")
+    )
+
+    // Get the "proper name" for JVM block name
+    val blockNameMap: Map[String, String] = {
+      // We can use the "latest" source, because we only use it to generate mappings
+      val blocksSourceURL = new java.net.URI("https://unicode.org/Public/UCD/latest/ucd/Blocks.txt").toURL()
+      val source = scala.io.Source.fromURL(blocksSourceURL, "UTF-8")
+      try {
+        source
+          .getLines()
+          .filterNot {
+            _.startsWith("#")
+          }
+          .flatMap { line =>
+            line.split(';') match {
+              case Array(_, name) =>
+                val trimmed = name.trim
+                val jvmName = trimmed.replaceAll(raw"[\s\-]", "_").toUpperCase
+                Some(jvmName -> trimmed)
+              case _ => None
+            }
+          }.toMap
+      } finally {
+        source.close()
+      }
+    }
+
+    val blocksAndCharacters = (0 to MAX_CODE_POINT)
+      .map(cp => UnicodeBlock.of(cp) -> cp).filterNot(_._1 == null)
+
+    val orderedBlocks = blocksAndCharacters.map(_._1).distinct.toArray
+
+    val blockLowAndHighCodePointsMap = {
+      blocksAndCharacters.groupBy(_._1).mapValues { v =>
+        val codePoints = v.map(_._2)
+        (codePoints.min, codePoints.max)
+      }
+    }
+
+    orderedBlocks.map { b =>
+      val minCodePoint = "0x%04x".format(blockLowAndHighCodePointsMap(b)._1)
+      val maxCodePoint = "0x%04x".format(blockLowAndHighCodePointsMap(b)._2)
+
+      historicalMap.get(b.toString) match {
+        case Some((historicalName, properName)) =>
+          s"""val $b = addUnicodeBlock("$properName", "$historicalName", $minCodePoint, $maxCodePoint)"""
+        case None =>
+          val properBlockName = blockNameMap.getOrElse(b.toString, {
+            throw new IllegalArgumentException("$b")
+          })
+          val jvmBlockName = properBlockName.toUpperCase.replaceAll("[\\s\\-_]", "_")
+          assert(jvmBlockName == b.toString)
+          s"""val $jvmBlockName = addUnicodeBlock("$properBlockName", $minCodePoint, $maxCodePoint)"""
+      }
+    }
+  }
+
+  private def computeCharTypes(): (Seq[Int], Seq[Int]) = {
+    val indicesAndTypes = (256 to FirstInvalidCP)
+      .map(i => (i, Character.getType(i)))
+      .foldLeft[List[(Int, Int)]](Nil) {
+        case (x :: xs, elem) if x._2 == elem._2 => x :: xs
+        case (prevs, elem) => elem :: prevs
+      }.reverse
+    val charTypeIndices = indicesAndTypes.map(_._1).tail
+    val charTypeIndicesDeltas = charTypeIndices
+      .zip(0 :: charTypeIndices.init)
+      .map(tup => tup._1 - tup._2)
+    val charTypes = indicesAndTypes.map(_._2)
+
+    (charTypeIndicesDeltas, charTypes)
+  }
+
+  private def computeZeroDigitCodePoints(start: Int): Array[Int] = {
+    checkDecimalDigitAssumptions()
+
+    val b = Array.newBuilder[Int]
+    for (cp <- start to MAX_CODE_POINT) {
+      if (Character.digit(cp, 10) == 0)
+        b += cp
+    }
+
+    b.result()
+  }
+
+  private def checkDecimalDigitAssumptions(): Unit = {
+    for (cp <- 0 to MAX_CODE_POINT) {
+      val d = Character.digit(cp, 10)
+      if (d == 0) {
+        // Every 0 digit is followed by digits from 1 to 9
+        for (i <- 1 to 9) {
+          val d2 = Character.digit(cp + i, 10)
+          if (d2 != i) {
+            throw new MessageOnlyException(
+                s"Assumption broken: code point ${(cp + i).toHexString} " +
+                s"should have digit $i but was $d2. " +
+                s"It follows zero digit code point ${cp.toHexString}.")
+          }
+        }
+      } else if (d >= 1 && d <= 9) {
+        // Every 1-9 digit must come after a 0 digit at the appropriate distance
+        val d2 = Character.digit(cp - d, 10)
+        if (d2 != 0) {
+          throw new MessageOnlyException(
+              s"Assumption broken: code point ${cp.toHexString} with digit $d " +
+              s"does not follow a zero digit code point. " +
+              s"It should have been ${(cp - d).toHexString}} but its digit was $d2.")
+        }
+      }
+    }
+  }
+
+  private def computeMirroredIndices(): Array[Int] = {
+    val b = Array.newBuilder[Int]
+
+    var prevCP = 0
+    var lastPropValue = false
+
+    for (cp <- 0 to FirstInvalidCP) {
+      val propValue = isMirrored(cp)
+      if (propValue != lastPropValue) {
+        b += (cp - prevCP)
+        prevCP = cp
+        lastPropValue = propValue
+      }
+    }
+
+    b.result()
+  }
+
+  private def computeCombiningClasses(): Array[Int] = {
+    val b = Array.newBuilder[Int]
+
+    /* The initial value is always 0 by construction, irrespective of the
+     * constants we define. That's why we don't use CombiningClassIsNone here.
+     */
+    var currentCombiningClass = 0
+
+    // We don't use FirstInvalidCP here because there is no valid value for invalid code points
+    for (cp <- 0 to MAX_CODE_POINT) {
+      val combiningClass = computeCombiningClass(cp)
+      while (combiningClass != currentCombiningClass) {
+        b += cp
+        currentCombiningClass = (currentCombiningClass + 1) % 3
+      }
+    }
+
+    val result = b.result()
+
+    // Turn all values into diffs
+    var i = result.length - 1
+    while (i > 0) {
+      result(i) -= result(i - 1)
+      i -= 1
+    }
+
+    result
+  }
+
+  private val Lithuanian = java.util.Locale.forLanguageTag("lt")
+
+  // Copied from jl.Character
+  private final val CombiningClassIsNone = 0
+  private final val CombiningClassIsAbove = 1
+  private final val CombiningClassIsOther = 2
+
+  /** Computes the combining class of a code point by testing how it behaves
+   *  through Lithuanian's toLowerCase mapping.
+   *
+   *  See the comment in jl.String.toLowerCaseLithuanian.
+   */
+  private def computeCombiningClass(cp: Int): Int = {
+    if (!isValidCodePoint(cp)) {
+      CombiningClassIsNone
+    } else {
+      val cpStr = cpToStr(cp)
+      if (("I" + cpStr).toLowerCase(Lithuanian).startsWith("i\u0307")) {
+        // includes 0x0307 itself
+        CombiningClassIsAbove
+      } else if (("I" + cpStr + "\u0307").toLowerCase(Lithuanian).startsWith("i\u0307")) {
+        CombiningClassIsOther
+      } else {
+        CombiningClassIsNone
+      }
+    }
+  }
+
+  private def generateCharacterTest(): Unit = {
+    val constants = List(
+      constantDef("ReferenceJDKVersion", ReferenceJDKVersion),
+    )
+
+    val allZeroDigitCodePoints = computeZeroDigitCodePoints(start = 0)
+
+    val toLowerCaseCodePointDiffString =
+      computeToCaseCodePointDiffString("toLowerCase", toLowerCase(_), _.toLowerCase())
+    val toUpperCaseCodePointDiffString =
+      computeToCaseCodePointDiffString("toUpperCase", toUpperCase(_), _.toUpperCase())
+    val toTitleCaseCodePointDiffStringToUpperCase =
+      computeToCaseCodePointDiffString("toTitleCase", toTitleCase(_), _.toUpperCase())
+
+    patchFile("test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala")(
+      "constants" -> Patch.Lines(constants),
+      "all-zero-digits" -> Patch.ArrayElements(allZeroDigitCodePoints.map(formatCP(_))),
+      "tolowercase-code-point-diff-string" -> Patch.Lines(toLowerCaseCodePointDiffString),
+      "touppercase-code-point-diff-string" -> Patch.Lines(toUpperCaseCodePointDiffString),
+      "totitlecase-code-point-diff-string-touppercase" -> Patch.Lines(toTitleCaseCodePointDiffStringToUpperCase),
+    )
+  }
+
+  private def computeToCaseCodePointDiffString(methodName: String,
+      cpToCase: Int => Int, strToCase: String => String): Array[String] = {
+
+    val b = Array.newBuilder[String]
+
+    for (cp <- 0 to MAX_CODE_POINT) {
+      val cpStr = cpToStr(cp)
+      val caseCP = cpToCase(cp)
+      val caseCPStr = cpToStr(caseCP)
+
+      if (strToCase(cpStr) != caseCPStr)
+        b += s"assertEquals(${formatCP(caseCP)}, Character.$methodName(${formatCP(cp)})) // $cpStr => $caseCPStr"
+    }
+
+    b.result()
+  }
+}

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/lang/CharacterTest.scala
@@ -12,6 +12,11 @@
 
 package org.scalajs.testsuite.javalib.lang
 
+/* This file contains automatically generated snippets.
+ * To regenerate them, run the sbt task `javalibInternal/regenerateUnicodeData`,
+ * whose implementation is in `project/UnicodeDataGen.scala`.
+ */
+
 import org.junit.Test
 import org.junit.Assert._
 import org.junit.Assume._
@@ -19,7 +24,14 @@ import org.junit.Assume._
 import org.scalajs.testsuite.utils.AssertThrows.assertThrows
 import org.scalajs.testsuite.utils.Platform._
 
+object CharacterTest {
+  // BEGIN GENERATED: [constants]
+  private final val ReferenceJDKVersion = 21
+  // END GENERATED: [constants]
+}
+
 class CharacterTest {
+  import CharacterTest._
 
   @Test def hashCodeChar(): Unit = {
     assertEquals(0, Character.hashCode('\u0000'))
@@ -217,6 +229,10 @@ class CharacterTest {
   @Test def digit(): Unit = {
     import Character.{MAX_RADIX, MIN_RADIX}
 
+    assumeTrue(
+        s"requires exactly the reference JDK version $ReferenceJDKVersion",
+        !executingInJVM || executingInJVMWithJDKIn(ReferenceJDKVersion to ReferenceJDKVersion))
+
     def test(expected: Int, codePoint: Int): Unit = {
       assertEquals(expected, Character.digit(codePoint, MAX_RADIX))
       if (codePoint <= Char.MaxValue)
@@ -264,12 +280,18 @@ class CharacterTest {
 
     // Every single valid digit
 
-    val All0s = Array[Int]('0', 0x660, 0x6f0, 0x7c0, 0x966, 0x9e6, 0xa66,
-        0xae6, 0xb66, 0xbe6, 0xc66, 0xce6, 0xd66, 0xe50, 0xed0, 0xf20, 0x1040,
-        0x1090, 0x17e0, 0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0,
-        0x1c40, 0x1c50, 0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xaa50, 0xabf0, 0xff10,
-        0x104a0, 0x11066, 0x110f0, 0x11136, 0x111d0, 0x116c0, 0x1d7ce, 0x1d7d8,
-        0x1d7e2, 0x1d7ec, 0x1d7f6)
+    val All0s: Array[Int] = Array(
+      // BEGIN GENERATED: [all-zero-digits]
+      0x0030, 0x0660, 0x06f0, 0x07c0, 0x0966, 0x09e6, 0x0a66, 0x0ae6, 0x0b66,
+      0x0be6, 0x0c66, 0x0ce6, 0x0d66, 0x0de6, 0x0e50, 0x0ed0, 0x0f20, 0x1040,
+      0x1090, 0x17e0, 0x1810, 0x1946, 0x19d0, 0x1a80, 0x1a90, 0x1b50, 0x1bb0,
+      0x1c40, 0x1c50, 0xa620, 0xa8d0, 0xa900, 0xa9d0, 0xa9f0, 0xaa50, 0xabf0,
+      0xff10, 0x104a0, 0x10d30, 0x11066, 0x110f0, 0x11136, 0x111d0, 0x112f0,
+      0x11450, 0x114d0, 0x11650, 0x116c0, 0x11730, 0x118e0, 0x11950, 0x11c50,
+      0x11d50, 0x11da0, 0x11f50, 0x16a60, 0x16ac0, 0x16b50, 0x1d7ce, 0x1d7d8,
+      0x1d7e2, 0x1d7ec, 0x1d7f6, 0x1e140, 0x1e2f0, 0x1e4f0, 0x1e950, 0x1fbf0
+      // END GENERATED: [all-zero-digits]
+    )
 
     for {
       zero <- All0s
@@ -857,23 +879,15 @@ class CharacterTest {
 
   /* Test all the code points for which delegating to `String.toLowerCase()`
    * is not a valid implementation.
-   *
-   * The list can be reproduced with the following script. It happens to
-   * coincide with the code points tested in the previous test.
-
-def format(codePoint: Int): String = "0x%04x".format(codePoint)
-
-for (cp <- 0 to Character.MAX_CODE_POINT) {
-  val cpStr: String = new String(Array(cp), 0, 1)
-  val lowerCP: Int = Character.toLowerCase(cp)
-  val lowerCPStr: String = new String(Array(lowerCP), 0, 1)
-
-  if (cpStr.toLowerCase() != lowerCPStr)
-    println(s"    assertEquals(${format(lowerCP)}, Character.toLowerCase(${format(cp)})) // $cpStr => $lowerCPStr")
-}
   */
   @Test def toLowerCaseCodePointStringLowerCaseDiffCharacterLowerCase(): Unit = {
+    assumeTrue(
+        s"requires exactly the reference JDK version $ReferenceJDKVersion",
+        !executingInJVM || executingInJVMWithJDKIn(ReferenceJDKVersion to ReferenceJDKVersion))
+
+    // BEGIN GENERATED: [tolowercase-code-point-diff-string]
     assertEquals(0x0069, Character.toLowerCase(0x0130)) // İ => i
+    // END GENERATED: [tolowercase-code-point-diff-string]
   }
 
   @Test def toUpperCaseCompareCharAndCodepoint(): Unit = {
@@ -973,21 +987,13 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
 
   /* Test all the code points for which delegating to `String.toUpperCase()`
    * is not a valid implementation.
-   *
-   * The list can be reproduced with the following script.
-
-def format(codePoint: Int): String = "0x%04x".format(codePoint)
-
-for (cp <- 0 to Character.MAX_CODE_POINT) {
-  val cpStr: String = new String(Array(cp), 0, 1)
-  val upperCP: Int = Character.toUpperCase(cp)
-  val upperCPStr: String = new String(Array(upperCP), 0, 1)
-
-  if (cpStr.toUpperCase() != upperCPStr)
-    println(s"    assertEquals(${format(upperCP)}, Character.toUpperCase(${format(cp)})) // $cpStr => $upperCPStr")
-}
   */
   @Test def toUpperCaseCodePointStringUpperCaseDiffCharacterUpperCase(): Unit = {
+    assumeTrue(
+        s"requires exactly the reference JDK version $ReferenceJDKVersion",
+        !executingInJVM || executingInJVMWithJDKIn(ReferenceJDKVersion to ReferenceJDKVersion))
+
+    // BEGIN GENERATED: [touppercase-code-point-diff-string]
     assertEquals(0x00df, Character.toUpperCase(0x00df)) // ß => ß
     assertEquals(0x0149, Character.toUpperCase(0x0149)) // ŉ => ŉ
     assertEquals(0x01f0, Character.toUpperCase(0x01f0)) // ǰ => ǰ
@@ -1090,6 +1096,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0xfb15, Character.toUpperCase(0xfb15)) // ﬕ => ﬕ
     assertEquals(0xfb16, Character.toUpperCase(0xfb16)) // ﬖ => ﬖ
     assertEquals(0xfb17, Character.toUpperCase(0xfb17)) // ﬗ => ﬗ
+    // END GENERATED: [touppercase-code-point-diff-string]
   }
 
   @Test def toTitleCaseCompareCharAndCodepoint(): Unit = {
@@ -1152,19 +1159,12 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0x1faf, Character.toTitleCase(0x1faf))
   }
 
-/*
-def format(codePoint: Int): String = "0x%04x".format(codePoint)
-
-for (cp <- 0 to Character.MAX_CODE_POINT) {
-  val cpStr: String = new String(Array(cp), 0, 1)
-  val titleCP: Int = Character.toTitleCase(cp)
-  val titleCPStr: String = new String(Array(titleCP), 0, 1)
-
-  if (cpStr.toUpperCase() != titleCPStr)
-    println(s"    assertEquals(${format(titleCP)}, Character.toTitleCase(${format(cp)})) // $cpStr => $titleCPStr")
-}
-*/
   @Test def toTitleCaseCodePointStringUpperCaseDiffCharacterTitleCase(): Unit = {
+    assumeTrue(
+        s"requires exactly the reference JDK version $ReferenceJDKVersion",
+        !executingInJVM || executingInJVMWithJDKIn(ReferenceJDKVersion to ReferenceJDKVersion))
+
+    // BEGIN GENERATED: [totitlecase-code-point-diff-string-touppercase]
     assertEquals(0x00df, Character.toTitleCase(0x00df)) // ß => ß
     assertEquals(0x0149, Character.toTitleCase(0x0149)) // ŉ => ŉ
     assertEquals(0x01c5, Character.toTitleCase(0x01c4)) // Ǆ => ǅ
@@ -1183,6 +1183,52 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0x0390, Character.toTitleCase(0x0390)) // ΐ => ΐ
     assertEquals(0x03b0, Character.toTitleCase(0x03b0)) // ΰ => ΰ
     assertEquals(0x0587, Character.toTitleCase(0x0587)) // և => և
+    assertEquals(0x10d0, Character.toTitleCase(0x10d0)) // ა => ა
+    assertEquals(0x10d1, Character.toTitleCase(0x10d1)) // ბ => ბ
+    assertEquals(0x10d2, Character.toTitleCase(0x10d2)) // გ => გ
+    assertEquals(0x10d3, Character.toTitleCase(0x10d3)) // დ => დ
+    assertEquals(0x10d4, Character.toTitleCase(0x10d4)) // ე => ე
+    assertEquals(0x10d5, Character.toTitleCase(0x10d5)) // ვ => ვ
+    assertEquals(0x10d6, Character.toTitleCase(0x10d6)) // ზ => ზ
+    assertEquals(0x10d7, Character.toTitleCase(0x10d7)) // თ => თ
+    assertEquals(0x10d8, Character.toTitleCase(0x10d8)) // ი => ი
+    assertEquals(0x10d9, Character.toTitleCase(0x10d9)) // კ => კ
+    assertEquals(0x10da, Character.toTitleCase(0x10da)) // ლ => ლ
+    assertEquals(0x10db, Character.toTitleCase(0x10db)) // მ => მ
+    assertEquals(0x10dc, Character.toTitleCase(0x10dc)) // ნ => ნ
+    assertEquals(0x10dd, Character.toTitleCase(0x10dd)) // ო => ო
+    assertEquals(0x10de, Character.toTitleCase(0x10de)) // პ => პ
+    assertEquals(0x10df, Character.toTitleCase(0x10df)) // ჟ => ჟ
+    assertEquals(0x10e0, Character.toTitleCase(0x10e0)) // რ => რ
+    assertEquals(0x10e1, Character.toTitleCase(0x10e1)) // ს => ს
+    assertEquals(0x10e2, Character.toTitleCase(0x10e2)) // ტ => ტ
+    assertEquals(0x10e3, Character.toTitleCase(0x10e3)) // უ => უ
+    assertEquals(0x10e4, Character.toTitleCase(0x10e4)) // ფ => ფ
+    assertEquals(0x10e5, Character.toTitleCase(0x10e5)) // ქ => ქ
+    assertEquals(0x10e6, Character.toTitleCase(0x10e6)) // ღ => ღ
+    assertEquals(0x10e7, Character.toTitleCase(0x10e7)) // ყ => ყ
+    assertEquals(0x10e8, Character.toTitleCase(0x10e8)) // შ => შ
+    assertEquals(0x10e9, Character.toTitleCase(0x10e9)) // ჩ => ჩ
+    assertEquals(0x10ea, Character.toTitleCase(0x10ea)) // ც => ც
+    assertEquals(0x10eb, Character.toTitleCase(0x10eb)) // ძ => ძ
+    assertEquals(0x10ec, Character.toTitleCase(0x10ec)) // წ => წ
+    assertEquals(0x10ed, Character.toTitleCase(0x10ed)) // ჭ => ჭ
+    assertEquals(0x10ee, Character.toTitleCase(0x10ee)) // ხ => ხ
+    assertEquals(0x10ef, Character.toTitleCase(0x10ef)) // ჯ => ჯ
+    assertEquals(0x10f0, Character.toTitleCase(0x10f0)) // ჰ => ჰ
+    assertEquals(0x10f1, Character.toTitleCase(0x10f1)) // ჱ => ჱ
+    assertEquals(0x10f2, Character.toTitleCase(0x10f2)) // ჲ => ჲ
+    assertEquals(0x10f3, Character.toTitleCase(0x10f3)) // ჳ => ჳ
+    assertEquals(0x10f4, Character.toTitleCase(0x10f4)) // ჴ => ჴ
+    assertEquals(0x10f5, Character.toTitleCase(0x10f5)) // ჵ => ჵ
+    assertEquals(0x10f6, Character.toTitleCase(0x10f6)) // ჶ => ჶ
+    assertEquals(0x10f7, Character.toTitleCase(0x10f7)) // ჷ => ჷ
+    assertEquals(0x10f8, Character.toTitleCase(0x10f8)) // ჸ => ჸ
+    assertEquals(0x10f9, Character.toTitleCase(0x10f9)) // ჹ => ჹ
+    assertEquals(0x10fa, Character.toTitleCase(0x10fa)) // ჺ => ჺ
+    assertEquals(0x10fd, Character.toTitleCase(0x10fd)) // ჽ => ჽ
+    assertEquals(0x10fe, Character.toTitleCase(0x10fe)) // ჾ => ჾ
+    assertEquals(0x10ff, Character.toTitleCase(0x10ff)) // ჿ => ჿ
     assertEquals(0x1e96, Character.toTitleCase(0x1e96)) // ẖ => ẖ
     assertEquals(0x1e97, Character.toTitleCase(0x1e97)) // ẗ => ẗ
     assertEquals(0x1e98, Character.toTitleCase(0x1e98)) // ẘ => ẘ
@@ -1279,6 +1325,7 @@ for (cp <- 0 to Character.MAX_CODE_POINT) {
     assertEquals(0xfb15, Character.toTitleCase(0xfb15)) // ﬕ => ﬕ
     assertEquals(0xfb16, Character.toTitleCase(0xfb16)) // ﬖ => ﬖ
     assertEquals(0xfb17, Character.toTitleCase(0xfb17)) // ﬗ => ﬗ
+    // END GENERATED: [totitlecase-code-point-diff-string-touppercase]
   }
 
   @Test def codePointCountString(): Unit = {


### PR DESCRIPTION
A number of snippets, both in the javalib and its tests, were generated by REPL scripts kept in comments. This was not great, as we needed to regenerate all of them separately, with a lot of manipulations.

We now introduce a single sbt task, completely automated, that regenerates and updates everything in-place.

We tried to keep the diffs as small as possible in this commit. However, there are two main changes:

* Some special code points were missing in the test data, although they were already listed in the javalib data.
* More importantly, we switched the generation of combining classes from downloading from `unicode.org` to inferring from the JDK behavior. This aligns it to all the other generated data.

The remaining changes are reformatting.

We add a CI task to ensure that the data in the source are kept up to date with the code generator.