### PR TITLE
Fix expectedSizes after a semantic merge conflict.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2079,7 +2079,7 @@ object Build {
             if (!useMinifySizes) {
               Some(ExpectedSizes(
                   fastLink = 439000 to 440000,
-                  fullLink = 264000 to 265000,
+                  fullLink = 263000 to 264000,
                   fastLinkGz = 57000 to 58000,
                   fullLinkGz = 43000 to 44000,
               ))


### PR DESCRIPTION
The recent commits e3678bdd93e333cf16c509d86faa3f3b5965d848 and 34b613fce3bc8fb2957b054897e317b28916d223 caused a semantic conflict on the expected sizes for the reversi.