### PR TITLE
Fix #5297: Fix modPow2Inverse used by BigInteger.modPow.

### DIFF
--- a/javalib/src/main/scala/java/math/Division.scala
+++ b/javalib/src/main/scala/java/math/Division.scala
@@ -593,10 +593,9 @@ private[math] object Division {
    *  @return {@code x<sup>-1</sup> (mod 2<sup>n</sup>)}.
    */
   def modPow2Inverse(x: BigInteger, n: Int): BigInteger = {
-    val y = new BigInteger(1, new Array[Int](1 << n))
-    y.numberLength = 1
+    val numberLength = (n + 31) >> 5 // ceil(n / 32)
+    val y = new BigInteger(1, numberLength, new Array[Int](numberLength))
     y.digits(0) = 1
-    y.sign = 1
     for (i <- 1 until n) {
       if (BitLevel.testBit(x.multiply(y), i)) {
         y.digits(i >> 5) |= (1 << (i & 31))

--- a/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
+++ b/test-suite/shared/src/test/scala/org/scalajs/testsuite/javalib/math/BigIntegerModPowTest.scala
@@ -291,4 +291,18 @@ class BigIntegerModPowTest {
     }
     assertEquals(1, result.signum())
   }
+
+  @Test def testModPow_Issue5297(): Unit = {
+    // scalastyle:off line.size.limit
+
+    // Values from Plutus conformance test (modulus is 79!)
+    val base = new BigInteger("295783465278346578267348527836475862348589358937497")
+    val exp = new BigInteger("89734578923487957289347527893478952378945268423487234782378423")
+    val modulus = new BigInteger("894618213078297528685144171539831652069808216779571907213868063227837990693501860533361810841010176000000000000000000")
+    val expected = new BigInteger("280175799933420074585178470510090012806707950340412289432212739835789837904455835552327022379259130346551828535037673")
+
+    assertEquals(expected, base.modPow(exp, modulus))
+
+    // scalastyle:on line.size.limit
+  }
 }


### PR DESCRIPTION
Its computation of the array size and its initialization of the associated `numberLength` were completely wrong. As soon as more than one `Int` was required to store the digits the result, it would start completely misbehaving.